### PR TITLE
Music: update intro script

### DIFF
--- a/dashboard/config/levels/custom/panels/musiclab_intro_panels_end_2.level
+++ b/dashboard/config/levels/custom/panels/musiclab_intro_panels_end_2.level
@@ -8,19 +8,6 @@
   "properties": {
     "encrypted": "false",
     "background": "music-black",
-    "level_data": {
-      "panels": [
-        {
-          "imageUrl": "https://images.code.org/294f99cfd6e1d55a2738e91a71b53570-musiclab_intro_end_2.png",
-          "text": "#### You're good to go!\n\nYou've learned the basics, and now you're ready to make your own mix! Be sure to explore the sound library - there is a lot to explore and use to make an amazing track."
-        },
-        {
-          "imageUrl": "https://images.code.org/aa31c5258bbb31a623d50ba9482e6a00-musiclab_intro_end_1.png",
-          "text": "You'll see even more new things in the toolbox, including:\n\n- A beat-making block\n\n- Sound effects like reverb and filter\n\n- A synthesizer block\n\n- A block for randomizing what gets played\n\n- ...and more!\n\nHave fun!",
-          "nextUrl": "/projects/music/new"
-        }
-      ]
-    },
     "panels": [
       {
         "imageUrl": "https://images.code.org/bb54629c8b6c3c6fa6b90c44f9e9c675-additional.png",

--- a/dashboard/config/levels/custom/panels/musiclab_intro_panels_function_2.level
+++ b/dashboard/config/levels/custom/panels/musiclab_intro_panels_function_2.level
@@ -9,18 +9,6 @@
     "encrypted": "false",
     "background": "music-black",
     "skipUrl": "/projects/music/new",
-    "level_data": {
-      "panels": [
-        {
-          "imageUrl": "https://images.code.org/e8cf0ed0263af03d3bed73749081b995-musiclab_intro_function_0.png",
-          "text": "A cool feature in Project Beats is that you can take a set of blocks and put them into your own block.  In coding, this is called making a *function*."
-        },
-        {
-          "imageUrl": "https://images.code.org/79cffd279632872b91b162a1fe460e15-musiclab_intro_function_1.png",
-          "text": "You can \"call\" your new function by using the block with the matching name, like this."
-        }
-      ]
-    },
     "panels": [
       {
         "imageUrl": "https://images.code.org/b70f091d88e6fd1d9f5e426b17b41bb2-functions1.png",

--- a/dashboard/config/levels/custom/panels/musiclab_intro_panels_start_2.level
+++ b/dashboard/config/levels/custom/panels/musiclab_intro_panels_start_2.level
@@ -11,13 +11,13 @@
     "skipUrl": "/projects/music/new",
     "panels": [
       {
-        "imageUrl": "https://images.code.org/479f77ca07254e8eb3fa6db34d0a186e-musiclab-big-banner-lower2.png",
+        "imageUrl": "https://images.code.org/c8c3c26b77b465b56cda6cc14fa9e410-musiclab-big-banner-lower3.png",
         "text": "#### Welcome to Music Lab!\n\nMusic Lab lets you mix, remix, and even perform music using code. Don’t worry if you don’t know much about code, or even music! All you need is a little time and some curiosity to start making your own creations.",
         "key": "musiclab_intro_panels_start-421d64b2-c4db-42cb-ac1f-de66a4d22fa7"
       }
     ],
     "name_suffix": "_onboard"
   },
-  "audit_log": "[{\"changed_at\":\"2024-04-10T22:40:05.572+00:00\",\"changed\":[\"cloned from \\\"musiclab_intro_panels_start\\\"\"],\"cloned_from\":\"musiclab_intro_panels_start\"},{\"changed_at\":\"2024-04-10 22:50:48 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2024-04-18 03:12:31 +0000\",\"changed\":[\"name\"],\"changed_by_id\":574,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2024-04-30 18:30:29 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2024-05-13 19:29:44 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-13 21:21:57 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2024-04-10T22:40:05.572+00:00\",\"changed\":[\"cloned from \\\"musiclab_intro_panels_start\\\"\"],\"cloned_from\":\"musiclab_intro_panels_start\"},{\"changed_at\":\"2024-04-10 22:50:48 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2024-04-18 03:12:31 +0000\",\"changed\":[\"name\"],\"changed_by_id\":574,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2024-04-30 18:30:29 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2024-05-13 19:29:44 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-13 21:21:57 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-15 00:29:38 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"}]"
 }]]></config>
 </Panels>

