### PR TITLE
After creating a section, redirect the user to where that section is visible

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -178,6 +178,7 @@ export default function SectionsSetUpContainer({
     const participantType = isNewSection
       ? queryParams('participantType')
       : section.participantType;
+    const redirectUrl = '/' + queryParams('redirectToPage');
 
     const form = document.querySelector(`#${FORM_ID}`);
     // If we find a missing field in the form, report which one and reset save status
@@ -232,14 +233,18 @@ export default function SectionsSetUpContainer({
             getCoteacherMetricInfoFromSection(section)
           );
         });
-        // Redirect to the sections list.
-        let redirectUrl = window.location.origin + '/home';
-        if (createAnotherSection) {
-          redirectUrl += '?openAddSectionDialog=true';
-        } else if (shouldShowCelebrationDialogOnRedirect) {
-          redirectUrl += '?showSectionCreationDialog=true';
+        // Redirect to the given redirectUrl if present, otherwise redirect to the
+        // sections list on the homepage.
+        let url =
+          window.location.origin + (redirectUrl ? redirectUrl : '/home');
+        if (!redirectUrl) {
+          if (createAnotherSection) {
+            url += '?openAddSectionDialog=true';
+          } else if (shouldShowCelebrationDialogOnRedirect) {
+            url += '?showSectionCreationDialog=true';
+          }
         }
-        navigateToHref(redirectUrl);
+        navigateToHref(url);
       })
       .catch(err => {
         setIsSaveInProgress(false);

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -178,7 +178,7 @@ export default function SectionsSetUpContainer({
     const participantType = isNewSection
       ? queryParams('participantType')
       : section.participantType;
-    const redirectUrl = '/' + queryParams('redirectToPage');
+    const redirectUrl = queryParams('redirectToPage');
 
     const form = document.querySelector(`#${FORM_ID}`);
     // If we find a missing field in the form, report which one and reset save status
@@ -236,7 +236,7 @@ export default function SectionsSetUpContainer({
         // Redirect to the given redirectUrl if present, otherwise redirect to the
         // sections list on the homepage.
         let url =
-          window.location.origin + (redirectUrl ? redirectUrl : '/home');
+          window.location.origin + (redirectUrl ? `/${redirectUrl}` : '/home');
         if (!redirectUrl) {
           if (createAnotherSection) {
             url += '?openAddSectionDialog=true';

--- a/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
@@ -25,9 +25,11 @@ import {
 // Navigates to the new section setup page if both params are non-null.
 const redirectToNewSectionPage = (participantType, loginType) => {
   if (!!participantType && !!loginType) {
-    navigateToHref(
-      `/sections/new?participantType=${participantType}&loginType=${loginType}`
-    );
+    const createSectionFromMyPl = participantType !== 'student';
+    const hrefNav =
+      `/sections/new?participantType=${participantType}&loginType=${loginType}` +
+      (createSectionFromMyPl ? '&redirectToPage=my-professional-learning' : '');
+    navigateToHref(hrefNav);
   }
 };
 

--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -79,7 +79,7 @@ class SectionActionDropdown extends Component {
    */
   editRedirectUrl = (sectionId, isPl) => {
     let editSectionUrl = '/sections/' + sectionId + '/edit';
-    editSectionUrl += isPl ? 'redirectToPage=my-professional-learning' : '';
+    editSectionUrl += isPl ? '?redirectToPage=my-professional-learning' : '';
     return editSectionUrl;
   };
 

--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -77,8 +77,9 @@ class SectionActionDropdown extends Component {
   /**
    * Returns the URL to the correct section to be edited
    */
-  editRedirectUrl = sectionId => {
-    const editSectionUrl = '/sections/' + sectionId + '/edit';
+  editRedirectUrl = (sectionId, isPl) => {
+    let editSectionUrl = '/sections/' + sectionId + '/edit';
+    editSectionUrl += isPl ? 'redirectToPage=my-professional-learning' : '';
     return editSectionUrl;
   };
 
@@ -114,7 +115,10 @@ class SectionActionDropdown extends Component {
       <span>
         <QuickActionsCell type={'header'}>
           <PopUpMenu.Item
-            href={this.editRedirectUrl(sectionData.id)}
+            href={this.editRedirectUrl(
+              sectionData.id,
+              sectionData.grades?.includes('pl')
+            )}
             className="edit-section-details-link"
           >
             {i18n.editSectionDetails()}

--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -86,8 +86,10 @@ function TeacherDashboardHeader({
   /**
    * Returns the URL to the correct section to be edited
    */
-  const editRedirectUrl = sectionId => {
-    return '/sections/' + sectionId + '/edit';
+  const editRedirectUrl = (sectionId, isPl) => {
+    let editSectionUrl = '/sections/' + sectionId + '/edit';
+    editSectionUrl += isPl ? 'redirectToPage=my-professional-learning' : '';
+    return editSectionUrl;
   };
 
   return (
@@ -130,7 +132,10 @@ function TeacherDashboardHeader({
           <div className={dashboardStyles.headerButtonSection}>
             <Button
               __useDeprecatedTag
-              href={editRedirectUrl(selectedSection.id)}
+              href={editRedirectUrl(
+                selectedSection.id,
+                selectedSection.grades?.includes('pl')
+              )}
               className="edit-section-details-link"
               icon="gear"
               size="narrow"

--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -86,10 +86,8 @@ function TeacherDashboardHeader({
   /**
    * Returns the URL to the correct section to be edited
    */
-  const editRedirectUrl = (sectionId, isPl) => {
-    let editSectionUrl = '/sections/' + sectionId + '/edit';
-    editSectionUrl += isPl ? 'redirectToPage=my-professional-learning' : '';
-    return editSectionUrl;
+  const editRedirectUrl = sectionId => {
+    return '/sections/' + sectionId + '/edit';
   };
 
   return (
@@ -132,10 +130,7 @@ function TeacherDashboardHeader({
           <div className={dashboardStyles.headerButtonSection}>
             <Button
               __useDeprecatedTag
-              href={editRedirectUrl(
-                selectedSection.id,
-                selectedSection.grades?.includes('pl')
-              )}
+              href={editRedirectUrl(selectedSection.id)}
               className="edit-section-details-link"
               icon="gear"
               size="narrow"

--- a/apps/test/unit/templates/teacherDashboard/AddSectionDialogTest.jsx
+++ b/apps/test/unit/templates/teacherDashboard/AddSectionDialogTest.jsx
@@ -94,7 +94,7 @@ describe('AddSectionDialog', () => {
       navigateToHrefSpy.restore();
     });
 
-    it('redirects to new section setup when selecting non-student participant type', () => {
+    it('redirects to new section setup with redirect to MyPL page when selecting non-student participant type', () => {
       const newSection = _.cloneDeep(defaultProps.section);
       const wrapper = shallow(
         <AddSectionDialog
@@ -109,7 +109,7 @@ describe('AddSectionDialog', () => {
       );
       expect(navigateToHrefSpy).to.be.called.once;
       expect(navigateToHrefSpy.getCall(0).args[0]).to.equal(
-        '/sections/new?participantType=teacher&loginType=email'
+        '/sections/new?participantType=teacher&loginType=email&redirectToPage=my-professional-learning'
       );
     });
 

--- a/apps/test/unit/templates/teacherDashboard/SectionActionDropdownTest.js
+++ b/apps/test/unit/templates/teacherDashboard/SectionActionDropdownTest.js
@@ -15,7 +15,7 @@ const sections = [
     loginType: 'word',
     studentCount: 0,
     code: 'ABCD',
-    grade: '10',
+    grades: ['10'],
     providerManaged: false,
     hidden: false,
   },
@@ -26,7 +26,7 @@ const sections = [
     loginType: 'google_classroom',
     studentCount: 0,
     code: 'EFGH',
-    grade: '11',
+    grades: ['11'],
     providerManaged: true,
     hidden: false,
   },
@@ -37,7 +37,7 @@ const sections = [
     loginType: 'picture',
     studentCount: 4,
     code: 'IJKL',
-    grade: '9',
+    grades: ['9'],
     providerManaged: false,
     hidden: false,
   },
@@ -48,9 +48,21 @@ const sections = [
     loginType: 'email',
     studentCount: 2,
     code: 'MNOP',
-    grade: '6',
+    grades: ['6'],
     providerManaged: false,
     hidden: true,
+  },
+  {
+    id: 5,
+    name: 'PL',
+    courseVersionName: 'cv',
+    loginType: 'email',
+    participantType: 'teacher',
+    studentCount: 2,
+    code: 'QRST',
+    grades: ['pl'],
+    providerManaged: false,
+    hidden: false,
   },
 ];
 
@@ -142,6 +154,21 @@ describe('SectionActionDropdown', () => {
     );
     const sectionId = wrapper.instance().props.sectionData.id;
     const expectedUrl = '/sections/' + sectionId + '/edit';
+    expect(wrapper).to.contain('Edit Section Details');
+    expect(wrapper.find('.edit-section-details-link').props().href).to.equal(
+      expectedUrl
+    );
+  });
+
+  it('sends selected user to the new edit page with redirect for pl section', () => {
+    const wrapper = shallow(
+      <SectionActionDropdown {...DEFAULT_PROPS} sectionData={sections[4]} />
+    );
+    const sectionId = wrapper.instance().props.sectionData.id;
+    const expectedUrl =
+      '/sections/' +
+      sectionId +
+      '/edit?redirectToPage=my-professional-learning';
     expect(wrapper).to.contain('Edit Section Details');
     expect(wrapper.find('.edit-section-details-link').props().href).to.equal(
       expectedUrl


### PR DESCRIPTION
Currently, when a user creates/edits a section they are then redirected to the Teacher Homepage regardless of which type of section it is (i.e. PL or non-PL). This PR redirects the user to the page where they will see the section they just created/edited.

## Teacher Homepage
### Creating a non-PL section (should redirect back to the Teacher Homepage)
https://github.com/code-dot-org/code-dot-org/assets/56283563/e4e17da3-0cba-4d70-96e3-24d81ba21271

### Creating a PL section (should redirect to the My PL page)
https://github.com/code-dot-org/code-dot-org/assets/56283563/8752859a-3e46-45ef-b8d6-6eba1e141fd0

### Editing a non-PL section (should redirect back to the Teacher Homepage)
https://github.com/code-dot-org/code-dot-org/assets/56283563/870e818a-d343-43de-8cbe-d84b7717e24d

## My PL page
### Creating a non-PL section (should redirect to the Teacher Homepage)
https://github.com/code-dot-org/code-dot-org/assets/56283563/b9b85b29-ef7c-41c1-a8a6-8d63e53e7138

### Creating a PL section (should redirect back to the My PL page)
https://github.com/code-dot-org/code-dot-org/assets/56283563/e6e9ad6e-2122-4676-9137-354fc2d78f12

### Editing a PL section (should redirect back to the My PL page)
https://github.com/code-dot-org/code-dot-org/assets/56283563/ad760093-4541-4d58-8a36-7516c966d126

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1838)

## Testing story
Local testing and updating unit tests.
