### PR TITLE
Switch TTS Bucket Path

### DIFF
--- a/bin/oneoff/migrate_tts_files.rb
+++ b/bin/oneoff/migrate_tts_files.rb
@@ -1,0 +1,124 @@
+#!/usr/bin/env ruby
+
+# This script will copy, if necessary, the TTS (Text-To-Speech) mp3 files that we
+# store in our cdo-tts bucket from their old locations that were based on a single
+# MD5 hash to a new one which uses a more robust SHA-256 hash.
+#
+# We will do this to prevent the creation of thousands of duplicate recordings in
+# the future due to new courses created from older versions of that course causing
+# a massive run of TTS generation for the same content.
+#
+# There were a lot of dangling files that could not be re-mapped since their original
+# strings do not seem to exist anymore. These files will not be copied since they
+# cannot be rehashed. There is a risk that they will fail to exist, but this process
+# in this script should exhaustively look at every single string to determine the
+# existence of its TTS file.
+#
+# Also, there are many missing TTS files. Finding a few, and looking at them on our
+# production site shows network errors as our app tries to load the TTS file. Our
+# app assumes they exist and they do not, and we have no process for identifying or
+# fixing this.
+#
+# With this in mind, I also want to record alongside the
+# <md5-hash>/<sha-hash>/<params>.mp3 a <params>.json file that contains information
+# about the provenance of the TTS file which should include:
+#   - text (string) -- The text being read by the agent.
+#   - key (string) -- The source within the level for the text. (long_instructions, etc)
+#   - level (string) -- The name of the level (replacing the old filename)
+#
+# Unfortunately, it is unclear how we would know that a TTS string was generated
+# before in order to clean up the bucket. We could, however, go through every string,
+# much like this script does, and find and clean up the dangling files. This script is
+# not very complicated and this amount of complexity might be better than any other
+# kind of bookkeeping.
+
+puts "Starting migration of TTS files."
+puts
+puts "This will not overwrite content."
+puts
+puts "This will report updates on each line with the following keys preceding the operation:"
+puts "[WRTE] - Creating a new file"
+puts "[UPDT] - Updating an existing file"
+puts "[COPY] - Copying an existing file to a new location"
+puts "[EXST] - We see the file we want to make already exists... do nothing."
+
+puts
+puts "Loading app"
+
+# Now go through all of our levels
+require_relative 'dashboard/config/environment'
+
+# The speed/shape are always the same
+locales = TextToSpeech::VOICES.keys
+
+KEYS = ['short_instructions', 'long_instructions', 'hint_markdown']
+
+puts "Enumerating Levels"
+
+found = {}
+Level.all.each do |level|
+  next unless level.published
+
+  # For all strings, determine if they are saved in S3
+  locales.each do |locale|
+    I18n.locale = locale
+    voice = TextToSpeech::VOICES[locale][:VOICE]
+    speed = TextToSpeech::VOICES[locale][:SPEED]
+    shape = TextToSpeech::VOICES[locale][:SHAPE]
+    authored_hints = (level.respond_to?(:localized_authored_hints) ? level.localized_authored_hints : level.authored_hints)
+
+    [
+      level.tts_short_instructions_text,
+      level.tts_long_instructions_text,
+      *JSON.parse(authored_hints || "[]").map do |hint|
+        TextToSpeech.sanitize(hint["hint_markdown"])
+      end
+    ].each_with_index do |text, i|
+      next if text.strip.blank?
+      md5_hash = Digest::MD5.hexdigest(text)
+      sha_hash = Digest::SHA256.hexdigest(text)
+
+      # The source for the text
+      key_index = [i, 2].min
+      key = KEYS[key_index]
+
+      next if found.key?(md5_hash + '-' + voice)
+      found[md5_hash + '-' + voice] = true
+      path = "#{voice}/#{speed}/#{shape}/#{md5_hash}/#{level.name}.mp3"
+      new_path = "generated/#{md5_hash}/#{sha_hash}/#{voice}-#{speed}-#{shape}.mp3"
+
+      if AWS::S3.exists_in_bucket(TTS_BUCKET, path)
+        if AWS::S3.exists_in_bucket(TTS_BUCKET, new_path)
+          puts "[EXST] #{path} -> #{new_path}"
+        else
+          puts "[COPY] #{path} -> #{new_path}"
+          AWS::S3.create_client.copy_object({
+                                              bucket: TTS_BUCKET,
+            copy_source: "/#{TTS_BUCKET}/#{path}",
+            key: new_path,
+                                            }
+)
+        end
+
+        # Create metadata for the copied file based on the info we have
+        metadata_path = "#{new_path.rpartition('.').first}.json"
+        metadata = {}
+        if AWS::S3.exists_in_bucket(TTS_BUCKET, metadata_path)
+          # Pull down the existing metadata
+          metadata = JSON.parse(AWS::S3.download_from_bucket(TTS_BUCKET, metadata_path))
+          puts "[UPDT] #{metadata_path}"
+        else
+          puts "[WRTE] #{metadata_path}"
+        end
+        metadata[level.name] = {
+          key: key,
+          locale: locale,
+          text: text
+        }
+        AWS::S3.upload_to_bucket(TTS_BUCKET, metadata_path, metadata.to_json, no_random: true)
+      else
+        puts "[WARN] TTS file not found for level #{level.name} #{key} and locale #{locale}"
+      end
+    end
+  end
+end

