### PR TITLE
retry aiproxy requests on 503 and 504

### DIFF
--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -252,7 +252,7 @@ class EvaluateRubricJob < ApplicationJob
   # Retry just once on a timeout. It is likely to timeout again.
   retry_on Net::ReadTimeout, Timeout::Error, wait: 10.seconds, attempts: ATTEMPTS_ON_TIMEOUT do |job, error|
     log_metric(metric_name: :TimeoutError)
-    log_to_firehose(job: job, error: error, event_name: 'retry-on-timeout')
+    log_to_firehose(job: job, error: error, event_name: 'timeout-error')
   end
 
   ATTEMPTS_ON_SERVICE_UNAVAILABLE = 3
@@ -262,7 +262,7 @@ class EvaluateRubricJob < ApplicationJob
   retry_on ServiceUnavailableError, wait: :exponentially_longer, attempts: ATTEMPTS_ON_SERVICE_UNAVAILABLE do |job, error|
     agent = error.message.downcase.include?('openai') ? 'openai' : 'none'
     log_metric(metric_name: :ServiceUnavailable, agent: agent)
-    log_to_firehose(job: job, error: error, event_name: 'retry-on-503', agent: agent)
+    log_to_firehose(job: job, error: error, event_name: 'service-unavailable', agent: agent)
   end
 
   ATTEMPTS_ON_GATEWAY_TIMEOUT = 3
@@ -272,7 +272,7 @@ class EvaluateRubricJob < ApplicationJob
   retry_on GatewayTimeoutError, wait: :exponentially_longer, attempts: ATTEMPTS_ON_GATEWAY_TIMEOUT do |job, error|
     agent = error.message.downcase.include?('openai') ? 'openai' : 'none'
     log_metric(metric_name: :GatewayTimeout, agent: agent)
-    log_to_firehose(job: job, error: error, event_name: 'retry-on-504', agent: agent)
+    log_to_firehose(job: job, error: error, event_name: 'gateway-timeout', agent: agent)
   end
 
   def self.log_metric(metric_name:, agent: nil, value: 1)

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -109,7 +109,7 @@ class EvaluateRubricJob < ApplicationJob
   # the AI proxy service.
   #
   # @param [Hash] response The parsed JSON response from the AI proxy.
-  def self.log_metrics(response)
+  def self.log_token_metrics(response)
     # Record the metadata
     # The aiproxy service will report the usage in the metadata via:
     # { metadata: { agent: 'openai', usage: { total_tokens: 1234, prompt_tokens: 432, completion_tokens: 802 } } }
@@ -343,7 +343,7 @@ class EvaluateRubricJob < ApplicationJob
     response = get_openai_evaluations(openai_params)
 
     # Log tokens and usage information
-    EvaluateRubricJob.log_metrics(response)
+    EvaluateRubricJob.log_token_metrics(response)
 
     # Get and validate the response data
     ai_evaluations = response['data']

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -99,6 +99,9 @@ class EvaluateRubricJob < ApplicationJob
   # The CloudWatch metric namespace
   AI_RUBRIC_METRICS_NAMESPACE = 'AiRubric'.freeze
 
+  # The firehose study name
+  AI_RUBRICS_FIREHOSE_STUDY = 'ai-rubrics'.freeze
+
   # Write out metrics reflected in the response to CloudWatch
   #
   # Currently, this keeps track of a curated set of metrics returned
