### PR TITLE
Generate pyodide assets without hashes in the filename

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -364,3 +364,6 @@ gem 'statsig', '~> 1.33'
 
 gem 'mailgun-ruby', '~>1.2.14'
 gem 'mailjet', '~> 1.7.3'
+
+# Generate assets without hashes embedded in the filename
+gem 'non-digest-assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -603,6 +603,9 @@ GEM
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    non-digest-assets (2.2.0)
+      activesupport (>= 5.2, < 7.1)
+      sprockets (>= 2.0, < 5.0)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
@@ -1064,6 +1067,7 @@ DEPENDENCIES
   net-ssh
   newrelic_rpm (~> 6.14.0)
   nokogiri (>= 1.10.0)
+  non-digest-assets
   octokit
   oj (~> 3.10)
   omniauth-clever (~> 2.0.0)!

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -8,9 +8,7 @@ import {loadPyodide, version} from 'pyodide';
 
 async function loadPyodideAndPackages() {
   self.pyodide = await loadPyodide({
-    indexURL: `https://cdn.jsdelivr.net/pyodide/v${version}/full`,
-    // This URL is not working on prod, so we will use the CDN for now.
-    // indexURL: `/assets/js/pyodide/${version}/`,
+    indexURL: `/assets/js/pyodide/${version}/`,
     // pre-load numpy as it will frequently be used, and matplotlib as we patch it.
     packages: ['numpy', 'matplotlib'],
   });

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -138,6 +138,13 @@ module Dashboard
     config.assets.paths << Rails.root.join('../shared/css')
     config.assets.paths << Rails.root.join('../shared/js')
 
+    # Configure the non-digest-assets gem to generate some assets/ without hashes in the filename:
+    NonDigestAssets.asset_selectors += [
+      # loadPyodide() hardcodes a list of path-names to load from HTTP, which won't work if Rails
+      # modifies the filename to include a hash:
+      %r{^js/pyodide/},
+    ]
+
     # Whether to fallback to assets pipeline if a precompiled asset is missed.
     config.assets.compile = !CDO.optimize_rails_assets
 

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -141,7 +141,7 @@ module Dashboard
     # Configure the non-digest-assets gem to generate some assets/ without hashes in the filename:
     NonDigestAssets.asset_selectors += [
       # loadPyodide() hardcodes a list of path-names to load from HTTP, which won't work if Rails
-      # modifies the filename to include a hash:
+      # modifies the filenames in assets/js/pyodide/** to include hashes:
       %r{^js/pyodide/},
     ]
 


### PR DESCRIPTION
`loadPyodide()` hardcodes a list of path-names in JS to load from HTTP, which won't work if Rails modifies the filename to output to the `dashboard/public/assets/js/pyodide/**` to include a hash.

This PR adds the non-digest-assets Gem to control which assets are output without hashes in the filenames.

After this PR, `RAILS_ENV=development bundle exec rake assets:precompile` produces output both with and without hashes, like so:
```
./dashboard/public/assets/js/pyodide/0.25.1/package.json
./dashboard/public/assets/js/pyodide/0.25.1/packaging-23.1-py3-none-any-952adfd0fbede825af3ddd33cf288778a247ef83d92de2118d02e7d188e2d917.whl
./dashboard/public/assets/js/pyodide/0.25.1/packaging-23.1-py3-none-any.whl
./dashboard/public/assets/js/pyodide/0.25.1/pandas-1.5.3-cp311-cp311-emscripten_3_1_46_wasm32-15ebfb3055ea2050434ea90b16d8bbc5f0ab62bb13954d42a368530530bc831e.whl
./dashboard/public/assets/js/pyodide/0.25.1/pandas-1.5.3-cp311-cp311-emscripten_3_1_46_wasm32.whl
./dashboard/public/assets/js/pyodide/0.25.1/pyodide-lock-6526dae570ab7db75019fe2c7ccc6b7b82765c56417a498a7b57e1aaebec39f5.json
./dashboard/public/assets/js/pyodide/0.25.1/pyodide-lock.json
./dashboard/public/assets/js/pyodide/0.25.1/pyodide.asm-512042dfdd406971c6fc920b6932e1a8eb5dd2ab3521aa89a020980e4a08bd4b.js
./dashboard/public/assets/js/pyodide/0.25.1/pyodide.asm-aa920641c032c3db42eb1fb018eec611dbef96f0fa4dbdfa6fe3cb1b335aed3c.wasm
./dashboard/public/assets/js/pyodide/0.25.1/pyodide.asm.js
./dashboard/public/assets/js/pyodide/0.25.1/pyodide.asm.wasm
```

Generating both with/without the filename hash does double the size of the pyodide assets directory, but this doesn't seem like a big deal because its only adding 65MB atm and assets is already 4G or so.

Can test with: http://localhost-studio.code.org:3000//s/allthethings/lessons/50/levels/1

An alternative approach to the problem is here: https://github.com/code-dot-org/code-dot-org/pull/58547