### PR TITLE
feat: add TTL for partial registration storage

### DIFF
--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -32,7 +32,12 @@ module PartialRegistration
     # Push the potential user's attributes into our application cache.
     cache_key = PartialRegistration.cache_key(user)
     user_attributes = Policies::User.user_attributes(user)
-    CDO.shared_cache.write(cache_key, user_attributes.to_json)
+
+    if DCDO.get('student-email-post-enabled', false)
+      CDO.shared_cache.write(cache_key, user_attributes.to_json, expires_in: 8.hours)
+    else
+      CDO.shared_cache.write(cache_key, user_attributes.to_json)
+    end
 
     # Put the cache key into the session, to
     # 1. track that a partial registration is in progress


### PR DESCRIPTION
This change adds a TTL to partial registration cache entries if the DCDO flag is enabled.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-836)
- [design](https://docs.google.com/document/d/1G9nXdae8Gt2Ea93enIJEdjSnF3xB9Rb-W4pCDnt46vo/edit#heading=h.25gc3zi9dtz9)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. With DCDO disabled, signed up for account
2. With DCDO disabled, signed up via Google OAuth
3. With DCDO enabled, signed up for account
4. With DCDO enabled, signed up via Google OAuth

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

This will be deployed via a DCDO feature flag

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