@@ -280,7 +283,7 @@ class EvaluateRubricJob < ApplicationJob
     FirehoseClient.instance.put_record(
       :analysis,
       {
-        study: 'ai-rubrics',
+        study: AI_RUBRICS_FIREHOSE_STUDY,
         study_group: 'v0',
         event: 'retry-on-timeout',
         data_string: "#{error.class.name}: #{error.message}",

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -233,7 +233,7 @@ class EvaluateRubricJob < ApplicationJob
 
   ATTEMPTS_ON_RATE_LIMIT = 3
 
-  # Retry on any reported rate limit (429 status) 'exponentially_longer' waits 3s, 18s, and then 83s.
+  # Retry on any reported rate limit (429 status). With 3 attempts, 'exponentially_longer' waits 3s, then 18s.
   retry_on TooManyRequestsError, wait: :exponentially_longer, attempts: ATTEMPTS_ON_RATE_LIMIT do |job, error|
     # Job arguments are always serializable, so we just pull out the hash
     # and send it as context.
@@ -258,7 +258,7 @@ class EvaluateRubricJob < ApplicationJob
   ATTEMPTS_ON_SERVICE_UNAVAILABLE = 3
 
   # Retry on a 503 Service Unavailable error, including those returned by aiproxy
-  # when openai returns 500. 'exponentially_longer' waits 3s, 18s, and then 83s.
+  # when openai returns 500.
   retry_on ServiceUnavailableError, wait: :exponentially_longer, attempts: ATTEMPTS_ON_SERVICE_UNAVAILABLE do |job, error|
     agent = error.message.downcase.include?('openai') ? 'openai' : 'none'
     log_metric(metric_name: :ServiceUnavailable, agent: agent)
@@ -268,7 +268,7 @@ class EvaluateRubricJob < ApplicationJob
   ATTEMPTS_ON_GATEWAY_TIMEOUT = 3
 
   # Retry on a 504 Gateway Timeout error, including those returned by aiproxy
-  # when openai request times out. 'exponentially_longer' waits 3s, 18s, and then 83s.
+  # when openai request times out.
   retry_on GatewayTimeoutError, wait: :exponentially_longer, attempts: ATTEMPTS_ON_GATEWAY_TIMEOUT do |job, error|
     agent = error.message.downcase.include?('openai') ? 'openai' : 'none'
     log_metric(metric_name: :GatewayTimeout, agent: agent)

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -247,10 +247,10 @@ class EvaluateRubricJob < ApplicationJob
     )
   end
 
-  ATTEMPTS_ON_TIMEOUT = 2
+  ATTEMPTS_ON_TIMEOUT_ERROR = 2
 
   # Retry just once on a timeout. It is likely to timeout again.
-  retry_on Net::ReadTimeout, Timeout::Error, wait: 10.seconds, attempts: ATTEMPTS_ON_TIMEOUT do |job, error|
+  retry_on Net::ReadTimeout, Timeout::Error, wait: 10.seconds, attempts: ATTEMPTS_ON_TIMEOUT_ERROR do |job, error|
     log_metric(metric_name: :TimeoutError)
     log_to_firehose(job: job, error: error, event_name: 'timeout-error')
   end

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -119,7 +119,7 @@ class EvaluateRubricJob < ApplicationJob
       tokens = response.dig('metadata', 'usage', name.to_s.underscore)
       next if tokens.nil?
       agent = response.dig('metadata', 'agent') || 'unknown'
-      log_count_metric(metric_name: name, agent: agent, value: tokens)
+      log_metric(metric_name: name, agent: agent, value: tokens)
     end
   end
 
@@ -251,7 +251,7 @@ class EvaluateRubricJob < ApplicationJob
 
   # Retry just once on a timeout. It is likely to timeout again.
   retry_on Net::ReadTimeout, Timeout::Error, wait: 10.seconds, attempts: RETRIES_ON_TIMEOUT do |job, error|
-    log_count_metric(metric_name: :RetryOnTimeout)
+    log_metric(metric_name: :RetryOnTimeout)
     log_to_firehose(job: job, error: error, event_name: 'retry-on-timeout')
   end
 
@@ -261,7 +261,7 @@ class EvaluateRubricJob < ApplicationJob
   # when openai returns 500. 'exponentially_longer' waits 3s, 18s, and then 83s.
   retry_on ServiceUnavailableError, wait: :exponentially_longer, attempts: RETRIES_ON_SERVICE_UNAVAILABLE do |job, error|
     agent = error.message.downcase.include?('openai') ? 'openai' : 'none'
-    log_count_metric(metric_name: :RetryOnServiceUnavailable, agent: agent)
+    log_metric(metric_name: :RetryOnServiceUnavailable, agent: agent)
     log_to_firehose(job: job, error: error, event_name: 'retry-on-503', agent: agent)
   end
 
@@ -271,11 +271,11 @@ class EvaluateRubricJob < ApplicationJob
   # when openai request times out. 'exponentially_longer' waits 3s, 18s, and then 83s.
   retry_on GatewayTimeoutError, wait: :exponentially_longer, attempts: RETRIES_ON_GATEWAY_TIMEOUT do |job, error|
     agent = error.message.downcase.include?('openai') ? 'openai' : 'none'
-    log_count_metric(metric_name: :RetryOnGatewayTimeout, agent: agent)
+    log_metric(metric_name: :RetryOnGatewayTimeout, agent: agent)
     log_to_firehose(job: job, error: error, event_name: 'retry-on-504', agent: agent)
   end
 
-  def self.log_count_metric(metric_name:, agent: nil, value: 1)
+  def self.log_metric(metric_name:, agent: nil, value: 1)
     Cdo::Metrics.push(
       AI_RUBRIC_METRICS_NAMESPACE,
       [

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -302,7 +302,7 @@ class EvaluateRubricJob < ApplicationJob
       ]
     )
 
-    log_to_firehose(job: job, error: error, event_name: 'retry-on-503')
+    log_to_firehose(job: job, error: error, event_name: 'retry-on-503', agent: agent)
   end
 
   RETRIES_ON_GATEWAY_TIMEOUT = 3
@@ -327,10 +327,10 @@ class EvaluateRubricJob < ApplicationJob
       ]
     )
 
