### PR TITLE
Add "Start Over" to CodeBridge

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2633,6 +2633,7 @@
   "startOverTitle": "Are you sure you want to start over?",
   "startOverBody": "This will reset the puzzle to its start state and reset all the data you've added or changed.",
   "startOverWorkspace": "This will reset the workspace to its start state and remove all the blocks you've added or changed.",
+  "startOverWorkspaceText": "This will reset the workspace to its start state and remove all the code you've added or changed.",
   "startWithUnit": "Start with unit:",
   "statsTableFailure": "Sorry, something went wrong. Please reload the page to try again.",
   "stayHere": "Stay here",

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -13,17 +13,21 @@ import {
   SetConfigFunction,
 } from '@codebridge/types';
 import React from 'react';
+
 import './styles/cdoIDE.css';
+import {ResetProjectFunction} from './codebridgeContext/types';
+import Workspace from './Workspace';
 
 type CodebridgeProps = {
   project: ProjectType;
   config: ConfigType;
   setProject: SetProjectFunction;
   setConfig: SetConfigFunction;
+  resetProject: ResetProjectFunction;
 };
 
 export const Codebridge = React.memo(
-  ({project, config, setProject, setConfig}: CodebridgeProps) => {
+  ({project, config, setProject, setConfig, resetProject}: CodebridgeProps) => {
     // keep our internal reducer backed copy synced up with our external whatever backed copy
     // see useSynchronizedProject for more info.
     const [internalProject, projectUtilities] = useSynchronizedProject(
@@ -40,6 +44,7 @@ export const Codebridge = React.memo(
       'preview-container': PreviewContainer,
       instructions: config.Instructions || Instructions,
       'file-tabs': FileTabs,
+      workspace: () => <Workspace EditorComponent={EditorComponent} />,
     };
 
     return (
@@ -49,6 +54,7 @@ export const Codebridge = React.memo(
           config,
           setProject,
           setConfig,
+          resetProject,
           ...projectUtilities,
         }}
       >

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -1,7 +1,5 @@
 import {CodebridgeContextProvider} from '@codebridge/codebridgeContext';
-import DisabledEditor from '@codebridge/Editor/DisabledEditor';
 import {FileBrowser} from '@codebridge/FileBrowser';
-import {FileTabs} from '@codebridge/FileTabs';
 import {useSynchronizedProject} from '@codebridge/hooks';
 import {Instructions} from '@codebridge/Instructions';
 import {PreviewContainer} from '@codebridge/PreviewContainer';
@@ -35,15 +33,11 @@ export const Codebridge = React.memo(
       setProject
     );
 
-    const EditorComponent = config.EditorComponent || DisabledEditor;
-
     const ComponentMap = {
       'file-browser': FileBrowser,
       'side-bar': SideBar,
-      editor: EditorComponent,
       'preview-container': PreviewContainer,
       instructions: config.Instructions || Instructions,
-      'file-tabs': FileTabs,
       workspace: Workspace,
     };
 

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -44,7 +44,7 @@ export const Codebridge = React.memo(
       'preview-container': PreviewContainer,
       instructions: config.Instructions || Instructions,
       'file-tabs': FileTabs,
-      workspace: () => <Workspace EditorComponent={EditorComponent} />,
+      workspace: Workspace,
     };
 
     return (

--- a/apps/src/codebridge/Editor/index.tsx
+++ b/apps/src/codebridge/Editor/index.tsx
@@ -39,7 +39,6 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
     return <div>Cannot currently edit files of type {file.language}</div>;
   }
 
-  console.log(`rendering editor for file ${file.id}/${1}`);
   return (
     <div className="editor-container">
       {file && (

--- a/apps/src/codebridge/Editor/index.tsx
+++ b/apps/src/codebridge/Editor/index.tsx
@@ -1,5 +1,4 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
-import {editableFileType} from '@codebridge/utils';
 import {LanguageSupport} from '@codemirror/language';
 import React, {useCallback, useMemo} from 'react';
 
@@ -7,19 +6,17 @@ import {getActiveFileForProject} from '@cdo/apps/lab2/projects/utils';
 import CodeEditor from '@cdo/apps/lab2/views/components/editor/CodeEditor';
 
 import './styles/editor.css';
+import {editableFileType} from '../utils';
 
-export const Editor = (
-  langMapping: {[key: string]: LanguageSupport},
-  editableFileTypes: string[]
-) => {
+interface EditorProps {
+  langMapping: {[key: string]: LanguageSupport};
+  editableFileTypes: string[];
+}
+
+export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
   const {project, saveFile} = useCodebridgeContext();
 
   const file = getActiveFileForProject(project);
-  // this is a stupid hack. the low level code-mirror editor won't update itself
-  // automatically if the doc is changed externally. So in lieu of doing it better,
-  // for now we just key the component off of the file ID + an incrementing value that
-  // hits every time the format button is pressed. That'll force a re-render and make it work.
-  // let's swap this out with something better.
 
   const onChange = useCallback(
     (value: string) => {
@@ -42,6 +39,7 @@ export const Editor = (
     return <div>Cannot currently edit files of type {file.language}</div>;
   }
 
+  console.log(`rendering editor for file ${file.id}/${1}`);
   return (
     <div className="editor-container">
       {file && (

--- a/apps/src/codebridge/Editor/styles/editor.css
+++ b/apps/src/codebridge/Editor/styles/editor.css
@@ -1,5 +1,5 @@
 .editor-container {
-  grid-area: editor;
+  /* grid-area: editor; */
   width: 100%;
   height: 100%;
   background-color: #292f36;

--- a/apps/src/codebridge/Editor/styles/editor.css
+++ b/apps/src/codebridge/Editor/styles/editor.css
@@ -1,5 +1,5 @@
 .editor-container {
-  /* grid-area: editor; */
+  grid-area: editor;
   width: 100%;
   height: 100%;
   background-color: #292f36;

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.css
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.css
@@ -3,13 +3,12 @@
   justify-content: flex-start;
   gap: 6px;
   align-items: flex-end;
-  height: 100%;
   overflow-x: scroll;
   max-width: 100%;
   background-color: #3f444b;
   color: white;
   scrollbar-width: none;
-  grid-area: file-tabs;
+  /* grid-area: file-tabs; */
 }
 
 .file-tab {

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.css
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.css
@@ -8,7 +8,7 @@
   background-color: #3f444b;
   color: white;
   scrollbar-width: none;
-  /* grid-area: file-tabs; */
+  grid-area: file-tabs;
 }
 
 .file-tab {

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -15,8 +15,6 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
   const onClickStartOver = useCallback(() => {
     if (dialogControl) {
       dialogControl.showDialog(DialogType.StartOver, resetProject);
-    } else {
-      console.log('no dialog control');
     }
   }, [dialogControl, resetProject]);
 

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -1,0 +1,37 @@
+import React, {useCallback, useContext} from 'react';
+
+import Button from '@cdo/apps/componentLibrary/button';
+import {
+  DialogContext,
+  DialogType,
+} from '@cdo/apps/lab2/views/dialogs/DialogManager';
+
+import {useCodebridgeContext} from '../codebridgeContext';
+
+const WorkspaceHeaderButtons: React.FunctionComponent = () => {
+  const dialogControl = useContext(DialogContext);
+  const {resetProject} = useCodebridgeContext();
+
+  const onClickStartOver = useCallback(() => {
+    if (dialogControl) {
+      dialogControl.showDialog(DialogType.StartOver, resetProject);
+    } else {
+      console.log('no dialog control');
+    }
+  }, [dialogControl, resetProject]);
+
+  return (
+    <div>
+      <Button
+        icon={{iconStyle: 'solid', iconName: 'refresh'}}
+        isIconOnly
+        color={'black'}
+        onClick={onClickStartOver}
+        ariaLabel={'Start Over'}
+        size={'xs'}
+      />
+    </div>
+  );
+};
+
+export default WorkspaceHeaderButtons;

--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -20,7 +20,7 @@ const Workspace = () => {
       <FileTabs />
       <Editor
         langMapping={config.languageMapping}
-        editableFileTypes={config.allowedLanguages}
+        editableFileTypes={config.editableFileTypes}
       />
     </PanelContainer>
   );

--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -7,6 +7,7 @@ import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 
 import HeaderButtons from './HeaderButtons';
 
+import moduleStyles from './workspace.module.scss';
 const Workspace = () => {
   const {config} = useCodebridgeContext();
   return (
@@ -14,14 +15,13 @@ const Workspace = () => {
       id="editor-workspace"
       headerContent={'Workspace'}
       rightHeaderContent={<HeaderButtons />}
+      className={moduleStyles.workspace}
     >
-      <div>
-        <FileTabs />
-        <Editor
-          langMapping={config.languageMapping}
-          editableFileTypes={config.allowedLanguages}
-        />
-      </div>
+      <FileTabs />
+      <Editor
+        langMapping={config.languageMapping}
+        editableFileTypes={config.allowedLanguages}
+      />
     </PanelContainer>
   );
 };

--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+
+import {FileTabs} from '../FileTabs';
+import {EditorComponent} from '../types';
+
+import HeaderButtons from './HeaderButtons';
+
+interface WorkspaceProps {
+  EditorComponent: EditorComponent | React.ExoticComponent;
+}
+
+const Workspace: React.FunctionComponent<WorkspaceProps> = ({
+  EditorComponent,
+}) => {
+  return (
+    <PanelContainer
+      id="editor-workspace"
+      headerContent={'Workspace'}
+      rightHeaderContent={<HeaderButtons />}
+    >
+      <div>
+        <FileTabs />
+        <EditorComponent />
+      </div>
+    </PanelContainer>
+  );
+};
+
+export default Workspace;

--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -2,18 +2,14 @@ import React from 'react';
 
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 
+import {useCodebridgeContext} from '../codebridgeContext';
+import {Editor} from '../Editor';
 import {FileTabs} from '../FileTabs';
-import {EditorComponent} from '../types';
 
 import HeaderButtons from './HeaderButtons';
 
-interface WorkspaceProps {
-  EditorComponent: EditorComponent | React.ExoticComponent;
-}
-
-const Workspace: React.FunctionComponent<WorkspaceProps> = ({
-  EditorComponent,
-}) => {
+const Workspace = () => {
+  const {config} = useCodebridgeContext();
   return (
     <PanelContainer
       id="editor-workspace"
@@ -22,10 +18,12 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({
     >
       <div>
         <FileTabs />
-        <EditorComponent />
+        <Editor
+          langMapping={config.languageMapping}
+          editableFileTypes={config.allowedLanguages}
+        />
       </div>
     </PanelContainer>
   );
 };
-
 export default Workspace;

--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -1,10 +1,9 @@
+import {useCodebridgeContext} from '@codebridge/codebridgeContext';
+import {Editor} from '@codebridge/Editor';
+import {FileTabs} from '@codebridge/FileTabs';
 import React from 'react';
 
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
-
-import {useCodebridgeContext} from '../codebridgeContext';
-import {Editor} from '../Editor';
-import {FileTabs} from '../FileTabs';
 
 import HeaderButtons from './HeaderButtons';
 

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -1,0 +1,5 @@
+.workspace {
+  height: 100%;
+  grid-area: workspace;
+  background-color: #292f36;
+}

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -1,5 +1,8 @@
+@import 'color.scss';
+
 .workspace {
   height: 100%;
   grid-area: workspace;
-  background-color: #292f36;
+  background-color: $darkest_gray;
+  color: $white;
 }

--- a/apps/src/codebridge/codebridgeContext/codebridgeContext.tsx
+++ b/apps/src/codebridge/codebridgeContext/codebridgeContext.tsx
@@ -21,6 +21,7 @@ import {
   MoveFileFunction,
   RenameFolderFunction,
   SetFileVisibilityFunction,
+  ResetProjectFunction,
 } from './types';
 
 type CodebridgeContextType = {
@@ -41,6 +42,7 @@ type CodebridgeContextType = {
   moveFile: MoveFileFunction;
   renameFolder: RenameFolderFunction;
   setFileVisibility: SetFileVisibilityFunction;
+  resetProject: ResetProjectFunction;
 };
 
 export const CodebridgeContext = createContext<CodebridgeContextType | null>(

--- a/apps/src/codebridge/codebridgeContext/types.ts
+++ b/apps/src/codebridge/codebridgeContext/types.ts
@@ -24,3 +24,5 @@ export type RenameFileFunction = (fileId: FileId, newName: string) => void;
 export type RenameFolderFunction = (folderId: string, newName: string) => void;
 export type MoveFileFunction = (fileId: FileId, folderId: FolderId) => void;
 export type SetFileVisibilityFunction = (fileId: FileId, hide: boolean) => void;
+
+export type ResetProjectFunction = () => void;

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -1,4 +1,4 @@
-import {useMemo, useEffect} from 'react';
+import {useMemo, useEffect, useCallback} from 'react';
 
 import header from '@cdo/apps/code-studio/header';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
@@ -21,6 +21,9 @@ export const useSource = (defaultSources: ProjectSources) => {
   const channelId = useAppSelector(state => state.lab.channel?.id);
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const initialSources = useInitialSources(defaultSources);
+  const levelStartSource = useAppSelector(
+    state => state.lab.levelProperties?.source
+  );
 
   const setSource = useMemo(
     () => (newSource: MultiFileSource) => {
@@ -28,6 +31,10 @@ export const useSource = (defaultSources: ProjectSources) => {
     },
     [dispatch]
   );
+
+  const resetToStartSource = useCallback(() => {
+    setSource(levelStartSource || (defaultSources.source as MultiFileSource));
+  }, [defaultSources.source, levelStartSource, setSource]);
 
   useEffect(() => {
     if (isStartMode) {
@@ -44,5 +51,5 @@ export const useSource = (defaultSources: ProjectSources) => {
     }
   }, [channelId, initialSources, dispatch]);
 
-  return {source, setSource};
+  return {source, setSource, resetToStartSource};
 };

--- a/apps/src/codebridge/types.ts
+++ b/apps/src/codebridge/types.ts
@@ -34,12 +34,11 @@ export type ConfigType = {
   gridLayout: string;
   gridLayoutRows?: string;
   gridLayoutColumns?: string;
-  editableFileTypes?: string[];
+  editableFileTypes: string[];
   previewFileTypes?: string[];
   blankEmptyEditor?: boolean;
   PreviewComponents?: {[key: string]: PreviewComponent};
   languageMapping: {[key: string]: LanguageSupport};
-  allowedLanguages: string[];
 };
 
 export type ProjectType = MultiFileSource;

--- a/apps/src/codebridge/types.ts
+++ b/apps/src/codebridge/types.ts
@@ -1,3 +1,5 @@
+import {LanguageSupport} from '@codemirror/language';
+
 import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
 
 export type {
@@ -38,6 +40,8 @@ export type ConfigType = {
   EmptyEditorComponent?: EmptyEditorComponent;
   blankEmptyEditor?: boolean;
   PreviewComponents?: {[key: string]: PreviewComponent};
+  languageMapping: {[key: string]: LanguageSupport};
+  allowedLanguages: string[];
 };
 
 export type ProjectType = MultiFileSource;

--- a/apps/src/codebridge/types.ts
+++ b/apps/src/codebridge/types.ts
@@ -34,10 +34,8 @@ export type ConfigType = {
   gridLayout: string;
   gridLayoutRows?: string;
   gridLayoutColumns?: string;
-  EditorComponent?: EditorComponent;
   editableFileTypes?: string[];
   previewFileTypes?: string[];
-  EmptyEditorComponent?: EmptyEditorComponent;
   blankEmptyEditor?: boolean;
   PreviewComponents?: {[key: string]: PreviewComponent};
   languageMapping: {[key: string]: LanguageSupport};

--- a/apps/src/codebridge/utils/getEmptyEditor.ts
+++ b/apps/src/codebridge/utils/getEmptyEditor.ts
@@ -3,9 +3,7 @@ import {ConfigType} from '@codebridge/types';
 import {DefaultEmptyEditor, BlankEmptyEditor} from '../DefaultEmptyEditors';
 
 export const getEmptyEditor = (config: ConfigType) => {
-  if (config.EmptyEditorComponent) {
-    return config.EmptyEditorComponent;
-  } else if (config.blankEmptyEditor) {
+  if (config.blankEmptyEditor) {
     return BlankEmptyEditor;
   } else {
     return DefaultEmptyEditor;

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -260,3 +260,11 @@ export interface ExtraLinksData {
   can_delete: boolean;
   level_name: string;
 }
+
+export const TEXT_BASED_LABS: AppName[] = [
+  'applab',
+  'javalab',
+  'weblab',
+  'pythonlab',
+  'weblab2',
+];

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -261,10 +261,5 @@ export interface ExtraLinksData {
   level_name: string;
 }
 
-export const TEXT_BASED_LABS: AppName[] = [
-  'applab',
-  'javalab',
-  'weblab',
-  'pythonlab',
-  'weblab2',
-];
+// Text-based labs that are currently supported by lab2.
+export const TEXT_BASED_LABS: AppName[] = ['aichat', 'pythonlab', 'weblab2'];

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -2,7 +2,6 @@ import React, {useEffect, useRef, useState} from 'react';
 import classNames from 'classnames';
 import {EditorState, Extension} from '@codemirror/state';
 import {EditorView, ViewUpdate} from '@codemirror/view';
-import PanelContainer from '../PanelContainer';
 import {useDispatch} from 'react-redux';
 import {editorConfig} from './editorConfig';
 import {darkMode as darkModeTheme} from './editorThemes';
@@ -83,11 +82,7 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
     }
   }, [startCode, editorView, channelId]);
 
-  return (
-    <PanelContainer id="code-editor" headerContent="Editor" hideHeaders={false}>
-      <div ref={editorRef} className={classNames('codemirror-container')} />
-    </PanelContainer>
-  );
+  return <div ref={editorRef} className={classNames('codemirror-container')} />;
 };
 
 export default CodeEditor;

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -28,9 +28,14 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   const channelId = useAppSelector(state => state.lab.channel?.id);
 
   useEffect(() => {
+    console.log(
+      `in editor setup useEffect, didInit is ${didInit}, editorRef is ${editorRef.current}`
+    );
     if (editorRef.current === null || didInit) {
+      console.log('returning early');
       return;
     }
+    console.log('not returning early');
 
     const onEditorUpdate = EditorView.updateListener.of(
       (update: ViewUpdate) => {
@@ -72,6 +77,7 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   // A new channelId means we are loading a new project, and we need to reset the editor.
   useEffect(() => {
     if (editorView && editorView.state.doc.toString() !== startCode) {
+      console.log('resetting editor');
       editorView.dispatch({
         changes: {
           from: 0,
@@ -82,7 +88,11 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
     }
   }, [startCode, editorView, channelId]);
 
-  return <div ref={editorRef} className={classNames('codemirror-container')} />;
+  return (
+    <div id="code-editor">
+      <div ref={editorRef} className={classNames('codemirror-container')} />;
+    </div>
+  );
 };
 
 export default CodeEditor;

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -28,14 +28,9 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   const channelId = useAppSelector(state => state.lab.channel?.id);
 
   useEffect(() => {
-    console.log(
-      `in editor setup useEffect, didInit is ${didInit}, editorRef is ${editorRef.current}`
-    );
     if (editorRef.current === null || didInit) {
-      console.log('returning early');
       return;
     }
-    console.log('not returning early');
 
     const onEditorUpdate = EditorView.updateListener.of(
       (update: ViewUpdate) => {
@@ -77,7 +72,6 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   // A new channelId means we are loading a new project, and we need to reset the editor.
   useEffect(() => {
     if (editorView && editorView.state.doc.toString() !== startCode) {
-      console.log('resetting editor');
       editorView.dispatch({
         changes: {
           from: 0,

--- a/apps/src/lab2/views/dialogs/StartOverDialog.tsx
+++ b/apps/src/lab2/views/dialogs/StartOverDialog.tsx
@@ -2,6 +2,8 @@ import Typography from '@cdo/apps/componentLibrary/typography';
 import React from 'react';
 import {BaseDialogProps} from './DialogManager';
 import moduleStyles from './confirm-dialog.module.scss';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {TEXT_BASED_LABS} from '@cdo/apps/lab2/types';
 const commonI18n = require('@cdo/locale');
 
 /**
@@ -11,13 +13,21 @@ const StartOverDialog: React.FunctionComponent<BaseDialogProps> = ({
   handleConfirm,
   handleCancel,
 }) => {
+  const currentAppName = useAppSelector(
+    state => state.lab.levelProperties?.appName
+  );
+  const isTextWorkspace =
+    currentAppName && TEXT_BASED_LABS.includes(currentAppName);
+
   return (
     <div className={moduleStyles.confirmDialog}>
       <Typography semanticTag="h1" visualAppearance="heading-lg">
         {commonI18n.startOverTitle()}
       </Typography>
       <Typography semanticTag="p" visualAppearance="body-two">
-        {commonI18n.startOverWorkspace()}
+        {isTextWorkspace
+          ? commonI18n.startOverWorkspaceText()
+          : commonI18n.startOverWorkspace()}
       </Typography>
       <div className={moduleStyles.buttonContainer}>
         <button

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -40,7 +40,7 @@ const defaultProject: ProjectSources = {
 const defaultConfig: ConfigType = {
   activeLeftNav: 'Files',
   languageMapping: pythonlabLangMapping,
-  allowedLanguages: ['py', 'csv', 'txt'],
+  editableFileTypes: ['py', 'csv', 'txt'],
   leftNav: [
     {
       icon: 'fa-square-check',

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -70,15 +70,15 @@ const defaultConfig: ConfigType = {
   gridLayoutRows: '32px 232px auto',
   gridLayoutColumns: '300px auto',
   gridLayout: `
-    "instructions file-tabs"
-    "instructions editor"
-    "file-browser editor"
+    "instructions workspace"
+    "instructions workspace"
+    "file-browser workspace"
   `,
 };
 
 const PythonlabView: React.FunctionComponent = () => {
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
-  const {source, setSource} = useSource(defaultProject);
+  const {source, setSource, resetToStartSource} = useSource(defaultProject);
 
   return (
     <div className={moduleStyles.pythonlab}>
@@ -89,6 +89,7 @@ const PythonlabView: React.FunctionComponent = () => {
             config={config}
             setProject={setSource}
             setConfig={setConfig}
+            resetProject={resetToStartSource}
           />
         )}
       </div>

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -2,7 +2,6 @@
 import React, {useState} from 'react';
 import moduleStyles from './pythonlab-view.module.scss';
 import {ConfigType} from '@codebridge/types';
-import {Editor} from '@codebridge/Editor';
 import {LanguageSupport} from '@codemirror/language';
 import {python} from '@codemirror/lang-python';
 import {Codebridge} from '@codebridge/Codebridge';
@@ -40,7 +39,8 @@ const defaultProject: ProjectSources = {
 
 const defaultConfig: ConfigType = {
   activeLeftNav: 'Files',
-  EditorComponent: () => Editor(pythonlabLangMapping, ['py', 'csv', 'txt']),
+  languageMapping: pythonlabLangMapping,
+  allowedLanguages: ['py', 'csv', 'txt'],
   leftNav: [
     {
       icon: 'fa-square-check',

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -38,7 +38,7 @@ const verticalLayout = {
 const defaultConfig: ConfigType = {
   activeLeftNav: 'Files',
   languageMapping: weblabLangMapping,
-  allowedLanguages: ['html', 'css'],
+  editableFileTypes: ['html', 'css'],
   leftNav: [
     {
       icon: 'fa-square-check',

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -152,7 +152,7 @@ const defaultProject: ProjectSources = {source: defaultSource};
 
 const Weblab2View = () => {
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
-  const {source, setSource} = useSource(defaultProject);
+  const {source, setSource, resetToStartSource} = useSource(defaultProject);
   const [showConfig, setShowConfig] = useState<
     'project' | 'config' | 'layout' | ''
   >('');
@@ -195,6 +195,7 @@ const Weblab2View = () => {
             config={config}
             setProject={setSource}
             setConfig={setConfig}
+            resetProject={resetToStartSource}
           />
         )}
 

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -18,9 +18,6 @@ const weblabLangMapping: {[key: string]: LanguageSupport} = {
   css: css(),
 };
 
-// const DefaultEditorComponent = () =>
-//   CDOEditor(weblabLangMapping, ['html', 'css']);
-
 const horizontalLayout = {
   gridLayoutRows: '32px 300px auto',
   gridLayoutColumns: '300px auto auto',
@@ -40,11 +37,8 @@ const verticalLayout = {
 
 const defaultConfig: ConfigType = {
   activeLeftNav: 'Files',
-  //EditorComponent: DefaultEditorComponent,
   languageMapping: weblabLangMapping,
   allowedLanguages: ['html', 'css'],
-  // editableFileTypes: ["html"],
-  // previewFileTypes: ["html"],
   leftNav: [
     {
       icon: 'fa-square-check',

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -21,17 +21,17 @@ const weblabLangMapping: {[key: string]: LanguageSupport} = {
 const horizontalLayout = {
   gridLayoutRows: '32px 300px auto',
   gridLayoutColumns: '300px auto auto',
-  gridLayout: `    "instructions file-tabs preview-container"
-      "instructions editor preview-container"
-      "file-browser editor preview-container"`,
+  gridLayout: `    "instructions workspace preview-container"
+      "instructions workspace preview-container"
+      "file-browser workspace preview-container"`,
 };
 
 const verticalLayout = {
   gridLayoutRows: '32px 300px auto auto',
   gridLayoutColumns: '300px auto',
-  gridLayout: `    "instructions file-tabs file-tabs"
-      "instructions editor editor"
-      "file-browser editor editor"
+  gridLayout: `    "instructions workspace workspace"
+      "instructions workspace workspace"
+      "file-browser workspace workspace"
       "file-browser preview-container preview-container"`,
 };
 
@@ -203,12 +203,9 @@ const Weblab2View = () => {
             ) => {
               if (configName === 'project') {
                 setSource(newConfig as ProjectType);
+              } else if (configName === 'config' || configName === 'layout') {
+                setConfig(newConfig as ConfigType);
               }
-              // else if (configName === 'config' || configName === 'layout') {
-              //   (newConfig as ConfigType).EditorComponent =
-              //     DefaultEditorComponent;
-              //   setConfig(newConfig as ConfigType);
-              // }
               setShowConfig('');
             }}
             cancelConfig={() => setShowConfig('')}

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -7,7 +7,6 @@ import {Config} from './Config';
 import {Codebridge} from '@codebridge/Codebridge';
 import {ConfigType, ProjectType} from '@codebridge/types';
 
-import {Editor as CDOEditor} from '@codebridge/Editor';
 import {html} from '@codemirror/lang-html';
 import {LanguageSupport} from '@codemirror/language';
 import {css} from '@codemirror/lang-css';
@@ -19,8 +18,8 @@ const weblabLangMapping: {[key: string]: LanguageSupport} = {
   css: css(),
 };
 
-const DefaultEditorComponent = () =>
-  CDOEditor(weblabLangMapping, ['html', 'css']);
+// const DefaultEditorComponent = () =>
+//   CDOEditor(weblabLangMapping, ['html', 'css']);
 
 const horizontalLayout = {
   gridLayoutRows: '32px 300px auto',
@@ -41,7 +40,9 @@ const verticalLayout = {
 
 const defaultConfig: ConfigType = {
   activeLeftNav: 'Files',
-  EditorComponent: DefaultEditorComponent,
+  //EditorComponent: DefaultEditorComponent,
+  languageMapping: weblabLangMapping,
+  allowedLanguages: ['html', 'css'],
   // editableFileTypes: ["html"],
   // previewFileTypes: ["html"],
   leftNav: [
@@ -208,11 +209,12 @@ const Weblab2View = () => {
             ) => {
               if (configName === 'project') {
                 setSource(newConfig as ProjectType);
-              } else if (configName === 'config' || configName === 'layout') {
-                (newConfig as ConfigType).EditorComponent =
-                  DefaultEditorComponent;
-                setConfig(newConfig as ConfigType);
               }
+              // else if (configName === 'config' || configName === 'layout') {
+              //   (newConfig as ConfigType).EditorComponent =
+              //     DefaultEditorComponent;
+              //   setConfig(newConfig as ConfigType);
+              // }
               setShowConfig('');
             }}
             cancelConfig={() => setShowConfig('')}


### PR DESCRIPTION
This adds a start over button to the CodeBridge workspace. To get this working I had to do a bit of refactoring:
- Instead of configuring the file tabs and editor as separate components in the layout, they are combined as one`workspace` component. In order to enable this I removed the direct passing of the editor component and instead pass the language mapping and editable file types to the config. This also had the benefit of moving the header for the editor above the file tabs.
- I added the same start over icon button to the new "Workspace" header that we use in Music Lab.
- I updated the `useSources` hook to return a start over function as well.  I was able to reuse logic from Music Lab/lab2 for this.
- I re-used the same start over dialog from Music Lab/lab2. This dialog specifically mentioned "blocks" in the text. I updated it to check the lab type, and show "code" instead if the lab is text-based.

The new flow now looks like this (it is very similar in Web Lab 2):
https://github.com/code-dot-org/code-dot-org/assets/33666587/1ea7ec39-0321-43ae-a6a4-ff7e7b92c51f



## Links
- jira ticket: [CT-552](https://codedotorg.atlassian.net/browse/CT-552)


## Testing story
Tested locally in Python Lab and Web Lab 2


## Follow-up work
We have a separate task to add full version history.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
