### PR TITLE
Fix eyes tests by using correct section name

### DIFF
--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -344,9 +344,9 @@ Then /^I create a new code review group for the section I saved$/ do
   GHERKIN
 end
 
-And /^I navigate to the V2 progress dashboard$/ do
+And /^I navigate to the V2 progress dashboard for "([^"]+)"$/ do |section_name|
   steps <<-GHERKIN
-    When I click selector "a:contains(Untitled Section)" once I see it to load a new page
+    When I click selector "a:contains(#{section_name})" once I see it to load a new page
     And I wait until element "#uitest-teacher-dashboard-nav" is visible
     And check that the URL contains "/teacher_dashboard/sections/"
     And I wait until element "#uitest-course-dropdown" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
@@ -8,7 +8,7 @@ Scenario: Teacher can open and close Icon Key and details
 
   When I sign in as "Teacher_Sally" and go home
   And I get levelbuilder access
-  And I navigate to the V2 progress dashboard
+  And I navigate to the V2 progress dashboard for "Untitled Section"
   
   # toggle to V2 progress view
   And I wait until element "h6:contains(Icon Key)" is visible
@@ -34,7 +34,7 @@ Scenario: Teacher can open and close lessons and see level data cells
     
   When I sign in as "Teacher_Sally" and go home
   And I get levelbuilder access
-  And I navigate to the V2 progress dashboard
+  And I navigate to the V2 progress dashboard for "Untitled Section"
 
   # Teacher can open lesson to view level data
   And I wait until element "#ui-test-lesson-header-2" is visible
@@ -51,7 +51,7 @@ Scenario: Teacher can navigate to student work by clicking level cell.
     
   When I sign in as "Teacher_Sally" and go home
   And I get levelbuilder access
-  And I navigate to the V2 progress dashboard
+  And I navigate to the V2 progress dashboard for "Untitled Section"
 
   # Teacher opens lesson data and clicks on level data cell
   And I wait until element "#ui-test-lesson-header-2" is visible
@@ -67,7 +67,7 @@ Scenario: Teacher can open lesson data, refresh the page, and lesson data will s
     
   When I sign in as "Teacher_Sally" and go home
   And I get levelbuilder access
-  And I navigate to the V2 progress dashboard
+  And I navigate to the V2 progress dashboard for "Untitled Section"
 
   # Open a lesson to see level data
   And I wait until element "#ui-test-lesson-header-2" is visible
@@ -99,7 +99,7 @@ Scenario: Teacher can view lesson progress for when students have completed a le
 
   When I sign in as "Teacher_Sally" and go home
   And I get levelbuilder access
-  And I navigate to the V2 progress dashboard
+  And I navigate to the V2 progress dashboard for "Untitled Section"
   And I wait until element "#uitest-circle" is visible
 
   And I open my eyes to test "V2 progress dashboard"
@@ -122,7 +122,7 @@ Scenario: Teacher can view student work, ask student to keep working, on rubric 
   # Teacher sees "needs feedback" in the table
   When I sign in as "Teacher_Sally" and go home
   And I get levelbuilder access
-  And I navigate to the V2 progress dashboard
+  And I navigate to the V2 progress dashboard for "Untitled Section"
 
   # Check that the needs feedback icon is present
   And I wait until element "#ui-test-lesson-header-1" is visible
@@ -176,7 +176,7 @@ Scenario: Teacher can view choice levels
 
   When I sign in as "Teacher_Sally" and go home
   And I get levelbuilder access
-  And I navigate to the V2 progress dashboard
+  And I navigate to the V2 progress dashboard for "Untitled Section"
 
   # View unexpanded choice level
   And I wait until element "#ui-test-lesson-header-1" is visible
@@ -226,7 +226,7 @@ Scenario: Teacher can view validated level
 
   When I sign in as "Dumbledore" and go home
   And I get levelbuilder access
-  And I navigate to the V2 progress dashboard
+  And I navigate to the V2 progress dashboard for "New Section"
 
   # eyes test for unexpanded lessons
   And I wait until element "#ui-test-lesson-header-1" is visible


### PR DESCRIPTION
Eyes test `Teacher can view validated level` was failing due to searching for `Untitled Section` instead of `New Section` in the step `I navigate to the V2 progress dashboard`.

This PR fixes the test failure by adding a section name to the `I navigate to the V2 progress dashboard` step.

## Links
https://codedotorg.slack.com/archives/C045UAX4WKH/p1715787586728989
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
