### PR TITLE
Possible fix to flaky application_detail_view.feature test

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
@@ -9,6 +9,7 @@ Feature: Teacher Application Detail View
 
     Then I click selector "table#summary-csp-teachers ~ .btn:contains(View all applications)"
     Then I wait until element "#status-filter" is visible
+    And I wait for 3 seconds
     Then I click selector "button:contains('Make not required')"
     And I wait until element "button:contains('Make required')" is visible
 

--- a/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
@@ -9,7 +9,7 @@ Feature: Teacher Application Detail View
 
     Then I click selector "table#summary-csp-teachers ~ .btn:contains(View all applications)"
     Then I wait until element "#status-filter" is visible
-    And I wait for 3 seconds
+    And I wait until element "button:contains('Make not required')" is visible
     Then I click selector "button:contains('Make not required')"
     And I wait until element "button:contains('Make required')" is visible
 


### PR DESCRIPTION
Adds wait time to the `application_detail_view.feature` test to potentially fix flakiness seen [here](https://cucumber-logs.s3.amazonaws.com/test/test/Safari_acquisition_products_pd_application_detail_view_output.html?versionId=nOjz6S9oaCXKkJr4FhB4ttcOf7f7Mh3p).

## Links
Jira ticket: [ACQ-1818](https://codedotorg.atlassian.net/browse/ACQ-1818)
Most recent Slack convo: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1715617287413969)

## Testing story
Tested locally on Sauce Labs