--- a/dashboard/config/levels/custom/panels/musiclab_intro_panels_start_2.level
+++ b/dashboard/config/levels/custom/panels/musiclab_intro_panels_start_2.level
@@ -2,30 +2,22 @@
   <config><![CDATA[{
   "published": true,
   "game_id": 73,
-  "created_at": "2024-04-10T22:40:05.000Z",
+  "created_at": "2024-04-20T01:13:21.000Z",
   "level_num": "custom",
   "user_id": 1,
   "properties": {
     "encrypted": "false",
     "background": "music-black",
     "skipUrl": "/projects/music/new",
-    "level_data": {
-      "panels": [
-        {
-          "imageUrl": "https://studio.code.org/shared/images/teacher-announcement/incubator-projectbeats.png",
-          "text": "#### Welcome to Project Beats!\n\nProject Beats lets you mix, remix, and even perform music using code. Don’t worry if you don’t know much about code, or even music! All you need is a little time and some curiosity to start making your own creations."
-        }
-      ]
-    },
     "panels": [
       {
-        "imageUrl": "https://images.code.org/9816fd1e1c94dcc62a6d04fa4d040a79-Music Lab Callout Graphic.png",
+        "imageUrl": "https://images.code.org/a412b8e703919b039c34e2199ef3c9df-musiclab-big-banner-lower.png",
         "text": "#### Welcome to Music Lab!\n\nMusic Lab lets you mix, remix, and even perform music using code. Don’t worry if you don’t know much about code, or even music! All you need is a little time and some curiosity to start making your own creations.",
         "key": "musiclab_intro_panels_start-421d64b2-c4db-42cb-ac1f-de66a4d22fa7"
       }
     ],
     "name_suffix": "_onboard"
   },
-  "audit_log": "[{\"changed_at\":\"2024-04-10T22:40:05.572+00:00\",\"changed\":[\"cloned from \\\"musiclab_intro_panels_start\\\"\"],\"cloned_from\":\"musiclab_intro_panels_start\"},{\"changed_at\":\"2024-04-10 22:50:48 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2024-04-18 03:12:31 +0000\",\"changed\":[\"name\"],\"changed_by_id\":574,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2024-04-30 18:30:29 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2024-04-10T22:40:05.572+00:00\",\"changed\":[\"cloned from \\\"musiclab_intro_panels_start\\\"\"],\"cloned_from\":\"musiclab_intro_panels_start\"},{\"changed_at\":\"2024-04-10 22:50:48 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2024-04-18 03:12:31 +0000\",\"changed\":[\"name\"],\"changed_by_id\":574,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2024-04-30 18:30:29 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2024-05-13 19:29:44 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"}]"
 }]]></config>
 </Panels>

--- a/dashboard/config/levels/custom/panels/musiclab_intro_panels_start_2.level
+++ b/dashboard/config/levels/custom/panels/musiclab_intro_panels_start_2.level
@@ -11,13 +11,13 @@
     "skipUrl": "/projects/music/new",
     "panels": [
       {
-        "imageUrl": "https://images.code.org/a412b8e703919b039c34e2199ef3c9df-musiclab-big-banner-lower.png",
+        "imageUrl": "https://images.code.org/479f77ca07254e8eb3fa6db34d0a186e-musiclab-big-banner-lower2.png",
         "text": "#### Welcome to Music Lab!\n\nMusic Lab lets you mix, remix, and even perform music using code. Don’t worry if you don’t know much about code, or even music! All you need is a little time and some curiosity to start making your own creations.",
         "key": "musiclab_intro_panels_start-421d64b2-c4db-42cb-ac1f-de66a4d22fa7"
       }
     ],
     "name_suffix": "_onboard"
   },
-  "audit_log": "[{\"changed_at\":\"2024-04-10T22:40:05.572+00:00\",\"changed\":[\"cloned from \\\"musiclab_intro_panels_start\\\"\"],\"cloned_from\":\"musiclab_intro_panels_start\"},{\"changed_at\":\"2024-04-10 22:50:48 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2024-04-18 03:12:31 +0000\",\"changed\":[\"name\"],\"changed_by_id\":574,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2024-04-30 18:30:29 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2024-05-13 19:29:44 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2024-04-10T22:40:05.572+00:00\",\"changed\":[\"cloned from \\\"musiclab_intro_panels_start\\\"\"],\"cloned_from\":\"musiclab_intro_panels_start\"},{\"changed_at\":\"2024-04-10 22:50:48 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2024-04-18 03:12:31 +0000\",\"changed\":[\"name\"],\"changed_by_id\":574,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2024-04-30 18:30:29 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":976,\"changed_by_email\":\"michael@code.org\"},{\"changed_at\":\"2024-05-13 19:29:44 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-13 21:21:57 +0000\",\"changed\":[\"panels\"],\"changed_by_id\":1,\"changed_by_email\":\"brendan+levelbuilder@code.org\"}]"
 }]]></config>
 </Panels>

