### PR TITLE
Use upstream ProxySQL 2.6.2

### DIFF
--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -13,9 +13,6 @@
 #   action :upgrade
 # end
 
-# Use patched ProxySQL with fix for Aurora 2.09 bug.
-# See: https://github.com/sysown/proxysql/issues/3082
-# Can we stop using the fork? Our patch was merged upstream https://github.com/sysown/proxysql/pull/3234
 proxysql_filename = 'proxysql_2.6.2-ubuntu20_amd64.deb'
 proxysql_file = "#{Chef::Config[:file_cache_path]}/#{proxysql_filename}"
 remote_file proxysql_file do

--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -15,16 +15,17 @@
 
 # Use patched ProxySQL with fix for Aurora 2.09 bug.
 # See: https://github.com/sysown/proxysql/issues/3082
-proxysql_filename = 'proxysql_2.0.15-ubuntu18_amd64.deb'
+# Can we stop using the fork? Our patch was merged upstream https://github.com/sysown/proxysql/pull/3234
+proxysql_filename = 'proxysql_2.6.2-ubuntu20_amd64.deb'
 proxysql_file = "#{Chef::Config[:file_cache_path]}/#{proxysql_filename}"
 remote_file proxysql_file do
-  source "https://github.com/code-dot-org/proxysql/releases/download/v2.0.15-aurora_2.09_fix/#{proxysql_filename}"
-  checksum "29fe79e54bce0f532084bfd8e5a13a55f1f8530f92be8a0e7db847aefcb1762f"
+  source "https://github.com/sysown/proxysql/releases/download/v2.6.2/#{proxysql_filename}"
+  checksum "bd4e4bf310927789d387341160c5a44b74d5fa0cd3d65783d40a75dd983791e1"
   action :create_if_missing
 end
 dpkg_package('proxysql') do
   source proxysql_file
-  version '2.0.15'
+  version '2.6.2'
   options '--force-confold'
 end
 


### PR DESCRIPTION
Switch back to using upstream ProxySQL and upgrade from version 2.0.x to version 2.6.2

We previously used a code.org fork of ProxySQL in order to get this patch: https://github.com/sysown/proxysql/pull/3234

That patch was applied to upstream, but we never switched back to upstream. As a result, our version of ProxySQL has been frozen at 2.0, which potentially isn't great for maintaining compatibility with the most recent aurora upgrades.

We broke the ability to provision "full stack" adhocs when we moved our fork of ProxySQL to our GitHub Organization because we haven't published a binary build, so this is a good opportunity to fix our provisioning logic. Being on mainline ProxySQL also lowers the risks with our upcoming Aurora 3 / MySQL 8 upgrade.

This is still a high risk change and should be deployed on a Friday afternoon in a limited 2nd production release so we can quickly revert, if needed.
