### PR TITLE
AI Chat: hide customization panel when all settings are hidden

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -478,16 +478,10 @@ const hasFilledOutModelCard = (modelCardInfo: ModelCardInfo) => {
   return true;
 };
 
-const allFieldsHidden = (
-  fieldVisibilities: AichatState['fieldVisibilities']
-) => {
-  for (const key of getTypedKeys(fieldVisibilities)) {
-    if (fieldVisibilities[key] !== Visibility.HIDDEN) {
-      return false;
-    }
-  }
-  return true;
-};
+const allFieldsHidden = (fieldVisibilities: AichatState['fieldVisibilities']) =>
+  getTypedKeys(fieldVisibilities).every(
+    key => fieldVisibilities[key] === Visibility.HIDDEN
+  );
 
 // Selectors
 export const selectHasFilledOutModelCard = createSelector(

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -29,6 +29,7 @@ import {
   ViewMode,
   Visibility,
 } from '../types';
+import {getTypedKeys} from '@cdo/apps/types/utils';
 
 const haveDifferentValues = (
   value1: AiCustomizations[keyof AiCustomizations],
@@ -460,18 +461,16 @@ const aichatSlice = createSlice({
 });
 
 const hasFilledOutModelCard = (modelCardInfo: ModelCardInfo) => {
-  for (const key of Object.keys(modelCardInfo)) {
-    const typedKey = key as keyof ModelCardInfo;
-
-    if (typedKey === 'isPublished') {
+  for (const key of getTypedKeys(modelCardInfo)) {
+    if (key === 'isPublished') {
       continue;
-    } else if (typedKey === 'exampleTopics') {
+    } else if (key === 'exampleTopics') {
       if (
         !modelCardInfo['exampleTopics'].filter(topic => topic.length).length
       ) {
         return false;
       }
-    } else if (!modelCardInfo[typedKey].length) {
+    } else if (!modelCardInfo[key].length) {
       return false;
     }
   }
@@ -479,11 +478,26 @@ const hasFilledOutModelCard = (modelCardInfo: ModelCardInfo) => {
   return true;
 };
 
+const allFieldsHidden = (
+  fieldVisibilities: AichatState['fieldVisibilities']
+) => {
+  for (const key of getTypedKeys(fieldVisibilities)) {
+    if (fieldVisibilities[key] !== Visibility.HIDDEN) {
+      return false;
+    }
+  }
+  return true;
+};
+
 // Selectors
 export const selectHasFilledOutModelCard = createSelector(
-  (state: {aichat: AichatState}) =>
-    state.aichat.currentAiCustomizations.modelCardInfo,
+  (state: RootState) => state.aichat.currentAiCustomizations.modelCardInfo,
   hasFilledOutModelCard
+);
+
+export const selectAllFieldsHidden = createSelector(
+  (state: RootState) => state.aichat.fieldVisibilities,
+  allFieldsHidden
 );
 
 registerReducers({aichat: aichatSlice.reducer});

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -19,6 +19,7 @@ import {
   setStartingAiCustomizations,
   setViewMode,
   clearChatMessages,
+  selectAllFieldsHidden,
 } from '../redux/aichatRedux';
 import {AichatLevelProperties, ViewMode} from '../types';
 import {isDisabled} from './modelCustomization/utils';
@@ -53,6 +54,8 @@ const AichatView: React.FunctionComponent = () => {
     state => state.aichat
   );
   const {botName, isPublished} = currentAiCustomizations.modelCardInfo;
+
+  const allFieldsHidden = useAppSelector(selectAllFieldsHidden);
 
   useEffect(() => {
     const studentAiCustomizations = JSON.parse(initialSources);
@@ -132,14 +135,16 @@ const AichatView: React.FunctionComponent = () => {
                 <Instructions beforeNextLevel={beforeNextLevel} />
               </PanelContainer>
             </div>
-            <div className={moduleStyles.customizationArea}>
-              <PanelContainer
-                id="aichat-model-customization-panel"
-                headerContent="Model Customization"
-              >
-                <ModelCustomizationWorkspace />
-              </PanelContainer>
-            </div>
+            {!allFieldsHidden && (
+              <div className={moduleStyles.customizationArea}>
+                <PanelContainer
+                  id="aichat-model-customization-panel"
+                  headerContent="Model Customization"
+                >
+                  <ModelCustomizationWorkspace />
+                </PanelContainer>
+              </div>
+            )}
           </>
         )}
         {viewMode === ViewMode.PRESENTATION && (

--- a/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
+++ b/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
@@ -10,8 +10,13 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {AichatLevelProperties} from '@cdo/apps/aichat/types';
 
 const ModelCustomizationWorkspace: React.FunctionComponent = () => {
-  const {temperature, systemPrompt, retrievalContexts, modelCardInfo} =
-    useAppSelector(state => state.aichat.fieldVisibilities);
+  const {
+    temperature,
+    systemPrompt,
+    retrievalContexts,
+    modelCardInfo,
+    selectedModelId,
+  } = useAppSelector(state => state.aichat.fieldVisibilities);
 
   const hidePresentationPanel = useAppSelector(
     state =>
@@ -20,7 +25,9 @@ const ModelCustomizationWorkspace: React.FunctionComponent = () => {
   );
 
   const showSetupCustomization =
-    isVisible(temperature) || isVisible(systemPrompt);
+    isVisible(temperature) ||
+    isVisible(systemPrompt) ||
+    isVisible(selectedModelId);
 
   return (
     <div className={styles.modelCustomizationWorkspace}>

--- a/apps/src/aichat/views/modelCustomization/constants.ts
+++ b/apps/src/aichat/views/modelCustomization/constants.ts
@@ -34,7 +34,7 @@ export const TECHNICAL_INFO_FIELDS = [
   'Retrieval Used',
 ] as const;
 
-const EMPTY_MODEL_CARD_INFO: ModelCardInfo = {
+export const EMPTY_MODEL_CARD_INFO: ModelCardInfo = {
   botName: '',
   description: '',
   intendedUse: '',

--- a/apps/src/lab2/levelEditors/aichatSettings/EditAichatSettings.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/EditAichatSettings.tsx
@@ -56,23 +56,13 @@ function sanitizeSettings(settings: LevelAichatSettings) {
   };
 }
 
-function sanitizeField<M extends object>(field: M, defaults: M) {
-  const validKeys = getTypedKeys<keyof M>(defaults);
-  // Delete entries for unrecognized keys
-  for (const key of getTypedKeys<keyof M>(field)) {
-    if (!getTypedKeys<keyof M>(defaults).includes(key)) {
-      delete field[key];
-    }
-  }
-
-  // Set default values for missing keys
-  for (const validKey of validKeys) {
-    if (field[validKey] === undefined) {
-      field[validKey] = defaults[validKey];
-    }
-  }
-
-  return field;
+function sanitizeField<F extends object>(field: F, defaults: F) {
+  // Iterate over default keys, keeping the value from the field if present, and otherwise using the default.
+  // This removes any extraneous keys and retains only expected keys.
+  return getTypedKeys<keyof F>(defaults).reduce(
+    (newField, key) => ({...newField, [key]: field[key] ?? defaults[key]}),
+    {}
+  );
 }
 
 /**

--- a/apps/src/types/utils.ts
+++ b/apps/src/types/utils.ts
@@ -14,3 +14,12 @@ export function convertOptionalStringToBoolean(
     return value === 'true';
   }
 }
+
+/**
+ * Return the keys of an object as a typed array.
+ */
+export function getTypedKeys<K extends string | number | symbol>(object: {
+  [key in K]: unknown;
+}): K[] {
+  return Object.keys(object) as K[];
+}


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Description

Hides the entire model customization panel if the visibility of all settings is set to "hidden". Also included a few other related quality of life fixes that I ended up adding as I was doing this (will add comments in the PR).
- `getTypedKeys` TypeScript util to get typed keys when iterating through an interface
- Add a check for selected model ID when deciding whether to hide the Setup panel
- Perform some sanitization when saving AI Chat settings in levelbuilder, to filter out unrecognized keys, and set missing values to defaults. Helpful when the format changes after data has already been written to a level.

UI when all fields are hidden:
<img width="1512" alt="Screenshot 2024-04-24 at 4 34 03 PM (2)" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/9bc113bb-26fc-4c38-ac03-f3d3b396dea8">

### Sanitizing Level AI Chat Settings

Before saving - manually added some extraneous data and removed some required fields (look for "extraKey-" prefixed fields)
<img width="770" alt="Screenshot 2024-04-24 at 4 48 06 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/fa0280c6-a3ec-4828-b7cb-1b0aa6134d32">

After saving, without actually updating anything in levelbuilder - notice that "extraKey-" fields are gone, and other missing fields are present with default values.
<img width="713" alt="Screenshot 2024-04-24 at 4 49 25 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/a94e6ee4-01f3-452e-ace9-2e9b8e4639a4">


## Links

https://codedotorg.atlassian.net/browse/LABS-701

## Testing story

Tested with allthethings levels.