### PR TITLE
feat: add DCDO flag for posting email param to finish signup page

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -281,7 +281,16 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   private def register_new_user(user)
     PartialRegistration.persist_attributes(session, user)
-    redirect_to new_user_registration_url
+
+    if DCDO.get('student-email-post-enabled', false)
+      @form_data = {
+        email: user.email
+      }
+
+      render 'omniauth/redirect', {layout: false}
+    else
+      redirect_to new_user_registration_url
+    end
   end
 
   # TODO: figure out how to avoid skipping CSRF verification for Powerschool

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -63,12 +63,10 @@ class RegistrationsController < Devise::RegistrationsController
 
     if @user.errors.blank?
       PartialRegistration.persist_attributes(session, @user)
-      redirect_to new_user_registration_path unless is_signup_post_enabled
-    else
-      render 'new' unless is_signup_post_enabled # Re-render form to display validation errors
+      redirect_to new_user_registration_path and return unless is_signup_post_enabled
     end
 
-    render 'new' if is_signup_post_enabled
+    render 'new'
   end
 
   #

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -41,6 +41,8 @@
           = link_to t('cancel'), users_cancel_path
 
     = f.hidden_field :locale, value: locale
+    - if DCDO.get('student-email-post-enabled', false)
+      = f.hidden_field :email, value: @user.email
     - if @user.errors.any?
       .row
         .span8

--- a/dashboard/app/views/omniauth/redirect.html.haml
+++ b/dashboard/app/views/omniauth/redirect.html.haml
@@ -1,0 +1,17 @@
+!!!
+%html{lang: "en"}
+  %head
+    %meta{charset: "UTF-8"}
+    %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}
+    %title= t('nav.user.loading')
+
+    = form_with(url: users_finish_sign_up_path, method: :post, html: {id: 'redirect-form'}) do |f|
+      = f.hidden_field :email, value: @form_data[:email]
+
+    :javascript
+      window.onload = function() {
+        document.getElementById("redirect-form").submit()
+      };
+
+  %body
+    %p=t('nav.user.loading')

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -181,6 +181,7 @@ Dashboard::Application.routes.draw do
     devise_scope :user do
       get '/oauth_sign_out/:provider', to: 'sessions#oauth_sign_out', as: :oauth_sign_out
       post '/users/begin_sign_up', to: 'registrations#begin_sign_up'
+      post '/users/finish_sign_up', to: 'registrations#new'
       patch '/dashboardapi/users', to: 'registrations#update'
       patch '/users/upgrade', to: 'registrations#upgrade'
       patch '/users/set_student_information', to: 'registrations#set_student_information'

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -4,6 +4,10 @@ class Policies::User
   def self.user_attributes(user)
     attributes = user.attributes
     authentication_options = user.authentication_options.map {|ao| ao.attributes.compact}
+
+    # Remove the plaintext email from the session cache
+    attributes.delete("email") if DCDO.get('student-email-post-enabled', false)
+
     attributes.merge('authentication_options_attributes' => authentication_options).compact
   end
 end

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -631,6 +631,32 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal uid, partial_user.uid
   end
 
+  test 'google_oauth2: renders redirector to complete registration if user is not found by credentials' do
+    Cpa.stubs(:cpa_experience).with(any_parameters).returns(false)
+    SignUpTracking.stubs(:begin_sign_up_tracking).returns(false)
+    DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
+    DCDO.stubs(:get).with('student-email-post-enabled', false).returns(true)
+    # Given I do not have a Code.org account
+    uid = "nonexistent-google-oauth2"
+
+    # When I hit the google oauth callback
+    auth = generate_auth_user_hash \
+      provider: AuthenticationOption::GOOGLE,
+      uid: uid,
+      user_type: '' # Google doesn't provider user_type
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+    assert_does_not_create(User) do
+      get :google_oauth2
+    end
+
+    # Then I go to the registration page to finish signing up
+    assert_template 'omniauth/redirect'
+    partial_user = User.new_from_partial_registration(session)
+    assert_equal AuthenticationOption::GOOGLE, partial_user.provider
+    assert_equal uid, partial_user.uid
+  end
+
   test 'google_oauth2: sets tokens in session/cache when redirecting to complete registration' do
     # Given I do not have a Code.org account
     uid = "nonexistent-google-oauth2"

--- a/dashboard/test/integration/registration/begin_sign_up_test.rb
+++ b/dashboard/test/integration/registration/begin_sign_up_test.rb
@@ -25,6 +25,25 @@ module RegistrationsControllerTests
       assert_redirected_to new_user_registration_path
     end
 
+    test 'persists user attributes on success - POST flow' do
+      SignUpTracking.expects(:log_begin_sign_up)
+      PartialRegistration.expects(:persist_attributes)
+      Cpa.stubs(:cpa_experience).with(any_parameters).returns(false)
+      DCDO.stubs(:get).with('student-email-post-enabled', false).returns(true)
+      DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
+
+      params = {
+        user: {
+          email: 'myemail@example.com',
+          password: 'mypassword',
+          password_confirmation: 'mypassword'
+        }
+      }
+      post '/users/begin_sign_up', params: params
+
+      assert_template 'new'
+    end
+
     test 'renders signup page with error if email is empty' do
       SignUpTracking.expects(:log_begin_sign_up)
       PartialRegistration.expects(:persist_attributes).never

--- a/dashboard/test/lib/policies/user_test.rb
+++ b/dashboard/test/lib/policies/user_test.rb
@@ -24,5 +24,13 @@ class Policies::UserTest < ActiveSupport::TestCase
       assert_equal ao_email, attrs_aos[0]['email']
       assert_equal user.authentication_options.count, attrs_aos.count
     end
+
+    test 'remove email from user session value' do
+      DCDO.stubs(:get).with('student-email-post-enabled', false).returns(true)
+      user = create :teacher
+
+      attrs = Policies::User.user_attributes(user)
+      assert_nil attrs['email']
+    end
   end
 end

--- a/dashboard/test/models/concerns/partial_registration_test.rb
+++ b/dashboard/test/models/concerns/partial_registration_test.rb
@@ -91,8 +91,10 @@ class PartialRegistrationTest < ActiveSupport::TestCase
 
     user = User.new_from_partial_registration @session do |u|
       u.name = 'Different fake name'
+      u.email = 'different-email@code.org'
     end
     assert_equal 'Different fake name', user.name
+    assert_equal 'different-email@code.org', user.email
   end
 
   test 'round-trip preserves important attributes (email)' do


### PR DESCRIPTION
This PR adds scaffolding to enable email addresses to bypass the partial registration cache and go directly into the finish signup page. This is accomplished by adding a new DCDO flag `student-email-post-enabled` which is off by default.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-834)
- [design](https://docs.google.com/document/d/1G9nXdae8Gt2Ea93enIJEdjSnF3xB9Rb-W4pCDnt46vo/edit#heading=h.25gc3zi9dtz9)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. With DCDO disabled, signed up for account
2. With DCDO disabled, signed up via Google OAuth
3. With DCDO enabled, signed up for account
4. With DCDO enabled, signed up via Google OAuth

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

This will be deployed via a DCDO feature flag

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
