### PR TITLE
Increase Database Transaction Durability During Aurora / MySQL Upgrade

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -149,7 +149,7 @@
         # Favor write performance over durability. In the event of a database server crash
         # we could lose roughly 1 second of transactions.
         # https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_flush_log_at_trx_commit
-        innodb_flush_log_at_trx_commit: 0
+        innodb_flush_log_at_trx_commit: 1
         # END: Dynamic configuration settings.
   AuroraWriterDBParameters:
     Type: AWS::RDS::DBParameterGroup
@@ -201,7 +201,7 @@
         # Favor write performance over durability. In the event of a database server crash
         # we could lose roughly 1 second of transactions.
         # https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_flush_log_at_trx_commit
-        innodb_flush_log_at_trx_commit: 0
+        innodb_flush_log_at_trx_commit: 1
         innodb_trx_commit_allow_data_loss: 1
         # END: Dynamic configuration settings.
   DBProxyRole:


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-1261

Increase durability of the relational database before, during, and shortly after the upgrade of our database servers from Aurora 2.x / MySQL 5.7 to Aurora 3.x / MySQL 8.0 because we'll be carrying out high risk upgrades and restarts of database instances and want to reduce the risk of data loss.

We expect write latency to increase while this change is enabled, so we will likely revert back to the less durable setting after the upgrade.

## Testing story

`bundle exec rake adhoc:start RAILS_ENV=adhoc DATABASE=yes STACK_NAME=adhoc-transaction-durability`

## Deployment strategy

This is a dynamic configuration setting and will take effect without a restart of any database instances when the CloudFormation Stack is updated on each environment.

## Follow-up work

Schedule a revert of this change after the upgrade is complete IF write latency is noticeably degraded.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
