### PR TITLE
Music: more callouts and validations

### DIFF
--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -46,10 +46,12 @@ const toolboxBlocks = {
     type: BlockTypes.PLAY_SOUND_AT_CURRENT_LOCATION_SIMPLE2,
   },
   [BlockTypes.PLAY_PATTERN_AT_CURRENT_LOCATION_SIMPLE2]: {
+    id: BlockTypes.PLAY_PATTERN_AT_CURRENT_LOCATION_SIMPLE2,
     kind: 'block',
     type: BlockTypes.PLAY_PATTERN_AT_CURRENT_LOCATION_SIMPLE2,
   },
   [BlockTypes.PLAY_CHORD_AT_CURRENT_LOCATION_SIMPLE2]: {
+    id: BlockTypes.PLAY_CHORD_AT_CURRENT_LOCATION_SIMPLE2,
     kind: 'block',
     type: BlockTypes.PLAY_CHORD_AT_CURRENT_LOCATION_SIMPLE2,
   },

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -4,6 +4,8 @@ import MusicPlayer from '../player/MusicPlayer';
 import {Condition, ConditionType} from '@cdo/apps/lab2/types';
 import ConditionsChecker from '@cdo/apps/lab2/progress/ConditionsChecker';
 import {PlaybackEvent} from '../player/interfaces/PlaybackEvent';
+import {ChordEvent} from '../player/interfaces/ChordEvent';
+import {PatternEvent} from '../player/interfaces/PatternEvent';
 import {Validator} from '@cdo/apps/lab2/progress/ProgressManager';
 
 export interface ConditionNames {
@@ -15,7 +17,9 @@ export const MusicConditions: ConditionNames = {
   PLAYED_SOUND_TRIGGERED: {name: 'played_sound_triggered'},
   PLAYED_SOUNDS: {name: 'played_sounds', valueType: 'number'},
   PLAYED_SOUND_ID: {name: 'played_sound_id', valueType: 'string'},
+  PLAYED_EMPTY_CHORDS: {name: 'played_empty_chords', valueType: 'number'},
   PLAYED_CHORDS: {name: 'played_chords', valueType: 'number'},
+  PLAYED_EMPTY_PATTERNS: {name: 'played_empty_patterns', valueType: 'number'},
   PLAYED_PATTERNS: {name: 'played_patterns', valueType: 'number'},
 };
 
@@ -49,10 +53,14 @@ export default class MusicValidator extends Validator {
     // Get number of sounds that have been started.
     let playedNumberSounds = 0;
 
-    // Get number of patterns that have been started.
+    // Get number of patterns that have been started, separately counting those
+    // that are empty and those with events.
+    let playedNumberEmptyPatterns = 0;
     let playedNumberPatterns = 0;
 
-    // Get number of chords that have been started.
+    // Get number of chords that have been started, separately counting those
+    // that are empty and those with notes.
+    let playedNumberEmptyChords = 0;
     let playedNumberChords = 0;
 
     const currentPlayheadPosition = this.player.getCurrentPlayheadPosition();
@@ -82,9 +90,19 @@ export default class MusicValidator extends Validator {
 
         playedNumberSounds++;
       } else if (eventData.type === 'pattern') {
-        playedNumberPatterns++;
+        const patternEvent = eventData as PatternEvent;
+        if (patternEvent.value.events.length === 0) {
+          playedNumberEmptyPatterns++;
+        } else {
+          playedNumberPatterns++;
+        }
       } else if (eventData.type === 'chord') {
-        playedNumberChords++;
+        const chordEvent = eventData as ChordEvent;
+        if (chordEvent.value.notes.length === 0) {
+          playedNumberEmptyChords++;
+        } else {
+          playedNumberChords++;
+        }
       }
     });
 
@@ -110,11 +128,19 @@ export default class MusicValidator extends Validator {
 
     // Add satisfied conditions for the played patterns.
     this.addPlayedConditions(
+      MusicConditions.PLAYED_EMPTY_PATTERNS.name,
+      playedNumberEmptyPatterns
+    );
+    this.addPlayedConditions(
       MusicConditions.PLAYED_PATTERNS.name,
       playedNumberPatterns
     );
 
     // Add satisfied conditions for the played chords.
+    this.addPlayedConditions(
+      MusicConditions.PLAYED_EMPTY_CHORDS.name,
+      playedNumberEmptyChords
+    );
     this.addPlayedConditions(
       MusicConditions.PLAYED_CHORDS.name,
       playedNumberChords

--- a/apps/src/music/views/Callouts.tsx
+++ b/apps/src/music/views/Callouts.tsx
@@ -78,6 +78,10 @@ const Callouts: React.FunctionComponent = () => {
   const elementLeft = elementRect.left + elementWidth / 2;
   const elementTop = elementRect.bottom + 4;
 
+  if (elementRect.width === 0) {
+    return null;
+  }
+
   return (
     <div
       id="callout"

--- a/apps/src/music/views/Callouts.tsx
+++ b/apps/src/music/views/Callouts.tsx
@@ -13,6 +13,12 @@ const availableCallouts: {
   'play-sound-block': {
     selector: `.blocklyFlyout g[data-id="${BlockTypes.PLAY_SOUND_AT_CURRENT_LOCATION_SIMPLE2}"]`,
   },
+  'play-notes-block': {
+    selector: `.blocklyFlyout g[data-id="${BlockTypes.PLAY_CHORD_AT_CURRENT_LOCATION_SIMPLE2}"]`,
+  },
+  'play-drums-block': {
+    selector: `.blocklyFlyout g[data-id="${BlockTypes.PLAY_PATTERN_AT_CURRENT_LOCATION_SIMPLE2}"]`,
+  },
   'play-sounds-together-block': {
     selector: `.blocklyFlyout g[data-id="${BlockTypes.PLAY_SOUNDS_TOGETHER}"]`,
   },


### PR DESCRIPTION
This adds some new callouts and validations to support the curriculum team, which is authoring `/s/music-introduction-2024` for classrooms.

Two new callouts: `play-notes-block` and `play-drums-block`, which point to those blocks inside the toolbox.

Two new validations, and adjustments to two existing validations:
- `played_empty_chords` is a count of how many empty `play notes` blocks are encountered.
- `played_chords` is now a count of how many `play notes` blocks with notes are encountered.
- `played_empty_patterns` is a count of how many empty `play drums` blocks are encountered.
- `played_patterns` is now a count of how many `play drums` blocks with events are encountered.

Also includes a small fix to not show the callouts arrow if the target element isn't visible. 