### PR TITLE
Gen AI: format markdown, bot icon to top of message

### DIFF
--- a/apps/src/aichat/views/ChatMessage.tsx
+++ b/apps/src/aichat/views/ChatMessage.tsx
@@ -5,6 +5,7 @@ import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {StrongText} from '@cdo/apps/componentLibrary/typography';
 import aiBotIcon from '@cdo/static/aichat/ai-bot-icon.svg';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 
 import {removeModelUpdateMessage} from '../redux/aichatRedux';
 import {ChatCompletionMessage, Role} from '../types';
@@ -70,7 +71,7 @@ const displayAssistantMessage = (status: string, chatMessageText: string) => {
           moduleStyles.assistantMessage
         )}
       >
-        {chatMessageText}
+        <SafeMarkdown markdown={chatMessageText} />
       </div>
     );
   } else if (status === Status.ERROR) {

--- a/apps/src/aichat/views/chatMessage.module.scss
+++ b/apps/src/aichat/views/chatMessage.module.scss
@@ -8,13 +8,13 @@
 }
 
 .userMessage {
-  margin: 0 0 15px 50px;
+  margin: 0 0 5px 50px;
   background-color: $brand_teal_5;
   border-radius: 16px 0 16px 16px;
 }
 
 .assistantMessageContainer {
-  margin: 0 50px 15px 0;
+  margin: 0 50px 5px 0;
   display: flex;
   align-items: start;
 }
@@ -45,6 +45,7 @@
   background-color: $light_gray_50;
   border-radius: 0 16px 16px 16px;
   margin-top: 14px; // a quarter of height of bot icon
+  overflow-x: scroll;
 }
 
 .inappropriateMessage {

--- a/apps/src/aichat/views/chatMessage.module.scss
+++ b/apps/src/aichat/views/chatMessage.module.scss
@@ -16,6 +16,7 @@
 .assistantMessageContainer {
   margin: 0 50px 15px 0;
   display: flex;
+  align-items: start;
 }
 
 .modelUpdateMessageTextContainer {
@@ -43,6 +44,7 @@
 .assistantMessage {
   background-color: $light_gray_50;
   border-radius: 0 16px 16px 16px;
+  margin-top: 14px; // a quarter of height of bot icon
 }
 
 .inappropriateMessage {


### PR DESCRIPTION
Two unrelated changes to the chat experience in gen AI:
- support markdown responses
- move the bot icon to the top of the response (this is what was spec'd in design, and is particularly noticeable with longer messages)

| Before | After |
| - | - |
| <img width="544" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/4b85a2e6-d24c-44af-9289-2c4de69fb0bf"> | <img width="542" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/fa3a1388-2e96-4d67-88e5-37af443ea5cf"> |

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-741

## Testing story

Tested manually in responses containing markdown, responses containing normal text, and errored responses.