### PR TITLE
Lab2: enable share mode

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -57,6 +57,8 @@ export interface LabState {
   validationState: ValidationState;
   // Level properties for the current level.
   levelProperties: LevelProperties | undefined;
+  // If this lab should presented in a "share" or "play-only" view, which may hide certain UI elements.
+  isShareView: boolean | undefined;
 }
 
 const initialState: LabState = {
@@ -67,6 +69,7 @@ const initialState: LabState = {
   initialSources: undefined,
   validationState: getInitialValidationState(),
   levelProperties: undefined,
+  isShareView: undefined,
 };
 
 // Thunks
@@ -275,6 +278,9 @@ const labSlice = createSlice({
       state.levelProperties = action.payload.levelProperties;
       state.initialSources = action.payload.initialSources;
     },
+    setIsShareView(state, action: PayloadAction<boolean>) {
+      state.isShareView = action.payload;
+    },
   },
   extraReducers: builder => {
     builder.addCase(setUpWithLevel.fulfilled, state => {
@@ -423,8 +429,13 @@ async function cleanUpProjectManager() {
   Lab2Registry.getInstance().clearProjectManager();
 }
 
-export const {setIsLoading, setPageError, clearPageError, setValidationState} =
-  labSlice.actions;
+export const {
+  setIsLoading,
+  setPageError,
+  clearPageError,
+  setValidationState,
+  setIsShareView,
+} = labSlice.actions;
 
 // These should not be set outside of the lab slice.
 const {setChannel, onLevelChange} = labSlice.actions;

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -80,7 +80,7 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
     return () => {
       // If we have an early return, we will abort the promise in progress.
       // An early return could happen if the level is changed mid-load.
-      promise.abort();
+      promise?.abort();
     };
   }, [
     channelId,

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -36,7 +36,7 @@ export function getServerLevelId(): number | undefined {
  * Returns if the lab should presented in a share/play-only view,
  * if present in App Options. Only used in standalone project levels.
  */
-export function isShareView(): boolean | undefined {
+export function getIsShareView(): boolean | undefined {
   const appOptions = getScriptData('appoptions') as PartialAppOptions;
   return appOptions.share;
 }

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -27,7 +27,7 @@ export function getStandaloneProjectId(): string | undefined {
  * This is specifically used in scenarios where the level ID is not provided
  * by other means (for example via header.js)
  */
-export function getServerLevelId(): number | undefined {
+export function getAppOptionsLevelId(): number | undefined {
   const appOptions = getScriptData('appoptions') as PartialAppOptions;
   return appOptions.levelId;
 }

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -7,8 +7,6 @@ interface PartialAppOptions {
   channel: string;
   levelId: number;
   share: boolean;
-  iframeEmbed: boolean;
-  iframeEmbedAppAndCode: boolean;
 }
 
 /**
@@ -24,24 +22,23 @@ export function getStandaloneProjectId(): string | undefined {
   return appOptions.channel;
 }
 
+/**
+ * Returns the level ID provided by App Options, if available.
+ * This is specifically used in scenarios where the level ID is not provided
+ * by other means (for example via header.js)
+ */
 export function getServerLevelId(): number | undefined {
   const appOptions = getScriptData('appoptions') as PartialAppOptions;
   return appOptions.levelId;
 }
 
+/**
+ * Returns if the lab should presented in a share/play-only view,
+ * if present in App Options. Only used in standalone project levels.
+ */
 export function isShareView(): boolean | undefined {
   const appOptions = getScriptData('appoptions') as PartialAppOptions;
   return appOptions.share;
-}
-
-export function isIframeEmbed(): boolean | undefined {
-  const appOptions = getScriptData('appoptions') as PartialAppOptions;
-  return appOptions.iframeEmbed;
-}
-
-export function isIframeEmbedAppAndCode(): boolean | undefined {
-  const appOptions = getScriptData('appoptions') as PartialAppOptions;
-  return appOptions.iframeEmbedAppAndCode;
 }
 
 /**

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -1,4 +1,4 @@
-import getScriptData from '@cdo/apps/util/getScriptData';
+import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 import {ProjectFile} from '../types';
 
 // Partial definition of the App Options structure, only defining the
@@ -18,8 +18,10 @@ interface PartialAppOptions {
  * Note: We are trying to use app options as little as possible.
  */
 export function getStandaloneProjectId(): string | undefined {
-  const appOptions = getScriptData('appoptions') as PartialAppOptions;
-  return appOptions.channel;
+  if (hasScriptData('script[data-appoptions]')) {
+    const appOptions = getScriptData('appoptions') as PartialAppOptions;
+    return appOptions.channel;
+  }
 }
 
 /**
@@ -28,8 +30,10 @@ export function getStandaloneProjectId(): string | undefined {
  * by other means (for example via header.js)
  */
 export function getAppOptionsLevelId(): number | undefined {
-  const appOptions = getScriptData('appoptions') as PartialAppOptions;
-  return appOptions.levelId;
+  if (hasScriptData('script[data-appoptions]')) {
+    const appOptions = getScriptData('appoptions') as PartialAppOptions;
+    return appOptions.levelId;
+  }
 }
 
 /**
@@ -37,8 +41,10 @@ export function getAppOptionsLevelId(): number | undefined {
  * if present in App Options. Only used in standalone project levels.
  */
 export function getIsShareView(): boolean | undefined {
-  const appOptions = getScriptData('appoptions') as PartialAppOptions;
-  return appOptions.share;
+  if (hasScriptData('script[data-appoptions]')) {
+    const appOptions = getScriptData('appoptions') as PartialAppOptions;
+    return appOptions.share;
+  }
 }
 
 /**

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -6,6 +6,9 @@ import {ProjectFile} from '../types';
 interface PartialAppOptions {
   channel: string;
   levelId: number;
+  share: boolean;
+  iframeEmbed: boolean;
+  iframeEmbedAppAndCode: boolean;
 }
 
 /**
@@ -24,6 +27,21 @@ export function getStandaloneProjectId(): string | undefined {
 export function getServerLevelId(): number | undefined {
   const appOptions = getScriptData('appoptions') as PartialAppOptions;
   return appOptions.levelId;
+}
+
+export function isShareView(): boolean | undefined {
+  const appOptions = getScriptData('appoptions') as PartialAppOptions;
+  return appOptions.share;
+}
+
+export function isIframeEmbed(): boolean | undefined {
+  const appOptions = getScriptData('appoptions') as PartialAppOptions;
+  return appOptions.iframeEmbed;
+}
+
+export function isIframeEmbedAppAndCode(): boolean | undefined {
+  const appOptions = getScriptData('appoptions') as PartialAppOptions;
+  return appOptions.iframeEmbedAppAndCode;
 }
 
 /**

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -1,11 +1,11 @@
 import getScriptData from '@cdo/apps/util/getScriptData';
-import {ProjectFile, ProjectType} from '../types';
+import {ProjectFile} from '../types';
 
 // Partial definition of the App Options structure, only defining the
 // pieces we need in this component.
 interface PartialAppOptions {
   channel: string;
-  projectType: ProjectType;
+  levelId: number;
 }
 
 /**
@@ -21,9 +21,9 @@ export function getStandaloneProjectId(): string | undefined {
   return appOptions.channel;
 }
 
-export function getProjectType(): string {
+export function getServerLevelId(): number | undefined {
   const appOptions = getScriptData('appoptions') as PartialAppOptions;
-  return appOptions.projectType;
+  return appOptions.levelId;
 }
 
 /**

--- a/apps/src/lab2/views/Lab2.tsx
+++ b/apps/src/lab2/views/Lab2.tsx
@@ -3,18 +3,47 @@
  *
  * The top-level component that houses all Lab2 framework components.
  */
-import React from 'react';
+import React, {useEffect} from 'react';
 import {Provider} from 'react-redux';
 import {getStore} from '@cdo/apps/redux';
-import {getStandaloneProjectId} from '@cdo/apps/lab2/projects/utils';
+import {
+  getServerLevelId,
+  getStandaloneProjectId,
+  isShareView,
+} from '@cdo/apps/lab2/projects/utils';
 import Lab2Wrapper from './Lab2Wrapper';
 import ProjectContainer from '../projects/ProjectContainer';
 import MetricsAdapter from './MetricsAdapter';
 import LabViewsRenderer from './LabViewsRenderer';
 import DialogManager from './dialogs/DialogManager';
 import ThemeWrapper from './ThemeWrapper';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {setCurrentLevelId} from '@cdo/apps/code-studio/progressRedux';
+import {setIsShareView} from '../lab2Redux';
 
 const Lab2: React.FunctionComponent = () => {
+  // Store some server-provided data in redux.
+
+  const dispatch = useAppDispatch();
+  const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
+
+  // Store the level ID provided by App Options in redux if necessary.
+  // This is needed on pages without a header, such as the share view.
+  const serverLevelId = getServerLevelId();
+  useEffect(() => {
+    if (!currentLevelId && serverLevelId) {
+      dispatch(setCurrentLevelId(serverLevelId.toString()));
+    }
+  }, [currentLevelId, serverLevelId, dispatch]);
+
+  // Store whether we are in share view in redux, from App Options.
+  const shareView = isShareView();
+  useEffect(() => {
+    if (shareView !== undefined) {
+      dispatch(setIsShareView(shareView));
+    }
+  }, [shareView, dispatch]);
+
   return (
     <Provider store={getStore()}>
       <ThemeWrapper>

--- a/apps/src/lab2/views/Lab2.tsx
+++ b/apps/src/lab2/views/Lab2.tsx
@@ -3,47 +3,18 @@
  *
  * The top-level component that houses all Lab2 framework components.
  */
-import React, {useEffect} from 'react';
+import React from 'react';
 import {Provider} from 'react-redux';
 import {getStore} from '@cdo/apps/redux';
-import {
-  getServerLevelId,
-  getStandaloneProjectId,
-  isShareView,
-} from '@cdo/apps/lab2/projects/utils';
+import {getStandaloneProjectId} from '@cdo/apps/lab2/projects/utils';
 import Lab2Wrapper from './Lab2Wrapper';
 import ProjectContainer from '../projects/ProjectContainer';
 import MetricsAdapter from './MetricsAdapter';
 import LabViewsRenderer from './LabViewsRenderer';
 import DialogManager from './dialogs/DialogManager';
 import ThemeWrapper from './ThemeWrapper';
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {setCurrentLevelId} from '@cdo/apps/code-studio/progressRedux';
-import {setIsShareView} from '../lab2Redux';
 
 const Lab2: React.FunctionComponent = () => {
-  // Store some server-provided data in redux.
-
-  const dispatch = useAppDispatch();
-  const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
-
-  // Store the level ID provided by App Options in redux if necessary.
-  // This is needed on pages without a header, such as the share view.
-  const serverLevelId = getServerLevelId();
-  useEffect(() => {
-    if (!currentLevelId && serverLevelId) {
-      dispatch(setCurrentLevelId(serverLevelId.toString()));
-    }
-  }, [currentLevelId, serverLevelId, dispatch]);
-
-  // Store whether we are in share view in redux, from App Options.
-  const shareView = isShareView();
-  useEffect(() => {
-    if (shareView !== undefined) {
-      dispatch(setIsShareView(shareView));
-    }
-  }, [shareView, dispatch]);
-
   return (
     <Provider store={getStore()}>
       <ThemeWrapper>

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -22,7 +22,7 @@ import {ErrorFallbackPage, ErrorUI} from './ErrorFallbackPage';
 import Lab2Registry from '../Lab2Registry';
 import Loading from './Loading';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {getServerLevelId, getIsShareView} from '../projects/utils';
+import {getAppOptionsLevelId, getIsShareView} from '../projects/utils';
 import {setCurrentLevelId} from '@cdo/apps/code-studio/progressRedux';
 
 export interface Lab2WrapperProps {
@@ -44,12 +44,12 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
 
   // Store the level ID provided by App Options in redux if necessary.
   // This is needed on pages without a header, such as the share view.
-  const serverLevelId = getServerLevelId();
+  const appOptionsLevelId = getAppOptionsLevelId();
   useEffect(() => {
-    if (!currentLevelId && serverLevelId) {
-      dispatch(setCurrentLevelId(serverLevelId.toString()));
+    if (!currentLevelId && appOptionsLevelId) {
+      dispatch(setCurrentLevelId(appOptionsLevelId.toString()));
     }
-  }, [currentLevelId, serverLevelId, dispatch]);
+  }, [currentLevelId, appOptionsLevelId, dispatch]);
 
   // Store whether we are in share view in redux, from App Options.
   const isShareView = getIsShareView();

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -6,7 +6,7 @@
 // boundary; a fade-in between levels; a loading spinner when a level takes a
 // while to load; and a sad bee when things go wrong.
 
-import React from 'react';
+import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 import classNames from 'classnames';
 import moduleStyles from './Lab2Wrapper.module.scss';
@@ -16,6 +16,9 @@ import {LabState, isLabLoading, hasPageError} from '../lab2Redux';
 import {ErrorFallbackPage, ErrorUI} from './ErrorFallbackPage';
 import Lab2Registry from '../Lab2Registry';
 import Loading from './Loading';
+import {getServerLevelId} from '../projects/utils';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {setCurrentLevelId} from '@cdo/apps/code-studio/progressRedux';
 
 export interface Lab2WrapperProps {
   children: React.ReactNode;
@@ -28,6 +31,16 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
     (state: {lab: LabState}) =>
       state.lab.pageError?.errorMessage || state.lab.pageError?.error?.message
   );
+  const dispatch = useAppDispatch();
+
+  // Store the level ID provided by App Options in redux. This is needed
+  // on pages without a header, such as the share view.
+  const serverLevelId = getServerLevelId();
+  useEffect(() => {
+    if (serverLevelId) {
+      dispatch(setCurrentLevelId(serverLevelId.toString()));
+    }
+  }, [serverLevelId, dispatch]);
 
   return (
     <ErrorBoundary

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -6,16 +6,24 @@
 // boundary; a fade-in between levels; a loading spinner when a level takes a
 // while to load; and a sad bee when things go wrong.
 
-import React from 'react';
+import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 import classNames from 'classnames';
 import moduleStyles from './Lab2Wrapper.module.scss';
 import ErrorBoundary from '../ErrorBoundary';
-import {LabState, isLabLoading, hasPageError} from '../lab2Redux';
+import {
+  LabState,
+  isLabLoading,
+  hasPageError,
+  setIsShareView,
+} from '../lab2Redux';
 
 import {ErrorFallbackPage, ErrorUI} from './ErrorFallbackPage';
 import Lab2Registry from '../Lab2Registry';
 import Loading from './Loading';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {getServerLevelId, isShareView} from '../projects/utils';
+import {setCurrentLevelId} from '@cdo/apps/code-studio/progressRedux';
 
 export interface Lab2WrapperProps {
   children: React.ReactNode;
@@ -28,6 +36,28 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
     (state: {lab: LabState}) =>
       state.lab.pageError?.errorMessage || state.lab.pageError?.error?.message
   );
+
+  // Store some server-provided data in redux.
+
+  const dispatch = useAppDispatch();
+  const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
+
+  // Store the level ID provided by App Options in redux if necessary.
+  // This is needed on pages without a header, such as the share view.
+  const serverLevelId = getServerLevelId();
+  useEffect(() => {
+    if (!currentLevelId && serverLevelId) {
+      dispatch(setCurrentLevelId(serverLevelId.toString()));
+    }
+  }, [currentLevelId, serverLevelId, dispatch]);
+
+  // Store whether we are in share view in redux, from App Options.
+  const shareView = isShareView();
+  useEffect(() => {
+    if (shareView !== undefined) {
+      dispatch(setIsShareView(shareView));
+    }
+  }, [shareView, dispatch]);
 
   return (
     <ErrorBoundary

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -22,7 +22,7 @@ import {ErrorFallbackPage, ErrorUI} from './ErrorFallbackPage';
 import Lab2Registry from '../Lab2Registry';
 import Loading from './Loading';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {getServerLevelId, isShareView} from '../projects/utils';
+import {getServerLevelId, getIsShareView} from '../projects/utils';
 import {setCurrentLevelId} from '@cdo/apps/code-studio/progressRedux';
 
 export interface Lab2WrapperProps {
@@ -52,12 +52,12 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
   }, [currentLevelId, serverLevelId, dispatch]);
 
   // Store whether we are in share view in redux, from App Options.
-  const shareView = isShareView();
+  const isShareView = getIsShareView();
   useEffect(() => {
-    if (shareView !== undefined) {
-      dispatch(setIsShareView(shareView));
+    if (isShareView !== undefined) {
+      dispatch(setIsShareView(isShareView));
     }
-  }, [shareView, dispatch]);
+  }, [isShareView, dispatch]);
 
   return (
     <ErrorBoundary

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -6,7 +6,7 @@
 // boundary; a fade-in between levels; a loading spinner when a level takes a
 // while to load; and a sad bee when things go wrong.
 
-import React, {useEffect} from 'react';
+import React from 'react';
 import {useSelector} from 'react-redux';
 import classNames from 'classnames';
 import moduleStyles from './Lab2Wrapper.module.scss';
@@ -16,9 +16,6 @@ import {LabState, isLabLoading, hasPageError} from '../lab2Redux';
 import {ErrorFallbackPage, ErrorUI} from './ErrorFallbackPage';
 import Lab2Registry from '../Lab2Registry';
 import Loading from './Loading';
-import {getServerLevelId} from '../projects/utils';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
-import {setCurrentLevelId} from '@cdo/apps/code-studio/progressRedux';
 
 export interface Lab2WrapperProps {
   children: React.ReactNode;
@@ -31,16 +28,6 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
     (state: {lab: LabState}) =>
       state.lab.pageError?.errorMessage || state.lab.pageError?.error?.message
   );
-  const dispatch = useAppDispatch();
-
-  // Store the level ID provided by App Options in redux. This is needed
-  // on pages without a header, such as the share view.
-  const serverLevelId = getServerLevelId();
-  useEffect(() => {
-    if (serverLevelId) {
-      dispatch(setCurrentLevelId(serverLevelId.toString()));
-    }
-  }, [serverLevelId, dispatch]);
 
   return (
     <ErrorBoundary

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -585,18 +585,14 @@ class ProjectsController < ApplicationController
   # Redirect to the correct view/edit page for Lab2 projects. If a project owner is on a /view
   # page, redirect to /edit. If a non-owner is on an /edit page, redirect to /view.
   # For legacy (non-Lab2) labs, this is handled on the front-end.
-  # We will also redirect away from share URLs to the correct view/edit page as Lab2 does not
-  # yet support separate share pages.
   private def redirect_edit_view_for_lab2
     return nil unless @level.uses_lab2?
-    sharing = params[:iframe_embed] == true || params[:share] == true
-    return nil if sharing
 
     project = Projects.new(get_storage_id).get(params[:channel_id])
     is_owner = project[:isOwner]
 
-    return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/edit" if is_owner && (sharing || request.path.ends_with?('/view'))
-    return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/view" if !is_owner && (sharing || request.path.ends_with?('/edit'))
+    return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/edit" if is_owner && request.path.ends_with?('/view')
+    return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/view" if !is_owner && request.path.ends_with?('/edit')
   end
 
   # Automatically catch authorization exceptions on any methods in this controller

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -589,10 +589,11 @@ class ProjectsController < ApplicationController
   # yet support separate share pages.
   private def redirect_edit_view_for_lab2
     return nil unless @level.uses_lab2?
+    sharing = params[:iframe_embed] == true || params[:share] == true
+    return nil if sharing
 
     project = Projects.new(get_storage_id).get(params[:channel_id])
     is_owner = project[:isOwner]
-    sharing = params[:iframe_embed] == true || params[:share] == true
 
     return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/edit" if is_owner && (sharing || request.path.ends_with?('/view'))
     return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/view" if !is_owner && (sharing || request.path.ends_with?('/edit'))

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -319,7 +319,7 @@ module LevelsHelper
 
     @app_options =
       if @level.uses_lab2?
-        {app: 'lab2', channel: view_options[:channel], projectType: @level.project_type}
+        {channel: view_options[:channel], levelId: @level.id}
       elsif @level.is_a? Blockly
         blockly_options
       elsif @level.is_a?(Weblab) || @level.is_a?(Fish) || @level.is_a?(Ailab) || @level.is_a?(Javalab)

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -319,7 +319,7 @@ module LevelsHelper
 
     @app_options =
       if @level.uses_lab2?
-        {channel: view_options[:channel], levelId: @level.id}
+        lab2_options
       elsif @level.is_a? Blockly
         blockly_options
       elsif @level.is_a?(Weblab) || @level.is_a?(Fish) || @level.is_a?(Ailab) || @level.is_a?(Javalab)
@@ -730,6 +730,12 @@ module LevelsHelper
     end
 
     app_options
+  end
+
+  def lab2_options
+    app_options = {channel: view_options[:channel], level_id: @level.id}
+    app_options.merge! level_view_options(@level.id)
+    app_options.camelize_keys
   end
 
   def build_copyright_strings

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -733,6 +733,7 @@ module LevelsHelper
   end
 
   def lab2_options
+    raise ArgumentError.new("#{@level} is not a Lab2 level") unless @level.uses_lab2?
     app_options = {channel: view_options[:channel], level_id: @level.id}
     level_options = level_view_options(@level.id)
     app_options[:share] = level_options[:share] if level_options[:share]

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -734,7 +734,8 @@ module LevelsHelper
 
   def lab2_options
     app_options = {channel: view_options[:channel], level_id: @level.id}
-    app_options.merge! level_view_options(@level.id)
+    level_options = level_view_options(@level.id)
+    app_options[:share] = level_options[:share] if level_options[:share]
     app_options.camelize_keys
   end
 

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -442,40 +442,4 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_response :redirect
     assert_redirected_to "/projects/music/#{channel_id}/view"
   end
-
-  test 'on lab2 levels navigating to a share URL redirects to /edit if user is project owner' do
-    channel_id = '12345'
-    Projects.any_instance.stubs(:get).returns({isOwner: true})
-
-    get :show, params: {path: "/projects/music/#{channel_id}", key: 'music', channel_id: channel_id, share: true}
-    assert_response :redirect
-    assert_redirected_to "/projects/music/#{channel_id}/edit"
-  end
-
-  test 'on lab2 levels navigating to a share URL redirects to /view if user is not project owner' do
-    channel_id = '12345'
-    Projects.any_instance.stubs(:get).returns({isOwner: false})
-
-    get :edit, params: {path: "/projects/music/#{channel_id}", key: 'music', channel_id: channel_id, share: true}
-    assert_response :redirect
-    assert_redirected_to "/projects/music/#{channel_id}/view"
-  end
-
-  test 'on lab2 levels navigating to an embed URL redirects to /edit if user is project owner' do
-    channel_id = '12345'
-    Projects.any_instance.stubs(:get).returns({isOwner: true})
-
-    get :show, params: {path: "/projects/music/#{channel_id}/embed", key: 'music', channel_id: channel_id, iframe_embed: true}
-    assert_response :redirect
-    assert_redirected_to "/projects/music/#{channel_id}/edit"
-  end
-
-  test 'on lab2 levels navigating to an embed URL redirects to /view if user is not project owner' do
-    channel_id = '12345'
-    Projects.any_instance.stubs(:get).returns({isOwner: false})
-
-    get :edit, params: {path: "/projects/music/#{channel_id}/embed", key: 'music', channel_id: channel_id, iframe_embed: true}
-    assert_response :redirect
-    assert_redirected_to "/projects/music/#{channel_id}/view"
-  end
 end

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -1134,4 +1134,26 @@ class LevelsHelperTest < ActionView::TestCase
     set_hint_prompt_options(level_options)
     assert_nil level_options[:hintPromptAttemptsThreshold]
   end
+
+  test "lab2_options refuses to generate options for non-Lab2 levels" do
+    @level = create(:gamelab)
+    assert_raises(ArgumentError) do
+      lab2_options
+    end
+  end
+
+  test "lab2_options generates options for Lab2 levels" do
+    @level = create(:music)
+
+    channel = 'channel123'
+    view_options(channel: channel)
+    level_view_options(@level.id, share: true)
+
+    options = lab2_options
+    assert_equal channel, options["channel"]
+    assert_equal @level.id, options["levelId"]
+    assert_equal true, options["share"]
+
+    reset_view_options
+  end
 end


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Description

This enables the "share" / "play" mode for Lab2 labs (i.e. the view presented when navigating to a /projects/\<app\>/\<channelId\> link, without /view or /edit). Previously, we were just redirecting the user back to /view or /edit, but we now allow access to this page.

One callout - because the share page is presented without a header, the code in header.js responsible for setting the current level ID never runs, so we instead grab the level ID from app options and store it in Redux in Lab2Wrapper. Longer term there's a discussion to be had about decoupling the code that initializes progress from header.js, as I'm sure there would be instances where we'd want some progress-related information available even if the header is not displayed.

Music Lab in "share" view (currently just displays the existing UI, but will eventually display the Music Lab share UI as part of LABS-654)

<img width="1512" alt="Screenshot 2024-04-24 at 3 34 16 PM (2)" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/349eebe3-db64-4107-b0c7-3aaed969d480">


## Links

Related to https://codedotorg.atlassian.net/browse/LABS-654

## Testing story

Tested this with standalone projects.