### PR TITLE
P20 893/cap user events logging with state columns

### DIFF
--- a/dashboard/app/models/cap/user_event.rb
+++ b/dashboard/app/models/cap/user_event.rb
@@ -36,5 +36,12 @@ module CAP
 
     validates :name, presence: true
     validates :policy, presence: true
+
+    before_save :ensure_state_is_set
+
+    private def ensure_state_is_set
+      self.state_before ||= user.child_account_compliance_state
+      self.state_after ||= user.child_account_compliance_state
+    end
   end
 end

--- a/dashboard/app/models/concerns/serialized_properties.rb
+++ b/dashboard/app/models/concerns/serialized_properties.rb
@@ -29,6 +29,10 @@ module SerializedProperties
     super
   end
 
+  def property_before_save(key)
+    properties_previous_change&.any? ? properties_previous_change.dig(0, key) : properties[key]
+  end
+
   def property_changed?(key)
     changes = changed_attributes['properties']
     return false if changes.nil?

--- a/dashboard/lib/services/child_account/event_logger.rb
+++ b/dashboard/lib/services/child_account/event_logger.rb
@@ -25,7 +25,11 @@ module Services
       def call
         return unless policy
 
-        CAP::UserEvent.create!(user: user, policy: policy, name: event_name)
+        # Get the value of the property before the user was last saved.
+        # This will be the current value if the value was not updated.
+        state_before = user.property_before_save('child_account_compliance_state')
+
+        CAP::UserEvent.create!(user: user, policy: policy, name: event_name, state_before: state_before, state_after: user.child_account_compliance_state)
       end
 
       private def policy

--- a/dashboard/test/models/concerns/serialized_properties_test.rb
+++ b/dashboard/test/models/concerns/serialized_properties_test.rb
@@ -1,0 +1,120 @@
+require 'test_helper'
+
+class SerializedPropertiesTest < ActiveSupport::TestCase
+  setup do
+    @user = create :user, properties: {us_state: 'CO'}
+  end
+
+  test 'assign_attributes ensures properties are merged' do
+    @user.assign_attributes({properties: {gender_student_input: 'f'}})
+
+    assert_equal 'CO', @user.us_state
+    assert_equal 'f', @user.gender_student_input
+  end
+
+  test 'assign_attributes adds properties when none already exist' do
+    user = create :user, properties: {}
+    user.assign_attributes({properties: {gender_student_input: 'f'}})
+
+    assert_equal 'f', user.gender_student_input
+  end
+
+  test 'property_before_save returns the original value after a save' do
+    @user.us_state = 'PA'
+    @user.save
+
+    assert_equal 'CO', @user.property_before_save('us_state')
+  end
+
+  test 'property_before_save returns the current value even if untouched' do
+    @user.gender_student_input = 'f'
+    @user.save
+
+    assert_equal 'CO', @user.property_before_save('us_state')
+  end
+
+  test 'property_before_save returns the current value even if unsaved' do
+    assert_equal @user.property_before_save('us_state'), 'CO'
+  end
+
+  test 'property_before_save returns nil if the value was previously not set' do
+    @user.gender_student_input = 'f'
+    @user.save
+
+    assert_nil @user.property_before_save('gender_student_input')
+  end
+
+  test 'property_before save returns the original value when the property is deleted' do
+    @user.us_state = nil
+    @user.save
+
+    assert_equal 'CO', @user.property_before_save('us_state')
+  end
+
+  test 'property_changed? returns true when the property is dirty' do
+    @user.us_state = 'PA'
+    assert @user.property_changed?('us_state')
+  end
+
+  test 'property_changed? returns false when the property has not changed' do
+    @user.gender_student_input = 'f'
+    refute @user.property_changed?('us_state')
+  end
+
+  test 'property_changed? returns false after the record is saved' do
+    @user.us_state = 'PA'
+    @user.save
+
+    refute @user.property_changed?('us_state')
+  end
+
+  test 'created the reader method' do
+    assert @user.respond_to?(:us_state)
+  end
+
+  test 'can read the correct value' do
+    assert_equal @user.us_state, 'CO'
+  end
+
+  test 'unset properties are nil' do
+    assert_nil @user.gender_student_input
+  end
+
+  test 'created the writer method' do
+    assert @user.respond_to?(:us_state=)
+  end
+
+  test 'can write and persist a new value' do
+    @user.us_state = 'PA'
+    assert @user.us_state == 'PA'
+  end
+
+  test 'created the query method' do
+    assert @user.respond_to?(:us_state?)
+  end
+
+  test 'query method returns true when the property is set' do
+    assert @user.us_state?
+  end
+
+  test 'query method returns false when the property is missing or nil' do
+    refute @user.gender_student_input?
+
+    @user.us_state = nil
+    refute @user.us_state?
+  end
+
+  test 'deletes the existing property when set to nil' do
+    @user.us_state = nil
+    @user.save!
+
+    refute @user.read_attribute('properties').key?('us_state')
+  end
+
+  test 'does not serialize any unset properties' do
+    @user.us_state = 'CO'
+    @user.save!
+
+    refute @user.read_attribute('properties').key?('gender_student_input')
+  end
+end


### PR DESCRIPTION
This adds the necessarily logic to record the before/after state to the CAP user events which is still pending via the https://github.com/code-dot-org/code-dot-org/pull/58568 pull request.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
