### PR TITLE
Flaky unit test - instructor cannot remove section owner

### DIFF
--- a/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
@@ -10,8 +10,6 @@ class Api::V1::SectionInstructorsControllerTest < ActionController::TestCase
     @section = create(:section, user: @teacher, login_type: 'word')
     @section2 = create(:section, user: @teacher, login_type: 'word')
     # These are auto-created for the section creator
-    @si1 = @section.instructors.first
-    @si2 = @section2.instructors.first
     @former_instructor = create(:section_instructor, section: @section, instructor: @teacher2, status: :removed)
     @former_instructor.destroy!
     @si3 = create(:section_instructor, section: @section2, instructor: @teacher2, status: :active)
@@ -127,10 +125,11 @@ class Api::V1::SectionInstructorsControllerTest < ActionController::TestCase
 
   test 'instructor cannot remove section owner' do
     section = create(:section, user: @teacher, login_type: 'word')
-    si = section.instructors.first
+    si = SectionInstructor.find_by(instructor_id: @teacher.id, section_id: section.id) # this is a user object
+    puts si
     create(:section_instructor, section: section, instructor: @teacher2, status: :active)
     sign_in @teacher2
-    delete :destroy, params: {id: si.id}
+    delete :destroy, params: {id: si.id} # this is looking for the section instructors entry id
     assert_response :forbidden
     assert si.reload.deleted_at.nil?
   end

--- a/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/section_instructors_controller_test.rb
@@ -125,11 +125,10 @@ class Api::V1::SectionInstructorsControllerTest < ActionController::TestCase
 
   test 'instructor cannot remove section owner' do
     section = create(:section, user: @teacher, login_type: 'word')
-    si = SectionInstructor.find_by(instructor_id: @teacher.id, section_id: section.id) # this is a user object
-    puts si
+    si = SectionInstructor.find_by(instructor_id: @teacher.id, section_id: section.id)
     create(:section_instructor, section: section, instructor: @teacher2, status: :active)
     sign_in @teacher2
-    delete :destroy, params: {id: si.id} # this is looking for the section instructors entry id
+    delete :destroy, params: {id: si.id}
     assert_response :forbidden
     assert si.reload.deleted_at.nil?
   end


### PR DESCRIPTION
Issue: The unit test instructor_cannot_remove_section_owner would intermittently fail because the assertion for deletion would return HTTP 204 No Content instead of HTTP 403 Forbidden.

```
test_instructor_cannot_remove_section_owner#Api::V1::SectionInstructorsControllerTest (1.35s)
        Expected response to be a <403: forbidden>, but was a <204: No Content>
        Response body: .
        Expected: 403
          Actual: 204
        test/controllers/api/v1/section_instructors_controller_test.rb:134
```

Root cause: 

- The HTTP call to Delete the section instructor was being made incorrectly with the instructor ID, which is the user ID rather than the ID for the entry from section instructor table. 
- Because of https://github.com/code-dot-org/code-dot-org/blob/1f8d78272f3897668876df0bc5a309a7abde61b9/dashboard/app/controllers/api/v1/json_api_controller.rb#L1, any JSON API would return a HTTP 403 for both unauthorized access and record not found.

So, although the request was returning HTTP 403, it wasn't exercising the authorization code path and was succeeding because the record wasn't found. In those intermittent cases, my guess is, there was a valid section_instructor record with the same ID as the instructor ID, and was successfully deleted. Don't have logs to confirm this theory though.

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1031

## Testing story

- Ran the unit test locally 
- Also added some logging in Ability.rb to ensure the expected code path is being tested

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
