### PR TITLE
Music: use sounds panel revision

### DIFF
--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -7,9 +7,16 @@ import experiments from '@cdo/apps/util/experiments';
 import color from '@cdo/apps/util/color';
 import SoundStyle from '../utils/SoundStyle';
 import AppConfig from '../appConfig';
+import DCDO from '@cdo/apps/dcdo';
 
 const FIELD_HEIGHT = 20;
 const FIELD_PADDING = 2;
+
+// Default to using SoundsPanel2, unless a URL parameter or a DCDO flag
+// forces the use of the older SoundsPanel.
+const useSoundsPanel1 =
+  AppConfig.getValue('sounds-panel-2') === 'false' ||
+  DCDO.get('music-lab-use-sounds-panel-1', false);
 
 /**
  * A custom field that renders the sample previewing and choosing UI, used in
@@ -113,10 +120,7 @@ class FieldSounds extends GoogleBlockly.Field {
       return;
     }
 
-    const CurrentSoundsPanel =
-      AppConfig.getValue('sounds-panel-2') === 'true'
-        ? SoundsPanel2
-        : SoundsPanel;
+    const CurrentSoundsPanel = useSoundsPanel1 ? SoundsPanel : SoundsPanel2;
 
     ReactDOM.render(
       <CurrentSoundsPanel
@@ -143,7 +147,7 @@ class FieldSounds extends GoogleBlockly.Field {
         }}
         onSelect={value => {
           this.setValue(value);
-          if (AppConfig.getValue('sounds-panel-2') !== 'true') {
+          if (useSoundsPanel1) {
             this.hide_();
           }
         }}

--- a/apps/src/music/views/EaseIntoView.tsx
+++ b/apps/src/music/views/EaseIntoView.tsx
@@ -2,24 +2,24 @@ import React, {useEffect, useRef} from 'react';
 
 const animationFramesPerSecond = 60;
 
-// ScrollIntoView: This component does an eased scroll of the container's content,
+// EaseIntoView: This component does an eased scroll of the container's content,
 // starting from a distance below the top, and scrolling to the top.  It's useful
 // to show the user that some new content is scrollable.
 
-interface ScrollIntoViewProps {
+interface EaseIntoViewProps {
   id?: string;
   className?: string;
-  doScroll: boolean;
+  doEase: boolean;
   delay: number;
   frames: number;
   distanceY: number;
   children: React.ReactNode;
 }
 
-const ScrollIntoView: React.FunctionComponent<ScrollIntoViewProps> = ({
+const EaseIntoView: React.FunctionComponent<EaseIntoViewProps> = ({
   id,
   className,
-  doScroll,
+  doEase,
   delay,
   frames,
   distanceY,
@@ -40,7 +40,7 @@ const ScrollIntoView: React.FunctionComponent<ScrollIntoViewProps> = ({
 
   // Initial render.
   useEffect(() => {
-    if (!doScroll) {
+    if (!doEase) {
       return;
     }
 
@@ -75,7 +75,7 @@ const ScrollIntoView: React.FunctionComponent<ScrollIntoViewProps> = ({
         }
       }
     }, 1000 / animationFramesPerSecond);
-  }, [delay, distanceY, doScroll, frames]);
+  }, [delay, distanceY, doEase, frames]);
 
   return (
     <div id={id} className={className} ref={containerRefCallback}>
@@ -84,4 +84,4 @@ const ScrollIntoView: React.FunctionComponent<ScrollIntoViewProps> = ({
   );
 };
 
-export default ScrollIntoView;
+export default EaseIntoView;

--- a/apps/src/music/views/SoundsPanel2.tsx
+++ b/apps/src/music/views/SoundsPanel2.tsx
@@ -253,8 +253,9 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
     useRef(null);
 
   // Capture whether the initially-selected sound is the default sound, in which
-  // case we will do a smooth scroll into view, rather than scroll directly
-  // to the current sound.
+  // case we will do a smooth ease into view, rather than scroll directly
+  // to the current sound.  Uses useRef so that changes to this value don't trigger
+  // additional executions of the "Initial render" useEffect, below.
   const isDefaultSoundSelected = useRef(
     currentValue === library.getDefaultSound()
   );

--- a/apps/src/music/views/SoundsPanel2.tsx
+++ b/apps/src/music/views/SoundsPanel2.tsx
@@ -12,14 +12,14 @@ import MusicLibrary, {
 import SoundStyle from '../utils/SoundStyle';
 import FocusLock from 'react-focus-lock';
 import SegmentedButtons from '@cdo/apps/componentLibrary/segmentedButtons';
-import ScrollIntoView from './ScrollIntoView';
+import EaseIntoView from './EaseIntoView';
 
 import musicI18n from '../locale';
 
-const scrollIntoViewDelayFramesFolders = 0;
-const scrollIntoViewDelayFramesSounds = 5;
-const scrollIntoViewFrames = 50;
-const scrollIntoViewDistanceY = 70;
+const easeIntoViewDelayFramesFolders = 0;
+const easeIntoViewDelayFramesSounds = 5;
+const easeIntoViewFrames = 50;
+const easeIntoViewDistanceY = 70;
 
 /*
  * Renders a UI for previewing and choosing samples.  Version 2 implements a new UI that shows a
@@ -270,7 +270,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   // Initial render.
   useEffect(() => {
     // If the user has selected a non-default sound, then jump directly to it.
-    // If the default sound is selected, then the ScrollIntoView component will do
+    // If the default sound is selected, then the EaseIntoView component will do
     // an initial scroll instead.
     if (!isDefaultSoundSelected.current) {
       // This timeout allows the initial scroll-to-current-selection to work
@@ -359,13 +359,13 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
         )}
         <div id="sounds-panel-body" className={styles.soundsPanelBody}>
           {mode === 'packs' && (
-            <ScrollIntoView
+            <EaseIntoView
               id="sounds-panel-left"
               className={styles.leftColumn}
-              doScroll={isDefaultSoundSelected.current}
-              delay={scrollIntoViewDelayFramesFolders}
-              frames={scrollIntoViewFrames}
-              distanceY={scrollIntoViewDistanceY}
+              doEase={isDefaultSoundSelected.current}
+              delay={easeIntoViewDelayFramesFolders}
+              frames={easeIntoViewFrames}
+              distanceY={easeIntoViewDistanceY}
             >
               {folders.map(folder => {
                 return (
@@ -381,18 +381,18 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
                   />
                 );
               })}
-            </ScrollIntoView>
+            </EaseIntoView>
           )}
-          <ScrollIntoView
+          <EaseIntoView
             id="sounds-panel-right"
             className={classNames(
               styles.rightColumn,
               mode === 'sounds' && styles.rightColumnFullWidth
             )}
-            doScroll={isDefaultSoundSelected.current}
-            delay={scrollIntoViewDelayFramesSounds}
-            frames={scrollIntoViewFrames}
-            distanceY={scrollIntoViewDistanceY}
+            doEase={isDefaultSoundSelected.current}
+            delay={easeIntoViewDelayFramesSounds}
+            frames={easeIntoViewFrames}
+            distanceY={easeIntoViewDistanceY}
           >
             {rightColumnSoundEntries.map(soundEntry => {
               return (
@@ -409,7 +409,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
                 />
               );
             })}
-          </ScrollIntoView>
+          </EaseIntoView>
         </div>
       </div>
     </FocusLock>

--- a/apps/src/music/views/SoundsPanel2.tsx
+++ b/apps/src/music/views/SoundsPanel2.tsx
@@ -252,7 +252,12 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
   const currentSoundRef: React.MutableRefObject<HTMLDivElement | null> =
     useRef(null);
 
-  const isDefaultSoundSelected = currentValue === library.getDefaultSound();
+  // Capture whether the initially-selected sound is the default sound, in which
+  // case we will do a smooth scroll into view, rather than scroll directly
+  // to the current sound.
+  const isDefaultSoundSelected = useRef(
+    currentValue === library.getDefaultSound()
+  );
 
   const onModeChange = useCallback((value: Mode) => {
     setMode(value);
@@ -267,7 +272,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
     // If the user has selected a non-default sound, then jump directly to it.
     // If the default sound is selected, then the ScrollIntoView component will do
     // an initial scroll instead.
-    if (!isDefaultSoundSelected) {
+    if (!isDefaultSoundSelected.current) {
       // This timeout allows the initial scroll-to-current-selection to work
       // when wrapping the content with FocusLock.
       setTimeout(() => {
@@ -275,7 +280,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
         currentSoundRef.current?.scrollIntoView();
       }, 0);
     }
-  }, [isDefaultSoundSelected]);
+  }, []);
 
   const currentFolderRefCallback = (ref: HTMLDivElement) => {
     currentFolderRef.current = ref;
@@ -357,7 +362,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
             <ScrollIntoView
               id="sounds-panel-left"
               className={styles.leftColumn}
-              doScroll={isDefaultSoundSelected}
+              doScroll={isDefaultSoundSelected.current}
               delay={scrollIntoViewDelayFramesFolders}
               frames={scrollIntoViewFrames}
               distanceY={scrollIntoViewDistanceY}
@@ -384,7 +389,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
               styles.rightColumn,
               mode === 'sounds' && styles.rightColumnFullWidth
             )}
-            doScroll={isDefaultSoundSelected}
+            doScroll={isDefaultSoundSelected.current}
             delay={scrollIntoViewDelayFramesSounds}
             frames={scrollIntoViewFrames}
             distanceY={scrollIntoViewDistanceY}

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -55,8 +55,8 @@ const optionsList = [
     name: 'sounds-panel-2',
     type: 'radio',
     values: [
-      {value: 'false', description: 'Use original sounds panel (default).'},
-      {value: 'true', description: 'Use new sounds panel.'},
+      {value: 'false', description: 'Use original sounds panel.'},
+      {value: 'true', description: 'Use new sounds panel (default).'},
     ],
   },
   {

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
@@ -34,7 +34,10 @@ Scenario Outline: Dragging play sound block
   And I click selector "#sounds-panel .sounds-panel-folder-row:nth-of-type(2)"
 
   # Click on the second sound inside the sounds panel.
-  And I click selector "#sounds-panel .sounds-panel-sound-row:nth-of-type(2)"
+  And I click selector "#sounds-panel .sounds-panel-sound-entry:nth-of-type(2)"
+
+  # Use escape key to close sounds panel.
+  And I press keys ":escape"
 
   # The sounds panel should be dismissed.
   And I wait until element "#sounds-panel" is not visible

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -49,6 +49,7 @@ class DCDOBase < DynamicConfigBase
       'incubator-canvas-block-enabled': DCDO.get('incubator-canvas-block-enabled', true),
       'progress-table-v2-metadata-enabled': DCDO.get('progress-table-v2-metadata-enabled', false),
       'music-lab-launch-2024': DCDO.get('music-lab-launch-2024', false),
+      'music-lab-use-sounds-panel-1': DCDO.get('music-lab-use-sounds-panel-1', false),
     }
   end
 end


### PR DESCRIPTION
With this change, the revised sounds panel introduced in https://github.com/code-dot-org/code-dot-org/pull/58275 becomes the default.

Two UI issues have been fixed:
- When the current sound was the default, and the sounds panel was opened, and another sound was clicked, we instantly scrolled to that new sound.
- When the current sound was not the default, and the sounds panel was opened, and the default sound was clicked, we did an eased scroll to the default sound.

The `ScrollIntoView` component has been renamed `EaseIntoView` to alleviate confusion with the browser's existing `scrollIntoView` function.

A DCDO flag of `"music-lab-use-sounds-panel-1"` can be set to `true` or the `sounds-panel-2=false` URL parameter can continue to be used to switch back to the legacy sounds panel.
