### PR TITLE
feat(email): add script to scan for legacy partial registration keys

### DIFF
--- a/bin/oneoff/remove_no_ttl_partial_registrations.rb
+++ b/bin/oneoff/remove_no_ttl_partial_registrations.rb
@@ -7,7 +7,7 @@ require_relative '../../dashboard/config/environment'
 
 # This script inspects all cache entries in the partial registration namespace for the presence of a TTL.
 # If no TTL is present, the cache entry is removed.
-DRY_RUN = false
+DRY_RUN = true
 
 puts "Processing... DRYRUN=#{DRY_RUN}"
 

--- a/bin/oneoff/remove_no_ttl_partial_registrations.rb
+++ b/bin/oneoff/remove_no_ttl_partial_registrations.rb
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+
+require 'socket'
+require 'timeout'
+
+require_relative '../../dashboard/config/environment'
+
+# This script inspects all cache entries in the partial registration namespace for the presence of a TTL.
+# If no TTL is present, the cache entry is removed.
+DRY_RUN = false
+
+puts "Processing... DRYRUN=#{DRY_RUN}"
+
+PARTIAL_REGISTRATION_SUFFIXES = [
+  /-partial-sso-migrated$/,
+  /-partial-sso$/,
+  /-partial-email$/
+]
+
+all_keys_without_expiration = []
+
+dalli_data = CDO.shared_cache.instance_variable_get(:@data)
+memcached_endpoints = dalli_data.instance_variable_get(:@servers)
+
+puts "Found endpoints #{memcached_endpoints}"
+
+memcached_endpoints.each do |endpoint|
+  hostname, port = endpoint.split(":")
+
+  puts "Checking #{hostname} #{port}"
+  sock = TCPSocket.new(hostname, 11211)
+
+  begin
+    # metadump doesn't return END in our version of memcached, wait 30 seconds for all output instead
+    # https://github.com/memcached/memcached/issues/667
+    Timeout.timeout(30) do
+      sock.write("lru_crawler metadump all\r\n")
+
+      # read keys until encountered an end (for memcached, this will be the Timeout)
+      loop do
+        data = sock.readline
+        break if !data || data.empty? || data == "END\r\n" || data == "ERROR\r\n"
+        matches = data.scan(/^key=(?<key>.*) exp=-1/)
+        break if matches.empty?
+        all_keys_without_expiration += matches.flatten!
+        ''
+      end
+    end
+  rescue EOFError
+    puts "Connection closed by remote host."
+  rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Timeout::Error
+    puts "Timeout reached while waiting for data."
+  ensure
+    sock.close
+  end
+end
+
+# Filter strings that match any of the regexes
+partial_registration_keys = all_keys_without_expiration.select do |string|
+  PARTIAL_REGISTRATION_SUFFIXES.any? {|regex| regex.match?(string)}
+end
+
+puts "Filtered keys:"
+puts partial_registration_keys
+
+unless DRY_RUN
+  partial_registration_keys.each do |key|
+    CDO.shared_cache.delete(key)
+    puts "Removed key #{key}"
+  end
+end

--- a/bin/oneoff/remove_no_ttl_partial_registrations.rb
+++ b/bin/oneoff/remove_no_ttl_partial_registrations.rb
@@ -41,9 +41,8 @@ memcached_endpoints.each do |endpoint|
         data = sock.readline
         break if !data || data.empty? || data == "END\r\n" || data == "ERROR\r\n"
         matches = data.scan(/^key=(?<key>.*) exp=-1/)
-        break if matches.empty?
-        all_keys_without_expiration += matches.flatten!
-        ''
+        next if matches.empty?
+        all_keys_without_expiration.concat(matches.flatten!)
       end
     end
   rescue EOFError


### PR DESCRIPTION
This oneoff script scans the shared memcached instance for keys that do not have a TTL and matches one of the partial registration keys. In `DRY_RUN=true`, the keys will be printed out. In `DRY_RUN=false` the keys will be removed.

This script only works for memcached caches as filesystem caches aren't utilized in production and thus not stored.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-836)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. With DCDO flag enabled, start registration. Script should not remove the key
2. With DCDO flag disabled, start registration. Script should remove the key
3. With `DRY_RUN=false`, script should remove the key.
4. With `DRY_RUN=true`, script should NOT remove the key
5. Ensured other keys are NOT removed

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

This script will be executed with one other person after the TTLs have been published for a week.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
