### PR TITLE
P20-558: Fix joins to sections

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -175,7 +175,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
       return
     end
     render json: {
-      sections: current_user.sections_as_student.map(&:summarize_without_students),
+      sections: current_user.sections_as_student.reload.map(&:summarize_without_students),
       studentSections: current_user.sections_as_student_participant.map(&:summarize_without_students),
       plSections: current_user.sections_as_pl_participant.map(&:summarize_without_students),
       result: result


### PR DESCRIPTION
## Issue
I couldn’t reproduce the bug locally, but based on the available information from production,
it seems that the `current_user` sections are already preloaded on prod.
Therefore, we need to refresh the preloaded collection of sections whenever a new section is added.

https://github.com/code-dot-org/code-dot-org/blob/4ff077e255571bd39479f7671486a98e655b8692/apps/src/templates/studioHomepages/JoinSection.jsx#L60-L68

## Links
- JIRA ticket: [P20-558](https://codedotorg.atlassian.net/browse/P20-558)