### PR TITLE
Width and height fix of invitation

### DIFF
--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -211,6 +211,7 @@ export default function currentUser(state = initialState, action) {
       aiRubricsDisabled: action.aiRubricsDisabled,
     };
   }
+
   if (action.type === SET_INITIAL_DATA) {
     const {
       id,

--- a/apps/src/templates/sectionProgressV2/progress-v2-invitation.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-v2-invitation.module.scss
@@ -15,22 +15,28 @@
 }
 
 .modal {
-  min-width: 90% !important;
+  max-width: 980px !important;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.remindMeLaterButton {
-  color: $neutral_dark !important;
-  text-decoration: underline !important;
-  margin: 12px 0 !important;
+@media screen and (max-width: 980px) {
+  .modal {
+    width: 90% !important; /* Set width to 90% of the viewport width */
+  }
 }
 
 img {
   max-width: 100%;
   max-height: 50vh;
   height: auto;
+}
+
+.remindMeLaterButton {
+  color: $neutral_dark !important;
+  text-decoration: underline !important;
+  margin: 12px 0 !important;
 }
 
 .xCloseButton {

--- a/apps/src/templates/sectionProgressV2/progress-v2-invitation.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-v2-invitation.module.scss
@@ -16,6 +16,7 @@
 
 .modal {
   max-width: 980px !important;
+  max-height: 90% !important;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
The width of the modal was a bit too large.  

![image](https://github.com/code-dot-org/code-dot-org/assets/24883357/892de391-8b44-4339-9155-a19eba91e245)


This changes the width and makes it more responsive to screen resizing. 


Uploading Screen Recording 2024-05-10 at 5.29.34 PM.mov…



## Links

[Thread](https://codedotorg.slack.com/archives/C06ERUABG01/p1715270034831359)

In the future, we want to see if we can optimize for a smaller height of the window, but after a few hours of tinkering, I was unable to get it to perfectly resize the height of the modal.  Bryan signed off on this change for now.  I will not close the ticket until we either get the A-OK or find a fix.