### PR TITLE
Ensures that a user who has already seen the V2 version will not get the pop-up

### DIFF
--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -230,6 +230,7 @@ export default function currentUser(state = initialState, action) {
       date_progress_table_invitation_last_delayed,
       has_seen_progress_table_v2_invitation,
       child_account_compliance_state,
+      progress_table_v2_timestamp,
     } = action.serverUser;
     analyticsReport.setUserProperties(
       id,
@@ -262,6 +263,7 @@ export default function currentUser(state = initialState, action) {
         date_progress_table_invitation_last_delayed,
       hasSeenProgressTableInvite: has_seen_progress_table_v2_invitation,
       childAccountComplianceState: child_account_compliance_state,
+      progressTableV2Timestamp: progress_table_v2_timestamp,
     };
   }
 

--- a/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
+++ b/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
@@ -32,13 +32,15 @@ function InviteToV2ProgressModal({
   setHasSeenProgressTableInvite,
   setShowProgressTableV2,
   setDateProgressTableInvitationDelayed,
+  showProgressTableV2,
 }) {
   const [invitationOpen, setInvitationOpen] = React.useState(false);
 
   React.useEffect(() => {
     if (
       dateProgressTableInvitationDelayed === undefined ||
-      hasSeenProgressTableInvite === undefined
+      hasSeenProgressTableInvite === undefined ||
+      showProgressTableV2 === undefined
     ) {
       // Do not proceed if data has not been fully loaded.
       return;
@@ -55,7 +57,8 @@ function InviteToV2ProgressModal({
 
     const showInvitation = () => {
       const alreadyViewedInvitation = !!hasSeenProgressTableInvite;
-      if (alreadyViewedInvitation) {
+      const alreadyViewedV2Dashboard = showProgressTableV2 !== null;
+      if (alreadyViewedV2Dashboard || alreadyViewedInvitation) {
         return false;
       } else {
         if (!!dateProgressTableInvitationDelayed) {
@@ -67,7 +70,11 @@ function InviteToV2ProgressModal({
     };
 
     setInvitationOpen(showInvitation());
-  }, [dateProgressTableInvitationDelayed, hasSeenProgressTableInvite]);
+  }, [
+    dateProgressTableInvitationDelayed,
+    hasSeenProgressTableInvite,
+    showProgressTableV2,
+  ]);
 
   const handleModalClose = React.useCallback(() => {
     analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_SEEN_INVITATION, {
@@ -173,6 +180,7 @@ InviteToV2ProgressModal.propTypes = {
   hasSeenProgressTableInvite: PropTypes.bool,
   setDateProgressTableInvitationDelayed: PropTypes.func.isRequired,
   setShowProgressTableV2: PropTypes.func.isRequired,
+  showProgressTableV2: PropTypes.bool,
 };
 
 export const UnconnectedInviteToV2ProgressModal = InviteToV2ProgressModal;
@@ -182,6 +190,7 @@ export default connect(
     dateProgressTableInvitationDelayed:
       state.currentUser.dateProgressTableInvitationDelayed,
     hasSeenProgressTableInvite: state.currentUser.hasSeenProgressTableInvite,
+    showProgressTableV2: state.currentUser.showProgressTableV2,
   }),
   dispatch => ({
     setHasSeenProgressTableInvite: hasSeenProgressTableInvite =>

--- a/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
+++ b/apps/src/templates/sectionProgressV2/InviteToV2ProgressModal.jsx
@@ -32,7 +32,7 @@ function InviteToV2ProgressModal({
   setHasSeenProgressTableInvite,
   setShowProgressTableV2,
   setDateProgressTableInvitationDelayed,
-  showProgressTableV2,
+  progressTableV2Timestamp,
 }) {
   const [invitationOpen, setInvitationOpen] = React.useState(false);
 
@@ -40,7 +40,7 @@ function InviteToV2ProgressModal({
     if (
       dateProgressTableInvitationDelayed === undefined ||
       hasSeenProgressTableInvite === undefined ||
-      showProgressTableV2 === undefined
+      progressTableV2Timestamp === undefined
     ) {
       // Do not proceed if data has not been fully loaded.
       return;
@@ -57,7 +57,7 @@ function InviteToV2ProgressModal({
 
     const showInvitation = () => {
       const alreadyViewedInvitation = !!hasSeenProgressTableInvite;
-      const alreadyViewedV2Dashboard = showProgressTableV2 !== null;
+      const alreadyViewedV2Dashboard = progressTableV2Timestamp !== null;
       if (alreadyViewedV2Dashboard || alreadyViewedInvitation) {
         return false;
       } else {
@@ -73,7 +73,7 @@ function InviteToV2ProgressModal({
   }, [
     dateProgressTableInvitationDelayed,
     hasSeenProgressTableInvite,
-    showProgressTableV2,
+    progressTableV2Timestamp,
   ]);
 
   const handleModalClose = React.useCallback(() => {
@@ -180,7 +180,7 @@ InviteToV2ProgressModal.propTypes = {
   hasSeenProgressTableInvite: PropTypes.bool,
   setDateProgressTableInvitationDelayed: PropTypes.func.isRequired,
   setShowProgressTableV2: PropTypes.func.isRequired,
-  showProgressTableV2: PropTypes.bool,
+  progressTableV2Timestamp: PropTypes.string,
 };
 
 export const UnconnectedInviteToV2ProgressModal = InviteToV2ProgressModal;
@@ -190,7 +190,7 @@ export default connect(
     dateProgressTableInvitationDelayed:
       state.currentUser.dateProgressTableInvitationDelayed,
     hasSeenProgressTableInvite: state.currentUser.hasSeenProgressTableInvite,
-    showProgressTableV2: state.currentUser.showProgressTableV2,
+    progressTableV2Timestamp: state.currentUser.progressTableV2Timestamp,
   }),
   dispatch => ({
     setHasSeenProgressTableInvite: hasSeenProgressTableInvite =>

--- a/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
@@ -56,7 +56,6 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
       setHasSeenProgressTableInvite: setHasSeenProgressTableInviteStub,
       hasSeenProgressTableInvite: false,
       dateProgressTableInvitationDelayed: null,
-      showProgressTableV2: null,
     });
 
     screen.getByText(i18n.progressTrackingAnnouncement());

--- a/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
@@ -12,7 +12,7 @@ const DEFAULT_PROPS = {
   setShowProgressTableV2: () => {},
   setHasSeenProgressTableInvite: () => {},
   setDateProgressTableInvitationDelayed: () => {},
-  showProgressTableV2: null,
+  progressTableV2Timestamp: null,
 };
 
 describe('UnconnectedInviteToV2ProgressModal', () => {
@@ -170,17 +170,7 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
 
   it('does not show the dialog if the user has already seen the V2 dashboard', () => {
     renderDefault({
-      showProgressTableV2: false,
-    });
-
-    expect(screen.queryByText(i18n.tryItNow())).to.be.null;
-    expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.be.null;
-    expect(screen.queryByText(i18n.remindMeLater())).to.be.null;
-  });
-
-  it('does not show the dialog if the user has already seen the V2 dashboard', () => {
-    renderDefault({
-      showProgressTableV2: true,
+      progressTableV2Timestamp: '2024-05-14T10:02:53.194-05:00',
     });
 
     expect(screen.queryByText(i18n.tryItNow())).to.be.null;

--- a/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/InviteToV2ProgressModalTest.jsx
@@ -12,6 +12,7 @@ const DEFAULT_PROPS = {
   setShowProgressTableV2: () => {},
   setHasSeenProgressTableInvite: () => {},
   setDateProgressTableInvitationDelayed: () => {},
+  showProgressTableV2: null,
 };
 
 describe('UnconnectedInviteToV2ProgressModal', () => {
@@ -55,6 +56,7 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
       setHasSeenProgressTableInvite: setHasSeenProgressTableInviteStub,
       hasSeenProgressTableInvite: false,
       dateProgressTableInvitationDelayed: null,
+      showProgressTableV2: null,
     });
 
     screen.getByText(i18n.progressTrackingAnnouncement());
@@ -160,6 +162,26 @@ describe('UnconnectedInviteToV2ProgressModal', () => {
     renderDefault({
       dateProgressTableInvitationDelayed: yesterday,
       hasSeenProgressTableInvite: false,
+    });
+
+    expect(screen.queryByText(i18n.tryItNow())).to.be.null;
+    expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.be.null;
+    expect(screen.queryByText(i18n.remindMeLater())).to.be.null;
+  });
+
+  it('does not show the dialog if the user has already seen the V2 dashboard', () => {
+    renderDefault({
+      showProgressTableV2: false,
+    });
+
+    expect(screen.queryByText(i18n.tryItNow())).to.be.null;
+    expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.be.null;
+    expect(screen.queryByText(i18n.remindMeLater())).to.be.null;
+  });
+
+  it('does not show the dialog if the user has already seen the V2 dashboard', () => {
+    renderDefault({
+      showProgressTableV2: true,
     });
 
     expect(screen.queryByText(i18n.tryItNow())).to.be.null;

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -42,6 +42,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         has_seen_progress_table_v2_invitation: current_user.has_seen_progress_table_v2_invitation?,
         date_progress_table_invitation_last_delayed: current_user.date_progress_table_invitation_last_delayed,
         child_account_compliance_state: current_user.child_account_compliance_state,
+        progress_table_v2_timestamp: current_user.progress_table_v2_timestamp,
       }
     else
       render json: {


### PR DESCRIPTION
Some of our testers have already been using the V2 dashboard.  This PR will ensure that any user who has already used our new view of the dashboard, will not get the pop-up invitation to use it. 

1. [Jira Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1089)
2. Tests are included :) 

Note: this will have merge conflicts with Liam's change.  Once Liam's change to add the amplitude events and modify when the banner shows up is in staging, I will re-merge staging here. 