### PR TITLE
Script to delete Units that are in_development state.

### DIFF
--- a/bin/curriculum/delete_unit.rb
+++ b/bin/curriculum/delete_unit.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'optparse'
+
+# Deletes a given script from the DB in the current environment
+# after checking for the current state of script and possible references
+# to script.
+
+def parse_options
+  OpenStruct.new.tap do |options|
+    options.unit_names = nil
+    options.dry_run = false
+
+    opt_parser = OptionParser.new do |opts|
+      opts.banner = "Usage: #{$0} [options]"
+
+      opts.separator ""
+
+      opts.on('-u', '--unit_names UnitName1,UnitName2', Array, 'Unit names to delete') do |unit_names|
+        options.unit_names = unit_names
+      end
+
+      opts.on('-n', '--dry-run', 'Perform basic validation without deleting any units.') do
+        options.dry_run = true
+      end
+
+      opts.on_tail("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+    end
+
+    opt_parser.parse!(ARGV)
+  end
+end
+
+options = parse_options
+raise "unit name is required. Use -h for options." if options.unit_names.nil?
+
+require_relative '../../dashboard/config/environment'
+options.unit_names.each do |unit_nm|
+  unit_to_del = Unit.find_by(name: unit_nm)
+  raise "Unit with name #{unit_nm} not found" if unit_to_del.nil?
+  raise "Only units in_development can be deleted as they wouldn't have usage and hence any DB references." unless unit_to_del.published_state == "in_development"
+
+  assigned_section_count = Section.where(script_id: unit_to_del.id).count
+  raise "Unit is currently assigned to some sections, deleting will break loading dashboard for those teachers." unless assigned_section_count == 0
+
+  user_progress_count = UserScript.where(script_id: unit_to_del.id).count
+  raise "Some users have existing progress in this unit" unless user_progress_count == 0
+
+  puts "No references to Unit found from sections or user progress."
+  if options.dry_run
+    puts "Skipping deletion due to dry run mode."
+  else
+    puts "Deleting Unit from DB."
+    unit_to_del.destroy
+  end
+end


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

Script to delete Units from the DB after validating the following
- The unit is in_development state
- There are not sections that have the unit assigned
- There is not user progress for the given unit

The script will be used to delete the unit `csc-ecosystems` as part of a fix for https://codedotorg.atlassian.net/browse/TEACH-872

## Links

JIRA https://codedotorg.atlassian.net/browse/TEACH-872

## Testing story

Validated the following scenarios
- Dry run mode
- Executing on units that are in other states, ex., published 
- Executing on units that are assigned to sections and have user progress
- Executing on units that have progress

## Deployment strategy

Will delete the unit from levelbuilder to avoid continuous reseeding. Once the content scoop is deployed, will execute the script on staging, test and then production.

## Follow-up work

Executing the script on test, staging and production, will use the same JIRA ticket to track.

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
