### PR TITLE
Adds sign up statsig events, nces data, experiments user config

### DIFF
--- a/apps/src/lib/util/StatsigReporter.js
+++ b/apps/src/lib/util/StatsigReporter.js
@@ -5,6 +5,7 @@ import {
   isDevelopmentEnvironment,
 } from '../../utils';
 import Statsig from 'statsig-js';
+import experiments from '@cdo/apps/util/experiments';
 
 // A flag that can be toggled to send events regardless of environment
 const ALWAYS_SEND = false;
@@ -12,7 +13,11 @@ const NO_EVENT_NAME = 'NO_VALID_EVENT_NAME_LOG_ERROR';
 
 class StatsigReporter {
   constructor() {
-    let user = {};
+    let user = {
+      custom: {
+        enabledExperiments: experiments.getEnabledExperiments(),
+      },
+    };
     const user_id_element = document.querySelector('script[data-user-id]');
     const user_id = user_id_element ? user_id_element.dataset.userId : null;
     const user_type_element = document.querySelector('script[data-user-type');
@@ -20,10 +25,8 @@ class StatsigReporter {
       ? user_type_element.dataset.userType
       : null;
     if (user_id) {
-      user = {
-        userID: this.formatUserId(user_id),
-        custom: {userType: user_type},
-      };
+      user.userID = this.formatUserId(user_id);
+      user.custom.userType = user_type;
     }
     const api_element = document.querySelector(
       'script[data-statsig-api-client-key]'
@@ -53,11 +56,11 @@ class StatsigReporter {
   }
 
   // Utilizes Statsig's function for updating a user once we've recognized a sign in
-  async setUserProperties(userId, userType) {
+  async setUserProperties(userId, userType, enabledExperiments) {
     const formattedUserId = this.formatUserId(userId);
     const user = {
       userID: formattedUserId,
-      custom: {userType: userType},
+      custom: {userType: userType, enabledExperiments: enabledExperiments},
     };
     if (!this.shouldPutRecord(ALWAYS_SEND)) {
       this.log(

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -88,10 +88,12 @@ $(document).ready(() => {
       cleanSchoolInfo();
       $('#user_age').val('21+');
     }
+    let ncesId = document.getElementById('uitest-school-dropdown').value;
     analyticsReporter.sendEvent(
       EVENTS.SIGN_UP_FINISHED_EVENT,
       {
         'user type': user_type,
+        'nces Id': ncesId,
       },
       PLATFORMS.BOTH
     );

--- a/apps/src/sites/studio/pages/devise/registrations/_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_sign_up.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 $(document).ready(() => {
-  analyticsReporter.sendEvent(EVENTS.SIGN_UP_STARTED_EVENT);
+  analyticsReporter.sendEvent(EVENTS.SIGN_UP_STARTED_EVENT, {}, PLATFORMS.BOTH);
 
   document
     .getElementById('signup_form_submit')
@@ -26,7 +26,11 @@ $(document).ready(() => {
 });
 
 function logUserLoginType(loginType) {
-  analyticsReporter.sendEvent(EVENTS.SIGN_UP_LOGIN_TYPE_PICKED_EVENT, {
-    'user login type': loginType,
-  });
+  analyticsReporter.sendEvent(
+    EVENTS.SIGN_UP_LOGIN_TYPE_PICKED_EVENT,
+    {
+      'user login type': loginType,
+    },
+    PLATFORMS.BOTH
+  );
 }

--- a/apps/src/templates/SchoolZipSearch.jsx
+++ b/apps/src/templates/SchoolZipSearch.jsx
@@ -54,7 +54,9 @@ export default function SchoolZipSearch({fieldNames, zip, disabled}) {
       setInputManually(true);
       sendAnalyticsEvent(EVENTS.ADD_MANUALLY_CLICKED, {});
     } else {
-      sendAnalyticsEvent(EVENTS.SCHOOL_SELECTED_FROM_LIST, {ncesId: schoolId});
+      sendAnalyticsEvent(EVENTS.SCHOOL_SELECTED_FROM_LIST, {
+        'nces Id': schoolId,
+      });
     }
     setSelectedSchoolNcesId(schoolId);
   };

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -194,7 +194,11 @@ export default function currentUser(state = initialState, action) {
     );
     // Calling Statsig separately to emphasize different user integrations
     // and because dual reporting is aspirationally temporary (March 2024)
-    statsigReporter.setUserProperties(id, user_type);
+    statsigReporter.setUserProperties(
+      id,
+      user_type,
+      experiments.getEnabledExperiments()
+    );
     return {
       ...state,
       userId: id,


### PR DESCRIPTION
This PR adds the nces ID to the statsig sign up finished event! Because we've already set up the other data to send in an 'english style' format a la 'user type' instead of 'user_type' or 'userType', I elected to continue with that formatting for this bit of data and updated the other call that hasn't happened in prod yet to match.

It also adds the sign up started and user login type picked events to statsig (see second image). 

It also updates the user config to include enabled experiments. I was able to verify that this works for both signed out users and signed in users (the following two images).

With events that happen right before a redirect, it's tough to catch the console log with the correct event logged locally. Instead, I flipped local_mode off and sent the events directly to statsig on our development side (so production data wouldn't be impacted) and took a screenshot from there:

<img width="781" alt="Screenshot 2024-04-22 at 5 38 16 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/8d6c10cf-6c3b-47d1-b48a-29026669b051">

<img width="1181" alt="Screenshot 2024-04-22 at 6 51 18 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/7672f131-652f-4191-9002-6522d33812ee">

<img width="775" alt="Screenshot 2024-04-22 at 7 12 21 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/5d264103-1e09-4b25-9397-9735d9c63588">
<img width="777" alt="Screenshot 2024-04-22 at 8 02 09 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/e2af4e0b-c6d9-45cc-8156-899057f8162e">


## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1825
- https://codedotorg.atlassian.net/browse/ACQ-1830

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
