### PR TITLE
Music: fix zero key

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -244,9 +244,9 @@ export default class MusicLibrary {
     }
     const folder = this.getFolderForFolderId(this.currentPackId);
     // Read key from the folder, or the first sound that has a key if not present on the folder.
-    return folder?.key !== undefined
-      ? folder?.key
-      : folder?.sounds.find(sound => sound.key !== undefined)?.key;
+    return (
+      folder?.key ?? folder?.sounds.find(sound => sound.key !== undefined)?.key
+    );
   }
 }
 

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -244,9 +244,9 @@ export default class MusicLibrary {
     }
     const folder = this.getFolderForFolderId(this.currentPackId);
     // Read key from the folder, or the first sound that has a key if not present on the folder.
-    return (
-      folder?.key || folder?.sounds.find(sound => sound.key !== undefined)?.key
-    );
+    return folder?.key !== undefined
+      ? folder?.key
+      : folder?.sounds.find(sound => sound.key !== undefined)?.key;
   }
 }
 


### PR DESCRIPTION
Fixes an issue in which switching to a pack with a `key` of `0` was not applying that key.
