### PR TITLE
[Python Lab] Enable file writing

### DIFF
--- a/apps/lib/pyodide/pandas-1.5.3-cp311-cp311-emscripten_3_1_45_wasm32.whl
+++ b/apps/lib/pyodide/pandas-1.5.3-cp311-cp311-emscripten_3_1_45_wasm32.whl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c99a9060f2921575d2fe3796220b81aec6973aa1cb25e321245b1ed4423f32e3
+size 21550321

--- a/apps/src/pythonlab/PythonConsole.tsx
+++ b/apps/src/pythonlab/PythonConsole.tsx
@@ -60,7 +60,6 @@ const PythonConsole: React.FunctionComponent = () => {
         <Button type={'button'} text="Clear output" onClick={clearOutput} />
       </div>
       <div>
-        Output:
         {codeOutput.map((outputLine, index) => {
           if (outputLine.type === 'img') {
             return (

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -72,17 +72,17 @@ const defaultConfig: ConfigType = {
 };
 
 const PythonlabView: React.FunctionComponent = () => {
-  const [currentProject, setCurrentProject] = useState<MultiFileSource>();
+  //const [currentProject, setCurrentProject] = useState<MultiFileSource>();
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
   const initialSources = useAppSelector(state => state.lab.initialSources);
   const channelId = useAppSelector(state => state.lab.channel?.id);
   const dispatch = useAppDispatch();
+  const source = useAppSelector(state => state.pythonlab.source);
 
   // TODO: This is (mostly) repeated in Weblab2View. Can we extract this out somewhere?
   // https://codedotorg.atlassian.net/browse/CT-499
   const setProject = useMemo(
     () => (newProject: MultiFileSource) => {
-      setCurrentProject(newProject);
       dispatch(setSource(newProject));
       if (Lab2Registry.getInstance().getProjectManager()) {
         const projectSources = {
@@ -96,18 +96,17 @@ const PythonlabView: React.FunctionComponent = () => {
 
   useEffect(() => {
     // We reset the project when the channelId changes, as this means we are on a new level.
-    setCurrentProject(
-      (initialSources?.source as MultiFileSource) || defaultProject
+    dispatch(
+      setSource((initialSources?.source as MultiFileSource) || defaultProject)
     );
-    dispatch(setSource(initialSources?.source as MultiFileSource));
   }, [channelId, dispatch, initialSources]);
 
   return (
     <div className={moduleStyles.pythonlab}>
       <div className={moduleStyles.editor}>
-        {currentProject && (
+        {source && (
           <CDOIDE
-            project={currentProject}
+            project={source}
             config={config}
             setProject={setProject}
             setConfig={setConfig}

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -7,9 +7,8 @@ import {LanguageSupport} from '@codemirror/language';
 import {python} from '@codemirror/lang-python';
 import {CDOIDE} from '@cdo/apps/weblab2/CDOIDE';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
-import Lab2Registry from '../lab2/Lab2Registry';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {setSource} from './pythonlabRedux';
+import {setAndSaveSource, setSource} from './pythonlabRedux';
 import PythonConsole from './PythonConsole';
 import {MAIN_PYTHON_FILE} from '@cdo/apps/lab2/constants';
 
@@ -72,7 +71,6 @@ const defaultConfig: ConfigType = {
 };
 
 const PythonlabView: React.FunctionComponent = () => {
-  //const [currentProject, setCurrentProject] = useState<MultiFileSource>();
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
   const initialSources = useAppSelector(state => state.lab.initialSources);
   const channelId = useAppSelector(state => state.lab.channel?.id);
@@ -83,13 +81,7 @@ const PythonlabView: React.FunctionComponent = () => {
   // https://codedotorg.atlassian.net/browse/CT-499
   const setProject = useMemo(
     () => (newProject: MultiFileSource) => {
-      dispatch(setSource(newProject));
-      if (Lab2Registry.getInstance().getProjectManager()) {
-        const projectSources = {
-          source: newProject,
-        };
-        Lab2Registry.getInstance().getProjectManager()?.save(projectSources);
-      }
+      dispatch(setAndSaveSource(newProject));
     },
     [dispatch]
   );

--- a/apps/src/pythonlab/patches/pythonScriptUtils.ts
+++ b/apps/src/pythonlab/patches/pythonScriptUtils.ts
@@ -75,6 +75,7 @@ export function writeSource(
 // - look for deleted folders or files.
 // - send an error message if a non-csv/txt file is updated (this is currently ignored).
 // - process hidden folders (we currently ignore them).
+// Tracked in https://codedotorg.atlassian.net/browse/CT-509
 export function getUpdatedSourceAndDeleteFiles(
   source: MultiFileSource,
   id: string,
@@ -82,8 +83,6 @@ export function getUpdatedSourceAndDeleteFiles(
   sendMessage: (message: PyodideMessage) => void
 ) {
   const workingDir = pyodide.FS.cwd();
-  // TODO: we should log an error for every new, non .csv or .txt file.
-  // should we do anything with a deleted csv or txt file??
   const directoryData = pyodide.FS.lookupPath(workingDir, {}).node;
   const directoryContents = Object.values(
     directoryData.contents

--- a/apps/src/pythonlab/patches/pythonScriptUtils.ts
+++ b/apps/src/pythonlab/patches/pythonScriptUtils.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {PyodideInterface} from 'pyodide';
 
 import {MultiFileSource} from '@cdo/apps/lab2/types';
@@ -87,7 +88,7 @@ export function getUpdatedSourceAndDeleteFiles(
   const directoryContents = Object.values(
     directoryData.contents
   ) as PyodidePathContent[];
-  const newSource = {...source};
+  const newSource = _.cloneDeep(source);
   updateAndDeleteSourceWithContents(
     directoryContents,
     newSource,
@@ -115,7 +116,7 @@ function updateAndDeleteSourceWithContents(
     if (pyodide.FS.isFile(content.mode)) {
       if (fileExtension === 'csv' || fileExtension === 'txt') {
         const file = Object.values(source.files).find(
-          f => f.name === content.name
+          f => f.name === content.name && f.folderId === folderId
         );
         try {
           const newContents = pyodide.FS.readFile(fullPath, {

--- a/apps/src/pythonlab/patches/pythonScriptUtils.ts
+++ b/apps/src/pythonlab/patches/pythonScriptUtils.ts
@@ -146,18 +146,12 @@ export async function importPackagesFromFiles(
   source: MultiFileSource,
   pyodide: PyodideInterface
 ) {
-  console.log(Object.values(source.files));
+  // Loading can throw erroneous console errors if a user has a package with the same name as one
+  // in the pyodide list of packages that we have not put in our repo. We can ignore these,
+  // any actual import errors will be caught by the runPythonAsync call.
   for (const file of Object.values(source.files)) {
-    console.log(`checking file ${file.name}`);
     if (file.name.endsWith('.py')) {
-      console.log(`loading packages for ${file.name}`);
-      await pyodide.loadPackagesFromImports(file.contents, {
-        messageCallback: message =>
-          console.log(`message: ${message} for ${file.name}`),
-        errorCallback: message =>
-          console.log(`message: ${message} for ${file.name}`),
-      });
-      console.log(`done loading packages for ${file.name}`);
+      await pyodide.loadPackagesFromImports(file.contents);
     }
   }
 }

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -37,9 +37,6 @@ self.onmessage = async event => {
   const {id, python, source} = event.data;
   try {
     writeSource(source, DEFAULT_FOLDER_ID, '', self.pyodide);
-    // Loading can throw erroneous console errors if a user has a package with the same name as one
-    // in the pyodide list of packages that we have not put in our repo. We can ignore these,
-    // any actual import errors will be caught by the runPythonAsync call.
     await importPackagesFromFiles(source, self.pyodide);
     let results = await self.pyodide.runPythonAsync(python);
     self.postMessage({type: 'run_complete', results, id});

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -35,16 +35,22 @@ self.onmessage = async event => {
   // make sure loading is done
   await initializePyodide();
   const {id, python, source} = event.data;
+  let results = '';
   try {
     writeSource(source, DEFAULT_FOLDER_ID, '', self.pyodide);
     await importPackagesFromFiles(source, self.pyodide);
-    let results = await self.pyodide.runPythonAsync(python);
+    results = await self.pyodide.runPythonAsync(python);
     console.log('getting updated source...');
-    const updatedSource = getUpdatedSource(self.pyodide, source);
-    self.postMessage({type: 'updated_source', updatedSource});
-    self.postMessage({type: 'run_complete', results, id});
+    const updatedSource = getUpdatedSource(
+      source,
+      id,
+      self.pyodide,
+      self.postMessage
+    );
+    self.postMessage({type: 'updated_source', message: updatedSource, id});
   } catch (error) {
-    self.postMessage({type: 'error', error: error.message, id});
+    self.postMessage({type: 'error', message: error.message, id});
   }
-  deleteSourceFiles(self.pyodide, source);
+  deleteSourceFiles(source, self.pyodide);
+  self.postMessage({type: 'run_complete', message: results, id});
 };

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -1,6 +1,5 @@
 import {
-  deleteSourceFiles,
-  getUpdatedSource,
+  getUpdatedSourceAndDeleteFiles,
   importPackagesFromFiles,
   writeSource,
 } from './patches/pythonScriptUtils';
@@ -40,17 +39,15 @@ self.onmessage = async event => {
     writeSource(source, DEFAULT_FOLDER_ID, '', self.pyodide);
     await importPackagesFromFiles(source, self.pyodide);
     results = await self.pyodide.runPythonAsync(python);
-    console.log('getting updated source...');
-    const updatedSource = getUpdatedSource(
-      source,
-      id,
-      self.pyodide,
-      self.postMessage
-    );
-    self.postMessage({type: 'updated_source', message: updatedSource, id});
   } catch (error) {
     self.postMessage({type: 'error', message: error.message, id});
   }
-  deleteSourceFiles(source, self.pyodide);
+  const updatedSource = getUpdatedSourceAndDeleteFiles(
+    source,
+    id,
+    self.pyodide,
+    self.postMessage
+  );
+  self.postMessage({type: 'updated_source', message: updatedSource, id});
   self.postMessage({type: 'run_complete', message: results, id});
 };

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -1,4 +1,9 @@
-import {deleteSourceFiles, writeSource} from './patches/pythonScriptUtils';
+import {
+  deleteSourceFiles,
+  importPackagesFromFiles,
+  writeCsvAndTextFiles,
+  writeSource,
+} from './patches/pythonScriptUtils';
 import {DEFAULT_FOLDER_ID} from '../weblab2/CDOIDE/constants';
 import {loadPyodide, version} from 'pyodide';
 
@@ -35,11 +40,12 @@ self.onmessage = async event => {
     // Loading can throw erroneous console errors if a user has a package with the same name as one
     // in the pyodide list of packages that we have not put in our repo. We can ignore these,
     // any actual import errors will be caught by the runPythonAsync call.
-    await self.pyodide.loadPackagesFromImports(python);
+    await importPackagesFromFiles(source, self.pyodide);
     let results = await self.pyodide.runPythonAsync(python);
     self.postMessage({type: 'run_complete', results, id});
   } catch (error) {
     self.postMessage({type: 'error', error: error.message, id});
   }
+  writeCsvAndTextFiles(self.pyodide, source);
   deleteSourceFiles(self.pyodide, source);
 };

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -1,7 +1,7 @@
 import {
   deleteSourceFiles,
+  getUpdatedSource,
   importPackagesFromFiles,
-  writeCsvAndTextFiles,
   writeSource,
 } from './patches/pythonScriptUtils';
 import {DEFAULT_FOLDER_ID} from '../weblab2/CDOIDE/constants';
@@ -39,10 +39,12 @@ self.onmessage = async event => {
     writeSource(source, DEFAULT_FOLDER_ID, '', self.pyodide);
     await importPackagesFromFiles(source, self.pyodide);
     let results = await self.pyodide.runPythonAsync(python);
+    console.log('getting updated source...');
+    const updatedSource = getUpdatedSource(self.pyodide, source);
+    self.postMessage({type: 'updated_source', updatedSource});
     self.postMessage({type: 'run_complete', results, id});
   } catch (error) {
     self.postMessage({type: 'error', error: error.message, id});
   }
-  writeCsvAndTextFiles(self.pyodide, source);
   deleteSourceFiles(self.pyodide, source);
 };

--- a/apps/src/pythonlab/pyodideWorkerManager.js
+++ b/apps/src/pythonlab/pyodideWorkerManager.js
@@ -8,10 +8,9 @@ import {
   appendOutputImage,
   appendSystemMessage,
   appendSystemOutMessage,
-  setSource,
+  setAndSaveSource,
 } from './pythonlabRedux';
 import {MAIN_PYTHON_FILE} from '@cdo/apps/lab2/constants';
-import Lab2Registry from '../lab2/Lab2Registry';
 
 // This syntax doesn't work with typescript, so this file is in js.
 const pyodideWorker = new Worker(
@@ -34,14 +33,7 @@ pyodideWorker.onmessage = event => {
   } else if (type === 'run_complete') {
     getStore().dispatch(appendSystemMessage('Program completed.'));
   } else if (type === 'updated_source') {
-    // we should probably extract this somewhere...
-    getStore().dispatch(setSource(message));
-    if (Lab2Registry.getInstance().getProjectManager()) {
-      const projectSources = {
-        source: message,
-      };
-      Lab2Registry.getInstance().getProjectManager()?.save(projectSources);
-    }
+    getStore().dispatch(setAndSaveSource(message));
     return;
   } else if (type === 'error') {
     getStore().dispatch(appendSystemMessage(`Error: ${message}`));

--- a/apps/src/pythonlab/pyodideWorkerManager.js
+++ b/apps/src/pythonlab/pyodideWorkerManager.js
@@ -33,6 +33,9 @@ pyodideWorker.onmessage = event => {
     getStore().dispatch(appendSystemMessage('Program completed.'));
   } else if (type === 'error') {
     getStore().dispatch(appendSystemMessage(`Error: ${data.error}`));
+  } else {
+    console.warn(`Unknown message type ${type} from pyodideWorker.`);
+    console.warn({data});
   }
   const onSuccess = callbacks[id];
   delete callbacks[id];

--- a/apps/src/pythonlab/python-console.module.scss
+++ b/apps/src/pythonlab/python-console.module.scss
@@ -4,4 +4,6 @@
   border: 1px solid white;
   margin: 0 5px 10px 0;
   height: 100%;
+  font-family:'Courier New', Courier, monospace;
+  white-space: pre;
 }

--- a/apps/src/pythonlab/pythonlabRedux.ts
+++ b/apps/src/pythonlab/pythonlabRedux.ts
@@ -1,5 +1,12 @@
-import {createSlice, PayloadAction} from '@reduxjs/toolkit';
+import {
+  AnyAction,
+  createSlice,
+  PayloadAction,
+  ThunkAction,
+} from '@reduxjs/toolkit';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {RootState} from '@cdo/apps/types/redux';
 const registerReducers = require('@cdo/apps/redux').registerReducers;
 
 export interface PythonlabState {
@@ -17,6 +24,23 @@ export const initialState: PythonlabState = {
   output: [],
 };
 
+// THUNKS
+// Set the source in the redux store and initiate a save to the project manager.
+export const setAndSaveSource = (
+  source: MultiFileSource
+): ThunkAction<void, RootState, undefined, AnyAction> => {
+  return dispatch => {
+    dispatch(pythonlabSlice.actions.setSource(source));
+    if (Lab2Registry.getInstance().getProjectManager()) {
+      const projectSources = {
+        source: source,
+      };
+      Lab2Registry.getInstance().getProjectManager()?.save(projectSources);
+    }
+  };
+};
+
+// SLICE
 const pythonlabSlice = createSlice({
   name: 'pythonlab',
   initialState,

--- a/apps/src/pythonlab/types.ts
+++ b/apps/src/pythonlab/types.ts
@@ -6,7 +6,7 @@ export interface PyodidePathContent {
 }
 
 export interface PyodideMessage {
-  type: string;
+  type: 'sysout' | 'updated_source' | 'run_complete' | 'error';
   message: string;
   id: string;
 }

--- a/apps/src/pythonlab/types.ts
+++ b/apps/src/pythonlab/types.ts
@@ -1,0 +1,6 @@
+export interface PyodidePathContent {
+  id: number;
+  name: string;
+  mode: number;
+  contents: Record<string, PyodidePathContent>;
+}

--- a/apps/src/pythonlab/types.ts
+++ b/apps/src/pythonlab/types.ts
@@ -4,3 +4,9 @@ export interface PyodidePathContent {
   mode: number;
   contents: Record<string, PyodidePathContent>;
 }
+
+export interface PyodideMessage {
+  type: string;
+  message: string;
+  id: string;
+}


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Summary
After #58051 we could read from existing files in the user's project. File writing also would not throw any errors and code could read from a file after writing to it. However, we wouldn't show any new files in the user's project after they wrote to them. This change updates the user's project correctly after each run with any new csv or text files, and any new folders. This required a few changes:
- After each run, iterate over the working directory in pyodide and send back an updated `source` object with new folders and new csv and text files. If we saw a new file that was not a csv or text file, we sent an error message.
- Update the pyodide message handler to handle updating the source when it receives an updated source.
- Instead of deleting files based on the original source, delete all files and folders in the working directory after each run. To save time this is done after reading each file/folder in the above step.
- Add a new redux thunk that handles setting the python source and saving via the project manager in one go. This allowed us to reuse logic in `PythonLabView`. 

Since I was testing some file parsing code I also made the Python Console monospaced and updating it to respect spacing.

Now you can create files and folders!
https://github.com/code-dot-org/code-dot-org/assets/33666587/fd6379af-a210-49af-9ec7-a0215626ed19

## Links

- jira ticket: [https://codedotorg.atlassian.net/browse/CT-456](CT-456)

## Testing story
Tested locally. I mostly used basic python methods for writing to files (`open`, `os` methods). I also tested using pandas to read from files, as that is what curriculum plans to use.


## Follow-up work
We have some details to figure out on the edge cases here. I started a [slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1713475557377839) and made a [follow-up task](https://codedotorg.atlassian.net/browse/CT-509). The main concern is we don't currently have the ability to prevent the user from running code that creates or edits non csv or text files. We can prevent them from showing up in the file browser, but it may cause confusion that users don't see an error message about this until after their program completes.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
