### PR TITLE
Convert  TeacherSections component to functional component

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {useEffect} from 'react';
 import {connect} from 'react-redux';
 
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
@@ -22,81 +22,82 @@ import {
 import CoteacherInviteNotification from './CoteacherInviteNotification';
 import SetUpSections from './SetUpSections';
 
-class TeacherSections extends Component {
-  static propTypes = {
-    //Redux provided
-    asyncLoadSectionData: PropTypes.func.isRequired,
-    asyncLoadCoteacherInvite: PropTypes.func.isRequired,
-    coteacherInvite: PropTypes.object,
-    coteacherInviteForPl: PropTypes.object,
-    studentSectionIds: PropTypes.array,
-    plSectionIds: PropTypes.array,
-    hiddenPlSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
-    hiddenStudentSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
-    sectionsAreLoaded: PropTypes.bool,
+function TeacherSections({
+  asyncLoadSectionData,
+  asyncLoadCoteacherInvite,
+  coteacherInvite,
+  coteacherInviteForPl,
+  studentSectionIds,
+  plSectionIds,
+  hiddenPlSectionIds,
+  hiddenStudentSectionIds,
+  sectionsAreLoaded,
+}) {
+  useEffect(() => {
+    asyncLoadSectionData();
+    asyncLoadCoteacherInvite();
+  }, [asyncLoadSectionData, asyncLoadCoteacherInvite]);
+
+  const shouldRenderSections = () => {
+    return studentSectionIds?.length > 0 || !!coteacherInvite;
   };
 
-  componentDidMount() {
-    this.props.asyncLoadSectionData();
-    this.props.asyncLoadCoteacherInvite();
-  }
+  const shouldRenderPlSections = () => {
+    return plSectionIds?.length > 0 || !!coteacherInviteForPl;
+  };
 
-  shouldRenderSections() {
-    return (
-      this.props.studentSectionIds?.length > 0 || !!this.props.coteacherInvite
-    );
-  }
-
-  shouldRenderPlSections() {
-    return (
-      this.props.plSectionIds?.length > 0 || !!this.props.coteacherInviteForPl
-    );
-  }
-
-  render() {
-    const {studentSectionIds, hiddenStudentSectionIds} = this.props;
-
-    return (
-      <div id="classroom-sections">
-        <ContentContainer heading={i18n.createSection()}>
-          <SetUpSections />
-          {!this.props.sectionsAreLoaded && (
-            <Spinner size="large" style={styles.spinner} />
-          )}
+  return (
+    <div id="classroom-sections">
+      <ContentContainer heading={i18n.createSection()}>
+        <SetUpSections />
+        {!sectionsAreLoaded && <Spinner size="large" style={styles.spinner} />}
+      </ContentContainer>
+      {shouldRenderSections() && (
+        <ContentContainer heading={i18n.sectionsTitle()}>
+          <CoteacherInviteNotification isForPl={false} />
+          <OwnedSections
+            sectionIds={studentSectionIds}
+            hiddenSectionIds={hiddenStudentSectionIds}
+          />
         </ContentContainer>
-        {this.shouldRenderSections() && (
-          <ContentContainer heading={i18n.sectionsTitle()}>
-            <CoteacherInviteNotification isForPl={false} />
-            <OwnedSections
-              sectionIds={studentSectionIds}
-              hiddenSectionIds={hiddenStudentSectionIds}
-            />
-          </ContentContainer>
-        )}
-        {this.shouldRenderPlSections() && (
-          <ContentContainer heading={i18n.plSectionsTitle()}>
-            <BodyTwoText>
-              {i18n.myProfessionalLearningSectionsHomepageDesc()}
-            </BodyTwoText>
-            <LinkButton
-              color={'purple'}
-              href={studio('/my-professional-learning')}
-              iconLeft={{
-                iconName: 'book-circle-arrow-right',
-                iconStyle: 'solid',
-              }}
-              size="s"
-              text={i18n.myProfessionalLearningSectionsHomepageButton()}
-            />
-          </ContentContainer>
-        )}
-        <RosterDialog />
-        <AddSectionDialog />
-      </div>
-    );
-  }
+      )}
+      {shouldRenderPlSections() && (
+        <ContentContainer heading={i18n.plSectionsTitle()}>
+          <BodyTwoText>
+            {i18n.myProfessionalLearningSectionsHomepageDesc()}
+          </BodyTwoText>
+          <LinkButton
+            color={'purple'}
+            href={studio('/my-professional-learning')}
+            iconLeft={{
+              iconName: 'book-circle-arrow-right',
+              iconStyle: 'solid',
+            }}
+            size="s"
+            text={i18n.myProfessionalLearningSectionsHomepageButton()}
+          />
+        </ContentContainer>
+      )}
+      <RosterDialog />
+      <AddSectionDialog />
+    </div>
+  );
 }
+
+TeacherSections.propTypes = {
+  asyncLoadSectionData: PropTypes.func.isRequired,
+  asyncLoadCoteacherInvite: PropTypes.func.isRequired,
+  coteacherInvite: PropTypes.object,
+  coteacherInviteForPl: PropTypes.object,
+  studentSectionIds: PropTypes.array,
+  plSectionIds: PropTypes.array,
+  hiddenPlSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+  hiddenStudentSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+  sectionsAreLoaded: PropTypes.bool,
+};
+
 export const UnconnectedTeacherSections = TeacherSections;
+
 export default connect(
   state => ({
     coteacherInvite: state.teacherSections.coteacherInvite,

--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -15,7 +15,6 @@ import RosterDialog from '../teacherDashboard/RosterDialog';
 import {
   asyncLoadCoteacherInvite,
   asyncLoadSectionData,
-  hiddenPlSectionIds,
   hiddenStudentSectionIds,
 } from '../teacherDashboard/teacherSectionsRedux';
 
@@ -29,7 +28,6 @@ function TeacherSections({
   coteacherInviteForPl,
   studentSectionIds,
   plSectionIds,
-  hiddenPlSectionIds,
   hiddenStudentSectionIds,
   sectionsAreLoaded,
 }) {
@@ -91,7 +89,6 @@ TeacherSections.propTypes = {
   coteacherInviteForPl: PropTypes.object,
   studentSectionIds: PropTypes.array,
   plSectionIds: PropTypes.array,
-  hiddenPlSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
   hiddenStudentSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
   sectionsAreLoaded: PropTypes.bool,
 };
@@ -104,7 +101,6 @@ export default connect(
     coteacherInviteForPl: state.teacherSections.coteacherInviteForPl,
     studentSectionIds: state.teacherSections.studentSectionIds,
     plSectionIds: state.teacherSections.plSectionIds,
-    hiddenPlSectionIds: hiddenPlSectionIds(state),
     hiddenStudentSectionIds: hiddenStudentSectionIds(state),
     sectionsAreLoaded: state.teacherSections.sectionsAreLoaded,
   }),


### PR DESCRIPTION
As part of the Colorado Privacy Act work the Platform team does, we add warning banners to different `Sections` components.

[P20-815](https://codedotorg.atlassian.net/browse/P20-815) requires adding a Warning Notification to the [TeacherSections](https://github.com/code-dot-org/code-dot-org/blob/50a3e70c3295eb21962c71f119167460b4e6ea39/apps/src/templates/studioHomepages/TeacherSections.jsx) component in the [TeacherHomepage](https://github.com/code-dot-org/code-dot-org/blob/98c6fa7aff8724aad45e34c75204d3c2e3b3ff7a/apps/src/templates/studioHomepages/TeacherHomepage.jsx#L270).

I'd like to update the existing code and convert the class component into a functional component.

## Links

- Jira task: [P20-815](https://codedotorg.atlassian.net/browse/P20-815)

## Testing story

<img width="1091" alt="Screenshot 2024-04-19 at 18 34 20" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/b772308c-b7b6-4de7-8788-1efdc7f1f47e">

## Caching

## PR Checklist:


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
