### PR TITLE
[Design2-110] DSCO - Dropdowns - Add gray color

### DIFF
--- a/apps/src/componentLibrary/common/constants.ts
+++ b/apps/src/componentLibrary/common/constants.ts
@@ -21,4 +21,5 @@ export const componentSizeToBodyTextSizeMap: {
 export const dropdownColors: {[key in DropdownColor]: DropdownColor} = {
   white: 'white',
   black: 'black',
+  gray: 'gray',
 };

--- a/apps/src/componentLibrary/common/types.ts
+++ b/apps/src/componentLibrary/common/types.ts
@@ -6,4 +6,4 @@ export type ComponentSizeXSToL = 'xs' | 's' | 'm' | 'l';
 /**
  * Possible colors for the dropdown components
  */
-export type DropdownColor = 'white' | 'black';
+export type DropdownColor = 'white' | 'black' | 'gray';

--- a/apps/src/componentLibrary/dropdown/checkboxDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/checkboxDropdown/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.0] (https://github.com/code-dot-org/code-dot-org/pull/58637)
+## [0.4.0](https://github.com/code-dot-org/code-dot-org/pull/58637)
 
 * added `gray` color to `CheckboxDropdown`
 * fixed `thin` `white` dropdown text color

--- a/apps/src/componentLibrary/dropdown/checkboxDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/checkboxDropdown/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] (https://github.com/code-dot-org/code-dot-org/pull/58637)
+
+* added `gray` color to `CheckboxDropdown`
+
 ## [0.3.2](https://github.com/code-dot-org/code-dot-org/pull/58469)
 
 * added support of all `aria-` attributes by `CheckboxDropdown` component

--- a/apps/src/componentLibrary/dropdown/checkboxDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/checkboxDropdown/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [0.4.0] (https://github.com/code-dot-org/code-dot-org/pull/58637)
 
 * added `gray` color to `CheckboxDropdown`
+* fixed `thin` `white` dropdown text color
 
 ## [0.3.2](https://github.com/code-dot-org/code-dot-org/pull/58469)
 

--- a/apps/src/componentLibrary/dropdown/checkboxDropdown/CheckboxDropdown.story.tsx
+++ b/apps/src/componentLibrary/dropdown/checkboxDropdown/CheckboxDropdown.story.tsx
@@ -245,8 +245,24 @@ GroupOfCheckboxDropdownColors.args = {
       color: dropdownColors.black,
       disabled: false,
     },
+    {
+      name: 'default-dropdown-gray',
+      allOptions: [
+        {value: 'option-1', label: 'Option 1'},
+        {value: 'option-2', label: 'Option 2'},
+      ],
+      checkedOptions: ['option-1'],
+      labelText: 'Gray Dropdown',
+      onChange: args => null,
+      onSelectAll: args => null,
+      onClearAll: args => null,
+      size: 'm',
+      color: dropdownColors.gray,
+      disabled: false,
+    },
   ],
 };
+
 export const GroupOfSizesOfCheckboxDropdown = MultipleTemplate.bind({});
 GroupOfSizesOfCheckboxDropdown.args = {
   components: [

--- a/apps/src/componentLibrary/dropdown/customDropdown.module.scss
+++ b/apps/src/componentLibrary/dropdown/customDropdown.module.scss
@@ -273,6 +273,10 @@
     color: $light_white;
     border-color: $light_white;
     background-color: $light_black;
+
+    span {
+      color: $light_white;
+    }
   }
 
   &:has(.dropdownButton:hover) {

--- a/apps/src/componentLibrary/dropdown/customDropdown.module.scss
+++ b/apps/src/componentLibrary/dropdown/customDropdown.module.scss
@@ -222,6 +222,48 @@
   }
 }
 
+.dropdownContainer-gray {
+  .dropdownLabel {
+    color: $light_black;
+  }
+
+  .dropdownButton {
+    color: $light_black;
+    border-color: $light_gray_400;
+    background-color: $light_white;
+  }
+
+  &:has(.dropdownButton:hover) {
+    .dropdownButton:not(:disabled) {
+      color: $light_black;
+      background-color: $light_gray_100;
+    }
+  }
+
+  &:has(.dropdownButton:active) {
+    .dropdownButton:not(:disabled) {
+      color: $light_black;
+      background-color: $light_white;
+    }
+  }
+
+  &:has(.dropdownButton:disabled) {
+    .dropdownButton {
+      color: $light_gray_200;
+      border-color: $light_gray_200 !important;
+      cursor: not-allowed;
+
+      .dropdownLabel {
+        color: $light_gray_200;
+      }
+    }
+
+    .dropdownLabel {
+      color: $light_gray_200;
+    }
+  }
+}
+
 .dropdownContainer-white {
   .dropdownLabel {
     color: $light_white;

--- a/apps/src/componentLibrary/dropdown/iconDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/iconDropdown/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0]()
+* added `gray` color to `IconDropdown`
+
 ## [0.2.2](https://github.com/code-dot-org/code-dot-org/pull/58469)
 * added support of all `aria-` attributes by `IconDropdown` component
 

--- a/apps/src/componentLibrary/dropdown/iconDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/iconDropdown/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.0]()
+## [0.3.0](https://github.com/code-dot-org/code-dot-org/pull/58637)
 * added `gray` color to `IconDropdown`
 
 ## [0.2.2](https://github.com/code-dot-org/code-dot-org/pull/58469)