--- a/bin/oneoff/migrate_tts_files.rb
+++ b/bin/oneoff/migrate_tts_files.rb
@@ -20,8 +20,8 @@
 # fixing this.
 #
 # With this in mind, I also want to record alongside the
-# <md5-hash>/<sha-hash>/<params>.mp3 a <params>.json file that contains information
-# about the provenance of the TTS file which should include:
+# <locale>/<md5-hash>/<sha-hash>/<params>.mp3 a <params>.json file that contains
+# metadata about the provenance of the TTS file which should include:
 #   - text (string) -- The text being read by the agent.
 #   - key (string) -- The source within the level for the text. (long_instructions, etc)
 #   - level (string) -- The name of the level (replacing the old filename)
@@ -85,19 +85,20 @@ Level.all.each do |level|
       next if found.key?(md5_hash + '-' + voice)
       found[md5_hash + '-' + voice] = true
       path = "#{voice}/#{speed}/#{shape}/#{md5_hash}/#{level.name}.mp3"
-      new_path = "generated/#{md5_hash}/#{sha_hash}/#{voice}-#{speed}-#{shape}.mp3"
+      new_path = "#{locale}/#{md5_hash}/#{sha_hash}/#{voice}-#{speed}-#{shape}.mp3"
 
       if AWS::S3.exists_in_bucket(TTS_BUCKET, path)
         if AWS::S3.exists_in_bucket(TTS_BUCKET, new_path)
           puts "[EXST] #{path} -> #{new_path}"
         else
           puts "[COPY] #{path} -> #{new_path}"
-          AWS::S3.create_client.copy_object({
-                                              bucket: TTS_BUCKET,
-            copy_source: "/#{TTS_BUCKET}/#{path}",
-            key: new_path,
-                                            }
-)
+          AWS::S3.create_client.copy_object(
+            {
+              bucket: TTS_BUCKET,
+              copy_source: "/#{TTS_BUCKET}/#{path}",
+              key: new_path,
+            }
+          )
         end
 
         # Create metadata for the copied file based on the info we have

--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -93,12 +93,16 @@ module TextToSpeech
       AWS::S3.upload_to_bucket(TTS_BUCKET, filename, resp.body, no_random: true)
 
       # Also upload metadata so we know what the text is supposed to be
