### PR TITLE
Add Music Lab announcement banners to Teacher and Student homepages

### DIFF
--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -1,7 +1,7 @@
 {
   "pages": {
-    "/home": "ai-teaching-assistant",
-    "/student-home": "hoc-2023-dance-ai"
+    "/home": "music-lab-launch",
+    "/student-home": "music-lab-launch"
   },
   "banners": {
     "superhero": {
@@ -20,24 +20,8 @@
       "buttonUrl": "https://code.org/hourofcode",
       "buttonId": "hoc-2023"
     },
-    "hoc-2023-dance-ai": {
-      "image": "/images/dance-hoc/dance-party-activity-ai-edition.png",
-      "title": "Dance Party: AI Edition",
-      "body": "Learn about artificial intelligence (AI) concepts to create your own virtual dance party showcasing today's top artists. With dozens of songs to choose from, reach every student no matter their music taste. It's time to strut your stuff!",
-      "buttonText": "Learn more",
-      "buttonUrl": "https://code.org/dance",
-      "buttonId": "hoc-2023-dance-ai"
-    },
-    "ai-teaching-assistant": {
-      "dcdo": "ai-teaching-assistant-launch",
-      "image": "/images/action-blocks/action-block-ai-ta.png",
-      "title": "AI Teaching Assistant",
-      "body": "Elevate teaching confidence and streamline assessment of student progress. This tool heralds a new chapter in personalized learning and instructional excellence.",
-      "buttonText": "Learn more about AI Teaching Assistant",
-      "buttonUrl": "https://code.org/ai-ta",
-      "buttonId": "ai-teaching-assistant"
-    },
     "music-lab-launch": {
+      "dcdo": "music-lab-launch-2024",
       "image": "/shared/images/banners/music-lab-with-afe-logo.png",
       "title": "Introducing Music Lab",
       "body": "Get creative with your favorite artist's music and code new songs and mixes!",


### PR DESCRIPTION
Adds the DCDO logic to show the Music Lab announcement banners on the Teacher and Student homepages on https://studio.code.org for the launch in a couple weeks.
- This will not show until the `music-lab-launch-2024` DCDO flag is set to true
- The object for this was added in this PR: https://github.com/code-dot-org/code-dot-org/pull/58308
- Removes outdated AI TA and Dance Party AI banner objects

## Links
Jira tickets:
- Teacher - [ACQ-1676](https://codedotorg.atlassian.net/browse/ACQ-1676)
- Student - [ACQ-1677](https://codedotorg.atlassian.net/browse/ACQ-1677)

## Testing story
Tested locally that the DCDO flag works

----

## Teacher homepage
<img width="1017" alt="Teacher" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/724bce25-cdac-4ade-9632-9c5d2eb4b802">

## Student homepage
<img width="1017" alt="Student" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/161cd324-802b-4b5f-b21e-c64f550ab306">
