### PR TITLE
Fixes school_type save error for new school association flow

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -106,11 +106,21 @@ $(document).ready(() => {
     countryInputEl.val(schoolData.countryCode);
 
     // Clear school_id if the searched school is not found.
+    // New school search flow
+    const newSchoolIdEl = $(
+      'select[name="user[school_info_attributes][school_id]"]'
+    );
     if (
-      ['-1', NO_SCHOOL_SETTING, CLICK_TO_ADD, SELECT_A_SCHOOL].includes(
-        schoolData.ncesSchoolId
+      [NO_SCHOOL_SETTING, CLICK_TO_ADD, SELECT_A_SCHOOL].includes(
+        newSchoolIdEl.val()
       )
     ) {
+      newSchoolIdEl.val('');
+      // Clear out zip before saving as well
+      $('input[name="user[school_info_attributes][school_zip]"]').val('');
+    }
+    // Old school search flow
+    if (schoolData.ncesSchoolId === '-1') {
       const schoolIdEl = $(
         'input[name="user[school_info_attributes][school_id]"]'
       );


### PR DESCRIPTION
I found the source of the school_type error!

Description of the error:
When trying to save a new user where the user ended up selecting 'I don't teach CS in a school setting' or left it submitted with 'Select a school', there would be a complaint from the save function about not being able to find the school_type of a null value (because it was trying to match those strings with an nces id from the school table). 

It turns out when I added those strings to the list in [this pr change](https://github.com/code-dot-org/code-dot-org/commit/cc0f1d913ab4e0cba0f5ec0e253f6c4b8f99971d#diff-9369331c93c559e6da4f5875db670364ad5469a94d62b009ebf96acf7f09da4eL104), I forgot that in the old flow, the school id field is an input, but in the new field it's a select. So the cleanSchool function wasn't resetting the nces id's to a null value. 

My fix sets the old flow to the only empty field it could get (back to how it was- just checking for '-1'), and adds a new check for the select field by the same form name for any of those 'non school' nces ids to get cleaned out. While I was in there, I decided to wipe out the zip field as well, as it doesn't make sense to capture that information without an actual school. You can see those fields get cleared out in the screen recording below.

I opted to add a few comments to hopefully provide clarity as well. 

Screen recording of me being able to create a new user with one of those dropdown elements selected:

https://github.com/code-dot-org/code-dot-org/assets/37230822/338b7f56-304f-44f4-bca9-8aa55352ce7d


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1859

## Testing story

I was also able to test that the old flow still works (just to be cautious- after all I'm changing it back to exactly how it was before my work). 

I set up new users inside and outside the experiment flag with and without schools, and verified that those with schools could be attributed back to an nces id with the RED query (below), and those without schools were tied to that empty school_infos row with just 'US' selected (which matches what is currently happening on production). 

select 
  u.id user_id,
  u.user_type,
  u.school_info_id,
  si.school_name school_infos_name,
  s.id school_id,
  s.name schools_name
from users u
left join school_infos si on si.id = u.school_info_id
left join schools s on s.id = si.school_id
where u.user_type = 'teacher' and school_id is not null;



<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
