### PR TITLE
Fix AI video caption order on code.org/videos

### DIFF
--- a/pegasus/sites.v3/code.org/views/carousel_how_ai_works_video.haml
+++ b/pegasus/sites.v3/code.org/views/carousel_how_ai_works_video.haml
@@ -2,7 +2,7 @@
 
 - video_download_path = ["//videos.code.org/ai_series/HowAIWorks_LLM_SM_CoBrand.mp4", "//videos.code.org/ai_series/HowAIWorks_Creativity_SM_CoBrand.mp4", "//videos.code.org/ai_series/ai-01-intro-to-ai.mp4", "//videos.code.org/ai_series/ai-02-machine-learning.mp4", "//videos.code.org/ai_series/ai-03-training-data.mp4", "//videos.code.org/ai_series/ai-04-neural-networks.mp4", "//videos.code.org/ai_series/ai-05-computer-vision.mp4", "//videos.code.org/ai_series/ai-06-ai-ethics-access-bias.mp4", "//videos.code.org/ai_series/ai-07-ai-ethics-privacy-work.mp4"]
 
-- video_caption = [hoc_s(:ai_vid_chatbots_caption), hoc_s(:ai_vid_creativity_caption), hoc_s(:ai_vid_intro_caption), hoc_s(:ai_vid_mlintro_caption), hoc_s(:ai_vid_trainingdata_caption), hoc_s(:ai_vid_neuralnetworks_caption), hoc_s(:ai_vid_computervision_caption), hoc_s(:ai_vid_ethics1_caption), hoc_s(:ai_vid_ethics2_caption)]
+- video_caption = [hoc_s(:ai_vid_intro_caption), hoc_s(:ai_vid_mlintro_caption), hoc_s(:ai_vid_trainingdata_caption), hoc_s(:ai_vid_neuralnetworks_caption), hoc_s(:ai_vid_computervision_caption), hoc_s(:ai_vid_chatbots_caption), hoc_s(:ai_vid_creativity_caption), hoc_s(:ai_vid_ethics1_caption), hoc_s(:ai_vid_ethics2_caption)]
 
 - video_code = ["Ok-xpKjKp2g", "OeU5m6vRyCk", "x2mRoFNm22g", "JrXazCEACVo", "2hXG8v8p0KM", "X-AWdfSFCHQ", "X994dDnmRmY", "tJQSyzBUAew", "zNxw5gJtHLc"]
 

--- a/pegasus/sites.v3/code.org/views/carousel_how_ai_works_video.haml
+++ b/pegasus/sites.v3/code.org/views/carousel_how_ai_works_video.haml
@@ -1,6 +1,6 @@
 - video_ai_index = 9
 
-- video_download_path = ["//videos.code.org/ai_series/HowAIWorks_LLM_SM_CoBrand.mp4", "//videos.code.org/ai_series/HowAIWorks_Creativity_SM_CoBrand.mp4", "//videos.code.org/ai_series/ai-01-intro-to-ai.mp4", "//videos.code.org/ai_series/ai-02-machine-learning.mp4", "//videos.code.org/ai_series/ai-03-training-data.mp4", "//videos.code.org/ai_series/ai-04-neural-networks.mp4", "//videos.code.org/ai_series/ai-05-computer-vision.mp4", "//videos.code.org/ai_series/ai-06-ai-ethics-access-bias.mp4", "//videos.code.org/ai_series/ai-07-ai-ethics-privacy-work.mp4"]
+- video_download_path = ["//videos.code.org/ai_series/ai-01-intro-to-ai.mp4", "//videos.code.org/ai_series/ai-02-machine-learning.mp4", "//videos.code.org/ai_series/ai-03-training-data.mp4", "//videos.code.org/ai_series/ai-04-neural-networks.mp4", "//videos.code.org/ai_series/ai-05-computer-vision.mp4", "//videos.code.org/ai_series/HowAIWorks_LLM_SM_CoBrand.mp4", "//videos.code.org/ai_series/HowAIWorks_Creativity_SM_CoBrand.mp4", "//videos.code.org/ai_series/ai-06-ai-ethics-access-bias.mp4", "//videos.code.org/ai_series/ai-07-ai-ethics-privacy-work.mp4"]
 
 - video_caption = [hoc_s(:ai_vid_intro_caption), hoc_s(:ai_vid_mlintro_caption), hoc_s(:ai_vid_trainingdata_caption), hoc_s(:ai_vid_neuralnetworks_caption), hoc_s(:ai_vid_computervision_caption), hoc_s(:ai_vid_chatbots_caption), hoc_s(:ai_vid_creativity_caption), hoc_s(:ai_vid_ethics1_caption), hoc_s(:ai_vid_ethics2_caption)]
 


### PR DESCRIPTION
Puts the captions on the How AI Works videos in the correct order on https://code.org/videos.

**Jira ticket:** [ACQ-1819](https://codedotorg.atlassian.net/browse/ACQ-1819)

---- 

https://github.com/code-dot-org/code-dot-org/assets/9256643/6edf1ca3-012e-4ecb-a31a-4da1c5a6eea0
