### PR TITLE
fix: require the `shared_resources` module to instantiate shared css

### DIFF
--- a/pegasus/test/test_hoc_routes.rb
+++ b/pegasus/test/test_hoc_routes.rb
@@ -2,6 +2,7 @@ require_relative './test_helper'
 require 'minitest/autorun'
 require 'rack/test'
 require 'mocha/mini_test'
+require 'shared_resources'
 require_relative 'fixtures/mock_pegasus'
 
 # Set up the rack environment to be test and recreate the Gatekeeper and DCDO in that mode.


### PR DESCRIPTION
The SASS css file compilation process gets corrupted with an error that shared css could not be located. This is due to the shared css path not being added to the SASS compilation path. If the test `test_hoc_routes` runs by itself without other tests, this test will cause the SASS module to run but since this test doesn't require the module `shared_resources`, the shared path is not added. Normally, the rake task :ci runs which includes the test `test_pegasus_documents` which requires `shared_resources`. This file injects the `shared/css` path to the `ruby-sass` gem which allows a successful compilation in the `test_hoc_routes` unit test.

I also was able to verify that order does not matter, while `:ci` does result in tests not having a predictable order, it doesn't matter if it's PegasusTest comes before HOCTest or vice versa.

However, if you run test_hoc_routes by itself, it will cause the CSS file to be corrupted because `shared_resources` never gets required (and thus is missing the path needed to compile SCSS files correctly).

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1713408245984199)

## Testing story

1. Ran `test_hoc_routes` without any changes, broken CSS resulted.
2. Ran `test_hoc_routes` with PR changes, CSS does not break.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

N/A

## Privacy

N/A

## Security

N/A
## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
