### PR TITLE
fix(lms): update the LtiResourceLinkId if the passed rlid changes

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -261,7 +261,9 @@ class LtiV1Controller < ApplicationController
       end
     end
 
-    lti_course, lti_integration, deployment_id, context_id, resource_link_id, nrps_url = nil
+    lti_course, lti_integration, deployment_id, context_id,  nrps_url = nil
+    resource_link_id = params[:rlid]
+
     if params[:section_code].present?
       # Section code present, meaning this is a sync from the teacher dashboard.
       # Populate vars from the section associated with the input code.
@@ -272,8 +274,13 @@ class LtiV1Controller < ApplicationController
       lti_integration = lti_course.lti_integration
       deployment_id = lti_course.lti_deployment_id
       context_id = lti_course.context_id
-      resource_link_id = lti_course.resource_link_id
       nrps_url = lti_course.nrps_url
+      # Prefer the resource link from the SSO parameter instead of the course one. The resource link could have changed.
+      # For example, the teacher could have had Code.org in one material/module but deleted that material/module and
+      # made a new one (deleted the old LtiResourceLink and created a brand new one). This results in a mismatch between
+      # what is stored on Code.org's LtiCourse. Therefore, when doing an SSO sync, prefer the latest RLID and update our
+      # records with that.
+      resource_link_id ||= lti_course.resource_link_id
     else
       # Section code isn't present, meaning this is a sync from an LTI launch.
       # Populate vars from the request params.
@@ -284,7 +291,6 @@ class LtiV1Controller < ApplicationController
       end
       deployment_id = params[:deployment_id]
       context_id = params[:context_id]
-      resource_link_id = params[:rlid]
       nrps_url = params[:nrps_url]
     end
 

--- a/dashboard/lib/queries/lti.rb
+++ b/dashboard/lib/queries/lti.rb
@@ -43,10 +43,18 @@ class Queries::Lti
   end
 
   def self.find_or_create_lti_course(lti_integration_id:, context_id:, deployment_id:, nrps_url:, resource_link_id:)
-    LtiCourse.find_or_create_by(lti_integration_id: lti_integration_id, context_id: context_id) do |c|
+    lti_course = LtiCourse.find_or_create_by(lti_integration_id: lti_integration_id, context_id: context_id) do |c|
       c.lti_deployment_id = deployment_id
       c.nrps_url = nrps_url
       c.resource_link_id = resource_link_id
     end
+
+    # Update the resource link id if the resource link has changed
+    unless lti_course.resource_link_id == resource_link_id
+      lti_course.resource_link_id = resource_link_id
+      lti_course.save!
+    end
+
+    lti_course
   end
 end

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -616,6 +616,23 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test 'sync - should update the LtiCourse resource link id if the params rlid has changed' do
+    user = create :teacher, :with_lti_auth
+    sign_in user
+    lti_integration = create :lti_integration
+    lti_course = create :lti_course, lti_integration: lti_integration, context_id: SecureRandom.uuid, resource_link_id: SecureRandom.uuid, nrps_url: 'https://example.com/nrps'
+    new_resource_id = SecureRandom.uuid
+    LtiAdvantageClient.any_instance.expects(:get_context_membership).with(lti_course.nrps_url, new_resource_id).returns({})
+    Services::Lti.expects(:parse_nrps_response).returns(@parsed_nrps_sections)
+    Services::Lti.expects(:sync_course_roster).returns(@sync_course_result_with_changes)
+
+    get '/lti/v1/sync_course', params: {lti_integration_id: lti_integration.id, deployment_id: 'foo', context_id: lti_course.context_id, rlid: new_resource_id, nrps_url: lti_course.nrps_url}
+
+    lti_course.reload
+    assert_response :ok
+    assert_equal new_resource_id, lti_course.resource_link_id
+  end
+
   test 'sync_course as json - syncs and returns course sections data' do
     lti_course_context_id = SecureRandom.uuid
     lti_course_resource_link_id = SecureRandom.uuid


### PR DESCRIPTION
In certain situations, the LtiResourceLink could have changed resulting in a mismatch when a teacher attempts to sync via the Manage Students page. When this occurs, the LMS responds with an access error for the given resource (since the resource could have been deleted).

To fix this, update the LtiCourse resource_link_id field with the latest value available from the SSO sync process.

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-868)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. Recorded an existing resource link id from a LtiCourse
2. SSO logged in on a new Canvas module
3. verified that the LtiCourse now has the updated module RLID
4. Manual synced in manage student
5. Verified that the LtiCourse RLID was used

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

N/A

## Privacy

N/A

## Security

N/A
## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
