### PR TITLE
increase section experiment limit to 2K

### DIFF
--- a/dashboard/app/models/experiments/single_section_experiment.rb
+++ b/dashboard/app/models/experiments/single_section_experiment.rb
@@ -35,7 +35,7 @@ class SingleSectionExperiment < Experiment
 
   # set a limit on the total number of SingleSectionExperiment records, to mitigate performance problems
   # when calling Experiment.get_all_enabled on hot codepaths
-  MAX_COUNT = 1_000
+  MAX_COUNT = 2_000
 
   def max_count
     MAX_COUNT


### PR DESCRIPTION
see [slack](https://codedotorg.slack.com/archives/C051P2V2RN0/p1713820338514529). we are running into this limit while trying to add users to the ai-rubrics experiment. we have 1000 of these objects in production today, so unless there are signs of performance problems, I'd like to propose increasing the limit.