### PR TITLE
Updates annotations to use observations when evidence is empty and to scroll to first line of evidence.

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2280,6 +2280,8 @@
   "rubricLevelTwoHeader": "Convincing Evidence",
   "rubricLevelFourHeader": "No Evidence",
   "rubricScores": "Rubric Scores",
+  "rubricNextLearningGoal": "Go to next learning goal",
+  "rubricPreviousLearningGoal": "Go to previous learning goal",
   "rubricAiHeaderText": "AI Teaching Assistant",
   "rubricTourNextButtonText": "Next Tip",
   "rubricTourStepOneTitle": "Getting Started with Your AI Teaching Assistant",

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -248,6 +248,12 @@ export function annotateLines(evidence, observations) {
     }
   }
 
+  // If there was no evidence given, we do at least want to include the
+  // observations column.
+  if (ret.length === 0) {
+    shouldIncludeObservationsColumn = true;
+  }
+
   // Somewhere, we annotated with the obserations column, or we have no other
   // sources of evidence. We want to list out the observations column in our
   // rendered list. So, here we parse out the observations column.
@@ -519,8 +525,17 @@ export default function LearningGoals({
   const aiEvidence = useMemo(() => {
     // Annotate the lines based on the AI observation
     clearAnnotations();
-    if (!!aiEvalInfo?.evidence && !productTour) {
-      return annotateLines(aiEvalInfo.evidence, aiEvalInfo.observations);
+
+    if (!!aiEvalInfo && !productTour) {
+      const annotations = annotateLines(
+        aiEvalInfo.evidence,
+        aiEvalInfo.observations
+      );
+      // Scroll to first evidence, if possible
+      if (annotations[0]?.firstLine) {
+        EditorAnnotator.scrollToLine(annotations[0].firstLine);
+      }
+      return annotations;
     } else if (productTour) {
       return [
         {
@@ -588,6 +603,7 @@ export default function LearningGoals({
               style.learningGoalButton,
               style.learningGoalButtonLeft
             )}
+            aria-label={i18n.rubricPreviousLearningGoal()}
             onClick={() => onCarouselPress(-1)}
           >
             <FontAwesome icon="angle-left" />
@@ -655,6 +671,7 @@ export default function LearningGoals({
               style.learningGoalButton,
               style.learningGoalButtonRight
             )}
+            aria-label={i18n.rubricNextLearningGoal()}
             onClick={() => onCarouselPress(1)}
           >
             <FontAwesome icon="angle-right" />


### PR DESCRIPTION
This adds both the scrolling to the first line of evidence and rendering observations as evidence when the AI fails to provide evidence, which hopefully will not happen too often but happens in practice.

## Links

- jira ticket: [AITT-604](https://codedotorg.atlassian.net/browse/AITT-604)
- jira ticket: [AITT-614](https://codedotorg.atlassian.net/browse/AITT-614)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
