### PR TITLE
Fix Forward: Enable RDS Performance Insights at DB Instance Level

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -336,8 +336,6 @@
       EnableIAMDatabaseAuthentication: true
       VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
-      PerformanceInsightsEnabled: <%= ['test', 'production'].include?(environment) %>
-      PerformanceInsightsRetentionPeriod: <%= rack_env?(:production) ? 465 : 7 %>
       EnableCloudwatchLogsExports:
         - general
         - audit
@@ -356,6 +354,8 @@
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
       DBParameterGroupName: default.aurora-mysql5.7 #Explicitly stop setting a custom Instance ParameterGroup.
+      EnablePerformanceInsights: <%= ['test', 'production'].include?(environment) %>
+      PerformanceInsightsRetentionPeriod: <%= rack_env?(:production) ? 465 : 7 %>
 <%    end -%>
 
   DBProxy:


### PR DESCRIPTION
Fix forward for #58418 which failed to provision on staging.
Performance Insights cannot be enabled at the cluster level if the cluster has already been provisioned. We have existing clusters provisioned with this template, so enable Performance Insights at the database instance level.

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_PerfInsights.Enabling.html


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
