### PR TITLE
Music: more RTL

### DIFF
--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -38,11 +38,11 @@ $default-spacing: 2px;
     text-align: center;
   }
 
-  [dir="ltr"] &Right, [dir="rtl"] &Left  {
+  [dir="ltr"] &Right, [dir="rtl"] &Left {
     right: 4px;
   }
 
-  [dir="ltr"] &Left, [dir="rtl"] &Right  {
+  [dir="ltr"] &Left, [dir="rtl"] &Right {
     left: 4px;
   }
 }

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -38,11 +38,11 @@ $default-spacing: 2px;
     text-align: center;
   }
 
-  &Right {
+  [dir="ltr"] &Right, [dir="rtl"] &Left  {
     right: 4px;
   }
 
-  &Left {
+  [dir="ltr"] &Left, [dir="rtl"] &Right  {
     left: 4px;
   }
 }

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -58,7 +58,8 @@ export default class MusicBlocklyWorkspace {
     container: HTMLElement,
     onBlockSpaceChange: (e: Abstract) => void,
     isReadOnlyWorkspace: boolean,
-    toolbox: {[key: string]: string[]}
+    toolbox: {[key: string]: string[]},
+    isRtl: boolean
   ) {
     if (this.workspace) {
       this.workspace.dispose();
@@ -82,6 +83,7 @@ export default class MusicBlocklyWorkspace {
       },
       readOnly: isReadOnlyWorkspace,
       useBlocklyDynamicCategories: true,
+      rtl: isRtl,
     } as BlocklyOptions);
 
     this.resizeBlockly();

--- a/apps/src/music/views/HeaderButtons.module.scss
+++ b/apps/src/music/views/HeaderButtons.module.scss
@@ -37,6 +37,10 @@
     width: initial;
     padding: 0 6px 0 2px;
 
+    html[dir="rtl"] & {
+      padding: 0 2px 0 6px;
+    }
+
     &Image {
       height: 20px;
       border-radius: 2px;
@@ -44,6 +48,10 @@
 
     &Content {
       padding: 0 16px 0 8px;
+
+      html[dir="rtl"] & {
+        padding: 0 8px 0 16px;
+      }
 
       &NoRightPadding {
         padding-right: 0;

--- a/apps/src/music/views/HeaderButtons.module.scss
+++ b/apps/src/music/views/HeaderButtons.module.scss
@@ -58,9 +58,6 @@
   &Skip {
     width: initial;
     padding: 0 11px;
-
-    &Content {
-      margin-right: 9px;
-    }
+    gap: 9px;
   }
 }

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -223,9 +223,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
           type="button"
           className={classNames(moduleStyles.button, moduleStyles.buttonSkip)}
         >
-          <span className={moduleStyles.buttonSkipContent}>
-            {commonI18n.skipToProject()}
-          </span>
+          {commonI18n.skipToProject()}
           <FontAwesome
             title={commonI18n.skipToProject()}
             icon="arrow-right"

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -160,7 +160,11 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
             </PanelContainer>
           </div>
 
-          <div id="timeline-area" className={moduleStyles.timelineArea}>
+          <div
+            dir="ltr"
+            id="timeline-area"
+            className={moduleStyles.timelineArea}
+          >
             <PanelContainer
               id="timeline-panel"
               headerContent={musicI18n.panelHeaderTimeline()}

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -75,6 +75,7 @@ class UnconnectedMusicView extends React.Component {
     userId: PropTypes.number,
     userType: PropTypes.string,
     signInState: PropTypes.oneOf(Object.values(SignInState)),
+    isRtl: PropTypes.bool,
     libraryName: PropTypes.string,
     setLibraryName: PropTypes.func,
     packId: PropTypes.string,
@@ -274,7 +275,8 @@ class UnconnectedMusicView extends React.Component {
       document.getElementById(BLOCKLY_DIV_ID),
       this.onBlockSpaceChange,
       this.props.isReadOnlyWorkspace,
-      levelData?.toolbox
+      levelData?.toolbox,
+      this.props.isRtl
     );
 
     this.library.setAllowedSounds(levelData?.sounds);
@@ -685,6 +687,8 @@ const MusicView = connect(
     userId: state.currentUser.userId,
     userType: state.currentUser.userType,
     signInState: state.currentUser.signInState,
+
+    isRtl: state.isRtl,
 
     libraryName: state.music.libraryName,
     packId: state.music.packId,

--- a/apps/src/music/views/controls.module.scss
+++ b/apps/src/music/views/controls.module.scss
@@ -66,10 +66,7 @@
   background-color: #fca401;
   color: $neutral_light;
   margin: 0;
-
-  .text {
-    padding-left: 10px;
-  }
+  gap: 10px;
 
   .text,
   .icon {


### PR DESCRIPTION
The Music Lab Blockly workspace new flips to RTL correctly.  

Also fixed a few easy RTL layout issues: the positioning of the header buttons; the layout inside the Run button; the layout inside the Skip to Project button; the layout inside the Start Over button; and keeping the timeline fully LTR for now.

<img width="1512" alt="Screenshot 2024-04-23 at 1 18 10 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/4736dcdf-a49c-4e3f-a435-f32b70433023">
