### PR TITLE
[Sprite Lab] add minimumScale option

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -576,6 +576,7 @@ export default class CoreLibrary {
       sprite.initialAngle = opts.initialAngle;
     }
 
+    const minimumScale = opts.minimumScale || 100;
     sprite.baseScale = 1;
     sprite.setScale = function (scale) {
       sprite.scale = scale * sprite.baseScale;
@@ -589,7 +590,7 @@ export default class CoreLibrary {
       sprite.baseScale =
         100 /
         Math.max(
-          100,
+          minimumScale,
           sprite.animation.getHeight(),
           sprite.animation.getWidth()
         );

--- a/apps/src/p5lab/spritelab/commands/spriteCommands.js
+++ b/apps/src/p5lab/spritelab/commands/spriteCommands.js
@@ -101,7 +101,7 @@ export const commands = {
             x: scale / 2 + scale * i,
             y: scale / 2 + scale * j,
           };
-          this.addSprite({animation, group, location, scale});
+          this.addSprite({animation, group, location, scale, minimumScale: 1});
         }
       }
     }


### PR DESCRIPTION
During the piloting of the new Game Design module, some great student projects were collected. One of which features a custom sprite costume that isn't tiling as expected with the new grid blocks:
![image (198)](https://github.com/code-dot-org/code-dot-org/assets/43474485/7cbe73ea-e62e-4d5a-b891-d2a3d6f9eacc)

The reason for this is that the image created by the student was 64x64, which is smaller than our expected minimum.
![image (199)](https://github.com/code-dot-org/code-dot-org/assets/43474485/7d0066b8-9b6e-44ac-9479-268ad038bb59)

When sprites are typically created in Sprite Lab, we automatically scale them down to 100x100, but we don't scale up small images. In the case of the grid block, it's important for the sprites to tile as cleanly as possible. A quick solution here is to add an option for a minimum scale. This makes it so the 64x64 costume image tiles cleanly:
![image (200)](https://github.com/code-dot-org/code-dot-org/assets/43474485/30692133-6b80-4d41-85f3-28f63653cbeb)

When sprites are created in other ways, there is no change to how they are scaled. See the animal sprite and smaller "dirt" sprite below:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/c2c7f365-d241-44e6-bc67-73e3e26af7bf)


In considering edges, I created the smallest image that the Piskel editor would allow (2x2). This image can be tiled as well, although I was surprised to learn P5 seems to automatically blur small images when they're scaled up. This also matches the existing behavior in the costume picking block field.

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/fad29184-16b2-402e-9d4f-7f88dc30ab87)
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/ed4dc89a-18e6-4c52-b3b0-e788e562288f)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
