### PR TITLE
[Google Blockly] update field-bitmap plugin

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -176,7 +176,7 @@
     "@amplitude/analytics-browser": "^1.5.4",
     "@blockly/block-shareable-procedures": "~4.0.5",
     "@blockly/field-angle": "^4.0.0",
-    "@blockly/field-bitmap": "^4.0.15",
+    "@blockly/field-bitmap": "^4.0.18",
     "@blockly/field-colour": "^4.0.0",
     "@blockly/field-grid-dropdown": "~4.0.9",
     "@blockly/keyboard-navigation": "~0.5.6",

--- a/apps/package.json
+++ b/apps/package.json
@@ -176,7 +176,7 @@
     "@amplitude/analytics-browser": "^1.5.4",
     "@blockly/block-shareable-procedures": "~4.0.5",
     "@blockly/field-angle": "^4.0.0",
-    "@blockly/field-bitmap": "^4.0.13",
+    "@blockly/field-bitmap": "^4.0.15",
     "@blockly/field-colour": "^4.0.0",
     "@blockly/field-grid-dropdown": "~4.0.9",
     "@blockly/keyboard-navigation": "~0.5.6",

--- a/apps/src/blockly/addons/cdoFieldBitmap.ts
+++ b/apps/src/blockly/addons/cdoFieldBitmap.ts
@@ -61,11 +61,11 @@ export class CdoFieldBitmap extends FieldBitmap {
    * @override
    */
   initView() {
-    this.blockDisplayPixels_ = [];
-    this.pixelSize = FIELD_HEIGHT / this.imgHeight_;
-    for (let r = 0; r < this.imgHeight_; r++) {
+    this.blockDisplayPixels = [];
+    this.pixelSize = FIELD_HEIGHT / this.imgHeight;
+    for (let r = 0; r < this.imgHeight; r++) {
       const row = [];
-      for (let c = 0; c < this.imgWidth_; c++) {
+      for (let c = 0; c < this.imgWidth; c++) {
         const square = Blockly.utils.dom.createSvgElement(
           'rect',
           {
@@ -80,7 +80,7 @@ export class CdoFieldBitmap extends FieldBitmap {
         );
         row.push(square);
       }
-      this.blockDisplayPixels_.push(row);
+      this.blockDisplayPixels.push(row);
     }
   }
 
@@ -95,7 +95,7 @@ export class CdoFieldBitmap extends FieldBitmap {
    */
   protected updateSize_() {
     {
-      const newWidth = this.pixelSize * this.imgWidth_;
+      const newWidth = this.pixelSize * this.imgWidth;
       if (this.borderRect_) {
         this.borderRect_.setAttribute('width', String(newWidth));
         this.borderRect_.setAttribute('height', String(FIELD_HEIGHT));

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3042,7 +3042,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@blockly/field-bitmap@npm:^4.0.15":
+"@blockly/field-bitmap@npm:^4.0.18":
   version: 4.0.18
   resolution: "@blockly/field-bitmap@npm:4.0.18"
   peerDependencies:
@@ -8041,7 +8041,7 @@ __metadata:
     "@babel/preset-react": ^7.24.1
     "@blockly/block-shareable-procedures": ~4.0.5
     "@blockly/field-angle": ^4.0.0
-    "@blockly/field-bitmap": ^4.0.15
+    "@blockly/field-bitmap": ^4.0.18
     "@blockly/field-colour": ^4.0.0
     "@blockly/field-grid-dropdown": ~4.0.9
     "@blockly/keyboard-navigation": ~0.5.6

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3042,12 +3042,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@blockly/field-bitmap@npm:^4.0.13":
-  version: 4.0.13
-  resolution: "@blockly/field-bitmap@npm:4.0.13"
+"@blockly/field-bitmap@npm:^4.0.15":
+  version: 4.0.18
+  resolution: "@blockly/field-bitmap@npm:4.0.18"
   peerDependencies:
     blockly: ^10.0.0
-  checksum: e66329f66b4f53024143b1570c788bab8e8d50360aa23e8e67f2132134fc36afaf70d4a1169dfb2bcd693b3be144f3361164b42a345ac1d4a26f1e845dac2466
+  checksum: 1e03b7bdd775479893959eee2b4a9aa65982cb4278658c6be3f29592367edcd9ed2a6339ce927683a0ab014ddea37a58e59a00e7933cefe900dfc57e26d6c7a4
   languageName: node
   linkType: hard
 
@@ -8041,7 +8041,7 @@ __metadata:
     "@babel/preset-react": ^7.24.1
     "@blockly/block-shareable-procedures": ~4.0.5
     "@blockly/field-angle": ^4.0.0
-    "@blockly/field-bitmap": ^4.0.13
+    "@blockly/field-bitmap": ^4.0.15
     "@blockly/field-colour": ^4.0.0
     "@blockly/field-grid-dropdown": ~4.0.9
     "@blockly/keyboard-navigation": ~0.5.6


### PR DESCRIPTION
On Friday, @onlinecsteacher reported a problem with a Sprite Lab level that seemed to be related to both validation code and unknown blocks: https://codedotorg.slack.com/archives/C05DMS18MEX/p1715362055216119

There were actually two unrelated bugs. First, a bug in a helper library was causing a levelbuilder drawing util to work improperly with 10 or more sprites. This code was originally authored on levelbuilder (by a former curriculum writer/current engineer), so I fixed it there.

The second bug was occurring when any of the new bitmap field blocks were set to "uneditable" using levelbuilder. This bug was located in the plugin source code. When `updateEditable` was called, some classes were changed on the block's svg rout, without any explicit check that the svg root existed. Because we convert our XML sources to JSON on a headless workspace, there was no svg. We would then catch this error and create the unknown block instead. Fortunately, this issue has already been fixed by a recent conversion to TypeScript:

Before: 
- https://github.com/google/blockly-samples/pull/2227/files#diff-6efe4a532d5c234a731eda77ea75231b966df4491f5312c4b99085e60e923a83L216-L217 (Load diff for deleted file then look at lines 216-217)
After:
- https://github.com/google/blockly-samples/pull/2227/files#diff-0f1f105a291bdfc437c7719119011212d9adf37d942efa05c54f2a3b4a0ad570R212-R215

For us to fix this, we just need to update the plugin version we are using and rename a couple of properties.

## Links

Jira: https://codedotorg.atlassian.net/browse/CT-572

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I manually tested that it's now possible to toggle the editable state of these blocks and load them onto a headless workspace. 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
