### PR TITLE
Skip JotForm Test that is Incompatible with MySQL Binary Logging

### DIFF
--- a/dashboard/test/models/concerns/pd/jot_form_backed_form_test.rb
+++ b/dashboard/test/models/concerns/pd/jot_form_backed_form_test.rb
@@ -33,6 +33,10 @@ module Pd
     self.use_transactional_test_case = true
 
     setup_all do
+      # Creating a temporary table within a transaction is not permitted when MySQL binary logging is enabled and is
+      # configured to use Global Transaction IDentifiers (GTID). JotForms likely aren't used anymore, so safe to skip
+      # these tests.
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       # create a temporary table for our DummyForm record. Note that because the
       # table is temporary, it will be automatically destroyed once the session has
       # ended so we don't need to worry about dropping the table in teardown
@@ -46,11 +50,13 @@ module Pd
     end
 
     setup do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       JotForm::JotFormRestClient.expects(:new).never
       DummyForm.stubs(:get_min_date)
     end
 
     test 'form_id and submission_id are required' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form = DummyForm.new
       assert form.invalid?
       assert_equal(
@@ -67,6 +73,7 @@ module Pd
     end
 
     test 'placeholder?' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       placeholder = DummyForm.new placeholder_params
       with_answers = DummyForm.new params_with_answers
 
@@ -75,6 +82,7 @@ module Pd
     end
 
     test 'response_exists? raises error when missing form_id' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       e = assert_raises do
         DummyForm.response_exists?(unique_key: generate_unique_key)
       end
@@ -82,6 +90,7 @@ module Pd
     end
 
     test 'response_exists? raises error when missing a unique attribute' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       e = assert_raises do
         DummyForm.response_exists?(form_id: get_form_id)
       end
@@ -89,6 +98,7 @@ module Pd
     end
 
     test 'response_exists?' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       placeholder = DummyForm.create! placeholder_params
 
       assert DummyForm.response_exists?(form_id: placeholder.form_id, unique_key: placeholder.unique_key)
@@ -96,6 +106,7 @@ module Pd
     end
 
     test 'create_placeholder! raises error when missing form_id' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       e = assert_raises do
         DummyForm.create_placeholder!(unique_key: generate_unique_key)
       end
@@ -103,6 +114,7 @@ module Pd
     end
 
     test 'create_placeholder! raises error when missing a unique attribute' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       e = assert_raises do
         DummyForm.create_placeholder!(form_id: get_form_id)
       end
@@ -110,6 +122,7 @@ module Pd
     end
 
     test 'create_placeholder! raises error when missing submission_id' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       e = assert_raises do
         DummyForm.create_placeholder!(unique_key: generate_unique_key, form_id: get_form_id)
       end
@@ -117,12 +130,14 @@ module Pd
     end
 
     test 'create_placeholder! creates a placeholder' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       assert_creates DummyForm do
         DummyForm.create_placeholder! placeholder_params
       end
     end
 
     test 'create_placeholder! logs a warning and skips duplicate submissions' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       original = DummyForm.create! placeholder_params
       next_submission_id = get_submission_id
 
@@ -138,16 +153,19 @@ module Pd
     end
 
     test 'static attribute values are included on new objects' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form = DummyFormWithStaticAttributeValues.new
       assert_equal 'fixed value', form.custom_field
     end
 
     test 'static attribute values are included in placeholders' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       placeholder = DummyFormWithStaticAttributeValues.create_placeholder! placeholder_params
       assert_equal 'fixed value', placeholder.custom_field
     end
 
     test 'static attribute values are included in response_exists? queries' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form_id = get_form_id
       unique_key = generate_unique_key
       DummyFormWithStaticAttributeValues.expects(:exists?).with(
@@ -160,6 +178,7 @@ module Pd
     end
 
     test 'duplicate? returns true for new records that match existing unique attributes' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       unique_key = generate_unique_key
       form_id = get_form_id
       form = DummyForm.new(
@@ -178,6 +197,7 @@ module Pd
     end
 
     test 'fill_placeholders syncs each placeholder' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       mock_placeholders = Array.new(2) do
         mock {|mock_placeholder| mock_placeholder.expects(:sync_from_jotform)}
       end
@@ -193,6 +213,7 @@ module Pd
     end
 
     test 'fill_placeholders collects errors and re-raises at the end' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form_id = get_form_id
       failed_submission_ids = Array.new(2) {get_submission_id}
 
@@ -230,6 +251,7 @@ module Pd
     end
 
     test 'placeholder sync_from_jotform updates answers from JotForm API' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       placeholder = DummyForm.new placeholder_params
 
       JotForm::Translation.expects(:new).with(placeholder.form_id).returns(
@@ -247,6 +269,7 @@ module Pd
     end
 
     test 'answers are checked against questions before validation' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form = DummyForm.new params_with_answers
 
       mock_processed_answers = mock
@@ -262,6 +285,7 @@ module Pd
     end
 
     test 'form_data_hash checks answers against questions once then caches' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form = DummyForm.new params_with_answers
 
       mock_processed_answers = mock
@@ -275,6 +299,7 @@ module Pd
     end
 
     test 'reassigning answers clears form_data_hash cache' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form = DummyForm.new params_with_answers
 
       # initial query and cache (see above test case)
@@ -294,6 +319,7 @@ module Pd
     end
 
     test 'attribute_mapping is used to populate attributes before validation' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form = DummyFormWithAttributeMapping.new params_with_answers
       form.expects(:form_data_hash).returns(FAKE_ANSWERS)
 
@@ -303,6 +329,7 @@ module Pd
     end
 
     test 'sync_from_jotform with no args syncs all forms' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       all_form_ids = Array.new(2) {get_form_id}
       DummyForm.expects(:all_form_ids).returns(all_form_ids)
       DummyForm.expects(:_sync_from_jotform).with(all_form_ids)
@@ -311,6 +338,7 @@ module Pd
     end
 
     test 'sync_from_jotform with a form_id only syncs that form' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form_id = get_form_id
       DummyForm.expects(:all_form_ids).never
       DummyForm.expects(:_sync_from_jotform).with([form_id])
@@ -319,6 +347,7 @@ module Pd
     end
 
     test 'jotform sync gets questions syncs new answers for each form' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form_ids = Array.new(2) {get_form_id}
       last_submission_id = get_submission_id
       min_date = Time.zone.today
@@ -350,6 +379,7 @@ module Pd
     end
 
     test 'jotform sync retrieves and processes all new submissions in batches and updates last submission id' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form_id = get_form_id
       base_get_submissions_params = {
         last_known_submission_id: nil,
@@ -394,6 +424,7 @@ module Pd
     end
 
     test 'jotform sync collects errors and updates last processed submission id' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form_id = get_form_id
 
       mock_questions = mock {expects(:last_submission_id).returns(nil).at_least_once}
@@ -457,6 +488,7 @@ module Pd
     end
 
     test 'jotform sync stops processing when an entire batch fails' do
+      skip 'test is incompatible with MySQL binary logging (when Global Transaction IDentifiers - GTID - are enabled)'
       form_id = get_form_id
       DummyForm.stubs(:sync_batch_size).returns(2)
       DummyForm.expects(:get_questions).with(form_id, force_sync: true).returns(


### PR DESCRIPTION
Infrastructure team needs to enable MySQL binary logging (with Global Transaction IDentifier - GTID - turned ON) to carry out an upgrade of the production database cluster with minimal downtime #58421 .  This test creates a temporary table within a database transaction, which is not permitted when using binary logging and GTID.

It appears that [we no longer utilize JotForms](https://codedotorg.slack.com/archives/C0T0PNTM3/p1715555245721159).

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Ask Acquisition Products to delete all of the JotForm code, database tables, and API keys.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
