### PR TITLE
Persist school_info from finish registration page

### DIFF
--- a/dashboard/lib/services/user.rb
+++ b/dashboard/lib/services/user.rb
@@ -46,7 +46,7 @@ class Services::User
     if params_school_info
       # Disable validation because the school info fields are optional on the registration page
       params_school_info[:validation_type] = SchoolInfo::VALIDATION_NONE
-      user.school_info = SchoolInfo.create(params_school_info)
+      user.assign_attributes(school_info_attributes: params_school_info)
     end
   end
 end

--- a/dashboard/lib/services/user.rb
+++ b/dashboard/lib/services/user.rb
@@ -3,6 +3,7 @@ class Services::User
   # new values to the given User instance.
   def self.assign_form_params(user, params)
     assign_auth_option_params(user, params)
+    assign_school_info_params(user, params)
     # Remove nested attributes, otherwise we might accidentally create new
     # nested objects rather than updating existing ones.
     # '_attributes' is how active_record identifies nested attrs.
@@ -31,6 +32,21 @@ class Services::User
         # Apply the form params to the AuthenticationOption
         user_ao.assign_attributes(params_ao.compact)
       end
+    end
+  end
+
+  # The user model accepts nested attributes for school_info. On the finish
+  # signup form, users can associate themselves with a school. This method
+  # looks for the school_info attributes in the form params and updates the
+  # User object. The user_school_infos record is created separately, in an
+  # after_save hook in the User model, so it doesn't need to be created here.
+  def self.assign_school_info_params(user, params)
+    # "school_info_attributes"=>{"country"=>"US", "school_type"=>"public", "school_state"=>"Washington", "school_name"=>"Foo School", "school_zip"=>"98021"}
+    params_school_info = params['school_info_attributes']
+    if params_school_info
+      # Disable validation because the school info fields are optional on the registration page
+      params_school_info[:validation_type] = SchoolInfo::VALIDATION_NONE
+      user.school_info = SchoolInfo.create(params_school_info)
     end
   end
 end

--- a/dashboard/lib/services/user.rb
+++ b/dashboard/lib/services/user.rb
@@ -45,7 +45,6 @@ class Services::User
     params_school_info = params['school_info_attributes']
     if params_school_info
       # Disable validation because the school info fields are optional on the registration page
-      params_school_info[:validation_type] = SchoolInfo::VALIDATION_NONE
       user.assign_attributes(school_info_attributes: params_school_info)
     end
   end

--- a/dashboard/test/lib/services/user_test.rb
+++ b/dashboard/test/lib/services/user_test.rb
@@ -12,6 +12,13 @@ class Services::UserTest < ActiveSupport::TestCase
         '0' => {
           'email' => expected_email
         }
+      },
+      'school_info_attributes' => {
+        'country' => 'US',
+        'school_type' => 'public',
+        'school_state' => 'Washington',
+        'school_name' => 'Test School',
+        'school_zip' => '99999'
       }
     }
     user = User.new(name: 'original_name')
@@ -22,5 +29,6 @@ class Services::UserTest < ActiveSupport::TestCase
 
     assert_equal expected_name, user.name
     assert_equal expected_email, user.authentication_options.first.email
+    assert_equal user.school_info.school_name, params.dig('school_info_attributes', 'school_name')
   end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -5212,7 +5212,7 @@ class UserTest < ActiveSupport::TestCase
       }
     }
     partial_teacher = build :teacher
-    partial_teacher.authentication_options = [AuthenticationOption.new(user: partial_teacher, email: 'old_email@email.com')]
+    partial_teacher.authentication_options = [AuthenticationOption.new(user: partial_teacher, email: 'old_email@email.com', credential_type: AuthenticationOption::EMAIL)]
     PartialRegistration.persist_attributes session, partial_teacher
     fully_registered_teacher = User.new_with_session(params, session)
     fully_registered_teacher.save


### PR DESCRIPTION
When we [modified the partial registration code](https://github.com/code-dot-org/code-dot-org/pull/54972) to allow account creation via LTI launch, we inadvertently started omitting the nested attributes for `school_info` when creating new teacher accounts.

This adds handling for `school_info` to make it behave more like `authentication_option`s, where we explicitly take the nested attributes from the params and attach them to the rehydrated user object.

<img width="846" alt="Screenshot 2024-04-24 at 1 17 50 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/bfc0a3a9-2489-48fe-bdbf-218934f0dff1">

```
[development] dashboard > User.find_by_email('teacher@schoolinfo.com').school_info
=>
#<SchoolInfo:0x00007f7ede271730
 id: 5,
 country: "US",
 school_type: "private",
 zip: 11111,
 state: "Alabama",
 school_district_id: nil,
 school_district_other: nil,
 school_district_name: nil,
 school_id: nil,
 school_other: nil,
 school_name: "school info test",
 full_address: nil,
 created_at: Thu, 25 Apr 2024 03:17:52.000000000 UTC +00:00,
 updated_at: Thu, 25 Apr 2024 03:17:52.000000000 UTC +00:00,
 validation_type: "none">
```

```
[development] dashboard > UserSchoolInfo.where(user_id: 23)
  UserSchoolInfo Load (24.7ms)  SELECT `user_school_infos`.* FROM `user_school_infos` WHERE `user_school_infos`.`user_id` = 23
=>
[#<UserSchoolInfo:0x00007f7edc451818
  id: 3,
  user_id: 23,
  start_date: Thu, 25 Apr 2024 03:17:52.000000000 UTC +00:00,
  end_date: nil,
  school_info_id: 5,
  last_confirmation_date: Thu, 25 Apr 2024 03:17:52.000000000 UTC +00:00,
  created_at: Thu, 25 Apr 2024 03:17:52.000000000 UTC +00:00,
  updated_at: Thu, 25 Apr 2024 03:17:52.000000000 UTC +00:00>]
```

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
