### PR TITLE
Add Music Lab skinny banners to code.org

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/music-lab-skinny-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/music-lab-skinny-banner.scss
@@ -1,0 +1,62 @@
+$width-sm: 640px;
+
+.music-lab-skinny-banner {
+  background: url('/images/music-lab/music-lab-homepage-banner-bg.png') center top;
+  background-size: cover;
+  padding: 1rem 2rem;
+
+  .wrapper {
+    max-width: 960px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 5rem;
+
+    @media (max-width: 900px) {
+      gap: 2rem;
+    }
+
+    @media (max-width: $width-sm) {
+      padding-block: 2rem;
+      flex-direction: column;
+      justify-content: center;
+      gap: 1rem;
+    }
+  }
+
+  .text-wrapper {
+    flex: 2;
+
+    @media (max-width: $width-sm) {
+      text-align: center;
+    }
+
+    .afe {
+      margin-bottom: 0.15rem;
+      justify-content: start;
+      gap: 0.25rem 0.5rem;
+
+      @media (max-width: $width-sm) {
+        justify-content: center;
+      }
+
+      & > figure {
+        width: 180px;
+
+        img {
+          width: 100%;
+        }
+      }
+    }
+  }
+
+  img {
+    max-width: 12rem;
+
+    @media (max-width: $width-sm) {
+      align-self: center;
+    }
+  }
+}

--- a/pegasus/sites.v3/code.org/public/student/elementary.haml
+++ b/pegasus/sites.v3/code.org/public/student/elementary.haml
@@ -6,6 +6,8 @@ theme: responsive_full_width
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 
 = view :poetry_banner
+// TODO - Remove this once the Music Lab launch is over
+= view :"music/music_lab_skinny_banner"
 
 %section.no-padding-bottom
   .wrapper

--- a/pegasus/sites.v3/code.org/public/student/middle-high.haml
+++ b/pegasus/sites.v3/code.org/public/student/middle-high.haml
@@ -5,6 +5,9 @@ theme: responsive_full_width
 
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 
+// TODO - Remove this once the Music Lab launch is over
+= view :"music/music_lab_skinny_banner"
+
 %section.no-padding-bottom
   .wrapper
     %h1=hoc_s(:middle_high_page_main_title)

--- a/pegasus/sites.v3/code.org/public/teach.haml
+++ b/pegasus/sites.v3/code.org/public/teach.haml
@@ -20,6 +20,8 @@ theme: responsive_full_width
     .clear
 
 = view :poetry_banner
+
+// TODO - Remove this once the Music Lab launch is over
 = view :"music/music_lab_skinny_banner"
 
 %section.why-teach-cs.bg-neutral-light

--- a/pegasus/sites.v3/code.org/public/teach.haml
+++ b/pegasus/sites.v3/code.org/public/teach.haml
@@ -20,6 +20,7 @@ theme: responsive_full_width
     .clear
 
 = view :poetry_banner
+= view :"music/music_lab_skinny_banner"
 
 %section.why-teach-cs.bg-neutral-light
   .wrapper

--- a/pegasus/sites.v3/code.org/views/music/music_lab_skinny_banner.haml
+++ b/pegasus/sites.v3/code.org/views/music/music_lab_skinny_banner.haml
@@ -1,0 +1,18 @@
+- if !!DCDO.get("music-lab-launch-2024", false)
+  %link{href: "/css/generated/music-lab-skinny-banner.css", rel: "stylesheet"}
+
+  %aside.music-lab-skinny-banner
+    .wrapper.flex-container.justify-space-between.align-items-center.wrap
+      .text-wrapper
+        %h5.white
+          =hoc_s("music_lab.introducing_music_lab")
+        %p.white
+          =hoc_s("music_lab.banner.desc")
+        .afe.flex-container.align-items-baseline.wrap
+          %p.body-three.no-margin-bottom.white
+            =hoc_s("music_lab.in_partnership_with")
+          %figure
+            %img{src: "/images/avatars/amazon_future_engineer_light.png", alt: hoc_s("music_lab.amazon_future_engineer")}
+      %img{src:"/images/music-lab/music-lab-banner-graphic.png", alt: ""}
+      %a.link-button.white{href: "/music"}
+        =hoc_s("music_lab.button.try_music_lab")


### PR DESCRIPTION
Adds Music Lab skinny banners to the following pages in preparation for the launch in a couple weeks:
- https://code.org/teach
- https://code.org/student/elementary
- https://code.org/student/middle-high

These will show up when the `music-lab-launch-2024` DCDO flag is set to `true`.

## Links
Jira tickets: [ACQ-1674](https://codedotorg.atlassian.net/browse/ACQ-1674) • [ACQ-1675](https://codedotorg.atlassian.net/browse/ACQ-1675)
Figma mock: [here](https://www.figma.com/file/2WMErkWkUqY8DNxPCa5hXB/Music-Lab-Launch?type=design&node-id=2461%3A1773&mode=design&t=novZSorHfmTIIQ3y-1)

## Testing story
Tested locally, and tested DCDO flag locally to make sure it works

----

## code.org/teach
![Desktop](https://github.com/code-dot-org/code-dot-org/assets/9256643/88637895-5049-45d1-a8f7-08b816532ae9)

## code.org/student/elementary
![Elementary](https://github.com/code-dot-org/code-dot-org/assets/9256643/e6490a2f-4d88-4d5b-ad9d-6128c3d2f79b)

## code.org/student/middle-high
![MidHigh](https://github.com/code-dot-org/code-dot-org/assets/9256643/fe204cf0-6127-4ee2-bed8-64150458840b)

## Reponsive

| Tablet | Mobile |
| ---- | ---- |
| ![Tablet](https://github.com/code-dot-org/code-dot-org/assets/9256643/f2b4d1f8-7643-4301-aa59-587bc96c19b7) | ![Mobile](https://github.com/code-dot-org/code-dot-org/assets/9256643/c92421d9-7238-4fdf-9ddf-74204d0ebcf7) |

## RTL
![localhost code org_3000_teach(Code org - 1366x768)](https://github.com/code-dot-org/code-dot-org/assets/9256643/e9da54a5-fb1f-4459-83a7-337c3edac60b)
