### PR TITLE
Create flag to control showing the diversity survey to even or odd us…

### DIFF
--- a/dashboard/app/helpers/survey_results_helper.rb
+++ b/dashboard/app/helpers/survey_results_helper.rb
@@ -13,6 +13,11 @@ module SurveyResultsHelper
     return false unless has_any_students?
     return false unless has_any_student_under_13?
 
+    diversity_audience = DCDO.get('diversity_audience', 'all')
+    return false if diversity_audience == 'none'
+    return false if diversity_audience == 'odd' && current_user.id.even?
+    return false if diversity_audience == 'even' && current_user.id.odd?
+
     # There is no reason not to show the survey, so show the survey.
     return true
   end

--- a/dashboard/test/helpers/survey_results_helper_test.rb
+++ b/dashboard/test/helpers/survey_results_helper_test.rb
@@ -44,11 +44,25 @@ class SurveyResultsHelperTest < ActionView::TestCase
   end
 
   test 'show diversity survey' do
+    current_survey = SurveyResult::DIVERSITY_2024
+
     stubs(:language).returns "en"
     stubs(:request).returns(stub(location: stub(try: "RD")))
     follower = create :follower, user: @teacher
     follower.student_user.update(age: 10)
-    assert show_diversity_survey? SurveyResult::DIVERSITY_2024
+    assert show_diversity_survey? current_survey
+
+    DCDO.stubs(:get).with('diversity_audience', 'all').returns('none')
+    refute show_diversity_survey? current_survey
+    DCDO.unstub(:get)
+
+    @teacher.id = 8_675_309
+    DCDO.stubs(:get).with('diversity_audience', 'all').returns('odd')
+    assert show_diversity_survey? current_survey
+    DCDO.unstub(:get)
+    DCDO.stubs(:get).with('diversity_audience', 'all').returns('even')
+    refute show_diversity_survey? current_survey
+    DCDO.unstub(:get)
   end
 
   test 'show nps survey' do
@@ -67,7 +81,6 @@ class SurveyResultsHelperTest < ActionView::TestCase
 
   test 'target audience' do
     DCDO.stubs(:get).with('nps_audience', 'none').returns('all')
-    puts(@teacher.id)
     assert target_audience? @teacher.id
     DCDO.unstub(:get)
     DCDO.stubs(:get).with('nps_audience', 'none').returns('none')


### PR DESCRIPTION
This change introduces a DCDO flag `diversity_audience` to control who will see the diversity survey. This mirrors an existing `nps_audience` flag to control the NPS survey audience.

Possible values:
* `all` (default) Show survey to all users who otherwise qualify
* `none` Suppress survey for all users
* `odd` Suppress survey for even-numbered user IDs
* `even` Suppress survey for odd-numbered user IDs

This is needed to avoid cluttering the homepage with multiple surveys at once when the NPS survey goes live later this month.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/TEACH-1056)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
