### PR TITLE
Add skinny banner and logo section to /districts page

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/districts-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/districts-styles.scss
@@ -28,8 +28,3 @@
     }
   }
 }
-
-.logos {
-  margin-block: 3rem;
-  gap: 4rem;
-}

--- a/pegasus/sites.v3/code.org/public/css/districts-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/districts-styles.scss
@@ -28,3 +28,8 @@
     }
   }
 }
+
+.logos {
+  margin-block: 3rem;
+  gap: 4rem;
+}

--- a/pegasus/sites.v3/code.org/public/districts.haml
+++ b/pegasus/sites.v3/code.org/public/districts.haml
@@ -13,6 +13,7 @@ theme: responsive_full_width
 -# Button urls
 - url_learn_more = "#email-signup-form"
 - url_enroll_now = "https://share.hsforms.com/1_4JKSt-hS1OCz86gmiczdgqs0ef"
+- district_partners_url = "https://code.org/educate/district/partners"
 
 -# FontAwesome icons
 - icon_laptop_file = "fa-solid fa-laptop-file"
@@ -23,6 +24,8 @@ theme: responsive_full_width
 - icon_folder_open = "fa-solid fa-folder-open"
 - icon_smile = "fa-solid fa-smile"
 - icon_money_check_dollar_pen = "fa-solid fa-money-check-dollar-pen"
+
+= view :top_skinny_banner, banner_id: "banner-districts", banner_url: nil, banner_icon: "fa-solid fa-megaphone", banner_text: hoc_s("districts_skinny_banner_title", markdown: :inline, locals: {district_partners_url: district_partners_url}), external_link: false, light_theme: true
 
 %section.hero-banner-basic.bg-neutral-dark{style: "display: block !important"}
   .wrapper
@@ -110,6 +113,20 @@ theme: responsive_full_width
     .button-wrapper.centered
       %a.link-button{href: url_learn_more} Learn more
       %a.link-button.secondary{href: url_enroll_now, target: "_blank", rel: "noopener noreferrer"} Enroll now
+
+%section.bg-neutral-light
+  %h2.centered
+    Meet the Districts in our District Program
+  %p.centered
+    Over 100 school districts have already joined!
+  .logos.flex-container.justify-center.align-items-start.wrap
+    %img{src: "/images/marketing/fill-110x60/detroit_public_schools_logo.png", alt: "Detroit Public Schools logo"}
+    %img{src: "/images/marketing/fill-110x60/hartford_public_schools_logo.png", alt: "Hartford Public Schools logo"}
+    %img{src: "/images/marketing/fill-86x60/miami_dade_county_public_schools_logo.png", alt: "Miami Dade County Public Schools logo"}
+    %img{src: "/images/marketing/fill-180x60/lausd_unified_logo.png", alt: "LAUSD Unified logo"}
+    %img{src: "/images/marketing/fill-111x60/clark_county_school_district_logo.png", alt: "Clark County School District logo"}
+  %div.centered
+    %a.link-button.secondary{href: district_partners_url, target: "_blank", rel: "noopener noreferrer"} See full district partner list
 
 %section.bg-primary-light.centered
   .wrapper

--- a/pegasus/sites.v3/code.org/public/districts.haml
+++ b/pegasus/sites.v3/code.org/public/districts.haml
@@ -119,12 +119,12 @@ theme: responsive_full_width
     Meet the Districts in our District Program
   %p.centered
     Over 100 school districts have already joined!
