### PR TITLE
Music: fix preview plays

### DIFF
--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -353,6 +353,7 @@ export default class MusicPlayer {
           effects: soundEvent.effects,
           originalBpm: soundData.bpm || DEFAULT_BPM,
           pitchShift: this.calculatePitchShift(soundData),
+          preview: soundData.type === 'preview',
         },
       ];
     } else if (event.type === 'pattern') {

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -353,7 +353,7 @@ export default class MusicPlayer {
           effects: soundEvent.effects,
           originalBpm: soundData.bpm || DEFAULT_BPM,
           pitchShift: this.calculatePitchShift(soundData),
-          preview: soundData.type === 'preview',
+          disableTempoAdjustment: soundData.type === 'preview',
         },
       ];
     } else if (event.type === 'pattern') {
@@ -551,7 +551,7 @@ export default class MusicPlayer {
   }
 
   private calculatePitchShift(soundData: SoundData) {
-    if (soundData.type === 'beat') {
+    if (['beat', 'preview'].includes(soundData.type)) {
       return 0;
     }
     const diff = this.key - (soundData.key || Key.C);

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -167,11 +167,16 @@ class ToneJSPlayer implements AudioPlayer {
       return;
     }
 
-    const playbackRate = Transport.bpm.value / sample.originalBpm;
+    const playbackRate = sample.preview
+      ? 1
+      : Transport.bpm.value / sample.originalBpm;
+
+    const pitchShift = sample.preview ? 0 : sample.pitchShift;
+
     const player = this.createPlayer(
       buffer,
       playbackRate,
-      sample.pitchShift
+      pitchShift
     ).toDestination();
 
     player.onstop = () => {

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -167,16 +167,14 @@ class ToneJSPlayer implements AudioPlayer {
       return;
     }
 
-    const playbackRate = sample.preview
+    const playbackRate = sample.disableTempoAdjustment
       ? 1
       : Transport.bpm.value / sample.originalBpm;
-
-    const pitchShift = sample.preview ? 0 : sample.pitchShift;
 
     const player = this.createPlayer(
       buffer,
       playbackRate,
-      pitchShift
+      sample.pitchShift
     ).toDestination();
 
     player.onstop = () => {

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -100,8 +100,8 @@ export interface SampleEvent {
   effects?: Effects;
   // Length in measures to play the sample for
   length?: number;
-  // Whether the event is a preview that should be played in original form.
-  preview?: boolean;
+  // Whether tempo should not be adjusted.
+  disableTempoAdjustment?: boolean;
 }
 
 /** A sequence of notes played on a sampler instrument */

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -100,6 +100,8 @@ export interface SampleEvent {
   effects?: Effects;
   // Length in measures to play the sample for
   length?: number;
+  // Whether the event is a preview that should be played in original form.
+  preview?: boolean;
 }
 
 /** A sequence of notes played on a sampler instrument */


### PR DESCRIPTION
With this change, plays of sounds marked with a `type` of `"preview"` no longer have their pitch shifted or rate changed.  This allows previews of packs (both in the pack dialog and the sound panel) to play in their original form, even if the current project is set to a different BPM or key.
