### PR TITLE
Music: Add strings for effects dropdown labels

### DIFF
--- a/apps/i18n/music/en_us.json
+++ b/apps/i18n/music/en_us.json
@@ -78,5 +78,10 @@
   "soundsFilterEffects": "Effects",
   "soundsFilterVocals": "Vocals",
   "packDialogTitle": "Choose a featured track",
-  "packDialogBody": "Level up your mix by adding sounds from a featured track."
+  "packDialogBody": "Level up your mix by adding sounds from a featured track.",
+  "effectsLabelsFull": "Full",
+  "effectsLabelsHigh": "High",
+  "effectsLabelsMedium": "Medium",
+  "effectsLabelsLow": "Low",
+  "effectsLabelsOff": "Off"
 }


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Description

Adding strings for effects labels

## Links

[jira ticket](https://codedotorg.atlassian.net/browse/LABS-682)


## Follow-up work

Putting these strings into use. I believe here is where the dropdown is where these values will be used:
https://github.com/code-dot-org/code-dot-org/blob/22d55bad670b4a861638d61baa2f8fd82b419c8a/apps/src/music/blockly/blocks/simple2.js#L205-L228
