### PR TITLE
Music: enable Amplitude analytics on standalone projects

### DIFF
--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -5,13 +5,17 @@ import {
   identify,
   setSessionId,
   flush,
+  setUserId,
 } from '@amplitude/analytics-browser';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {isDevelopmentEnvironment} from '@cdo/apps/utils';
+import {
+  getEnvironment,
+  isDevelopmentEnvironment,
+  isProductionEnvironment,
+} from '@cdo/apps/utils';
 import {Block} from 'blockly';
-
-const BlockTypes = require('../blockly/blockTypes').BlockTypes;
-const FIELD_SOUNDS_NAME = require('../blockly/constants').FIELD_SOUNDS_NAME;
+import {BlockTypes} from '../blockly/blockTypes';
+import {FIELD_SOUNDS_NAME} from '../blockly/constants';
 
 const API_KEY_ENDPOINT = '/musiclab/analytics_key';
 
@@ -25,7 +29,7 @@ const blockFeatureList = [
   BlockTypes.PLAY_REST_AT_CURRENT_LOCATION_SIMPLE2,
 ];
 
-const triggerBlocks = [
+const triggerBlocks: string[] = [
   BlockTypes.TRIGGERED_AT,
   BlockTypes.TRIGGERED_AT_SIMPLE,
   BlockTypes.TRIGGERED_AT_SIMPLE2,
@@ -45,8 +49,6 @@ interface BlockStats {
 
 interface SessionEndPayload {
   durationSeconds: number;
-  mostInstructionsVisited: number;
-  lastInstructionsVisited: number;
   soundsUsed: string[];
   blockStats: BlockStats;
   featuresUsed: {[feature: string]: boolean};
@@ -61,8 +63,6 @@ export default class AnalyticsReporter {
   private sessionInProgress: boolean;
   private identifyObj: Identify;
   private sessionStartTime: number;
-  private maxInstructionsSeen: number;
-  private currentInstructionsPage: number;
   private soundsUsed: Set<string>;
   private blockStats: BlockStats;
   private featuresUsed: {[feature: string]: boolean};
@@ -71,8 +71,6 @@ export default class AnalyticsReporter {
     this.sessionInProgress = false;
     this.identifyObj = new Identify();
     this.sessionStartTime = -1;
-    this.maxInstructionsSeen = 0;
-    this.currentInstructionsPage = 0;
     this.soundsUsed = new Set();
     this.blockStats = {
       endingBlockCount: 0,
@@ -101,9 +99,7 @@ export default class AnalyticsReporter {
       this.sessionInProgress = true;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.log(
-        `[AMPLITUDE ANALYTICS] Did not initialize analytics reporter.  (${message})`
-      );
+      this.log(`Did not initialize analytics reporter.  (${message})`);
 
       // Log an error if this is not development. On development, this error is expected.
       if (!isDevelopmentEnvironment()) {
@@ -125,16 +121,14 @@ export default class AnalyticsReporter {
     return init(responseJson.key, undefined, {minIdLength: 1}).promise;
   }
 
-  setUserProperties(userId: string, userType: string, signInState: string) {
+  setUserProperties(userId: number, userType: string, signInState: string) {
     if (!this.sessionInProgress) {
       this.log('No session in progress');
       return;
     }
 
-    // Temporarily disabled, pending user privacy compliance discussions.
-    // if (userId) {
-    //   setUserId(hashString(userId));
-    // }
+    const formattedUserId = this.formatUserId(userId);
+    setUserId(formattedUserId);
 
     this.identifyObj.set('userType', userType);
     this.identifyObj.set('signInState', signInState);
@@ -169,29 +163,6 @@ export default class AnalyticsReporter {
     }
 
     track(eventType, payload).promise;
-  }
-
-  onVideoClosed(id: string, duration: number) {
-    const logMessage = `Video closed. Id: ${id}. Duration: ${duration}}`;
-
-    if (!this.sessionInProgress) {
-      this.log(`No session in progress.  (${logMessage})`);
-      return;
-    } else {
-      this.log(logMessage);
-    }
-
-    track('Video closed', {id, duration}).promise;
-  }
-
-  onInstructionsVisited(page: number) {
-    if (!this.sessionInProgress) {
-      this.log('No session in progress');
-      return;
-    }
-
-    this.currentInstructionsPage = page;
-    this.maxInstructionsSeen = Math.max(this.maxInstructionsSeen, page);
   }
 
   onBlocksUpdated(blocks: Block[]) {
@@ -253,8 +224,6 @@ export default class AnalyticsReporter {
 
     const payload: SessionEndPayload = {
       durationSeconds: duration / 1000,
-      mostInstructionsVisited: this.maxInstructionsSeen,
-      lastInstructionsVisited: this.currentInstructionsPage,
       soundsUsed: Array.from(this.soundsUsed),
       blockStats: this.blockStats,
       featuresUsed: this.featuresUsed,
@@ -267,6 +236,19 @@ export default class AnalyticsReporter {
   }
 
   log(message: string) {
-    console.log(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
+    console.log(`[MUSIC AMPLITUDE ANALYTICS EVENT]: ${message}`);
+  }
+
+  private formatUserId(userId: number) {
+    const userIdString = userId.toString() || 'none';
+    if (!userId) {
+      return userIdString;
+    }
+    if (isProductionEnvironment()) {
+      return userIdString.padStart(5, '0');
+    } else {
+      const environment = getEnvironment();
+      return `${environment}-${userIdString}`;
+    }
   }
 }

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -240,10 +240,10 @@ export default class AnalyticsReporter {
   }
 
   private formatUserId(userId: number) {
-    const userIdString = userId.toString() || 'none';
     if (!userId) {
-      return userIdString;
+      return 'none';
     }
+    const userIdString = userId.toString();
     if (isProductionEnvironment()) {
       return userIdString.padStart(5, '0');
     } else {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -150,8 +150,8 @@ class UnconnectedMusicView extends React.Component {
   }
 
   componentDidMount() {
-    // Only record Amplitude analytics events on /projectbeats
-    if (this.props.onProjectBeats) {
+    // Only record Amplitude analytics events on standalone projects
+    if (this.props.isProjectLevel) {
       this.analyticsReporter.startSession().then(() => {
         this.analyticsReporter.setUserProperties(
           this.props.userId,
@@ -164,7 +164,7 @@ class UnconnectedMusicView extends React.Component {
     // we need a way of reporting analytics when the user navigates away from the page. Check with Amplitude for the
     // correct approach.
     window.addEventListener('beforeunload', event => {
-      if (this.props.onProjectBeats) {
+      if (this.props.isProjectLevel) {
         this.analyticsReporter.endSession();
       }
     });
@@ -182,7 +182,7 @@ class UnconnectedMusicView extends React.Component {
     this.musicBlocklyWorkspace.resizeBlockly();
 
     if (
-      this.props.onProjectBeats &&
+      this.props.isProjectLevel &&
       (prevProps.userId !== this.props.userId ||
         prevProps.userType !== this.props.userType ||
         prevProps.signInState !== this.props.signInState)
@@ -438,7 +438,7 @@ class UnconnectedMusicView extends React.Component {
         }
       });
 
-      if (this.props.onProjectBeats) {
+      if (this.props.isProjectLevel) {
         this.analyticsReporter.onBlocksUpdated(
           this.musicBlocklyWorkspace.getAllBlocks()
         );
@@ -461,7 +461,7 @@ class UnconnectedMusicView extends React.Component {
   setPlaying = play => {
     if (play) {
       this.playSong();
-      if (this.props.onProjectBeats) {
+      if (this.props.isProjectLevel) {
         this.analyticsReporter.onButtonClicked('play');
       }
     } else {
@@ -477,7 +477,7 @@ class UnconnectedMusicView extends React.Component {
     if (!this.props.isPlaying) {
       return;
     }
-    if (this.props.onProjectBeats) {
+    if (this.props.isProjectLevel) {
       this.analyticsReporter.onButtonClicked('trigger', {id});
     }
 
@@ -647,7 +647,7 @@ class UnconnectedMusicView extends React.Component {
   render() {
     return (
       <AnalyticsContext.Provider
-        value={this.props.onProjectBeats ? this.analyticsReporter : null}
+        value={this.props.isProjectLevel ? this.analyticsReporter : null}
       >
         <KeyHandler
           togglePlaying={this.togglePlaying}


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

## Description

Enable Amplitude analytics on standalone music projects (rather than /projectbeats)

<img width="1378" alt="Screenshot 2024-04-30 at 12 06 14 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/ae319dc4-65eb-45ae-9ca2-c1d2f84765c3">

## Links

https://codedotorg.atlassian.net/browse/LABS-727

## Testing story

Tested with standalone projects and script levels - confirmed that events are only emitted for standalone projects.