-    log_to_firehose(job: job, error: error, event_name: 'retry-on-504')
+    log_to_firehose(job: job, error: error, event_name: 'retry-on-504', agent: agent)
   end
 
-  def self.log_to_firehose(job:, error:, event_name:)
+  def self.log_to_firehose(job:, error:, event_name:, agent: nil)
     options = job.arguments.first
     script_level = ScriptLevel.find(options[:script_level_id])
 
@@ -348,6 +348,7 @@ class EvaluateRubricJob < ApplicationJob
           script_name: script_level.script.name,
           lesson_number: script_level.lesson.relative_position,
           level_name: script_level.level.name,
+          agent: agent
         }.to_json
       }
     )

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -278,7 +278,7 @@ class EvaluateRubricJob < ApplicationJob
   # Retry on a 503 Service Unavailable error, including those returned by aiproxy
   # when openai returns 500. 'exponentially_longer' waits 3s, 18s, and then 83s.
   retry_on ServiceUnavailableError, wait: :exponentially_longer, attempts: RETRIES_ON_SERVICE_UNAVAILABLE do |_job, error|
-    agent = error.message.include?('openai') ? 'openai' : 'aiproxy'
+    agent = error.message.downcase.include?('openai') ? 'openai' : 'none'
 
     Cdo::Metrics.push(
       AI_RUBRIC_METRICS_NAMESPACE,
@@ -301,7 +301,7 @@ class EvaluateRubricJob < ApplicationJob
   # Retry on a 504 Gateway Timeout error, including those returned by aiproxy
   # when openai request times out. 'exponentially_longer' waits 3s, 18s, and then 83s.
   retry_on GatewayTimeoutError, wait: :exponentially_longer, attempts: RETRIES_ON_GATEWAY_TIMEOUT do |_job, error|
-    agent = error.message.include?('openai') ? 'openai' : 'aiproxy'
+    agent = error.message.downcase.include?('openai') ? 'openai' : 'none'
 
     Cdo::Metrics.push(
       AI_RUBRIC_METRICS_NAMESPACE,

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -251,7 +251,7 @@ class EvaluateRubricJob < ApplicationJob
 
   # Retry just once on a timeout. It is likely to timeout again.
   retry_on Net::ReadTimeout, Timeout::Error, wait: 10.seconds, attempts: RETRIES_ON_TIMEOUT do |job, error|
-    log_metric(metric_name: :RetryOnTimeout)
+    log_metric(metric_name: :TimeoutError)
     log_to_firehose(job: job, error: error, event_name: 'retry-on-timeout')
   end
 
@@ -261,7 +261,7 @@ class EvaluateRubricJob < ApplicationJob
   # when openai returns 500. 'exponentially_longer' waits 3s, 18s, and then 83s.
   retry_on ServiceUnavailableError, wait: :exponentially_longer, attempts: RETRIES_ON_SERVICE_UNAVAILABLE do |job, error|
     agent = error.message.downcase.include?('openai') ? 'openai' : 'none'
-    log_metric(metric_name: :RetryOnServiceUnavailable, agent: agent)
+    log_metric(metric_name: :ServiceUnavailable, agent: agent)
     log_to_firehose(job: job, error: error, event_name: 'retry-on-503', agent: agent)
   end
 
@@ -271,7 +271,7 @@ class EvaluateRubricJob < ApplicationJob
   # when openai request times out. 'exponentially_longer' waits 3s, 18s, and then 83s.
   retry_on GatewayTimeoutError, wait: :exponentially_longer, attempts: RETRIES_ON_GATEWAY_TIMEOUT do |job, error|
     agent = error.message.downcase.include?('openai') ? 'openai' : 'none'
-    log_metric(metric_name: :RetryOnGatewayTimeout, agent: agent)
+    log_metric(metric_name: :GatewayTimeout, agent: agent)
     log_to_firehose(job: job, error: error, event_name: 'retry-on-504', agent: agent)
   end
 

--- a/dashboard/app/jobs/evaluate_rubric_job.rb
+++ b/dashboard/app/jobs/evaluate_rubric_job.rb
@@ -34,6 +34,8 @@ class EvaluateRubricJob < ApplicationJob
   UNIT_AND_LEVEL_TO_LESSON_S3_NAME['focus-on-coding3-2023'] = UNIT_AND_LEVEL_TO_LESSON_S3_NAME['csd3-2023']
   UNIT_AND_LEVEL_TO_LESSON_S3_NAME.freeze
 
+  AIPROXY_API_TIMEOUT = 165
+
   # This is raised if there is any raised error due to a rate limit, e.g. a 429
   # received from the aiproxy service.
   class TooManyRequestsError < StandardError
@@ -504,7 +506,7 @@ class EvaluateRubricJob < ApplicationJob
       uri,
       body: URI.encode_www_form(openai_params),
       headers: {'Content-Type' => 'application/x-www-form-urlencoded'},
-      timeout: 120
+      timeout: AIPROXY_API_TIMEOUT
     )
 
     # Raise too many requests error if we see a 429

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -274,7 +274,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     end
 
     # Run the job (and track attempts)
-    assert_performed_jobs EvaluateRubricJob::ATTEMPTS_ON_TIMEOUT do
+    assert_performed_jobs EvaluateRubricJob::ATTEMPTS_ON_TIMEOUT_ERROR do
       perform_enqueued_jobs do
         EvaluateRubricJob.perform_later(
           user_id: @student.id,
@@ -327,7 +327,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     end
 
     # Run the job (and track attempts)
-    assert_performed_jobs EvaluateRubricJob::ATTEMPTS_ON_RATE_LIMIT do
+    assert_performed_jobs EvaluateRubricJob::ATTEMPTS_ON_SERVICE_UNAVAILABLE do
       perform_enqueued_jobs do
         EvaluateRubricJob.perform_later(
           user_id: @student.id,
@@ -380,7 +380,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     end
 
     # Run the job (and track attempts)
-    assert_performed_jobs EvaluateRubricJob::ATTEMPTS_ON_RATE_LIMIT do
+    assert_performed_jobs EvaluateRubricJob::ATTEMPTS_ON_GATEWAY_TIMEOUT do
       perform_enqueued_jobs do
         EvaluateRubricJob.perform_later(
           user_id: @student.id,

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -269,6 +269,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     FirehoseClient.instance.expects(:put_record).with do |stream, data|
       data[:study] == EvaluateRubricJob::AI_RUBRICS_FIREHOSE_STUDY &&
         data[:event] == 'retry-on-timeout' &&
+        JSON.parse(data[:data_json])['agent'].nil? &&
         stream == :analysis
     end
 
@@ -321,6 +322,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     FirehoseClient.instance.expects(:put_record).with do |stream, data|
       data[:study] == EvaluateRubricJob::AI_RUBRICS_FIREHOSE_STUDY &&
         data[:event] == 'retry-on-503' &&
+        JSON.parse(data[:data_json])['agent'] == 'openai' &&
         stream == :analysis
     end
 
@@ -373,6 +375,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     FirehoseClient.instance.expects(:put_record).with do |stream, data|
       data[:study] == EvaluateRubricJob::AI_RUBRICS_FIREHOSE_STUDY &&
         data[:event] == 'retry-on-504' &&
+        JSON.parse(data[:data_json])['agent'] == 'openai' &&
         stream == :analysis
     end
 

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -317,6 +317,13 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       )
     )
 
+    # ensure firehose event is logged
+    FirehoseClient.instance.expects(:put_record).with do |stream, data|
+      data[:study] == EvaluateRubricJob::AI_RUBRICS_FIREHOSE_STUDY &&
+        data[:event] == 'retry-on-503' &&
+        stream == :analysis
+    end
+
     # Run the job (and track attempts)
     assert_performed_jobs EvaluateRubricJob::RETRIES_ON_RATE_LIMIT do
       perform_enqueued_jobs do
@@ -361,6 +368,13 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
         includes_dimensions(:RetryOnGatewayTimeout, Environment: CDO.rack_env, Agent: 'openai')
       )
     )
