### PR TITLE
Fixing forward finish sign up analytics event

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -88,12 +88,10 @@ $(document).ready(() => {
       cleanSchoolInfo();
       $('#user_age').val('21+');
     }
-    let ncesId = document.getElementById('uitest-school-dropdown').value;
     analyticsReporter.sendEvent(
       EVENTS.SIGN_UP_FINISHED_EVENT,
       {
         'user type': user_type,
-        'nces Id': ncesId,
       },
       PLATFORMS.BOTH
     );


### PR DESCRIPTION
A change in [this PR](https://github.com/code-dot-org/code-dot-org/pull/58176/files) broke the finish_sign_up (client side) event for effectively all cases because it did not account for the current flow nces id format. This pr removes that param entirely to get the event pushing again (both with and without the new school association flow experiment flag). 

I was able to fake non-local logging to see the events showed up in statsig for all four cases:
Old flow + school selected
Old flow and no school selected
New flow + school selected
New flow and no school selected
<img width="1204" alt="Screenshot 2024-05-01 at 2 41 06 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/87e3b9af-d834-470f-8a1c-1c28f9d810ba">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1851

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
