### PR TITLE
Fix forward for local and staging statsig calls to avoid calling without key

### DIFF
--- a/apps/src/lib/util/StatsigReporter.js
+++ b/apps/src/lib/util/StatsigReporter.js
@@ -104,6 +104,9 @@ class StatsigReporter {
   }
 
   getIsInExperiment(name, parameter, defaultValue) {
+    if (this.local_mode) {
+      return false;
+    }
     return Statsig.getExperiment(name).get(parameter, defaultValue);
   }
 


### PR DESCRIPTION
Kaitie discovered an issue with [my AB test pr](https://github.com/code-dot-org/code-dot-org/pull/58470) that breaks local environments because those don't have Statsig keys. To avoid this, I return false (aka, not in the experiment) locally instead of trying to communicate with Statsig.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
