### PR TITLE
Add amplitude event to code.org/music and update activity links

### DIFF
--- a/pegasus/helpers/analytics_constants.rb
+++ b/pegasus/helpers/analytics_constants.rb
@@ -37,6 +37,7 @@ module AnalyticsConstants
     TEACHER_LOGIN_EVENT = 'Teacher Login'.freeze,
     VIDEO_LIBRARY_PAGE_VISIT_EVENT = 'Video Library Page Visited'.freeze,
     INTL_PL_PAGE_VISIT_EVENT = 'International Professional Learning Page Visited'.freeze,
-    INTL_PL_PARTNERS_PAGE_VISIT_EVENT = 'International Professional Learning Partners Page Visited'.freeze
+    INTL_PL_PARTNERS_PAGE_VISIT_EVENT = 'International Professional Learning Partners Page Visited'.freeze,
+    MUSIC_PAGE_VISITED_EVENT = 'Music Lab Marketing Page Visited'.freeze
   ].freeze
 end

--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -116,7 +116,7 @@
           "text_h1": "music_lab.banner.heading",
           "text_desc": "music_lab.banner.desc",
           "button_label_primary": "music_lab.button.try_music_lab",
-          "button_url_primary": "https://studio.code.org/s/music-intro-2024",
+          "button_url_primary": "https://studio.code.org/s/music-intro-2024/reset",
           "button_label_secondary": "music_lab.button.learn_more",
           "button_url_secondary": "/music",
           "text_desc_02": "music_lab.in_partnership_with",

--- a/pegasus/sites.v3/code.org/public/music/index.haml
+++ b/pegasus/sites.v3/code.org/public/music/index.haml
@@ -15,7 +15,7 @@ theme: responsive_full_width
         =hoc_s("music_lab.banner.heading")
       %p.body-one.white
         =hoc_s("music_lab.banner.desc")
-      %a.link-button.white{href: CDO.studio_url("/s/music-intro-2024")}
+      %a.link-button.white{href: CDO.studio_url("/s/music-intro-2024/reset")}
         =hoc_s("music_lab.button.try_music_lab")
       .afe.flex-container.align-items-baseline.wrap
         %p.add-margin-top.no-margin-bottom.white

--- a/pegasus/sites.v3/code.org/public/music/index.haml
+++ b/pegasus/sites.v3/code.org/public/music/index.haml
@@ -86,3 +86,5 @@ theme: responsive_full_width
       =hoc_s(:dance_afe_disclaimer)
 
 = view :swiper_page_music_lab
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::MUSIC_PAGE_VISITED_EVENT

--- a/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
+++ b/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
@@ -16,5 +16,5 @@
           %p
             %i{class: "#{icon_check}"}
             = item
-    %a.link-button.no-margin-bottom{href: CDO.studio_url("/s/music-intro-2024")}
+    %a.link-button.no-margin-bottom{href: CDO.studio_url("/s/music-intro-2024/reset")}
       =hoc_s("music_lab.button.try_music_lab")


### PR DESCRIPTION
Adds Amplitude (and Statsig) events to https://code.org/music, and updates the existing urls to the activity to include a `/reset` at the end in a few places.

## Links
Jira ticket: [ACQ-1869](https://codedotorg.atlassian.net/browse/ACQ-1869)

## Testing story
Local testing

----

<img width="1316" alt="Screenshot 2024-05-07 at 2 19 38 PM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/b0bb2252-c269-42be-9f46-693f9dd6fc67">
