### PR TITLE
Adding new initiative names for foundations of CS and programming.

### DIFF
--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -60,8 +60,8 @@ module Curriculum
         pd_workshop_activity_csd: 'PD Workshop Activity CSD',
         pd_workshop_activity_csp: 'PD Workshop Activity CSP',
         pd_workshop_activity_csa: 'PD Workshop Activity CSA',
-        FCS: 'Foundations of CS',
-        FP: 'Foundations of Programming'
+        foundations_of_cs: 'Foundations of CS',
+        foundations_of_programming: 'Foundations of Programming'
       }
     ).freeze
 

--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -59,7 +59,9 @@ module Curriculum
         pd_workshop_activity_csf: 'PD Workshop Activity CSF',
         pd_workshop_activity_csd: 'PD Workshop Activity CSD',
         pd_workshop_activity_csp: 'PD Workshop Activity CSP',
-        pd_workshop_activity_csa: 'PD Workshop Activity CSA'
+        pd_workshop_activity_csa: 'PD Workshop Activity CSA',
+        FCS: 'Foundations of CS',
+        FP: 'Foundations of Programming'
       }
     ).freeze
 


### PR DESCRIPTION
Two new options for initiatives to associate with a script (`Foundations of CS` and `Foundations of Programming`)

![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/5a1de088-f3db-4fa2-82e5-8df5785ad659)

![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/3a8927b5-b75b-4383-beea-0c89b86e3d42)

## Links

JIRA https://codedotorg.atlassian.net/browse/TEACH-1059

## Testing story

- Manually updated initiative for a script through local levelbuilder environment.
- Drone for other validation
- Confirmed with PM and RED on the initiative names https://codedotorg.slack.com/archives/C045UAX4WKH/p1715014774483159

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
