### PR TITLE
Show half hour on certificates for courses under 30 minutes

### DIFF
--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -277,6 +277,8 @@ class CertificateImage
       if template_file == 'self_paced_pl_certificate.png'
         total_minutes = unit_or_unit_group&.duration_in_minutes || 0
         total_hours_to_half_hour = (total_minutes / 30).round / 2.0
+        # Round up to half an hour if less than 30 minutes.
+        total_hours_to_half_hour = 0.5 if total_hours_to_half_hour == 0
         hours_string = format('%<duration>g', duration: total_hours_to_half_hour)
         apply_text(image, hours_string, 30, 'Times bold', 'rgb(87,87,87)', -248, 124, 80, 30)
       end


### PR DESCRIPTION
We received this Zendesk ticket where a user was seeing "0 minutes" on their certificate for "Teaching CSD Module 1" (a 10-minute intro module). The issue was that the time rounds to the nearest 30 minutes so this rounded down to 0 minutes. This PR fixes this by having any courses that are rounded to "0 minutes" show "30 minutes" instead.

### Without fix
![old](https://github.com/code-dot-org/code-dot-org/assets/56283563/d786dad5-5677-4eb7-bea0-936902ab8a70)

### With fix
![new](https://github.com/code-dot-org/code-dot-org/assets/56283563/e79d07f4-f97d-40ec-9109-0847255e1a80)

## Links
Zendesk ticket: [here](https://codeorg.zendesk.com/agent/tickets/496068)

## Testing story
Local testing.
