### PR TITLE
Remove Build Metrics Database Connection Configuration.

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -550,8 +550,6 @@ logs_bucket:
 redshift_host:
 redshift_password:
 
-devinternal_db_writer: !Secret
-
 # Until we have a better configuration setting service, use AWS Secrets Manager to store these non-secret values.
 db_cluster_id: !StackSecret
 db_endpoint_writer: !StackSecret

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -32,7 +32,6 @@ disable_s3_image_uploads: true
 
 chef_local_mode: true
 
-devinternal_db_writer: !Secret
 dashboard_honeybadger_api_key: '00000000'
 pegasus_honeybadger_api_key:   '00000000'
 google_safe_browsing_key: fake_api_key

--- a/config/levelbuilder.yml.erb
+++ b/config/levelbuilder.yml.erb
@@ -3,7 +3,6 @@ firebase_name: cdo-v3-lb
 use_acapela:                true
 use_pusher:                 true
 jotform_api_key:
-devinternal_db_writer:
 dashboard_microsoft_key:
 dashboard_microsoft_secret:
 


### PR DESCRIPTION
Follow up to #58108 

Once the above Pull Request has been deployed to all managed environments and engineer workstations, remove the configuration setting that stores the database connection information (hostname, SQL login credentials, etc.) for the build metrics database.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

1. Delete the `devinternal_db_writer` Attribute from Manage Chef from any Environment where it is configured.
2. Wait until each Chef Managed environment has successfully completed a build (they populate globals.yml from Chef Secrets and our configuration system does not permit an entry in globals.yml that is NOT defined in config.yml)
3. Merge this change.
4. Delete all occurrences of the `devinternal_db_writer` AWS Secret

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
