### PR TITLE
add analytic events for product tour

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -156,6 +156,12 @@ const EVENTS = {
     'TA Rubric AI Eval started from section request',
   TA_RUBRIC_WINDOW_MOVE_START: 'TA Rubric window move start',
   TA_RUBRIC_WINDOW_MOVE_END: 'TA Rubric window move end',
+  TA_RUBRIC_TOUR_STARTED: 'First view of TA Rubric product tour',
+  TA_RUBRIC_TOUR_RESTARTED: 'TA Rubric product tour restart from ? button',
+  TA_RUBRIC_TOUR_NEXT: 'TA Rubric product tour next button clicked',
+  TA_RUBRIC_TOUR_BACK: 'TA Rubric product tour back button clicked',
+  TA_RUBRIC_TOUR_CLOSED: 'TA Rubric product tour closed',
+  TA_RUBRIC_TOUR_COMPLETE: 'User viewed all of TA Rubric product tour',
 
   // AI Tutor
   AI_TUTOR_PANEL_OPENED: 'AI Tutor Panel Opened',

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState, useRef} from 'react';
 import PropTypes from 'prop-types';
 import style from './rubrics.module.scss';
 import i18n from '@cdo/locale';
@@ -61,6 +61,8 @@ export default function RubricContainer({
   const [feedbackAdded, setFeedbackAdded] = useState(false);
 
   const [productTour, setProductTour] = useState(false);
+  const tourStep = useRef(null);
+  const tourRestarted = useRef(false);
 
   const tabSelectCallback = tabSelection => {
     setSelectedTab(tabSelection);
@@ -169,13 +171,59 @@ export default function RubricContainer({
     getTourStatus();
   }, [getTourStatus]);
 
-  const onTourExit = () => {
+  const tourRestartHandler = () => {
+    tourRestarted.current = true;
     updateTourStatus();
+    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_TOUR_RESTARTED, {
+      ...(reportingData || {}),
+    });
+  };
+
+  const onTourStart = stepIndex => {
+    tourStep.current = stepIndex;
+    if (tourRestarted.current) {
+      tourRestarted.current = false;
+    } else {
+      analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_TOUR_STARTED, {
+        ...(reportingData || {}),
+      });
+    }
+  };
+
+  const onTourExit = stepIndex => {
+    updateTourStatus();
+    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_TOUR_CLOSED, {
+      ...(reportingData || {}),
+      step: stepIndex,
+    });
+  };
+
+  const onTourComplete = () => {
+    updateTourStatus();
+    analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_TOUR_COMPLETE, {
+      ...(reportingData || {}),
+    });
   };
 
   const onStepChange = (nextStepIndex, nextElement) => {
-    if (nextStepIndex === 1) {
-      document.getElementById('tour-fab-bg').scrollBy(0, 1000);
+    if (tourStep.current !== null && nextStepIndex !== tourStep.current) {
+      if (nextStepIndex < tourStep.current) {
+        analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_TOUR_BACK, {
+          ...(reportingData || {}),
+          step: tourStep.current,
+          nextStep: nextStepIndex,
+        });
+      } else {
+        analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_TOUR_NEXT, {
+          ...(reportingData || {}),
+          step: tourStep.current,
+          nextStep: nextStepIndex,
+        });
+      }
+      tourStep.current = nextStepIndex;
+      if (nextStepIndex === 1) {
+        document.getElementById('tour-fab-bg').scrollBy(0, 1000);
+      }
     }
   };
 
