### PR TITLE
Align Statsig user config to match JS client

### DIFF
--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -49,7 +49,7 @@ module Metrics
           event_name: event_name,
           event_value: event_value,
           metadata: metadata,
-      }.compact
+        }.compact
         puts "Logging Event: #{event_details.to_json}"
       end
     end

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -45,11 +45,14 @@ module Metrics
       private def log_event_to_stdout(user:, event_name:, event_value:, metadata:, enabled_experiments:)
         event_details = {
           user_id: user.id,
-          enabled_experiments: enabled_experiments,
+          custom_ids: {
+            user_type: user.user_type,
+            enabled_experiments: enabled_experiments,
+          }.compact,
           event_name: event_name,
           event_value: event_value,
           metadata: metadata,
-        }.compact
+        }
         puts "Logging Event: #{event_details.to_json}"
       end
     end

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -4,14 +4,14 @@ module Metrics
   module Events
     class << self
       # Logs an event, delegating to the appropriate handler based on environment
-      def log_event(user:, event_name:, event_value: nil, metadata: {})
+      def log_event(user:, event_name:, event_value: nil, metadata: {}, enabled_experiments: nil)
         event_value = event_name if event_value.nil?
         managed_test_environment = CDO.running_web_application? && CDO.test_system?
 
         if CDO.rack_env?(:development)
-          log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata)
+          log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments)
         elsif CDO.rack_env?(:production) || managed_test_environment
-          log_event_with_statsig(user: user, event_name: event_name, event_value: event_value, metadata: metadata)
+          log_event_with_statsig(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments)
         else
           # We don't want to log in other environments, just return silently
           return
@@ -24,26 +24,32 @@ module Metrics
       end
 
       # Logs an event to Statsig
-      private def log_event_with_statsig(user:, event_name:, event_value:, metadata:)
+      private def log_event_with_statsig(user:, event_name:, event_value:, metadata:, enabled_experiments:)
         # Re-initialize Statsig to make sure it's avaiable in current thread.
         Cdo::StatsigInitializer.init
-        statsig_user = build_statsig_user(user)
+        statsig_user = build_statsig_user(user: user, enabled_experiments: enabled_experiments)
         Statsig.log_event(statsig_user, event_name, event_value, metadata)
       end
 
       # Builds a StatsigUser object from a user entity
-      private def build_statsig_user(user)
-        StatsigUser.new({'userID' => user.id.to_s})
+      private def build_statsig_user(user:, enabled_experiments:)
+        custom_ids = {
+          user_type: user.user_type,
+          enabled_experiments: enabled_experiments,
+        }.compact
+
+        StatsigUser.new({'userID' => user.id.to_s, 'custom_ids' => custom_ids})
       end
 
       # Logs an event to stdout, useful for development and debugging
-      private def log_event_to_stdout(user:, event_name:, event_value:, metadata:)
+      private def log_event_to_stdout(user:, event_name:, event_value:, metadata:, enabled_experiments:)
         event_details = {
           user_id: user.id,
+          enabled_experiments: enabled_experiments,
           event_name: event_name,
           event_value: event_value,
-          metadata: metadata
-        }
+          metadata: metadata,
+      }.compact
         puts "Logging Event: #{event_details.to_json}"
       end
     end

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -4,8 +4,9 @@ module Metrics
   module Events
     class << self
       # Logs an event, delegating to the appropriate handler based on environment
-      def log_event(user:, event_name:, event_value: nil, metadata: {}, enabled_experiments: nil)
+      def log_event(user:, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false)
         event_value = event_name if event_value.nil?
+        enabled_experiments = get_enabled_experiments ? user.get_active_experiment_names : nil
         managed_test_environment = CDO.running_web_application? && CDO.test_system?
 
         if CDO.rack_env?(:development)


### PR DESCRIPTION
In an effort to align the backend Statsig Metrics wrapper with the frontend wrapper, the following changes are necessary:

* Move the `user_type` to the Statsig user object (previously this was a value in the metadata hash)
* Add a `get_enabled_experiments` as an optional parameter, which will be a list of experiments a user might be enrolled in. The reason for this being optional is to save on db queries where experiments may not be relevant

Both of these will be values in the custom_ids hash in the StatsigUser class, per the [Statsig docs](https://docs.statsig.com/server/rubySDK#type-statsiguser).

Example usage:

```
metadata = {
    'some_data' => 'foo',
}
Metrics::Events.log_event(
    user: user,
    event_name: 'lti_user_signin',
    metadata: metadata,
    get_enabled_experiments: true,
)
```

**Old formatted event:**
<img width="798" alt="Screenshot 2024-04-25 at 5 29 22 PM" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/42a8e6aa-961f-4710-9290-c88704495082">


**New formatted event:**
<img width="793" alt="Screenshot 2024-04-26 at 12 36 12 PM" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/67b702df-619e-4b05-ab57-65ca18fd587a">




## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