--- a/apps/src/componentLibrary/dropdown/iconDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/iconDropdown/CHANGELOG.md
@@ -3,20 +3,26 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.3.0](https://github.com/code-dot-org/code-dot-org/pull/58637)
+
 * added `gray` color to `IconDropdown`
+* fixed `thin` `white` dropdown text color
 
 ## [0.2.2](https://github.com/code-dot-org/code-dot-org/pull/58469)
+
 * added support of all `aria-` attributes by `IconDropdown` component
 
 ## [0.2.1](https://github.com/code-dot-org/code-dot-org/pull/58209)
+
 * minor styles and stories updates for consistency
 * added `className` prop
 
 ## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/57827)
+
 * added `thick` and `thin` label style types (`labelType` prop)
 * added black and white background color fill
 
 ## [0.1.0](https://github.com/code-dot-org/code-dot-org/pull/56683)
+
 * Created `IconDropdown` component
 * created stories for  `IconDropdown` component
 * created tests for  `IconDropdown` component

--- a/apps/src/componentLibrary/dropdown/iconDropdown/IconDropdown.story.tsx
+++ b/apps/src/componentLibrary/dropdown/iconDropdown/IconDropdown.story.tsx
@@ -275,6 +275,31 @@ GroupOfIconDropdownColors.args = {
       color: dropdownColors.black,
       disabled: false,
     },
+    {
+      name: 'default-dropdown-gray',
+      options: [
+        {
+          value: 'option-1',
+          label: 'Option 1',
+          icon: {iconName: 'check', iconStyle: 'solid'},
+        },
+        {
+          value: 'option-2',
+          label: 'Option 2',
+          icon: {iconName: 'xmark', iconStyle: 'solid'},
+        },
+      ],
+      selectedOption: {
+        value: 'option-1',
+        label: 'Option 1',
+        icon: {iconName: 'check', iconStyle: 'solid'},
+      },
+      labelText: 'Gray Dropdown',
+      onChange: args => null,
+      size: 'm',
+      color: dropdownColors.gray,
+      disabled: false,
+    },
   ],
 };
 export const GroupOfSizesOfIconDropdown = MultipleTemplate.bind({});

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
@@ -2,27 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0]()
+* added `grey` color `SimpleDropdown`
+
 ## [0.5.2](https://github.com/code-dot-org/code-dot-org/pull/58469)
+
 * added support of all `aria-` attributes by `SimpleDropdown` component
 
 ## [0.5.1](https://github.com/code-dot-org/code-dot-org/pull/58209)
+
 * minor story update
 
 ## [0.5.0](https://github.com/code-dot-org/code-dot-org/pull/57827)
+
 * added dropdownTextThickness prop to allow for setting the font weight of the dropdown text
 * removed unnecessary margin-bottom that was fetched from typography styles
 * added black and white background color fill
 
 ## [0.4.0](https://github.com/code-dot-org/code-dot-org/pull/57105)
+
 * use `width: 100%` instead of `width: auto` as default when styling `select` element.
 * style select element with the use of `select` css selector instead of `.dropdown`
 
 ## [0.3.0](https://github.com/code-dot-org/code-dot-org/pull/57105)
+
 * moved `SimpleDropdown` to dropdown folder
 
 ## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/56724)
+
 * Added `itemGroups` prop to allow for grouped options in dropdown.
 
 ## [0.1.0](https://github.com/code-dot-org/code-dot-org/pull/55514)
+
 * created component's skeleton
 * Initial commit

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.6.0]()
-* added `grey` color `SimpleDropdown`
+## [0.6.0](https://github.com/code-dot-org/code-dot-org/pull/58637)
+* added `gray` color `SimpleDropdown`
 
 ## [0.5.2](https://github.com/code-dot-org/code-dot-org/pull/58469)
 

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.6.0](https://github.com/code-dot-org/code-dot-org/pull/58637)
+
 * added `gray` color `SimpleDropdown`
+* fixed `thin` `white` dropdown text color
 
 ## [0.5.2](https://github.com/code-dot-org/code-dot-org/pull/58469)
 

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/SimpleDropdown.story.tsx
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/SimpleDropdown.story.tsx
@@ -169,6 +169,18 @@ GroupOfDropdownColors.args = {
       size: 'm',
       color: 'black',
     },
+    {
+      name: 'default-dropdown-gray',
+      items: [
+        {value: 'option-1', text: 'Option 1'},
+        {value: 'option-2', text: 'Option 2'},
+      ],
+      selectedValue: 'option-1',
+      labelText: 'Gray Dropdown',
+      onChange: args => console.log(args),
+      size: 'm',
+      color: 'gray',
+    },
   ],
 };
 export const GroupOfSizesOfDropdown = MultipleTemplate.bind({});

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/SimpleDropdown.tsx
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/SimpleDropdown.tsx
@@ -32,7 +32,7 @@ export interface SimpleDropdownProps extends AriaAttributes {
   /** SimpleDropdown color. Sets the color of dropdown arrow, text, label and border color.
    * White stands for 'white' dropdown that'll be rendered on dark background,
    * 'black' stands for black dropdown that'll be rendered on the white/light background. */
-  color?: 'white' | 'black';
+  color?: 'white' | 'black' | 'gray';
   /** SimpleDropdown size */
   size: ComponentSizeXSToL;
 }

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
@@ -148,7 +148,7 @@
     color: $light_white;
   }
 
