### PR TITLE
Open LTI sync dialog links in new tabs

### DIFF
--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
@@ -74,7 +74,11 @@ export default function LtiSectionSyncDialog({
       <div>
         <h2 style={styles.dialogHeader}>{i18n.errorOccurredTitle()}</h2>
         {errorMessages.map((errorMessage: string, index: React.Key) => (
-          <SafeMarkdown key={index} markdown={errorMessage} />
+          <SafeMarkdown
+            openExternalLinksInNewTab={true}
+            key={index}
+            markdown={errorMessage}
+          />
         ))}
       </div>
     );
@@ -181,7 +185,10 @@ export default function LtiSectionSyncDialog({
             {dialogTitle}
           </h2>
           <div onClick={handleDocsClick}>
-            <SafeMarkdown markdown={dialogDescription} />
+            <SafeMarkdown
+              openExternalLinksInNewTab={true}
+              markdown={dialogDescription}
+            />
           </div>
           <div
             style={styles.summaryContainer}


### PR DESCRIPTION
Adds the property to the markdown components in the LTI sync confirmation modal that causes links to open in new tabs.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-879)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
