### PR TITLE
Datablock Storage: don't copy a column when renaming if the value is undefined on that row

### DIFF
--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -268,7 +268,7 @@ class DatablockStorageTable < ApplicationRecord
 
     # First rename the column in all the JSON records
     records.each do |record|
-      record.record_json[new_column_name] = record.record_json.delete(old_column_name)
+      record.record_json[new_column_name] = record.record_json.delete(old_column_name) if record.record_json.key?(old_column_name)
     end
 
     # Second rename the column in the table definition


### PR DESCRIPTION
Fixes [#56735](https://github.com/code-dot-org/code-dot-org/issues/56735)

Co-authored-by: Cassi Brenci <cnbrenci@users.noreply.github.com>