### PR TITLE
Add How AI Works video carousel to code.org/ai page

### DIFF
--- a/apps/src/sites/code.org/pages/views/swiper_page_ai.js
+++ b/apps/src/sites/code.org/pages/views/swiper_page_ai.js
@@ -10,6 +10,7 @@ register();
 
 const swiperActionBlocks = document.querySelector('swiper-container.swiper-01');
 const swiperQuotes = document.querySelector('swiper-container.swiper-02');
+const swiperVideos = document.querySelector('swiper-container.how-ai-works');
 
 const commonParams = {
   pagination: {
@@ -57,6 +58,19 @@ const quotesParams = {
   },
 };
 
+const videosParams = {
+  ...commonParams,
+  autoHeight: false,
+  // Responsive breakpoints
+  breakpoints: {
+    // when window width is >= 768px
+    768: {
+      slidesPerView: 2,
+      slidesPerGroup: 2,
+    },
+  },
+};
+
 const setSwiperParams = (swiper, params) => {
   Object.assign(swiper, params);
   swiper.initialize();
@@ -65,6 +79,7 @@ const setSwiperParams = (swiper, params) => {
 const swipers = [
   {swiper: swiperActionBlocks, params: actionBlocksParams},
   {swiper: swiperQuotes, params: quotesParams},
+  {swiper: swiperVideos, params: videosParams},
 ];
 
 swipers.forEach(({swiper, params}) => setSwiperParams(swiper, params));

--- a/apps/src/sites/code.org/pages/views/swiper_page_videos.js
+++ b/apps/src/sites/code.org/pages/views/swiper_page_videos.js
@@ -24,7 +24,6 @@ const swiperParams = {
     clickable: true,
   },
   spaceBetween: 24,
-  observeSlideChildren: true,
   // Responsive breakpoints
   breakpoints: {
     // when window width is >= 768px

--- a/pegasus/sites.v3/code.org/public/ai/index.haml
+++ b/pegasus/sites.v3/code.org/public/ai/index.haml
@@ -142,16 +142,7 @@ theme: responsive_full_width
   .wrapper
     %h2=hoc_s(:ai_video_series_title)
     %p=hoc_s(:ai_video_series_desc, markdown: :inline, locals: {how_ai_works_url: "/ai/how-ai-works"})
-    .video-series
-      = view :ai_vid_intro
-      = view :ai_vid_mlintro
-      = view :ai_vid_trainingdata
-      = view :ai_vid_neuralnetworks
-      = view :ai_vid_computervision
-      = view :ai_vid_chatbots
-      = view :ai_vid_creativity
-      = view :ai_vid_ethics1
-      = view :ai_vid_ethics2
+    = view :carousel_how_ai_works_video
 
 %section
   .wrapper


### PR DESCRIPTION
Adds the How AI Works video carousel to https://code.org/ai. Uses the same carousel view seen on https://code.org/videos.

**Jira ticket:** [ACQ-1798](https://codedotorg.atlassian.net/browse/ACQ-1798)

----

## Before

https://github.com/code-dot-org/code-dot-org/assets/9256643/e23a2b0e-4bae-4607-a162-d61e15ed83f5


## After

https://github.com/code-dot-org/code-dot-org/assets/9256643/ed4c626c-d0c4-4273-a630-4d10c2450d94

