### PR TITLE
Scroll to bottom on new message, allow new lines

### DIFF
--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -30,9 +30,10 @@ const ChatWorkspace: React.FunctionComponent = () => {
 
   useEffect(() => {
     if (conversationContainerRef.current) {
-      console.log(conversationContainerRef.current.scrollTop);
-      conversationContainerRef.current.scrollTop =
-        conversationContainerRef.current?.scrollHeight;
+      conversationContainerRef.current.scrollTo({
+        top: conversationContainerRef.current.scrollHeight,
+        behavior: 'smooth',
+      });
     }
   }, [conversationContainerRef, storedMessages, isWaitingForChatResponse]);
 

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useRef, useEffect} from 'react';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {useSelector} from 'react-redux';
 import ChatWarningModal from '@cdo/apps/aichat/views/ChatWarningModal';
@@ -26,6 +26,16 @@ const ChatWorkspace: React.FunctionComponent = () => {
     (state: {aichat: AichatState}) => state.aichat.isWaitingForChatResponse
   );
 
+  const conversationContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (conversationContainerRef.current) {
+      console.log(conversationContainerRef.current.scrollTop);
+      conversationContainerRef.current.scrollTop =
+        conversationContainerRef.current?.scrollHeight;
+    }
+  }, [conversationContainerRef, storedMessages, isWaitingForChatResponse]);
+
   const dispatch = useAppDispatch();
 
   const onCloseWarningModal = useCallback(
@@ -51,6 +61,7 @@ const ChatWorkspace: React.FunctionComponent = () => {
       <div
         id="chat-workspace-conversation"
         className={moduleStyles.conversationArea}
+        ref={conversationContainerRef}
       >
         {storedMessages.map(message => (
           <ChatMessage message={message} key={message.id} />

--- a/apps/src/aichat/views/chatMessage.module.scss
+++ b/apps/src/aichat/views/chatMessage.module.scss
@@ -4,6 +4,7 @@
   padding: 10px 10px;
   border-radius: 10px;
   overflow: hidden;
+  white-space: pre-line;
 }
 
 .userMessage {


### PR DESCRIPTION
Two unrelated improvements to the chat UI:
- scroll to the bottom of the chat window when a new message is appended (currently, it doesn't scroll, and you have to manually scroll to the bottom)
- don't remove newlines that are included in the model response

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-735
- Jira: https://codedotorg.atlassian.net/browse/LABS-741

| Before (newlines stripped) | After (newlines included) |
| - | - |
| ![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/5813b173-d8ec-4b76-9e87-11d7790751ff) | ![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/aa794f5e-15bc-48fb-a6d7-57e75060e1aa) |

https://github.com/code-dot-org/code-dot-org/assets/25372625/0185c0a9-106a-4488-8e75-38808e8c25ca

## Testing story

Tested manually (see video/screenshots above). I also noticed that this change preserves newlines in a user message as well (ie, if you hit shift+enter while entering a message, that newline is reflected in the chat workspace)