### PR TITLE
Music: save pack to channel

### DIFF
--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -150,7 +150,7 @@ export default class ProjectManager {
   /**
    * Try to force save with the last sourcesToSave, if it exists.
    * This is used to flush out any remaining enqueued saves.
-   * @returns  a promise that resolves to a Response. If the save is successful, the response
+   * @returns a promise that resolves to a Response. If the save is successful, the response
    * will be empty, otherwise it will contain failure information.
    */
   async flushSave() {
@@ -317,6 +317,14 @@ export default class ProjectManager {
       // Even if only the source changed, we still update the channel to modify the last
       // updated time.
       this.channelToSave ||= this.lastChannel;
+
+      if (this.sourcesToSave?.labConfig) {
+        this.channelToSave = {
+          ...this.channelToSave,
+          labConfig: this.sourcesToSave?.labConfig,
+        };
+      }
+
       let channelResponse;
       try {
         channelResponse = await this.channelsStore.save(this.channelToSave);

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -318,6 +318,9 @@ export default class ProjectManager {
       // updated time.
       this.channelToSave ||= this.lastChannel;
 
+      // If the sources contain a labConfig entry, then also save this to the
+      // channel, which means that the labConfig entry will also be saved in the
+      // Project model in the database, specifically inside the value field JSON.
       if (this.sourcesToSave?.labConfig) {
         this.channelToSave = {
           ...this.channelToSave,

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -18,7 +18,9 @@ export interface Channel {
   publishedAt: string | null;
   createdAt: string;
   updatedAt: string;
-  // Optional lab-specific configuration for this project
+  // Optional lab-specific configuration for this project.  If provided, this will be saved
+  // to the Project model in the database along with the other entries in this interface,
+  // inside the value field JSON.
   labConfig?: {[key: string]: object};
 }
 

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -18,6 +18,8 @@ export interface Channel {
   publishedAt: string | null;
   createdAt: string;
   updatedAt: string;
+  // Optional lab-specific configuration for this project
+  labConfig?: {[key: string]: object};
 }
 
 export type DefaultChannel = Pick<Channel, 'name'>;


### PR DESCRIPTION
This is a way to save a Music Lab project's pack ID to the `Project` database model's `value` JSON column.  We want to do this so that we can later display an image based on this pack ID in places where we enumerate Music Lab projects, such as playlist UI and project UI.  By having the pack ID available in the database, we won't need to hit S3 for sources when we do that enumeration.

It turns out that a simple way to do this is to simply include the `labConfig` information that we are already saving as part of the sources.  For Music Lab, this conveniently includes both the `library` and the `packId`, both of which could prove useful when enumerating projects.

We should keep an eye on `labConfig` for this and future Lab2 labs to ensure that it continues to include metadata that we want to store in the database.

Here's an example of a `value` JSON with this change:

```
{"name":"Untitled Project","level":"https://studio.code.org/projects/music","createdAt":"2024-04-23T04:44:07.000+00:00","updatedAt":"2024-04-23T04:46:22.595+00:00","id":"AOEdvCQ5T7Zyr4YaxX5xbA","isOwner":true,"publishedAt":null,"projectType":"music","labConfig":{"music":{"library":"launch2024","packId":"electro"}}} 
```

Thanks to @molly-moen and @sanchitmalhotra126 for helping think through this. 