### PR TITLE
show deprecated course page for script levels with deprecated levels

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -64,8 +64,9 @@ class ScriptLevelsController < ApplicationController
     @current_user = current_user && User.includes(:teachers).where(id: current_user.id).first
     authorize! :read, ScriptLevel
     @script = ScriptLevelsController.get_script(request)
+    @script_level = ScriptLevelsController.get_script_level(@script, params)
 
-    if @script.is_deprecated
+    if @script.is_deprecated || @script_level.level.deprecated?
       return render 'errors/deprecated_course'
     end
 
@@ -103,7 +104,6 @@ class ScriptLevelsController < ApplicationController
 
     @public_caching = configure_caching(@script)
 
-    @script_level = ScriptLevelsController.get_script_level(@script, params)
     raise ActiveRecord::RecordNotFound unless @script_level
 
     if @script.login_required? || (!params.nil? && params[:login_required] == "true")

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -66,7 +66,9 @@ class ScriptLevelsController < ApplicationController
     @script = ScriptLevelsController.get_script(request)
     @script_level = ScriptLevelsController.get_script_level(@script, params)
 
-    if @script.is_deprecated || @script_level.level.deprecated?
+    # Check if the script or current level is deprecated
+    level_is_deprecated = @script_level&.level_deprecated?
+    if @script.is_deprecated || level_is_deprecated
       return render 'errors/deprecated_course'
     end
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -740,6 +740,10 @@ class ScriptLevel < ApplicationRecord
     level_example_links
   end
 
+  def level_deprecated?
+    level&.deprecated?
+  end
+
   private def kind
     if level.unplugged?
       LEVEL_KIND.unplugged


### PR DESCRIPTION
Last year, we deprecated several scripts related to CS in Algebra: https://github.com/code-dot-org/code-dot-org/pull/53211

However, there are other scripts that use levels of these types. We are gradually working on marking these level types as deprecated:
* Calc/Eval: https://github.com/code-dot-org/code-dot-org/pull/58160 
* Algebra Game: https://github.com/code-dot-org/code-dot-org/pull/58168
* Contract Match: https://github.com/code-dot-org/code-dot-org/pull/58191

For projects of these types, we're using the deprecation page and ensuring that the projects no longer show up in the user's personal project table. For levels in scripts, we're currently relying on a script setting. With this change, we can hide unsupported levels in _any_ script. We wouldn't expect deprecated Algebra levels to show up in other scripts, especially those recommend externally. If this does happen we will now show the deprecation warning on those particular script levels. For example, I have found calc/eval levels in scripts like `s/algebrademo`. This script isn't recommended anywhere but could potentially have been bookmarked if it was ever shared externally.

**Before:**

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/573f38d9-381d-42c7-8d18-964e9e6ff4e3)


**After:**

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/3c2797c0-34fe-48d9-97bb-c653876c823c)

This is a more robust solution than just deprecating whole scripts because our content authoring system doesn't guarantee that these unsupported levels won't show up elsewhere. 
Note that this doesn't deprecate the whole script or its lessons - just the individual script levels. Eventually we might want to consider automatically showing the deprecation page for any script that includes deprecated levels (since we realistically can't support it). [That work](https://github.com/code-dot-org/code-dot-org/pull/58161) is drafted but currently blocked. Algebra levels show up in places like `allthethings` which we obviously don't want to deprecate, but that is being addressed too: https://github.com/code-dot-org/code-dot-org/pull/58190

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
