### PR TITLE
Panels: remove deprecated level data when saving level

### DIFF
--- a/apps/src/lab2/levelEditors/panels/EditPanels.tsx
+++ b/apps/src/lab2/levelEditors/panels/EditPanels.tsx
@@ -103,6 +103,13 @@ const EditPanels: React.FunctionComponent<EditPanelsProps> = ({
         name="level[panels]"
         value={JSON.stringify(panels)}
       />
+      {/* This extra empty input is used to clear out any old panels data saved to the level's "level_data" field */}
+      <input
+        type="hidden"
+        id="level_level_data"
+        name="level[level_data]"
+        value={JSON.stringify({})}
+      />
       <Heading3>Preview</Heading3>
       <div className={moduleStyles.panelsContainer}>
         <Toast message={toastMessage} index={toastIndex} />


### PR DESCRIPTION
A quick fix to automatically clean up unused data in Panels levels whenever they're saved.

Example diff after saving level:
<img width="1116" alt="Screenshot 2024-05-15 at 1 42 26 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/b7a8009f-06a9-4432-b8ef-bf0496ad2635">

## Testing story

Tested locally with Music Lab panels levels.