### PR TITLE
feat(email): do not render the 'finish signup' if email was not passed in

### DIFF
--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -24,6 +24,14 @@ module PartialRegistration
     end
   end
 
+  def self.can_finish_signup?(params, session)
+    if DCDO.get('student-email-post-enabled', false)
+      params&.dig(:user)&.dig(:email)&.present? && in_progress?(session)
+    else
+      in_progress?(session)
+    end
+  end
+
   def self.in_progress?(session)
     session[SESSION_KEY] && CDO.shared_cache.exist?(session[SESSION_KEY])
   end

--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -26,7 +26,7 @@ module PartialRegistration
 
   def self.can_finish_signup?(params, session)
     if DCDO.get('student-email-post-enabled', false)
-      params&.dig(:user)&.dig(:email)&.present? && in_progress?(session)
+      params[:user]&.dig(:email)&.present? && in_progress?(session)
     else
       in_progress?(session)
     end

--- a/dashboard/app/views/devise/registrations/new.html.haml
+++ b/dashboard/app/views/devise/registrations/new.html.haml
@@ -1,4 +1,4 @@
-- if PartialRegistration.in_progress?(session)
+- if PartialRegistration.can_finish_signup?(params, session)
   = render 'finish_sign_up'
 - else
   = render 'sign_up'

--- a/dashboard/app/views/omniauth/redirect.html.haml
+++ b/dashboard/app/views/omniauth/redirect.html.haml
@@ -6,7 +6,7 @@
     %title= t('nav.user.loading')
 
     = form_with(url: users_finish_sign_up_path, method: :post, html: {id: 'redirect-form'}) do |f|
-      = f.hidden_field :email, value: @form_data[:email]
+      = f.hidden_field "user[email]", value: @form_data[:email]
 
     :javascript
       window.onload = function() {

--- a/dashboard/test/models/concerns/partial_registration_test.rb
+++ b/dashboard/test/models/concerns/partial_registration_test.rb
@@ -45,6 +45,32 @@ class PartialRegistrationTest < ActiveSupport::TestCase
     refute PartialRegistration.in_progress? @session
   end
 
+  describe 'can_finish_signup?' do
+    before do
+      DCDO.stubs(:get).with('student-email-post-enabled', false).returns(true)
+    end
+
+    it 'can_finish_signup? is false when params are not present' do
+      PartialRegistration.persist_attributes @session, build(:user)
+      refute PartialRegistration.can_finish_signup?(nil, @session)
+    end
+
+    it 'can_finish_signup? is false when no user params are present' do
+      PartialRegistration.persist_attributes @session, build(:user)
+      refute PartialRegistration.can_finish_signup?({}, @session)
+    end
+
+    it 'can_finish_signup? is false when email is not present' do
+      PartialRegistration.persist_attributes @session, build(:user)
+      refute PartialRegistration.can_finish_signup?({user: {}}, @session)
+    end
+
+    it 'can_finish_signup? is true when email is present' do
+      PartialRegistration.persist_attributes @session, build(:user)
+      assert PartialRegistration.can_finish_signup?({user: {email: 'anything@code.org'}}, @session)
+    end
+  end
+
   test 'new_from_partial_registration raises unless a partial registration is available' do
     exception = assert_raise RuntimeError do
       User.new_from_partial_registration @session


### PR DESCRIPTION
This change ensures that the finish signup page will not be rendered unless the email parameter is passed in for the DCDO post email flow

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-836)
- [design](https://docs.google.com/document/d/1G9nXdae8Gt2Ea93enIJEdjSnF3xB9Rb-W4pCDnt46vo/edit#heading=h.25gc3zi9dtz9)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. With DCDO disabled, go to finish sign up page via email, then go to home page, and back to trying to sign up. Should go straight to finish sign up.
2. With DCDO disabled, go to finish sign up page via Google, then go to home page, and back to trying to sign up. Should go straight to finish sign up.
3. With DCDO enabled, go to finish sign up page via email, then go to home page, and back to trying to sign up. Should restart from the first page
4. With DCDO enabled, go to finish sign up page via Google, then go to home page, and back to trying to sign up. Should restart from the first page

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

This will be deployed via a DCDO feature flag

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
