### PR TITLE
Adds state_before and state_after columns to cap_user_events

### DIFF
--- a/dashboard/app/models/cap_user_event.rb
+++ b/dashboard/app/models/cap_user_event.rb
@@ -2,12 +2,14 @@
 #
 # Table name: cap_user_events
 #
-#  id         :bigint           not null, primary key
-#  name       :string(64)       not null
-#  user_id    :integer          not null
-#  policy     :string(16)       not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id           :bigint           not null, primary key
+#  name         :string(64)       not null
+#  user_id      :integer          not null
+#  policy       :string(16)       not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  state_before :string(1)
+#  state_after  :string(1)
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20240514181513_add_before_state_and_after_state_to_cap_user_events.rb
+++ b/dashboard/db/migrate/20240514181513_add_before_state_and_after_state_to_cap_user_events.rb
@@ -1,0 +1,6 @@
+class AddBeforeStateAndAfterStateToCapUserEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :cap_user_events, :state_before, :string, limit: 1
+    add_column :cap_user_events, :state_after, :string, limit: 1
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_01_215821) do
+ActiveRecord::Schema.define(version: 2024_05_14_181513) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -174,6 +174,8 @@ ActiveRecord::Schema.define(version: 2024_05_01_215821) do
     t.string "policy", limit: 16, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "state_before", limit: 1
+    t.string "state_after", limit: 1
     t.index ["name", "policy"], name: "index_cap_user_events_on_name_and_policy"
     t.index ["policy"], name: "index_cap_user_events_on_policy"
     t.index ["user_id"], name: "index_cap_user_events_on_user_id"


### PR DESCRIPTION
Migration to adds two columns to track the change of state during CPA events.

The state is managed as a single character, so the columns match this by being 1 character length strings.

## Links

- jira ticket: [P20-893](https://codedotorg.atlassian.net/browse/P20-893) (ongoing)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
