### PR TITLE
Add permission to invoke Gen AI Sagemaker endpoints

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -189,7 +189,7 @@ Resources:
           # SageMaker Invoke Endpoint access
           - Effect: Allow
             Action: 'sagemaker:InvokeEndpoint'
-            Resource: '*'
+            Resource: !Sub “arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:endpoint/gen-ai-*”
 
   # ---------------------------------------------
   # Frontend Servers

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -186,6 +186,10 @@ Resources:
           - Effect: Allow
             Action: 's3:*'
             Resource: '*'
+          # SageMaker Invoke Endpoint access
+          - Effect: Allow
+            Action: 'sagemaker:InvokeEndpoint'
+            Resource: '*'
 
   # ---------------------------------------------
   # Frontend Servers

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -13,6 +13,7 @@ class AichatController < ApplicationController
     unless has_required_params?
       return render status: :bad_request, json: {}
     end
+    puts "Received chat completion request with params: #{params}"
 
     # Check for PII / Profanity
     # Copied from ai_tutor_interactions_controller.rb - not sure if filtering is working.
@@ -24,8 +25,11 @@ class AichatController < ApplicationController
     return render(status: :ok, json: {status: filter_result.type, flagged_content: filter_result.content}) if filter_result
 
     input_json = AichatHelper.format_inputs_for_sagemaker_request(params[:aichatModelCustomizations], params[:storedMessages], params[:newMessage])
+    puts "Sending input to SageMaker: #{input_json}"
     sagemaker_response = AichatHelper.request_sagemaker_chat_completion(input_json)
+    puts "sagemaker_response: #{sagemaker_response}"
     latest_assistant_response = AichatHelper.get_sagemaker_assistant_response(sagemaker_response)
+    puts "latest_assistant_response: #{latest_assistant_response}"
     payload = {
       role: "assistant",
       content: latest_assistant_response

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -13,7 +13,6 @@ class AichatController < ApplicationController
     unless has_required_params?
       return render status: :bad_request, json: {}
     end
-    puts "Received chat completion request with params: #{params}"
 
     # Check for PII / Profanity
     # Copied from ai_tutor_interactions_controller.rb - not sure if filtering is working.
@@ -25,11 +24,8 @@ class AichatController < ApplicationController
     return render(status: :ok, json: {status: filter_result.type, flagged_content: filter_result.content}) if filter_result
 
     input_json = AichatHelper.format_inputs_for_sagemaker_request(params[:aichatModelCustomizations], params[:storedMessages], params[:newMessage])
-    puts "Sending input to SageMaker: #{input_json}"
     sagemaker_response = AichatHelper.request_sagemaker_chat_completion(input_json)
-    puts "sagemaker_response: #{sagemaker_response}"
     latest_assistant_response = AichatHelper.get_sagemaker_assistant_response(sagemaker_response)
-    puts "latest_assistant_response: #{latest_assistant_response}"
     payload = {
       role: "assistant",
       content: latest_assistant_response

--- a/dashboard/app/helpers/aichat_helper.rb
+++ b/dashboard/app/helpers/aichat_helper.rb
@@ -40,7 +40,6 @@ module AichatHelper
   end
 
   def self.request_sagemaker_chat_completion(input_json)
-    puts "Inside aicht_helper.rb - Sending input to SageMaker: #{input_json}"
     SAGEMAKER_CLIENT.invoke_endpoint(
       endpoint_name: SAGEMAKER_MODEL_ENDPOINT, # required
       body: input_json.to_json, # required

--- a/dashboard/app/helpers/aichat_helper.rb
+++ b/dashboard/app/helpers/aichat_helper.rb
@@ -40,6 +40,7 @@ module AichatHelper
   end
 
   def self.request_sagemaker_chat_completion(input_json)
+    puts "Inside aicht_helper.rb - Sending input to SageMaker: #{input_json}"
     SAGEMAKER_CLIENT.invoke_endpoint(
       endpoint_name: SAGEMAKER_MODEL_ENDPOINT, # required
       body: input_json.to_json, # required


### PR DESCRIPTION
PR co-authored-by: @sanchitmalhotra126 

This PR updates AWS API permissions to web application servers so that SageMaker endpoints that are prefixed with 'gen-ai' are accessible.

@sureshc said there are different ways to implement this. For now, this PR adds a Stack Parameter that specifies the SageMaker Endpoints and passes that value to the Policy configuration.
More context in [Slack thread discuss](https://codedotorg.slack.com/archives/C03CK49G9/p1713890995791009)
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
