### PR TITLE
[AI Tutor] CT-508: Reenable warning modal with session storage

### DIFF
--- a/apps/src/aiTutor/redux/aiTutorRedux.ts
+++ b/apps/src/aiTutor/redux/aiTutorRedux.ts
@@ -21,6 +21,7 @@ export interface AITutorState {
   chatMessages: ChatCompletionMessage[];
   isWaitingForChatResponse: boolean;
   chatMessageError: boolean;
+  isChatOpen: boolean;
 }
 
 export interface InstructionsState {
@@ -42,6 +43,7 @@ const initialState: AITutorState = {
   chatMessages: initialChatMessages,
   isWaitingForChatResponse: false,
   chatMessageError: false,
+  isChatOpen: false,
 };
 
 const formatQuestionForAITutor = (chatContext: ChatContext) => {
@@ -158,6 +160,9 @@ const aiTutorSlice = createSlice({
         state.chatMessages[index] = _.merge({}, lastMessage, action.payload);
       }
     },
+    setIsChatOpen: (state, action: PayloadAction<boolean>) => {
+      state.isChatOpen = action.payload;
+    },
   },
   extraReducers: builder => {
     builder.addCase(askAITutor.fulfilled, state => {
@@ -182,4 +187,5 @@ export const {
   clearChatMessages,
   setIsWaitingForChatResponse,
   updateLastChatMessage,
+  setIsChatOpen,
 } = aiTutorSlice.actions;

--- a/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
+++ b/apps/src/aiTutor/views/AITutorChatWorkspace.tsx
@@ -6,6 +6,7 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import style from './ai-tutor.module.scss';
 import AssistantMessage from './AssistantMessage';
 import UserMessage from './UserMessage';
+import WarningModal from './WarningModal';
 
 const AITutorChatWorkspace: React.FunctionComponent = () => {
   const storedMessages = useAppSelector(state => state.aiTutor.chatMessages);
@@ -35,6 +36,7 @@ const AITutorChatWorkspace: React.FunctionComponent = () => {
         )
       )}
       {showWaitingAnimation()}
+      <WarningModal />
     </div>
   );
 };

--- a/apps/src/aiTutor/views/AITutorFloatingActionButton.tsx
+++ b/apps/src/aiTutor/views/AITutorFloatingActionButton.tsx
@@ -1,12 +1,15 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {Provider} from 'react-redux';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {useAppSelector, useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {getStore} from '@cdo/apps/redux';
-import style from './ai-tutor.module.scss';
 import aiFabIcon from '@cdo/static/ai-fab-background.png';
-import AITutorContainer from './AITutorContainer';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {setIsChatOpen} from '@cdo/apps/aiTutor/redux/aiTutorRedux';
+
+import AITutorContainer from './AITutorContainer';
+import style from './ai-tutor.module.scss';
 
 /**
  * Renders an AI Bot icon button in the bottom left corner over other UI elements that controls
@@ -15,18 +18,19 @@ import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 const AITutorFloatingActionButton: React.FunctionComponent = () => {
   const store = getStore();
-  const [isOpen, setIsOpen] = useState(false);
+  const dispatch = useAppDispatch();
   const level = useAppSelector(state => state.aiTutor.level);
+  const isChatOpen = useAppSelector(state => state.aiTutor.isChatOpen);
 
   const handleClick = () => {
-    const event = isOpen
+    const event = isChatOpen
       ? EVENTS.AI_TUTOR_PANEL_CLOSED
       : EVENTS.AI_TUTOR_PANEL_OPENED;
     analyticsReporter.sendEvent(event, {
       levelId: level?.id,
       levelType: level?.type,
     });
-    setIsOpen(!isOpen);
+    dispatch(setIsChatOpen(!isChatOpen));
   };
 
   return (
@@ -39,7 +43,7 @@ const AITutorFloatingActionButton: React.FunctionComponent = () => {
         type="button"
       />
       <Provider store={store}>
-        <AITutorContainer open={isOpen} closeTutor={handleClick} />
+        <AITutorContainer open={isChatOpen} closeTutor={handleClick} />
       </Provider>
     </div>
   );

--- a/apps/src/aiTutor/views/WarningModal.tsx
+++ b/apps/src/aiTutor/views/WarningModal.tsx
@@ -1,5 +1,6 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import style from './chat-workspace.module.scss';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {
   BodyTwoText,
   Heading2,
@@ -7,49 +8,64 @@ import {
 } from '@cdo/apps/componentLibrary/typography';
 import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
 import Button from '@cdo/apps/templates/Button';
+import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
 
 const WarningModal = () => {
-  const [open, setOpen] = useState(true);
+  const sessionStorageKey = 'AITutorWarningModalSeenKey';
+  const isChatOpen = useAppSelector(state => state.aiTutor.isChatOpen);
+
+  const [hasSeenWarningModal, setHasSeenWarningModal] = useState(() => {
+    // Check session storage to see if modal has been shown
+    return JSON.parse(tryGetSessionStorage(sessionStorageKey, false)) || false;
+  });
+
+  useEffect(() => {
+    if (!hasSeenWarningModal) {
+      // As soon as the modal is considered to be shown, mark it as seen in session storage
+      trySetSessionStorage(sessionStorageKey, 'true');
+    }
+  }, [hasSeenWarningModal]);
 
   const onClose = () => {
-    setOpen(false);
+    setHasSeenWarningModal(true);
   };
 
-  if (open) {
-    return (
-      <AccessibleDialog onClose={onClose} className={style.chatWarningModal}>
-        <Heading2>Remember to chat responsibly!</Heading2>
-
-        <button type="button" onClick={onClose} className={style.xCloseButton}>
-          <i id="x-close" className="fa-solid fa-xmark" />
-        </button>
-        <hr />
-        <BodyTwoText>
-          <StrongText>All messages sent to AI Tutor are recorded</StrongText>
-        </BodyTwoText>
-        <BodyTwoText>
-          Inappropriate messages will be flagged and your teacher will be
-          notified.
-        </BodyTwoText>
-        <br />
-        <BodyTwoText>
-          In order to protect your privacy, anything considered personal
-          information (name, phone number, address, etc.) should not be
-          submitted to AI Tutor.
-        </BodyTwoText>
-        <hr />
-        <div className={style.bottomSection}>
-          <Button
-            onClick={onClose}
-            color={Button.ButtonColor.brandSecondaryDefault}
-            text="Ask AI Tutor"
-          />
-        </div>
-      </AccessibleDialog>
-    );
-  } else {
+  // If the user has already seen the warning modal or chat is not open, don't show it
+  if (!isChatOpen || hasSeenWarningModal) {
     return null;
   }
+
+  return (
+    <AccessibleDialog onClose={onClose} className={style.chatWarningModal}>
+      <Heading2>Remember to chat responsibly!</Heading2>
+
+      <button type="button" onClick={onClose} className={style.xCloseButton}>
+        <i id="x-close" className="fa-solid fa-xmark" />
+      </button>
+      <hr />
+      <BodyTwoText>
+        <StrongText>All messages sent to AI Tutor are recorded</StrongText>
+      </BodyTwoText>
+      <BodyTwoText>
+        Inappropriate messages will be flagged and your teacher will be
+        notified.
+      </BodyTwoText>
+      <br />
+      <BodyTwoText>
+        In order to protect your privacy, anything considered personal
+        information (name, phone number, address, etc.) should not be submitted
+        to AI Tutor.
+      </BodyTwoText>
+      <hr />
+      <div className={style.bottomSection}>
+        <Button
+          onClick={onClose}
+          color={Button.ButtonColor.brandSecondaryDefault}
+          text="Ask AI Tutor"
+        />
+      </div>
+    </AccessibleDialog>
+  );
 };
 
 export default WarningModal;


### PR DESCRIPTION
When I moved the `WarningModal` component (which had previously been working) to be a child of the AI Tutor Floating Action Button, it stopped working.

I kept getting the error
```
Your focus-trap must have at least one container with at least one tabbable node in it at all times
```

Through some investigation, I discovered other (working) Accessible Dialogs were not valid as children of the Floating Action Button, which made me think that this has something to do with React, ex. there might be a timing issue where the focus trap tries to activate before these elements are rendered. (Functionally, this is a "modal within a modal.")

As a speculative fix, I updated the `AITutorFloatingActionButton` component so the open/closed state of the chat was stored as a global state variable. This fixed the `Your focus-trap must have at least one container with at least one tabbable node in it at all times` issue.

Then, I noticed that the existing implementation will open the Warning Modal whenever the chat window is opened, which is annoyingly frequent. I used a similar model as the AI TA folks to persist whether the modal has been seen to session storage. 

Here's a demo!

https://github.com/code-dot-org/code-dot-org/assets/26844240/077e7fe3-297e-4b3e-be58-4f6b00968021

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/CT-508

## Testing story

I tested locally that:

- Opening the FAB (floating action button) for the first time renders the modal
- Dismissing the warning modal (via either button) and then opening/reopening the FAB doesn't render the warning modal, even after changing levels
- Opening a new tab re-renders the modal 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
