### PR TITLE
Applab: fix screen import ID conflict between screen and element

### DIFF
--- a/apps/src/applab/ImportScreensDialog.jsx
+++ b/apps/src/applab/ImportScreensDialog.jsx
@@ -25,6 +25,13 @@ const SCALE = 0.1;
 const MARGIN = 10;
 const ICON_HEIGHT = applabConstants.APP_HEIGHT * SCALE;
 
+export const IMPORT_FAILURE_MESSAGE = `
+  Cannot import the following screens because their IDs or
+  contained design element IDs are already used in your existing
+  project. Fix the IDs in either project so they aren't
+  duplicated between the two projects before trying to import the following.
+`;
+
 // TODO: possibly refactor AssetRow to make it work here instead of
 // or with this component
 class AssetListItemUnwrapped extends React.Component {
@@ -206,13 +213,7 @@ export class ImportScreensDialog extends React.Component {
             {nonImportableScreens.length > 0 && (
               <div style={styles.section}>
                 <h2 style={multiCheckboxStyles.header}>Cannot Import</h2>
-                <p style={styles.subtext}>
-                  Cannot import the following screens because their IDs or
-                  contained design element IDs are already used in your existing
-                  project. Fix the IDs in either project so they aren't
-                  duplicated across different screens before trying to import
-                  the following.
-                </p>
+                <p style={styles.subtext}>{IMPORT_FAILURE_MESSAGE}</p>
                 <ul style={multiCheckboxStyles.list}>
                   {nonImportableScreens.map(screen => (
                     <li key={screen.id} style={multiCheckboxStyles.listItem}>

--- a/apps/src/applab/ImportScreensDialog.jsx
+++ b/apps/src/applab/ImportScreensDialog.jsx
@@ -101,7 +101,7 @@ class ScreenListItemUnwrapped extends React.Component {
             )}
           {screen.conflictingIds.length > 0 && (
             <p style={styles.warning}>
-              Uses existing element IDs:{' '}
+              Uses existing element or screen IDs:{' '}
               {quotedCommaJoin(screen.conflictingIds)}.
             </p>
           )}
@@ -207,9 +207,9 @@ export class ImportScreensDialog extends React.Component {
               <div style={styles.section}>
                 <h2 style={multiCheckboxStyles.header}>Cannot Import</h2>
                 <p style={styles.subtext}>
-                  Cannot import the following screens because they contain
-                  design elements with IDs already used in your existing
-                  project. Fix the IDs in either project so they aren't
+                  Cannot import the following screens because their IDs or
+                  contained design elements IDs are already used in your
+                  existing project. Fix the IDs in either project so they aren't
                   duplicated across different screens before trying to import
                   the following.
                 </p>

--- a/apps/src/applab/ImportScreensDialog.jsx
+++ b/apps/src/applab/ImportScreensDialog.jsx
@@ -208,8 +208,8 @@ export class ImportScreensDialog extends React.Component {
                 <h2 style={multiCheckboxStyles.header}>Cannot Import</h2>
                 <p style={styles.subtext}>
                   Cannot import the following screens because their IDs or
-                  contained design elements IDs are already used in your
-                  existing project. Fix the IDs in either project so they aren't
+                  contained design element IDs are already used in your existing
+                  project. Fix the IDs in either project so they aren't
                   duplicated across different screens before trying to import
                   the following.
                 </p>

--- a/apps/src/applab/import.js
+++ b/apps/src/applab/import.js
@@ -38,14 +38,21 @@ function getImportableScreen(dom) {
   const id = dom.id;
   const willReplace = designMode.getAllScreenIds().includes(id);
   const conflictingIds = [];
+
+  // Catch edge case where the to be imported screen ID
+  // conflicts with an existing element ID.
+  if (!willReplace && !elementUtils.isIdAvailable(id)) {
+    conflictingIds.push(id);
+  }
+
   Array.from(dom.children).forEach(child => {
     if (!elementUtils.isIdAvailable(child.id)) {
       var existingElement = elementUtils.getPrefixedElementById(child.id);
       if (existingElement) {
         let existingElementScreen = $(existingElement).parents('.screen')[0];
 
-        // Catch situation where existing element is a screen itself and
-        // has an ID that matches an element being imported
+        // Catch edge case where the found existingElement is a screen itself,
+        // rather than a child element.
         if ($(existingElement).hasClass('screen')) {
           existingElementScreen = existingElement;
         }

--- a/apps/src/applab/import.js
+++ b/apps/src/applab/import.js
@@ -43,6 +43,9 @@ function getImportableScreen(dom) {
       var existingElement = elementUtils.getPrefixedElementById(child.id);
       if (existingElement) {
         let existingElementScreen = $(existingElement).parents('.screen')[0];
+
+        // Catch situation where existing element is a screen itself and
+        // has an ID that matches an element being imported
         if ($(existingElement).hasClass('screen')) {
           existingElementScreen = existingElement;
         }

--- a/apps/src/applab/import.js
+++ b/apps/src/applab/import.js
@@ -42,7 +42,10 @@ function getImportableScreen(dom) {
     if (!elementUtils.isIdAvailable(child.id)) {
       var existingElement = elementUtils.getPrefixedElementById(child.id);
       if (existingElement) {
-        const existingElementScreen = $(existingElement).parents('.screen')[0];
+        let existingElementScreen = $(existingElement).parents('.screen')[0];
+        if ($(existingElement).hasClass('screen')) {
+          existingElementScreen = existingElement;
+        }
         if (elementUtils.getId(existingElementScreen) !== id) {
           conflictingIds.push(child.id);
         }

--- a/apps/src/applab/import.js
+++ b/apps/src/applab/import.js
@@ -39,7 +39,7 @@ function getImportableScreen(dom) {
   const willReplace = designMode.getAllScreenIds().includes(id);
   const conflictingIds = [];
 
-  // Catch edge case where the to be imported screen ID
+  // Catch edge case where the ID of the imported screen
   // conflicts with an existing element ID.
   if (!willReplace && !elementUtils.isIdAvailable(id)) {
     conflictingIds.push(id);
@@ -47,7 +47,7 @@ function getImportableScreen(dom) {
 
   Array.from(dom.children).forEach(child => {
     if (!elementUtils.isIdAvailable(child.id)) {
-      var existingElement = elementUtils.getPrefixedElementById(child.id);
+      const existingElement = elementUtils.getPrefixedElementById(child.id);
       if (existingElement) {
         let existingElementScreen = $(existingElement).parents('.screen')[0];
 

--- a/apps/test/unit/applab/ImportScreensDialogTest.js
+++ b/apps/test/unit/applab/ImportScreensDialogTest.js
@@ -149,7 +149,7 @@ describe('ScreenListItem', () => {
     );
     expect(item.text()).to.contain('main_screen');
     expect(item.text()).to.contain(
-      'Uses existing element IDs: "input1", "input2".'
+      'Uses existing element or screen IDs: "input1", "input2".'
     );
     // we don't want to show other errors related to importing.
     expect(item.text()).not.to.contain(
@@ -351,11 +351,11 @@ describe('ImportScreensDialog', () => {
                 <div>
                   <h2>Cannot Import</h2>
                   <p>
-                    Cannot import the following screens because they contain
-                    design elements with IDs already used in your existing
-                    project. Fix the IDs in either project so they aren't
-                    duplicated across different screens before trying to import
-                    the following.
+                    Cannot import the following screens because their IDs or
+                    contained design element IDs are already used in your
+                    existing project. Fix the IDs in either project so they
+                    aren't duplicated across different screens before trying to
+                    import the following.
                   </p>
                   <ul>
                     <li>

--- a/apps/test/unit/applab/ImportScreensDialogTest.js
+++ b/apps/test/unit/applab/ImportScreensDialogTest.js
@@ -13,6 +13,7 @@ import {
   ImportScreensDialog,
   ScreenListItem,
   AssetListItem,
+  IMPORT_FAILURE_MESSAGE,
 } from '@cdo/apps/applab/ImportScreensDialog';
 import AssetThumbnail from '@cdo/apps/code-studio/components/AssetThumbnail';
 
@@ -350,13 +351,7 @@ describe('ImportScreensDialog', () => {
               <div>
                 <div>
                   <h2>Cannot Import</h2>
-                  <p>
-                    Cannot import the following screens because their IDs or
-                    contained design element IDs are already used in your
-                    existing project. Fix the IDs in either project so they
-                    aren't duplicated across different screens before trying to
-                    import the following.
-                  </p>
+                  <p>{IMPORT_FAILURE_MESSAGE}</p>
                   <ul>
                     <li>
                       <ScreenListItem


### PR DESCRIPTION
Applab has a feature that allows you to import "screens" from other projects:

| <img width="150" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/d20402cf-56c2-4410-8b41-58b1ced36ec4"> | <img width="400" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/97c09d51-f5f2-4625-8c49-a09774008470">|
| - | - |

When using this feature, we have code that:
- handles a conflict between two projects with screens with the same IDs, and
- handles conflicts between two projects with individual elements (eg, buttons) with the same IDs.

A recent curriculum update ([more detail here](https://codedotorg.slack.com/archives/C05DMS18MEX/p1716247158785079?thread_ts=1716230450.073589&cid=C05DMS18MEX)) exposed the fact that we don't handle two other sets of potential conflicts:

Conflict between... | Current project | Imported screen | Result |
| - | - | - | - |
| | screen ID | element ID | error, dialog hangs |
| | element ID | screen ID | Import "succeeds", silently wipes element with name conflict from existing project |

The change here is to treat these conflicts the same way that we treat conflicts between individual elements (eg, a button in the existing project matches a button in the screen to import). I include a slight rewording of the error message to support these cases.

**Updated experience**
Conflicts between screen IDs and element IDs appear in list of IDs preventing import. In this case, the project trying to do the import has a button with the ID `screen1`, and the screen to import has the ID `screen1`

<img width="482" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25372625/1939c5b1-9fd7-4157-affd-90a70cd28533">

## Links

- jira: https://codedotorg.atlassian.net/browse/LABS-691
- [slack discussion](https://codedotorg.slack.com/archives/C05DMS18MEX/p1716247158785079?thread_ts=1716230450.073589&cid=C05DMS18MEX)

## Testing story

I tested manually:
- Each of the "cross-type" collision types (ie, screen ID-element ID collisions) blocks import gracefully per the screenshot above.
- Screen ID-screen ID collision still offers the user the opportunity to overwrite their existing screen.
- Element ID-element ID collision continues to blocks import of a screen.
- Screen imports without any of these collisions succeed.