### PR TITLE
[Blockly] always remove 'block_id_' prefix before highlighting blocks

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1588,10 +1588,7 @@ StudioApp.prototype.resizeToolboxHeader = function () {
 StudioApp.prototype.highlight = function (id, spotlight) {
   if (this.isUsingBlockly() && !isEditWhileRun(getStore().getState())) {
     if (id) {
-      var m = id.match(/^block_id_(\d+)$/);
-      if (m) {
-        id = m[1];
-      }
+      id = id.replace(/^block_id_/, '');
     }
 
     Blockly.mainBlockSpace.highlightBlock(id, spotlight);

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1591,7 +1591,7 @@ StudioApp.prototype.highlight = function (id, spotlight) {
       id = id.replace(/^block_id_/, '');
     }
 
-    Blockly.mainBlockSpace.highlightBlock(id, spotlight);
+    Blockly.cdoUtils.highlightBlock(id, spotlight);
   }
 };
 

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -701,3 +701,12 @@ export function processToolboxXml(toolboxString: string) {
   const modifiedXmlString = new XMLSerializer().serializeToString(xmlDoc);
   return modifiedXmlString;
 }
+
+export function highlightBlock(id: string, spotlight: boolean) {
+  // Google Blockly doesn't consider the selected block to be a highlighted block,
+  // so we unselect it first.
+  if (Blockly.selected) {
+    Blockly.selected.unselect();
+  }
+  Blockly.getMainWorkspace().highlightBlock(id, spotlight);
+}

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -349,6 +349,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     processToolboxXml(toolbox) {
       return toolbox;
     },
+    highlightBlock(id, spotlight) {
+      Blockly.mainBlockSpace.highlightBlock(id, spotlight);
+    },
   };
   blocklyWrapper.customBlocks = customBlocks;
 

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -77,6 +77,7 @@ type GoogleBlocklyType = typeof GoogleBlockly;
 
 // Type for the Blockly instance created and modified by googleBlocklyWrapper.
 export interface BlocklyWrapperType extends GoogleBlocklyType {
+  selected: BlockSvg;
   blockCountMap: Map<string, number> | undefined;
   blockLimitMap: Map<string, number> | undefined;
   readOnly: boolean;


### PR DESCRIPTION
Block highlighting during program execution was not working on Google Blockly. This feature is especially important for our sequencing-based labs like Artist/Maze, and even more especially when there is a "Step" button available. In the CDO Blockly days, we could assume that generated block ids were just integers, however Google Blockly uses a random string of characters. This was causing a regular expression to not match for any Google Blockly block ids. Without stripping the prefix, Blockly is unable to find the block by id and highlight it. We can use a simple `.replace()` with a new simpler regular expression. The expression's `^` ensures that the `'block_id_'` pattern must occur right at the start of the string.

**CDO Blockly - Baseline, no regressions**


https://github.com/code-dot-org/code-dot-org/assets/43474485/89a892e2-ede9-473a-9349-680c63bb4793



**Google Blockly before**

https://github.com/code-dot-org/code-dot-org/assets/43474485/2414f976-151b-4e02-9a56-d8659ba36565


**Google Blockly after**


https://github.com/code-dot-org/code-dot-org/assets/43474485/302f8689-5660-4290-a57c-cfde0d6d74d7

Separately, I also noticed a difference in how each Blockly version handles (or doesn't handle) the currently selected block when highlighting. CDO Blockly's `highlightBlock` function unselects the selected block:
https://github.com/code-dot-org/blockly/blob/v4.1.0/core/ui/block_space/block_space.js#L782-L804

However, Google Blockly does not: https://github.com/google/blockly/blob/171befa7462b4a5288ce0fa775814c267f424e2c/core/workspace_svg.ts#L1284-L1314

We can match the intended behavior by manually unselecting the selected block before calling `highlightBlock`. I created a `cdoUtils` function to handle this extra step for Google Blockly only.


## Links

Jira - https://codedotorg.atlassian.net/browse/CT-555
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
