### PR TITLE
Add auto-height false to carousel_teach_page.haml

### DIFF
--- a/pegasus/sites.v3/code.org/views/carousel_teach_page.haml
+++ b/pegasus/sites.v3/code.org/views/carousel_teach_page.haml
@@ -15,7 +15,7 @@
 - slides_button_label = [hoc_s(:call_to_action_explore_ai_curricula), hoc_s(:call_to_action_explore_csc), hoc_s(:call_to_action_explore_csd), hoc_s(:call_to_action_explore_hoc_short), hoc_s(:call_to_action_explore_maker), hoc_s(:call_to_action_explore_csa_short), hoc_s(:call_to_action_explore_csf), hoc_s(:call_to_action_explore_csp)]
 
 .carousel-wrapper
-  %swiper-container.three-col{navigation: "true", "navigation-next-el": ".swiper-nav-next", "navigation-prev-el": ".swiper-nav-prev", init: "false"}
+  %swiper-container.three-col{navigation: "true", "navigation-next-el": ".swiper-nav-next", "navigation-prev-el": ".swiper-nav-prev", "auto-height": "false", init: "false"}
     - slides_index.times do |index|
       %swiper-slide
         .action-block.action-block--one-col.flex-space-between


### PR DESCRIPTION
Adds an `auto-height="false"` attribute to the carousel on https://code.org/teach so it doesn't change height on mobile.

## Before
https://github.com/code-dot-org/code-dot-org/assets/9256643/eeb48484-5ca7-4432-bbac-c49cbd1552a5

## After
https://github.com/code-dot-org/code-dot-org/assets/9256643/c595bf9b-64e2-4ffe-84de-367048f6f1f6