--- a/dashboard/config/scripts_json/music-intro-2024.script_json
+++ b/dashboard/config/scripts_json/music-intro-2024.script_json
@@ -11,7 +11,7 @@
     "new_name": null,
     "family_name": "music-intro",
     "serialized_at": "2024-05-13 09:12:22 UTC",
-    "published_state": "stable",
+    "published_state": "beta",
     "instruction_type": "self_paced",
     "instructor_audience": "teacher",
     "participant_audience": "student",

--- a/dashboard/config/scripts_json/music-intro-2024.script_json
+++ b/dashboard/config/scripts_json/music-intro-2024.script_json
@@ -10,8 +10,8 @@
     },
     "new_name": null,
     "family_name": "music-intro",
-    "serialized_at": "2024-02-15 22:58:00 UTC",
-    "published_state": "beta",
+    "serialized_at": "2024-05-13 09:12:22 UTC",
+    "published_state": "stable",
     "instruction_type": "self_paced",
     "instructor_audience": "teacher",
     "participant_audience": "student",
@@ -172,15 +172,12 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "musiclab_intro_panels_start"
-        ],
         "progression": "Intro"
       },
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "musiclab_intro_panels_start"
+          "musiclab_intro_panels_start_2"
         ],
         "lesson.key": "Music Lab introduction",
         "lesson_group.key": "",
@@ -188,7 +185,7 @@
         "activity_section.key": "7cd580e8-2712-436c-b0ac-50a2b299722d"
       },
       "level_keys": [
-        "musiclab_intro_panels_start"
+        "musiclab_intro_panels_start_2"
       ]
     },
     {
@@ -297,15 +294,12 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "musiclab_intro_panels_function"
-        ],
         "progression": "Functions"
       },
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "musiclab_intro_panels_function"
+          "musiclab_intro_panels_function_2"
         ],
         "lesson.key": "Music Lab introduction",
         "lesson_group.key": "",
@@ -313,7 +307,7 @@
         "activity_section.key": "9895cbc4-dab4-467d-99cb-6670db634a63"
       },
       "level_keys": [
-        "musiclab_intro_panels_function"
+        "musiclab_intro_panels_function_2"
       ]
     },
     {
@@ -372,15 +366,12 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "musiclab_intro_panels_end"
-        ],
         "progression": "Outro"
       },
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "musiclab_intro_panels_end"
+          "musiclab_intro_panels_end_2"
         ],
         "lesson.key": "Music Lab introduction",
         "lesson_group.key": "",
@@ -388,16 +379,16 @@
         "activity_section.key": "5f0a9dec-52d3-466e-b76b-e4a921b23a10"
       },
       "level_keys": [
-        "musiclab_intro_panels_end"
+        "musiclab_intro_panels_end_2"
       ]
     }
   ],
   "levels_script_levels": [
     {
       "seeding_key": {
-        "level.key": "musiclab_intro_panels_start",
+        "level.key": "musiclab_intro_panels_start_2",
         "script_level.level_keys": [
-          "musiclab_intro_panels_start"
+          "musiclab_intro_panels_start_2"
         ],
         "lesson.key": "Music Lab introduction",
         "lesson_group.key": "",
@@ -455,9 +446,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "musiclab_intro_panels_function",
+        "level.key": "musiclab_intro_panels_function_2",
         "script_level.level_keys": [
-          "musiclab_intro_panels_function"
+          "musiclab_intro_panels_function_2"
         ],
         "lesson.key": "Music Lab introduction",
         "lesson_group.key": "",
@@ -491,9 +482,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "musiclab_intro_panels_end",
+        "level.key": "musiclab_intro_panels_end_2",
         "script_level.level_keys": [
-          "musiclab_intro_panels_end"
+          "musiclab_intro_panels_end_2"
         ],
         "lesson.key": "Music Lab introduction",
         "lesson_group.key": "",


### PR DESCRIPTION
This updates the `/s/music-intro-2024` script to get three new panels levels that mention "Music Lab" rather than "Project Beats".  

These levels have already been translated by virtue of being in the internal `/s/music-onboard` script, and I've locally verified that swapping them in gets us those translations.

One image has been updated, and `level_data` properties that are no longer used have been removed.

This leaves the `published_state` of `/s/music-intro-2024` as `"beta"` since we don't want it to be listed in the curriculum catalog.