### PR TITLE
Fix Violations of and Reenable `Style/HashTransformValues` and `Style/HashTransformKeys`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -225,11 +225,6 @@ Style/GlobalVars:
 Style/HashLikeCase:
   Enabled: false
 
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/HashTransformKeys:
-  Enabled: false
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowedMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -230,11 +230,6 @@ Style/HashLikeCase:
 Style/HashTransformKeys:
   Enabled: false
 
-# Offense count: 12
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/HashTransformValues:
-  Enabled: false
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowedMethods.

--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -418,9 +418,9 @@ module I18n
             source_data = JSON.load_file(source_path)
             return if source_data.blank?
 
-            redactable_data = source_data.map do |level_url, i18n_strings|
-              [level_url, select_redactable(i18n_strings)]
-            end.to_h
+            redactable_data = source_data.transform_values do |i18n_strings|
+              select_redactable(i18n_strings)
+            end
 
             backup_path = source_path.sub('source', 'original')
             I18nScriptUtils.write_json_file(backup_path, redactable_data)

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2017_2018_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2017_2018_ccd
@@ -69,7 +69,7 @@ end
 AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/school_stats_201718.csv") do |filename|
   SchoolStatsByYear.transaction do
     SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00"}) do |row|
-      row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+      row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
 
       {
         school_id:          row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2018_2019_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2018_2019_ccd
@@ -115,7 +115,7 @@ end
 AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/School_lvl_demo.csv") do |filename|
   SchoolStatsByYear.transaction do
     SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00"}) do |row|
-      row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+      row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
 
       {
         school_id:      row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2019_2020_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2019_2020_ccd
@@ -77,7 +77,7 @@ end
 AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/schools.csv") do |filename|
   SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'UTF-8'}, dry_run: DRY_RUN) do |row|
     # remove quote and eq sign from ="12345"
-    row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+    row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
 
     {
       school_id:          row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2020_2021_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2020_2021_ccd
@@ -77,7 +77,7 @@ end
 AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/schools_public.csv") do |filename|
   SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'UTF-8'}, dry_run: DRY_RUN) do |row|
     # remove quote and eq sign from ="12345"
-    row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+    row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
 
     {
       school_id:          row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_ccd
@@ -79,7 +79,7 @@ end
 AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/schools_public.csv") do |filename|
   SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, dry_run: DRY_RUN) do |row|
     # remove quote and eq sign from ="12345"
-    row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+    row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
 
     {
       school_id:          row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2022_2023_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2022_2023_ccd
@@ -69,7 +69,7 @@ end
 AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/schools_public.csv") do |filename|
   SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, dry_run: DRY_RUN) do |row|
     # remove quote and eq sign from ="12345" (the ="" is required to preserve leading 0's in zip codes)
-    row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+    row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
     school_id = row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s
     # NCES did not provide Title 1 Status in the table this year so we are using last year's as a placeholder
     previous_year_entry = SchoolStatsByYear.where(school_id: school_id, school_year: LAST_SURVEY_YEAR)

--- a/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
@@ -94,8 +94,7 @@ class Api::V1::PeerReviewSubmissionsController < ApplicationController
       where(submitter_id: enrollments.map(&:user_id)).
       pluck(:submitter_id, :script_id, :level_id, :created_at).
       group_by {|pr| pr[0..2]}. # group by [submitter_id, script_id, level_id]
-      map {|k, prs| [k, prs.map {|pr| pr[3]}]}. # only keep :created_at in values
-      to_h
+      transform_values {|prs| prs.map {|pr| pr[3]}} # only keep :created_at in values
 
     enrollments.each do |enrollment|
       peer_review_submissions = Hash.new

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -123,9 +123,9 @@ class Foorm::Submission < ApplicationRecord
   def formatted_answers_with_facilitator_number(number)
     return {} unless workshop_metadata.facilitator_specific?
 
-    formatted_answers.map do |question_id, answer_text|
-      [question_id + "_#{number}", answer_text]
-    end.to_h
+    formatted_answers.transform_keys do |question_id|
+      question_id + "_#{number}"
+    end
   end
 
   # Store the JSON parsable "{}" if we attempt to store a blank submission,

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -325,7 +325,7 @@ class School < ApplicationRecord
       CDO.log.info "Seeding 2019-2020 public school data."
       AWS::S3.seed_from_file('cdo-nces', "2019-2020/ccd/schools.csv") do |filename|
         merge_from_csv(filename, {headers: true, quote_char: "\x00"}, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|
-          row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+          row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
           {
             id:                           row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,
             name:                         row['School Name'].upcase,
@@ -349,7 +349,7 @@ class School < ApplicationRecord
       CDO.log.info "Seeding 2020-2021 public school data."
       AWS::S3.seed_from_file('cdo-nces', "2020-2021/ccd/schools_public.csv") do |filename|
         merge_from_csv(filename, {headers: true, quote_char: "\x00"}, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|
-          row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+          row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
           {
             id:                           row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,
             name:                         row['School Name'].upcase,
@@ -404,7 +404,7 @@ class School < ApplicationRecord
       CDO.log.info "Seeding 2021-2022 public school data."
       AWS::S3.seed_from_file('cdo-nces', "2021-2022/ccd/schools_public.csv") do |filename|
         merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|
-          row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+          row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
           {
             id:                           row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,
             name:                         row['School Name'].upcase,
@@ -428,7 +428,7 @@ class School < ApplicationRecord
       CDO.log.info "Seeding 2022-2023 public school data."
       AWS::S3.seed_from_file('cdo-nces', "2022-2023/ccd/schools_public.csv") do |filename|
         merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|
-          row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+          row = row.to_h.transform_values {|v| sanitize_string_for_db(v)}
           {
             id:                           row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,
             name:                         row['School Name'].upcase,

--- a/dashboard/lib/core_extensions.rb
+++ b/dashboard/lib/core_extensions.rb
@@ -4,7 +4,7 @@ module CoreExtensions
   module Hash
     module Camelizing
       def camelize_keys
-        map {|key, value| [key.to_s.camelize(:lower), value]}.to_h
+        transform_keys {|key| key.to_s.camelize(:lower)}
       end
     end
   end


### PR DESCRIPTION
These are both pretty straightforward:

> Looks for uses of `_.each_with_object({}) …`, `_.map ….to_h`, and `Hash[_.map …]` that are actually just transforming the keys/values of a hash, and tries to use a simpler & faster call to `transform_keys`/`transform_values` instead.

TIL that these methods exist!

Changes applied automatically with

```
bundle exec rubocop --autocorrect-all --only Style/HashTransformKeys
bundle exec rubocop --autocorrect-all --only Style/HashTransformValues
```

Changes seem straightforward and safe, and look consistently like clear improvements to me. Please let me know if you disagree, but this one seems like an easy win!

## Links

- https://docs.rubocop.org/rubocop/cops_style.html#stylehashtransformkeys
- https://docs.rubocop.org/rubocop/cops_style.html#stylehashtransformvalues
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashTransformKeys
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashTransformValues

## Testing story

Relying on existing tests to verify that none of these changes result in any difference to functionality.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
