### PR TITLE
Only validate the username if it is changing

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -553,7 +553,7 @@ class User < ApplicationRecord
 
   USERNAME_REGEX = /\A#{UserHelpers::USERNAME_ALLOWED_CHARACTERS.source}+\z/i
   validates_length_of :username, within: 5..20, allow_blank: true
-  validates_format_of :username, with: USERNAME_REGEX, allow_blank: true
+  validates_format_of :username, if: :username_changed?, with: USERNAME_REGEX, allow_blank: true
   validates_uniqueness_of :username, allow_blank: true, case_sensitive: false, on: :create, if: -> {errors.blank?}
   validates_uniqueness_of :username, case_sensitive: false, on: :update, if: -> {errors.blank? && username_changed?}
   validates_presence_of :username, if: :username_required?

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -5266,4 +5266,24 @@ class UserTest < ActiveSupport::TestCase
     pl_units_started = user.pl_units_started
     assert_equal 100, pl_units_started[0][:percent_completed]
   end
+
+  test "username characters are only validated when changed" do
+    student = create :student
+    # White spaces are not allowed in usernames
+    student.username = "big husky"
+    student.save!(validate: false)
+
+    # We only want to validate the username if it changes.
+    # An invalid username should not block other attributes of the user from
+    # changing.
+    # This is a temporary behavior while we investigate why users have invalid
+    # usernames.
+    student.update!(name: "#{student.name} Jr.")
+
+    # The username has changed to a new invalid value, so we expected validation
+    # to fail.
+    assert_raises(ActiveRecord::RecordInvalid) do
+      student.update!(username: "very big husky")
+    end
+  end
 end


### PR DESCRIPTION
We received a Zendesk ticket where a User reported an issue where they couldn’t update the state they lived in. Upon investigation, we found that the User couldn’t update their state because their username was invalid (it had a white space in it “big husky”). The User model runs most of its validations before every save we don’t want it to get into a bad state. 

We queried Redshift and found that there are about 6,000 users with a whitespace in their name.

As a workaround, we are only going to validate the username whenever it changes.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/P20-933)

## Testing story
* Unit tests

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
* [Long term fix](https://codedotorg.atlassian.net/browse/P20-932)
