### PR TITLE
[AI Tutor] Fix: Scope markdown styling changes to aiTutorMarkdown class

### DIFF
--- a/apps/src/aiTutor/views/AssistantMessage.tsx
+++ b/apps/src/aiTutor/views/AssistantMessage.tsx
@@ -52,7 +52,10 @@ const AssistantMessage: React.FC<AssistantMessageProps> = ({message}) => {
           id={'chat-workspace-message-body'}
           className={classNames(style.message, style.assistantMessage)}
         >
-          <SafeMarkdown markdown={message.chatMessageText} />
+          <SafeMarkdown
+            markdown={message.chatMessageText}
+            className={style.aiTutorMarkdown}
+          />
         </div>
         {message.id && (
           <>

--- a/apps/src/aiTutor/views/chat-workspace.module.scss
+++ b/apps/src/aiTutor/views/chat-workspace.module.scss
@@ -140,3 +140,11 @@ $default-spacing: 2px;
   gap: 10px;
   align-items: center;
 }
+
+.aiTutorMarkdown {
+  pre {
+    // Color copied for consistency with bootstrap styles auto-applied to SafeMarkdown component
+    background-color: #f7f7f9;
+    color: $purple;
+  }
+}


### PR DESCRIPTION
This PR nestles the styling changes accidentally applied globally into an aiTutorMarkdown class. 

## Links

Relevant Slack thread 1: https://codedotorg.slack.com/archives/C0T0PNTM3/p1714580889285179
Relevant Slack thread 2: https://codedotorg.slack.com/archives/C0T0PNTM3/p1714588078482439

## Testing story

I confirmed that the change is applying to the AI Tutor blocks...

<img width="795" alt="Screenshot 2024-05-01 at 3 09 10 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/718f3d11-fda0-4e48-a526-4e2dc00eb228">

But not the page that caused the UI test failure: 

<img width="254" alt="Screenshot 2024-05-01 at 3 09 20 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/3c0d19e8-9cd1-40de-9e8e-77a68d99cc4d">

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
