### PR TITLE
[ProgressV2] Fix bug where modal was not sending amplitude metrics

### DIFF
--- a/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
+++ b/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
@@ -7,7 +7,6 @@ import Button from '@cdo/apps/componentLibrary/button/Button';
 import {Heading2, BodyTwoText} from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
 import {default as LinkedButton} from '@cdo/apps/templates/Button';
 import {
@@ -25,6 +24,7 @@ const MILLISECONDS_IN_ONE_DAY = 1000 * 3600 * 24;
 
 function InviteToV2ProgressModal({
   sectionId,
+  onShowProgressTableV2Change,
 
   // from redux
   dateProgressTableInvitationDelayed,
@@ -91,9 +91,14 @@ function InviteToV2ProgressModal({
     });
     setHasSeenProgressTableInviteData();
     setHasSeenProgressTableInvite(true);
-    new UserPreferences().setShowProgressTableV2(true);
+    onShowProgressTableV2Change();
     setShowProgressTableV2(true);
-  }, [sectionId, setHasSeenProgressTableInvite, setShowProgressTableV2]);
+  }, [
+    sectionId,
+    setHasSeenProgressTableInvite,
+    setShowProgressTableV2,
+    onShowProgressTableV2Change,
+  ]);
 
   const handleDelayInvitation = React.useCallback(() => {
     analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_DELAY_INVITATION, {
@@ -165,6 +170,7 @@ function InviteToV2ProgressModal({
 InviteToV2ProgressModal.propTypes = {
   setHasSeenProgressTableInvite: PropTypes.func.isRequired,
   sectionId: PropTypes.number,
+  onShowProgressTableV2Change: PropTypes.func.isRequired,
   dateProgressTableInvitationDelayed: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -102,7 +102,10 @@ function SectionProgressSelector({
         <SectionProgressV2 />
       ) : (
         <>
-          <InviteToV2ProgressModal sectionId={sectionId} />
+          <InviteToV2ProgressModal
+            sectionId={sectionId}
+            onShowProgressTableV2Change={onShowProgressTableV2Change}
+          />
           <SectionProgress allowUserToSelectV2View={true} />
         </>
       )}

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -28,26 +28,22 @@ function SectionProgressSelector({
 }) {
   const [toggleUsed, setToggleUsed] = React.useState(false);
 
-  const onShowProgressTableV2Change = useCallback(
-    e => {
-      e.preventDefault();
-      const shouldShowV2 = !showProgressTableV2;
-      new UserPreferences().setShowProgressTableV2(shouldShowV2);
-      setShowProgressTableV2(shouldShowV2);
-      setToggleUsed(true);
+  const onShowProgressTableV2Change = useCallback(() => {
+    const shouldShowV2 = !showProgressTableV2;
+    new UserPreferences().setShowProgressTableV2(shouldShowV2);
+    setShowProgressTableV2(shouldShowV2);
+    setToggleUsed(true);
 
-      if (shouldShowV2) {
-        analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW_NEW_PROGRESS, {
-          sectionId: sectionId,
-        });
-      } else {
-        analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW_OLD_PROGRESS, {
-          sectionId: sectionId,
-        });
-      }
-    },
-    [showProgressTableV2, setShowProgressTableV2, sectionId]
-  );
+    if (shouldShowV2) {
+      analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW_NEW_PROGRESS, {
+        sectionId: sectionId,
+      });
+    } else {
+      analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW_OLD_PROGRESS, {
+        sectionId: sectionId,
+      });
+    }
+  }, [showProgressTableV2, setShowProgressTableV2, sectionId]);
 
   const debouncedOnShowProgressTableV2Change = _.debounce(
     onShowProgressTableV2Change,
@@ -56,6 +52,15 @@ function SectionProgressSelector({
       leading: true,
       trailing: false,
     }
+  );
+
+  const onToggleClick = useCallback(
+    e => {
+      e.preventDefault();
+
+      debouncedOnShowProgressTableV2Change();
+    },
+    [debouncedOnShowProgressTableV2Change]
   );
 
   // If progress table is disabled, only show the v1 table.
@@ -83,7 +88,7 @@ function SectionProgressSelector({
       <Link
         type="primary"
         size="s"
-        onClick={debouncedOnShowProgressTableV2Change}
+        onClick={onToggleClick}
         id="ui-test-toggle-progress-view"
       >
         {displayV2
@@ -104,7 +109,7 @@ function SectionProgressSelector({
         <>
           <InviteToV2ProgressModal
             sectionId={sectionId}
-            onShowProgressTableV2Change={onShowProgressTableV2Change}
+            onShowProgressTableV2Change={debouncedOnShowProgressTableV2Change}
           />
           <SectionProgress allowUserToSelectV2View={true} />
         </>

--- a/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
@@ -15,7 +15,7 @@ const DEFAULT_PROPS = {
   setDateProgressTableInvitationDelayed: () => {},
 };
 
-describe('UnconnectedInviteToV2ProgressModal', () => {
+describe('InviteToV2ProgressModal', () => {
   let postStub;
 
   beforeEach(() => {

--- a/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
@@ -9,6 +9,7 @@ import i18n from '@cdo/locale';
 import {expect} from '../../../util/reconfiguredChai';
 
 const DEFAULT_PROPS = {
+  onShowProgressTableV2Change: () => {},
   setShowProgressTableV2: () => {},
   setHasSeenProgressTableInvite: () => {},
   setDateProgressTableInvitationDelayed: () => {},
@@ -49,8 +50,10 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
   it('allows user to accept the invitation', () => {
     const setShowProgressTableV2Stub = sinon.stub();
     const setHasSeenProgressTableInviteStub = sinon.stub();
+    const onShowProgressTableV2ChangeStub = sinon.stub();
 
     renderDefault({
+      onShowProgressTableV2Change: onShowProgressTableV2ChangeStub,
       setShowProgressTableV2: setShowProgressTableV2Stub,
       setHasSeenProgressTableInvite: setHasSeenProgressTableInviteStub,
       hasSeenProgressTableInvite: false,
@@ -64,9 +67,7 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
     expect(setHasSeenProgressTableInviteStub).to.have.been.calledOnce;
     expect(setShowProgressTableV2Stub).to.have.been.calledOnce;
 
-    expect(postStub).calledWith('/api/v1/users/show_progress_table_v2', {
-      show_progress_table_v2: true,
-    });
+    expect(onShowProgressTableV2ChangeStub).to.have.been.calledOnce;
     expect(postStub).calledWith(
       '/api/v1/users/has_seen_progress_table_v2_invitation',
       {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fixes a bug where the invitation modal was not:
* Sending an amplitude metric
* Showing the feedback banner instead of the coming soon banner.
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
