### PR TITLE
Music: show pack image in mini-player

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -21,7 +21,7 @@ export interface Channel {
   // Optional lab-specific configuration for this project.  If provided, this will be saved
   // to the Project model in the database along with the other entries in this interface,
   // inside the value field JSON.
-  labConfig?: {[key: string]: object};
+  labConfig?: {[key: string]: {[key: string]: string}};
 }
 
 export type DefaultChannel = Pick<Channel, 'name'>;
@@ -31,7 +31,7 @@ export interface ProjectSources {
   // Source code can either be a string or a nested JSON object (for multi-file).
   source: string | MultiFileSource;
   // Optional lab-specific configuration for this project
-  labConfig?: {[key: string]: object};
+  labConfig?: {[key: string]: {[key: string]: string}};
   // Add other properties (animations, html, etc) as needed.
 }
 

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -159,6 +159,21 @@ export default class MusicLibrary {
     return folders.find(folder => folder.id === folderId) || null;
   }
 
+  // Given a pack ID (e.g. "pack1"), return the path for its image.
+  getPackImageUrl(packId: string): string | undefined {
+    const folder = this.getFolderForFolderId(packId);
+    if (!folder) {
+      return undefined;
+    }
+
+    return (
+      folder.imageSrc &&
+      `${getBaseAssetUrl()}${this.libraryJson.path}/${folder.path}/${
+        folder.imageSrc
+      }`
+    );
+  }
+
   // A progression step might specify a smaller set of allowed sounds.
   setAllowedSounds(allowedSounds: Sounds): void {
     this.allowedSounds = allowedSounds;

--- a/apps/src/music/views/MiniMusicPlayer.module.scss
+++ b/apps/src/music/views/MiniMusicPlayer.module.scss
@@ -6,6 +6,7 @@
   flex-direction: column;
   gap: 10px;
   padding: 10px;
+  user-select: none;
 
   .entry {
     background-color: $neutral_dark80;
@@ -15,12 +16,14 @@
     display: flex;
     align-items: center;
     box-sizing: border-box;
-    padding: 10px;
+    padding: 4px;
+    padding-inline-end: 15px;
+    gap: 20px;
 
     .control {
-      width: 60px;
-      padding-left: 10px;
+      display: contents;
       box-sizing: border-box;
+      text-align: center;
 
       .icon {
         transition: opacity 0.1s ease-in;
@@ -28,20 +31,35 @@
       }
     }
 
+    .pack {
+      width: 42px;
+      height: 42px;
+
+      &Image {
+        height: 42px;
+        width: 42px;
+        max-width: initial;
+      }
+    }
+
     .name {
       flex-grow: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .other {
-      width: 60px;
-      display: flex;
-      justify-content: flex-end;
-      margin-right: 10px;
+      display: contents;
 
-      .icon {
-        transition: opacity 0.1s ease-in;
-        color: $neutral_light;
-        font-size: 16px;
+      &Link {
+        display: contents;
+
+        .icon {
+          transition: opacity 0.1s ease-in;
+          color: $neutral_light;
+          font-size: 16px;
+        }
       }
     }
   }

--- a/apps/src/music/views/MiniMusicPlayer.tsx
+++ b/apps/src/music/views/MiniMusicPlayer.tsx
@@ -13,7 +13,6 @@ import {setUpBlocklyForMusicLab} from '../blockly/setup';
 import Lab2Registry from '../../lab2/Lab2Registry';
 import moduleStyles from './MiniMusicPlayer.module.scss';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
-import {getBaseAssetUrl} from '../appConfig';
 
 interface MiniPlayerViewProps {
   projects: Channel[];
@@ -98,27 +97,6 @@ const MiniPlayerView: React.FunctionComponent<MiniPlayerViewProps> = ({
     setCurrentProjectId(undefined);
   }, []);
 
-  const getPackImageUrl = (packId: string) => {
-    const library = MusicLibrary.getInstance();
-    if (!library) {
-      return undefined;
-    }
-
-    const folder = library.getFolderForFolderId(packId);
-    if (!folder) {
-      return undefined;
-    }
-
-    const libraryGroupPath = library.getPath();
-
-    return (
-      folder.imageSrc &&
-      `${getBaseAssetUrl()}${libraryGroupPath}/${folder.path}/${
-        folder.imageSrc
-      }`
-    );
-  };
-
   // Some loading UI while we're fetching the library
   if (isLoading) {
     return <div>Loading...</div>;
@@ -140,7 +118,9 @@ const MiniPlayerView: React.FunctionComponent<MiniPlayerViewProps> = ({
             <div className={moduleStyles.pack}>
               {project.labConfig?.music?.packId && (
                 <img
-                  src={getPackImageUrl(project.labConfig?.music?.packId)}
+                  src={MusicLibrary.getInstance()?.getPackImageUrl(
+                    project.labConfig?.music?.packId
+                  )}
                   className={moduleStyles.packImage}
                   alt=""
                 />

--- a/apps/src/music/views/MiniMusicPlayer.tsx
+++ b/apps/src/music/views/MiniMusicPlayer.tsx
@@ -13,6 +13,7 @@ import {setUpBlocklyForMusicLab} from '../blockly/setup';
 import Lab2Registry from '../../lab2/Lab2Registry';
 import moduleStyles from './MiniMusicPlayer.module.scss';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
+import {getBaseAssetUrl} from '../appConfig';
 
 interface MiniPlayerViewProps {
   projects: Channel[];
@@ -97,6 +98,27 @@ const MiniPlayerView: React.FunctionComponent<MiniPlayerViewProps> = ({
     setCurrentProjectId(undefined);
   }, []);
 
+  const getPackImageUrl = (packId: string) => {
+    const library = MusicLibrary.getInstance();
+    if (!library) {
+      return undefined;
+    }
+
+    const folder = library.getFolderForFolderId(packId);
+    if (!folder) {
+      return undefined;
+    }
+
+    const libraryGroupPath = library.getPath();
+
+    return (
+      folder.imageSrc &&
+      `${getBaseAssetUrl()}${libraryGroupPath}/${folder.path}/${
+        folder.imageSrc
+      }`
+    );
+  };
+
   // Some loading UI while we're fetching the library
   if (isLoading) {
     return <div>Loading...</div>;
@@ -115,6 +137,16 @@ const MiniPlayerView: React.FunctionComponent<MiniPlayerViewProps> = ({
                 : onPlaySong(project);
             }}
           >
+            {project.labConfig?.music?.packId && (
+              <div className={moduleStyles.pack}>
+                <img
+                  src={getPackImageUrl(project.labConfig?.music?.packId)}
+                  className={moduleStyles.packImage}
+                  alt=""
+                />
+              </div>
+            )}
+
             <div className={moduleStyles.control}>
               <FontAwesomeV6Icon
                 iconName={project.id === currentProjectId ? 'stop' : 'play'}
@@ -122,21 +154,24 @@ const MiniPlayerView: React.FunctionComponent<MiniPlayerViewProps> = ({
                 className={moduleStyles.icon}
               />
             </div>
+
             <div className={moduleStyles.name}>{project.name}</div>
-            <a
-              href={`/projects/music/${project.id}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={e => e.stopPropagation()}
-            >
-              <div className={moduleStyles.other}>
+
+            <div className={moduleStyles.other}>
+              <a
+                href={`/projects/music/${project.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={e => e.stopPropagation()}
+                className={moduleStyles.otherLink}
+              >
                 <FontAwesomeV6Icon
                   iconName="arrow-up-right-from-square"
                   iconStyle="solid"
                   className={moduleStyles.icon}
                 />
-              </div>
-            </a>
+              </a>
+            </div>
           </div>
         );
       })}

--- a/apps/src/music/views/MiniMusicPlayer.tsx
+++ b/apps/src/music/views/MiniMusicPlayer.tsx
@@ -137,15 +137,15 @@ const MiniPlayerView: React.FunctionComponent<MiniPlayerViewProps> = ({
                 : onPlaySong(project);
             }}
           >
-            {project.labConfig?.music?.packId && (
-              <div className={moduleStyles.pack}>
+            <div className={moduleStyles.pack}>
+              {project.labConfig?.music?.packId && (
                 <img
                   src={getPackImageUrl(project.labConfig?.music?.packId)}
                   className={moduleStyles.packImage}
                   alt=""
                 />
-              </div>
-            )}
+              )}
+            </div>
 
             <div className={moduleStyles.control}>
               <FontAwesomeV6Icon

--- a/apps/src/music/views/PackDialog.tsx
+++ b/apps/src/music/views/PackDialog.tsx
@@ -5,7 +5,6 @@ import styles from './PackDialog.module.scss';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {setPackId} from '../redux/musicRedux';
 import MusicLibrary, {SoundFolder} from '../player/MusicLibrary';
-import {getBaseAssetUrl} from '../appConfig';
 import classNames from 'classnames';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import MusicPlayer from '../player/MusicPlayer';
@@ -13,7 +12,6 @@ import {DEFAULT_PACK} from '../constants';
 import musicI18n from '../locale';
 
 interface PackEntryProps {
-  libraryGroupPath: string;
   playingPreview: string | null;
   folder: SoundFolder;
   isSelected: boolean;
@@ -22,19 +20,18 @@ interface PackEntryProps {
 }
 
 const PackEntry: React.FunctionComponent<PackEntryProps> = ({
-  libraryGroupPath,
   playingPreview,
   folder,
   isSelected,
   onSelect,
   onPreview,
 }) => {
+  const library = MusicLibrary.getInstance();
+
   const previewSound = folder.sounds.find(sound => sound.type === 'preview');
   const soundPath = previewSound && folder.id + '/' + previewSound.src;
   const isPlayingPreview = previewSound && playingPreview === soundPath;
-  const imageSrc =
-    folder.imageSrc &&
-    `${getBaseAssetUrl()}${libraryGroupPath}/${folder.path}/${folder.imageSrc}`;
+  const imageSrc = library?.getPackImageUrl(folder.id);
 
   const onPreviewClick = useCallback(
     (e: Event) => {
@@ -183,7 +180,6 @@ const PackDialog: React.FunctionComponent<PackDialogProps> = ({player}) => {
   if (!library) return null;
 
   const folders = library.getRestrictedPacks();
-  const libraryGroupPath = library.getPath();
 
   if (currentPackId) {
     return null;
@@ -209,7 +205,6 @@ const PackDialog: React.FunctionComponent<PackDialogProps> = ({player}) => {
               return (
                 <PackEntry
                   key={folderIndex}
-                  libraryGroupPath={libraryGroupPath}
                   playingPreview={playingPreviewState}
                   folder={folder}
                   isSelected={folder.id === selectedFolderId}


### PR DESCRIPTION
With the pack ID now available in project enumeration, courtesy of https://github.com/code-dot-org/code-dot-org/pull/58179, the Music Lab mini-player is able to display the pack image.

This change also tidies up styling, and improves the RTL layout.

### LTR

<img width="410" alt="Screenshot 2024-04-25 at 8 37 23 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/0ee673c4-d986-4ee7-8efc-6198855213aa">

### RTL

<img width="410" alt="Screenshot 2024-04-25 at 8 37 12 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/355f73b4-528b-4b65-b016-81179e567d91">

### Kudos

Thanks to @markabarrett for making a compelling case to include this.