### PR TITLE
[Google Blockly] Register custom procedure blocks in old labs

### DIFF
--- a/apps/src/maze/blocks.js
+++ b/apps/src/maze/blocks.js
@@ -34,6 +34,7 @@ var msg = require('./locale');
 
 // Install extensions to Blockly's language and JavaScript generator.
 exports.install = function (blockly, blockInstallOptions) {
+  Blockly.cdoUtils.registerCustomProcedureBlocks();
   var skin = blockInstallOptions.skin;
   var generator = blockly.getGenerator();
   blockly.JavaScript = generator;

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -136,6 +136,7 @@ function getSpriteOrDropdownIndex(
 
 // Install extensions to Blockly's language and JavaScript generator.
 exports.install = function (blockly, blockInstallOptions) {
+  Blockly.cdoUtils.registerCustomProcedureBlocks();
   var skin = blockInstallOptions.skin;
   var isK1 = blockInstallOptions.isK1;
   var generator = blockly.getGenerator();

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -80,6 +80,7 @@ const DIRECTION_VALUES = [
 
 // Install extensions to Blockly's language and JavaScript generator.
 exports.install = function (blockly, blockInstallOptions) {
+  Blockly.cdoUtils.registerCustomProcedureBlocks();
   var skin = blockInstallOptions.skin;
 
   var generator = blockly.getGenerator();


### PR DESCRIPTION
To support the Sprite Lab migration, we implemented custom versions of the new shareable procedures. When we were ready to migrate Minecraft later, we simply needed to register the blocks. (https://github.com/code-dot-org/code-dot-org/pull/55993/files#diff-972ff80c7f8bd964897bbfa702b7e753dd5e99a06b72a5664a259dd6a6be33a7)

Now we can do the same for Maze, Artist (aka Turtle), and Play Lab (aka Studio) to help prepare them for migration. I tested these changes with a variety of Maze levels and saw the expected improvements, detailed below. I didn't specifically test Artist or Play Lab yet, but `registerCustomProcedureBlocks` doesn't do anything if we're in the CDO Blockly Wrapper, so there's really no risk with this change.

As a review, here are some ways you can tell that we're using our custom blocks:
- Modal function editor should work
- Call blocks have "edit" buttons if the modal editor is enabled
- Definition blocks have an SVG frame if they're on the primary student workspace
- Definition blocks should not have a "gear" UI in the corner
- Definition blocks never turn gray


Block type|CDO Blockly - baseline| Google Blockly - Staging | Google Blockly - this branch|
|-|-|-|-|
|Call blocks with edit buttons - modal <br/>Course 4.16.2|<img width="200" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/1ec3094a-c62a-4890-a12c-a6c6c240d681">|<img width="197" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/980aa49c-5254-48a4-b52b-439046c5c062">|<img width="189" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/c76ca30b-fcfa-4111-803b-d01b0d96912e">|
|Definition block - modal <br/>Course 4.16.2|<img width="631" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/2c278631-b5a6-4691-af48-3054fffdc558">|N/A<img width="630" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/393cdf62-287d-4842-9bbe-74bb641fe7da">|<img width="636" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/477ba5eb-89cf-4ba0-a1c9-ac9fea2f715f">|
|Definition block - no modal <br/>Course E.14.3|<img width="249" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/569bf0e3-a463-43f8-a73e-31cfc98134c7">|<img width="262" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/ea0d5caf-c796-4b72-9a3e-e0e62574b981">|<img width="246" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/111140fa-7c99-4a83-9963-bc33a06f3338">|
|Definition block - no modal - undeletable "stone" blocks <br/>Course E.14.4|<img width="248" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/68126d14-ea3a-4371-8672-c36dbe0b0e8a">|<img width="257" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/45d99aa5-0680-4a06-bda2-0f2b55a47e6e">|<img width="249" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/23f0e908-57d2-489f-983e-3d748683153d">|

## Links

Jira -https://codedotorg.atlassian.net/browse/CT-558
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## Follow-up work

Support functions with parameters. :(

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
