### PR TITLE
Empty AWS connection pool after app-server fork

### DIFF
--- a/lib/cdo/app_server_hooks.rb
+++ b/lib/cdo/app_server_hooks.rb
@@ -34,6 +34,7 @@ module Cdo
       # intialized in config/initializers/statsig.rb
       require 'cdo/statsig'
       Cdo::StatsigInitializer.init
+      Aws.empty_connection_pools!
     end
   end
 end


### PR DESCRIPTION
Thanks to a [helpful reproduction](https://github.com/aws/aws-sdk-ruby/issues/1331#issuecomment-2082184096) of a long-standing concurrency bug in the AWS SDK, we now know that the `RuntimeError: can't add a new key into hash during iteration` error can be caused by an application-server fork that occurs while another thread is iterating through the AWS connection pool. The fix is to call [`Aws.empty_connection_pools!`](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws.html#empty_connection_pools!-class_method) in the app-server fork hook to clear the connection pool from the child process.

## Links

aws/aws-sdk-ruby#1331
aws/aws-sdk-ruby#1438

## Testing story

I didn't test this at all, I don't even know if this issue has still been occurring in the app - just thought I'd share the solution as soon as I heard about it!

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
