### PR TITLE
Music: use pack dialog buttons

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -1,7 +1,7 @@
 import {ResponseValidator} from '@cdo/apps/util/HttpClient';
 import {Key} from '../utils/Notes';
 import {baseAssetUrlRestricted, DEFAULT_PACK} from '../constants';
-import appConfig, {getBaseAssetUrl} from '../appConfig';
+import {getBaseAssetUrl} from '../appConfig';
 
 export default class MusicLibrary {
   private static instance: MusicLibrary;
@@ -183,10 +183,7 @@ export default class MusicLibrary {
 
   getRestrictedPacks(): SoundFolder[] {
     return this.getAllowedSounds().filter(
-      folder =>
-        folder.restricted &&
-        (appConfig.getValue('show-pack-dialog-buttons') !== 'true' ||
-          folder.id !== DEFAULT_PACK)
+      folder => folder.restricted && folder.id !== DEFAULT_PACK
     );
   }
 

--- a/apps/src/music/views/PackDialog.tsx
+++ b/apps/src/music/views/PackDialog.tsx
@@ -5,7 +5,7 @@ import styles from './PackDialog.module.scss';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {setPackId} from '../redux/musicRedux';
 import MusicLibrary, {SoundFolder} from '../player/MusicLibrary';
-import appConfig, {getBaseAssetUrl} from '../appConfig';
+import {getBaseAssetUrl} from '../appConfig';
 import classNames from 'classnames';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import MusicPlayer from '../player/MusicPlayer';
@@ -122,27 +122,19 @@ const PackDialog: React.FunctionComponent<PackDialogProps> = ({player}) => {
 
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
 
-  const showButtons = appConfig.getValue('show-pack-dialog-buttons') === 'true';
-
   const handleSelectFolder = useCallback(
     (folder: SoundFolder) => {
       if (!library) {
         return;
       }
 
-      if (showButtons) {
-        if (selectedFolderId === folder.id) {
-          setSelectedFolderId(null);
-        } else {
-          setSelectedFolderId(folder.id);
-        }
+      if (selectedFolderId === folder.id) {
+        setSelectedFolderId(null);
       } else {
-        // Immediately select the pack.
-        dispatch(setPackId(folder.id));
-        library.setCurrentPackId(folder.id);
+        setSelectedFolderId(folder.id);
       }
     },
-    [selectedFolderId, dispatch, library, showButtons]
+    [selectedFolderId, library]
   );
 
   const setPackToDefault = useCallback(() => {
@@ -228,29 +220,27 @@ const PackDialog: React.FunctionComponent<PackDialogProps> = ({player}) => {
             })}
           </div>
 
-          {showButtons && (
-            <div className={styles.buttonContainer}>
-              <button
-                onClick={setPackToDefault}
-                className={styles.skip}
-                type="button"
-              >
-                Skip
-              </button>
-              <button
-                onClick={setPackToSelectedFolder}
-                className={classNames(
-                  styles.continue,
-                  styles.button,
-                  !selectedFolderId && styles.continueDisabled
-                )}
-                disabled={!selectedFolderId}
-                type="button"
-              >
-                Continue
-              </button>
-            </div>
-          )}
+          <div className={styles.buttonContainer}>
+            <button
+              onClick={setPackToDefault}
+              className={styles.skip}
+              type="button"
+            >
+              Skip
+            </button>
+            <button
+              onClick={setPackToSelectedFolder}
+              className={classNames(
+                styles.continue,
+                styles.button,
+                !selectedFolderId && styles.continueDisabled
+              )}
+              disabled={!selectedFolderId}
+              type="button"
+            >
+              Continue
+            </button>
+          </div>
         </div>
       </div>
     </FocusLock>

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -101,14 +101,6 @@ const optionsList = [
       },
     ],
   },
-  {
-    name: 'show-pack-dialog-buttons',
-    type: 'radio',
-    values: [
-      {value: 'false', description: 'Hide pack dialog buttons.'},
-      {value: 'true', description: 'Show pack dialog buttons.'},
-    ],
-  },
 ];
 
 export default class MusicMenu extends React.Component {


### PR DESCRIPTION
Switch to always use the pack dialog buttons added as an option in https://github.com/code-dot-org/code-dot-org/pull/58092.
