### PR TITLE
Direct Redshift Notifications to `#data-alerts` Slack Channel

### DIFF
--- a/bin/cron/export_mysql_database_to_redshift
+++ b/bin/cron/export_mysql_database_to_redshift
@@ -17,7 +17,7 @@ DAILY_TASK_MAX_EXECUTION_TIME = 16.hours
 # As of early 2020, the Task that exports 'level_sources' takes about 30 hours to complete.
 WEEKLY_TASK_MAX_EXECUTION_TIME = 40.hours
 # We want to notify the RED team about the export status.
-NOTIFICATION_CHANNEL = 'ask-data'
+NOTIFICATION_CHANNEL = 'data-alerts'
 
 def main
   ChatClient.message NOTIFICATION_CHANNEL, 'Beginning daily export from Aurora MySQL database to Redshift.'


### PR DESCRIPTION
The RED team has settled this on the channel they'd like to use for automated notifications. See [slack
thread](https://codedotorg.slack.com/archives/C0SUN2W3D/p1715628737726949?thread_ts=1715368244.381839&cid=C0SUN2W3D) for more context