### PR TITLE
Fix Lab2 bubble choice UI test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -94,10 +94,10 @@ Feature: BubbleChoice
     And I click selector "#x-close" once I see it
     And I wait until element "#x-close" is not visible
     
-    # Go to another Lab2 level
-    And I click selector ".progress-bubble:first"
-    And I wait until element "#lab2-music" is visible
-    And check that the url contains "/s/allthethings/lessons/52/levels/1"
+    # Go to another Lab2 level (panels)
+    And I click selector ".progress-bubble:nth(5)"
+    And I wait until element "#lab2-panels" is visible
+    And check that the url contains "/s/allthethings/lessons/52/levels/6"
 
     # Go back to the Lab2 BubbleChoice sublevel
     And I go back


### PR DESCRIPTION
Seems like there are some issues with loading Music Lab in UI tests on Safari/iPad, so we'll just use a different Lab2 level instead (level type isn't important, just needs to be a lab2 level)

https://codedotorg.slack.com/archives/C0T0PNTM3/p1715724643985969

## Testing story

Tested locally with Sauce Labs