+
+    # ensure firehose event is logged
+    FirehoseClient.instance.expects(:put_record).with do |stream, data|
+      data[:study] == EvaluateRubricJob::AI_RUBRICS_FIREHOSE_STUDY &&
+        data[:event] == 'retry-on-504' &&
+        stream == :analysis
+    end
 
     # Run the job (and track attempts)
     assert_performed_jobs EvaluateRubricJob::RETRIES_ON_RATE_LIMIT do

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -277,6 +277,41 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'job is retried when proxy server returns 503' do
+    # Perform an otherwise successful run
+    EvaluateRubricJob.stubs(:get_lesson_s3_name).with(@script_level).returns('fake-lesson-s3-name')
+
+    # Create a project
+    channel_token = ChannelToken.find_or_create_channel_token(@script_level.level, @fake_ip, @storage_id, @script_level.script_id)
+    channel_id = channel_token.channel
+
+    stub_project_source_data(channel_id)
+
+    stub_lesson_s3_data
+
+    stub_get_openai_evaluations(status: 503)
+
+    # verify the correct metric is published
+    Cdo::Metrics.expects(:push).with(
+      EvaluateRubricJob::AI_RUBRIC_METRICS_NAMESPACE,
+      all_of(
+        includes_metrics(RetryOnServiceUnavailable: 1),
+        includes_dimensions(:RetryOnServiceUnavailable, Environment: CDO.rack_env)
+      )
+    )
+
+    # Run the job (and track attempts)
+    assert_performed_jobs EvaluateRubricJob::RETRIES_ON_RATE_LIMIT do
+      perform_enqueued_jobs do
+        EvaluateRubricJob.perform_later(
+          user_id: @student.id,
+          requester_id: @student.id,
+          script_level_id: @script_level.id
+        )
+      end
+    end
+  end
+
   test "job records REQUEST_TOO_LARGE on http status 413" do
     EvaluateRubricJob.stubs(:get_lesson_s3_name).with(@script_level).returns('fake-lesson-s3-name')
 

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -292,7 +292,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     # the stub response currently returns a json object, so just make sure that
     # response contains "openai" rather than going through the trouble of composing
     # a more accurate response representing a 503 error.
