### PR TITLE
Music Play View - part 2

### DIFF
--- a/apps/src/lab2/projects/ChannelsStore.ts
+++ b/apps/src/lab2/projects/ChannelsStore.ts
@@ -16,6 +16,8 @@ export interface ChannelsStore {
 
   redirectToRemix: (channel: Channel) => void;
 
+  redirectToView: (channel: Channel) => void;
+
   publish: (channel: Channel) => Promise<Response>;
 
   unpublish: (channel: Channel) => Promise<Response>;
@@ -47,6 +49,10 @@ export class LocalChannelsStore implements ChannelsStore {
     // Remix is not supported for local storage.
   }
 
+  redirectToView() {
+    // View is not supported for local storage.
+  }
+
   publish() {
     // Publishing is not supported for local storage.
     return Promise.resolve(new Response(''));
@@ -76,6 +82,10 @@ export class RemoteChannelsStore implements ChannelsStore {
 
   redirectToRemix(channel: Channel) {
     projectsApi.redirectToRemix(channel.id, channel.projectType);
+  }
+
+  redirectToView(channel: Channel) {
+    projectsApi.redirectToView(channel.id, channel.projectType);
   }
 
   publish(channel: Channel) {

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -222,6 +222,15 @@ export default class ProjectManager {
     this.channelsStore.redirectToRemix(this.lastChannel);
   }
 
+  redirectToView() {
+    this.throwErrorIfDestroyed('redirectToView');
+    if (!this.lastChannel || !this.lastChannel.projectType) {
+      this.logAndThrowError('Cannot view without channel');
+      return;
+    }
+    this.channelsStore.redirectToView(this.lastChannel);
+  }
+
   /**
    * Publish the current channel.
    */

--- a/apps/src/lab2/projects/projectsApi.ts
+++ b/apps/src/lab2/projects/projectsApi.ts
@@ -23,3 +23,10 @@ export async function redirectToRemix(
 ) {
   utils.navigateToHref(`${rootUrl}${projectType}/${channelId}/remix`);
 }
+
+export async function redirectToView(
+  channelId: string,
+  projectType: ProjectType
+) {
+  utils.navigateToHref(`${rootUrl}${projectType}/${channelId}/view`);
+}

--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -1,16 +1,6 @@
 @import 'color.scss';
 @import './common.scss';
 
-.shareViewContainer {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  z-index: 1,
-}
-
 .labContainer {
   position: fixed;
   top: 52px;

--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -23,6 +23,11 @@
     pointer-events: none;
   }
 
+  &ShareView {
+    top: 0;
+    bottom: 0;
+  }
+
   .pageErrorContainer {
     @extend %full-container-overlay;
     animation: fadein 0.5s;

--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -1,6 +1,17 @@
 @import 'color.scss';
 @import './common.scss';
 
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  opacity: 0.8;
+  background-color: $light_black;
+  z-index: 1,
+}
 
 .labContainer {
   position: fixed;

--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -1,7 +1,7 @@
 @import 'color.scss';
 @import './common.scss';
 
-.overlay {
+.shareViewContainer {
   position: fixed;
   top: 0;
   bottom: 0;

--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -8,8 +8,6 @@
   left: 0;
   height: 100%;
   width: 100%;
-  opacity: 0.8;
-  background-color: $light_black;
   z-index: 1,
 }
 

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -73,8 +73,8 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
       <div
         id="lab-container"
         className={classNames(
-          moduleStyles.labContainer,
-          isLoading && moduleStyles.labContainerLoading
+          !isShareView && moduleStyles.labContainer,
+          isShareView && moduleStyles.shareViewContainer
         )}
       >
         {children}

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -73,8 +73,8 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
       <div
         id="lab-container"
         className={classNames(
-          isLoading && moduleStyles.labContainerLoading,
           moduleStyles.labContainer,
+          isLoading && moduleStyles.labContainerLoading,
           isShareView && moduleStyles.labContainerShareView
         )}
       >

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -73,8 +73,9 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
       <div
         id="lab-container"
         className={classNames(
-          !isShareView && moduleStyles.labContainer,
-          isShareView && moduleStyles.shareViewContainer
+          isLoading && moduleStyles.labContainerLoading,
+          moduleStyles.labContainer,
+          isShareView && moduleStyles.labContainerShareView
         )}
       >
         {children}

--- a/apps/src/mixins.scss
+++ b/apps/src/mixins.scss
@@ -32,18 +32,3 @@
   }
 }
 
-@mixin slider-thumb {
-  height: 20px;
-  width: 4px;
-  border-radius: 1px;
-  background: white;
-  box-shadow: 1px 1px $neutral_dark80;
-}
-
-@mixin slider-track {
-  width: 100%;
-  height: 6px;
-  background: $light_gray_700;   
-  border-radius: 10px;
-  border: 0.5px solid $neutral_dark;
-}

--- a/apps/src/mixins.scss
+++ b/apps/src/mixins.scss
@@ -31,4 +31,3 @@
     border: none !important;
   }
 }
-

--- a/apps/src/mixins.scss
+++ b/apps/src/mixins.scss
@@ -31,3 +31,19 @@
     border: none !important;
   }
 }
+
+@mixin slider-thumb {
+  border: 1px solid $neutral_dark;
+  height: 32px;
+  width: 6px;
+  border-radius: 1px;
+  background: yellow;
+}
+
+@mixin slider-track {
+  width: 100%;
+  height: 6px;
+  background: $light_gray_700;   
+  border-radius: 1px;
+  border: 0.5px solid $neutral_dark;
+}

