### PR TITLE
Incubator: update test

### DIFF
--- a/dashboard/test/helpers/incubator_helper_test.rb
+++ b/dashboard/test/helpers/incubator_helper_test.rb
@@ -9,7 +9,7 @@ class IncubatorHelperTest < ActionView::TestCase
   end
 
   setup do
-    @teacher_yes = create(:teacher, id: 80)
+    @teacher_yes = create(:teacher)
     @student = create(:student)
   end
 


### PR DESCRIPTION
We were seeing some instances of this error when running this unit test:
```
ActiveRecord::RecordNotUnique: Mysql2::Error: Duplicate entry '80' for key 'PRIMARY'
```

A specific key was never needed in the final version of https://github.com/code-dot-org/code-dot-org/pull/48647 because we didn't end up using the idea that only a subset of users would get the banner.  It's now removed.
