### PR TITLE
Port datasets controller to datablock storage

### DIFF
--- a/apps/src/storage/levelbuilder/DatasetList.jsx
+++ b/apps/src/storage/levelbuilder/DatasetList.jsx
@@ -44,6 +44,10 @@ class DatasetList extends React.Component {
           color={Button.ButtonColor.blue}
           size={Button.ButtonSize.large}
         />
+        <p>
+          After adding a new dataset, you'll need to
+          <a href="./manifest/edit">edit the manifest</a>.
+        </p>
       </div>
     );
   }

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -237,7 +237,7 @@ class DatablockStorageController < ApplicationController
   def read_records
     table = find_table_or_shared_table
 
-    render json: table.read_records.map(&:record_json)
+    render json: table.read_records
   end
 
   def update_record

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -118,9 +118,6 @@ class DatablockStorageController < ApplicationController
   def import_csv
     table = table_or_create
 
-    # import_csv should overwrite existing data:
-    table.records.delete_all
-
     table.import_csv params[:table_data_csv]
     table.save!
 

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -7,7 +7,6 @@ require 'uri'
 class DatasetsController < ApplicationController
   before_action :authenticate_user!
   before_action :require_levelbuilder_mode
-  # before_action :initialize_firebase
   authorize_resource class: false
 
   LIVE_DATASETS = ['Daily Weather', 'Top 200 USA', 'Top 200 Worldwide', 'Viral 50 USA', 'Viral 50 Worldwide',
@@ -70,16 +69,13 @@ class DatasetsController < ApplicationController
   end
 
   # POST /datasets/manifest/update
-  # TODO: unfirebase, #56998
   def update_manifest
     parsed_manifest = JSON.parse(params['manifest'])
-    response = @firebase.set_library_manifest parsed_manifest
-    render json: {}, status: response.code
+    db_manifest = DatablockStorageLibraryManifest.instance
+    db_manifest.library_manifest = parsed_manifest
+    db_manifest.save!
+    render json: {}
   rescue JSON::ParserError
     render json: {msg: 'Invalid JSON'}
-  end
-
-  private def initialize_firebase
-    @firebase = FirebaseHelper.new('shared')
   end
 end

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -22,11 +22,19 @@ class DatasetsController < ApplicationController
   # GET /datasets/:dataset_name/
   def show
     @table_name = params[:dataset_name]
-    table = DatablockStorageTable.find_shared_table @table_name
-    @dataset = {
-      columns: table.get_columns,
-      records: table.read_records.map(&:to_json),
-    }
+    begin
+      table = DatablockStorageTable.find_shared_table @table_name
+      @dataset = {
+        columns: table.get_columns,
+        records: table.read_records,
+      }
+    rescue
+      # This must be a new shared table, so no existing dataset
+      @dataset = {
+        columns: [],
+        records: [],
+      }
+    end
     @live_datasets = LIVE_DATASETS
   end
 

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -15,8 +15,7 @@ class DatasetsController < ApplicationController
 
   # GET /datasets
   def index
-    tables = @firebase.get_shared_table_list
-    @datasets = tables.map {|name, _| name}
+    @datasets = DatablockStorageTable.get_shared_table_names
     @live_datasets = LIVE_DATASETS
   end
 

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -31,6 +31,7 @@ class DatasetsController < ApplicationController
   end
 
   # POST /datasets/:dataset_name/
+  # TODO: unfirebase, #56998
   def update
     records, columns = @firebase.csv_as_table(params[:csv_data])
     @firebase.delete_shared_table params[:dataset_name]
@@ -44,17 +45,20 @@ class DatasetsController < ApplicationController
   end
 
   # DELETE /datasets/:dataset_name/
+  # TODO: unfirebase, #56998
   def destroy
     response = @firebase.delete_shared_table params[:dataset_name]
     render json: {}, status: response.code
   end
 
   # GET /datasets/manifest/edit
+  # TODO: unfirebase, #56998
   def edit_manifest
     @dataset_library_manifest = @firebase.get_library_manifest
   end
 
   # POST /datasets/manifest/update
+  # TODO: unfirebase, #56998
   def update_manifest
     parsed_manifest = JSON.parse(params['manifest'])
     response = @firebase.set_library_manifest parsed_manifest

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -26,7 +26,7 @@ class DatasetsController < ApplicationController
       table = DatablockStorageTable.find_shared_table @table_name
       @dataset = {
         columns: table.get_columns,
-        records: table.read_records,
+        records: table.read_records.map(&:to_json),
       }
     rescue
       # This must be a new shared table, so no existing dataset

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -1,6 +1,3 @@
-# TODO: unfirebase, migrate this to datablock storage, ok to be migrated but not enabled: #56998
-# TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
-
 require 'json'
 require 'uri'
 

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -22,7 +22,11 @@ class DatasetsController < ApplicationController
   # GET /datasets/:dataset_name/
   def show
     @table_name = params[:dataset_name]
-    @dataset = @firebase.get_shared_table params[:dataset_name]
+    table = DatablockStorageTable.find_shared_table @table_name
+    @dataset = {
+      columns: table.get_columns,
+      records: table.read_records.map(&:to_json),
+    }
     @live_datasets = LIVE_DATASETS
   end
 

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -7,7 +7,7 @@ require 'uri'
 class DatasetsController < ApplicationController
   before_action :authenticate_user!
   before_action :require_levelbuilder_mode
-  before_action :initialize_firebase
+  # before_action :initialize_firebase
   authorize_resource class: false
 
   LIVE_DATASETS = ['Daily Weather', 'Top 200 USA', 'Top 200 Worldwide', 'Viral 50 USA', 'Viral 50 Worldwide',
@@ -58,10 +58,10 @@ class DatasetsController < ApplicationController
   end
 
   # DELETE /datasets/:dataset_name/
-  # TODO: unfirebase, #56998
   def destroy
-    response = @firebase.delete_shared_table params[:dataset_name]
-    render json: {}, status: response.code
+    table_name = params[:dataset_name]
+    table = DatablockStorageTable.find_shared_table table_name
+    table.destroy!
   end
 
   # GET /datasets/manifest/edit

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -65,9 +65,8 @@ class DatasetsController < ApplicationController
   end
 
   # GET /datasets/manifest/edit
-  # TODO: unfirebase, #56998
   def edit_manifest
-    @dataset_library_manifest = @firebase.get_library_manifest
+    @dataset_library_manifest = DatablockStorageLibraryManifest.instance.library_manifest
   end
 
   # POST /datasets/manifest/update

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -158,10 +158,9 @@ class LevelsController < ApplicationController
     @in_script = @level.script_levels.any? || any_parent_in_script
     @standalone = ProjectsController::STANDALONE_PROJECTS.values.map {|h| h[:name]}.include?(@level.name)
     if @level.is_a? Applab
-      # TODO: unfirebase, migrate this to datablock storage, ok to be migrated but not enabled: #56998
+      # TODO: unfirebase, this is migrated to datablock storage but NOT TESTED: #56998
       # TODO: post-firebase-cleanup, remove this code: #56994
-      fb = FirebaseHelper.new('shared')
-      @dataset_library_manifest = fb.get_library_manifest
+      @dataset_library_manifest = DatablockStorageLibraryManifest.instance.library_manifest
     end
   end
 

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -158,8 +158,6 @@ class LevelsController < ApplicationController
     @in_script = @level.script_levels.any? || any_parent_in_script
     @standalone = ProjectsController::STANDALONE_PROJECTS.values.map {|h| h[:name]}.include?(@level.name)
     if @level.is_a? Applab
-      # TODO: unfirebase, this is migrated to datablock storage but NOT TESTED: #56998
-      # TODO: post-firebase-cleanup, remove this code: #56994
       @dataset_library_manifest = DatablockStorageLibraryManifest.instance.library_manifest
     end
   end

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -99,7 +99,8 @@ class DatablockStorageTable < ApplicationRecord
   end
 
   def read_records
-    is_shared_table ? shared_table.records : records
+    record_rows = is_shared_table ? shared_table.records : records
+    record_rows.map(&:record_json)
   end
 
   ##########################################################
@@ -117,7 +118,7 @@ class DatablockStorageTable < ApplicationRecord
 
     CSV.generate do |csv|
       csv << column_names
-      read_records.map(&:record_json).each do |record_json|
+      read_records.each do |record_json|
         csv << column_names.map {|x| record_json[x]}
       end
     end
@@ -130,7 +131,7 @@ class DatablockStorageTable < ApplicationRecord
   def get_column(column_name)
     if get_columns.include? column_name
       read_records.map do |record|
-        record.record_json[column_name]
+        record[column_name]
       end
     else
       [] # javascript expects a list with every element undefined to indicate column doesn't exists error

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -188,6 +188,9 @@ class DatablockStorageTable < ApplicationRecord
       # Preserve the old column's order while adding any new columns
       self.columns += (cols_in_records - columns).to_a
       save!
+
+      # Reload association because we didn't modify records thru it
+      records.reload
     end
   end
 
@@ -235,6 +238,7 @@ class DatablockStorageTable < ApplicationRecord
 
     # import_csv should overwrite existing data:
     records.delete_all
+    records.columns = ['id']
 
     create_records(new_records)
   rescue CSV::MalformedCSVError => exception

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -238,7 +238,7 @@ class DatablockStorageTable < ApplicationRecord
 
     # import_csv should overwrite existing data:
     records.delete_all
-    records.columns = ['id']
+    self.columns = ['id']
 
     create_records(new_records)
   rescue CSV::MalformedCSVError => exception

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -29,22 +29,9 @@ class DatasetsControllerTest < ActionController::TestCase
   end
 
   test 'update_manifest: can update manifest' do
-    test_response = mock
-    test_response.expects(:code).returns(200)
-    # TODO: unfirebase, write a version of this for Datablock Storage: #57004
-    # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
-    FirebaseHelper.any_instance.stubs(:set_library_manifest).returns(test_response)
     post :update_manifest, params: {manifest: @test_manifest.to_json}
     assert_response :success
-  end
 
-  test 'update_manifest: passes through the error code' do
-    test_response = mock
-    test_response.expects(:code).returns(401)
-    # TODO: unfirebase, write a version of this for Datablock Storage: #57004
-    # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
-    FirebaseHelper.any_instance.stubs(:set_library_manifest).returns(test_response)
-    post :update_manifest, params: {manifest: @test_manifest.to_json}
-    assert_response :unauthorized
+    assert_equal JSON.parse(@test_manifest.to_json), DatablockStorageLibraryManifest.instance.library_manifest
   end
 end


### PR DESCRIPTION
The datasets controller allows editing the standard shared tables available students. Its used by content editors mainly. This ports the datasets controller to editing our datablock storage controller objects.

Methods/behaviors that we wanted to share with datablock_storage_controller.rb were migrated to datablock_storage_table.rb object so they're easy to share.

Also adds a link from the datasets controller to the manifest controller

Fixes #56998

Co-authored-by: Cassi Brenci <cnbrenci@users.noreply.github.com>