### PR TITLE
Lab2: fix progress merge

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -390,7 +390,7 @@ export default connect(
       updateQueryParam('user_id', userId);
       updateQueryParam('version');
       if (isAsync) {
-        dispatch(queryUserProgress(userId));
+        dispatch(queryUserProgress(userId, false));
         dispatch(setViewAsUserId(userId));
       } else {
         reload();

--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -282,10 +282,10 @@ type ProgressThunkAction = ThunkAction<
 >;
 
 export const queryUserProgress =
-  (userId: string): ProgressThunkAction =>
+  (userId: string, mergeProgress: boolean = true): ProgressThunkAction =>
   (dispatch, getState) => {
     const state = getState().progress;
-    return userProgressFromServer(state, dispatch, userId);
+    return userProgressFromServer(state, dispatch, userId, mergeProgress);
   };
 
 // The user has navigated to a new level in the current lesson,
@@ -386,7 +386,8 @@ export function sendSuccessReport(appType: string): ProgressThunkAction {
 const userProgressFromServer = (
   state: ProgressState,
   dispatch: ThunkDispatch<{progress: ProgressState}, undefined, AnyAction>,
-  userId: string | null = null
+  userId: string | null = null,
+  mergeProgress: boolean
 ) => {
   if (!state.scriptName) {
     const message = `Could not request progress for user ID ${userId} from server: scriptName must be present in progress redux.`;
@@ -440,12 +441,14 @@ const userProgressFromServer = (
     if (data.progress) {
       dispatch(setScriptProgress(data.progress));
 
-      // Note that we set the full progress object above in redux but also set
-      // a map containing just level results. This is the legacy code path and
-      // the goal is to eventually update all code paths to use unitProgress
-      // instead of levelResults.
-      const levelResults = _.mapValues(data.progress, getLevelResult);
-      dispatch(mergeResults(levelResults));
+      if (mergeProgress) {
+        // Note that we set the full progress object above in redux but also set
+        // a map containing just level results. This is the legacy code path and
+        // the goal is to eventually update all code paths to use unitProgress
+        // instead of levelResults.
+        const levelResults = _.mapValues(data.progress, getLevelResult);
+        dispatch(mergeResults(levelResults));
+      }
 
       if (data.peerReviewsPerformed) {
         dispatch(mergePeerReviewProgress(data.peerReviewsPerformed));

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -1390,7 +1390,7 @@ describe('progressReduxTest', () => {
       });
     });
 
-    it('requests user progress and dispatches appropriate actions', () => {
+    it('requests user progress and dispatches appropriate actions (default)', () => {
       const responseData = {
         isVerifiedInstructor: true,
         teacherViewingStudent: true,
@@ -1403,7 +1403,7 @@ describe('progressReduxTest', () => {
         current_lesson: 1,
       };
       serverResponse(responseData);
-      const promise = userProgressFromServer(state, dispatch, 1);
+      const promise = userProgressFromServer(state, dispatch, 1, true);
       server.respond();
 
       const expectedDispatchActions = [
@@ -1415,6 +1415,39 @@ describe('progressReduxTest', () => {
         'progress/setScriptCompleted',
         'progress/setScriptProgress',
         'progress/mergeResults',
+        'progress/mergePeerReviewProgress',
+        'progress/setCurrentLessonId',
+      ];
+      return promise.then(serverResponseData => {
+        assert.deepEqual(expectedDispatchActions, getDispatchActions());
+        assert.deepEqual(responseData, serverResponseData);
+      });
+    });
+
+    it('requests user progress and dispatches appropriate actions (no merge)', () => {
+      const responseData = {
+        isVerifiedInstructor: true,
+        teacherViewingStudent: true,
+        deeperLearningCourse: false,
+        focusAreaLessonIds: [1, 2],
+        lockableAuthorized: true,
+        completed: true,
+        progress: {},
+        peerReviewsPerformed: true,
+        current_lesson: 1,
+      };
+      serverResponse(responseData);
+      const promise = userProgressFromServer(state, dispatch, 1, false);
+      server.respond();
+
+      const expectedDispatchActions = [
+        'progress/clearResults',
+        'verifiedInstructor/SET_VERIFIED',
+        'progress/setIsSummaryView',
+        'progress/updateFocusArea',
+        'lessonLock/AUTHORIZE_LOCKABLE',
+        'progress/setScriptCompleted',
+        'progress/setScriptProgress',
         'progress/mergePeerReviewProgress',
         'progress/setCurrentLessonId',
       ];


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/58269.  

This fixes an issue in the teacher panel when a teacher switches between viewing users with different amounts of progress in a Lab2 level.  The server response for level progress was being merged into the current state, but because we don't reload the whole page, switching to a user with less progress than the last user didn't remove any progress, leading to more green bubbles filled than should be.  

Now, this particular code path uses an optional parameter to skip the progress merge.

### Before

The green bubbles filled for a student's progress remain filled when switching back to the teacher.

https://github.com/code-dot-org/code-dot-org/assets/2205926/bd2d26c0-81a0-417e-bb7b-edfe01eae313

### After

Now, the green bubbles filled for a student's progress are cleared when switching back to the teacher.

https://github.com/code-dot-org/code-dot-org/assets/2205926/d95c82b4-dfbe-4cb4-9cbc-73d5be223dbc

