### PR TITLE
Add finish button to last level of a lab2 progression

### DIFF
--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -362,19 +362,13 @@ export function sendSuccessReport(appType: string): ProgressThunkAction {
         'content-type': 'application/json',
       },
       body: JSON.stringify(data),
-    })
-      .then(response => {
-        if (response.ok && levelId !== null) {
-          // Update the progress store by merging in this
-          // particular result immediately.
-          dispatch(mergeResults({[levelId]: idealPassResult}));
-        }
-        return response.json();
-      })
-      .then(data => {
-        // TODO: use data.redirect to navigate to the next level.
-        // Last level of a script will be redirected to the script overview page.
-      });
+    }).then(response => {
+      if (response.ok && levelId !== null) {
+        // Update the progress store by merging in this
+        // particular result immediately.
+        dispatch(mergeResults({[levelId]: idealPassResult}));
+      }
+    });
   };
 }
 

--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -362,13 +362,19 @@ export function sendSuccessReport(appType: string): ProgressThunkAction {
         'content-type': 'application/json',
       },
       body: JSON.stringify(data),
-    }).then(response => {
-      if (response.ok && levelId !== null) {
-        // Update the progress store by merging in this
-        // particular result immediately.
-        dispatch(mergeResults({[levelId]: idealPassResult}));
-      }
-    });
+    })
+      .then(response => {
+        if (response.ok && levelId !== null) {
+          // Update the progress store by merging in this
+          // particular result immediately.
+          dispatch(mergeResults({[levelId]: idealPassResult}));
+        }
+        return response.json();
+      })
+      .then(data => {
+        // TODO: use data.redirect to navigate to the next level.
+        // Last level of a script will be redirected to the script overview page.
+      });
   };
 }
 

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -68,6 +68,9 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   const showNextButton =
     (!hasConditions || satisfied) && levelIndex + 1 < currentLevelCount;
 
+  const showFinishButton =
+    (!hasConditions || satisfied) && levelIndex + 1 === currentLevelCount;
+
   const dispatch = useAppDispatch();
 
   const {theme} = useContext(ThemeContext);
@@ -90,6 +93,8 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
       message={message || undefined}
       messageIndex={index}
       showNextButton={showNextButton}
+      showFinishButton={showFinishButton}
+      beforeNextLevel={beforeNextLevel}
       onNextPanel={onNextPanel}
       theme={theme}
       {...{baseUrl, layout, imagePopOutDirection, handleInstructionsTextClick}}
@@ -108,6 +113,10 @@ interface InstructionsPanelProps {
   imageUrl?: string;
   /** If the next button should be shown. */
   showNextButton?: boolean;
+  /** If the finish button should be shown. */
+  showFinishButton?: boolean;
+  /** Additional callback to fire before navigating to the next level. */
+  beforeNextLevel?: () => void;
   /** Callback to call when clicking the next button. */
   onNextPanel?: () => void;
   /** If the instructions panel should be rendered vertically or horizontally. Defaults to vertical. */
@@ -135,6 +144,8 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
   messageIndex,
   imageUrl,
   showNextButton,
+  showFinishButton,
+  beforeNextLevel,
   onNextPanel,
   layout = 'vertical',
   imagePopOutDirection = 'right',
@@ -150,6 +161,15 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
   const vertical = layout === 'vertical';
 
   const canShowNextButton = showNextButton && onNextPanel;
+
+  const canShowFinishButton = showFinishButton;
+
+  const onFinish = () => {
+    if (beforeNextLevel) {
+      beforeNextLevel();
+    }
+    console.log('Congrats! You finished!');
+  };
 
   return (
     <div
@@ -216,7 +236,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
             />
           </div>
         )}
