### PR TITLE
Fix odd spacing on My PL page

### DIFF
--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -104,6 +104,9 @@ function LandingPage({
     workshopsAsParticipant?.length === 0 &&
     plCoursesStarted?.length === 0;
 
+  const joinedPlSectionsStyling =
+    joinedPlSections?.length > 0 ? '' : style.joinedPlSectionsWithNoSections;
+
   // Load PL section info into redux
   const dispatch = useDispatch();
   useEffect(() => {
@@ -312,13 +315,7 @@ function LandingPage({
         {showGettingStartedBanner && RenderGettingStartedBanner()}
         {lastWorkshopSurveyUrl && RenderLastWorkshopSurveyBanner()}
         {plCoursesStarted?.length >= 1 && RenderSelfPacedPL()}
-        <div
-          className={
-            joinedPlSections?.length > 0
-              ? ''
-              : style.joinedPlSectionsWithNoSections
-          }
-        >
+        <div className={joinedPlSectionsStyling}>
           <JoinSectionArea
             initialJoinedStudentSections={joinedStudentSections}
             initialJoinedPlSections={joinedPlSections}

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -312,12 +312,20 @@ function LandingPage({
         {showGettingStartedBanner && RenderGettingStartedBanner()}
         {lastWorkshopSurveyUrl && RenderLastWorkshopSurveyBanner()}
         {plCoursesStarted?.length >= 1 && RenderSelfPacedPL()}
-        <JoinSectionArea
-          initialJoinedStudentSections={joinedStudentSections}
-          initialJoinedPlSections={joinedPlSections}
-          isTeacher={true}
-          isPlSections={true}
-        />
+        <div
+          className={
+            joinedPlSections?.length > 0
+              ? ''
+              : style.joinedPlSectionsWithNoSections
+          }
+        >
+          <JoinSectionArea
+            initialJoinedStudentSections={joinedStudentSections}
+            initialJoinedPlSections={joinedPlSections}
+            isTeacher={true}
+            isPlSections={true}
+          />
+        </div>
         <EnrolledWorkshops />
         <section>
           <Heading2>{i18n.plLandingRecommendedHeading()}</Heading2>

--- a/apps/src/code-studio/pd/professional_learning_landing/landingPage.module.scss
+++ b/apps/src/code-studio/pd/professional_learning_landing/landingPage.module.scss
@@ -34,6 +34,10 @@ section {
   margin-top: 1.5rem;
 }
 
+.joinedPlSectionsWithNoSections {
+  margin-bottom: 4rem;
+}
+
 // TODO - this can be removed once the components on this page
 // are updated to use the Typography component.
 h2 {


### PR DESCRIPTION
In the "Joined PL Sections" section of the My PL page, if the user isn't in any sections then the spacing looks odd and leaves little room before the "Recommended for you" section below. So, this PR adds conditional formatting if the user isn't enrolled in any PL sections.

### Previous "Joined PL Sections" with no sections (odd spacing)
![old my pl no section](https://github.com/code-dot-org/code-dot-org/assets/56283563/f40101b8-9741-421d-adb6-d32abeac19eb)

### Previous "Joined PL Sections" with sections (no change)
![old my pl with section](https://github.com/code-dot-org/code-dot-org/assets/56283563/a72bab51-3349-42f9-86ed-55a73e3e2d42)

### New "Joined PL Sections" with no sections (fixed spacing)
![New joined pl no section](https://github.com/code-dot-org/code-dot-org/assets/56283563/6fc87e50-aed2-495f-b500-c4fed4d3fd16)

### New "Joined PL Sections" with sections (no change)
![New joined pl with section](https://github.com/code-dot-org/code-dot-org/assets/56283563/ec32aabf-03cf-4b66-871d-b760eda7d7fb)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1865)

## Testing story
Local testing.
