### PR TITLE
Fix Violation of and Reenable `Rails/ApplicationMailer`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -112,11 +112,6 @@ Naming/MethodParameterName:
 Naming/VariableNumber:
   Enabled: false
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/ApplicationMailer:
-  Enabled: false
-
 # Offense count: 469
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Whitelist, AllowedMethods, AllowedReceivers.

--- a/dashboard/test/mailers/concerns/action_mailer_metrics_test.rb
+++ b/dashboard/test/mailers/concerns/action_mailer_metrics_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class ActionMailerMetricsTest < ActionMailer::TestCase
-  class TestActionMailer < ActionMailer::Base
+  class TestActionMailer < ApplicationMailer
     include ActionMailerMetrics
     def testing_email
       mail to: "test@example.com", subject: "the subject", body: "Hello"


### PR DESCRIPTION
> Checks that mailers subclass `ApplicationMailer` with Rails 5.0.

This is a pretty simple one; rather than inheriting from the base class to create our testing class, inherit from [the actual class used by Dashboard](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/mailers/application_mailer.rb), which in our case is just that base class plus some extra metrics.

## Links

- https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/ApplicationMailer
- https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsapplicationmailer

## Testing story

The only thing updated here is a test file, so I'm entirely relying on tests to verify that this continues to work.