-    stub_get_openai_evaluations(status: 503, message: 'openai')
+    stub_get_openai_evaluations(status: 503, message: 'OpenAI')
 
     # The superclass, ApplicationJob, logs metrics around all jobs.
     # Those calls must be stubbed to test metrics for this job.
@@ -337,7 +337,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     # the stub response currently returns a json object, so just make sure that
     # response contains "openai" rather than going through the trouble of composing
     # a more accurate response representing a 504 error.
-    stub_get_openai_evaluations(status: 504, message: 'openai')
+    stub_get_openai_evaluations(status: 504, message: 'OpenAI')
 
     # The superclass, ApplicationJob, logs metrics around all jobs.
     # Those calls must be stubbed to test metrics for this job.

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -581,7 +581,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       uri,
       body: URI.encode_www_form(expected_form_data),
       headers: {'Content-Type' => 'application/x-www-form-urlencoded'},
-      timeout: 120
+      timeout: EvaluateRubricJob::AIPROXY_API_TIMEOUT
     )
 
     if raises

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -268,7 +268,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     # ensure firehose event is logged
     FirehoseClient.instance.expects(:put_record).with do |stream, data|
       data[:study] == EvaluateRubricJob::AI_RUBRICS_FIREHOSE_STUDY &&
-        data[:event] == 'retry-on-timeout' &&
+        data[:event] == 'timeout-error' &&
         JSON.parse(data[:data_json])['agent'].nil? &&
         stream == :analysis
     end
