### PR TITLE
Update JotForms Model Test

### DIFF
--- a/dashboard/test/models/concerns/pd/jot_form_backed_form_test.rb
+++ b/dashboard/test/models/concerns/pd/jot_form_backed_form_test.rb
@@ -33,16 +33,18 @@ module Pd
     self.use_transactional_test_case = true
 
     setup_all do
-      # create a temporary table for our DummyForm record. Note that because the
-      # table is temporary, it will be automatically destroyed once the session has
-      # ended so we don't need to worry about dropping the table in teardown
-      ActiveRecord::Base.connection.create_table(:pd_dummy_forms, temporary: true) do |t|
+      # Create a  table for our DummyForm record.
+      ActiveRecord::Base.connection.create_table(:pd_dummy_forms) do |t|
         t.integer :form_id, length: 8
         t.integer :submission_id, length: 8
         t.string :unique_key
         t.string :custom_field
         t.text :answers
       end
+    end
+
+    teardown_all do
+      ActiveRecord::Base.connection.drop_table(:pd_dummy_forms, {if_exists: true})
     end
 
     setup do


### PR DESCRIPTION
Update JotForms model test to stop using a temporary table to unblock MySQL 8 upgrade. We'd like to enable MySQL binary logging (with Global Transaction IDentifiers - GTID - ON) #58421 , but creating a temporary table within a transaction is not permitted under those conditions. Switch to using a real database table and tear it down after the test file completes.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
