### PR TITLE
P20-57: Skip CAP compliance check for students whose birthdays are not set

### DIFF
--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -94,6 +94,7 @@ class Policies::ChildAccount
   # Child Account Policy.
   private_class_method def self.parent_permission_required?(user)
     return false unless user.student?
+    return false unless user.birthday
 
     policy = state_policy(user)
     return false unless policy

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -2,6 +2,10 @@ require 'cdo/activity_constants'
 require 'policies/child_account'
 
 FactoryBot.define do
+  trait :skip_validation do
+    to_create {|instance| instance.save(validate: false)}
+  end
+
   factory :course_offering do
     sequence(:key, 'a') {|c| "bogus-course-offering-#{c}"}
     sequence(:display_name, 'a') {|c| "bogus-course-offering-#{c}"}

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -39,6 +39,7 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       [[:non_compliant_child, :with_lti_auth], true],
       [[:non_compliant_child, :with_pending_parent_permission, {created_at: '2023-06-30T23:59:59Z'}], true],
       [[:non_compliant_child, :with_pending_parent_permission, {created_at: '2023-07-01T00:00:00Z'}], false],
+      [[:non_compliant_child, :skip_validation, {birthday: nil}], true],
     ]
     test_matrix.each do |traits, compliance|
       user = create(*traits)


### PR DESCRIPTION
## Error
```
NoMethodError: undefined method `in_time_zone` for nil:NilClass
```
https://github.com/code-dot-org/code-dot-org/blob/6b83cf15a8babdfa2d6996ac99b49fbbcb570518/dashboard/lib/policies/child_account.rb#L102
- https://codedotorg.slack.com/archives/C55JZ1BPZ/p1715789728789109
- https://app.honeybadger.io/projects/3240/faults/107871815

## Links

- JIRA ticket: [P20-57](https://codedotorg.atlassian.net/browse/P20-57)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/58337