### PR TITLE
Gen AI: dedupe error logging

### DIFF
--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -69,7 +69,7 @@ class AichatController < ApplicationController
         status: :ok,
         json: {
           status: SharedConstants::AICHAT_ERROR_TYPE[:PROFANITY_MODEL],
-          session_id: log_chat_session(new_messages)
+          session_id: session_id
         }
       )
     end


### PR DESCRIPTION
Checking out logs from today's bug bash, and noticed duplicate logs being generated. A result of a [last minute change](https://github.com/code-dot-org/code-dot-org/pull/58351/commits/fd722fc84c044be03dc3fac29998810b4f30cab7) to this PR, where I accidentally started logging twice when we observe profanity from the model 🤦 . This change resolves that duplication.

## Testing story

Tested manually that I could repro before this change, and no longer repro after.