-      metadata_path = "#{filename}.mp3"
-      metadata = {
-        level: name,
+      metadata_path = "#{filename.rpartition('.').first}.json"
+      metadata = {}
+      if AWS::S3.exists_in_bucket(TTS_BUCKET, metadata_path)
+        # Pull down the existing metadata
+        metadata = JSON.parse(AWS::S3.download_from_bucket(TTS_BUCKET, metadata_path))
+      end
+      metadata[name] = {
         key: key,
         locale: locale,
-        text: text,
+        text: text
       }
       AWS::S3.upload_to_bucket(TTS_BUCKET, metadata_path, metadata.to_json, no_random: true)
     end

--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -37,6 +37,8 @@ TTSSafeScrubber.tags = ['xml']
 module TextToSpeech
   extend ActiveSupport::Concern
 
+  UPDATED_TTS_PATH_DCDO_KEY = 'updated_tts_path'.freeze
+
   # Pull the VOICES out of the SharedConstants (updating the locale keys to
   # match the expectation of the I18n gem since these locale keys are using
   # the JavaScript i18n expectations)
@@ -76,7 +78,7 @@ module TextToSpeech
     loc_voice = TextToSpeech.localized_voice(locale: locale)
 
     # Determine the location based on the experiment enabled
-    use_new_path = DCDO.get('updated_tts_path', false)
+    use_new_path = DCDO.get(UPDATED_TTS_PATH_DCDO_KEY, false)
     if use_new_path
       # New path
       "#{locale}/#{content_md5}/#{content_sha}/#{loc_voice[:VOICE]}-#{loc_voice[:SPEED]}-#{loc_voice[:SHAPE]}.mp3"

--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -43,6 +43,7 @@ module TextToSpeech
   # match the expectation of the I18n gem since these locale keys are using
   # the JavaScript i18n expectations)
   VOICES = SharedConstants::VOICES.transform_keys do |locale|
+    return locale unless locale.to_s.include?('_')
     lang, country = locale.to_s.split('_')
     :"#{lang}-#{country.upcase}"
   end.freeze

--- a/dashboard/test/models/concerns/text_to_speech_test.rb
+++ b/dashboard/test/models/concerns/text_to_speech_test.rb
@@ -66,7 +66,7 @@ class TextToSpeechTest < ActiveSupport::TestCase
     assert_equal 'sharon22k/180/100/71c7e35e3633b5dfce472bcbed146e9f/level-with-instructions.mp3', @level_with_instructions.tts_path(@level_with_instructions.tts_short_instructions_text)
     assert_equal 'sharon22k/180/100/e3b3f56615d1e5f2608d2f1130a7ef54/level-with-instructions-override.mp3', @level_with_instructions_override.tts_path(@level_with_instructions_override.tts_short_instructions_text)
 
-    DCDO.stubs(:get).with('updated_tts_path', false).returns(true)
+    DCDO.stubs(:get).with(TextToSpeech::UPDATED_TTS_PATH_DCDO_KEY, false).returns(true)
     assert_equal 'en-US/d41d8cd98f00b204e9800998ecf8427e/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sharon22k-180-100.mp3', @level_without_instructions.tts_path(@level_without_instructions.tts_short_instructions_text)
     assert_equal 'en-US/71c7e35e3633b5dfce472bcbed146e9f/f79d6e6828e6718bed14558024294018fc4411cd41cee4bac066656f70d8f718/sharon22k-180-100.mp3', @level_with_instructions.tts_path(@level_with_instructions.tts_short_instructions_text)
     assert_equal 'en-US/e3b3f56615d1e5f2608d2f1130a7ef54/ce603774135699e9abdfd65eb1f2733774da58af91782528e82ef5f9efdb8fba/sharon22k-180-100.mp3', @level_with_instructions_override.tts_path(@level_with_instructions_override.tts_short_instructions_text)

--- a/dashboard/test/models/concerns/text_to_speech_test.rb
+++ b/dashboard/test/models/concerns/text_to_speech_test.rb
@@ -2,40 +2,49 @@ require 'test_helper'
 
 class TextToSpeechTest < ActiveSupport::TestCase
   setup do
-    @level_without_instructions = Level.create
+    @level_without_instructions = Level.create(name: 'level-without-instructions')
     @level_with_instructions = Level.create(
-      {short_instructions: 'regular instructions that *can* also contain **formatting**'}
+      {
+        short_instructions: 'regular instructions that *can* also contain **formatting**',
+        name: 'level-with-instructions',
+      }
     )
     @level_with_instructions_override = Level.create(
       {
         short_instructions: 'regular instructions that *can* also contain **formatting**',
-        tts_short_instructions_override: 'override'
+        name: 'level-with-instructions-override',
+        tts_short_instructions_override: 'override',
       }
     )
     @level_with_long_instructions = Level.create(
       {
-        long_instructions: '*regular* `markdown_instructions` with _some_ [extra](formatting)'
+        long_instructions: '*regular* `markdown_instructions` with _some_ [extra](formatting)',
+        name: 'level-with-long-instructions',
       }
     )
     @level_with_long_instructions_override = Level.create(
       {
         long_instructions: 'regular markdown_instructions',
+        name: 'level-with-long-instructions-override',
         tts_long_instructions_override: 'markdown override'
       }
     )
     @level_with_raw_html = Level.create(
       {
-        long_instructions: 'This should have <br/> no <strong>excess</strong> formatting'
+        long_instructions: 'This should have <br/> no <strong>excess</strong> formatting',
+        name: 'level-with-raw-html',
       }
     )
     @level_with_block_html = Level.create(
       {
-        long_instructions: "This block should get stripped:\n\n<div><p>Test</p></div>"
+        long_instructions: "This block should get stripped:\n\n<div><p>Test</p></div>",
+        name: 'level-with-block-html',
       }
     )
     @level_with_xml = Level.create(
       {
-        long_instructions: "This block should get stripped:\n\n<xml><block type='maze_turn'><title name='DIR'>turnLeft</title></block></xml>"
+        long_instructions: "This block should get stripped:\n\n<xml><block type='maze_turn'><title name='DIR'>turnLeft</title></block></xml>",
+        name: 'level-with-xml',
       }
     )
   end
@@ -53,15 +62,27 @@ class TextToSpeechTest < ActiveSupport::TestCase
   end
 
   test 'tts_short_instructions_audio_file' do
-    assert_equal 'sharon22k/180/100/d41d8cd98f00b204e9800998ecf8427e/.mp3', @level_without_instructions.tts_path(@level_without_instructions.tts_short_instructions_text)
-    assert_equal 'sharon22k/180/100/71c7e35e3633b5dfce472bcbed146e9f/.mp3', @level_with_instructions.tts_path(@level_with_instructions.tts_short_instructions_text)
-    assert_equal 'sharon22k/180/100/e3b3f56615d1e5f2608d2f1130a7ef54/.mp3', @level_with_instructions_override.tts_path(@level_with_instructions_override.tts_short_instructions_text)
+    assert_equal 'sharon22k/180/100/d41d8cd98f00b204e9800998ecf8427e/level-without-instructions.mp3', @level_without_instructions.tts_path(@level_without_instructions.tts_short_instructions_text)
+    assert_equal 'sharon22k/180/100/71c7e35e3633b5dfce472bcbed146e9f/level-with-instructions.mp3', @level_with_instructions.tts_path(@level_with_instructions.tts_short_instructions_text)
+    assert_equal 'sharon22k/180/100/e3b3f56615d1e5f2608d2f1130a7ef54/level-with-instructions-override.mp3', @level_with_instructions_override.tts_path(@level_with_instructions_override.tts_short_instructions_text)
+
+    DCDO.stubs(:get).with('updated_tts_path', false).returns(true)
+    assert_equal 'en-US/d41d8cd98f00b204e9800998ecf8427e/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sharon22k-180-100.mp3', @level_without_instructions.tts_path(@level_without_instructions.tts_short_instructions_text)
+    assert_equal 'en-US/71c7e35e3633b5dfce472bcbed146e9f/f79d6e6828e6718bed14558024294018fc4411cd41cee4bac066656f70d8f718/sharon22k-180-100.mp3', @level_with_instructions.tts_path(@level_with_instructions.tts_short_instructions_text)
+    assert_equal 'en-US/e3b3f56615d1e5f2608d2f1130a7ef54/ce603774135699e9abdfd65eb1f2733774da58af91782528e82ef5f9efdb8fba/sharon22k-180-100.mp3', @level_with_instructions_override.tts_path(@level_with_instructions_override.tts_short_instructions_text)
+    DCDO.unstub(:get)
   end
 
   test 'tts_long_instructions_audio_file' do
-    assert_equal 'sharon22k/180/100/d41d8cd98f00b204e9800998ecf8427e/.mp3', @level_without_instructions.tts_path(@level_without_instructions.tts_long_instructions_text)
-    assert_equal 'sharon22k/180/100/30a2253e7b14efb1e925743d4afcf405/.mp3', @level_with_long_instructions.tts_path(@level_with_long_instructions.tts_long_instructions_text)
-    assert_equal 'sharon22k/180/100/25352162fcc2d1e5c4ea3f91b9b39c3f/.mp3', @level_with_long_instructions_override.tts_path(@level_with_long_instructions_override.tts_long_instructions_text)
+    assert_equal 'sharon22k/180/100/d41d8cd98f00b204e9800998ecf8427e/level-without-instructions.mp3', @level_without_instructions.tts_path(@level_without_instructions.tts_long_instructions_text)
+    assert_equal 'sharon22k/180/100/30a2253e7b14efb1e925743d4afcf405/level-with-long-instructions.mp3', @level_with_long_instructions.tts_path(@level_with_long_instructions.tts_long_instructions_text)
+    assert_equal 'sharon22k/180/100/25352162fcc2d1e5c4ea3f91b9b39c3f/level-with-long-instructions-override.mp3', @level_with_long_instructions_override.tts_path(@level_with_long_instructions_override.tts_long_instructions_text)
+
+    DCDO.stubs(:get).with('updated_tts_path', false).returns(true)
+    assert_equal 'en-US/d41d8cd98f00b204e9800998ecf8427e/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sharon22k-180-100.mp3', @level_without_instructions.tts_path(@level_without_instructions.tts_long_instructions_text)
+    assert_equal 'en-US/30a2253e7b14efb1e925743d4afcf405/80210df1ddaa6daaf02b4f65cf48af881a15ce4e39eb2e42ad32c160111694ff/sharon22k-180-100.mp3', @level_with_long_instructions.tts_path(@level_with_long_instructions.tts_long_instructions_text)
+    assert_equal 'en-US/25352162fcc2d1e5c4ea3f91b9b39c3f/961af80b7a080677af7a38483c3d39b432f60493ec527bc4e45e495223c4f3b9/sharon22k-180-100.mp3', @level_with_long_instructions_override.tts_path(@level_with_long_instructions_override.tts_long_instructions_text)
+    DCDO.unstub(:get)
   end
 
   test 'sanitize html and xml' do
@@ -226,10 +247,19 @@ class TextToSpeechTest < ActiveSupport::TestCase
 
   test 'tts_url should return nil given locale not supported for TTS' do
     assert_nil(@level_without_instructions.tts_url(@level_without_instructions.tts_short_instructions_text, :'te-ST'))
+
+    DCDO.stubs(:get).with('updated_tts_path', false).returns(true)
+    assert_nil(@level_without_instructions.tts_url(@level_without_instructions.tts_short_instructions_text, :'te-ST'))
+    DCDO.unstub(:get)
   end
 
   test 'tts_url should return a url to a tts file' do
-    expected_tts_url = 'https://tts.code.org/sharon22k/180/100/71c7e35e3633b5dfce472bcbed146e9f/.mp3'
+    expected_tts_url = 'https://tts.code.org/sharon22k/180/100/71c7e35e3633b5dfce472bcbed146e9f/level-with-instructions.mp3'
     assert_equal(expected_tts_url, @level_with_instructions.tts_url(@level_with_instructions.tts_short_instructions_text, :'en-US'))
+
+    DCDO.stubs(:get).with('updated_tts_path', false).returns(true)
+    expected_tts_url = 'https://tts.code.org/en-US/71c7e35e3633b5dfce472bcbed146e9f/f79d6e6828e6718bed14558024294018fc4411cd41cee4bac066656f70d8f718/sharon22k-180-100.mp3'
+    assert_equal(expected_tts_url, @level_with_instructions.tts_url(@level_with_instructions.tts_short_instructions_text, :'en-US'))
+    DCDO.unstub(:get)
   end
 end

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -567,6 +567,7 @@ class BlocklyTest < ActiveSupport::TestCase
   test 'localizes authored hints with embedded behavior block' do
     DCDO.stubs(:get).with(Blockly::BLOCKLY_I18N_IN_TEXT_DCDO_KEY, false).returns(true)
     DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
+    DCDO.stubs(:get).with(TextToSpeech::UPDATED_TTS_PATH_DCDO_KEY, false).returns(true)
     test_locale = :'es-MX'
     level_name = 'test_localize_authored_hints_with_embedded_behavior_block'
     hint = <<~HINT


### PR DESCRIPTION
This updates the `TextToSpeech` module to change the path where the files are stored to be more robust toward handling data deduplication.

The motivation is that when courses are cloned, this causes a major spike in our usage of our third-party TTS generation service which is needlessly expensive. During these spikes, something around 90% of the generated content is content we already have.

Also, we have no way of knowing the provenance of the generated files in the current scheme. We are both missing a lot of audio files (which indeed silently error out on the production site itself) and have a ton of disconnected files that are no longer used hanging out in our bucket. This update doesn't ensure that this doesn't happen, but rather also records a metadata file such that we can know which files are similarly abandoned in the future and perhaps write a script to periodically clean the bucket.

On that note, this update also includes a one-off script that will copy the current files to the new scheme. See "deployment" for details on the order of operations.

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Data

This is a report generated by analyzing the bucket metadata showing the redundant work of the current implementation that would be 100% avoided by the new approach:

```
There are 29967 unique strings with TTS generated audio files.
There are 57070 audio files that have been generated.

Maximum number of redundant tts strings: 180
  Within: sharon22k/180/100/2ca6aec7e2b9280a05a9d98590324740 ex: csa-prework-m4-predict-level-2023.mp3
  For which, 55 were made the same day: 2024-01-12

The highest volume day was: 2021-09-15
  On that day, 2474 strings were generated. Only some were new.
  For instance, string 11cc9ad331b803cf33f2ca1e0aa34390/ml-intro ai lab-shapes v1.mp3 is new.
  For instance, string 1626a98ef8edf7263915099c3529fd77/ml-mini project-ai lab 2.mp3 is new.
  There were 2453 redundant strings generated.

On 2020-01-21 there was a dramatic generation.
  On that day, 2217 strings were generated. Only some were new.
  For instance, string 0028a3f8bd24a1099e546c74a9c958f2/Overworld Plant Crops.mp3 is new.
  For instance, string 007b52e163344d32ca3dffa4fc66fde2/Course 4 Artist Vars 4.mp3 is new.
  There were 1556 redundant strings generated.

On 2022-05-19 there was a dramatic generation.
  On that day, 2053 strings were generated. Only some were new.
  For instance, string 14089f06d9474ce94ea56e6020b58036/CSA U2L9-L5_2022.mp3 is new.
  For instance, string 1651affc172939c9afb5f3cef2a6bee4/CSA U1L12-L5_2022.mp3 is new.
  There were 2033 redundant strings generated.

On 2023-06-28 there was a dramatic generation.
  On that day, 1992 strings were generated. Only some were new.
  For instance, string 1797bf3a29a185365951772a29971f26/U6_L03_Lists Practice_Choice_1-1.mp3 is new.
  For instance, string 3c5bf2cb21491819b2493da7949812e3/U6_L03_Lists Practice_Choice_2-4.mp3 is new.
  There were 1983 redundant strings generated.

On 2020-02-17 there was a dramatic generation.
  On that day, 1879 strings were generated. Only some were new.
  For instance, string 01fdbbbc6a4daaf588ec78427ea92f5d/courseF_farmer_ramp11.mp3 is new.
  For instance, string 0239c0248cca1709124972373f999d11/iceage_repeat.mp3 is new.
  There were 1265 redundant strings generated.

In total, in the 5 days with the most volume, we generated 10615 strings.
Of those, roughly 9290 were strings we already had.

We performed 801% more work than necessary.
```

## Links

- jira ticket: [P20-280](https://codedotorg.atlassian.net/browse/P20-280) - High call rate to Acapela-TTS
- jira ticket: [P20-762](https://codedotorg.atlassian.net/browse/P20-762) - Transition generated Acapela files to using MD5+SHA1 hashes

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

Updated the existing tests to check the old and new behavior based on stubbing the experiment value.

## Deployment strategy

We will do the following:

1. Deploy this change
2. Run the one-off script to copy the bucket contents for known text
3. Set the `updated_tts_path` DCDO variable to `true`

If there is any problem, we turn off that flag and it will revert to using the old contents.

Eventually, we will be able to permanently set that flag in a subsequent PR and then delete the old files.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
