### PR TITLE
Control When Project Tables are Truncated For Controller Unit Tests

### DIFF
--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -101,12 +101,5 @@ module SetupTest
     # so reset them to ensure that they are not reused across tests.
     BucketHelper.s3 = nil if defined?(BucketHelper)
     AWS::S3.s3 = nil
-
-    # Reset AUTO_INCREMENT, since it is unaffected by transaction rollback.
-    DASHBOARD_TEST_TABLES.each do |table|
-      # rubocop:disable CustomCops/DashboardDbUsage
-      DASHBOARD_DB.execute("ALTER TABLE `#{table}` AUTO_INCREMENT = 1")
-      # rubocop:enable CustomCops/DashboardDbUsage
-    end
   end
 end

--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -41,16 +41,16 @@ VCR.configure do |c|
   end
 end
 
-# Truncate database tables to ensure repeatable tests.
-DASHBOARD_TEST_TABLES = %w(channel_tokens user_project_storage_ids projects project_commits code_review_comments code_reviews).freeze
-DASHBOARD_TEST_TABLES.each do |table|
-  # rubocop:disable CustomCops/DashboardDbUsage
-  DASHBOARD_DB[table.to_sym].truncate
-  # rubocop:enable CustomCops/DashboardDbUsage
-end.freeze
-
 module SetupTest
   def around(&block)
+    # Truncate database tables to ensure repeatable tests.
+    DASHBOARD_TEST_TABLES = %w(channel_tokens user_project_storage_ids projects project_commits code_review_comments code_reviews).freeze
+    DASHBOARD_TEST_TABLES.each do |table|
+      # rubocop:disable CustomCops/DashboardDbUsage
+      DASHBOARD_DB[table.to_sym].truncate
+      # rubocop:enable CustomCops/DashboardDbUsage
+    end.freeze
+
     random = Random.new(0)
     # 4 test wrappers:
     # VCR (record/replay HTTP interactions)

--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -17,32 +17,32 @@ require 'cdo/aws/s3'
 
 raise 'Test helper must only be used in `test` environment!' unless rack_env? :test
 
+VCR.configure do |c|
+  c.cassette_library_dir = File.expand_path 'fixtures/vcr', __dir__
+  c.allow_http_connections_when_no_cassette = true
+  c.hook_into :webmock
+  # Filter unnecessary headers from the http interactions.
+  c.before_record do |i|
+    %w(
+      X-Amz-Security-Token
+      X-Amz-Content-Sha256
+      Authorization
+      X-Amz-Date
+      Accept
+      Accept-Encoding
+      User-Agent
+      Host
+      Content-Type
+    ).each {|h| i.request.headers.delete h}
+    %w(
+      X-Amz-Request-Id
+      X-Amz-Id-2
+    ).each {|h| i.response.headers.delete h}
+  end
+end
+
 module SetupTest
   DASHBOARD_TEST_TABLES = %w(channel_tokens user_project_storage_ids projects project_commits code_review_comments code_reviews).freeze
-
-  VCR.configure do |c|
-    c.cassette_library_dir = File.expand_path 'fixtures/vcr', __dir__
-    c.allow_http_connections_when_no_cassette = true
-    c.hook_into :webmock
-    # Filter unnecessary headers from the http interactions.
-    c.before_record do |i|
-      %w(
-        X-Amz-Security-Token
-        X-Amz-Content-Sha256
-        Authorization
-        X-Amz-Date
-        Accept
-        Accept-Encoding
-        User-Agent
-        Host
-        Content-Type
-      ).each {|h| i.request.headers.delete h}
-      %w(
-        X-Amz-Request-Id
-        X-Amz-Id-2
-      ).each {|h| i.response.headers.delete h}
-    end
-  end
 
   def around(&block)
     # Truncate database tables to ensure repeatable tests.

--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -27,20 +27,20 @@ module SetupTest
     # Filter unnecessary headers from the http interactions.
     c.before_record do |i|
       %w(
-      X-Amz-Security-Token
-      X-Amz-Content-Sha256
-      Authorization
-      X-Amz-Date
-      Accept
-      Accept-Encoding
-      User-Agent
-      Host
-      Content-Type
-    ).each {|h| i.request.headers.delete h}
+        X-Amz-Security-Token
+        X-Amz-Content-Sha256
+        Authorization
+        X-Amz-Date
+        Accept
+        Accept-Encoding
+        User-Agent
+        Host
+        Content-Type
+      ).each {|h| i.request.headers.delete h}
       %w(
-      X-Amz-Request-Id
-      X-Amz-Id-2
-    ).each {|h| i.response.headers.delete h}
+        X-Amz-Request-Id
+        X-Amz-Id-2
+      ).each {|h| i.response.headers.delete h}
     end
   end
 

--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -17,13 +17,16 @@ require 'cdo/aws/s3'
 
 raise 'Test helper must only be used in `test` environment!' unless rack_env? :test
 
-VCR.configure do |c|
-  c.cassette_library_dir = File.expand_path 'fixtures/vcr', __dir__
-  c.allow_http_connections_when_no_cassette = true
-  c.hook_into :webmock
-  # Filter unnecessary headers from the http interactions.
-  c.before_record do |i|
-    %w(
+module SetupTest
+  DASHBOARD_TEST_TABLES = %w(channel_tokens user_project_storage_ids projects project_commits code_review_comments code_reviews).freeze
+
+  VCR.configure do |c|
+    c.cassette_library_dir = File.expand_path 'fixtures/vcr', __dir__
+    c.allow_http_connections_when_no_cassette = true
+    c.hook_into :webmock
+    # Filter unnecessary headers from the http interactions.
+    c.before_record do |i|
+      %w(
       X-Amz-Security-Token
       X-Amz-Content-Sha256
       Authorization
@@ -34,17 +37,15 @@ VCR.configure do |c|
       Host
       Content-Type
     ).each {|h| i.request.headers.delete h}
-    %w(
+      %w(
       X-Amz-Request-Id
       X-Amz-Id-2
     ).each {|h| i.response.headers.delete h}
+    end
   end
-end
 
-module SetupTest
   def around(&block)
     # Truncate database tables to ensure repeatable tests.
-    DASHBOARD_TEST_TABLES = %w(channel_tokens user_project_storage_ids projects project_commits code_review_comments code_reviews).freeze
     DASHBOARD_TEST_TABLES.each do |table|
       # rubocop:disable CustomCops/DashboardDbUsage
       DASHBOARD_DB[table.to_sym].truncate


### PR DESCRIPTION
The logic to `TRUNCATE` dashboard projects tables before running controller unit tests was executing any time `common_test_helper` was `require`d. Explicitly `TRUNCATE` before each controller unit test so that these tables are not modified until we explicitly do so. We no longer need to reset the auto-increment counter because `TRUNCATE` does that. 

We still need Rails to rollback transactions after executing each test in case they write to non-project tables.

This change potentially unblocks #57507 which in turn is needed to support upgrading to MySQL 8.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Move the VCR configuration and the project table truncate to a `setup` method within the module and change all controller unit tests to explicitly invoke that setup method.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
