### PR TITLE
Move assign handler to CurriculumCatalog component

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -10,6 +10,17 @@ import CourseCatalogNoSearchResultPenguin from '../../../static/curriculum_catal
 import {Heading5, BodyTwoText} from '@cdo/apps/componentLibrary/typography';
 import CurriculumCatalogFilters from './CurriculumCatalogFilters';
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
+import {
+  assignToSection,
+  sectionsForDropdown,
+  unassignSection,
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import MultipleSectionsAssigner from '@cdo/apps/templates/MultipleSectionsAssigner';
+import {
+  CreateSectionsToAssignSectionsDialog,
+  SignInToAssignSectionsDialog,
+  UpgradeAccountToAssignSectionsDialog,
+} from '@cdo/apps/templates/curriculumCatalog/noSectionsToAssignDialogs';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {
@@ -17,6 +28,7 @@ import {
   getStretchRecommendations,
 } from '@cdo/apps/util/curriculumRecommender/curriculumRecommender';
 import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
+import {connect} from 'react-redux';
 
 const CurriculumCatalog = ({
   curriculaData,
@@ -26,6 +38,7 @@ const CurriculumCatalog = ({
   isSignedOut,
   isTeacher,
   curriculaTaught,
+  sectionsForDropdown,
   ...props
 }) => {
   const [filteredCurricula, setFilteredCurricula] = useState(curriculaData);
@@ -64,6 +77,68 @@ const CurriculumCatalog = ({
         curriculum_offering: assignmentData.assignedTitle,
       }
     );
+  };
+
+  const [isAssignDialogOpen, setIsAssignDialogOpen] = useState(false);
+  const [courseKeyForAssign, setCourseKeyForAssign] = useState(null);
+  const handleClickAssign = (cardType, courseKey) => {
+    setIsAssignDialogOpen(true);
+    setCourseKeyForAssign(courseKey);
+    analyticsReporter.sendEvent(
+      EVENTS.CURRICULUM_CATALOG_ASSIGN_CLICKED_EVENT,
+      {
+        curriculum_offering: courseKey,
+        has_sections: sectionsForDropdown.length > 0,
+        is_signed_in: !isSignedOut,
+        card_type: cardType,
+      }
+    );
+  };
+
+  const renderAssignDialog = () => {
+    console.log(sectionsForDropdown);
+    const curriculumToAssign = filteredCurricula.find(
+      curriculum => curriculum.key === courseKeyForAssign
+    );
+    const courseDisplayNameWithLatestYear =
+      curriculumToAssign?.display_name_with_latest_year;
+    if (isSignedOut) {
+      return (
+        <SignInToAssignSectionsDialog
+          onClose={() => setIsAssignDialogOpen(false)}
+        />
+      );
+    } else if (isTeacher && sectionsForDropdown.length > 0) {
+      return (
+        <MultipleSectionsAssigner
+          assignmentName={courseDisplayNameWithLatestYear}
+          onClose={() => setIsAssignDialogOpen(false)}
+          sections={sectionsForDropdown}
+          participantAudience="student"
+          onAssignSuccess={handleAssignSuccess}
+          isAssigningCourse={!!curriculumToAssign?.course_id}
+          courseId={curriculumToAssign?.course_id}
+          scriptId={curriculumToAssign?.script_id}
+          courseOfferingId={curriculumToAssign?.course_offering_id}
+          courseVersionId={curriculumToAssign?.course_version_id}
+          sectionDirections={i18n.chooseSectionsDirectionsOnCatalog()}
+          {...props}
+        />
+      );
+    } else if (isTeacher) {
+      return (
+        <CreateSectionsToAssignSectionsDialog
+          onClose={() => setIsAssignDialogOpen(false)}
+          onClick={() => {}}
+        />
+      );
+    } else {
+      return (
+        <UpgradeAccountToAssignSectionsDialog
+          onClose={() => setIsAssignDialogOpen(false)}
+        />
+      );
+    }
   };
 
   const handleCloseAssignSuccessMessage = () => {
@@ -233,6 +308,7 @@ const CurriculumCatalog = ({
                   courseOfferingId={course_offering_id}
                   scriptId={script_id}
                   isStandAloneUnit={is_standalone_unit}
+                  handleClickAssign={handleClickAssign}
                   onAssignSuccess={response => handleAssignSuccess(response)}
                   deviceCompatibility={device_compatibility}
                   description={description}
@@ -300,6 +376,7 @@ const CurriculumCatalog = ({
       <div className={style.catalogContentContainer}>
         {renderSearchResults()}
       </div>
+      {isAssignDialogOpen && renderAssignDialog()}
     </>
   );
 };
@@ -312,6 +389,24 @@ CurriculumCatalog.propTypes = {
   isSignedOut: PropTypes.bool.isRequired,
   isTeacher: PropTypes.bool.isRequired,
   curriculaTaught: PropTypes.arrayOf(PropTypes.number),
+  sectionsForDropdown: PropTypes.array,
+  assignToSection: PropTypes.func.isRequired,
+  unassignSection: PropTypes.func.isRequired,
 };
 
-export default CurriculumCatalog;
+// export default CurriculumCatalog;
+
+export default connect(
+  (state, ownProps) => ({
+    sectionsForDropdown: sectionsForDropdown(
+      state.teacherSections,
+      ownProps.courseOfferingId,
+      ownProps.courseVersionId,
+      state.progress?.scriptId
+    ),
+  }),
+  {
+    assignToSection,
+    unassignSection,
+  }
+)(CurriculumCatalog);

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -96,7 +96,6 @@ const CurriculumCatalog = ({
   };
 
   const renderAssignDialog = () => {
-    console.log(sectionsForDropdown);
     const curriculumToAssign = filteredCurricula.find(
       curriculum => curriculum.key === courseKeyForAssign
     );
@@ -122,6 +121,7 @@ const CurriculumCatalog = ({
           courseOfferingId={curriculumToAssign?.course_offering_id}
           courseVersionId={curriculumToAssign?.course_version_id}
           sectionDirections={i18n.chooseSectionsDirectionsOnCatalog()}
+          isStandAloneUnit={curriculumToAssign?.is_standalone_unit}
           {...props}
         />
       );

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -277,7 +277,9 @@ const ExpandedCurriculumCatalogCard = ({
                   <Button
                     color={Button.ButtonColor.brandSecondaryDefault}
                     type="button"
-                    onClick={() => assignButtonOnClick('expanded-card')}
+                    onClick={() =>
+                      assignButtonOnClick('expanded-card', courseKey)
+                    }
                     aria-label={assignButtonDescription}
                     text={i18n.assignToClassSections()}
                     className={centererStyle.buttonFlex}

--- a/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
@@ -66,7 +66,6 @@ describe('CurriculumCatalog', () => {
     registerReducers({responsive, teacherSections});
     store = getStore();
     store.dispatch(setResponsiveSize(ResponsiveSize.lg));
-    store.dispatch(setSections(sections));
 
     replacedLocation = undefined;
     window.history.replaceState = (_, __, newLocation) => {
@@ -876,6 +875,78 @@ describe('CurriculumCatalog', () => {
       expect(storedRecommenderResults[firstTestCurriculum.key].key).to.equal(
         recommendedStretchCurriculum.key
       );
+    });
+  });
+
+  it('clicking Assign button as a teacher with sections shows dialog with sections and catalog-specific text with year', () => {
+    store.dispatch(setSections(sections));
+    const props = {...defaultProps, isSignedOut: false, isTeacher: true};
+    render(
+      <Provider store={store}>
+        <CurriculumCatalog {...props} />
+      </Provider>
+    );
+
+    const assignButton = screen.getByRole('button', {
+      name: new RegExp(
+        `Assign ${allCurricula[0].display_name} to your classroom`
+      ),
+    });
+
+    sections.forEach(
+      section => expect(screen.queryByText(section.name)).to.be.null
+    );
+    fireEvent.click(assignButton);
+    sections.forEach(section => screen.getByText(section.name));
+    screen.getByText(
+      `Which section(s) do you want to assign "${allCurricula[0].display_name_with_latest_year}" to?`,
+      {
+        exact: false,
+      }
+    );
+    screen.getByText('The most recent recommended version', {
+      exact: false,
+    });
+  });
+
+  it('clicking Assign button as a teacher without sections shows dialog to create section', () => {
+    store.dispatch(setSections([]));
+    const props = {...defaultProps, isSignedOut: false, isTeacher: true};
+    render(
+      <Provider store={store}>
+        <CurriculumCatalog {...props} />
+      </Provider>
+    );
+
+    const assignButton = screen.getByRole('button', {
+      name: new RegExp(
+        `Assign ${allCurricula[0].display_name} to your classroom`
+      ),
+    });
+
+    fireEvent.click(assignButton);
+    screen.getByRole('heading', {
+      name: 'Create class section to assign a curriculum',
+    });
+  });
+
+  it('clicking Assign button as a signed out user shows dialog to sign in', () => {
+    const props = {...defaultProps, isSignedOut: true};
+    render(
+      <Provider store={store}>
+        <CurriculumCatalog {...props} />
+      </Provider>
+    );
+
+    const assignButton = screen.getByRole('button', {
+      name: new RegExp(
+        `Assign ${allCurricula[0].display_name} to your classroom`
+      ),
+    });
+
+    fireEvent.click(assignButton);
+    screen.getByRole('heading', {
+      name: 'Sign in or create account to assign a curriculum',
     });
   });
 });

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -15,12 +15,9 @@ import {
   translatedCourseOfferingCsTopics,
   translatedLabels,
 } from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
-import teacherSections, {
-  setSections,
-} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 import {expect} from '../../../util/reconfiguredChai';
-import {sections} from '../studioHomepages/fakeSectionUtils';
 
 describe('CurriculumCatalogCard', () => {
   const translationIconTitle = 'Curriculum is available in your language';
@@ -66,6 +63,7 @@ describe('CurriculumCatalogCard', () => {
       isSignedOut: true,
       onQuickViewClick: () => {},
       handleSetExpandedCardKey: () => {},
+      handleClickAssign: () => {},
       isTeacher: true,
       setExpandedCardKey: () => {},
       recommendedSimilarCurriculum: {},
@@ -271,67 +269,6 @@ describe('CurriculumCatalogCard', () => {
       name: new RegExp(
         `Assign ${defaultProps.courseDisplayName} to your classroom`
       ),
-    });
-  });
-
-  it('clicking Assign button as a teacher with sections shows dialog with sections and catalog-specific text with year', () => {
-    store.dispatch(setSections(sections));
-    renderCurriculumCard({
-      ...defaultProps,
-      isSignedOut: false,
-      isTeacher: true,
-    });
-
-    const assignButton = screen.getByRole('button', {
-      name: new RegExp(
-        `Assign ${defaultProps.courseDisplayName} to your classroom`
-      ),
-    });
-
-    sections.forEach(
-      section => expect(screen.queryByText(section.name)).to.be.null
-    );
-    fireEvent.click(assignButton);
-    sections.forEach(section => screen.getByText(section.name));
-    screen.getByText(defaultProps.courseDisplayNameWithLatestYear, {
-      exact: false,
-    });
-    screen.getByText('The most recent recommended version', {
-      exact: false,
-    });
-  });
-
-  it('clicking Assign button as a teacher without sections shows dialog to create section', () => {
-    renderCurriculumCard({
-      ...defaultProps,
-      isSignedOut: false,
-      isTeacher: true,
-    });
-
-    const assignButton = screen.getByRole('button', {
-      name: new RegExp(
-        `Assign ${defaultProps.courseDisplayName} to your classroom`
-      ),
-    });
-
-    fireEvent.click(assignButton);
-    screen.getByRole('heading', {
-      name: 'Create class section to assign a curriculum',
-    });
-  });
-
-  it('clicking Assign button as a signed out user shows dialog to sign in', () => {
-    renderCurriculumCard();
-
-    const assignButton = screen.getByRole('button', {
-      name: new RegExp(
-        `Assign ${defaultProps.courseDisplayName} to your classroom`
-      ),
-    });
-
-    fireEvent.click(assignButton);
-    screen.getByRole('heading', {
-      name: 'Sign in or create account to assign a curriculum',
     });
   });
 });


### PR DESCRIPTION
Swiper seems to have an issue when dialogs are rendered by swiper elements. So, when I started prototyping the carousel of assignable curriculum, this happened:

https://github.com/code-dot-org/code-dot-org/assets/46464143/759a2fba-5b5f-4774-998c-050b53734605

Moving the assign dialog rendering up a step solves this issue. It is unfortunate as it means there will be some duplicated logic, but, given the issues with the video lightbox, I figured this would be the simplest fix. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