-        {(message || canShowNextButton) && (
+        {(message || canShowNextButton || canShowFinishButton) && (
           <div
             key={messageIndex + ' - ' + message}
             id="instructions-feedback"
@@ -238,9 +258,19 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   id="instructions-feedback-button"
                   type="button"
                   onClick={onNextPanel}
-                  className={moduleStyles.buttonNext}
+                  className={moduleStyles.buttonContinue}
                 >
                   {commonI18n.continue()}
+                </button>
+              )}
+              {canShowFinishButton && (
+                <button
+                  id="instructions-feedback-button"
+                  type="button"
+                  onClick={onFinish}
+                  className={moduleStyles.buttonContinue}
+                >
+                  {commonI18n.finish()}
                 </button>
               )}
             </div>

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -9,7 +9,6 @@ import {
   currentLevelIndex,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import Button from '@cdo/apps/componentLibrary/button/Button';
 import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import {LabState} from '../../lab2Redux';
 import {ProjectLevelData} from '../../types';
@@ -270,20 +269,26 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                 />
               )}
               {canShowContinueButton && (
-                <Button
-                  text={commonI18n.continue()}
+                <button
+                  id="instructions-continue-button"
+                  type="button"
                   onClick={onNextPanel}
                   className={moduleStyles.button}
-                />
+                >
+                  {commonI18n.continue()}
+                </button>
               )}
               {canShowFinishButton && (
                 <>
-                  <Button
-                    text={commonI18n.finish()}
-                    disabled={isFinished}
+                  <button
+                    id="instructions-finish-button"
+                    type="button"
                     onClick={onFinish}
+                    disabled={isFinished}
                     className={moduleStyles.button}
-                  />
+                  >
+                    {commonI18n.finish()}
+                  </button>
                   {isFinished && <Heading6>{finalMessage}</Heading6>}
                 </>
               )}

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -9,6 +9,7 @@ import {
   currentLevelIndex,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import Button from '@cdo/apps/componentLibrary/button/Button';
 import {LabState} from '../../lab2Redux';
 import {ProjectLevelData} from '../../types';
 import {ThemeContext} from '../ThemeWrapper';
@@ -63,11 +64,14 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
     (state: {lab: LabState}) => state.lab.validationState
   );
 
-  // If there are no validation conditions, we can show the next button so long as
+  // If there are no validation conditions, we can show the continue button so long as
   // there is another level. If validation is present, also check that conditions are satisfied.
-  const showNextButton =
+  const showContinueButton =
     (!hasConditions || satisfied) && levelIndex + 1 < currentLevelCount;
 
+  // If there are no validation conditions, we can show the finish button so long as
+  // this is the last level in the progression. If validation is present, also
+  // check that conditions are satisfied.
   const showFinishButton =
     (!hasConditions || satisfied) && levelIndex + 1 === currentLevelCount;
 
@@ -92,7 +96,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
       text={instructionsText}
       message={message || undefined}
       messageIndex={index}
-      showNextButton={showNextButton}
+      showContinueButton={showContinueButton}
       showFinishButton={showFinishButton}
       beforeNextLevel={beforeNextLevel}
       onNextPanel={onNextPanel}
@@ -111,8 +115,8 @@ interface InstructionsPanelProps {
   messageIndex?: number;
   /** Optional image URL to display. */
   imageUrl?: string;
-  /** If the next button should be shown. */
-  showNextButton?: boolean;
+  /** If the continue button should be shown. */
+  showContinueButton?: boolean;
   /** If the finish button should be shown. */
   showFinishButton?: boolean;
   /** Additional callback to fire before navigating to the next level. */
@@ -143,7 +147,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
   message,
   messageIndex,
   imageUrl,
-  showNextButton,
+  showContinueButton,
   showFinishButton,
   beforeNextLevel,
   onNextPanel,
@@ -161,7 +165,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
 
   const vertical = layout === 'vertical';
 
-  const canShowNextButton = showNextButton && onNextPanel;
+  const canShowContinueButton = showContinueButton && onNextPanel;
 
   const canShowFinishButton = showFinishButton;
 
@@ -240,7 +244,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
             />
           </div>
         )}
