### PR TITLE
Datablock Storage: raise StudentFacingError if called without a table_name

### DIFF
--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -326,7 +326,11 @@ class DatablockStorageController < ApplicationController
   end
 
   private def where_table
-    DatablockStorageTable.where(project_id: @project_id, table_name: params[:table_name])
+    if params[:table_name]
+      DatablockStorageTable.where(project_id: @project_id, table_name: params[:table_name])
+    else
+      raise StudentFacingError, "You must specify a table"
+    end
   end
 
   private def table_or_create


### PR DESCRIPTION
I believe this will fixes [#58591](https://github.com/code-dot-org/code-dot-org/issues/58591), which we got from honeybadger.