### PR TITLE
Update SETUP Documentation for Redis on macOS

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -128,7 +128,16 @@ These steps are for Apple devices running **macOS 14.x**, including those runnin
    ```
    git lfs install --skip-repo
    ```
-
+1. Start your local **Redis server**
+   1. Start redis server:
+       ```
+       brew services start redis
+       ```
+   2. The output from `brew` should confirm that `redis` has started
+       ```
+       ==> Successfully started `redis` (label: homebrew.mxcl.redis)
+       ```
+   3. macOS will notify you that `redis` has been configured to start automatically upon user login. Confirm this in System Settings --> General --> Login Items --> `redis-server` 
 1. Setup your local **MySql server**
    1. Start mysql server:
         ```


### PR DESCRIPTION
Update macOS setup documentation to explicitly start the `redis` service and configure it to start automatically. This is useful now that we're using `redis` to store Rails sessions #58019 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
