### PR TITLE
Link pyodide build into dashboard/public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ npm-debug.log
 /dashboard/db/ui_test_data.*
 /dashboard/public/blockly
 /dashboard/public/code-studio
+/dashboard/public/pyodide
 /dashboard/public/shared
 /dashboard/public/styleguide
 /pegasus/config/newrelic.yml

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -8,9 +8,7 @@ import {loadPyodide, version} from 'pyodide';
 
 async function loadPyodideAndPackages() {
   self.pyodide = await loadPyodide({
-    indexURL: `https://cdn.jsdelivr.net/pyodide/v${version}/full`,
-    // This URL is not working on prod, so we will use the CDN for now.
-    // indexURL: `/assets/js/pyodide/${version}/`,
+    indexURL: `/pyodide/${version}/`,
     // pre-load numpy as it will frequently be used, and matplotlib as we patch it.
     packages: ['numpy', 'matplotlib'],
   });

--- a/lib/rake/package.rake
+++ b/lib/rake/package.rake
@@ -60,8 +60,9 @@ namespace :package do
     desc 'Update Dashboard symlink for apps package.'
     timed_task_with_logging 'symlink' do
       Dir.chdir(apps_dir) do
-        target = CDO.use_my_apps ? apps_dir('build/package') : 'apps-package'
-        RakeUtils.ln_s target, dashboard_dir('public', 'blockly')
+        package_dir = CDO.use_my_apps ? apps_dir('build/package') : 'apps-package'
+        RakeUtils.ln_s package_dir, dashboard_dir('public', 'blockly')
+        RakeUtils.ln_s File.join(package_dir, 'js', 'pyodide'), dashboard_dir('public', 'pyodide')
       end
     end
   end


### PR DESCRIPTION
Makes pyodide available on the `/pyodide` studio URL in both local dev mode and in non-local dev mode (e.g. prod).

This PR:
1) Modifies `rake package:apps:symlink` (called as part of rake install) to install a symlink from `dashboard/public/pyodide` (available on the studio URL /pyodide) to either apps/build/package (local dev) or dashboard/public/apps-package (non-local dev).
2) Directs pyiodideWebWorker to `loadPyodide()` wasm and whl files from the local server at URL `/pyodide/{version}`

Why? Pyodide build is available in two different local paths depending on whether we're in local dev mode or not:
1) When locals.yml has: `use_my_apps: true` (i.e. we're in local apps dev mode), we have webpack configured (using @pyodide/pyodide-webpack-plugin) to build pyodide into apps/build/package/js/pyodide. This is uploaded to S3 as part of staging & test builds as an apps-package tarball.
2) When using `use_my_apps: false`, we use the apps-package from S3, which has the pyodide build available in dashboard/public/apps-package/js/pyodide

Can test using: http://localhost-studio.code.org:3000//s/allthethings/lessons/50/levels/1

An alternative approach to the problem is here: https://github.com/code-dot-org/code-dot-org/pull/58547