### PR TITLE
Music: test main site embed

### DIFF
--- a/pegasus/sites.v3/code.org/public/music/embed.haml
+++ b/pegasus/sites.v3/code.org/public/music/embed.haml
@@ -1,0 +1,3 @@
+%h1 Project beats embed
+
+%iframe{width: 500, height: 300, src: CDO.studio_url("/musiclab/embed?channels=channels=GMXc39iEI-pz-bECeFZGkxeHDPEdJat1k6Wpp6QxLjQ&library=launch2024", CDO.default_scheme)}

--- a/pegasus/sites.v3/code.org/public/music/embed.haml
+++ b/pegasus/sites.v3/code.org/public/music/embed.haml
@@ -1,3 +1,3 @@
 %h1 Project beats embed
 
-%iframe{width: 500, height: 300, src: CDO.studio_url("/musiclab/embed?channels=channels=GMXc39iEI-pz-bECeFZGkxeHDPEdJat1k6Wpp6QxLjQ&library=launch2024", CDO.default_scheme)}
+%iframe{width: 500, height: 300, src: CDO.studio_url("/musiclab/embed?channels=#{request.params['channels']}&library=#{request.params['library']}", CDO.default_scheme)}


### PR DESCRIPTION
A test to see if embedding the Music mini-player on the main site, using an `iframe`, works.  

The temporary URL is https://code.org/music/embed?channels=[channels]&library=[library].
