### PR TITLE
Update Legacy `user_id` Implementation to Support New Session Store

### DIFF
--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -1,4 +1,5 @@
 require 'rack/request'
+require 'rack/session/abstract/id'
 require 'ipaddr'
 require 'json'
 require 'country_codes'

--- a/lib/test/cdo/rack/test_request.rb
+++ b/lib/test/cdo/rack/test_request.rb
@@ -1,0 +1,101 @@
+require_relative '../../test_helper'
+require 'cdo/rack/request'
+
+class RequestTest
+  class RequestExtensionTest < Minitest::Test
+    # Manually implement a subset of methods that RequestExtension expects the
+    # Request class it's extending to define, so we can test our custom
+    # functionality without needing a complete Request object.
+    # See https://github.com/rack/rack/blob/v2.2.6.4/lib/rack/request.rb
+    class MockRequest
+      def http_host_and_port(host, port)
+        return host if port == 80
+        "#{host}:#{port}"
+      end
+
+      def trusted_proxy?(ip)
+        Rack::Request.ip_filter.call(ip)
+      end
+
+      def cookies
+        {}
+      end
+    end
+    MockRequest.prepend Cdo::RequestExtension
+
+    def setup
+      @mock_request = MockRequest.new
+    end
+
+    def test_trusted_proxies
+      # Standard IP addresse as used by the base Request implementation still
+      # work.
+      assert @mock_request.trusted_proxy?('localhost')
+      refute @mock_request.trusted_proxy?('93.184.215.14') # example.com
+
+      # IP Addresses within our custom set of trusted proxies also work.
+      # Note: we may need to update this test if the contents of
+      # lib/cdo/trusted_proxies.json ever change.
+      assert @mock_request.trusted_proxy?('44.220.202.0')
+      assert @mock_request.trusted_proxy?('18.175.65.0')
+      assert @mock_request.trusted_proxy?('3.35.130.128')
+    end
+
+    def test_referer_site_with_port
+      # Returns actual referer if it's internal.
+      @mock_request.stubs(:referer).returns('http://localhost-studio.code.org:3000/home')
+      assert_equal 'localhost-studio.code.org:3000', @mock_request.referer_site_with_port
+      @mock_request.stubs(:referer).returns('http://studio.code.org/home')
+      assert_equal 'studio.code.org', @mock_request.referer_site_with_port
+      @mock_request.stubs(:referer).returns('https://www.csedweek.org/')
+      assert_equal 'www.csedweek.org:443', @mock_request.referer_site_with_port
+
+      # Normalizes unrecognized or invalid referers to code.org.
+      @mock_request.stubs(:referer).returns('https://example.com')
+      assert_equal 'code.org', @mock_request.referer_site_with_port
+      @mock_request.stubs(:referer).returns('not actually a valid URI')
+      assert_equal 'code.org', @mock_request.referer_site_with_port
+    end
+
+    def test_site_from_host
+      hosts_to_expected = {
+        # "Base" domains and subdomains are returned unmodified
+        'studio.code.org': 'studio.code.org',
+        'code.org': 'code.org',
+        'advocacy.code.org': 'advocacy.code.org',
+        'hourofcode.com': 'hourofcode.com',
+
+        # Localhost- and environment-specific subdomains are normalized to the
+        # "base".
+        'localhost-studio.code.org': 'studio.code.org',
+        'staging-studio.code.org': 'studio.code.org',
+        'localhost.code.org': 'code.org',
+        'test.code.org': 'code.org',
+        'test-advocacy.code.org': 'advocacy.code.org',
+        'localhost.hourofcode.com': 'hourofcode.com',
+
+        # Entirely unrecognized domains are normalized to just code.org
+        'example.com': 'code.org',
+      }
+
+      hosts_to_expected.each do |host, expected|
+        @mock_request.stubs(:host).returns(host.to_s)
+        message = "expected to get #{expected} when calling site_from_host with host #{host.inspect}"
+        assert_equal expected, @mock_request.site_from_host, message
+      end
+    end
+
+    def test_user_id_from_session_store
+      mock_session_store = Minitest::Mock.new
+      def mock_session_store.with; {}; end
+      @mock_request.stubs(:dashboard_session_store).returns(mock_session_store)
+
+      # defaults to nil
+      assert_nil @mock_request.user_id_from_session_store
+
+      # Will fetch user id from the session if it exists
+      def mock_session_store.with; {'warden.user.user.key' => [['user_id']]}; end
+      assert_equal 'user_id', @mock_request.user_id_from_session_store
+    end
+  end
+end

--- a/lib/test/cdo/rack/test_request.rb
+++ b/lib/test/cdo/rack/test_request.rb
@@ -28,17 +28,20 @@ class RequestTest
     end
 
     def test_trusted_proxies
-      # Standard IP addresse as used by the base Request implementation still
-      # work.
+      # Standard IP addresses and hostnames as used by the base Request
+      # implementation still work as expected.
       assert @mock_request.trusted_proxy?('localhost')
       refute @mock_request.trusted_proxy?('93.184.215.14') # example.com
 
-      # IP Addresses within our custom set of trusted proxies also work.
-      # Note: we may need to update this test if the contents of
-      # lib/cdo/trusted_proxies.json ever change.
-      assert @mock_request.trusted_proxy?('44.220.202.0')
-      assert @mock_request.trusted_proxy?('18.175.65.0')
-      assert @mock_request.trusted_proxy?('3.35.130.128')
+      # IP addresses within our custom set of trusted proxies should all be
+      # trusted. This list is dynamic and automatically updated, so we sample
+      # from it for testing rather than hardcoding anything.
+      proxy_ranges = JSON.parse(File.read(deploy_dir('lib/cdo/trusted_proxies.json')))['ranges']
+      proxy_ranges.sample(5).each do |proxy_range|
+        proxy_ip = proxy_range.split('/').first
+        message = "expected #{proxy_ip.inspect} to be trusted"
+        assert @mock_request.trusted_proxy?(proxy_ip), message
+      end
     end
 
     def test_referer_site_with_port


### PR DESCRIPTION
In response to us moving session data out of the cookie and into a persistent store, also update the legacy implementation of `user_id` we have in Rack to read the user id from that store rather than the cookie.

This is definitely a little bit gross; it involves not just pulling in some Dashboard-specific configuration details and manually initializing a Dashboard-specific class, but also actually referencing the underlying Dashboard application itself, all in some code that intentionally lives in the `lib/` directory.

Note that this PR is opened not against staging, but against https://github.com/code-dot-org/code-dot-org/pull/58019

## Testing story

Added a unit test for the new functionality. Also noticed while I was doing so that we didn't have any existing unit tests for any of the existing functionality in this class, so I added a couple.

## Deployment strategy

Merging this PR will not actually deploy any change; it will just update my main feature branch with this new functionality. That branch can then be independently reviewed and deployed at an appropriate time.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
