### PR TITLE
Quick clean up for adding finish button to lab2 levels.

### DIFF
--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -176,7 +176,8 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
     setIsFinished(true);
   }, [beforeFinish]);
 
-  // When the level changes, the Finish button is active again if user returns to last level.
+  // Set the Finish button to active based on the showFinishButton prop which changes
+  // when the level changes.
   useEffect(() => {
     setIsFinished(false);
   }, [canShowFinishButton]);

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -176,8 +176,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
     setIsFinished(true);
   }, [beforeFinish]);
 
-  // Set the Finish button to active based on the showFinishButton prop which changes
-  // when the level changes.
+  // Reset the Finish button state when it changes from shown to hidden.
   useEffect(() => {
     setIsFinished(false);
   }, [canShowFinishButton]);

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -8,7 +8,7 @@ import {
   levelCount,
   currentLevelIndex,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import {LabState} from '../../lab2Redux';
 import {ProjectLevelData} from '../../types';
@@ -169,8 +169,6 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
 
   const canShowFinishButton = showFinishButton;
 
-  const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
-
   const onFinish = useCallback(() => {
     if (beforeFinish) {
       beforeFinish();
@@ -181,7 +179,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
   // When the level changes, the Finish button is active again if user returns to last level.
   useEffect(() => {
     setIsFinished(false);
-  }, [currentLevelId]);
+  }, [canShowFinishButton]);
 
   const finalMessage =
     'You finished this lesson! Check in with your teacher for the next activity';


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is a quick follow-up to https://github.com/code-dot-org/code-dot-org/pull/58493 which added a 'Finish' button to a lab2 level that is last in a lesson progression. 
This PR replaces a `useEffect` dependency on `currentLevelId` with `canShowFinishButton` to avoid using redux in the `InstructionsPanel` inner component so that it is reusable outside of the `Instructions` parent component.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
