### PR TITLE
Enable Performance Insights on Database Clusters

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -124,8 +124,6 @@
         # BEGIN: Static configuration settings.
         # WARNING - Changing these settings triggers restart of each database instance in the cluster during Stack Update.
 
-        performance_schema: 1
-
         # In conjunction with GTID, enabling binary logging causes Pegasus tests that utilize fake dashboard to fail
         # because they create/drop temporary tables within a transaction:
         # https://github.com/code-dot-org/code-dot-org/blob/654d0cf90dd65848fdd045df3b9e4f85903d9f68/pegasus/test/fixtures/fake_dashboard.rb#L257-L271
@@ -158,7 +156,7 @@
       Family: aurora-mysql5.7
       Parameters:
         # BEGIN: Static configuration settings. Changing these settings will trigger a restart of each database instance.
-        performance_schema: 1
+
         # END: Static configuration settings.
 
         # BEGIN: Dynamic configuration settings. Changing these settings does NOT require nor trigger restart of instances.
@@ -175,8 +173,6 @@
       Parameters:
         # BEGIN: Static configuration settings.
         # WARNING - Changing these settings triggers restart of each database instance in the cluster during Stack Update.
-
-        performance_schema: 1
 
         # In conjunction with GTID, enabling binary logging causes Pegasus tests that utilize fake dashboard to fail
         # because they create/drop temporary tables within a transaction:
@@ -348,6 +344,8 @@
       EnableIAMDatabaseAuthentication: true
       VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
+      PerformanceInsightsEnabled: <%= ['test', 'production'].include?(environment) %>
+      PerformanceInsightsRetentionPeriod: <%= rack_env?(:production) ? 465 : 7 %>
       EnableCloudwatchLogsExports:
         - general
         - audit


### PR DESCRIPTION
Enable AWS Relational Database Service Performance Insights on test and production database clusters with Performance Insights managing the MySQL performance schema. This change ensures we can reliably monitor and analyze the performance of our relational database.

We had previously manually enabled Performance Insights on the production writer database instance, production reader database instance, and the test writer database instance. We had previously enabled the MySQL Performance Schema, but removing that configuration allows Performance Insights to manage the MySQL Performance Schema.

More details:
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_PerfInsights.EnableMySQL.html#USER_PerfInsights.effect-of-pfs

<img width="1246" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/2157034/c9bbf2df-91f9-464a-bca8-c884c207e876">


This change ensures that we use code to configure detailed performance monitoring of our relational database and also eliminates two problems:

- The production database reverted back to logging generic MySQL Waits in Performance Insights after a restartm requiring us to manually execute SQL updates to configure Aurora specific Waits.
- Performance Insights sometimes displays a warning that the test database cluster's writer instance has a performance schema table that is full and that we need to manually truncate to continue having Performance Insights log and analyze certain types of data. 

## Deployment strategy

We should deploy this before the MySQL 8 upgrade as this configuration template logic works best when applied to a new cluster, which we may be provisioning in production.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
