### PR TITLE
Adding a table to track users as they go through the Child Account Po…

### DIFF
--- a/dashboard/app/models/cap_user_event.rb
+++ b/dashboard/app/models/cap_user_event.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: cap_user_events
+#
+#  id         :bigint           not null, primary key
+#  name       :string(64)       not null
+#  user_id    :integer          not null
+#  policy     :string(16)       not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_cap_user_events_on_name_and_policy  (name,policy)
+#  index_cap_user_events_on_policy           (policy)
+#  index_cap_user_events_on_user_id          (user_id)
+#
+class CapUserEvent < ApplicationRecord
+  belongs_to :user
+end

--- a/dashboard/db/migrate/20240501215821_create_cap_user_events.rb
+++ b/dashboard/db/migrate/20240501215821_create_cap_user_events.rb
@@ -2,7 +2,6 @@ class CreateCapUserEvents < ActiveRecord::Migration[6.1]
   def change
     create_table :cap_user_events do |t|
       t.string :name, null: false, limit: 64
-      t.datetime :occurred_at, null: false
       t.references :user, null: false, foreign_key: true, type: :integer, index: true
       t.string :policy, null: false, limit: 16
 

--- a/dashboard/db/migrate/20240501215821_create_cap_user_events.rb
+++ b/dashboard/db/migrate/20240501215821_create_cap_user_events.rb
@@ -1,0 +1,15 @@
+class CreateCapUserEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :cap_user_events do |t|
+      t.string :name, null: false, limit: 64
+      t.datetime :occurred_at, null: false
+      t.references :user, null: false, foreign_key: true, type: :integer, index: true
+      t.string :policy, null: false, limit: 16
+
+      t.timestamps
+    end
+
+    add_index :cap_user_events, [:name, :policy]
+    add_index :cap_user_events, :policy
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_16_200438) do
+ActiveRecord::Schema.define(version: 2024_05_01_215821) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -166,6 +166,18 @@ ActiveRecord::Schema.define(version: 2024_04_16_200438) do
     t.text "qtip_config"
     t.string "on"
     t.string "callout_text"
+  end
+
+  create_table "cap_user_events", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "name", limit: 64, null: false
+    t.datetime "occurred_at", null: false
+    t.integer "user_id", null: false
+    t.string "policy", limit: 16, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name", "policy"], name: "index_cap_user_events_on_name_and_policy"
+    t.index ["policy"], name: "index_cap_user_events_on_policy"
+    t.index ["user_id"], name: "index_cap_user_events_on_user_id"
   end
 
   create_table "census_state_course_codes", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
@@ -2411,6 +2423,7 @@ ActiveRecord::Schema.define(version: 2024_04_16_200438) do
 
   add_foreign_key "ai_tutor_interaction_feedbacks", "ai_tutor_interactions"
   add_foreign_key "ai_tutor_interaction_feedbacks", "users"
+  add_foreign_key "cap_user_events", "users"
   add_foreign_key "census_submission_form_maps", "census_submissions"
   add_foreign_key "census_summaries", "schools"
   add_foreign_key "hint_view_requests", "users"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -170,7 +170,6 @@ ActiveRecord::Schema.define(version: 2024_05_01_215821) do
 
   create_table "cap_user_events", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 64, null: false
-    t.datetime "occurred_at", null: false
     t.integer "user_id", null: false
     t.string "policy", limit: 16, null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
As a PM responsible for Code.org's implementation of the Colorado Privacy Act, I want data about how users move through our pipeline. For example, how many parent permission emails are sent? What is the average amount of time it takes for a user to get parent permission once an email is sent?

This PR creates a new DB table where we will log Child Account Policy events which our PM's can query and answer the questions they have. See the JIRA task for the DB schema to implement.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/P20-893)

## Testing story
* `bundle exec rake db:migrate`
* `bundle exec rake db:rollback`


## Follow-up work
* A follow-up PR will actually log the events.