### PR TITLE
feat: add rubocop to enforce webmocks are enabled only after test_helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ require:
   - './tools/customLinters/rubocop_dashboard_db_usage.rb'
   - './tools/customLinters/rubocop_pegasus_requires.rb'
   - './tools/customLinters/rubocop_dashboard_requires.rb'
+  - './tools/customLinters/rubocop_dashboard_webmock_require_order.rb'
 
 AllCops:
   SuggestExtensions: false

--- a/dashboard/test/controllers/media_proxy_controller_test.rb
+++ b/dashboard/test/controllers/media_proxy_controller_test.rb
@@ -1,6 +1,6 @@
+require 'test_helper'
 require 'webmock/minitest'
 WebMock.disable_net_connect!(allow_localhost: true)
-require 'test_helper'
 
 class MediaProxyControllerTest < ActionController::TestCase
   IMAGE_URI = 'http://www.example.com/foo.jpg'

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -1,6 +1,6 @@
+require 'test_helper'
 require 'webmock/minitest'
 WebMock.disable_net_connect!(allow_localhost: true)
-require 'test_helper'
 
 class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers

--- a/dashboard/test/controllers/programming_expressions_controller_test.rb
+++ b/dashboard/test/controllers/programming_expressions_controller_test.rb
@@ -1,6 +1,6 @@
+require 'test_helper'
 require 'webmock/minitest'
 WebMock.disable_net_connect!(allow_localhost: true)
-require 'test_helper'
 
 class ProgrammingExpressionsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -1,5 +1,5 @@
-require 'webmock/minitest'
 require 'test_helper'
+require 'webmock/minitest'
 
 class ProjectsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers

--- a/dashboard/test/controllers/redirect_proxy_controller_test.rb
+++ b/dashboard/test/controllers/redirect_proxy_controller_test.rb
@@ -1,6 +1,6 @@
+require 'test_helper'
 require 'webmock/minitest'
 WebMock.disable_net_connect!(allow_localhost: true)
-require 'test_helper'
 
 class RedirectProxyControllerTest < ActionController::TestCase
   LONG_URI = 'https://studio.code.org/s/course1/lessons/3/levels/2'

--- a/dashboard/test/controllers/xhr_proxy_controller_test.rb
+++ b/dashboard/test/controllers/xhr_proxy_controller_test.rb
@@ -1,7 +1,7 @@
+require 'test_helper'
 require 'webmock/minitest'
 WebMock.disable_net_connect!(allow_localhost: true)
 require_relative '../../../shared/test/spy_newrelic_agent'
-require 'test_helper'
 
 class XhrProxyControllerTest < ActionController::TestCase
   XHR_REDIRECT_URI = 'https://www.wikipedia.org/bar/a1b2'

--- a/tools/customLinters/rubocop_dashboard_webmock_require_order.rb
+++ b/tools/customLinters/rubocop_dashboard_webmock_require_order.rb
@@ -1,0 +1,30 @@
+module CustomCops
+  # Custom cop that checks that the webmock must only happen after requiring test_helper
+  # test_helper can include web requests, so if mocking out all web requests, it should be done only after
+  # test_helper has been initialized.
+  class WebmockStubRequireOrder < RuboCop::Cop::Base
+    extend RuboCop::Cop::AutoCorrector
+    MSG = 'test_helper must be before webmock'
+
+    def_node_matcher :require_statement?, <<~PATTERN
+      {
+        (send nil? :require (str $_))
+      }
+    PATTERN
+
+    def on_send(node)
+      return unless require_statement?(node) do |package|
+        if (package == 'test_helper') && @webmock_require.present?
+          add_offense(node, message: MSG) do |corrector|
+            corrector.insert_before(@webmock_require, "#{node.source}\n")
+            corrector.remove(node)
+          end
+        end
+
+        if package == 'webmock/minitest'
+          @webmock_require = node
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When using webmock to mock out web requests, webmock will error if any live web request is made without being stubbed. `test_helper` does make web requests and will therefore cause webmock to fail. If `test_helper` is initialized by another a test, the webmock will not fail.

To ensure consistency, ensure that `test_helper` is required prior to `webmock`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1714684610229909)

## Testing story

Ran rubocop and autocorrect, spot inspection.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
