### PR TITLE
[Sprite Lab] Add fox instructor

### DIFF
--- a/apps/static/spritelab/fox.png
+++ b/apps/static/spritelab/fox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:568f63feaeb91564be18b50901ae165f2b0efb0ff5ee58ffc7d8bba134572738
+size 19921


### PR DESCRIPTION
Adds a fox instructor image.

https://codedotorg.atlassian.net/browse/LABS-774

https://codedotorg.slack.com/archives/C05DMS18MEX/p1715099539114169

<img width="330" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/89fcb69b-18d9-4304-ae4b-913e28ea1598">
