### PR TITLE
Add embedded projects section to code.org/music

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -225,7 +225,7 @@ div.divider {
 // Add a thick box shadow to an element
 // See code.org/teach for an example
 .box-shadow-primary {
-  box-shadow: 8px 8px 0 var(--brand_primary_light);
+  box-shadow: 8px 8px 0 rgba(171, 223, 229, 0.50);
 }
 
 // Add a soft box shadow to an element

--- a/pegasus/sites.v3/code.org/public/css/page/music-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/page/music-styles.scss
@@ -80,3 +80,16 @@ ul.featured-artists {
     column-gap: 1rem;
   }
 }
+
+section.student-projects {
+  .grid-container {
+    @media (min-width: $width-md) {
+      grid-template-columns: 60% auto;
+    }
+  }
+
+  .text-wrapper {
+    background: var(--neutral_light);
+    padding: 2rem;
+  }
+}

--- a/pegasus/sites.v3/code.org/public/music/index.haml
+++ b/pegasus/sites.v3/code.org/public/music/index.haml
@@ -3,9 +3,6 @@ title: Music Lab
 theme: responsive_full_width
 ---
 
-- button_url = CDO.studio_url("/s/music-intro-2024")
-- button_string = hoc_s("music_lab.button.try_music_lab")
-
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/music-styles.css", rel: "stylesheet"}
 
@@ -18,8 +15,8 @@ theme: responsive_full_width
         =hoc_s("music_lab.banner.heading")
       %p.body-one.white
         =hoc_s("music_lab.banner.desc")
-      %a.link-button.white{href: button_url}
-        =button_string
+      %a.link-button.white{href: CDO.studio_url("/s/music-intro-2024")}
+        =hoc_s("music_lab.button.try_music_lab")
       .afe.flex-container.align-items-baseline.wrap
         %p.add-margin-top.no-margin-bottom.white
           =hoc_s("music_lab.in_partnerhip_with")
@@ -39,9 +36,10 @@ theme: responsive_full_width
     .flex-1-5
       = view :"music/music_lab_featured_artists"
 
--# %section
--#   .wrapper
--#     TODO - FEATURED PROJECTS
+%section.student-projects
+  .wrapper
+    %h2=hoc_s("music_lab.student_projects.heading")
+    = view :"music/music_lab_student_projects"
 
 %section.bg-primary-light
   .wrapper.flex-container.justify-space-between.align-items-center.wrap.flex-direction-column-tablet.gap-1

--- a/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
+++ b/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
@@ -1,18 +1,17 @@
--# FontAwesome icons
+-# FontAwesome icon
 - icon_check = "fa-solid fa-check-circle"
-
-:ruby
-  list_item = [hoc_s("music_lab.student_projects.list_create"), hoc_s("music_lab.student_projects.list_artist"),  hoc_s("music_lab.student_projects.list_share")]
+- embed_src = CDO.studio_url("/musiclab/embed?channels=#{request.params['channels']}&library=#{request.params['library']}", CDO.default_scheme)
+- list_items = [hoc_s("music_lab.student_projects.list_create"), hoc_s("music_lab.student_projects.list_artist"),  hoc_s("music_lab.student_projects.list_share")]
 
 .grid-container.gap-2
-  %iframe.rounded-corners.box-shadow-primary{width: "100%", height: 300, src: CDO.studio_url("/musiclab/embed?channels=#{request.params['channels']}&library=#{request.params['library']}", CDO.default_scheme)}
+  %iframe.rounded-corners.box-shadow-primary{width: "100%", height: 300, src: embed_src}
   .text-wrapper.rounded-corners
     %h3.heading-sm
       =hoc_s("music_lab.student_projects.subheading")
     %p.body-two
       =hoc_s("music_lab.student_projects.desc")
     %ul.clear-styles
-      - list_item.each do |item|
+      - list_items.each do |item|
         %li
           %p
             %i{class: "#{icon_check}"}

--- a/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
+++ b/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
@@ -1,0 +1,21 @@
+-# FontAwesome icons
+- icon_check = "fa-solid fa-check-circle"
+
+:ruby
+  list_item = [hoc_s("music_lab.student_projects.list_create"), hoc_s("music_lab.student_projects.list_artist"),  hoc_s("music_lab.student_projects.list_share")]
+
+.grid-container.gap-2
+  %iframe.rounded-corners.box-shadow-primary{width: "100%", height: 300, src: CDO.studio_url("/musiclab/embed?channels=#{request.params['channels']}&library=#{request.params['library']}", CDO.default_scheme)}
+  .text-wrapper.rounded-corners
+    %h3.heading-sm
+      =hoc_s("music_lab.student_projects.subheading")
+    %p.body-two
+      =hoc_s("music_lab.student_projects.desc")
+    %ul.clear-styles
+      - list_item.each do |item|
+        %li
+          %p
+            %i{class: "#{icon_check}"}
+            = item
+    %a.link-button.no-margin-bottom{href: CDO.studio_url("/s/music-intro-2024")}
+      =hoc_s("music_lab.button.try_music_lab")


### PR DESCRIPTION
Adds the embedded student projects section to https://code.org/music
- Depends on an `iframe` coming from the student learning team (see related PR below)
- Fully responsive and works with LTR and RTL languages
  - I can adjust the styles of the `iframe` if needed once we see the final version

**Related PR:** 
- https://github.com/code-dot-org/code-dot-org/pull/58173

**Jira ticket:**  [ACQ-1839](https://codedotorg.atlassian.net/browse/ACQ-1839)

----

![localhost code org_3000_music](https://github.com/code-dot-org/code-dot-org/assets/9256643/29eefa5f-7c7a-4806-a4af-9968ee2ce166)


## Responsive 

https://github.com/code-dot-org/code-dot-org/assets/9256643/fe0bb2a7-6f9f-4804-9bc6-32a9044c2784

## RTL
<img width="1081" alt="RTL" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/211fffb6-2988-4269-9177-b4ec9e9076ca">
