### PR TITLE
show custom error message when student code is too long to evaluate

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -114,6 +114,7 @@
   "aiEvaluationStatus_error": "AI analysis cannot be completed due to an error.  Please try again later or contact support.",
   "aiEvaluationStatus_pii_error": "AI analysis cannot be completed due to the presence of potential personal information in the student's code.",
   "aiEvaluationStatus_profanity_error": "AI analysis cannot be completed due to profanity in the student's code.",
+  "aiEvaluationStatus_request_too_large": "The AI analysis failed due to lengthy student code. Our team is addressing the issue. Please manually grade this student's project in the meantime.",
   "aiEvaluationStatusAll_not_attempted": "No students have attempted this level. No AI analysis available.",
   "aiEvaluationStatusAll_already_evaluated": "AI analysis already completed for all available student projects.",
   "aiEvaluationStatusAll_ready": "AI analysis can be generated for {unevaluatedCount} student projects.",

--- a/apps/src/templates/rubrics/RubricTabButtons.jsx
+++ b/apps/src/templates/rubrics/RubricTabButtons.jsx
@@ -44,6 +44,8 @@ export default function RubricTabButtons({
         return i18n.aiEvaluationStatus_pii_error();
       case STATUS.PROFANITY_ERROR:
         return i18n.aiEvaluationStatus_profanity_error();
+      case STATUS.REQUEST_TOO_LARGE:
+        return i18n.aiEvaluationStatus_request_too_large();
     }
   };
 

--- a/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
+++ b/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
@@ -28,6 +28,8 @@ export const STATUS = {
   PII_ERROR: 'pii_error',
   // profanity present in code
   PROFANITY_ERROR: 'profanity_error',
+  // request too large
+  REQUEST_TOO_LARGE: 'request_too_large',
 };
 
 const fetchAiEvaluationStatus = (rubricId, studentUserId) => {
@@ -86,6 +88,10 @@ export default function RunAIAssessmentButton({
               data.status === RubricAiEvaluationStatus.PROFANITY_VIOLATION
             ) {
               setStatus(STATUS.PROFANITY_ERROR);
+            } else if (
+              data.status === RubricAiEvaluationStatus.REQUEST_TOO_LARGE
+            ) {
+              setStatus(STATUS.REQUEST_TOO_LARGE);
             } else {
               setStatus(STATUS.READY);
             }
@@ -124,6 +130,10 @@ export default function RunAIAssessmentButton({
                 data.status === RubricAiEvaluationStatus.PROFANITY_VIOLATION
               ) {
                 setStatus(STATUS.PROFANITY_ERROR);
+              } else if (
+                data.status === RubricAiEvaluationStatus.REQUEST_TOO_LARGE
+              ) {
+                setStatus(STATUS.REQUEST_TOO_LARGE);
               }
             });
           }

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -631,6 +631,49 @@ describe('RubricContainer', () => {
     expect(wrapper.find('Button').at(0).props().disabled).to.be.true;
   });
 
+  it('shows request too large error message for status 1003', async () => {
+    const returnedJson = {
+      attempted: true,
+      lastAttemptEvaluated: false,
+      status: 1003,
+    };
+    const returnedJsonAll = {
+      attemptedCount: 1,
+      attemptedUnevaluatedCount: 0,
+      csrfToken: 'abcdef',
+    };
+
+    const userFetchStub = stubFetchEvalStatusForUser(returnedJson);
+    const allFetchStub = stubFetchEvalStatusForAll(returnedJsonAll);
+    stubFetchTeacherEvaluations(noEvals);
+    stubFetchAiEvaluations(mockAiEvaluations);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <RubricContainer
+          rubric={defaultRubric}
+          studentLevelInfo={defaultStudentInfo}
+          teacherHasEnabledAi={true}
+          currentLevelName={'test_level'}
+          reportingData={{}}
+          sectionId={42}
+          open
+        />
+      </Provider>
+    );
+
+    // Perform fetches
+    await wait();
+
+    wrapper.update();
+    expect(userFetchStub).to.have.been.called;
+    expect(allFetchStub).to.have.been.called;
+    expect(wrapper.text()).to.include(
+      i18n.aiEvaluationStatus_request_too_large()
+    );
+    expect(wrapper.find('Button').at(0).props().disabled).to.be.true;
+  });
+
   // react testing library
   it('moves rubric container when user clicks and drags component', async () => {
     stubFetchEvalStatusForUser(successJson);

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -208,16 +208,10 @@ class EvaluateRubricJob < ApplicationJob
       puts "EvaluateRubricJob RequestTooLargeError: #{exception.message}"
     end
 
-    # Record the failure, if we can
-    begin
-      rubric_ai_evaluation = pass_in_or_create_rubric_ai_evaluation(self)
-      rubric_ai_evaluation.status = SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:REQUEST_TOO_LARGE]
-      rubric_ai_evaluation.save!
-    rescue StandardError
-      # Ignore cascading errors when the rubric record does not exist
-    end
-
-    # We gracefully just fail, here, and we do not file this exception
+    # Record the failure mode, so we can show the right message to the teacher
+    rubric_ai_evaluation = pass_in_or_create_rubric_ai_evaluation(self)
+    rubric_ai_evaluation.status = SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:REQUEST_TOO_LARGE]
+    rubric_ai_evaluation.save!
   end
 
   RETRIES_ON_RATE_LIMIT = 3

