### PR TITLE
Upsize Session Storage Redis Cluster

### DIFF
--- a/aws/cloudformation/components/session_store.yml.erb
+++ b/aws/cloudformation/components/session_store.yml.erb
@@ -7,9 +7,9 @@
     Type: AWS::ElastiCache::ReplicationGroup
     Properties:
       ReplicationGroupDescription: Session Store Replication Group
-      # 3 nodes of cache.r7g.large will cost ($0.219 * 730 * 3) = ~$480/month
-      # and provide just under 40GB of storage.
-      CacheNodeType: <%= rack_env?(:production) ? 'cache.r7g.large' : 'cache.t4g.micro' -%>
+      # 3 nodes of cache.r7g.xlarge will cost ($0.437 * 730 * 3) = ~$960/month
+      # and provide just under 80GB of storage.
+      CacheNodeType: <%= rack_env?(:production) ? 'cache.r7g.xlarge' : 'cache.t4g.micro' -%>
 
       Engine: Redis
       EngineVersion: 7.1


### PR DESCRIPTION
Specifically, go up from the smallest current generation memory-optimized node size (`cache.r7g.large`) to the second-smallest current generation memory-optimized node size (`cache.r7g.xlarge`). This should effectively double both costs and total storage capacity. At current usage rates, we are [consuming ~2-3% of total storage space per day](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~'AWS*2fElastiCache~'DatabaseMemoryUsagePercentage~'CacheClusterId~'ausxf3ubdbzebgu-001~'CacheNodeId~'0001)~(~'...~'ausxf3ubdbzebgu-002~'.~'.)~(~'...~'ausxf3ubdbzebgu-003~'.~'.))~region~'us-east-1~title~'Database*20Memory*20Usage*20Percentage~stat~'Average~view~'timeSeries~start~'-PT168H~end~'P0D)), so doubling that should allow us to comfortably store multiple months worth of session data before we begin expiring.

Note that our sessions are currently configured to last at most 200 days, at which point they will be expired regardless of database capacity. This new size does not quite allow us to store a full 200 days worth of sessions, however, so in practice sessions that have not been used recently will end up getting expired before then. We could consider either further increasing database size or configuring a shorter expiration period, which would grant us a bit of a buffer and might be desirable. Not required for initial implementation, though.

One other thing to note about this change is that I'm not 100% certain we can change the size of these nodes without disruption to the service; based on [some initial reading](https://repost.aws/knowledge-center/elasticache-redis-minimize-time-scaling), it seems likely that our existing data will be preserved but there's a chance the IP address of the write instance will change, which would require a DTP (or possibly just a cycling of frontends) in order to pick up. In any case, disruption is not actually a problem for us at this point; we are not yet relying on this service for any user-facing functionality, so the worst-case scenario is we lose a bit of metrics data. If anything, this is a nice experiment so we can get a good sense of what a potential upgrade will look like in the future once we have started to rely on these servers.

## Testing story

I have done zero testing here; it seems pretty safe, and the new size is gated behind an "if in the production environment" check anyway, so I'm not entirely sure *how* I would test it out. Let me know if you have any thoughts or concerns about this!

## Deployment strategy

This template will be automatically executed by the production build as part of our standard deployment process; no special consideration that I'm aware of.
