### PR TITLE
feat: add custom error page for 500 errors

### DIFF
--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -13,6 +13,9 @@ module AWS
     # List from: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HTTPStatusCodes.html#HTTPStatusCodes-cached-errors
     CLIENT_ERROR_CODES = [400, 403, 404, 405, 414].freeze
     SERVER_ERROR_CODES = [500, 501, 502, 503, 504].freeze
+    CUSTOM_ERROR_PAGES = {
+      500 => '/assets/error-pages/500.html'
+    }.freeze
     ERROR_CACHE_TTL = 60
     # Configure CloudFront to forward these headers for S3 origins.
     S3_FORWARD_HEADERS = %w(
@@ -155,7 +158,7 @@ module AWS
                 ErrorCachingMinTTL: ERROR_CACHE_TTL,
                 ErrorCode: error,
                 ResponseCode: error,
-                ResponsePagePath: '/assets/error-pages/site-down.html'
+                ResponsePagePath: CUSTOM_ERROR_PAGES[error] || '/assets/error-pages/site-down.html'
               }.tap do |error_response_hash|
                 # Don't use friendly error pages on some environments (such as adhocs and LevelBuilder).
                 unless CDO.custom_error_response


### PR DESCRIPTION
A new sad bee page was created specifically for 500s to instruct the user to sign out, clear cookies, and run other troubleshooting steps that most commonly resolve 500 errors. However, this page does not apply to other error codes (503, 504, 404, etc.) as we don't necessarily want users to be signing out when the server is timing out or having other issues.

![sad bee new](https://github.com/code-dot-org/code-dot-org/assets/538214/778f767f-f4de-45c4-bccd-6b96386333ce)

## Testing story

Created adhoc with `adhoc:cdn:start`

Updated `config/adhoc.yml.erb` and set `custom_error_response`  to `true`. Observed updated distribution error page configuration

![image](https://github.com/code-dot-org/code-dot-org/assets/538214/66e0a6f7-d75f-4681-98e6-a20aa85725c1)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
