### PR TITLE
Datablock Storage: retry create_record calls

### DIFF
--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -224,7 +224,9 @@ class DatablockStorageController < ApplicationController
     raise "record must be a hash" unless record_json.is_a? Hash
 
     table = table_or_create
-    table.create_records [record_json]
+    Retryable.retryable(tries: 1, on: [ActiveRecord::RecordNotUnique]) do
+      table.create_records [record_json]
+    end
     table.save!
 
     render json: record_json


### PR DESCRIPTION
Fixes: [#58593](https://github.com/code-dot-org/code-dot-org/issues/58593)

`DatablockStorageTable.create_records()` can fail with ActiveRecord::RecordNotUnique. This occurs if another process allocated an ID within the same table_name. In most cases, this is prevented by the row lock: `DatablockStorageRecord.where(project_id: project_id, table_name: table_name).lock.minimum(:record_id)`, but if the min record_id is changed due to a delete, this can be invalid.

In these cases, we just retry one more time before giving up.

I want to hold up on merging this one because #58601 may render this one unnecessary (it wouldn't hurt, other than adding complexity)