--- a/apps/src/mixins.scss
+++ b/apps/src/mixins.scss
@@ -33,11 +33,11 @@
 }
 
 @mixin slider-thumb {
-  border: 1px solid $neutral_dark;
-  height: 32px;
-  width: 6px;
+  height: 20px;
+  width: 4px;
   border-radius: 1px;
   background: white;
+  box-shadow: 1px 1px $neutral_dark80;
 }
 
 @mixin slider-track {

--- a/apps/src/mixins.scss
+++ b/apps/src/mixins.scss
@@ -37,13 +37,13 @@
   height: 32px;
   width: 6px;
   border-radius: 1px;
-  background: yellow;
+  background: white;
 }
 
 @mixin slider-track {
   width: 100%;
   height: 6px;
   background: $light_gray_700;   
-  border-radius: 1px;
+  border-radius: 10px;
   border: 0.5px solid $neutral_dark;
 }

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -383,7 +383,10 @@ export default class MusicBlocklyWorkspace {
   }
 
   updateHighlightedBlocks(playingBlockIds: string[]) {
-    if (this.headlessMode || !this.workspace) {
+    if (this.headlessMode) {
+      return;
+    }
+    if (!this.workspace) {
       this.metricsReporter.logWarning(
         'updateHighlightedBlocks called before workspace initialized.'
       );

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -21,6 +21,7 @@ import MusicPlayer from '../player/MusicPlayer';
 import useUpdatePlayer from './hooks/useUpdatePlayer';
 import AdvancedControls from './AdvancedControls';
 import PackDialog from './PackDialog';
+import MusicPlayView from './MusicPlayView';
 
 interface MusicLabViewProps {
   blocklyDivId: string;
@@ -63,6 +64,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   const hideHeaders = useAppSelector(state => state.music.hideHeaders);
   const appName = useAppSelector(state => state.lab.levelProperties?.appName);
   const skipUrl = useAppSelector(state => state.lab.levelProperties?.skipUrl);
+  const isPlayView = useAppSelector(state => state.lab.isShareView);
 
   const progressManager = useContext(ProgressManagerContext);
 
@@ -182,6 +184,10 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   const showAdvancedControls =
     AppConfig.getValue('player') === 'tonejs' &&
     AppConfig.getValue('advanced-controls-enabled') === 'true';
+
+  if (isPlayView) {
+    return <MusicPlayView setPlaying={setPlaying} />;
+  }
 
   return (
     <div id="music-lab" className={moduleStyles.musicLab}>

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -19,13 +19,13 @@ interface MusicPlayViewProps {
 const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
   setPlaying,
 }) => {
-  const {isPlaying, lastMeasure, currentPlayheadPosition} = useAppSelector(
-    state => state.music
-  );
-  const progressValue =
-    lastMeasure === 1
+  const isPlaying = useAppSelector(state => state.music.isPlaying);
+  const progressValue = useAppSelector(state => {
+    const {currentPlayheadPosition, lastMeasure} = state.music;
+    return lastMeasure === 1
       ? 0
       : ((currentPlayheadPosition - 1) / (lastMeasure - 1)) * 100;
+  });
   const progressSliderValue = progressValue.toString();
 
   const projectName = useAppSelector(state => state.lab.channel?.name);
@@ -47,9 +47,12 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
   // Requires HTTPS connection.
   // For testing purposes, we can pass a query parameter canShare=true to force the button to appear.
   const canShareInternal = queryParams('canShare') === 'true';
-  const canShare =
-    (navigator && navigator.canShare && navigator.canShare(shareData)) ||
-    canShareInternal;
+  const canShare = useMemo(() => {
+    return (
+      (navigator && navigator.canShare && navigator.canShare(shareData)) ||
+      canShareInternal
+    );
+  }, [canShareInternal, shareData]);
 
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   const onShareProject = useCallback(() => {
@@ -57,9 +60,7 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
   }, [shareData]);
   const onViewCode = useCallback(() => {
     if (projectManager) {
-      projectManager.flushSave().then(() => {
-        projectManager.redirectToView();
-      });
+      projectManager.redirectToView();
     }
   }, [projectManager]);
   const onRemix = useCallback(() => {
@@ -71,23 +72,21 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
   }, [projectManager]);
 
   return (
-    <div className={moduleStyles.musicPlayViewContainer}>
-      <div className={moduleStyles.musicPlayViewCardContainer}>
+    <div className={moduleStyles.container}>
+      <div className={moduleStyles.cardContainer}>
         <img
-          className={moduleStyles.musicPlayViewImage}
+          className={moduleStyles.playViewImage}
           src={musicPlayViewLogo}
           alt="Code.org play view logo"
         />
-        <div className={moduleStyles.musicPlayViewCard}>
-          <div className={moduleStyles.musicPlayViewInfoSection}>
-            <Heading2 className={moduleStyles.musicPlayViewInfoText}>
-              {projectName}
-            </Heading2>
-            <BodyTwoText className={moduleStyles.musicPlayViewInfoText}>
+        <div className={moduleStyles.card}>
+          <div className={moduleStyles.infoSection}>
+            <Heading2 className={moduleStyles.infoText}>{projectName}</Heading2>
+            <BodyTwoText className={moduleStyles.infoText}>
               {musicI18n.builtWithMusicLab()}
             </BodyTwoText>
           </div>
-          <div className={moduleStyles.musicPlayViewPlaySection}>
+          <div className={moduleStyles.playSection}>
             <Button
               isIconOnly={true}
               icon={{
@@ -99,7 +98,7 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
               size="l"
               color="white"
               type="secondary"
-              className={moduleStyles.musicPlayViewButton}
+              className={moduleStyles.playViewButton}
             />
             <input
               type="range"
@@ -110,7 +109,7 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
             />
           </div>
 
-          <div className={moduleStyles.musicPlayViewButtonsSection}>
+          <div className={moduleStyles.buttonsSection}>
             <Button
               text={commonI18n.viewCode()}
               type="tertiary"

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -22,18 +22,17 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
   const {isPlaying, lastMeasure, currentPlayheadPosition} = useAppSelector(
     state => state.music
   );
-  const [progressSliderValue, setProgressSliderValue] = useState('0');
-  useEffect(() => {
-    setProgressSliderValue(
-      (((currentPlayheadPosition - 1) / (lastMeasure - 1)) * 100).toString()
-    );
-  }, [currentPlayheadPosition, lastMeasure]);
+  const progressValue =
+    lastMeasure === 1
+      ? 0
+      : ((currentPlayheadPosition - 1) / (lastMeasure - 1)) * 100;
+  const progressSliderValue = progressValue.toString();
 
   const projectName = useAppSelector(state => state.lab.channel?.name);
-  // TODO: Use isLoading to disable play button and/or show some loading indicator (spinner, etc)
-  // const isLoading = useAppSelector(
-  //   state => state.music.soundLoadingProgress < 1
-  // );
+  // Disable play button until sound is loaded.
+  const isLoading = useAppSelector(
+    state => state.music.soundLoadingProgress < 1
+  );
 
   const shareData = useMemo(
     () => ({
@@ -95,6 +94,7 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
                 iconName: !isPlaying ? 'play' : 'stop',
               }}
               onClick={() => setPlaying(!isPlaying)}
+              disabled={isLoading}
               size="s"
               color="white"
               type="secondary"

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -20,13 +20,14 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
   setPlaying,
 }) => {
   const isPlaying = useAppSelector(state => state.music.isPlaying);
-  const progressValue = useAppSelector(state => {
+  const progressSliderValue = useAppSelector(state => {
     const {currentPlayheadPosition, lastMeasure} = state.music;
-    return lastMeasure === 1
-      ? 0
-      : ((currentPlayheadPosition - 1) / (lastMeasure - 1)) * 100;
+    const value =
+      lastMeasure === 1
+        ? 0
+        : ((currentPlayheadPosition - 1) / (lastMeasure - 1)) * 100;
+    return value.toString();
   });
-  const progressSliderValue = progressValue.toString();
 
   const projectName = useAppSelector(state => state.lab.channel?.name);
   // Disable play button until sound is loaded.
@@ -59,9 +60,7 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
     navigator?.share(shareData);
   }, [shareData]);
   const onViewCode = useCallback(() => {
-    if (projectManager) {
-      projectManager.redirectToView();
-    }
+    projectManager?.redirectToView();
   }, [projectManager]);
   const onRemix = useCallback(() => {
     if (projectManager) {

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -114,34 +114,32 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
               text={commonI18n.viewCode()}
               type="tertiary"
               color="white"
-              size="s"
+              size="xs"
               iconLeft={{iconStyle: 'solid', iconName: 'code'}}
               onClick={onViewCode}
             />
-            <Button
-              text={commonI18n.makeMyOwn()}
-              type="tertiary"
-              color="white"
-              size="s"
-              iconLeft={{iconStyle: 'regular', iconName: 'pen-to-square'}}
-              onClick={onRemix}
-            />
-          </div>
-          {canShare && (
-            <div className={moduleStyles.musicPlayViewButtonsSection}>
+            {canShare && (
               <Button
                 text={musicI18n.share()}
                 type="tertiary"
                 color="white"
-                size="s"
+                size="xs"
                 iconLeft={{
                   iconStyle: 'solid',
                   iconName: 'arrow-up-from-bracket',
                 }}
                 onClick={onShareProject}
               />
-            </div>
-          )}
+            )}
+            <Button
+              text={commonI18n.makeMyOwn()}
+              type="tertiary"
+              color="white"
+              size="xs"
+              iconLeft={{iconStyle: 'regular', iconName: 'pen-to-square'}}
+              onClick={onRemix}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useCallback, useMemo, useEffect, useState} from 'react';
+import React, {memo, useCallback, useMemo} from 'react';
 
 import {Button} from '@cdo/apps/componentLibrary/button';
 import {Heading2, BodyTwoText} from '@cdo/apps/componentLibrary/typography';
@@ -83,8 +83,12 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
         />
         <div className={moduleStyles.musicPlayViewCard}>
           <div className={moduleStyles.musicPlayViewInfoSection}>
-            <Heading2>{projectName}</Heading2>
-            <BodyTwoText>{musicI18n.builtWithMusicLab()}</BodyTwoText>
+            <Heading2 className={moduleStyles.musicPlayViewInfoText}>
+              {projectName}
+            </Heading2>
+            <BodyTwoText className={moduleStyles.musicPlayViewInfoText}>
+              {musicI18n.builtWithMusicLab()}
+            </BodyTwoText>
           </div>
           <div className={moduleStyles.musicPlayViewPlaySection}>
             <Button

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useCallback, useMemo} from 'react';
+import React, {memo, useCallback, useMemo, useEffect, useState} from 'react';
 
 import {Button} from '@cdo/apps/componentLibrary/button';
 import {Heading2, BodyTwoText} from '@cdo/apps/componentLibrary/typography';
@@ -22,11 +22,11 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
   const {isPlaying, lastMeasure, currentPlayheadPosition} = useAppSelector(
     state => state.music
   );
-  let progressSliderValue =
-    ((currentPlayheadPosition - 1) / (lastMeasure - 1)) * 100;
-  if (!progressSliderValue) {
-    progressSliderValue = 0;
-  }
+  const progressSliderValue = (
+    ((currentPlayheadPosition - 1) / (lastMeasure - 1)) *
+    100
+  ).toString();
+
   const projectName = useAppSelector(state => state.lab.channel?.name);
   // TODO: Use isLoading to disable play button and/or show some loading indicator (spinner, etc)
   // const isLoading = useAppSelector(
@@ -97,7 +97,13 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
               color="white"
               type="secondary"
             />
-            <input type="range" value={progressSliderValue} min="0" max="100" />
+            <input
+              type="range"
+              readOnly
+              value={progressSliderValue}
+              min="0"
+              max="100"
+            />
           </div>
 
           <div className={moduleStyles.musicPlayViewButtonsSection}>

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -130,6 +130,7 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
           {canShare && (
             <div className={moduleStyles.musicPlayViewButtonsSection}>
               <Button
+                className={moduleStyles.musicPlayViewShareButton}
                 text={musicI18n.share()}
                 type="secondary"
                 color="white"

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -22,10 +22,12 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
   const {isPlaying, lastMeasure, currentPlayheadPosition} = useAppSelector(
     state => state.music
   );
-  const progressSliderValue = (
-    ((currentPlayheadPosition - 1) / (lastMeasure - 1)) *
-    100
-  ).toString();
+  const [progressSliderValue, setProgressSliderValue] = useState('0');
+  useEffect(() => {
+    setProgressSliderValue(
+      (((currentPlayheadPosition - 1) / (lastMeasure - 1)) * 100).toString()
+    );
+  }, [currentPlayheadPosition, lastMeasure]);
 
   const projectName = useAppSelector(state => state.lab.channel?.name);
   // TODO: Use isLoading to disable play button and/or show some loading indicator (spinner, etc)

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -3,25 +3,33 @@ import React, {memo, useCallback, useMemo} from 'react';
 import {Button} from '@cdo/apps/componentLibrary/button';
 import {Heading2, BodyTwoText} from '@cdo/apps/componentLibrary/typography';
 import commonI18n from '@cdo/locale';
-import codeOrgLogo from '@cdo/static/code-dot-org-white-logo.svg';
+import musicPlayViewLogo from '@cdo/static/music/music-play-view.png';
 
 import moduleStyles from './music-play-view.module.scss';
 
 import musicI18n from '../locale';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {queryParams} from '@cdo/apps/code-studio/utils';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 
 interface MusicPlayViewProps {
-  isPlaying: boolean;
-  onPlay: () => void;
-  onStop: () => void;
-  projectName: string;
+  setPlaying: (value: boolean) => void;
 }
 
 const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
-  isPlaying,
-  onPlay,
-  onStop,
-  projectName,
+  setPlaying,
 }) => {
+  const {isPlaying, lastMeasure, currentPlayheadPosition} = useAppSelector(
+    state => state.music
+  );
+  const progressSliderValue =
+    ((currentPlayheadPosition - 1) / (lastMeasure - 1)) * 100;
+  const projectName = useAppSelector(state => state.lab.channel?.name);
+  // TODO: Use isLoading to disable play button and/or show some loading indicator (spinner, etc)
+  // const isLoading = useAppSelector(
+  //   state => state.music.soundLoadingProgress < 1
+  // );
+
   const shareData = useMemo(
     () => ({
       title: projectName,
@@ -35,71 +43,94 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
   // Requires HTTPS connection (adhoc or production page).
   // Was unable to access it on localhost with our routing (http://localhost-studio.code.org:3000/
   // is not considered a safe URL by browser, only http://localhost:3000/ is).
-  const canShare =
-    navigator && navigator.canShare && navigator.canShare(shareData);
 
+  // For testing purposes, we can pass a query parameter canShare=true to force the button to appear.
+  const canShareInternal = queryParams('canShare') === 'true';
+  const canShare =
+    (navigator && navigator.canShare && navigator.canShare(shareData)) ||
+    canShareInternal;
+
+  const projectManager = Lab2Registry.getInstance().getProjectManager();
   const onShareProject = useCallback(() => {
     navigator?.share(shareData);
   }, [shareData]);
   const onViewCode = useCallback(() => {
-    console.log('view code');
-  }, []);
+    if (projectManager) {
+      projectManager.flushSave().then(() => {
+        projectManager.redirectToView();
+      });
+    }
+  }, [projectManager]);
   const onRemix = useCallback(() => {
-    console.log('make my own');
-  }, []);
+    if (projectManager) {
+      projectManager.flushSave().then(() => {
+        projectManager.redirectToRemix();
+      });
+    }
+  }, [projectManager]);
 
   return (
     <div className={moduleStyles.musicPlayViewContainer}>
-      <div className={moduleStyles.musicPlayViewCard}>
-        <div className={moduleStyles.musicPlayViewInfoSection}>
-          <img src={codeOrgLogo} alt="Code.org" />
-          <Heading2>{projectName}</Heading2>
-          <BodyTwoText>Built with Music Lab</BodyTwoText>
-        </div>
+      <div className={moduleStyles.musicPlayViewCardContainer}>
+        <img
+          className={moduleStyles.musicPlayViewImage}
+          src={musicPlayViewLogo}
+          alt="Code.org play view logo"
+        />
+        <div className={moduleStyles.musicPlayViewCard}>
+          <div className={moduleStyles.musicPlayViewInfoSection}>
+            <Heading2>{projectName}</Heading2>
+            <BodyTwoText>{musicI18n.builtWithMusicLab()}</BodyTwoText>
+          </div>
+          <div className={moduleStyles.musicPlayViewPlaySection}>
+            <Button
+              isIconOnly={true}
+              icon={{
+                iconStyle: 'solid',
+                iconName: !isPlaying ? 'play' : 'stop',
+              }}
+              onClick={() => setPlaying(!isPlaying)}
+              size="s"
+              color="white"
+              type="secondary"
+            />
+            <input type="range" value={progressSliderValue} min="0" max="100" />
+          </div>
 
-        <div className={moduleStyles.musicPlayViewPlaySection}>
-          <Button
-            isIconOnly={true}
-            icon={{iconStyle: 'solid', iconName: !isPlaying ? 'play' : 'stop'}}
-            onClick={!isPlaying ? onPlay : onStop}
-            size="s"
-            color="white"
-            type="secondary"
-          />
-          {/*TODO: get the total length of the song, show current player position/play progress*/}
-          <input type="range" min="0" max="100" />
-        </div>
-
-        <div className={moduleStyles.musicPlayViewButtonsSection}>
-          <Button
-            text={commonI18n.viewCode()}
-            type="secondary"
-            color="white"
-            size="s"
-            iconLeft={{iconStyle: 'solid', iconName: 'code'}}
-            onClick={onViewCode}
-          />
-          <Button
-            text={commonI18n.makeMyOwn()}
-            type="secondary"
-            color="white"
-            size="s"
-            iconLeft={{iconStyle: 'solid', iconName: 'user-music'}}
-            onClick={onRemix}
-          />
-        </div>
-        {canShare && (
           <div className={moduleStyles.musicPlayViewButtonsSection}>
             <Button
-              text={musicI18n.share()}
+              text={commonI18n.viewCode()}
               type="secondary"
               color="white"
               size="s"
-              iconLeft={{iconStyle: 'solid', iconName: 'share'}}
-              onClick={onShareProject}
+              iconLeft={{iconStyle: 'solid', iconName: 'code'}}
+              onClick={onViewCode}
+            />
+            <Button
+              text={commonI18n.makeMyOwn()}
+              type="secondary"
+              color="white"
+              size="s"
+              iconLeft={{iconStyle: 'regular', iconName: 'pen-to-square'}}
+              onClick={onRemix}
             />
           </div>
-        )}
+          {canShare && (
+            <div className={moduleStyles.musicPlayViewButtonsSection}>
+              <Button
+                text={musicI18n.share()}
+                type="secondary"
+                color="white"
+                size="s"
+                iconLeft={{
+                  iconStyle: 'solid',
+                  iconName: 'arrow-up-from-bracket',
+                }}
+                onClick={onShareProject}
+              />
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -112,7 +112,7 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
           <div className={moduleStyles.musicPlayViewButtonsSection}>
             <Button
               text={commonI18n.viewCode()}
-              type="secondary"
+              type="tertiary"
               color="white"
               size="s"
               iconLeft={{iconStyle: 'solid', iconName: 'code'}}
@@ -120,7 +120,7 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
             />
             <Button
               text={commonI18n.makeMyOwn()}
-              type="secondary"
+              type="tertiary"
               color="white"
               size="s"
               iconLeft={{iconStyle: 'regular', iconName: 'pen-to-square'}}
@@ -130,9 +130,8 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
           {canShare && (
             <div className={moduleStyles.musicPlayViewButtonsSection}>
               <Button
-                className={moduleStyles.musicPlayViewShareButton}
                 text={musicI18n.share()}
-                type="secondary"
+                type="tertiary"
                 color="white"
                 size="s"
                 iconLeft={{

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -22,8 +22,11 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
   const {isPlaying, lastMeasure, currentPlayheadPosition} = useAppSelector(
     state => state.music
   );
-  const progressSliderValue =
+  let progressSliderValue =
     ((currentPlayheadPosition - 1) / (lastMeasure - 1)) * 100;
+  if (!progressSliderValue) {
+    progressSliderValue = 0;
+  }
   const projectName = useAppSelector(state => state.lab.channel?.name);
   // TODO: Use isLoading to disable play button and/or show some loading indicator (spinner, etc)
   // const isLoading = useAppSelector(

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -42,12 +42,9 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
     [projectName]
   );
 
-  // Share button will only appear when users browser supports the Web Share API
+  // Share button will only appear when user's browser supports the Web Share API.
   // (Can be mobile browsers and some desktop browser like macOS Safari)
-  // Requires HTTPS connection (adhoc or production page).
-  // Was unable to access it on localhost with our routing (http://localhost-studio.code.org:3000/
-  // is not considered a safe URL by browser, only http://localhost:3000/ is).
-
+  // Requires HTTPS connection.
   // For testing purposes, we can pass a query parameter canShare=true to force the button to appear.
   const canShareInternal = queryParams('canShare') === 'true';
   const canShare =

--- a/apps/src/music/views/MusicPlayView.tsx
+++ b/apps/src/music/views/MusicPlayView.tsx
@@ -96,9 +96,10 @@ const MusicPlayView: React.FunctionComponent<MusicPlayViewProps> = ({
               }}
               onClick={() => setPlaying(!isPlaying)}
               disabled={isLoading}
-              size="s"
+              size="l"
               color="white"
               type="secondary"
+              className={moduleStyles.musicPlayViewButton}
             />
             <input
               type="range"

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -108,6 +108,7 @@ class UnconnectedMusicView extends React.Component {
     setUndoStatus: PropTypes.func,
     showCallout: PropTypes.func,
     clearCallout: PropTypes.func,
+    isPlayView: PropTypes.bool,
   };
 
   constructor(props) {
@@ -271,13 +272,15 @@ class UnconnectedMusicView extends React.Component {
     }
     await this.loadAndInitializePlayer(libraryName || DEFAULT_LIBRARY);
 
-    this.musicBlocklyWorkspace.init(
-      document.getElementById(BLOCKLY_DIV_ID),
-      this.onBlockSpaceChange,
-      this.props.isReadOnlyWorkspace,
-      levelData?.toolbox,
-      this.props.isRtl
-    );
+    this.props.isPlayView
+      ? this.musicBlocklyWorkspace.initHeadless()
+      : this.musicBlocklyWorkspace.init(
+          document.getElementById(BLOCKLY_DIV_ID),
+          this.onBlockSpaceChange,
+          this.props.isReadOnlyWorkspace,
+          levelData?.toolbox,
+          this.props.isRtl
+        );
 
     this.library.setAllowedSounds(levelData?.sounds);
     this.props.setShowInstructions(
@@ -295,6 +298,10 @@ class UnconnectedMusicView extends React.Component {
       }
       this.loadCode(codeToLoad);
     }
+
+    // Go ahead and compile and execute the initial song once code is loaded.
+    this.compileSong();
+    this.executeCompiledSong();
 
     Globals.setShowSoundFilters(
       AppConfig.getValue('show-sound-filters') === 'true' ||
@@ -702,6 +709,7 @@ const MusicView = connect(
     isProjectLevel: state.lab.levelProperties?.isProjectLevel,
     isReadOnlyWorkspace: isReadOnlyWorkspace(state),
     startingPlayheadPosition: state.music.startingPlayheadPosition,
+    isPlayView: state.lab.isShareView,
   }),
   dispatch => ({
     setLibraryName: libraryName => dispatch(setLibraryName(libraryName)),

--- a/apps/src/music/views/music-play-view.module.scss
+++ b/apps/src/music/views/music-play-view.module.scss
@@ -52,6 +52,12 @@
       display: flex;
       align-items: center;
       gap: 1rem;
+      background: $neutral_dark;
+      padding: 10px;
+
+      .musicPlayViewButton {
+        border-color: transparent;
+      }
 
       input[type=range] {
         -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
@@ -90,8 +96,7 @@
 
     .musicPlayViewButtonsSection {
       display: flex;
-      gap: 1rem;
-      justify-content: center;
+      justify-content: space-between;
       margin-top: 10px;
     }
   }

--- a/apps/src/music/views/music-play-view.module.scss
+++ b/apps/src/music/views/music-play-view.module.scss
@@ -1,4 +1,5 @@
 @import 'color';
+@import '../../mixins.scss';
 
 .musicPlayViewContainer {
   display: flex;
@@ -52,14 +53,39 @@
       align-items: center;
       gap: 1rem;
 
-      input[type='range'] {
-        overflow: hidden;
-        width: 100%;
-        accent-color: yellow;
-
-        background-color: $light_gray_800;
-        color: $light_gray_800;
+      input[type=range] {
+        -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
+        width: 100%; /* Specific width is required for Firefox. */
+        background: transparent; /* Otherwise white in Chrome */
       }
+      
+      input[type=range]::-ms-track {
+        width: 100%;      
+        /* Hides the slider so custom styles can be added */
+        background: transparent; 
+        border-color: transparent;
+        color: transparent;
+      }
+
+      input[type=range]::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        @include slider-thumb;
+        margin-top: -14px; /* You need to specify a margin in Chrome, but in Firefox it is automatic */
+      }
+
+      /* Firefox */
+      input[type=range]::-moz-range-thumb {
+        @include slider-thumb;
+      }
+
+      input[type=range]::-webkit-slider-runnable-track{
+        @include slider-track;
+      }
+
+      /* Firefox */
+      input[type=range]::-moz-range-track {
+        @include slider-track;
+      }    
     }
 
     .musicPlayViewButtonsSection {

--- a/apps/src/music/views/music-play-view.module.scss
+++ b/apps/src/music/views/music-play-view.module.scss
@@ -9,25 +9,38 @@
   width: 100%;
   background-color: $light_black;
 
+
+  .musicPlayViewCardContainer {
+    max-width: 360px;
+    border-color: $neutral_dark60;
+    border-width: 1px;
+    border-style: solid;
+    border-radius: 5px;
+  }
+
+  .musicPlayViewImage {
+    align-self: center;
+    display: flex;
+    flex-direction: column;
+    max-width: 350px;
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius: 0.5rem;
+  }
+
   .musicPlayViewCard {
     display: flex;
     flex-direction: column;
     max-width: 350px;
     background-color: $light_gray_900;
     gap: .5rem;
-    padding: 2rem;
-    border-radius: 0.5rem;
+    padding: 1.5rem;
+    border-bottom-left-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
 
     .musicPlayViewInfoSection {
       display: flex;
       flex-direction: column;
       gap: .5rem;
-
-      img {
-        width: 56px;
-        align-self: center;
-      }
-
       h2, p {
         color: $light_white;
         margin-bottom: 0;
@@ -42,8 +55,8 @@
       input[type='range'] {
         overflow: hidden;
         width: 100%;
-        height: 4px;
-        accent-color: $light_gray_200;
+        height: 5px;
+        accent-color: yellow;
 
         background-color: $light_gray_800;
         color: $light_gray_800;

--- a/apps/src/music/views/music-play-view.module.scss
+++ b/apps/src/music/views/music-play-view.module.scss
@@ -9,14 +9,13 @@
   height: 100%;
   width: 100%;
   background-color: $light_black;
+  border-radius: 4px;
 
 
   .musicPlayViewCardContainer {
     max-width: 360px;
-    border-color: $neutral_dark60;
-    border-width: 1px;
-    border-style: solid;
-    border-radius: 5px;
+    border-radius: 4px;
+    box-shadow: 3px 3px 6px black;
   }
 
   .musicPlayViewImage {
@@ -26,6 +25,7 @@
     max-width: 350px;
     border-top-left-radius: 0.5rem;
     border-top-right-radius: 0.5rem;
+    border-radius: 4px;
   }
 
   .musicPlayViewCard {
@@ -35,8 +35,7 @@
     background-color: $light_gray_900;
     gap: .5rem;
     padding: 1.5rem;
-    border-bottom-left-radius: 0.5rem;
-    border-bottom-right-radius: 0.5rem;
+    border-radius: 4px;
 
     .musicPlayViewInfoSection {
       display: flex;
@@ -54,6 +53,10 @@
       gap: 1rem;
       background: $neutral_dark;
       padding: 10px;
+      border-width: 1px;
+      border-style: solid;
+      border-color: $light_gray_700;
+      border-radius: 4px;
 
       .musicPlayViewButton {
         border-color: transparent;
@@ -76,7 +79,7 @@
       input[type=range]::-webkit-slider-thumb {
         -webkit-appearance: none;
         @include slider-thumb;
-        margin-top: -14px; /* You need to specify a margin in Chrome, but in Firefox it is automatic */
+        margin-top: -8px; /* You need to specify a margin in Chrome, but in Firefox it is automatic */
       }
 
       /* Firefox */

--- a/apps/src/music/views/music-play-view.module.scss
+++ b/apps/src/music/views/music-play-view.module.scss
@@ -48,6 +48,12 @@
     }
 
     .musicPlayViewPlaySection {
+      align-items: center;
+      box-sizing: border-box;
+      padding: 15px;
+      gap: 20px;
+      height: 50px;
+      background-color: $light_black;
       display: flex;
       align-items: center;
       gap: 1rem;
@@ -55,7 +61,6 @@
       input[type='range'] {
         overflow: hidden;
         width: 100%;
-        height: 5px;
         accent-color: yellow;
 
         background-color: $light_gray_800;

--- a/apps/src/music/views/music-play-view.module.scss
+++ b/apps/src/music/views/music-play-view.module.scss
@@ -40,8 +40,8 @@
     .musicPlayViewInfoSection {
       display: flex;
       flex-direction: column;
-      gap: .5rem;
-      h2, p {
+      gap: 0.5rem;
+      .musicPlayViewInfoText {
         color: $light_white;
         margin-bottom: 0;
       }
@@ -50,7 +50,7 @@
     .musicPlayViewPlaySection {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 1rem;
 
       input[type='range'] {
         overflow: hidden;
@@ -65,7 +65,7 @@
 
     .musicPlayViewButtonsSection {
       display: flex;
-      gap: .5rem;
+      gap: 1rem;
       justify-content: center;
     }
   }

--- a/apps/src/music/views/music-play-view.module.scss
+++ b/apps/src/music/views/music-play-view.module.scss
@@ -66,6 +66,11 @@
       display: flex;
       gap: 1rem;
       justify-content: center;
+
+      .musicPlayViewShareButton {
+        margin-top: 5px;
+        width: 10rem;
+      }
     }
   }
 }

--- a/apps/src/music/views/music-play-view.module.scss
+++ b/apps/src/music/views/music-play-view.module.scss
@@ -1,7 +1,22 @@
 @import 'color';
-@import '../../mixins.scss';
 
-.musicPlayViewContainer {
+@mixin slider-thumb {
+  height: 20px;
+  width: 4px;
+  border-radius: 1px;
+  background: white;
+  box-shadow: 1px 1px $neutral_dark80;
+}
+
+@mixin slider-track {
+  width: 100%;
+  height: 6px;
+  background: $light_gray_700;   
+  border-radius: 10px;
+  border: 0.5px solid $neutral_dark;
+}
+
+.container {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -12,23 +27,21 @@
   border-radius: 4px;
 
 
-  .musicPlayViewCardContainer {
+  .cardContainer {
     max-width: 360px;
     border-radius: 4px;
     box-shadow: 3px 3px 6px black;
   }
 
-  .musicPlayViewImage {
+  .playViewImage {
     align-self: center;
     display: flex;
     flex-direction: column;
     max-width: 350px;
-    border-top-left-radius: 0.5rem;
-    border-top-right-radius: 0.5rem;
     border-radius: 4px;
   }
 
-  .musicPlayViewCard {
+  .card {
     display: flex;
     flex-direction: column;
     max-width: 350px;
@@ -37,17 +50,17 @@
     padding: 1.5rem;
     border-radius: 4px;
 
-    .musicPlayViewInfoSection {
+    .infoSection {
       display: flex;
       flex-direction: column;
       gap: 0.5rem;
-      .musicPlayViewInfoText {
+      .infoText {
         color: $light_white;
         margin-bottom: 0;
       }
     }
 
-    .musicPlayViewPlaySection {
+    .playSection {
       display: flex;
       align-items: center;
       gap: 1rem;
@@ -58,49 +71,42 @@
       border-color: $light_gray_700;
       border-radius: 4px;
 
-      .musicPlayViewButton {
+      .playViewButton {
         border-color: transparent;
       }
 
-      input[type=range] {
+      .buttonsSection {
+        display: flex;
+        justify-content: space-between;
+        margin-top: 10px;
+      }
+
+      input[type="range"] {
         -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
         width: 100%; /* Specific width is required for Firefox. */
         background: transparent; /* Otherwise white in Chrome */
       }
-      
-      input[type=range]::-ms-track {
-        width: 100%;      
-        /* Hides the slider so custom styles can be added */
-        background: transparent; 
-        border-color: transparent;
-        color: transparent;
-      }
 
-      input[type=range]::-webkit-slider-thumb {
+      input[type="range"]::-webkit-slider-thumb {
         -webkit-appearance: none;
+
         @include slider-thumb;
         margin-top: -8px; /* You need to specify a margin in Chrome, but in Firefox it is automatic */
       }
 
       /* Firefox */
-      input[type=range]::-moz-range-thumb {
+      input[type="range"]::-moz-range-thumb {
         @include slider-thumb;
       }
 
-      input[type=range]::-webkit-slider-runnable-track{
+      input[type="range"]::-webkit-slider-runnable-track{
         @include slider-track;
       }
 
       /* Firefox */
-      input[type=range]::-moz-range-track {
+      input[type="range"]::-moz-range-track {
         @include slider-track;
       }    
-    }
-
-    .musicPlayViewButtonsSection {
-      display: flex;
-      justify-content: space-between;
-      margin-top: 10px;
     }
   }
 }

--- a/apps/src/music/views/music-play-view.module.scss
+++ b/apps/src/music/views/music-play-view.module.scss
@@ -48,12 +48,6 @@
     }
 
     .musicPlayViewPlaySection {
-      align-items: center;
-      box-sizing: border-box;
-      padding: 15px;
-      gap: 20px;
-      height: 50px;
-      background-color: $light_black;
       display: flex;
       align-items: center;
       gap: 1rem;

--- a/apps/src/music/views/music-play-view.module.scss
+++ b/apps/src/music/views/music-play-view.module.scss
@@ -75,12 +75,6 @@
         border-color: transparent;
       }
 
-      .buttonsSection {
-        display: flex;
-        justify-content: space-between;
-        margin-top: 10px;
-      }
-
       input[type="range"] {
         -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
         width: 100%; /* Specific width is required for Firefox. */
@@ -107,6 +101,12 @@
       input[type="range"]::-moz-range-track {
         @include slider-track;
       }    
+    }
+
+    .buttonsSection {
+      display: flex;
+      justify-content: space-between;
+      margin-top: 10px;
     }
   }
 }

--- a/apps/src/music/views/music-play-view.module.scss
+++ b/apps/src/music/views/music-play-view.module.scss
@@ -92,11 +92,7 @@
       display: flex;
       gap: 1rem;
       justify-content: center;
-
-      .musicPlayViewShareButton {
-        margin-top: 5px;
-        width: 10rem;
-      }
+      margin-top: 10px;
     }
   }
 }

--- a/apps/static/music/music-play-view.png
+++ b/apps/static/music/music-play-view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ad28f51ba1b9c79eef07c81ddf1d81050e38ef9797b8455aaa609a13a607891
+size 721765

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -365,7 +365,8 @@ class ProjectsController < ApplicationController
       params[:channel_id] = params[:channel_id].tr(cipher, alphabet)
     end
 
-    redirect_for_lab2 = redirect_view_for_lab2
+    set_lab2_responsive_view_options
+    redirect_for_lab2 = redirect_edit_view_for_lab2
     return redirect_for_lab2 if redirect_for_lab2
 
     iframe_embed = params[:iframe_embed] == true
@@ -589,12 +590,9 @@ class ProjectsController < ApplicationController
   # Redirect to the correct view/edit page for Lab2 projects. If a project owner is on a /view
   # page, redirect to /edit. If a non-owner is on an /edit page, redirect to /view.
   # For legacy (non-Lab2) labs, this is handled on the front-end.
-  private def redirect_view_for_lab2
+  private def redirect_edit_view_for_lab2
     return nil unless @level.uses_lab2?
-    # If the user is on the play view '/projects/channel_id', set `response_content`.`
-    if params[:share] == true
-      view_options(responsive_content: true)
-    end
+
     project = Projects.new(get_storage_id).get(params[:channel_id])
     is_owner = project[:isOwner]
 
@@ -602,6 +600,14 @@ class ProjectsController < ApplicationController
     return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/view" if !is_owner && request.path.ends_with?('/edit')
   end
 
+  private def set_lab2_responsive_view_options
+    return nil unless @level.uses_lab2?
+  
+    # If the user is on the play view '/projects/channel_id', set `response_content`.`
+    if params[:share] == true
+      view_options(responsive_content: true)
+    end
+  end
   # Automatically catch authorization exceptions on any methods in this controller
   # Overrides handler defined in application_controller.rb.
   # Special for projects controller - when forbidden, redirect to home instead

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -365,13 +365,13 @@ class ProjectsController < ApplicationController
       params[:channel_id] = params[:channel_id].tr(cipher, alphabet)
     end
 
-    set_lab2_responsive_view_options
     redirect_for_lab2 = redirect_edit_view_for_lab2
     return redirect_for_lab2 if redirect_for_lab2
 
     iframe_embed = params[:iframe_embed] == true
     iframe_embed_app_and_code = params[:iframe_embed_app_and_code] == true
     sharing = iframe_embed || params[:share] == true
+    set_lab2_responsive_view_options(sharing)
     readonly = params[:readonly] == true
     if iframe_embed || iframe_embed_app_and_code
       # explicitly set security related headers so that this page can actually
@@ -600,11 +600,11 @@ class ProjectsController < ApplicationController
     return redirect_to "/projects/#{params[:key]}/#{params[:channel_id]}/view" if !is_owner && request.path.ends_with?('/edit')
   end
 
-  private def set_lab2_responsive_view_options
+  private def set_lab2_responsive_view_options(sharing)
     return nil unless @level.uses_lab2?
-  
+
     # If the user is on the play view '/projects/channel_id', set `response_content`.`
-    if params[:share] == true
+    if sharing == true
       view_options(responsive_content: true)
     end
   end

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -365,7 +365,7 @@ class ProjectsController < ApplicationController
       params[:channel_id] = params[:channel_id].tr(cipher, alphabet)
     end
 
-    redirect_for_lab2 = redirect_edit_view_for_lab2
+    redirect_for_lab2 = redirect_view_for_lab2
     return redirect_for_lab2 if redirect_for_lab2
 
     iframe_embed = params[:iframe_embed] == true
@@ -589,9 +589,12 @@ class ProjectsController < ApplicationController
   # Redirect to the correct view/edit page for Lab2 projects. If a project owner is on a /view
   # page, redirect to /edit. If a non-owner is on an /edit page, redirect to /view.
   # For legacy (non-Lab2) labs, this is handled on the front-end.
-  private def redirect_edit_view_for_lab2
+  private def redirect_view_for_lab2
     return nil unless @level.uses_lab2?
-
+    # If the user is on the play view '/projects/channel_id', set `response_content`.`
+    if params[:share] == true
+      view_options(responsive_content: true)
+    end
     project = Projects.new(get_storage_id).get(params[:channel_id])
     is_owner = project[:isOwner]
 


### PR DESCRIPTION
This PR updates the Music Lab play view and follows up https://github.com/code-dot-org/code-dot-org/pull/58068.

Note that the adhoc based on this branch is available at https://adhoc-alice-play-view-updates-studio.cdn-code.org/home.
[Example project in play view](https://adhoc-alice-play-view-updates-studio.cdn-code.org/projects/music/lpef7b3VcqvntTmBLG2c1w).

Updates in this PR include:
- Adds `MusicPlayView` to `MusicLabView` so that when `isShareView` is set to `true`, the play view is rendered.
- In `MusicView`, when `isPlayView` is set to `true`, a headless `musicBlocklyWorkspace` is initialized, i.e., the UI of the blockly workspace is not rendered. Thanks to @sanchitmalhotra126 for pairing with me on this! I based this part of the PR on Sanchit's [WIP branch](https://github.com/code-dot-org/code-dot-org/compare/staging...sanchit/wip-music-play-view).
- Adds functionality to the play/stop slider and shows progress as song plays.
- Adds functionality to the 'View code' button (view/edit mode) and Make my Own' button (remix).
- Adds `redirectToView` to `projectsApi`.
- Adds the music play image from product.
- Updated styling of play view based on product/design preferences.

The 'Share' button in play view is displayed on most mobile devices. But you can view this button if you add the query param '?canShare=true' to the end of the project play view url, e.g., https://adhoc-alice-play-view-updates-studio.cdn-code.org/projects/music/lpef7b3VcqvntTmBLG2c1w?canShare=true 

## After Update

Play view card on desk top:
<img width="431" alt="Screenshot 2024-04-30 at 6 00 23 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/559d5f00-c125-484e-b59f-e9ae8c4b8c7c">


Play view full screen on desk top:
<img width="1404" alt="Screenshot 2024-04-30 at 6 00 18 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/3efb773f-d9c4-4488-8e7e-e565e34d51b4">

Play view on mobile:
<img width="379" alt="Screenshot 2024-04-30 at 6 02 24 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/e2697fed-3583-4830-a019-f8584aba2dd5">


Screencast video of play view on desktop:

https://github.com/code-dot-org/code-dot-org/assets/107423305/9b93f33a-6027-4bb2-859d-a6667dc00927







<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Follow-up will be to refactor the slider and include adding color to progress.

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
