### PR TITLE
[AI Tutor] CT-503: Format OpenAI responses using markdown

### DIFF
--- a/apps/src/aiTutor/constants.ts
+++ b/apps/src/aiTutor/constants.ts
@@ -4,7 +4,7 @@ import {
 } from '@cdo/apps/aiTutor/types';
 
 export const systemPrompt =
-  'You are a tutor in a high school classroom where the students are learning Java using the Code.org curriculum. Answer their questions in plain, easy-to-understand English. Do not write any code. Do not answer the question if it is not about Java or computer programming.';
+  'You are a tutor in a high school classroom where the students are learning Java using the Code.org curriculum. Answer their questions in plain, easy-to-understand English. Do not write any code. Do not answer the question if it is not about Java or computer programming. Please format all responses in Markdown where appropriate. Use four spaces for indentation instead of tabs.';
 
 // Initial messages we set when the user selects a tutor type.
 // General Chat

--- a/apps/src/aiTutor/views/AssistantMessage.tsx
+++ b/apps/src/aiTutor/views/AssistantMessage.tsx
@@ -42,7 +42,6 @@ const AssistantMessage: React.FC<AssistantMessageProps> = ({message}) => {
     }
   };
 
-  console.log('chatMessageText', message.chatMessageText);
   return (
     <div className={style.assistantMessageContainer}>
       <Typography semanticTag="h5" visualAppearance="heading-xs">

--- a/apps/src/aiTutor/views/AssistantMessage.tsx
+++ b/apps/src/aiTutor/views/AssistantMessage.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import {ChatCompletionMessage} from '@cdo/apps/aiTutor/types';
 import Typography from '@cdo/apps/componentLibrary/typography/Typography';
 import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 
 import {saveFeedback, FeedbackData} from '../interactionsApi';
 import style from './chat-workspace.module.scss';
@@ -41,6 +42,7 @@ const AssistantMessage: React.FC<AssistantMessageProps> = ({message}) => {
     }
   };
 
+  console.log('chatMessageText', message.chatMessageText);
   return (
     <div className={style.assistantMessageContainer}>
       <Typography semanticTag="h5" visualAppearance="heading-xs">
@@ -51,7 +53,7 @@ const AssistantMessage: React.FC<AssistantMessageProps> = ({message}) => {
           id={'chat-workspace-message-body'}
           className={classNames(style.message, style.assistantMessage)}
         >
-          {message.chatMessageText}
+          <SafeMarkdown markdown={message.chatMessageText} />
         </div>
         {message.id && (
           <>

--- a/apps/src/aiTutor/views/chat-workspace.module.scss
+++ b/apps/src/aiTutor/views/chat-workspace.module.scss
@@ -140,3 +140,9 @@ $default-spacing: 2px;
   gap: 10px;
   align-items: center;
 }
+
+pre {
+  color: $purple;
+  // Color copied for consistency with other <code> tags in SafeMarkdown component
+  background-color: #f7f7f9;
+}

--- a/apps/src/aiTutor/views/chat-workspace.module.scss
+++ b/apps/src/aiTutor/views/chat-workspace.module.scss
@@ -143,6 +143,6 @@ $default-spacing: 2px;
 
 pre {
   color: $purple;
-  // Color copied for consistency with other <code> tags in SafeMarkdown component
+  // Color copied for consistency with bootstrap styles auto-applied to SafeMarkdown component
   background-color: #f7f7f9;
 }


### PR DESCRIPTION
The following PR formats the AI response in markdown, so code blocks are properly rendered. 

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/CT-503

## Testing story

![Screenshot 2024-04-26 at 3 32 44 PM](https://github.com/code-dot-org/code-dot-org/assets/26844240/53b28d2f-1fc8-4ae8-b23d-73284b1f7add)

![Screenshot 2024-04-26 at 3 33 36 PM](https://github.com/code-dot-org/code-dot-org/assets/26844240/c6a08973-c666-4daa-8eef-9974a816668f)

![Screenshot 2024-04-26 at 3 34 10 PM](https://github.com/code-dot-org/code-dot-org/assets/26844240/4e387255-253a-45dd-aecd-41d5e8e08159)

## Follow-up work

We want to add the ability to copy a code block -- this is in a separate PR because it's riskier and requires refactoring the `SafeMarkdown` component. 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
