### PR TITLE
Lab2: add source validator for labs with JSON sources

### DIFF
--- a/apps/src/lab2/constants.ts
+++ b/apps/src/lab2/constants.ts
@@ -17,6 +17,8 @@ export const BLOCKLY_LABS: AppName[] = [
   'spritelab',
 ];
 
+export const LABS_WITH_JSON_SOURCES: AppName[] = ['aichat'];
+
 export const MAIN_PYTHON_FILE = 'main.py';
 
 export const START_SOURCES = 'start_sources';

--- a/apps/src/lab2/responseValidators.ts
+++ b/apps/src/lab2/responseValidators.ts
@@ -6,7 +6,7 @@ import {
   ProjectSources,
 } from './types';
 import Lab2Registry from './Lab2Registry';
-import {BLOCKLY_LABS} from './constants';
+import {BLOCKLY_LABS, LABS_WITH_JSON_SOURCES} from './constants';
 
 // Validator for Blockly sources.
 const BlocklySourceResponseValidator: ResponseValidator<
@@ -46,6 +46,20 @@ const PythonSourceResponseValidator: ResponseValidator<
   return sourceValidatorHelper(response, pythonValidator);
 };
 
+const JsonSourceResponseValidator: ResponseValidator<
+  ProjectSources
+> = response => {
+  const jsonValidator = (responseToValidate: Record<string, unknown>) => {
+    try {
+      JSON.parse(responseToValidate.source as string);
+    } catch (e) {
+      throw new ValidationError('Error parsing JSON: ' + e);
+    }
+  };
+
+  return sourceValidatorHelper(response, jsonValidator);
+};
+
 // Default source validator. This just checks if there is a source field.
 const DefaultSourceResponseValidator: ResponseValidator<
   ProjectSources
@@ -62,6 +76,8 @@ export const SourceResponseValidator: ResponseValidator<
   } else if (appName !== null && BLOCKLY_LABS.includes(appName)) {
     // Blockly labs
     return BlocklySourceResponseValidator(response);
+  } else if (appName !== null && LABS_WITH_JSON_SOURCES.includes(appName)) {
+    return JsonSourceResponseValidator(response);
   } else {
     // Everything else uses the default validator
     return DefaultSourceResponseValidator(response);

--- a/apps/src/lab2/responseValidators.ts
+++ b/apps/src/lab2/responseValidators.ts
@@ -46,6 +46,7 @@ const PythonSourceResponseValidator: ResponseValidator<
   return sourceValidatorHelper(response, pythonValidator);
 };
 
+// Validator for labs that use JSON sources
 const JsonSourceResponseValidator: ResponseValidator<
   ProjectSources
 > = response => {

--- a/apps/src/lab2/responseValidators.ts
+++ b/apps/src/lab2/responseValidators.ts
@@ -46,7 +46,7 @@ const PythonSourceResponseValidator: ResponseValidator<
   return sourceValidatorHelper(response, pythonValidator);
 };
 
-// Validator for labs that use JSON sources
+// Validator for non-Blockly labs that use JSON sources
 const JsonSourceResponseValidator: ResponseValidator<
   ProjectSources
 > = response => {


### PR DESCRIPTION
Quick convenience fix; in local development, we're running into a lot of AI Chat levels that share channel IDs with old labs that have incompatible sources, and have to manually go into S3 to delete the old sources. For other labs (Blockly/Python lab), the response validators will let us fall back to empty sources, so this adds similar behavior for AI Chat and any other labs that use JSON sources; if the JSON cannot be parsed, we'll fall back to empty sources.

## Testing story

Tested with AI chat levels in the gen-ai-foundations-draft script.