@@ -321,7 +321,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     # ensure firehose event is logged
     FirehoseClient.instance.expects(:put_record).with do |stream, data|
       data[:study] == EvaluateRubricJob::AI_RUBRICS_FIREHOSE_STUDY &&
-        data[:event] == 'retry-on-503' &&
+        data[:event] == 'service-unavailable' &&
         JSON.parse(data[:data_json])['agent'] == 'openai' &&
         stream == :analysis
     end
@@ -374,7 +374,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     # ensure firehose event is logged
     FirehoseClient.instance.expects(:put_record).with do |stream, data|
       data[:study] == EvaluateRubricJob::AI_RUBRICS_FIREHOSE_STUDY &&
-        data[:event] == 'retry-on-504' &&
+        data[:event] == 'gateway-timeout' &&
         JSON.parse(data[:data_json])['agent'] == 'openai' &&
         stream == :analysis
     end

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -265,6 +265,13 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       )
     )
 
+    # ensure firehose event is logged
+    FirehoseClient.instance.expects(:put_record).with do |stream, data|
+      data[:study] == EvaluateRubricJob::AI_RUBRICS_FIREHOSE_STUDY &&
+        data[:event] == 'retry-on-timeout' &&
+        stream == :analysis
+    end
+
     # Run the job (and track attempts)
     assert_performed_jobs EvaluateRubricJob::RETRIES_ON_TIMEOUT do
       perform_enqueued_jobs do

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -256,12 +256,12 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       anything
     )
 
-    # ensure RetryOnTimeout metric is logged
+    # ensure TimeoutError metric is logged
     Cdo::Metrics.expects(:push).with(
       EvaluateRubricJob::AI_RUBRIC_METRICS_NAMESPACE,
       all_of(
-        includes_metrics(RetryOnTimeout: 1),
-        includes_dimensions(:RetryOnTimeout, Environment: CDO.rack_env)
+        includes_metrics(TimeoutError: 1),
+        includes_dimensions(:TimeoutError, Environment: CDO.rack_env)
       )
     )
 
@@ -309,12 +309,12 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       anything
     )
 
-    # ensure RetryOnServiceUnavailable metric is logged
+    # ensure ServiceUnavailable metric is logged
     Cdo::Metrics.expects(:push).with(
       EvaluateRubricJob::AI_RUBRIC_METRICS_NAMESPACE,
       all_of(
-        includes_metrics(RetryOnServiceUnavailable: 1),
-        includes_dimensions(:RetryOnServiceUnavailable, Environment: CDO.rack_env, Agent: 'openai')
+        includes_metrics(ServiceUnavailable: 1),
+        includes_dimensions(:ServiceUnavailable, Environment: CDO.rack_env, Agent: 'openai')
       )
     )
 
@@ -362,12 +362,12 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
       anything
     )
 
