### PR TITLE
Music: update tutorial script

### DIFF
--- a/dashboard/config/scripts_json/music-tutorial-2024.script_json
+++ b/dashboard/config/scripts_json/music-tutorial-2024.script_json
@@ -11,7 +11,7 @@
     "new_name": null,
     "family_name": "music-tutorial-2024",
     "serialized_at": "2024-05-14 21:00:37 UTC",
-    "published_state": "beta",
+    "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
     "participant_audience": "student",


### PR DESCRIPTION
This updates the `/s/music-tutorial-2024` script to have a `published_state` of `"stable"`.  This should ensure that it shows up in the curriculum catalog.

This change is in a pull request so that we can merge it alongside the other changes involved in the launch of Music Lab.

