### PR TITLE
Add amplitude event for CAP State sign out button click

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -35,6 +35,7 @@ const EVENTS = {
   // Child Account Policy
   CAP_STATE_FORM_SHOW: 'CAP State Form Shown',
   CAP_STATE_FORM_PROVIDED: 'CAP State Form Submitted',
+  CAP_STATE_FORM_DISMISSED: 'CAP State Form Sign Out Button Clicked',
 
   // School Selection Component
   COUNTRY_SELECTED: 'User Selects Country',

--- a/apps/src/sites/studio/pages/layouts/_student_information_interstitial.js
+++ b/apps/src/sites/studio/pages/layouts/_student_information_interstitial.js
@@ -8,6 +8,7 @@ const retrieveInfoForCap = getScriptData('retrieveInfoForCap');
 const userId = getScriptData('userId');
 const inSection = getScriptData('inSection');
 const previousStateValue = getScriptData('currentUsState');
+const selectedLanguage = getScriptData('selectedLanguage');
 const forceStudentInterstitial = queryParams('forceStudentInterstitial');
 
 $(document).ready(function () {
@@ -21,6 +22,7 @@ $(document).ready(function () {
       analyticsReporter.sendEvent(EVENTS.CAP_STATE_FORM_SHOW, {
         user_id: userId,
         in_section: inSection,
+        selected_language: selectedLanguage,
       });
   }
 
@@ -32,10 +34,19 @@ $(document).ready(function () {
         in_section: inSection,
         us_state: newStateValue,
         previous_us_state: previousStateValue,
+        selected_language: selectedLanguage,
       });
 
     retrieveInfoForCap || forceStudentInterstitial
       ? location.reload()
       : modal.modal('hide');
+  });
+
+  $('#sign-out-btn').on('click', function () {
+    analyticsReporter.sendEvent(EVENTS.CAP_STATE_FORM_DISMISSED, {
+      user_id: userId,
+      in_section: inSection,
+      selected_language: selectedLanguage,
+    });
   });
 });

--- a/apps/src/sites/studio/pages/layouts/_student_information_interstitial.js
+++ b/apps/src/sites/studio/pages/layouts/_student_information_interstitial.js
@@ -42,7 +42,7 @@ $(document).ready(function () {
       : modal.modal('hide');
   });
 
-  $('#sign-out-btn').on('click', function () {
+  $('#sign-out-btn').on('click', () => {
     analyticsReporter.sendEvent(EVENTS.CAP_STATE_FORM_DISMISSED, {
       user_id: userId,
       in_section: inSection,

--- a/apps/src/sites/studio/pages/layouts/_student_information_interstitial.js
+++ b/apps/src/sites/studio/pages/layouts/_student_information_interstitial.js
@@ -43,10 +43,11 @@ $(document).ready(function () {
   });
 
   $('#sign-out-btn').on('click', () => {
-    analyticsReporter.sendEvent(EVENTS.CAP_STATE_FORM_DISMISSED, {
-      user_id: userId,
-      in_section: inSection,
-      selected_language: selectedLanguage,
-    });
+    (retrieveInfoForCap || forceStudentInterstitial) &&
+      analyticsReporter.sendEvent(EVENTS.CAP_STATE_FORM_DISMISSED, {
+        user_id: userId,
+        in_section: inSection,
+        selected_language: selectedLanguage,
+      });
   });
 });

--- a/dashboard/app/views/layouts/_student_information_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_student_information_interstitial.html.haml
@@ -30,4 +30,4 @@
         .form-group#information_form_buttons
           = link_to t('nav.user.logout'), destroy_user_session_url, class: 'btn primary-button', id: 'sign-out-btn'
           = f.submit t('continue'), class: 'btn primary-button', id: 'submit-btn'
-%script{src: webpack_asset_path('js/layouts/_student_information_interstitial.js'), data: {retrieveInfoForCap: cap_user_info_required?(student, country).to_json, userId: student.id.to_json, inSection: (!student.sections_as_student.empty?).to_json, currentUsState: student.us_state.to_json}}
+%script{src: webpack_asset_path('js/layouts/_student_information_interstitial.js'), data: {retrieveInfoForCap: cap_user_info_required?(student, country).to_json, userId: student.id.to_json, inSection: (!student.sections_as_student.empty?).to_json, currentUsState: student.us_state.to_json, selectedLanguage: request.locale.to_json}}


### PR DESCRIPTION
Adds amplitude event for clicking the Sign Out button when the Student Information Interstital is shown for CAP purposes. Also adds an extra property `selected_language` to each CPA amplitude event payload.
## New Amplitude Event for Sign out button clicked

<img width="1792" alt="Screenshot 2024-05-09 at 11 45 39 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/21afcae7-0c84-44e5-972f-4c79cac26a40">

## Previous CAP amplitude events with new `selected_language` property
<img width="1792" alt="Screenshot 2024-05-09 at 11 45 13 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/fd28995e-0473-4a4b-a719-1f1e3e045d64">



## Links

- jira ticket: []()
- slack thread: [here](https://codedotorg.slack.com/archives/C06VA9TFY7R/p1715275188463799)

## Testing story
Local testing, log statements when events triggered