-    # ensure RetryOnGatewayTimeout metric is logged
+    # ensure GatewayTimeout metric is logged
     Cdo::Metrics.expects(:push).with(
       EvaluateRubricJob::AI_RUBRIC_METRICS_NAMESPACE,
       all_of(
-        includes_metrics(RetryOnGatewayTimeout: 1),
-        includes_dimensions(:RetryOnGatewayTimeout, Environment: CDO.rack_env, Agent: 'openai')
+        includes_metrics(GatewayTimeout: 1),
+        includes_dimensions(:GatewayTimeout, Environment: CDO.rack_env, Agent: 'openai')
       )
     )
 

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -322,6 +322,51 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'job is retried when proxy server returns 504' do
+    # Perform an otherwise successful run
+    EvaluateRubricJob.stubs(:get_lesson_s3_name).with(@script_level).returns('fake-lesson-s3-name')
+
+    # Create a project
+    channel_token = ChannelToken.find_or_create_channel_token(@script_level.level, @fake_ip, @storage_id, @script_level.script_id)
+    channel_id = channel_token.channel
+
+    stub_project_source_data(channel_id)
+
+    stub_lesson_s3_data
+
+    # the stub response currently returns a json object, so just make sure that
+    # response contains "openai" rather than going through the trouble of composing
+    # a more accurate response representing a 504 error.
+    stub_get_openai_evaluations(status: 504, message: 'openai')
+
+    # The superclass, ApplicationJob, logs metrics around all jobs.
+    # Those calls must be stubbed to test metrics for this job.
+    Cdo::Metrics.stubs(:push).with(
+      ApplicationJob::METRICS_NAMESPACE,
+      anything
+    )
+
+    # ensure RetryOnGatewayTimeout metric is logged
+    Cdo::Metrics.expects(:push).with(
+      EvaluateRubricJob::AI_RUBRIC_METRICS_NAMESPACE,
+      all_of(
+        includes_metrics(RetryOnGatewayTimeout: 1),
+        includes_dimensions(:RetryOnGatewayTimeout, Environment: CDO.rack_env, Agent: 'openai')
+      )
+    )
+
+    # Run the job (and track attempts)
+    assert_performed_jobs EvaluateRubricJob::RETRIES_ON_RATE_LIMIT do
+      perform_enqueued_jobs do
+        EvaluateRubricJob.perform_later(
+          user_id: @student.id,
+          requester_id: @student.id,
+          script_level_id: @script_level.id
+        )
+      end
+    end
+  end
+
   test "job records REQUEST_TOO_LARGE on http status 413" do
     EvaluateRubricJob.stubs(:get_lesson_s3_name).with(@script_level).returns('fake-lesson-s3-name')
 

--- a/dashboard/test/jobs/evaluate_rubric_job_test.rb
+++ b/dashboard/test/jobs/evaluate_rubric_job_test.rb
@@ -224,7 +224,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     stub_get_openai_evaluations(status: 429)
 
     # Run the job (and track attempts)
