### PR TITLE
[Google Blockly] skip creating dropdown field arrow for uneditable blocks

### DIFF
--- a/apps/src/blockly/addons/cdoFieldDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldDropdown.ts
@@ -151,13 +151,19 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
   }
 
   /**
-   * Override of createTextArrow_ to fix the arrow position on Safari.
-   * We need to add dominant-baseline="central" to the arrow element in order to
-   * center it on Safari.
-   * We can remove this if this Blockly issue is fixed:
-   * https://github.com/google/blockly/issues/7890
+   * We override createTextArrow_ to skip creating the arrow for uneditable blocks.
+   *
+   * Additionally, we need fix the arrow position on Safari, but only until
+   * upgrading to Blockly v11. After this, we should be able to just call
+   * super.createTextArrow_() after the early return.
    *  @override */
   createTextArrow_() {
+    if (!this.getSourceBlock()?.isEditable()) {
+      return;
+    }
+
+    // Once we are on v11, we should be able to use the parent class method
+    // for everything below this point.
     const arrow = Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.TSPAN,
       {},


### PR DESCRIPTION
Yesterday I noticed some minor UI differences in dropdown fields when they are on gray "stone" (undeletable) blocks. On CDO Blockly, if a stone block has an editable dropdown field, it will have a teal arrow and a yellow background. I brought this up with @code-dot-org/product-design on Slack and Mark had the following requests:

1. Remove the dropdown arrow for stone blocks that can't be edited
2. Change the dropdown arrow to dark gray (match the block) for stone blocks that can be edited
3. Match the pattern of the teal blocks by keeping the direction box light gray for both kinds of stone blocks

**Mark's mock-up (using CDO Blockly blocks)**
![Screenshot 2024-05-07 at 11 15 31 AM](https://github.com/code-dot-org/code-dot-org/assets/43474485/6b4c6631-ca91-42c4-9a5f-faa91b3435fe)

This PR addresses the first request. Fortunately, the 2nd and 3rd requests already match Google Blockly as we weren't doing any of the recoloring yet.


**With changes (Google Blockly blocks)**

![image (197)](https://github.com/code-dot-org/code-dot-org/assets/43474485/a7ae04b7-c390-4272-9d69-794ff19b18d9)


## Links

Slack thread - https://codedotorg.slack.com/archives/C0SUN2SSF/p1715022245209579
Jira - https://codedotorg.atlassian.net/browse/CT-557

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
