### PR TITLE
[LevelBuilder] Including the unit name in the deletion confirmation message.

### DIFF
--- a/dashboard/app/views/scripts/index.html.haml
+++ b/dashboard/app/views/scripts/index.html.haml
@@ -18,4 +18,4 @@
           - if script_level
             %td= link_to 'Play', script_next_path(script)
           %td= link_to(t('crud.edit'), edit_script_path(script))
-          %td= link_to t('crud.destroy'), script_path(script), method: :delete, data: { confirm: t('crud.confirm') }
+          %td= link_to t('crud.destroy'), script_path(script), method: :delete, data: { confirm: "Deleting [#{script.name}], #{t('crud.confirm')}" }


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

Issue: The confirmation waring popup when deleting an unit does not include the script name, making it hard to determine which script was actually selected for deletion.
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/b49d7445-3255-401a-9c1e-0d92ea391863)


Fix: Including the script name in the confirmation popup.
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/27b81f66-65f5-4880-9e52-f70768d33950)

## Links

None, identified improvement as part of task https://codedotorg.atlassian.net/browse/TEACH-872

## Testing story

Validated manually in local environment

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
