### PR TITLE
Remove Violation of and Reenable `Lint/EmptyFile`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -60,11 +60,6 @@ Lint/EmptyBlock:
 Lint/EmptyClass:
   Enabled: false
 
-# Offense count: 1
-# Configuration parameters: AllowComments.
-Lint/EmptyFile:
-  Enabled: false
-
 # Offense count: 9
 Lint/MissingSuper:
   Enabled: false


### PR DESCRIPTION
> Enforces that Ruby source files are not empty.

This is a pretty simple one! We fortunately only have a single violation of this rule, and it's a file that hasn't been touched for the entire history of this repository and as far as I can tell is not referenced anywhere. Feels pretty safe to remove.

## Links

- https://docs.rubocop.org/rubocop/cops_lint.html#lintemptyfile
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/EmptyFile

## Testing story

Relying on existing tests to verify that this file is not actually used anywhere.