-        {(message || canShowNextButton || canShowFinishButton) && (
+        {(message || canShowContinueButton || canShowFinishButton) && (
           <div
             key={messageIndex + ' - ' + message}
             id="instructions-feedback"
@@ -257,32 +261,27 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   handleInstructionsTextClick={handleInstructionsTextClick}
                 />
               )}
+              {canShowContinueButton && (
+                <Button
+                  text={commonI18n.continue()}
+                  disabled={isFinished}
+                  onClick={onNextPanel}
+                  className={moduleStyles.button}
+                />
+              )}
+              {canShowFinishButton && (
+                <Button
+                  text={commonI18n.finish()}
+                  disabled={isFinished}
+                  onClick={onFinish}
+                  className={moduleStyles.button}
+                />
+              )}
               {finalMessage && isFinished && (
                 <EnhancedSafeMarkdown
                   markdown={finalMessage}
                   className={moduleStyles.markdownText}
                 />
-              )}
-              {canShowNextButton && (
-                <button
-                  id="instructions-feedback-button"
-                  type="button"
-                  onClick={onNextPanel}
-                  className={moduleStyles.buttonContinue}
-                >
-                  {commonI18n.continue()}
-                </button>
-              )}
-              {canShowFinishButton && (
-                <button
-                  id="instructions-feedback-button"
-                  type="button"
-                  onClick={onFinish}
-                  className={moduleStyles.buttonContinue}
-                  disabled={isFinished}
-                >
-                  {commonI18n.finish()}
-                </button>
               )}
             </div>
           </div>

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -153,6 +153,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
   handleInstructionsTextClick,
 }) => {
   const [showBigImage, setShowBigImage] = useState(false);
+  const [isFinished, setIsFinished] = useState(false);
 
   const imageClicked = () => {
     setShowBigImage(!showBigImage);
@@ -168,8 +169,11 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
     if (beforeNextLevel) {
       beforeNextLevel();
     }
-    console.log('Congrats! You finished!');
+    setIsFinished(true);
   };
+
+  const finalMessage =
+    '<strong>You finished this lesson! Check in with your teacher for the next activity.</strong>';
 
   return (
     <div
@@ -253,6 +257,12 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   handleInstructionsTextClick={handleInstructionsTextClick}
                 />
               )}
