### PR TITLE
removed delete link from level editor

### DIFF
--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -127,3 +127,4 @@
 = link_to t('crud.show'), @level
 |
 = link_to t('crud.back'), levels_path
+| (Note: To delete levels that have already been created, please contact the engineering team)

--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -127,5 +127,3 @@
 = link_to t('crud.show'), @level
 |
 = link_to t('crud.back'), levels_path
-= '|' unless @level.new_record?
-= link_to t('crud.destroy'), @level, method: :delete, data: { confirm: t('crud.confirm') } unless @level.new_record?


### PR DESCRIPTION
Due to issues caused by deleting levels after they have been propagated to other environments, this update removes the 'destroy' link from the levelbuilder level editor and adds a message to contact engineering to delete these levels.

Before:
![image](https://github.com/code-dot-org/code-dot-org/assets/5552007/33b27195-6500-45d4-a88d-c3961dfdb2e6)

After:
![image](https://github.com/code-dot-org/code-dot-org/assets/5552007/58c838a2-1bb8-4d68-a173-415a9460eb77)

## Links

Jira Ticket: [AITT-605](https://codedotorg.atlassian.net/browse/AITT-605?atlOrigin=eyJpIjoiZmY4YThhNWY0YWQyNDA4MzkwN2JhZTFjNTY3N2Y0NWIiLCJwIjoiaiJ9)
