### PR TITLE
Music: fix drum preview highlight speeding up

### DIFF
--- a/apps/src/music/blockly/FieldChord.ts
+++ b/apps/src/music/blockly/FieldChord.ts
@@ -6,7 +6,7 @@ import {ChordEventValue} from '../player/interfaces/ChordEvent';
 import MusicLibrary from '../player/MusicLibrary';
 import {getNoteName} from '../utils/Notes';
 import {generateGraphDataFromChord, ChordGraphNote} from '../utils/Chords';
-import {LoadFinishedCallback} from '../types';
+import MusicPlayer from '../player/MusicPlayer';
 const experiments = require('@cdo/apps/util/experiments');
 const color = require('@cdo/apps/util/color');
 
@@ -17,16 +17,13 @@ const FIELD_PADDING = 2;
 
 interface FieldChordOptions {
   getLibrary: () => MusicLibrary;
-  previewChord: (value: ChordEventValue) => void;
-  previewNote: (note: number, instrument: string, onStop?: () => void) => void;
-  cancelPreviews: () => void;
+  previewChord: MusicPlayer['previewChord'];
+  previewNote: MusicPlayer['previewNote'];
+  cancelPreviews: MusicPlayer['cancelPreviews'];
   currentValue: ChordEventValue;
-  setupSampler: (
-    instrument: string,
-    onLoadFinished?: LoadFinishedCallback
-  ) => void;
-  isInstrumentLoading: (instrument: string) => boolean;
-  isInstrumentLoaded: (instrument: string) => boolean;
+  setupSampler: MusicPlayer['setupSampler'];
+  isInstrumentLoading: MusicPlayer['isInstrumentLoading'];
+  isInstrumentLoaded: MusicPlayer['isInstrumentLoaded'];
   registerInstrumentLoadCallback: (
     callback: (instrumentName: string) => void
   ) => void;

--- a/apps/src/music/blockly/FieldPattern.js
+++ b/apps/src/music/blockly/FieldPattern.js
@@ -106,7 +106,6 @@ class FieldPattern extends GoogleBlockly.Field {
       <PatternPanel
         library={this.options.getLibrary()}
         initValue={this.getValue()}
-        bpm={this.options.getBPM()}
         onChange={value => {
           this.setValue(value);
         }}

--- a/apps/src/music/blockly/fields.js
+++ b/apps/src/music/blockly/fields.js
@@ -45,12 +45,11 @@ export const fieldSoundsDefinition = {
 export const fieldPatternDefinition = {
   type: FIELD_PATTERN_TYPE,
   name: FIELD_PATTERN_NAME,
-  getBPM: () => Globals.getPlayer().getBPM(),
   previewSound: (id, onStop) => {
     Globals.getPlayer().previewSound(id, onStop);
   },
-  previewPattern: (patternValue, onStop) => {
-    Globals.getPlayer().previewPattern(patternValue, onStop);
+  previewPattern: (patternValue, onTick, onStop) => {
+    Globals.getPlayer().previewPattern(patternValue, onTick, onStop);
   },
   currentValue: DEFAULT_PATTERN,
   ...instrumentCommonOptions,
@@ -59,8 +58,8 @@ export const fieldPatternDefinition = {
 export const fieldChordDefinition = {
   type: FIELD_CHORD_TYPE,
   name: FIELD_CHORD_NAME,
-  previewChord: (chordValue, onStop) => {
-    Globals.getPlayer().previewChord(chordValue, onStop);
+  previewChord: (chordValue, onTick, onStop) => {
+    Globals.getPlayer().previewChord(chordValue, onTick, onStop);
   },
   previewNote: (note, instrument, onStop) => {
     Globals.getPlayer().previewNote(note, instrument, onStop);

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -187,7 +187,11 @@ export default class MusicPlayer {
     );
   }
 
-  previewChord(chordValue: ChordEventValue, onStop?: () => void) {
+  previewChord(
+    chordValue: ChordEventValue,
+    onTick?: (tick: number) => void,
+    onStop?: () => void
+  ) {
     const chordEvent: ChordEvent = {
       type: 'chord',
       when: 1,
@@ -201,7 +205,7 @@ export default class MusicPlayer {
     if (this.audioPlayer.supportsSamplers()) {
       const sequence = this.convertChordEventToSequence(chordEvent);
       if (sequence) {
-        this.audioPlayer.playSequenceImmediately(sequence);
+        this.audioPlayer.playSequenceImmediately(sequence, onTick, onStop);
       }
     } else {
       this.audioPlayer.playSamplesImmediately(
@@ -221,7 +225,11 @@ export default class MusicPlayer {
     this.previewChord(singleNoteEvent);
   }
 
-  previewPattern(patternValue: PatternEventValue, onStop?: () => void) {
+  previewPattern(
+    patternValue: PatternEventValue,
+    onTick?: (tick: number) => void,
+    onStop?: () => void
+  ) {
     const patternEvent: PatternEvent = {
       type: 'pattern',
       when: 1,
@@ -235,7 +243,7 @@ export default class MusicPlayer {
     if (this.audioPlayer.supportsSamplers()) {
       const sequence = this.patternEventToSequence(patternEvent);
       if (sequence) {
-        this.audioPlayer.playSequenceImmediately(sequence);
+        this.audioPlayer.playSequenceImmediately(sequence, onTick, onStop);
       }
     } else {
       this.audioPlayer.playSamplesImmediately(

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -1,6 +1,7 @@
 import {SoundLoadCallbacks} from '../types';
 import SoundCache from './SoundCache';
 import {
+  Clock,
   Filter,
   GrainPlayer,
   PingPongDelay,
@@ -32,7 +33,6 @@ const EMPTY_EFFECTS_KEY = '';
  * An {@link AudioPlayer} implementation using the Tone.js library.
  *
  * TODO:
- * - Effects
  * - Sample sequences
  */
 class ToneJSPlayer implements AudioPlayer {
@@ -47,6 +47,7 @@ class ToneJSPlayer implements AudioPlayer {
     [event in PlayerEvent]?: ((payload?: string) => void)[];
   };
   private loadingInstruments: {[instrumentName: string]: boolean};
+  private currentSequencePreviewClock: Clock | null;
 
   constructor(
     bpm = DEFAULT_BPM,
@@ -60,6 +61,7 @@ class ToneJSPlayer implements AudioPlayer {
     this.effectBusses = {};
     this.registeredCallbacks = {};
     this.loadingInstruments = {};
+    this.currentSequencePreviewClock = null;
     this.generateEffectBusses();
   }
 
@@ -154,9 +156,7 @@ class ToneJSPlayer implements AudioPlayer {
 
   async playSampleImmediately(sample: SampleEvent, onStop?: () => void) {
     await this.startContextIfNeeded();
-    if (this.currentPreview) {
-      this.currentPreview.player.stop();
-    }
+    this.cancelPreviews();
 
     const buffer = await this.soundCache.loadSound(sample.sampleUrl);
     if (!buffer) {
@@ -197,27 +197,54 @@ class ToneJSPlayer implements AudioPlayer {
     );
   }
 
-  async playSequenceImmediately({instrument, events}: SamplerSequence) {
+  async playSequenceImmediately(
+    {instrument, events}: SamplerSequence,
+    onTick?: (tick: number) => void,
+    onStop?: () => void
+  ) {
+    this.cancelPreviews();
     if (this.samplers[instrument] === undefined) {
       this.metricsReporter.logError(`Instrument not loaded: ${instrument}`);
       return;
     }
 
+    let lastSampleStart = 0;
     await this.startContextIfNeeded();
     events.forEach(({notes, playbackPosition}) => {
+      const offsetSeconds = Transport.toSeconds(
+        this.playbackTimeToTransportTime(playbackPosition)
+      );
+      lastSampleStart = Math.max(lastSampleStart, offsetSeconds);
       this.samplers[instrument][EMPTY_EFFECTS_KEY].unsync().triggerAttack(
         notes,
-        `+${Transport.toSeconds(
-          this.playbackTimeToTransportTime(playbackPosition)
-        )}`,
+        `+${offsetSeconds}`,
         1
       );
     });
+
+    // Create a clock that ticks forward every 16th note, and stops when the sequence finishes.
+    // We can assume the sequence will finish one 16th note after the last sample starts.
+    const clockEnd = lastSampleStart + Transport.toSeconds('16n');
+    let tick = 1;
+    const clock = new Clock(() => {
+      onTick?.(tick++);
+    }, Transport.toFrequency('16n'))
+      .on('stop', () => {
+        this.currentSequencePreviewClock = null;
+        onStop?.();
+      })
+      .start()
+      .stop(`+${clockEnd}`);
+    this.currentSequencePreviewClock = clock;
   }
 
   cancelPreviews() {
     if (this.currentPreview) {
       this.currentPreview.player.stop();
+    }
+
+    if (this.currentSequencePreviewClock) {
+      this.currentSequencePreviewClock.stop();
     }
 
     this.stopAllSamplers();

--- a/apps/src/music/player/types.ts
+++ b/apps/src/music/player/types.ts
@@ -45,8 +45,16 @@ export interface AudioPlayer {
     onStop?: () => void
   ): Promise<void>;
 
-  /** Play a sequence of notes immediately (used for previews) */
-  playSequenceImmediately(sequence: SamplerSequence): Promise<void>;
+  /**
+   * Play a sequence of notes immediately (used for previews)
+   * @param onTick Callback to call each interval of the sequence (assumed to be a 16th note)
+   * @param onStop Callback to call when the sequence is done playing
+   */
+  playSequenceImmediately(
+    sequence: SamplerSequence,
+    onTick?: (tick: number) => void,
+    onStop?: () => void
+  ): Promise<void>;
 
   /** Cancel active previews */
   cancelPreviews(): void;

--- a/apps/src/music/views/PatternPanel.tsx
+++ b/apps/src/music/views/PatternPanel.tsx
@@ -11,22 +11,21 @@ import PreviewControls from './PreviewControls';
 import MusicLibrary, {SoundData} from '../player/MusicLibrary';
 import {PatternEventValue} from '../player/interfaces/PatternEvent';
 import LoadingOverlay from './LoadingOverlay';
-import {LoadFinishedCallback} from '../types';
+import MusicPlayer from '../player/MusicPlayer';
 
 // Generate an array containing tick numbers from 1..16.
 const arrayOfTicks = Array.from({length: 16}, (_, i) => i + 1);
 
 interface PatternPanelProps {
-  bpm: number;
   library: MusicLibrary;
   initValue: PatternEventValue;
   onChange: (value: PatternEventValue) => void;
-  previewSound: (path: string) => void;
-  previewPattern: (pattern: PatternEventValue, onStop: () => void) => void;
-  cancelPreviews: () => void;
-  setupSampler: (kit: string, onLoadFinished?: LoadFinishedCallback) => void;
-  isInstrumentLoading: (kit: string) => boolean;
-  isInstrumentLoaded: (kit: string) => boolean;
+  previewSound: MusicPlayer['previewSound'];
+  previewPattern: MusicPlayer['previewPattern'];
+  cancelPreviews: MusicPlayer['cancelPreviews'];
+  setupSampler: MusicPlayer['setupSampler'];
+  isInstrumentLoading: MusicPlayer['isInstrumentLoading'];
+  isInstrumentLoaded: MusicPlayer['isInstrumentLoaded'];
   registerInstrumentLoadCallback: (callback: (kit: string) => void) => void;
 }
 
@@ -35,7 +34,6 @@ interface PatternPanelProps {
  * custom Blockly Field {@link FieldPattern}
  */
 const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
-  bpm,
   library,
   initValue,
   onChange,
@@ -112,17 +110,17 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
   }, [onChange, currentValue]);
 
   const startPreview = useCallback(() => {
-    setCurrentPreviewTick(1);
-    const intervalId = setInterval(
-      () => setCurrentPreviewTick(tick => tick + 1),
-      // Tick forward every 16th note, i.e. 4 times per beat.
-      (60 / bpm / 4) * 1000
+    previewPattern(
+      currentValue,
+      (tick: number) => setCurrentPreviewTick(tick),
+      () => setCurrentPreviewTick(0)
     );
-    previewPattern(currentValue, () => {
-      clearInterval(intervalId);
-      setCurrentPreviewTick(0);
-    });
-  }, [previewPattern, bpm, setCurrentPreviewTick, currentValue]);
+  }, [previewPattern, setCurrentPreviewTick, currentValue]);
+
+  const stopPreview = useCallback(() => {
+    setCurrentPreviewTick(0);
+    cancelPreviews();
+  }, [setCurrentPreviewTick, cancelPreviews]);
 
   useEffect(() => {
     if (!isInstrumentLoaded(currentValue.kit)) {
@@ -190,7 +188,8 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
         enabled={currentValue.events.length > 0}
         playPreview={startPreview}
         onClickClear={onClear}
-        cancelPreviews={cancelPreviews}
+        cancelPreviews={stopPreview}
+        isPlayingPreview={currentPreviewTick > 0}
       />
     </div>
   );

--- a/apps/src/music/views/PreviewControls.tsx
+++ b/apps/src/music/views/PreviewControls.tsx
@@ -1,8 +1,7 @@
 import React, {useCallback} from 'react';
 import classNames from 'classnames';
-
-const FontAwesome = require('../../templates/FontAwesome');
-const moduleStyles = require('./preview-controls.module.scss').default;
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
+import moduleStyles from './preview-controls.module.scss';
 
 /**
  * Set of controls for previewing sounds in various custom Music Lab block fields
@@ -35,7 +34,10 @@ const ClearButton: React.FunctionComponent<ClearButtonProps> = ({
       onClick={onClick}
       type="button"
     >
-      <FontAwesome icon={'trash-o'} className={moduleStyles.previewButton} />
+      <FontAwesomeV6Icon
+        iconName={'trash-can'}
+        className={moduleStyles.previewButton}
+      />
     </button>
   );
 };
@@ -43,20 +45,32 @@ const ClearButton: React.FunctionComponent<ClearButtonProps> = ({
 interface PreviewButtonProps {
   enabled: boolean;
   playPreview: () => void;
+  cancelPreviews: () => void;
+  isPlayingPreview: boolean;
 }
 
 const PreviewButton: React.FunctionComponent<PreviewButtonProps> = ({
   enabled,
   playPreview,
+  cancelPreviews,
+  isPlayingPreview,
 }) => {
+  const onClick = useCallback(() => {
+    if (isPlayingPreview) {
+      cancelPreviews();
+    } else {
+      playPreview();
+    }
+  }, [cancelPreviews, isPlayingPreview, playPreview]);
+
   return (
     <button
       className={moduleStyles.buttonContainer}
-      onClick={enabled ? playPreview : undefined}
+      onClick={enabled ? onClick : undefined}
       type="button"
     >
-      <FontAwesome
-        icon={'play-circle'}
+      <FontAwesomeV6Icon
+        iconName={isPlayingPreview ? 'stop-circle' : 'play-circle'}
         className={classNames(
           moduleStyles.previewButton,
           !enabled && moduleStyles.previewButtonDisabled


### PR DESCRIPTION
Fixes the behavior of the preview highlight in the play drums block, finally addressing a long standing piece of tech debt in the PatternPanel component. Instead of PatternPanel creating its own timer to tick through the preview animation, we now provide an "onTick" callback from the ToneJSPlayer layer, so that the player can serve as the source of truth for timing. ToneJS's sampler doesn't have any sort of callbacks for when a sample is played unfortunately, but they do have a Clock class which is meant to be highly accurate and understands ToneJS time values (ex. 16th notes). So i opted to use this Clock class to start a timer within the ToneJS player whenever a sequence is previewed to provide accurate tick timing callbacks.

Also makes a slight behavior change where the preview button will change from play to stop when the preview is started, and needs to be explicitly stopped again if the user wants to restart the preview mid-playback. This is just to prevent the play button from being spammed to reduce the likelihood of of any race conditions occurring.

## Links

https://codedotorg.atlassian.net/browse/LABS-789

## Testing story

Tested on standalone projects with the drums and notes blocks.