+              {finalMessage && isFinished && (
+                <EnhancedSafeMarkdown
+                  markdown={finalMessage}
+                  className={moduleStyles.markdownText}
+                />
+              )}
               {canShowNextButton && (
                 <button
                   id="instructions-feedback-button"
@@ -269,6 +279,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   type="button"
                   onClick={onFinish}
                   className={moduleStyles.buttonContinue}
+                  disabled={isFinished}
                 >
                   {commonI18n.finish()}
                 </button>

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -273,7 +273,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   id="instructions-continue-button"
                   type="button"
                   onClick={onNextPanel}
-                  className={moduleStyles.button}
+                  className={moduleStyles.buttonInstruction}
                 >
                   {commonI18n.continue()}
                 </button>
@@ -285,7 +285,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                     type="button"
                     onClick={onFinish}
                     disabled={isFinished}
-                    className={moduleStyles.button}
+                    className={moduleStyles.buttonInstruction}
                   >
                     {commonI18n.finish()}
                   </button>

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -147,13 +147,7 @@
 
 .button {
   width: 100%;  
-  margin-bottom: 10px !important;
-  &:disabled, &[aria-disabled="true"] {
-    cursor: not-allowed;
-    border-color: $light_gray_200;
-    background-color: $light_gray_200;
-    color: $light_white;
-  }
+  margin-bottom: 10px !important;  
 }
 
 .markdownText {

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -155,6 +155,12 @@
   border-radius: 4px;
   height: 38px;
   margin: 0 0 10px 0;
+  &:disabled, &[aria-disabled="true"] {
+    cursor: not-allowed;
+    border-color: $light_gray_200;
+    background-color: $light_gray_200;
+    color: $light_white;
+  }
 }
 
 .markdownText {

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -145,7 +145,7 @@
   border: dashed $neutral_white 2px;
 }
 
-.buttonNext {
+.buttonContinue {
   font-size: 14px;
   background-color: $brand_secondary_default;
   border-color: $brand_secondary_default;

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -146,8 +146,21 @@
 }
 
 .button {
-  width: 100%;  
-  margin-bottom: 10px !important;  
+  font-size: 14px;
+  background-color: $brand_secondary_default;
+  border-color: $brand_secondary_default;
+  color: $neutral_light;
+  width: 100%;
+  padding: 5px 10px;
+  border-radius: 4px;
+  height: 38px;
+  margin-bottom: 10px;
+  &:disabled, &[aria-disabled="true"] {
+    cursor: not-allowed;
+    border-color: $light_gray_200;
+    background-color: $light_gray_200;
+    color: $light_white;
+  }
 }
 
 .markdownText {

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -145,7 +145,7 @@
   border: dashed $neutral_white 2px;
 }
 
-.button {
+.buttonInstruction {
   font-size: 14px;
   background-color: $brand_secondary_default;
   border-color: $brand_secondary_default;
@@ -154,7 +154,7 @@
   padding: 5px 10px;
   border-radius: 4px;
   height: 38px;
-  margin-bottom: 10px;
+  margin: 0 0 10px 0;
   &:disabled, &[aria-disabled="true"] {
     cursor: not-allowed;
     border-color: $light_gray_200;

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -145,16 +145,9 @@
   border: dashed $neutral_white 2px;
 }
 
-.buttonContinue {
-  font-size: 14px;
-  background-color: $brand_secondary_default;
-  border-color: $brand_secondary_default;
-  color: $neutral_light;
-  width: 100%;
-  padding: 5px 10px;
-  border-radius: 4px;
-  height: 38px;
-  margin: 0 0 10px 0;
+.button {
+  width: 100%;  
+  margin-bottom: 10px !important;
   &:disabled, &[aria-disabled="true"] {
     cursor: not-allowed;
     border-color: $light_gray_200;

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -24,7 +24,7 @@ class ActivitiesController < ApplicationController
 
   def milestone
     # TODO: do we use the :result and :testResult params for the same thing?
-    solved = (params[:result] == 'true')
+    solved = params[:result] || (params[:result] == 'true')
     script_name = ''
 
     if params[:script_level_id]

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -24,7 +24,7 @@ class ActivitiesController < ApplicationController
 
   def milestone
     # TODO: do we use the :result and :testResult params for the same thing?
-    solved = params[:result] || (params[:result] == 'true')
+    solved = (params[:result] == 'true')
     script_name = ''
 
     if params[:script_level_id]


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds a 'Finish' button to the last level (lab2) of a lesson. After a user clicks on the 'Finish' button, we post to `milestone` so that the level bubble turns green (or purple for an assessment level). Then a message is displayed below the disabled button.

Before clicking:


<img width="414" alt="Screenshot 2024-05-09 at 10 41 37 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/704dcd2a-effa-426d-bf3e-1d568a339596">

After clicking:


<img width="417" alt="Screenshot 2024-05-09 at 10 41 25 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/69df8821-2007-44da-8706-9fcb5b9fe07e">


Note that currently, validation has not been added to `aichat` levels. Also, for music lab levels, the 'Continue' or 'Finish' buttons appear after validation conditions are satisfied.
When the 'Continue'/'Finish' button is clicked, we post to `milestone` [with `idealPassResult`](https://github.com/code-dot-org/code-dot-org/blob/0caf8a106432725986d8037ca27a43b4e7b56898/apps/src/code-studio/progressRedux.ts#L351-L352) so that we will always pass or attain a green (or purple for assessment levels) bubble after clicking the button.

Future work includes sending accurate data to the backend and consuming the server response, i.e., the `redirect` url.

Scrreencast videos AFTER update:


https://github.com/code-dot-org/code-dot-org/assets/107423305/3a74fca0-0e0c-4716-85bc-b0866a39f911


https://github.com/code-dot-org/code-dot-org/assets/107423305/ab3700c9-39a7-4a34-a800-4814ef0bfde6

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-768)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally in both music lab and aichat progressions.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Currently, an assessment level does not turn 'bubble' after 'Continue' or 'Finish' button is clicked until the page reloads. Investigate ~~and resolve if possible~~. 
Update: this is existing behavior but not noticeable in legacy labs since page always reloads on level change. Here's an example in a CSP progression. Note that bubble turns green immediately for an app lab level even before page reload but not for an assessment level - at 0:25 in video.

https://github.com/code-dot-org/code-dot-org/assets/107423305/811fd750-e8e0-4fa7-b1fc-a64d7a0f6bf5

I see in `ProgressBubble.jsx` that assessment levels render a progress bubble differently.
https://github.com/code-dot-org/code-dot-org/blob/48feb7d3930f4cb6560a01abb9faaf056f7697d8/apps/src/templates/progress/ProgressBubble.jsx#L70-L85



<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
