### PR TITLE
fix: mock out web requests only after test_helper has started

### DIFF
--- a/dashboard/test/controllers/curriculum_proxy_controller_test.rb
+++ b/dashboard/test/controllers/curriculum_proxy_controller_test.rb
@@ -1,7 +1,8 @@
-require 'webmock/minitest'
-WebMock.disable_net_connect!(allow_localhost: true)
 require_relative '../../../shared/test/spy_newrelic_agent'
 require 'test_helper'
+
+require 'webmock/minitest'
+WebMock.disable_net_connect!(allow_localhost: true)
 
 class CurriculumProxyControllerTest < ActionController::TestCase
   test "should redirect from studio.code.org/docs path to curriculum.code.org/docs path" do


### PR DESCRIPTION
The curriculum controller proxy mocks out web requests and expects no requests to be made. However, `test_helper` causes some web requests to be made. Therefore, mock out web requests only after `test_helper` has initialized.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- [slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1714684610229909)

## Testing story

1. Ran test standalone, it should pass
2. Run test first in group, it should pass
3. Run test last in group, it should pass

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
