### PR TITLE
[Gen ai] Log level path instead of level id on Amplitude/Statsig

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -17,7 +17,6 @@ import {
 } from '@cdo/generated-scripts/sharedConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
-import {ProgressState} from '@cdo/apps/code-studio/progressRedux';
 
 import {
   AI_CUSTOMIZATIONS_LABELS,
@@ -109,14 +108,12 @@ export const updateAiCustomization = createAsyncThunk(
   async (_, thunkAPI) => {
     const rootState = (await thunkAPI.getState()) as RootState;
     const {currentAiCustomizations, savedAiCustomizations} = rootState.aichat;
-    const levelPath = getLevelPath(rootState.progress);
     const {dispatch} = thunkAPI;
 
     await saveAiCustomization(
       currentAiCustomizations,
       savedAiCustomizations,
       EVENTS.UPDATE_CHATBOT,
-      levelPath,
       dispatch
     );
   }
@@ -133,12 +130,10 @@ export const publishModel = createAsyncThunk(
 
     const rootState = thunkAPI.getState() as RootState;
     const {currentAiCustomizations, savedAiCustomizations} = rootState.aichat;
-    const levelPath = getLevelPath(rootState.progress);
     await saveAiCustomization(
       currentAiCustomizations,
       savedAiCustomizations,
       EVENTS.PUBLISH_MODEL_CARD_INFO,
-      levelPath,
       dispatch
     );
     dispatch(setViewMode(ViewMode.PRESENTATION));
@@ -154,7 +149,6 @@ export const saveModelCard = createAsyncThunk(
     const rootState = (await thunkAPI.getState()) as RootState;
     const modelCardInfo =
       rootState.aichat.currentAiCustomizations.modelCardInfo;
-    const levelPath = getLevelPath(rootState.progress);
     if (!hasFilledOutModelCard(modelCardInfo)) {
       dispatch(setModelCardProperty({property: 'isPublished', value: false}));
     }
@@ -166,24 +160,10 @@ export const saveModelCard = createAsyncThunk(
       currentAiCustomizations,
       savedAiCustomizations,
       EVENTS.SAVE_MODEL_CARD_INFO,
-      levelPath,
       dispatch
     );
   }
 );
-
-const getLevelPath = (progress: ProgressState) => {
-  const levelId = progress.currentLevelId;
-  const lessons = progress?.lessons;
-  let levelPath = null;
-  if (levelId && lessons) {
-    const levels = lessons[0].levels;
-    const levelBasePath = lessons[0].lessonEditPath.slice(0, -4);
-    const index = levels.findIndex(level => level.activeId === levelId);
-    levelPath = `${levelBasePath}levels/${index + 1}`;
-  }
-  return levelPath;
-};
 
 // This variable keeps track of the most recent message ID so that we can
 // assign a unique message id in increasing sequence to a new message.
@@ -199,7 +179,6 @@ const saveAiCustomization = async (
   currentAiCustomizations: AiCustomizations,
   savedAiCustomizations: AiCustomizations,
   eventDescription: string,
-  levelPath: string | null,
   dispatch: ThunkDispatch<unknown, unknown, AnyAction>
 ) => {
   // Remove any empty example topics on save
@@ -261,7 +240,7 @@ const saveAiCustomization = async (
         eventDescription,
         {
           propertyUpdated: property,
-          levelPath,
+          levelPath: window.location.pathname,
         },
         PLATFORMS.BOTH
       );


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR logs the level path instead of level id when sending an event to Amplitude/Statsig. This was requested by @samantha-code .

<img width="1217" alt="Screenshot 2024-05-07 at 4 14 51 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/7bee364f-5c1f-428b-86ce-93495cabd923">




## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
