### PR TITLE
Added tests for Progress View V2 Invitation

### DIFF
--- a/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
+++ b/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
@@ -164,6 +164,8 @@ InviteToV2ProgressModal.propTypes = {
   setShowProgressTableV2: PropTypes.func.isRequired,
 };
 
+export const UnconnectedInviteToV2ProgressModal = InviteToV2ProgressModal;
+
 export default connect(
   state => ({
     dateProgressTableInvitationDelayed:

--- a/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
+++ b/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
@@ -34,11 +34,13 @@ function InviteToV2ProgressModal({
   const [invitationOpen, setInvitationOpen] = React.useState(false);
 
   React.useEffect(() => {
-    const timeSinceInvitationLastDelayed = () => {
+    const numDaysSinceInvitationLastDelayed = () => {
+      const MILLISECONDS_IN_ONE_DAY = 1000 * 3600 * 24;
       const startingDate = new Date(dateProgressTableInvitationDelayed);
       const today = new Date();
       const differenceInMilliseconds = today.getTime() - startingDate.getTime();
-      const differenceInDays = differenceInMilliseconds / (1000 * 3600 * 24);
+      const differenceInDays =
+        differenceInMilliseconds / MILLISECONDS_IN_ONE_DAY;
       return Math.floor(differenceInDays);
     };
 
@@ -48,7 +50,7 @@ function InviteToV2ProgressModal({
         return false;
       } else {
         if (!!dateProgressTableInvitationDelayed) {
-          return timeSinceInvitationLastDelayed() > 3;
+          return numDaysSinceInvitationLastDelayed() > 3;
         } else {
           return true;
         }

--- a/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
+++ b/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
@@ -21,6 +21,8 @@ import styles from './progress-v2-invitation.module.scss';
 
 const newProgressViewGraphic = require('@cdo/static/teacherDashboard/progressOpenBetaAnnouncementGraphic.png');
 
+const MILLISECONDS_IN_ONE_DAY = 1000 * 3600 * 24;
+
 function InviteToV2ProgressModal({
   sectionId,
 
@@ -35,7 +37,6 @@ function InviteToV2ProgressModal({
 
   React.useEffect(() => {
     const numDaysSinceInvitationLastDelayed = () => {
-      const MILLISECONDS_IN_ONE_DAY = 1000 * 3600 * 24;
       const startingDate = new Date(dateProgressTableInvitationDelayed);
       const today = new Date();
       const differenceInMilliseconds = today.getTime() - startingDate.getTime();

--- a/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
@@ -37,10 +37,10 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
   it('renders the dialog with required elements', () => {
     renderDefault();
 
-    expect(screen.getByText(i18n.progressTrackingAnnouncement())).be.visible;
-    expect(screen.getByText(i18n.tryItNow())).be.visible;
-    expect(screen.getByText(i18n.remindMeLater())).be.visible;
-    expect(screen.getByLabelText(i18n.closeDialog())).be.visible;
+    expect(screen.getByText(i18n.progressTrackingAnnouncement())).to.exist;
+    expect(screen.getByText(i18n.tryItNow())).to.exist;
+    expect(screen.getByText(i18n.remindMeLater())).to.exist;
+    expect(screen.getByLabelText(i18n.closeDialog())).to.exist;
   });
 
   it('allows user to accept the invitation', () => {
@@ -52,7 +52,7 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
       setHasSeenProgressTableInvite: setHasSeenProgressTableInviteStub,
     });
 
-    expect(screen.getByText(i18n.progressTrackingAnnouncement())).be.visible;
+    expect(screen.getByText(i18n.progressTrackingAnnouncement())).to.exist;
     const acceptButton = screen.getByText(i18n.tryItNow());
     fireEvent.click(acceptButton);
 
@@ -135,10 +135,10 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
         'Wed May 01 2024 14:22:23 GMT-0500 (Central Daylight Time)',
     });
 
-    expect(screen.getByText(i18n.progressTrackingAnnouncement())).be.visible;
-    expect(screen.getByText(i18n.tryItNow())).be.visible;
-    expect(screen.getByText(i18n.remindMeLater())).be.visible;
-    expect(screen.getByLabelText(i18n.closeDialog())).be.visible;
+    expect(screen.getByText(i18n.progressTrackingAnnouncement())).to.exist;
+    expect(screen.getByText(i18n.tryItNow())).to.exist;
+    expect(screen.getByText(i18n.remindMeLater())).to.exist;
+    expect(screen.getByLabelText(i18n.closeDialog())).to.exist;
   });
 
   it('does not show the dialog if it has been less than three days since they delayed the pop-up', () => {

--- a/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
@@ -71,7 +71,6 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
   });
 
   it('allows user to accept the invitation', () => {
-    // const postStub = sinon.stub($, 'post');
     const setShowProgressTableV2Stub = sinon.stub();
     const setHasSeenProgressTableInviteStub = sinon.stub();
 
@@ -96,17 +95,12 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
         has_seen_progress_table_v2_invitation: true,
       }
     );
-
-    // postStub.reset();
   });
 
   it('allows user to decline the invitation', () => {
-    // const postStub = sinon.stub($, 'post');
-    const setShowProgressTableV2Stub = sinon.stub();
     const setHasSeenProgressTableInviteStub = sinon.stub();
 
     renderDefault({
-      setShowProgressTableV2: setShowProgressTableV2Stub,
       setHasSeenProgressTableInvite: setHasSeenProgressTableInviteStub,
     });
 
@@ -120,6 +114,56 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
         has_seen_progress_table_v2_invitation: true,
       }
     );
-    // postStub.reset();
+    expect(screen.queryByText(i18n.tryItNow())).to.be.null;
+    expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.be.null;
+    expect(screen.queryByText(i18n.remindMeLater())).to.be.null;
+  });
+
+  // it('allows user to delay the invitation', () => {
+  //   renderDefault();
+
+  //   const delayButton = screen.getByText(i18n.remindMeLater());
+  //   fireEvent.click(delayButton);
+
+  //   expect(postStub).calledWith(
+  //     '/api/v1/users/date_progress_table_invitation_last_delayed'
+  //   ).to.be.true;
+  //   expect(screen.queryByText(i18n.tryItNow())).to.be.null;
+  //   expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.be.null;
+  //   expect(screen.queryByText(i18n.remindMeLater())).to.be.null;
+  // });
+
+  it('does not show the dialog if they have already accepted or rejected the invitation', () => {
+    renderDefault({hasSeenProgressTableInvite: true});
+
+    expect(screen.queryByText(i18n.tryItNow())).to.be.null;
+    expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.be.null;
+    expect(screen.queryByText(i18n.remindMeLater())).to.be.null;
+  });
+
+  it('shows the dialog if it has been more than three days since they delayed the pop-up', () => {
+    renderDefault({
+      dateProgressTableInvitationDelayed:
+        'Wed May 01 2024 14:22:23 GMT-0500 (Central Daylight Time)',
+    });
+
+    expect(screen.getByText(i18n.progressTrackingAnnouncement())).be.visible;
+    expect(screen.getByText(i18n.tryItNow())).be.visible;
+    expect(screen.getByText(i18n.remindMeLater())).be.visible;
+    expect(screen.getByLabelText(i18n.closeDialog())).be.visible;
+  });
+
+  it('does not show the dialog if it has been less than three days since they delayed the pop-up', () => {
+    const today = new Date();
+    const yesterday = new Date(today);
+
+    yesterday.setDate(yesterday.getDate() - 1);
+    renderDefault({
+      dateProgressTableInvitationDelayed: yesterday,
+    });
+
+    expect(screen.queryByText(i18n.tryItNow())).to.be.null;
+    expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.be.null;
+    expect(screen.queryByText(i18n.remindMeLater())).to.be.null;
   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
@@ -1,25 +1,12 @@
 import {fireEvent, render, screen} from '@testing-library/react';
 import $ from 'jquery';
 import React from 'react';
-import {Provider} from 'react-redux';
 import sinon from 'sinon';
 
-import {
-  getStore,
-  registerReducers,
-  restoreRedux,
-  stubRedux,
-} from '@cdo/apps/redux';
-import currentUser, {
-  setHasSeenProgressTableInvite,
-} from '@cdo/apps/templates/currentUserRedux';
 import {UnconnectedInviteToV2ProgressModal} from '@cdo/apps/templates/sectionProgressV2/InviteToV2ProgressModal';
 import i18n from '@cdo/locale';
 
 import {expect} from '../../../util/reconfiguredChai';
-
-// const setShowProgressTableV2Stub = sinon.stub();
-// const setHasSeenProgressTableInviteStub = sinon.stub();
 
 const DEFAULT_PROPS = {
   setShowProgressTableV2: () => {},
@@ -28,36 +15,22 @@ const DEFAULT_PROPS = {
 };
 
 describe('UnconnectedInviteToV2ProgressModal', () => {
-  let store;
   let postStub;
 
   beforeEach(() => {
     postStub = sinon.stub($, 'post').returns(Promise.resolve({}));
-
-    stubRedux();
-    registerReducers({
-      currentUser,
-    });
-
-    store = getStore();
-    store.dispatch(setHasSeenProgressTableInvite(false));
   });
 
   afterEach(() => {
-    restoreRedux();
     postStub.restore();
-    // setHasSeenProgressTableInviteStub.restore();
-    // setShowProgressTableV2Stub.restore();
   });
 
   function renderDefault(propOverrides = {}) {
     render(
-      <Provider store={store}>
-        <UnconnectedInviteToV2ProgressModal
-          {...DEFAULT_PROPS}
-          {...propOverrides}
-        />
-      </Provider>
+      <UnconnectedInviteToV2ProgressModal
+        {...DEFAULT_PROPS}
+        {...propOverrides}
+      />
     );
   }
 
@@ -119,22 +92,37 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
     expect(screen.queryByText(i18n.remindMeLater())).to.be.null;
   });
 
-  // it('allows user to delay the invitation', () => {
-  //   renderDefault();
+  it('allows user to delay the invitation', () => {
+    renderDefault();
 
-  //   const delayButton = screen.getByText(i18n.remindMeLater());
-  //   fireEvent.click(delayButton);
+    const delayButton = screen.getByText(i18n.remindMeLater());
+    fireEvent.click(delayButton);
 
-  //   expect(postStub).calledWith(
-  //     '/api/v1/users/date_progress_table_invitation_last_delayed'
-  //   ).to.be.true;
-  //   expect(screen.queryByText(i18n.tryItNow())).to.be.null;
-  //   expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.be.null;
-  //   expect(screen.queryByText(i18n.remindMeLater())).to.be.null;
-  // });
+    sinon.assert.calledOnce(postStub);
+    sinon.assert.calledWithMatch(
+      postStub,
+      '/api/v1/users/date_progress_table_invitation_last_delayed'
+    );
+
+    expect(screen.queryByText(i18n.tryItNow())).to.be.null;
+    expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.be.null;
+    expect(screen.queryByText(i18n.remindMeLater())).to.be.null;
+  });
 
   it('does not show the dialog if they have already accepted or rejected the invitation', () => {
     renderDefault({hasSeenProgressTableInvite: true});
+
+    expect(screen.queryByText(i18n.tryItNow())).to.be.null;
+    expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.be.null;
+    expect(screen.queryByText(i18n.remindMeLater())).to.be.null;
+  });
+
+  it('does not show the dialog if they have already accepted or rejected the invitation after delaying invitation', () => {
+    renderDefault({
+      hasSeenProgressTableInvite: true,
+      dateProgressTableInvitationDelayed:
+        'Wed May 01 2024 14:22:23 GMT-0500 (Central Daylight Time)',
+    });
 
     expect(screen.queryByText(i18n.tryItNow())).to.be.null;
     expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.be.null;

--- a/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
@@ -37,10 +37,10 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
   it('renders the dialog with required elements', () => {
     renderDefault();
 
-    expect(screen.getByText(i18n.progressTrackingAnnouncement())).to.exist;
-    expect(screen.getByText(i18n.tryItNow())).to.exist;
-    expect(screen.getByText(i18n.remindMeLater())).to.exist;
-    expect(screen.getByLabelText(i18n.closeDialog())).to.exist;
+    screen.getByText(i18n.progressTrackingAnnouncement());
+    screen.getByText(i18n.tryItNow());
+    screen.getByText(i18n.remindMeLater());
+    screen.getByLabelText(i18n.closeDialog());
   });
 
   it('allows user to accept the invitation', () => {
@@ -52,7 +52,7 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
       setHasSeenProgressTableInvite: setHasSeenProgressTableInviteStub,
     });
 
-    expect(screen.getByText(i18n.progressTrackingAnnouncement())).to.exist;
+    screen.getByText(i18n.progressTrackingAnnouncement());
     const acceptButton = screen.getByText(i18n.tryItNow());
     fireEvent.click(acceptButton);
 
@@ -135,10 +135,10 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
         'Wed May 01 2024 14:22:23 GMT-0500 (Central Daylight Time)',
     });
 
-    expect(screen.getByText(i18n.progressTrackingAnnouncement())).to.exist;
-    expect(screen.getByText(i18n.tryItNow())).to.exist;
-    expect(screen.getByText(i18n.remindMeLater())).to.exist;
-    expect(screen.getByLabelText(i18n.closeDialog())).to.exist;
+    screen.getByText(i18n.progressTrackingAnnouncement());
+    screen.getByText(i18n.tryItNow());
+    screen.getByText(i18n.remindMeLater());
+    screen.getByLabelText(i18n.closeDialog());
   });
 
   it('does not show the dialog if it has been less than three days since they delayed the pop-up', () => {

--- a/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
@@ -1,0 +1,113 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import $ from 'jquery';
+import React from 'react';
+import {Provider} from 'react-redux';
+import sinon from 'sinon';
+
+import {
+  getStore,
+  registerReducers,
+  restoreRedux,
+  stubRedux,
+} from '@cdo/apps/redux';
+import currentUser, {
+  setHasSeenProgressTableInvite,
+} from '@cdo/apps/templates/currentUserRedux';
+import {UnconnectedInviteToV2ProgressModal} from '@cdo/apps/templates/sectionProgressV2/InviteToV2ProgressModal';
+import i18n from '@cdo/locale';
+
+import {expect} from '../../../util/reconfiguredChai';
+
+const setShowProgressTableV2Stub = sinon.stub();
+const setHasSeenProgressTableInviteStub = sinon.stub();
+
+const DEFAULT_PROPS = {
+  setShowProgressTableV2: setShowProgressTableV2Stub,
+  setHasSeenProgressTableInvite: setHasSeenProgressTableInviteStub,
+  setDateProgressTableInvitationDelayed: () => {},
+};
+
+describe('UnconnectedInviteToV2ProgressModal', () => {
+  let store;
+  let postStub;
+
+  beforeEach(() => {
+    postStub = sinon.stub($, 'post').returns(Promise.resolve({}));
+
+    stubRedux();
+    registerReducers({
+      currentUser,
+    });
+
+    store = getStore();
+    store.dispatch(setHasSeenProgressTableInvite(false));
+  });
+
+  afterEach(() => {
+    restoreRedux();
+    postStub.restore();
+    setHasSeenProgressTableInviteStub.restore();
+    setShowProgressTableV2Stub.restore();
+  });
+
+  function renderDefault(propOverrides = {}) {
+    render(
+      <Provider store={store}>
+        <UnconnectedInviteToV2ProgressModal
+          {...DEFAULT_PROPS}
+          {...propOverrides}
+        />
+      </Provider>
+    );
+  }
+
+  it('renders the dialog with required elements', () => {
+    renderDefault();
+
+    expect(screen.getByText(i18n.progressTrackingAnnouncement())).be.visible;
+    expect(screen.getByText(i18n.tryItNow())).be.visible;
+    expect(screen.getByText(i18n.remindMeLater())).be.visible;
+    expect(screen.getByLabelText(i18n.closeDialog())).be.visible;
+  });
+
+  it('allows user to accept the invitation', () => {
+    // const postStub = sinon.stub($, 'post');
+    renderDefault();
+
+    expect(screen.getByText(i18n.progressTrackingAnnouncement())).be.visible;
+    const acceptButton = screen.getByText(i18n.tryItNow());
+    fireEvent.click(acceptButton);
+
+    expect(setHasSeenProgressTableInviteStub).to.have.been.calledOnce;
+    expect(setShowProgressTableV2Stub).to.have.been.calledOnce;
+
+    expect(postStub).calledWith('/api/v1/users/show_progress_table_v2', {
+      show_progress_table_v2: true,
+    });
+    expect(postStub).calledWith(
+      '/api/v1/users/has_seen_progress_table_v2_invitation',
+      {
+        has_seen_progress_table_v2_invitation: true,
+      }
+    );
+
+    // postStub.reset();
+  });
+
+  it('allows user to decline the invitation', () => {
+    // const postStub = sinon.stub($, 'post');
+    renderDefault();
+
+    const xButton = screen.getByLabelText(i18n.closeDialog());
+    fireEvent.click(xButton);
+
+    expect(setHasSeenProgressTableInviteStub).to.have.been.calledOnce;
+    expect(postStub).calledWith(
+      '/api/v1/users/has_seen_progress_table_v2_invitation',
+      {
+        has_seen_progress_table_v2_invitation: true,
+      }
+    );
+    // postStub.reset();
+  });
+});

--- a/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
@@ -18,12 +18,12 @@ import i18n from '@cdo/locale';
 
 import {expect} from '../../../util/reconfiguredChai';
 
-const setShowProgressTableV2Stub = sinon.stub();
-const setHasSeenProgressTableInviteStub = sinon.stub();
+// const setShowProgressTableV2Stub = sinon.stub();
+// const setHasSeenProgressTableInviteStub = sinon.stub();
 
 const DEFAULT_PROPS = {
-  setShowProgressTableV2: setShowProgressTableV2Stub,
-  setHasSeenProgressTableInvite: setHasSeenProgressTableInviteStub,
+  setShowProgressTableV2: () => {},
+  setHasSeenProgressTableInvite: () => {},
   setDateProgressTableInvitationDelayed: () => {},
 };
 
@@ -46,8 +46,8 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
   afterEach(() => {
     restoreRedux();
     postStub.restore();
-    setHasSeenProgressTableInviteStub.restore();
-    setShowProgressTableV2Stub.restore();
+    // setHasSeenProgressTableInviteStub.restore();
+    // setShowProgressTableV2Stub.restore();
   });
 
   function renderDefault(propOverrides = {}) {
@@ -72,7 +72,13 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
 
   it('allows user to accept the invitation', () => {
     // const postStub = sinon.stub($, 'post');
-    renderDefault();
+    const setShowProgressTableV2Stub = sinon.stub();
+    const setHasSeenProgressTableInviteStub = sinon.stub();
+
+    renderDefault({
+      setShowProgressTableV2: setShowProgressTableV2Stub,
+      setHasSeenProgressTableInvite: setHasSeenProgressTableInviteStub,
+    });
 
     expect(screen.getByText(i18n.progressTrackingAnnouncement())).be.visible;
     const acceptButton = screen.getByText(i18n.tryItNow());
@@ -96,7 +102,13 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
 
   it('allows user to decline the invitation', () => {
     // const postStub = sinon.stub($, 'post');
-    renderDefault();
+    const setShowProgressTableV2Stub = sinon.stub();
+    const setHasSeenProgressTableInviteStub = sinon.stub();
+
+    renderDefault({
+      setShowProgressTableV2: setShowProgressTableV2Stub,
+      setHasSeenProgressTableInvite: setHasSeenProgressTableInviteStub,
+    });
 
     const xButton = screen.getByLabelText(i18n.closeDialog());
     fireEvent.click(xButton);


### PR DESCRIPTION
Test following the[ PR for the invitation modal to V2 Progress view.](https://github.com/code-dot-org/code-dot-org/pull/58372)

Note: eyes tests will be in future PR

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