-  .logos.flex-container.justify-center.align-items-start.wrap
-    %img{src: "/images/marketing/fill-110x60/detroit_public_schools_logo.png", alt: "Detroit Public Schools logo"}
-    %img{src: "/images/marketing/fill-110x60/hartford_public_schools_logo.png", alt: "Hartford Public Schools logo"}
-    %img{src: "/images/marketing/fill-86x60/miami_dade_county_public_schools_logo.png", alt: "Miami Dade County Public Schools logo"}
-    %img{src: "/images/marketing/fill-180x60/lausd_unified_logo.png", alt: "LAUSD Unified logo"}
-    %img{src: "/images/marketing/fill-111x60/clark_county_school_district_logo.png", alt: "Clark County School District logo"}
+  .logos-wrapper
+    %img{src: "/images/marketing/fill-110x60/detroit_public_schools_logo.png", alt: "Detroit Public Schools logo", style: "max-width: 110px"}
+    %img{src: "/images/marketing/fill-110x60/hartford_public_schools_logo.png", alt: "Hartford Public Schools logo", style: "max-width: 110px"}
+    %img{src: "/images/marketing/fill-86x60/miami_dade_county_public_schools_logo.png", alt: "Miami Dade County Public Schools logo", style: "max-width: 86px"}
+    %img{src: "/images/marketing/fill-180x60/lausd_unified_logo.png", alt: "LAUSD Unified logo", style: "max-width: 180px"}
+    %img{src: "/images/marketing/fill-111x60/clark_county_school_district_logo.png", alt: "Clark County School District logo", style: "max-width: 111px"}
   %div.centered
     %a.link-button.secondary{href: district_partners_url, target: "_blank", rel: "noopener noreferrer"} See full district partner list
 

--- a/pegasus/sites.v3/code.org/public/images/marketing/clark_county_school_district_logo.png
+++ b/pegasus/sites.v3/code.org/public/images/marketing/clark_county_school_district_logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e103b331436ca801e9fb3a7bf49827cfe947067018b6ed164c211cdc162d1ff1
+size 6453

--- a/pegasus/sites.v3/code.org/public/images/marketing/detroit_public_schools_logo.png
+++ b/pegasus/sites.v3/code.org/public/images/marketing/detroit_public_schools_logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff61664631cfc9804974a64ffa6a38f3f42596aa0c5f954fd0021234c11b38ce
+size 5400

--- a/pegasus/sites.v3/code.org/public/images/marketing/hartford_public_schools_logo.png
+++ b/pegasus/sites.v3/code.org/public/images/marketing/hartford_public_schools_logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1bb35f59c83326604d3f99572762034b4ce865b8b734e9ea09e52f7b8d227da
+size 3548

--- a/pegasus/sites.v3/code.org/public/images/marketing/lausd_unified_logo.png
+++ b/pegasus/sites.v3/code.org/public/images/marketing/lausd_unified_logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0c4143e4b4d45a363b4db54dda926d055d37e5fa77e4781767f16e2a56ec2a4
+size 4876

--- a/pegasus/sites.v3/code.org/public/images/marketing/miami_dade_county_public_schools_logo.png
+++ b/pegasus/sites.v3/code.org/public/images/marketing/miami_dade_county_public_schools_logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b9ee2df05061cb476290c650869d0a82ba7f0853834070b6bc67327201399c8
+size 7305

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10838,6 +10838,8 @@
   about_page_donors_link_1: "Make a donations"
   about_page_donors_link_2: "[see our list of donors](%{donors_url})"
 
+  districts_skinny_banner_title: "Over 100+ Districts have joined our District Program! [See district partners](%{district_partners_url})"
+
   teach_ai_title: "Real-world Examples. Practical Resources."
   teach_ai_description: "The AI Guidance for Schools Toolkit is a resource for policymakers, school leaders, and staff to develop initial guidance on AI in their schools."
   teach_ai_button_label: "View the Toolkit"


### PR DESCRIPTION
Adds skinny banner and logo section to /districts page.

### Skinny banner (links to [/educate/districts/partners](https://code.org/educate/district/partners))
![skinny banner](https://github.com/code-dot-org/code-dot-org/assets/56283563/bac9b8ff-b757-4192-8593-887bc0a27ee5)

### Logo section
![meet districts section](https://github.com/code-dot-org/code-dot-org/assets/56283563/a324cb8c-53b6-4abf-841b-acb06617f50c)

Responsive:
![responsive](https://github.com/code-dot-org/code-dot-org/assets/56283563/51d08a9d-271c-4393-aafa-79b21be568e7)

RTL:
![RTL](https://github.com/code-dot-org/code-dot-org/assets/56283563/7a669519-32f6-447c-9425-5b2df9c96543)

## Links
Jira ticket: [items 2 and 3 from the ticket](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1687)
Figma: [here](https://www.figma.com/file/2CJiUNWSyspeHnLIt5Lw9z/District%2FAdmin-Landing-Page?type=design&node-id=1913-825&mode=design&t=clWkAFlOb2hYxocQ-0)

## Testing story
Local testing.

## Follow-up work
Item 4 from the ticket.
