### PR TITLE
[Blockly] resize main workspace svg after inject

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2941,7 +2941,7 @@ StudioApp.prototype.handleUsingBlockly_ = function (config) {
   // https://openradar.appspot.com/31725316
   // Resize the Blockly workspace after 500ms when clientWidth/Height
   // should be correct.
-  window.setTimeout(() => Blockly.svgResize(Blockly.mainBlockSpace), 500);
+  window.setTimeout(() => Blockly.fireUiEvent(window, 'resize'), 500);
 };
 
 /**

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -36,7 +36,6 @@ import logToCloud from './logToCloud';
 import msg from '@cdo/locale';
 import project from './code-studio/initApp/project';
 import puzzleRatingUtils from './puzzleRatingUtils';
-import userAgentParser from './code-studio/initApp/userAgentParser';
 import {
   KeyCodes,
   TestResults,
@@ -2938,13 +2937,11 @@ StudioApp.prototype.handleUsingBlockly_ = function (config) {
   }
   this.setStartBlocks_(config, true);
 
-  if (userAgentParser.isMobile() && userAgentParser.isSafari()) {
-    // Mobile Safari resize events fire too early, see:
-    // https://openradar.appspot.com/31725316
-    // Rerun the blockly resize handler after 500ms when clientWidth/Height
-    // should be correct
-    window.setTimeout(() => Blockly.fireUiEvent(window, 'resize'), 500);
-  }
+  // In some cases, resize events fire too early. For example, see:
+  // https://openradar.appspot.com/31725316
+  // Resize the Blockly workspace after 500ms when clientWidth/Height
+  // should be correct.
+  window.setTimeout(() => Blockly.svgResize(Blockly.mainBlockSpace), 500);
 };
 
 /**

--- a/apps/src/blockly/eventHandlers.ts
+++ b/apps/src/blockly/eventHandlers.ts
@@ -111,6 +111,14 @@ export function adjustCalloutsOnViewportChange(
   }
 }
 
+export function resizeWorkspaceOnLoad(event: GoogleBlockly.Events.Abstract) {
+  if (event && event.type === Blockly.Events.FINISHED_LOADING) {
+    setTimeout(() => {
+      Blockly.common.svgResize(Blockly.getMainWorkspace());
+    }, 1000);
+  }
+}
+
 // When the browser is resized, we need to re-adjust the width of any open flyout.
 export function reflowToolbox() {
   const mainWorkspace = Blockly.getMainWorkspace() as WorkspaceSvg;

--- a/apps/src/blockly/eventHandlers.ts
+++ b/apps/src/blockly/eventHandlers.ts
@@ -111,14 +111,6 @@ export function adjustCalloutsOnViewportChange(
   }
 }
 
-export function resizeWorkspaceOnLoad(event: GoogleBlockly.Events.Abstract) {
-  if (event && event.type === Blockly.Events.FINISHED_LOADING) {
-    setTimeout(() => {
-      Blockly.common.svgResize(Blockly.getMainWorkspace());
-    }, 1000);
-  }
-}
-
 // When the browser is resized, we need to re-adjust the width of any open flyout.
 export function reflowToolbox() {
   const mainWorkspace = Blockly.getMainWorkspace() as WorkspaceSvg;

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -76,6 +76,7 @@ import {
   adjustCalloutsOnViewportChange,
   disableOrphans,
   reflowToolbox,
+  resizeWorkspaceOnLoad,
   updateBlockLimits,
 } from './eventHandlers';
 import {initializeScrollbarPair} from './addons/cdoScrollbar';
@@ -729,6 +730,8 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       .getFlyout()
       ?.getWorkspace()
       ?.addChangeListener(adjustCalloutsOnViewportChange);
+
+    workspace.addChangeListener(resizeWorkspaceOnLoad);
 
     initializeScrollbarPair(workspace);
 

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -784,6 +784,13 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     return workspace;
   };
 
+  // Used by StudioApp to tell Blockly to resize for Mobile Safari.
+  blocklyWrapper.fireUiEvent = function (element, eventName) {
+    if (eventName === 'resize') {
+      blocklyWrapper.svgResize(blocklyWrapper.mainBlockSpace);
+    }
+  };
+
   blocklyWrapper.setMainWorkspace = function (mainWorkspace) {
     this.mainWorkspace = mainWorkspace;
   };

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -76,7 +76,6 @@ import {
   adjustCalloutsOnViewportChange,
   disableOrphans,
   reflowToolbox,
-  resizeWorkspaceOnLoad,
   updateBlockLimits,
 } from './eventHandlers';
 import {initializeScrollbarPair} from './addons/cdoScrollbar';
@@ -731,8 +730,6 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       ?.getWorkspace()
       ?.addChangeListener(adjustCalloutsOnViewportChange);
 
-    workspace.addChangeListener(resizeWorkspaceOnLoad);
-
     initializeScrollbarPair(workspace);
 
     window.addEventListener('resize', reflowToolbox);
@@ -785,13 +782,6 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     }
 
     return workspace;
-  };
-
-  // Used by StudioApp to tell Blockly to resize for Mobile Safari.
-  blocklyWrapper.fireUiEvent = function (element, eventName) {
-    if (eventName === 'resize') {
-      blocklyWrapper.svgResize(blocklyWrapper.mainBlockSpace);
-    }
   };
 
   blocklyWrapper.setMainWorkspace = function (mainWorkspace) {


### PR DESCRIPTION
During the November Sprite Lab bug bash, @molly-moen observed that the workspace was being cut off weirdly on iPad Firefox and Safari. This bug wasn't unique to Sprite Lab so it didn't block the migration. Recently, I noticed it was still coming up in classroom playtests of other labs. For example here it is on CDO Blockly in Artist:
<img width="454" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/0d9bd07a-252a-46d8-9761-d19fb44067b3">
Yesterday I was looking into some unrelated bugs affecting touch devices and I was able to repro the issue on my iPad. 

As it turns out, this issue was addressed previously by forcing an extra resize after 0.5 seconds on mobile Safari. (See previous version of code.)

Unfortunately, iPads do not self-report as mobile devices, and the issue isn't limited to Safari. To fix the issue consistently, and avoid a whack-a-mole scenario, I suggest we always resize the workspace svg after inject is called. The 500ms timeout is preserved to ensure that our platform has had time to have the correct dimensions.

I confirmed that this fixes the issue without regressions by checking a variety of labs (Sprite Lab on Google Blockly, Artist on CDO Blockly) with different browsers (Safari/Firefox/Chrome) on multiple devices (iPad and MacBook).

Artist on Firefox (iPad)
![IMG_01D130E89379-1](https://github.com/code-dot-org/code-dot-org/assets/43474485/5cb7a11f-0cca-4843-ab89-27aa59c8084e)

Sprite Lab on Safari (iPad)
![IMG_B41FD3BD746C-1](https://github.com/code-dot-org/code-dot-org/assets/43474485/ee9b1e94-82ac-4e94-8b81-17f3b8eec7bb)

Artist on Chrome (Macbook)
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/79a1f136-397e-4223-b7af-961f56ac6982)


## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

Jira - https://codedotorg.atlassian.net/browse/CT-199
Bug bash doc - https://docs.google.com/document/d/1KGkzjXfUY9_EmYOFLk5mXcknDscFPZKqVz4vhmh5hMY/edit#heading=h.8pchje6bd7q8

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

At one point I tried to call `Blockly.svgResize` directly instead of firing a UI event. To do so required adding a definition for this to the CDO Blockly Wrapper. However, a variety of tests started failing, because they couldn't find the method. I think it's possible (and unfortunate) that this means our tests are attempting to access `Blockly` as the actual Blockly instance rather than the wrapper.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
