### PR TITLE
Gen AI: hide scrollbar when not needed

### DIFF
--- a/apps/src/aichat/views/chatMessage.module.scss
+++ b/apps/src/aichat/views/chatMessage.module.scss
@@ -45,7 +45,7 @@
   background-color: $light_gray_50;
   border-radius: 0 16px 16px 16px;
   margin-top: 14px; // a quarter of height of bot icon
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .inappropriateMessage {


### PR DESCRIPTION
Seeing a scrollbar on bot responses on Windows/Chrome when scroll isn't needed. Setting to `auto` allows for scroll (and shows scrollbar) when needed, but hides otherwise.

**Before (fixed now)**

![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/50116466-f6f7-4a6d-8731-ea40b74a6e30)

## Links

- [css overflow docs](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)

## Testing story

Tested on Dan's machine that the scrollbar was visible in a case where it was needed, and is otherwise not shown.