-    assert_performed_jobs EvaluateRubricJob::RETRIES_ON_RATE_LIMIT do
+    assert_performed_jobs EvaluateRubricJob::ATTEMPTS_ON_RATE_LIMIT do
       perform_enqueued_jobs do
         EvaluateRubricJob.perform_later(
           user_id: @student.id,
@@ -274,7 +274,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     end
 
     # Run the job (and track attempts)
-    assert_performed_jobs EvaluateRubricJob::RETRIES_ON_TIMEOUT do
+    assert_performed_jobs EvaluateRubricJob::ATTEMPTS_ON_TIMEOUT do
       perform_enqueued_jobs do
         EvaluateRubricJob.perform_later(
           user_id: @student.id,
@@ -327,7 +327,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     end
 
     # Run the job (and track attempts)
-    assert_performed_jobs EvaluateRubricJob::RETRIES_ON_RATE_LIMIT do
+    assert_performed_jobs EvaluateRubricJob::ATTEMPTS_ON_RATE_LIMIT do
       perform_enqueued_jobs do
         EvaluateRubricJob.perform_later(
           user_id: @student.id,
@@ -380,7 +380,7 @@ class EvaluateRubricJobTest < ActiveJob::TestCase
     end
 
     # Run the job (and track attempts)
-    assert_performed_jobs EvaluateRubricJob::RETRIES_ON_RATE_LIMIT do
+    assert_performed_jobs EvaluateRubricJob::ATTEMPTS_ON_RATE_LIMIT do
       perform_enqueued_jobs do
         EvaluateRubricJob.perform_later(
           user_id: @student.id,


### PR DESCRIPTION
## Description

Starts https://codedotorg.atlassian.net/browse/AITT-464. The sequence or PRs looks like this:
* https://github.com/code-dot-org/code-dot-org/pull/58354
* https://github.com/code-dot-org/code-dot-org/pull/58411 (this PR)
* https://github.com/code-dot-org/aiproxy/pull/74 

this PR handles 503 and 504 requests from OpenAI, and logs metrics and firehose rather than honeybadger in those cases. 

### response codes

Here is some discussion of why 503 and 504 are reasonable to return in this case:
* https://stackoverflow.com/questions/18709834/http-status-424-or-500-for-error-on-external-dependency
* https://stackoverflow.com/questions/25398364/http-status-code-for-external-dependency-error/25398605#25398605

One concern with using these response codes is that the same codes might also be returned due to other infrastructure problems. To address this, I've added an "agent" dimension to each metric and firehose event, which will be "openai" when the problem is due to an openai error and "none" when the problem is between dashboard and aiproxy.

### timeouts

This PR and https://github.com/code-dot-org/aiproxy/pull/74 also change some timeouts, in order to: (1) to avoid the problem where the active job gives up on the request a moment before aiproxy returns a 504, and (2) make the timeouts a bit longer in hopes of reducing how often they happen in the first place.

Together with https://github.com/code-dot-org/aiproxy/pull/74 , we have the following timeouts, which should ensure that openai timeouts are returned to active job as 504 before any other timeouts are reached:
* 150s: aiproxy request to openai
* 165s: active job request to aiproxy
* 180s: aiproxy load balancer. see https://github.com/code-dot-org/aiproxy/blob/d53e627366fb4fdf209d86128ecdaec8c3b2763e/cicd/3-app/aiproxy/template.yml#L65

## command line output

Performing the job from rails console to confirm that firehose logging is working, with an artificially low timeout:
```
[development] dashboard > EvaluateRubricJob.perform_now(user_id: 219, requester_id: 1, script_level_id: 160880)
...
Stopped retrying EvaluateRubricJob due to a Net::ReadTimeout, which reoccurred on 2 attempts.
Skipped sending records to analysis-events:
["{\"study\":\"ai-rubrics\",\"study_group\":\"v0\",\"event\":\"retry-on-timeout\",\"data_string\":\"Net::ReadTimeout: Net::ReadTimeout with #\\u003cTCPSocket:(closed)\\u003e\",\"data_json\":\"{\\\"user_id\\\":219,\\\"requester_id\\\":1,\\\"script_level_id\\\":160880,\\\"script_name\\\":\\\"csd3-2023\\\",\\\"lesson_number\\\":11,\\\"level_name\\\":\\\"CSD U3 Sprites scene challenge_2023\\\"}\",\"created_at\":\"2024-05-06T16:28:25.476+00:00\",\"environment\":\"development\",\"device\":\"\\\"server-side\\\"\"}"]
```

## Testing story

- new unit tests
- end-to-end testing with local aiproxy:
  - since it is hard to simulate openai returning 500, I modified my local aiproxy with https://github.com/code-dot-org/aiproxy/pull/74 to unconditionally `return 'openai error', 503`
  - to test the 504 pathway, I temporarily reduced the `OPENAI_API_TIMEOUT` in aiproxy to 1 second.
  - in each case, I was able to verify the metrics showing up in cloudwatch and firehose

## Deployment strategy

Ideally we deploy this PR before the aiproxy PR, so that we know how to handle the new response codes before aiproxy starts returning them. If we do it in the other order, we might see the same error cases show up differently in Honey Badger, drawing unnecessary attention from the DOTD.

## Follow-up work

Move from firehose logging to cloudwatch logging once that is supported.