### PR TITLE
Update tasks.yml with learning goal ai tables

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -48,6 +48,9 @@ cron-pii:
 - dashboard.projects
 - dashboard.foorm_%
 - dashboard.potential_teachers
+- dashboard.learning_goal_ai_evaluations
+- dashboard.learning_goal_teacher_evaluations
+- dashboard.learning_goal_ai_evaluation_feedbacks
 cron:
 - dashboard.experiments
 - dashboard.authored_hint_view_requests


### PR DESCRIPTION
notes from Baker's original commit message:

> Adding 3 tables to be included in DMS to support analysis of new AI features.
>     
> I've added to the pii section because there is free response (teacher feedback) data that may be included in one of the tables and I want to keep the other related tables co-located in the same schema.
> 