### PR TITLE
[AI Tutor] CT-566: Update styling of close button

### DIFF
--- a/apps/src/aiTutor/views/AITutorContainer.tsx
+++ b/apps/src/aiTutor/views/AITutorContainer.tsx
@@ -1,8 +1,8 @@
 import classnames from 'classnames';
 import React, {useState} from 'react';
 import Draggable, {DraggableEventHandler} from 'react-draggable';
+import Button from '@cdo/apps/componentLibrary/button';
 
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import aiBotOutlineIcon from '@cdo/static/ai-bot-outline.png';
 
@@ -53,13 +53,14 @@ const AITutorContainer: React.FC<AITutorContainerProps> = ({
             <span>{aiTutorHeaderText}</span>
           </div>
           <div className={style.aiTutorHeaderRightSide}>
-            <button
-              type="button"
+            <Button
+              color="white"
+              icon={{iconName: 'times', iconStyle: 'solid'}}
+              type="tertiary"
+              isIconOnly={true}
               onClick={closeTutor}
-              className={classnames(style.buttonStyle, style.closeButton)}
-            >
-              <FontAwesome icon="xrk" className="" title="Close AI Tutor" />
-            </button>
+              size="s"
+            />
           </div>
         </div>
 


### PR DESCRIPTION
This updates the close button in the upper-right-hand corner of the AI Tutor modal to use the design system button, solving an issue I forgot about where the button was there, but the contrast was not high enough for it to be seen.

<img width="782" alt="Screenshot 2024-05-08 at 11 32 25 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/43585b5f-9eda-4cae-a32b-652461e8dadf">

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/CT-566

## Testing story

Tested locally. 

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