--- a/dashboard/app/models/rubric_ai_evaluation.rb
+++ b/dashboard/app/models/rubric_ai_evaluation.rb
@@ -74,4 +74,8 @@ class RubricAiEvaluation < ApplicationRecord
   def share_filtering_failure?
     pii_failure? || profanity_failure?
   end
+
+  def request_too_large?
+    status == SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:REQUEST_TOO_LARGE]
+  end
 end

--- a/dashboard/app/models/rubric_ai_evaluation.rb
+++ b/dashboard/app/models/rubric_ai_evaluation.rb
@@ -74,8 +74,4 @@ class RubricAiEvaluation < ApplicationRecord
   def share_filtering_failure?
     pii_failure? || profanity_failure?
   end
-
-  def request_too_large?
-    status == SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:REQUEST_TOO_LARGE]
-  end
 end

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -261,6 +261,27 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     end
   end
 
+  test "job records REQUEST_TOO_LARGE on http status 413" do
+    EvaluateRubricJob.stubs(:get_lesson_s3_name).with(@script_level).returns('fake-lesson-s3-name')
+
+    # create a project
+    channel_token = ChannelToken.find_or_create_channel_token(@script_level.level, @fake_ip, @storage_id, @script_level.script_id)
+    channel_id = channel_token.channel
+
+    stub_project_source_data(channel_id)
+
+    stub_lesson_s3_data(response_type: 'json')
+
+    stub_get_openai_evaluations(response_type: 'json', status: 413)
+
+    # run the job
+    perform_enqueued_jobs do
+      EvaluateRubricJob.perform_later(user_id: @student.id, requester_id: @student.id, script_level_id: @script_level.id)
+    end
+
+    assert_equal SharedConstants::RUBRIC_AI_EVALUATION_STATUS[:REQUEST_TOO_LARGE], RubricAiEvaluation.where(user_id: @student.id).first.status
+  end
+
   test "metrics for tokens used are logged" do
     # Perform an otherwise successful run
     EvaluateRubricJob.stubs(:get_lesson_s3_name).with(@script_level).returns('fake-lesson-s3-name')
@@ -444,6 +465,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     response = stub(
       body: {metadata: metadata, data: fake_ai_evaluations}.to_json,
       code: status,
+      message: 'message',
       request: request,
       success?: status == 200
     )

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -631,6 +631,8 @@ module SharedConstants
     PII_VIOLATION: 1001,
     # Profanity Failure
     PROFANITY_VIOLATION: 1002,
+    # Request Too Large
+    REQUEST_TOO_LARGE: 1003,
   }.freeze
 
   EMAIL_LINKS = OpenStruct.new(


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/aiproxy/pull/67. See that PR for context.

## Screenshots

https://github.com/code-dot-org/code-dot-org/assets/8001765/08ac9921-f91a-4507-9662-3e88fc858867

## Testing story

* new ruby unit test for EvaluateRubricJob
* new js test for showing the new status code
* manual testing shown in video above

## Deployment strategy

https://github.com/code-dot-org/aiproxy/pull/67 has already been deployed to aiproxy, so this PR can be merged/deployed any time.

## Follow-up work

switch to turbo model with larger context window