### PR TITLE
UI changes from School Association BugBash

### DIFF
--- a/apps/src/templates/SchoolDataInputs.jsx
+++ b/apps/src/templates/SchoolDataInputs.jsx
@@ -117,7 +117,9 @@ export default function SchoolDataInputs({
                 value={zip}
               />
               {zip && !zipSearchReady && (
-                <BodyThreeText>{i18n.zipInvalidMessage()}</BodyThreeText>
+                <BodyThreeText className={style.errorMessage}>
+                  {i18n.zipInvalidMessage()}
+                </BodyThreeText>
               )}
             </label>
             <SchoolZipSearch

--- a/apps/src/templates/SchoolDataInputs.jsx
+++ b/apps/src/templates/SchoolDataInputs.jsx
@@ -77,7 +77,7 @@ export default function SchoolDataInputs({
   };
 
   return (
-    <div className={style.outerContainer}>
+    <div className={style.schoolAssociationWrapper}>
       {includeHeaders && (
         <div>
           <Heading2 className={style.topPadding}>

--- a/apps/src/templates/SchoolDataInputs.jsx
+++ b/apps/src/templates/SchoolDataInputs.jsx
@@ -92,7 +92,6 @@ export default function SchoolDataInputs({
         </BodyTwoText>
         <SimpleDropdown
           id="uitest-country-dropdown"
-          className={style.dropdown}
           name={fieldNames.country}
           items={COUNTRY_ITEMS}
           selectedValue={country}

--- a/apps/src/templates/SchoolZipSearch.jsx
+++ b/apps/src/templates/SchoolZipSearch.jsx
@@ -97,7 +97,6 @@ export default function SchoolZipSearch({fieldNames, zip, disabled}) {
           <SimpleDropdown
             id="uitest-school-dropdown"
             disabled={disabled}
-            className={style.dropdown}
             name={fieldNames.ncesSchoolId}
             itemGroups={[
               {

--- a/apps/src/templates/SchoolZipSearch.jsx
+++ b/apps/src/templates/SchoolZipSearch.jsx
@@ -6,7 +6,7 @@ import style from './school-association.module.scss';
 import classNames from 'classnames';
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
 import SchoolNameInput from '@cdo/apps/templates/SchoolNameInput';
-import Button from '@cdo/apps/templates/Button';
+import {Button} from '@cdo/apps/componentLibrary/button';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
@@ -115,7 +115,9 @@ export default function SchoolZipSearch({fieldNames, zip, disabled}) {
           <Button
             text={i18n.noSchoolSetting()}
             disabled={disabled}
-            styleAsText={true}
+            color={'purple'}
+            type={'tertiary'}
+            size={'xs'}
             onClick={e => {
               e.preventDefault();
               setSelectedSchoolNcesId(NO_SCHOOL_SETTING);
@@ -129,7 +131,9 @@ export default function SchoolZipSearch({fieldNames, zip, disabled}) {
           <SchoolNameInput fieldNames={{schoolName: fieldNames.schoolName}} />
           <Button
             text={i18n.returnToResults()}
-            styleAsText={true}
+            color={'purple'}
+            type={'tertiary'}
+            size={'xs'}
             onClick={() => {
               setInputManually(false);
               setSelectedSchoolNcesId(SELECT_A_SCHOOL);

--- a/apps/src/templates/school-association.module.scss
+++ b/apps/src/templates/school-association.module.scss
@@ -9,6 +9,26 @@
   h2 {
     margin-bottom: 0.25rem;
   }
+
+  label {
+    width: 100%;
+  }
+
+  input {
+    width: 100%;
+    box-sizing: border-box;
+    height: 46px !important;
+    font-size: 1rem;
+    margin-top: 0.37rem !important;
+    border-radius: 0.25rem;
+    border: 1px solid;
+    text-indent: 0.75rem;
+  }
+
+  select {
+    font-weight: 400 !important;
+    width: 100% !important;
+  }
 }
 
 .inputContainer {
@@ -17,21 +37,6 @@
   width: 400px;
   display: flex;
   flex-direction: column;
-
-  & > div > label > * {
-    width: 100%;
-  }
-
-  & > div > label > input {
-    box-sizing: border-box;
-    height: 46px !important;
-    font-size: 1rem;
-    margin-top: 0.37rem !important;
-    border-radius: 0.25rem;
-    border: 1px solid;
-    background-color: inherit;
-    text-indent: 0.75rem;
-  }
 
   .padding {
     padding-top: 0.75rem;
@@ -42,12 +47,3 @@
       color: $light_gray_300 !important;
     }
   }
-
-.dropdown {
-  & > div {
-    select {
-      font-weight: 400 !important;
-      width: 100% !important;
-    }
-  }
-}

--- a/apps/src/templates/school-association.module.scss
+++ b/apps/src/templates/school-association.module.scss
@@ -1,7 +1,7 @@
 @import 'color.scss';
 @import 'font.scss';
 
-.outerContainer {
+.schoolAssociationWrapper {
   text-align: center;
   display: grid;
   padding: 0.75rem;

--- a/apps/src/templates/school-association.module.scss
+++ b/apps/src/templates/school-association.module.scss
@@ -29,6 +29,21 @@
     font-weight: 400 !important;
     width: 100% !important;
   }
+
+  button {
+    border: 0;
+    padding-inline: 0;
+
+    &:hover {
+      background: none !important;
+      text-decoration: underline !important;
+    }
+  }
+
+  .errorMessage {
+    margin-block: 0.125rem 0;
+    color: $light_negative_500;
+  }
 }
 
 .inputContainer {
@@ -44,6 +59,6 @@
   }
 
   .disabledLabel {
-      color: $light_gray_300 !important;
-    }
+    color: $light_gray_300 !important;
   }
+}


### PR DESCRIPTION
This PR addresses a few styling updates:

1. The zip error is now red and has top padding
2. The dropdowns are full width
3. The inputs are white background and full width
4. The buttons below the school dropdown now use the new button component, and override the styling on hover so they become underlined in that state instead of having a purple background

<img width="645" alt="Screenshot 2024-04-30 at 2 18 55 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/86413986-a3f5-4a01-8a8c-dc60bfa80d07">
<img width="621" alt="Screenshot 2024-04-30 at 2 19 08 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/73ef1402-1fa7-4457-8595-d6b7621d41c8">
<img width="607" alt="Screenshot 2024-04-30 at 2 19 15 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/309969b8-7765-4ffb-a95d-78fbaed88411">


before:
<img width="803" alt="Screenshot 2024-04-30 at 2 24 10 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/e4308623-90f1-4235-a8cb-e64842a1e858">
<img width="805" alt="Screenshot 2024-04-30 at 2 24 01 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/4b77a6bb-1bcd-45a3-917c-1f65df7d7755">
<img width="828" alt="Screenshot 2024-04-30 at 2 25 35 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/5932883a-55a0-423a-882d-2d6343e3f723">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1855
- https://codedotorg.atlassian.net/browse/ACQ-1857
- https://codedotorg.atlassian.net/browse/ACQ-1856

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
