### PR TITLE
Gen AI: disallow 0 temperature

### DIFF
--- a/apps/src/aichat/views/modelCustomization/constants.ts
+++ b/apps/src/aichat/views/modelCustomization/constants.ts
@@ -6,7 +6,7 @@ import {
 } from '../../types';
 import {modelDescriptions} from '@cdo/apps/aichat/constants';
 
-export const MIN_TEMPERATURE = 0;
+export const MIN_TEMPERATURE = 0.1;
 export const MAX_TEMPERATURE = 1;
 export const SET_TEMPERATURE_STEP = 0.1;
 export const MAX_RETRIEVAL_CONTEXTS = 20;


### PR DESCRIPTION
Per play test, 0 is not a valid temperature -- more detail in [this Slack thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1714580593796689).