### PR TITLE
Add Music Lab dashboard banner content to announcements.json

### DIFF
--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -36,6 +36,14 @@
       "buttonText": "Learn more about AI Teaching Assistant",
       "buttonUrl": "https://code.org/ai-ta",
       "buttonId": "ai-teaching-assistant"
+    },
+    "music-lab-launch": {
+      "image": "/shared/images/banners/music-lab-with-afe-logo.png",
+      "title": "Introducing Music Lab",
+      "body": "Get creative with your favorite artist's music and code new songs and mixes!",
+      "buttonText": "Learn more",
+      "buttonUrl": "https://code.org/music",
+      "buttonId": "music-lab-launch-student"
     }
   }
 }

--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -43,7 +43,7 @@
       "body": "Get creative with your favorite artist's music and code new songs and mixes!",
       "buttonText": "Learn more",
       "buttonUrl": "https://code.org/music",
-      "buttonId": "music-lab-launch-student"
+      "buttonId": "music-lab-launch"
     }
   }
 }

--- a/shared/images/banners/music-lab-with-afe-logo.png
+++ b/shared/images/banners/music-lab-with-afe-logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6423dae394dbf49f22621967a9788678c8cb0400812f16aef14aec7e05feb1be
+size 75678


### PR DESCRIPTION
Adds Music Lab banner content to `announcements.json` so it can be translated ahead of the Music Lab launch. These are **not live** yet and will go live with a DCDO flag that I'll add in these tickets next sprint: [ACQ-1676](https://codedotorg.atlassian.net/browse/ACQ-1676) • [ACQ-1677](https://codedotorg.atlassian.net/browse/ACQ-1677)

**Jira ticket:** [ACQ-1847](https://codedotorg.atlassian.net/browse/ACQ-1847)

----

<img width="991" alt="Screenshot 2024-04-29 at 9 28 45 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/17b8a55a-5994-435d-8575-88be601f0ecd">
