### PR TITLE
Music: Include Music Lab in project create menus

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2140,7 +2140,7 @@
   "projectTypeMinecraftAquatic": "Minecraft Aquatic",
   "projectTypeMinecraftDesigner": "Minecraft Designer",
   "projectTypeMinecraftHero": "Minecraft Hero",
-  "projectTypeMusic": "Project Beats",
+  "projectTypeMusic": "Music Lab",
   "projectTypePlaylab": "Play Lab",
   "projectTypePlaylabPreReader": "Play Lab (Pre-reader)",
   "projectTypePoetry": "Poetry",

--- a/apps/src/templates/projects/NewProjectButtons.jsx
+++ b/apps/src/templates/projects/NewProjectButtons.jsx
@@ -117,6 +117,10 @@ const PROJECT_INFO = {
     label: i18n.projectTypePoetry(),
     thumbnail: '/shared/images/fill-70x70/courses/logo_poetry.png',
   },
+  music: {
+    label: i18n.projectTypeMusic(),
+    thumbnail: '/shared/images/fill-70x70/courses/logo_music.png',
+  },
 };
 
 const TILES_PER_ROW = 4;

--- a/apps/src/templates/projects/NewProjectButtons.jsx
+++ b/apps/src/templates/projects/NewProjectButtons.jsx
@@ -120,6 +120,7 @@ const PROJECT_INFO = {
   music: {
     label: i18n.projectTypeMusic(),
     thumbnail: '/shared/images/fill-70x70/courses/logo_music.png',
+    urlOverride: '/s/music-intro-2024/reset',
   },
 };
 
@@ -143,7 +144,13 @@ class NewProjectButtons extends React.Component {
           (projectTypesRow, rowIndex) => (
             <div style={styles.row} key={rowIndex}>
               {projectTypesRow.map((projectType, index) => (
-                <a key={index} href={'/projects/' + projectType + '/new'}>
+                <a
+                  key={index}
+                  href={
+                    PROJECT_INFO[projectType].urlOverride ||
+                    '/projects/' + projectType + '/new'
+                  }
+                >
                   <div
                     className="newProject-button-tile"
                     style={[

--- a/apps/src/templates/projects/StartNewProject.jsx
+++ b/apps/src/templates/projects/StartNewProject.jsx
@@ -50,7 +50,7 @@ export default class StartNewProject extends React.Component {
       ? DEFAULT_PROJECT_TYPES_ADVANCED
       : DEFAULT_PROJECT_TYPES_BASIC;
 
-    const OPEN_ENDED_PROJECT_TYPES = ['spritelab', 'dance', 'poetry'];
+    const OPEN_ENDED_PROJECT_TYPES = ['spritelab', 'dance', 'poetry', 'music'];
 
     const DRAWING_PROJECT_TYPES = ['artist', 'frozen'];
 

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -463,7 +463,7 @@ en:
       minecraft_codebuilder: 'Minecraft: Code Connection'
       minecraft_designer: 'Minecraft'
       minecraft_hero: 'Minecraft Hero'
-      music: 'Project Beats'
+      music: 'Music Lab'
       playlab: 'Play Lab'
       playlab_k1: 'Play Lab (Pre-reader)'
       poetry: 'Poetry'

--- a/lib/cdo/create_header.rb
+++ b/lib/cdo/create_header.rb
@@ -31,6 +31,9 @@ class CreateHeader
     poetry_hoc: {
       image: "logo_poetry.png"
     },
+    music: {
+      url: CDO.studio_url("/s/music-intro-2024/reset")
+    },
   }.freeze
 
   # project info data can be inferred from the key, except when otherwise

--- a/lib/cdo/create_header.rb
+++ b/lib/cdo/create_header.rb
@@ -56,6 +56,7 @@ class CreateHeader
       everyone_entries + applab_gamelab
 
     entries << "dance"
+    entries << "music"
 
     if options[:project_type] && !(entries.include? options[:project_type])
       entries.unshift(options[:project_type])

--- a/shared/images/courses/logo_music.png
+++ b/shared/images/courses/logo_music.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8f92a6ba2fe78958c16e22ff41b85a6c4d33d1c31195a41e17c27971722f8a8c
-size 393632
+oid sha256:4482ee013e578aef8910d6ec99983fa85634977750449c7234ab3a6b0f70fdbc
+size 10352


### PR DESCRIPTION
Add Music Lab to the create menu in the top right.
Add Music Lab to the create UI on the /projects page.

Unlike other project types, new project for music lab points to `/s/music-intro-2024/reset` to guide the user through the intro progression before dumping them into an empty project.

This also has a side effect of changing the label for music lab projects to Music Lab from Project Beats.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[LABS-634 [Anyone] Rename effects dropdown labels](https://codedotorg.atlassian.net/browse/LABS-634)

## Testing story

Tested locally that create menu looks and works as expected.
Tested that other project types still have correct create links.

![image](https://github.com/code-dot-org/code-dot-org/assets/24951544/b68e768b-4718-4369-8ac9-5d4bcf7edd7f)

![image](https://github.com/code-dot-org/code-dot-org/assets/24951544/0b32f2fc-ffcf-4f5b-bb17-cd5d7b9df9cc)
