### PR TITLE
Turn off poetry banner at the end of April 2024

### DIFF
--- a/pegasus/sites.v3/code.org/views/poetry_banner.haml
+++ b/pegasus/sites.v3/code.org/views/poetry_banner.haml
@@ -1,4 +1,4 @@
-- display_poetry_banner = true
+- display_poetry_banner = false
 
 - if display_poetry_banner
   %link{href: "/css/generated/poetry-skinny-banner.css", rel: "stylesheet"}


### PR DESCRIPTION
Turns off the poetry banner on each page it's being used:
- [/teach](https://code.org/teach) page
- [/naipi](https://code.org/naipi) page
- [/curriculum/csc](https://code.org/curriculum/csc) page
- [/curriculum/elementary-school](https://code.org/curriculum/elementary-school) page
- [/student/elementary](https://code.org/student/elementary) page

### Example of /teach page before change
![example teach page old](https://github.com/code-dot-org/code-dot-org/assets/56283563/edcb2b54-ade0-4a48-a705-669ed1361def)

### Example of /teach page with change
![example teach page new](https://github.com/code-dot-org/code-dot-org/assets/56283563/e0e0d3dd-6d97-4025-b314-ba269ac316ed)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?selectedIssue=ACQ-1599)

## Testing story
Local testing.
