### PR TITLE
[ProgressV2] Add timestamps for v1 or v2 toggles - fixed

### DIFF
--- a/apps/src/templates/rubrics/introjs.scss
+++ b/apps/src/templates/rubrics/introjs.scss
@@ -445,4 +445,5 @@ tr.introjs-showElement > th {
   z-index: 1;
   opacity: 0;
 }
+/* stylelint-disable-next-line */
 /*# sourceMappingURL=introjs.css.map */

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
@@ -57,7 +57,7 @@ describe('SectionProgressSelector', () => {
     postStub = sinon.stub($, 'post');
     postStub.returns(Promise.resolve());
 
-    sinon.stub(_, 'once').callsFake(fn => fn);
+    sinon.stub(_, 'debounce').callsFake(fn => fn);
   });
 
   afterEach(() => {
@@ -188,32 +188,5 @@ describe('SectionProgressSelector', () => {
 
     expect(screen.queryByText(V2_PAGE_LINK_TEXT)).to.not.exist;
     expect(screen.queryByTestId(V2_TEST_ID)).to.not.exist;
-  });
-
-  it('calls analytics when toggling to v2', () => {
-    renderDefault();
-
-    const remindLaterLink = screen.getByText('Remind me later');
-    fireEvent.click(remindLaterLink);
-
-    const toggle = screen.getByRole('link', {name: V1_PAGE_LINK_TEXT});
-    fireEvent.click(toggle);
-
-    expect(postStub).to.have.been.calledWith(
-      '/api/v1/users/set_progress_table_timestamp'
-    );
-  });
-
-  it('calls analytics when toggling to v1', () => {
-    renderDefault();
-    store.dispatch(setShowProgressTableV2(true));
-
-    const toggle = screen.getByRole('link', {name: V2_PAGE_LINK_TEXT});
-
-    fireEvent.click(toggle);
-
-    expect(postStub).to.have.been.calledWith(
-      '/api/v1/users/set_progress_table_timestamp'
-    );
   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
@@ -1,5 +1,6 @@
 import {render, screen, fireEvent} from '@testing-library/react';
 import $ from 'jquery';
+import _ from 'lodash';
 import React from 'react';
 import {Provider} from 'react-redux';
 import sinon from 'sinon';
@@ -33,6 +34,8 @@ const DEFAULT_PROPS = {};
 describe('SectionProgressSelector', () => {
   let store;
 
+  let postStub;
+
   beforeEach(() => {
     stubRedux();
     registerReducers({
@@ -50,10 +53,18 @@ describe('SectionProgressSelector', () => {
     DCDO.set('progress-table-v2-enabled', true);
     DCDO.set('progress-table-v2-default-v2', false);
     DCDO.set('progress-table-v2-closed-beta-enabled', false);
+
+    postStub = sinon.stub($, 'post');
+    postStub.returns(Promise.resolve());
+
+    sinon.stub(_, 'once').callsFake(fn => fn);
   });
 
   afterEach(() => {
     restoreRedux();
+
+    postStub.restore();
+    sinon.restore();
   });
 
   function renderDefault(propOverrides = {}) {
@@ -128,7 +139,6 @@ describe('SectionProgressSelector', () => {
   });
 
   it('sets user preference when link clicked', () => {
-    const stub = sinon.stub($, 'post');
     renderDefault();
 
     const remindLaterLink = screen.getByText('Remind me later');
@@ -136,11 +146,12 @@ describe('SectionProgressSelector', () => {
     const link = screen.getByText(V1_PAGE_LINK_TEXT);
     fireEvent.click(link);
 
-    expect(stub).calledWith('/api/v1/users/show_progress_table_v2', {
-      show_progress_table_v2: true,
-    });
-
-    stub.reset();
+    expect(postStub).to.have.been.calledWith(
+      '/api/v1/users/show_progress_table_v2',
+      {
+        show_progress_table_v2: true,
+      }
+    );
   });
 
   it('shows v1 only if user not in closed beta', () => {
@@ -177,5 +188,32 @@ describe('SectionProgressSelector', () => {
 
     expect(screen.queryByText(V2_PAGE_LINK_TEXT)).to.not.exist;
     expect(screen.queryByTestId(V2_TEST_ID)).to.not.exist;
+  });
+
+  it('calls analytics when toggling to v2', () => {
+    renderDefault();
+
+    const remindLaterLink = screen.getByText('Remind me later');
+    fireEvent.click(remindLaterLink);
+
+    const toggle = screen.getByRole('link', {name: V1_PAGE_LINK_TEXT});
+    fireEvent.click(toggle);
+
+    expect(postStub).to.have.been.calledWith(
+      '/api/v1/users/set_progress_table_timestamp'
+    );
+  });
+
+  it('calls analytics when toggling to v1', () => {
+    renderDefault();
+    store.dispatch(setShowProgressTableV2(true));
+
+    const toggle = screen.getByRole('link', {name: V2_PAGE_LINK_TEXT});
+
+    fireEvent.click(toggle);
+
+    expect(postStub).to.have.been.calledWith(
+      '/api/v1/users/set_progress_table_timestamp'
+    );
   });
 });

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,7 @@ require 'cdo/firehose'
 class Api::V1::UsersController < Api::V1::JSONApiController
   before_action :load_user
   skip_before_action :verify_authenticity_token
-  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name, :cached_page_auth_redirect, :post_show_progress_table_v2, :post_ai_rubrics_disabled, :post_date_progress_table_invitation_last_delayed, :post_has_seen_progress_table_v2_invitation, :get_current_permissions, :post_disable_lti_roster_sync, :update_ai_tutor_access]
+  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name, :cached_page_auth_redirect, :post_show_progress_table_v2, :post_ai_rubrics_disabled, :post_date_progress_table_invitation_last_delayed, :post_has_seen_progress_table_v2_invitation, :get_current_permissions, :post_disable_lti_roster_sync, :update_ai_tutor_access, :post_set_progress_table_timestamp]
   skip_before_action :clear_sign_up_session_vars, only: [:current]
 
   private def to_bool(val)
@@ -198,6 +198,19 @@ class Api::V1::UsersController < Api::V1::JSONApiController
     return head :unauthorized unless current_user
 
     current_user.show_progress_table_v2 = !!params[:show_progress_table_v2].try(:to_bool)
+    current_user.save
+
+    head :no_content
+  end
+
+  def post_set_progress_table_timestamp
+    return head :unauthorized unless current_user
+
+    if !!params[:is_v2_table].try(:to_bool)
+      current_user.progress_table_v2_timestamp = DateTime.now
+    else
+      current_user.progress_table_v1_timestamp = DateTime.now
+    end
     current_user.save
 
     head :no_content

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,7 @@ require 'cdo/firehose'
 class Api::V1::UsersController < Api::V1::JSONApiController
   before_action :load_user
   skip_before_action :verify_authenticity_token
-  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name, :cached_page_auth_redirect, :post_show_progress_table_v2, :post_ai_rubrics_disabled, :post_date_progress_table_invitation_last_delayed, :post_has_seen_progress_table_v2_invitation, :get_current_permissions, :post_disable_lti_roster_sync, :update_ai_tutor_access, :post_set_progress_table_timestamp]
+  skip_before_action :load_user, only: [:current, :netsim_signed_in, :post_sort_by_family_name, :cached_page_auth_redirect, :post_show_progress_table_v2, :post_ai_rubrics_disabled, :post_date_progress_table_invitation_last_delayed, :post_has_seen_progress_table_v2_invitation, :get_current_permissions, :post_disable_lti_roster_sync, :update_ai_tutor_access]
   skip_before_action :clear_sign_up_session_vars, only: [:current]
 
   private def to_bool(val)
@@ -197,21 +197,15 @@ class Api::V1::UsersController < Api::V1::JSONApiController
   def post_show_progress_table_v2
     return head :unauthorized unless current_user
 
-    current_user.show_progress_table_v2 = !!params[:show_progress_table_v2].try(:to_bool)
-    current_user.save
+    show_v2_arg = !!params[:show_progress_table_v2].try(:to_bool)
+    current_user.show_progress_table_v2 = show_v2_arg
 
-    head :no_content
-  end
-
-  def post_set_progress_table_timestamp
-    return head :unauthorized unless current_user
-
-    if !!params[:is_v2_table].try(:to_bool)
+    if show_v2_arg
       current_user.progress_table_v2_timestamp = DateTime.now
     else
       current_user.progress_table_v1_timestamp = DateTime.now
     end
-    current_user.save
+    current_user.save!
 
     head :no_content
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -154,6 +154,8 @@ class User < ApplicationRecord
     progress_table_v2_closed_beta
     lti_roster_sync_enabled
     ai_tutor_access_denied
+    progress_table_v2_timestamp
+    progress_table_v1_timestamp
     has_seen_progress_table_v2_invitation
     date_progress_table_invitation_last_delayed
     user_provided_us_state

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -912,6 +912,7 @@ Dashboard::Application.routes.draw do
         post 'users/sort_by_family_name', to: 'users#post_sort_by_family_name'
 
         post 'users/show_progress_table_v2', to: 'users#post_show_progress_table_v2'
+        post 'users/set_progress_table_timestamp', to: 'users#post_set_progress_table_timestamp'
         post 'users/date_progress_table_invitation_last_delayed', to: 'users#post_date_progress_table_invitation_last_delayed'
         post 'users/has_seen_progress_table_v2_invitation', to: 'users#post_has_seen_progress_table_v2_invitation'
         post 'users/ai_rubrics_disabled', to: 'users#post_ai_rubrics_disabled'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -912,7 +912,6 @@ Dashboard::Application.routes.draw do
         post 'users/sort_by_family_name', to: 'users#post_sort_by_family_name'
 
         post 'users/show_progress_table_v2', to: 'users#post_show_progress_table_v2'
-        post 'users/set_progress_table_timestamp', to: 'users#post_set_progress_table_timestamp'
         post 'users/date_progress_table_invitation_last_delayed', to: 'users#post_date_progress_table_invitation_last_delayed'
         post 'users/has_seen_progress_table_v2_invitation', to: 'users#post_has_seen_progress_table_v2_invitation'
         post 'users/ai_rubrics_disabled', to: 'users#post_ai_rubrics_disabled'

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -87,16 +87,16 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     refute @user.show_progress_table_v2
   end
 
-  test 'a post request to set_progress_table_timestamp updates appropriate timestamp' do
+  test 'a post request to show_progress_table_v2 updates appropriate timestamp' do
     sign_in(@user)
     assert_nil @user.progress_table_v2_timestamp
-    post :post_set_progress_table_timestamp, params: {user_id: 'me', is_v2_table: true}
+    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: true}
     assert_response :success
     @user.reload
     assert @user.progress_table_v2_timestamp
     assert_nil @user.progress_table_v1_timestamp
 
-    post :post_set_progress_table_timestamp, params: {user_id: 'me', is_v2_table: false}
+    post :post_show_progress_table_v2, params: {user_id: 'me', show_progress_table_v2: false}
     assert_response :success
     @user.reload
     assert @user.progress_table_v2_timestamp

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -87,6 +87,22 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     refute @user.show_progress_table_v2
   end
 
+  test 'a post request to set_progress_table_timestamp updates appropriate timestamp' do
+    sign_in(@user)
+    assert_nil @user.progress_table_v2_timestamp
+    post :post_set_progress_table_timestamp, params: {user_id: 'me', is_v2_table: true}
+    assert_response :success
+    @user.reload
+    assert @user.progress_table_v2_timestamp
+    assert_nil @user.progress_table_v1_timestamp
+
+    post :post_set_progress_table_timestamp, params: {user_id: 'me', is_v2_table: false}
+    assert_response :success
+    @user.reload
+    assert @user.progress_table_v2_timestamp
+    assert @user.progress_table_v1_timestamp
+  end
+
   test 'a post request to disable_lti_roster_sync updates lti_roster_sync_enabled' do
     teacher = create :teacher, lti_roster_sync_enabled: true
     sign_in(teacher)


### PR DESCRIPTION
## Warning!!

The [AP CSP Create Performance Task](https://apcentral.collegeboard.org/courses/ap-computer-science-principles/exam) is in progress. The most critical dates are from April 3 - April 30, 2024. Please consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking anything in these two labs. Even small changes, such as a different button color, are considered significant during this time period. Reach out to the Student Learning team or Curriculum team for more details.

<!-- end warning -->

Adds two user properties with timestamps for when the user most recently switched to the corresponding progress page.

These user properties are not shown or sent to the front-end, they are only going to be used for internal user investigation and adoption metrics.

This PR also fixes a race condition made in the first attempt. See slack thread for details: https://codedotorg.slack.com/archives/C0T0PNTM3/p1715290571199679

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[TEACH-1013](https://codedotorg.atlassian.net/browse/TEACH-1013)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked