### PR TITLE
Fix and test PL unit completion for contained levels

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1939,6 +1939,10 @@ class User < ApplicationRecord
     levels = pl_scripts.map(&:levels).flatten
     level_ids = levels.pluck(:id)
 
+    # Handle levels-within-levels
+    # For bubble choice levels, a UserLevel is created for the parent, so no need to handle children
+    # However, for non-bubble choice levels, a UserLevel is only created for the child level, so we need
+    # to include it in the list of level_ids to chck for
     levels.filter {|l| l.contained_levels.count > 0 && !l.is_a?(BubbleChoice)}.each do |level|
       contained_levels = level.contained_levels
       level_ids += contained_levels.pluck(:id)

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -5220,7 +5220,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal fully_registered_teacher.authentication_options.first.email, params.dig('authentication_options_attributes', '0', 'email')
   end
 
-  test 'pl_units_started handles BubbleChoice levels correctly' do
+  test 'pl_units_started only counts parent BubbleChoice level' do
     pl_unit = create :pl_unit
     create :course_version, content_root: pl_unit
 


### PR DESCRIPTION
Fixes a case where, when a unit contained a bubble choice level, greater than 100% completion was being shown. To fix that, I changed the logic to look for the levels, instead of the units, associated with a UserLevel.

This did come with a side effect of not counting predict levels correctly. Predict levels are set up such that the Blockly level is in the ScriptLevel and contains the FreeResponse/Multi level. However, the UserLevel is created for the FreeResponse/Multi level. I added some special handling for that case.

I added a test for both BubbleChoice and predict levels.

I largely used the investigation in https://github.com/code-dot-org/code-dot-org/pull/57121 as a starting point here!

## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
