### PR TITLE
Music: fix drums and notes previews not playing

### DIFF
--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -205,7 +205,7 @@ class ToneJSPlayer implements AudioPlayer {
 
     await this.startContextIfNeeded();
     events.forEach(({notes, playbackPosition}) => {
-      this.samplers[instrument][EMPTY_EFFECTS_KEY].triggerAttack(
+      this.samplers[instrument][EMPTY_EFFECTS_KEY].unsync().triggerAttack(
         notes,
         `+${Transport.toSeconds(
           this.playbackTimeToTransportTime(playbackPosition)


### PR DESCRIPTION
Fix for an issue where, after running the project and playing the song a few times, drums/notes previews would sometimes not play. The issue seemed to be that samplers were still `sync`ed to the transport, so the fix is just to `unsync` from the transport whenever playing previews.

(Note that this does not solve the preview bar speeding up issue. Opened https://codedotorg.atlassian.net/browse/LABS-789 to track and fix that separately).

## Links

https://codedotorg.atlassian.net/browse/LABS-769

## Testing story

Tested with standalone projects with a variety of drum and notes blocks.