-  select {
+  &.dropdownContainer.dropdownContainer-thin select, select {
     color: $light_white;
     border-color: $light_white;
     background-color: $light_black;
@@ -239,6 +239,7 @@
   &.dropdownContainer-thin {
     select {
       @include body-two;
+      color: inherit;
       margin-bottom: 0;
     }
   }

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
@@ -95,6 +95,54 @@
   }
 }
 
+.dropdownContainer-gray {
+  .dropdownLabel {
+    color: $light_black;
+  }
+
+  select {
+    color: $light_black;
+    border-color: $light_gray_400;
+    background-color: $light_white;
+  }
+
+  .dropdownArrowDiv:after {
+    color: $light_black;
+  }
+
+  &:has(select:hover) {
+    select:not(:disabled) {
+      color: $light_black;
+      background-color: $light_gray_100;
+    }
+
+    .dropdownArrowDiv:after {
+      color: $light_black;
+    }
+  }
+
+  &:has(select:active) {
+    select:not(:disabled) {
+      color: $light_black;
+    }
+
+    .dropdownArrowDiv:after {
+      color: $light_black;
+    }
+  }
+
+  &:has(select:disabled) {
+    select {
+      color: $light_gray_200;
+      border-color: $light_gray_200;
+    }
+
+    .dropdownArrowDiv:after {
+      color: $light_gray_200;
+    }
+  }
+}
+
 .dropdownContainer-white {
   .dropdownLabel {
     color: $light_white;

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -199,6 +199,7 @@ $light_gray_50: #F7F8FA;
 $light_gray_100: #EAEBEB;
 $light_gray_200: #D4D5D7;
 $light_gray_300: #BFC1C3;
+$light_gray_400: #A9ACAF;
 $light_gray_500: #94979B;
 $light_gray_700: #6A6E73;
 $light_gray_800: #54595E;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [Design2-110] DSCO - Dropdowns - Add gray color

* added gray color to `SimpleDropdown`, `CheckboxDropdown`, `IconDropdown`
* fixed `thin` `white` Dropdowns text color

Before:
<img width="1257" alt="Знімок екрана 2024-05-15 о 14 41 15" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/1d567dcb-8042-4d6b-906f-4ff10d610680">
<img width="1257" alt="Знімок екрана 2024-05-15 о 14 41 08" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/e10870ef-70b5-4108-955e-3dbc307e2d33">
<img width="1257" alt="Знімок екрана 2024-05-15 о 14 41 00" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/36c0c99b-ec06-404c-ac06-e81a3688e330">
<img width="484" alt="Знімок екрана 2024-05-16 о 21 10 29" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/daaebb62-8d2d-458f-868f-4adb382a875e">
<img width="521" alt="Знімок екрана 2024-05-16 о 21 06 39" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/4972d94d-1f82-4274-8fee-3379c4341971">
<img width="484" alt="Знімок екрана 2024-05-16 о 21 09 57" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/097a9c37-3ba5-46bd-b006-17586e02b268">


After:

<img width="1257" alt="Знімок екрана 2024-05-15 о 15 11 47" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/8ef0be65-0395-4825-aeb9-3ea3c6c91103">
<img width="1257" alt="Знімок екрана 2024-05-15 о 15 09 46" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/c911f2eb-4006-4880-b096-3779e4229fbc">
<img width="1257" alt="Знімок екрана 2024-05-15 о 15 07 05" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/e1e0eb2e-3d58-4c23-9bfe-f6fccc17c05e">
<img width="521" alt="Знімок екрана 2024-05-16 о 21 06 18" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/f26227e7-3e61-4f3f-a8ba-4e51ca906b56">
<img width="484" alt="Знімок екрана 2024-05-16 о 21 09 28" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/d45b2046-c236-40cd-b76c-0a5fa0d727ea">
<img width="484" alt="Знімок екрана 2024-05-16 о 21 09 39" src="https://github.com/code-dot-org/code-dot-org/assets/22244040/ef7067d8-68f6-4c19-988c-c6a47ea38bf7">


## Links
- jira ticket: [Design2-110](https://codedotorg.atlassian.net/browse/DESIGN2-110)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
