### PR TITLE
Fixing flaky UI test Firefox_teacher_tools_level_types_bubble_choice Viewing BubbleChoice progress

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -36,6 +36,6 @@ Feature: BubbleChoice
     And I wait until element ".teacher-panel" is visible
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
-    When I click selector ".teacher-panel table td:contains(Alice)" once I see it
+    When I click selector ".teacher-panel table td:contains(Alice)" once I see it to load a new page
     And I wait for 4 seconds
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -7,7 +7,7 @@ Feature: BubbleChoice
 
     # Complete the level
     And I wait until element ".submitButton" is visible
-    And I click selector ".submitButton"
+    And I click selector ".submitButton" to load a new page
 
     # Make sure you are taken back to the BubbleChoice activity page with progress
     And I wait until current URL contains "/lessons/40/levels/1"


### PR DESCRIPTION
The eyes test is flaky in two different instances, but both fail because of `"ReferenceError: $ is not defined"`. 

Root cause: The error indicate JQuery hasn't loaded. The failure happens right after a new page load. Although we have a check for JQuery to be loaded, in these failure cases, the check runs on the old page before navigating away from it to the new page. 

Fix: Updating the navigation action to also wait for the new page load.

## Links

JIRA https://codedotorg.atlassian.net/browse/TEACH-1042

## Testing story

Drone runs

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
