### PR TITLE
Ceara/aitt 602 levelbuilder instructions test

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -171,7 +171,6 @@ class ScriptsController < ApplicationController
       return render 'errors/deprecated_course'
     end
     raise "The new unit editor does not support level variants with experiments" if @script.is_migrated && @script.script_levels.any?(&:has_experiment?)
-    @show_all_instructions = params[:show_all_instructions]
     @script_data = {
       script: @script ? @script.summarize_for_unit_edit : {},
       has_course: @script&.unit_groups&.any?,

--- a/dashboard/app/views/scripts/edit.html.haml
+++ b/dashboard/app/views/scripts/edit.html.haml
@@ -18,21 +18,3 @@
   .edit_container
   %script{src: webpack_asset_path('js/scripts/edit.js'),
           data: {levelBuilderEditScript: @script_data.to_json}}
-
-- if @show_all_instructions
-  - @script.lessons.each do |lesson|
-    %br
-      %h1= lesson.localized_title
-      %br
-      - lesson.script_levels.each do |sl|
-        %div{style: 'padding-left:40px'}
-          = link_to edit_level_path(sl.level) do
-            %h2= "Puzzle #{sl.position} Instructions (#{sl.level.name}):"
-        %br
-        %div{style: 'padding-left:80px'}
-          - md = sl.level.properties['markdown'] || sl.level.properties['long_instructions']
-          - if md.present?
-            = ActionView::Base.new.render(inline: md, type: :md)
-          - else
-            = sl.level.properties['short_instructions']
-        %br


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Description

Adds a ruby integration test that verifies that the levelbuilder `/instructions` view is successfully created. There is one test that creates a simple `/instructions` page, and another test that creates a page with a variety of level types to display, including ones that previously broke the page. 

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/AITT-602
Follow up to this commit: https://github.com/code-dot-org/code-dot-org/pull/54547

## Testing story

When I undo the fix to the instructions page from [this commit](https://github.com/code-dot-org/code-dot-org/pull/54547), the new test fails, with the fix from that commit, the test passes

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
