### PR TITLE
Music: fix empty timeline

### DIFF
--- a/apps/src/music/views/TimelineSimple2Events.tsx
+++ b/apps/src/music/views/TimelineSimple2Events.tsx
@@ -4,13 +4,21 @@ import {useMusicSelector} from './types';
 import {FunctionEvents} from '../player/interfaces/FunctionEvents';
 
 /**
- * Compute the bounds for the given function, given the list of unique sounds and all functions.
+ * Compute the extents for the given function, given the list of unique sounds and all functions.
+ * Returns null if the function doesn't generate any sound events and doesn't call any functions.
  */
-const getFunctionBounds = (
+interface FunctionExtents {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+const getFunctionExtents = (
   orderedFunction: FunctionEvents,
   uniqueSounds: string[],
   orderedFunctions: FunctionEvents[]
-) => {
+): FunctionExtents | null => {
   let left = Number.MAX_SAFE_INTEGER,
     top = Number.MAX_SAFE_INTEGER,
     right = 0,
@@ -41,16 +49,16 @@ const getFunctionBounds = (
       orderedF => orderedF.uniqueInvocationId === calledFunctionId
     );
     if (calledFunction) {
-      const bounds = getFunctionBounds(
+      const extents = getFunctionExtents(
         calledFunction,
         uniqueSounds,
         orderedFunctions
       );
-      if (bounds) {
-        left = Math.min(left, bounds.left);
-        right = Math.max(right, bounds.right);
-        top = Math.min(top, bounds.top);
-        bottom = Math.max(bottom, bounds.bottom);
+      if (extents) {
+        left = Math.min(left, extents.left);
+        right = Math.max(right, extents.right);
+        top = Math.min(top, extents.top);
+        bottom = Math.max(bottom, extents.bottom);
       }
     }
   }
@@ -58,6 +66,47 @@ const getFunctionBounds = (
   return {left, right, top, bottom};
 };
 
+/**
+ * Renders function extents for a single function in the simple2 model.
+ */
+interface FunctionExtents2EventsProps {
+  index: number;
+  paddingOffset: number;
+  barWidth: number;
+  eventHeight: number;
+  functionExtents: FunctionExtents | null;
+}
+
+const FunctionExtentsSimple2: React.FunctionComponent<
+  FunctionExtents2EventsProps
+> = ({index, paddingOffset, barWidth, eventHeight, functionExtents}) => {
+  if (!functionExtents) {
+    return null;
+  }
+
+  return (
+    <div
+      key={index}
+      style={{
+        position: 'absolute',
+        backgroundColor:
+          index === 0 ? 'rgba(0 0 0 / 0)' : 'rgba(255 255 255 / 0.12)',
+        borderRadius: 8,
+        left: paddingOffset + (functionExtents.left - 1) * barWidth,
+        width: (functionExtents.right - functionExtents.left) * barWidth,
+        top: 32 + functionExtents.top * eventHeight,
+        height:
+          (functionExtents.bottom - functionExtents.top) * eventHeight - 3,
+      }}
+    >
+      &nbsp;
+    </div>
+  );
+};
+
+/**
+ * Renders timeline events in the simple2 model.
+ */
 interface TimelineSimple2EventsProps {
   paddingOffset: number;
   barWidth: number;
@@ -65,9 +114,6 @@ interface TimelineSimple2EventsProps {
   getEventHeight: (numUniqueRows: number, availableHeight?: number) => number;
 }
 
-/**
- * Renders timeline events for the simple2 model.
- */
 const TimelineSimple2Events: React.FunctionComponent<
   TimelineSimple2EventsProps
 > = ({paddingOffset, barWidth, eventVerticalSpace, getEventHeight}) => {
@@ -93,15 +139,21 @@ const TimelineSimple2Events: React.FunctionComponent<
     return uniqueSounds;
   }, [soundEvents]);
 
-  // Next, for each function, determine the boundaries of the sound events
+  // Next, for each function, determine the pixel extents of the sound events
   // generated, including by functions it calls.
-  // The outcome is an object with each function's boundaries.
-  // Each timeline boundary has left/right position in measures, and
+  // The outcome is an object with each function's extents.
+  // Each timeline extent has left/right position in measures, and
   // top/bottom position in rows.
   const uniqueFunctionExtentsArray = useMemo(() => {
-    return orderedFunctions.map(orderedFunction =>
-      getFunctionBounds(orderedFunction, currentUniqueSounds, orderedFunctions)
-    );
+    return orderedFunctions
+      .map(orderedFunction =>
+        getFunctionExtents(
+          orderedFunction,
+          currentUniqueSounds,
+          orderedFunctions
+        )
+      )
+      .filter(orderedFunction => orderedFunction);
   }, [orderedFunctions, currentUniqueSounds]);
 
   const eventHeight = useMemo(
@@ -119,34 +171,15 @@ const TimelineSimple2Events: React.FunctionComponent<
   return (
     <div id="timeline-events">
       <div id="timeline-events-function-extents">
-        {uniqueFunctionExtentsArray
-          .filter(uniqueFunction => uniqueFunction)
-          .map(
-            (uniqueFunction, index) =>
-              uniqueFunction && (
-                <div
-                  key={index}
-                  style={{
-                    position: 'absolute',
-                    backgroundColor:
-                      index === 0
-                        ? 'rgba(0 0 0 / 0)'
-                        : 'rgba(255 255 255 / 0.12)',
-                    borderRadius: 8,
-                    left: paddingOffset + (uniqueFunction.left - 1) * barWidth,
-                    width:
-                      (uniqueFunction.right - uniqueFunction.left) * barWidth,
-                    top: 32 + uniqueFunction.top * eventHeight,
-                    height:
-                      (uniqueFunction.bottom - uniqueFunction.top) *
-                        eventHeight -
-                      3,
-                  }}
-                >
-                  &nbsp;
-                </div>
-              )
-          )}
+        {uniqueFunctionExtentsArray.map((functionExtents, index) => (
+          <FunctionExtentsSimple2
+            index={index}
+            paddingOffset={paddingOffset}
+            barWidth={barWidth}
+            eventHeight={eventHeight}
+            functionExtents={functionExtents}
+          />
+        ))}
       </div>
       <div id="timeline-events-sound-events">
         {soundEvents.map((eventData, index) => (

--- a/apps/src/music/views/TimelineSimple2Events.tsx
+++ b/apps/src/music/views/TimelineSimple2Events.tsx
@@ -16,6 +16,13 @@ const getFunctionBounds = (
     right = 0,
     bottom = 0;
 
+  if (
+    orderedFunction.playbackEvents.length === 0 &&
+    orderedFunction.calledFunctionIds.length === 0
+  ) {
+    return null;
+  }
+
   for (const playbackEvent of orderedFunction.playbackEvents) {
     left = Math.min(left, playbackEvent.when);
     right = Math.max(right, playbackEvent.when + playbackEvent.length);
@@ -39,10 +46,12 @@ const getFunctionBounds = (
         uniqueSounds,
         orderedFunctions
       );
-      left = Math.min(left, bounds.left);
-      right = Math.max(right, bounds.right);
-      top = Math.min(top, bounds.top);
-      bottom = Math.max(bottom, bounds.bottom);
+      if (bounds) {
+        left = Math.min(left, bounds.left);
+        right = Math.max(right, bounds.right);
+        top = Math.min(top, bounds.top);
+        bottom = Math.max(bottom, bounds.bottom);
+      }
     }
   }
 
@@ -110,24 +119,34 @@ const TimelineSimple2Events: React.FunctionComponent<
   return (
     <div id="timeline-events">
       <div id="timeline-events-function-extents">
-        {uniqueFunctionExtentsArray.map((uniqueFunction, index) => (
-          <div
-            key={index}
-            style={{
-              position: 'absolute',
-              backgroundColor:
-                index === 0 ? 'rgba(0 0 0 / 0)' : 'rgba(255 255 255 / 0.12)',
-              borderRadius: 8,
-              left: paddingOffset + (uniqueFunction.left - 1) * barWidth,
-              width: (uniqueFunction.right - uniqueFunction.left) * barWidth,
-              top: 32 + uniqueFunction.top * eventHeight,
-              height:
-                (uniqueFunction.bottom - uniqueFunction.top) * eventHeight - 3,
-            }}
-          >
-            &nbsp;
-          </div>
-        ))}
+        {uniqueFunctionExtentsArray
+          .filter(uniqueFunction => uniqueFunction)
+          .map(
+            (uniqueFunction, index) =>
+              uniqueFunction && (
+                <div
+                  key={index}
+                  style={{
+                    position: 'absolute',
+                    backgroundColor:
+                      index === 0
+                        ? 'rgba(0 0 0 / 0)'
+                        : 'rgba(255 255 255 / 0.12)',
+                    borderRadius: 8,
+                    left: paddingOffset + (uniqueFunction.left - 1) * barWidth,
+                    width:
+                      (uniqueFunction.right - uniqueFunction.left) * barWidth,
+                    top: 32 + uniqueFunction.top * eventHeight,
+                    height:
+                      (uniqueFunction.bottom - uniqueFunction.top) *
+                        eventHeight -
+                      3,
+                  }}
+                >
+                  &nbsp;
+                </div>
+              )
+          )}
       </div>
       <div id="timeline-events-sound-events">
         {soundEvents.map((eventData, index) => (


### PR DESCRIPTION
This fixes a bug in which a timeline with no elements was almost infinitely scrollable horizontally.

### Before

Prior to this change, an empty timeline had a really big invisible element for the function bounds, allowing the user to scroll almost infinitely into empty space.

<img width="1512" alt="Screenshot 2024-04-23 at 1 05 21 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/03477731-19fc-4572-9837-38661954cd3a">

### After

With this change, the function bounds are no longer rendered if there's nothing inside them.

<img width="1512" alt="Screenshot 2024-04-23 at 1 05 44 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/37447b6c-a05c-48a7-94ea-c74dc2025c80">


The function bounds still work appropriately.

<img width="1512" alt="Screenshot 2024-04-23 at 1 05 48 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/581f338c-91ab-4252-a0b5-a5806477922d">

