### PR TITLE
Music: pack dialog grid

### DIFF
--- a/apps/src/music/views/PackDialog.module.scss
+++ b/apps/src/music/views/PackDialog.module.scss
@@ -49,63 +49,70 @@
       margin-bottom: 14px;
     }
 
-    .packs {
+    .packsContainer {
       width: 100%;
       height: 100%;
       overflow-y: auto;
       flex: 1;
-      display: grid;
-      grid-template-columns: 25% 25% 25% 25%;
-
       background-color: $neutral_dark;
       border: solid $neutral_dark 2px;
       box-sizing: border-box;
       border-radius: 5px;
+      padding: 16px;
 
-      .pack {
-        box-sizing: border-box;
-        padding: 16px;
-        cursor: pointer;
+      .packs {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, 232px);
+        grid-gap: 4px;
+        justify-content: space-around;
 
-        &Selected {
-          background-color: $dark_black;
-          border-radius: 5px;
-        }
+        .pack {
+          box-sizing: border-box;
+          cursor: pointer;
+          width: 232px;
+          padding: 16px;
 
-        &Image {
-          width: 100%;
-          transform: scale(1, 1);
-          transition: 0.1s ease-in-out;
+          &Selected {
+            background-color: $dark_black;
+            border-radius: 5px;
+          }
 
-          &:hover, &Selected {
-            transform: scale(1.03, 1.03);
+          &Image {
+            width: 100%;
+            transform: scale(1, 1);
             transition: 0.1s ease-in-out;
-          }
-        }
+            border-radius: 5px;
 
-        &Footer {
-          margin-top: 10px;
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-
-          &Name {
-            font-size: 16px;
+            &:hover, &Selected {
+              transform: scale(1.03, 1.03);
+              transition: 0.1s ease-in-out;
+            }
           }
 
-          &Artist {
-            font-size: 11px;
-          }
+          &Footer {
+            margin-top: 10px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
 
-          &Preview {
-            margin-right: 10px;
+            &Name {
+              font-size: 16px;
+            }
 
-            .preview {
-              color: $neutral_dark40;
+            &Artist {
+              font-size: 11px;
+            }
 
-              &Playing {
-                color: $neutral_dark70;
-                cursor: default;
+            &Preview {
+              margin-right: 10px;
+
+              .preview {
+                color: $neutral_dark40;
+
+                &Playing {
+                  color: $neutral_dark70;
+                  cursor: default;
+                }
               }
             }
           }

--- a/apps/src/music/views/PackDialog.tsx
+++ b/apps/src/music/views/PackDialog.tsx
@@ -200,19 +200,21 @@ const PackDialog: React.FunctionComponent<PackDialogProps> = ({player}) => {
 
           <div className={styles.body}>{musicI18n.packDialogBody()}</div>
 
-          <div className={styles.packs}>
-            {folders.map((folder, folderIndex) => {
-              return (
-                <PackEntry
-                  key={folderIndex}
-                  playingPreview={playingPreviewState}
-                  folder={folder}
-                  isSelected={folder.id === selectedFolderId}
-                  onSelect={handleSelectFolder}
-                  onPreview={onPreview}
-                />
-              );
-            })}
+          <div className={styles.packsContainer}>
+            <div className={styles.packs}>
+              {folders.map((folder, folderIndex) => {
+                return (
+                  <PackEntry
+                    key={folderIndex}
+                    playingPreview={playingPreviewState}
+                    folder={folder}
+                    isSelected={folder.id === selectedFolderId}
+                    onSelect={handleSelectFolder}
+                    onPreview={onPreview}
+                  />
+                );
+              })}
+            </div>
           </div>
 
           <div className={styles.buttonContainer}>


### PR DESCRIPTION
The pack dialog's grid of packs now has fixed-width entries.

### Screenshots

Here are a couple different window widths, showing how the grid has fixed-width entries, with the number of columns being dynamic:

<img width="1295" alt="Screenshot 2024-04-28 at 10 12 59 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/c47d709d-e90e-433d-81b7-b613fa9c6b2e">

###

<img width="1295" alt="music-pack-dialog-grid-1" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/a83651b8-1b37-47df-9c22-47879171c505">


