### PR TITLE
[AI Tutor] CT-543: Use SegmentedButton for TutorTab toggle

### DIFF
--- a/apps/src/aiTutor/views/teacherDashboard/TutorTab.tsx
+++ b/apps/src/aiTutor/views/teacherDashboard/TutorTab.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import InteractionsTable from './InteractionsTable';
 import AccessControls from './AccessControls';
-import Button from '@cdo/apps/templates/Button';
+import SegmentedButtons from '@cdo/apps/componentLibrary/segmentedButtons/SegmentedButtons';
 
 /**
  * Renders table of student chat messages and toggles to control student access to AI Tutor.
@@ -10,38 +10,33 @@ interface TutorTabProps {
   sectionId: number;
 }
 
+export const TAB_NAMES = {
+  ACCESS: 'access',
+  INTERACTIONS: 'interactions',
+};
+
 const TutorTab: React.FC<TutorTabProps> = ({sectionId}) => {
-  const [showControls, setShowControls] = useState<boolean>(false);
-
-  const onClickControls = () => {
-    setShowControls(true);
-  };
-
-  const onClickShowChats = () => {
-    setShowControls(false);
-  };
+  const [selectedTab, setSelectedTab] = useState(TAB_NAMES.ACCESS);
 
   return (
     <div>
-      <Button
-        color={Button.ButtonColor.brandSecondaryDefault}
-        key="controlAccess"
-        onClick={onClickControls}
-        size={Button.ButtonSize.default}
-        text="Control Student Access to AI Tutor"
-        disabled={showControls}
+      <SegmentedButtons
+        className="ai-tutor-tab-buttons"
+        selectedButtonValue={selectedTab}
+        size="s"
+        buttons={[
+          {label: 'View Access Controls', value: TAB_NAMES.ACCESS},
+          {
+            label: 'View Interactions',
+            value: TAB_NAMES.INTERACTIONS,
+          },
+        ]}
+        onChange={setSelectedTab}
       />
-      <Button
-        color={Button.ButtonColor.brandSecondaryDefault}
-        key="showChats"
-        onClick={onClickShowChats}
-        size={Button.ButtonSize.default}
-        text="Show Student Chats with AI Tutor"
-        disabled={!showControls}
-      />
-      {showControls ? (
+      {selectedTab === TAB_NAMES.ACCESS && (
         <AccessControls sectionId={sectionId} />
-      ) : (
+      )}
+      {selectedTab === TAB_NAMES.INTERACTIONS && (
         <InteractionsTable sectionId={sectionId} />
       )}
     </div>


### PR DESCRIPTION
The following PR changes the UI for switching views from "interactions" to "access" in AI Tutor from two buttons to a segmented button (see below).

**Before**
<img width="1039" alt="Screenshot 2024-05-06 at 3 19 04 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/6d26c92e-3fde-4d3a-8700-2ccbd891bbc9">

**After**
<img width="1081" alt="Screenshot 2024-05-06 at 3 19 55 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/96e62fea-8e29-4a5a-b018-d57ebadb4e30">


## Links
Jira ticket: https://codedotorg.atlassian.net/browse/CT-543

## Testing story
Tested locally.

## Deployment strategy

## Follow-up work
Tickets are filed for additional table styling.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