@@ -204,9 +252,11 @@ export default function RubricContainer({
           enabled={canProvideFeedback && productTour}
           initialStep={INITIAL_STEP}
           steps={STEPS}
+          onStart={onTourStart}
           onExit={onTourExit}
           onChange={onStepChange}
           onBeforeChange={onBeforeStepChange}
+          onComplete={onTourComplete}
           options={{
             scrollToElement: false,
             exitOnOverlayClick: false,
@@ -233,7 +283,7 @@ export default function RubricContainer({
                 id="ui-restart-product-tour"
                 data-testid="restart-product-tour"
                 type="button"
-                onClick={updateTourStatus}
+                onClick={tourRestartHandler}
                 className={classnames(style.buttonStyle, style.closeButton)}
               >
                 <FontAwesome icon="circle-question" />

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -281,7 +281,7 @@ export default function RubricContainer({
             {canProvideFeedback && (
               <button
                 id="ui-restart-product-tour"
-                data-testid="restart-product-tour"
+                aria-label="restart product tour"
                 type="button"
                 onClick={tourRestartHandler}
                 className={classnames(style.buttonStyle, style.closeButton)}

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -822,7 +822,7 @@ describe('RubricContainer', () => {
       </Provider>
     );
 
-    waitFor(
+    await waitFor(
       () =>
         expect(queryByText('Getting Started with Your AI Teaching Assistant'))
           .to.exist
@@ -900,7 +900,7 @@ describe('RubricContainer', () => {
       </Provider>
     );
 
-    waitFor(() =>
+    await waitFor(() =>
       expect(sendEventSpy).to.have.been.calledWith(
         EVENTS.TA_RUBRIC_TOUR_STARTED,
         {}
@@ -935,7 +935,7 @@ describe('RubricContainer', () => {
 
     fireEvent.click(nextButton);
 
-    waitFor(() =>
+    await waitFor(() =>
       expect(sendEventSpy).to.have.been.calledWith(EVENTS.TA_RUBRIC_TOUR_NEXT, {
         step: 0,
         nextStep: 1,
@@ -946,7 +946,7 @@ describe('RubricContainer', () => {
 
     fireEvent.click(backButton);
 
-    waitFor(() =>
+    await waitFor(() =>
       expect(sendEventSpy).to.have.been.calledWith(EVENTS.TA_RUBRIC_TOUR_BACK, {
         step: 1,
         nextStep: 0,
@@ -981,7 +981,7 @@ describe('RubricContainer', () => {
 
     fireEvent.click(skipButton);
 
-    waitFor(() =>
+    await waitFor(() =>
       expect(sendEventSpy).to.have.been.calledWith(
         EVENTS.TA_RUBRIC_TOUR_CLOSED,
         {
@@ -1017,19 +1017,18 @@ describe('RubricContainer', () => {
     const nextButton = await findByText('Next Tip');
 
     fireEvent.click(nextButton);
-    await wait();
+    await findByText('Understanding the AI Assessment');
     fireEvent.click(nextButton);
-    await wait();
+    await findByText('Using Evidence');
     fireEvent.click(nextButton);
-    await wait();
+    await findByText('Understanding AI Confidence');
     fireEvent.click(nextButton);
-    await wait();
+    await findByText('Assigning a Rubric Score');
     fireEvent.click(nextButton);
-
     const doneButton = await findByText('Done');
     fireEvent.click(doneButton);
 
-    waitFor(() =>
+    await waitFor(() =>
       expect(sendEventSpy).to.have.been.calledWith(
         EVENTS.TA_RUBRIC_TOUR_COMPLETE,
         {}
@@ -1069,7 +1068,7 @@ describe('RubricContainer', () => {
     const element = await findByRole('button', {name: 'restart product tour'});
     fireEvent.click(element);
 
-    waitFor(() =>
+    await waitFor(() =>
       expect(sendEventSpy).to.have.been.calledWith(
         EVENTS.TA_RUBRIC_TOUR_RESTARTED,
         {}

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -1,5 +1,5 @@
 // react testing library import
-import {render, fireEvent, act} from '@testing-library/react';
+import {render, fireEvent, act, waitFor} from '@testing-library/react';
 import {mount, shallow} from 'enzyme';
 import $ from 'jquery';
 import React from 'react';
@@ -822,9 +822,11 @@ describe('RubricContainer', () => {
       </Provider>
     );
 
-    await wait();
-    expect(queryByText('Getting Started with Your AI Teaching Assistant')).to
-      .exist;
+    waitFor(
+      () =>
+        expect(queryByText('Getting Started with Your AI Teaching Assistant'))
+          .to.exist
+    );
   });
 
   it('does not display product tour when getTourStatus returns true', async function () {
@@ -848,7 +850,6 @@ describe('RubricContainer', () => {
     );
 
     await wait();
-
     expect(queryByText('Getting Started with Your AI Teaching Assistant')).to
       .not.exist;
   });
@@ -874,7 +875,6 @@ describe('RubricContainer', () => {
     );
 
     await wait();
-
     expect(queryByText('Getting Started with Your AI Teaching Assistant')).to
       .not.exist;
   });
@@ -900,11 +900,11 @@ describe('RubricContainer', () => {
       </Provider>
     );
 
-    await wait();
-
-    expect(sendEventSpy).to.have.been.calledWith(
-      EVENTS.TA_RUBRIC_TOUR_STARTED,
-      {}
+    waitFor(() =>
+      expect(sendEventSpy).to.have.been.calledWith(
+        EVENTS.TA_RUBRIC_TOUR_STARTED,
+        {}
+      )
     );
 
     sendEventSpy.restore();
@@ -918,7 +918,7 @@ describe('RubricContainer', () => {
     stubFetchTeacherEvaluations(noEvals);
     stubFetchTourStatus({seen: null});
 
-    const {getByText} = render(
+    const {findByText} = render(
       <Provider store={store}>
         <RubricContainer
           rubric={defaultRubric}
@@ -931,29 +931,27 @@ describe('RubricContainer', () => {
       </Provider>
     );
 
-    await wait();
-
-    const nextButton = getByText('Next Tip');
+    const nextButton = await findByText('Next Tip');
 
     fireEvent.click(nextButton);
 
-    await wait();
+    waitFor(() =>
+      expect(sendEventSpy).to.have.been.calledWith(EVENTS.TA_RUBRIC_TOUR_NEXT, {
+        step: 0,
+        nextStep: 1,
+      })
+    );
 
-    expect(sendEventSpy).to.have.been.calledWith(EVENTS.TA_RUBRIC_TOUR_NEXT, {
-      step: 0,
-      nextStep: 1,
-    });
-
-    const backButton = getByText('Back');
+    const backButton = await findByText('Back');
 
     fireEvent.click(backButton);
 
-    await wait();
-
-    expect(sendEventSpy).to.have.been.calledWith(EVENTS.TA_RUBRIC_TOUR_BACK, {
-      step: 1,
-      nextStep: 0,
-    });
+    waitFor(() =>
+      expect(sendEventSpy).to.have.been.calledWith(EVENTS.TA_RUBRIC_TOUR_BACK, {
+        step: 1,
+        nextStep: 0,
+      })
+    );
 
     sendEventSpy.restore();
   });
@@ -966,7 +964,7 @@ describe('RubricContainer', () => {
     stubFetchTeacherEvaluations(noEvals);
     stubFetchTourStatus({seen: null});
 
-    const {getByText} = render(
+    const {findByRole} = render(
       <Provider store={store}>
         <RubricContainer
           rubric={defaultRubric}
@@ -979,20 +977,18 @@ describe('RubricContainer', () => {
       </Provider>
     );
 
-    await wait();
-
-    // Had to access this button indirectly because RTL can't find it by text
-    const skipButton = getByText(
-      'Getting Started with Your AI Teaching Assistant'
-    ).closest('div').childNodes[1];
+    const skipButton = await findByRole('button', {name: '×'});
 
     fireEvent.click(skipButton);
 
-    await wait();
-
-    expect(sendEventSpy).to.have.been.calledWith(EVENTS.TA_RUBRIC_TOUR_CLOSED, {
-      step: 0,
-    });
+    waitFor(() =>
+      expect(sendEventSpy).to.have.been.calledWith(
+        EVENTS.TA_RUBRIC_TOUR_CLOSED,
+        {
+          step: 0,
+        }
+      )
+    );
 
     sendEventSpy.restore();
   });
@@ -1005,7 +1001,7 @@ describe('RubricContainer', () => {
     stubFetchTeacherEvaluations(noEvals);
     stubFetchTourStatus({seen: null});
 
-    const {getByText} = render(
+    const {findByText} = render(
       <Provider store={store}>
         <RubricContainer
           rubric={defaultRubric}
@@ -1018,9 +1014,7 @@ describe('RubricContainer', () => {
       </Provider>
     );
 
-    await wait();
-
-    const nextButton = getByText('Next Tip');
+    const nextButton = await findByText('Next Tip');
 
     fireEvent.click(nextButton);
     await wait();
@@ -1031,15 +1025,15 @@ describe('RubricContainer', () => {
     fireEvent.click(nextButton);
     await wait();
     fireEvent.click(nextButton);
-    await wait();
 
-    const doneButton = getByText('Done');
+    const doneButton = await findByText('Done');
     fireEvent.click(doneButton);
-    await wait();
 
-    expect(sendEventSpy).to.have.been.calledWith(
-      EVENTS.TA_RUBRIC_TOUR_COMPLETE,
-      {}
+    waitFor(() =>
+      expect(sendEventSpy).to.have.been.calledWith(
+        EVENTS.TA_RUBRIC_TOUR_COMPLETE,
+        {}
+      )
     );
 
     sendEventSpy.restore();
@@ -1054,7 +1048,7 @@ describe('RubricContainer', () => {
     stubFetchTourStatus({seen: true});
     stubUpdateTourStatus({seen: false});
 
-    const {getByTestId, queryByText} = render(
+    const {findByRole, queryByText} = render(
       <Provider store={store}>
         <RubricContainer
           rubric={defaultRubric}
@@ -1072,14 +1066,14 @@ describe('RubricContainer', () => {
     expect(queryByText('Getting Started with Your AI Teaching Assistant')).to
       .not.exist;
 
-    const element = getByTestId('restart-product-tour');
-    console.log(element);
+    const element = await findByRole('button', {name: 'restart product tour'});
     fireEvent.click(element);
-    await wait();
 
-    expect(sendEventSpy).to.have.been.calledWith(
-      EVENTS.TA_RUBRIC_TOUR_RESTARTED,
-      {}
+    waitFor(() =>
+      expect(sendEventSpy).to.have.been.calledWith(
+        EVENTS.TA_RUBRIC_TOUR_RESTARTED,
+        {}
+      )
     );
 
     sendEventSpy.restore();


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

Added amplitude analytics events for the following product tour states:
- Product tour begins on initial page load (i.e., teacher is seeing it for the first time)
- Product tour next button is clicked
- Product tour back button is clicked
- User exits product tour
- User completes product tour (i.e., views all steps and clicks done button)
- User restarts product tour using ? button

## Links
Jira ticket: [AITT-584](https://codedotorg.atlassian.net/browse/AITT-584?atlOrigin=eyJpIjoiNTExYjBmNmUyNWNlNDBkZmI1NDJlYjI1NzA4YWIyMjgiLCJwIjoiaiJ9)

## Testing story
Unit tests built for all amplitude events