### PR TITLE
Update ruby-prof gem to support ARM chipset

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ group :development, :test do
   gem 'brakeman'
   gem 'database_cleaner-active_record', '~> 2.1.0'
   gem 'haml-rails' # haml (instead of erb) generators
-  gem 'ruby-prof'
+  gem 'ruby-prof', '>= 1.7.0'
   gem 'vcr', require: false
   # For unit testing.
   gem 'webmock', '~> 3.8', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1111,7 +1111,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rails-accessibility
-  ruby-prof
+  ruby-prof (>= 1.7.0)
   ruby-progressbar
   sass-rails (~> 6.0.0)
   sassc-rails!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -806,7 +806,7 @@ GEM
     rubocop-rails-accessibility (0.2.0)
       rubocop (>= 1.0.0)
     ruby-openid (2.9.2)
-    ruby-prof (0.15.9)
+    ruby-prof (1.7.0)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)


### PR DESCRIPTION
The current version of ruby-prof that we install (0.15.9) is failing to install on development environments that use the ARM chipset. Upgrade to the latest (1.7.0).

We only use this gem in `development` and `test` environments so this change is likely low risk.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
