### PR TITLE
Updating client side finish sign up event, moving experiment call

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -53,15 +53,10 @@ let userInRegionalPartnerVariant = experiments.isEnabled(
   experiments.OPT_IN_EMAIL_REG_PARTNER
 );
 
-const isInSchoolAssociationExperiment = statsigReporter.getIsInExperiment(
-  'school_association_update_2024',
-  'showNewFlow',
-  false
-);
-
 $(document).ready(() => {
   const schoolInfoMountPoint = document.getElementById('school-info-inputs');
   let user_type = $('#user_user_type').val();
+  let isInSchoolAssociationExperiment = false;
   init();
 
   function init() {
@@ -75,7 +70,6 @@ $(document).ready(() => {
         'width:135px;';
     }
     setUserType(user_type);
-    renderSchoolInfo();
     renderParentSignUpSection();
   }
 
@@ -221,6 +215,12 @@ $(document).ready(() => {
     fadeInFields(TEACHER_ONLY_FIELDS);
     hideFields(STUDENT_ONLY_FIELDS);
     toggleVisShareEmailRegPartner(isInUnitedStates);
+    isInSchoolAssociationExperiment = statsigReporter.getIsInExperiment(
+      'school_association_update_2024',
+      'showNewFlow',
+      false
+    );
+    renderSchoolInfo();
   }
 
   function switchToStudent() {

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -54,7 +54,7 @@ let userInRegionalPartnerVariant = experiments.isEnabled(
 );
 
 const isInSchoolAssociationExperiment = statsigReporter.getIsInExperiment(
-  'sign_up_flow_school_association_update_2024',
+  'school_association_update_2024',
   'showNewFlow',
   false
 );
@@ -91,14 +91,34 @@ $(document).ready(() => {
 
     alreadySubmitted = true;
     // Clean up school data and set age for teachers.
+    let has_school = false;
+    let has_marketing_value = false;
+    const has_display_name = $('input[name="user[name]"]')?.val() !== '';
     if (user_type === 'teacher') {
       cleanSchoolInfo();
       $('#user_age').val('21+');
+      // If the new or old school association flow has a school, update to true
+      if (
+        $('select[name="user[school_info_attributes][school_id]"]')?.val() ||
+        $('input[name="user[school_info_attributes][school_id]"]')?.val()
+      ) {
+        has_school = true;
+      }
+      // Check if either of the marketing opt in/out radio buttons are selected
+      if (
+        $('input[id="user_email_preference_opt_in_yes"]')?.is(':checked') ||
+        $('input[id="user_email_preference_opt_in_no"]')?.is(':checked')
+      ) {
+        has_marketing_value = true;
+      }
     }
     analyticsReporter.sendEvent(
       EVENTS.SIGN_UP_FINISHED_EVENT,
       {
         'user type': user_type,
+        'has school': has_school,
+        'has marketing value selected': has_marketing_value,
+        'has display name': has_display_name,
       },
       PLATFORMS.BOTH
     );


### PR DESCRIPTION
This PR covers two updates and may be easier to review one commit at a time!

First: 

The current finish sign up event fires each time the button is pressed, which means we may get multiple events for the same user if they haven't selected at minimum: user type, display name (and for teachers): email opt in preference. 

These additions to the event add has_school (by checking for the existence of an nces id in both the old flow and the new flow), and display name and email opt in preference (by checking if either radio button is filled in). 

I was able to test this on the old flow in all sorts of permutations (see the list below and one expanded example) and on the new flow by setting up the new experiment name and checking that the school designation still works (photo after). I was also able to confirm that the student flow still works. 

Second:

This PR moves the experiment allocation point. Now, we only call the experiment once we have a user type = teacher. This required me to change the order of the render, so I'd love if someone could check out this branch and move through the flow locally to double check my own local testing. Happy to pair on this- it will require editing one line in the StatsigAnalytics file and adding a manual override for your session ID to the experiment.

<img width="1300" alt="Screenshot 2024-05-14 at 2 17 12 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/5323a5af-cf99-4e08-9ddb-c60acbfd7437">
<img width="708" alt="Screenshot 2024-05-14 at 2 17 27 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/545e7d7c-e3a3-48aa-9512-54cfc794ac47">
<img width="1290" alt="Screenshot 2024-05-14 at 3 54 23 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/bc3c406f-82d6-4fcf-8212-1d0708d7b5d6">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1889
- https://codedotorg.atlassian.net/browse/ACQ-1890

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
