### PR TITLE
Speculative Fix for unused_blocks eyes test

### DIFF
--- a/dashboard/test/ui/features/star_labs/unused_blocks.feature
+++ b/dashboard/test/ui/features/star_labs/unused_blocks.feature
@@ -5,6 +5,7 @@ Scenario: Solve a level with unused blocks
   When I open my eyes to test "Unused Blocks"
   Given I am on "http://studio.code.org/s/allthethings/lessons/4/levels/4?noautoplay=true"
   And I wait for the page to fully load
+  And I wait for 1 seconds
 
   # Drag a block into the middle of the workspace
   When I drag block "1" to offset "200, 200"


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->
## Summary
`unused_blocks.feature` has been flaky due to the blocks being positioned incorrectly ([example failure](https://eyes.applitools.com/app/test-results/00000251689423476305/00000251689423476199/steps/1?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor)). The working theory for this was we need to impose a wait before starting the test. I ran the UI test and it failed 2 out of 3 times with no change. If I added either a 1 second or 2 second timeout, it passed 3 times in a row. Therefore I've added a 1 second wait before starting the test, and we can see if the flakiness resolves.

## Links

- jira ticket: [CT-497](https://codedotorg.atlassian.net/browse/CT-497)


## Testing story
Tested via a tunnel to saucelabs. I tested it against the test environment to try to ensure similar conditions.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
