### PR TITLE
Log full model response, make error message clearer on model profanity

### DIFF
--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -59,8 +59,9 @@ class AichatController < ApplicationController
       session_id = log_chat_session(new_messages)
 
       Honeybadger.notify(
-        'Profanity returned from aichat model',
+        'Profanity returned from aichat model (blocked before reaching student)',
         context: {
+          model_response: latest_assistant_response,
           flagged_content: filter_result.content,
           aichat_session_id: session_id
         }


### PR DESCRIPTION
Two small post-bug bash improvements to logging profanity generated by the model:
- make error message clearer to DOTD and other developers that the profane content didn't actually reach the student
- log the full content of the model response, rather than just the flagged word