### PR TITLE
Cleaning up School Infos validation and dedup processing

### DIFF
--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -89,24 +89,7 @@ class SchoolInfo < ApplicationRecord
 
   def sync_from_schools
     # If a SchoolInfo is linked to a School then the SchoolInfo pulls its data from the School
-    # It seems like there is some code that is passing in mismatched data at times.
-    # As of Nov. 2, 2017 there were 7 rows in school_infos with non-null school_id and conflicting
-    # data between schools and school_infos. Until we better understand what is causing that we don't want
-    # to flat out fail if we get conflicting inputs. Instead we overwrite the passed in fields with what
-    # is on the School and report the mismatch to HoneyBadger.
     unless school.nil? && school_id.nil?
-      original = {}
-      original[:country] = country
-      original[:school_type] = school_type
-      original[:state] = state
-      original[:zip] = zip
-      original[:school_district_id] = school_district_id
-      original[:school_district_other] = school_district_other
-      original[:school_district_name] = school_district_name
-      original[:school_other] = school_other
-      original[:school_name] = school_name
-      original[:full_address] = full_address
-
       self.country = 'US' # Everything in SCHOOLS is a US school
       self.school_type = school.school_type
       self.state = school.state
@@ -118,21 +101,6 @@ class SchoolInfo < ApplicationRecord
       self.school_name = nil
       self.full_address = nil
       self.validation_type = VALIDATION_FULL
-
-      # Report if we are overriding a non-nil value that was originally passed in
-      something_overwritten = original.map {|key, value| value && value != self[key]}.reduce {|acc, b| acc || b}
-      if something_overwritten
-        Honeybadger.notify(
-          error_message: "Overwriting passed in data for new SchoolInfo",
-          error_class: "SchoolInfo.sync_from_schools",
-          context: {
-            original_input: original,
-            school_id: school.id
-          }
-        )
-        # Don't interrupt callback chain by returning false
-        return nil
-      end
     end
   end
 

--- a/dashboard/lib/school_info_deduplicator.rb
+++ b/dashboard/lib/school_info_deduplicator.rb
@@ -19,7 +19,7 @@ module SchoolInfoDeduplicator
 
     final_attr = process_school_info_attributes(school_info_attr)
 
-    return false unless SchoolInfo.new(final_attr).valid?
+    return nil unless SchoolInfo.new(final_attr).valid?
 
     SchoolInfo.where(final_attr).first
   end

--- a/dashboard/lib/school_info_deduplicator.rb
+++ b/dashboard/lib/school_info_deduplicator.rb
@@ -15,7 +15,7 @@ module SchoolInfoDeduplicator
   # Returns the SchoolInfo if it already exists.
   # Returns nil if the SchoolInfo is new or if it is invalid.
   def get_duplicate_school_info(school_info_attr)
-    return SchoolInfo.where(school_id: attr[:school_id], validation_type: SchoolInfo::VALIDATION_FULL).first if school_info_attr[:school_id]
+    return SchoolInfo.where(school_id: school_info_attr[:school_id], validation_type: SchoolInfo::VALIDATION_FULL).first if school_info_attr[:school_id]
 
     final_attr = process_school_info_attributes(school_info_attr)
 

--- a/dashboard/lib/school_info_deduplicator.rb
+++ b/dashboard/lib/school_info_deduplicator.rb
@@ -17,11 +17,11 @@ module SchoolInfoDeduplicator
   def get_duplicate_school_info(school_info_attr)
     return SchoolInfo.where(school_id: attr[:school_id], validation_type: SchoolInfo::VALIDATION_FULL).first if school_info_attr[:school_id]
 
-    attr = process_school_info_attributes(school_info_attr)
+    final_attr = process_school_info_attributes(school_info_attr)
 
-    return false unless SchoolInfo.new(attr).valid?
+    return false unless SchoolInfo.new(final_attr).valid?
 
-    SchoolInfo.where(attr).first
+    SchoolInfo.where(final_attr).first
   end
 
   # Processes school info attributes (as they come in from a form) to be passed into SchoolInfo.new

--- a/dashboard/lib/school_info_deduplicator.rb
+++ b/dashboard/lib/school_info_deduplicator.rb
@@ -15,22 +15,13 @@ module SchoolInfoDeduplicator
   # Returns the SchoolInfo if it already exists.
   # Returns nil if the SchoolInfo is new or if it is invalid.
   def get_duplicate_school_info(school_info_attr)
+    return SchoolInfo.where(school_id: attr[:school_id], validation_type: SchoolInfo::VALIDATION_FULL).first if school_info_attr[:school_id]
+    
     attr = process_school_info_attributes(school_info_attr)
 
     return false unless SchoolInfo.new(attr).valid?
 
-    # If the SchoolInfo is related to a School then any fully validated school info for that same school id is a match
-    school_info =
-      if attr[:school_id]
-        SchoolInfo.where(school_id: attr[:school_id], validation_type: SchoolInfo::VALIDATION_FULL).first
-      else
-        SchoolInfo.where(attr).first
-      end
-    if school_info
-      return school_info
-    end
-
-    return nil
+    SchoolInfo.where(attr).first
   end
 
   # Processes school info attributes (as they come in from a form) to be passed into SchoolInfo.new

--- a/dashboard/lib/school_info_deduplicator.rb
+++ b/dashboard/lib/school_info_deduplicator.rb
@@ -16,7 +16,7 @@ module SchoolInfoDeduplicator
   # Returns nil if the SchoolInfo is new or if it is invalid.
   def get_duplicate_school_info(school_info_attr)
     return SchoolInfo.where(school_id: attr[:school_id], validation_type: SchoolInfo::VALIDATION_FULL).first if school_info_attr[:school_id]
-    
+
     attr = process_school_info_attributes(school_info_attr)
 
     return false unless SchoolInfo.new(attr).valid?

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -123,12 +123,6 @@ class SchoolInfoTest < ActiveSupport::TestCase
     assert_equal school_info.validation_type, SchoolInfo::VALIDATION_FULL
   end
 
-  test 'inconsitant school data notifies' do
-    Honeybadger.expects(:notify)
-    school_info = build :school_info_with_public_school_only, country: 'Different Country'
-    assert school_info.valid?, school_info.errors.full_messages
-  end
-
   test 'consitant school data does not notify' do
     Honeybadger.expects(:notify).never
     school_info = build :school_info_with_public_school_only, country: 'US'


### PR DESCRIPTION
We used to send a honeybadger error if a user was trying to submit data that didn't align with our school database data. This usually meant they were selecting a school type (i.e. private, charter, public) that mismatched their accurate school type. Unfortunately, the old search didn't filter the search results on that input, so these mismatches were entirely possible. 

In the new search, the zip code will just return the schools without asking for a school type at all, so it's no longer relevant. And for the old search, we want to override the info with school data anyway (which means the Honeybadger event is no longer necessary). 

Bethany and I looked at this together and started working on it a few weeks ago, with her draft work in this pr: https://github.com/code-dot-org/code-dot-org/pull/58259/files.

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1843

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
