### PR TITLE
Music: update project type

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2140,7 +2140,7 @@
   "projectTypeMinecraftAquatic": "Minecraft Aquatic",
   "projectTypeMinecraftDesigner": "Minecraft Designer",
   "projectTypeMinecraftHero": "Minecraft Hero",
-  "projectTypeMusic": "Project Beats",
+  "projectTypeMusic": "Music Lab",
   "projectTypePlaylab": "Play Lab",
   "projectTypePlaylabPreReader": "Play Lab (Pre-reader)",
   "projectTypePoetry": "Poetry",


### PR DESCRIPTION
With this change, the Project Type listed at https://studio.code.org/projects is now "Music Lab", rather than "Project Beats", for a Music Lab project.

<img width="997" alt="Screenshot 2024-05-13 at 8 06 38 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/7b416a21-1ff0-4096-a5f8-efc4f82df733">
