### PR TITLE
Added ui tests for invitation to V2 progress view

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
@@ -253,3 +253,48 @@ Feature: Using the teacher dashboard
     And I click selector "button.ui-test-join-section"
     Then I wait until element ".announcement-notification" is visible
     And element ".announcement-notification" contains text matching "You are already an instructor for section"
+
+  Scenario: Decline invitation to new progress view
+    Given I create an authorized teacher-associated student named "Sally"
+    Given I am assigned to unit "allthethings"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+
+    When I sign in as "Teacher_Sally" and go home
+    And I get levelbuilder access
+    And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
+    Then I navigate to teacher dashboard for the section I saved
+    Then I append "/?enableExperiments=section_progress_v2" to the URL
+    Then I click selector "#ui-close-dialog"
+    And I wait until element "#uitest-course-dropdown" is visible
+    And I select the "All the Things! *" option in dropdown "uitest-course-dropdown"
+
+  Scenario: Accept invitation to new progress view and see new view immediately. 
+    Given I create an authorized teacher-associated student named "Sally"
+    Given I am assigned to unit "allthethings"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+
+    When I sign in as "Teacher_Sally" and go home
+    And I get levelbuilder access
+    And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
+    Then I navigate to teacher dashboard for the section I saved
+    Then I append "/?enableExperiments=section_progress_v2" to the URL
+    Then I click selector "#accept-invitation"
+    And I wait until element "h6:contains(Icon Key)" is visible
+    And I wait until element "#ui-test-progress-table-v2" is visible
+
+  Scenario: Delay responding to invitation to new progress view and see old view immediately. 
+    Given I create an authorized teacher-associated student named "Sally"
+    Given I am assigned to unit "allthethings"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+
+    When I sign in as "Teacher_Sally" and go home
+    And I get levelbuilder access
+    And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
+    Then I navigate to teacher dashboard for the section I saved
+    Then I append "/?enableExperiments=section_progress_v2" to the URL
+    Then I click selector "#accept-invitation"
+    And I wait until element "#uitest-course-dropdown" is visible
+    And I select the "All the Things! *" option in dropdown "uitest-course-dropdown"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
@@ -295,6 +295,6 @@ Feature: Using the teacher dashboard
     And I save the section id from row 0 of the section table
     Then I navigate to teacher dashboard for the section I saved
     Then I append "/?enableExperiments=section_progress_v2" to the URL
-    Then I click selector "#accept-invitation"
+    Then I click selector "#remind-me-later-option"
     And I wait until element "#uitest-course-dropdown" is visible
     And I select the "All the Things! *" option in dropdown "uitest-course-dropdown"


### PR DESCRIPTION
Quick and little ui tests for a user accepting, declining, and delaying the invitation.   Ran these locally and they passed.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
