### PR TITLE
Fix ai rubric showing on non ai levels

### DIFF
--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -134,7 +134,10 @@ function initPage() {
             studentLevelInfo={studentLevelInfo}
             reportingData={reportingData}
             currentLevelName={config.level_name}
-            aiEnabled={experiments.isEnabled('ai-rubrics')}
+            aiEnabled={
+              experiments.isEnabled('ai-rubrics') &&
+              rubric.learningGoals.some(lg => lg.aiEnabled)
+            }
           />
         </Provider>,
         rubricFabMountPoint

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -255,7 +255,7 @@ export default function RubricContainer({
         })}
       >
         <Steps
-          enabled={canProvideFeedback && productTour}
+          enabled={canProvideFeedback && productTour && teacherHasEnabledAi}
           initialStep={INITIAL_STEP}
           steps={STEPS}
           onStart={onTourStart}
@@ -284,7 +284,7 @@ export default function RubricContainer({
             <span>{i18n.rubricAiHeaderText()}</span>
           </div>
           <div className={style.rubricHeaderRightSide}>
-            {canProvideFeedback && (
+            {canProvideFeedback && teacherHasEnabledAi && (
               <button
                 id="ui-restart-product-tour"
                 aria-label="restart product tour"
@@ -320,13 +320,13 @@ export default function RubricContainer({
           <RubricContent
             productTour={productTour}
             rubric={
-              canProvideFeedback && productTour
+              canProvideFeedback && productTour && teacherHasEnabledAi
                 ? DUMMY_PROPS['rubricDummy']
                 : rubric
             }
             open={open}
             studentLevelInfo={
-              canProvideFeedback && productTour
+              canProvideFeedback && productTour && teacherHasEnabledAi
                 ? DUMMY_PROPS['studentLevelInfoDummy']
                 : studentLevelInfo
             }
@@ -336,7 +336,7 @@ export default function RubricContainer({
             reportingData={reportingData}
             visible={selectedTab === TAB_NAMES.RUBRIC}
             aiEvaluations={
-              canProvideFeedback && productTour
+              canProvideFeedback && productTour && teacherHasEnabledAi
                 ? DUMMY_PROPS['aiEvaluationsDummy']
                 : aiEvaluations
             }

--- a/apps/src/templates/rubrics/RubricTabButtons.jsx
+++ b/apps/src/templates/rubrics/RubricTabButtons.jsx
@@ -69,7 +69,7 @@ export default function RubricTabButtons({
           ]}
           onChange={value => tabSelectCallback(value)}
         />
-        {selectedTab === TAB_NAMES.RUBRIC && (
+        {selectedTab === TAB_NAMES.RUBRIC && teacherHasEnabledAi && (
           <div>
             <RunAIAssessmentButton
               canProvideFeedback={canProvideFeedback}
@@ -87,6 +87,7 @@ export default function RubricTabButtons({
       </div>
       {selectedTab === TAB_NAMES.RUBRIC &&
         canProvideFeedback &&
+        teacherHasEnabledAi &&
         !!statusText() && (
           <InfoAlert
             className={'uitest-eval-status-text'}

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -329,6 +329,29 @@ describe('RubricContainer', () => {
     );
   });
 
+  it('does not show a button for running analysis if AI is not enabled for level', async () => {
+    stubFetchEvalStatusForUser({});
+    stubFetchEvalStatusForAll({});
+    stubFetchAiEvaluations({});
+    stubFetchTeacherEvaluations(noEvals);
+    stubFetchTourStatus({seen: true});
+
+    const {queryByText} = render(
+      <Provider store={store}>
+        <RubricContainer
+          rubric={defaultRubric}
+          studentLevelInfo={defaultStudentInfo}
+          teacherHasEnabledAi={false}
+          currentLevelName={'test_level'}
+          reportingData={{}}
+          open
+        />
+      </Provider>
+    );
+    await wait();
+    expect(queryByText(i18n.runAiAssessment())).to.not.exist;
+  });
+
   it('shows status text when student has not attempted level', async () => {
     const userFetchStub = stubFetchEvalStatusForUser(notAttemptedJson);
     const allFetchStub = stubFetchEvalStatusForAll(notAttemptedJsonAll);
@@ -868,6 +891,31 @@ describe('RubricContainer', () => {
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
           currentLevelName={'non-assessment-level'}
+          reportingData={{}}
+          open
+        />
+      </Provider>
+    );
+
+    await wait();
+    expect(queryByText('Getting Started with Your AI Teaching Assistant')).to
+      .not.exist;
+  });
+
+  it('does not display product tour when on non-AI level', async function () {
+    stubFetchEvalStatusForUser(readyJson);
+    stubFetchEvalStatusForAll(readyJsonAll);
+    stubFetchAiEvaluations(mockAiEvaluations);
+    stubFetchTeacherEvaluations(noEvals);
+    stubFetchTourStatus({seen: null});
+
+    const {queryByText} = render(
+      <Provider store={store}>
+        <RubricContainer
+          rubric={defaultRubric}
+          studentLevelInfo={defaultStudentInfo}
+          teacherHasEnabledAi={false}
+          currentLevelName={'test-level'}
           reportingData={{}}
           open
         />


### PR DESCRIPTION
Previously, the AI analysis features would show on non-AI enabled levels. This was causing confusion for some teachers. This update removes AI buttons and information from non-AI enabled levels.

Before:
![image](https://github.com/code-dot-org/code-dot-org/assets/5552007/9bba34c4-04e8-4f82-a827-656f55830e0d)

After:
![image](https://github.com/code-dot-org/code-dot-org/assets/5552007/27a8b02a-0578-4ae6-a459-163d28c9c242)

## Links
[AITT-618](https://codedotorg.atlassian.net/browse/AITT-618)
[AITT-606](https://codedotorg.atlassian.net/browse/AITT-606)
## Testing story
Added unit tests to test that AI components are not displayed on non-AI levels

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
