### PR TITLE
Raise StudentFacingError when set_kvp is called with too long a key

### DIFF
--- a/dashboard/app/models/datablock_storage_kvp.rb
+++ b/dashboard/app/models/datablock_storage_kvp.rb
@@ -45,6 +45,8 @@ class DatablockStorageKvp < ApplicationRecord
     else
       DatablockStorageKvp.insert_all(kvps)
     end
+  rescue ActiveRecord::ValueTooLong
+    raise StudentFacingError.new(:MAX_KEY_LENGTH_EXCEEDED), "The key is too large, it must be shorter than #{columns_hash['key'].limit} characters ('bytes')"
   end
 
   def self.set_kvp(project_id, key, value)
@@ -65,7 +67,7 @@ class DatablockStorageKvp < ApplicationRecord
 
   private def max_value_length
     if value.to_json.bytesize > MAX_VALUE_LENGTH
-      raise StudentFacingError.new(:MAX_VALUE_LENGTH_EXCEEDED), "Value data cannot exceed #{MAX_VALUE_LENGTH} bytes"
+      raise StudentFacingError.new(:MAX_VALUE_LENGTH_EXCEEDED), "The value is too large, it must be shorter than #{MAX_VALUE_LENGTH} characters ('bytes')"
     end
   end
 end

--- a/dashboard/app/models/datablock_storage_kvp.rb
+++ b/dashboard/app/models/datablock_storage_kvp.rb
@@ -46,7 +46,7 @@ class DatablockStorageKvp < ApplicationRecord
       DatablockStorageKvp.insert_all(kvps)
     end
   rescue ActiveRecord::ValueTooLong
-    raise StudentFacingError.new(:MAX_KEY_LENGTH_EXCEEDED), "The key is too large, it must be shorter than #{columns_hash['key'].limit} characters ('bytes')"
+    raise StudentFacingError.new(:MAX_KEY_LENGTH_EXCEEDED), "The key is too large, it must be shorter than #{columns_hash['key'].limit} bytes ('characters')"
   end
 
   def self.set_kvp(project_id, key, value)
@@ -67,7 +67,7 @@ class DatablockStorageKvp < ApplicationRecord
 
   private def max_value_length
     if value.to_json.bytesize > MAX_VALUE_LENGTH
-      raise StudentFacingError.new(:MAX_VALUE_LENGTH_EXCEEDED), "The value is too large, it must be shorter than #{MAX_VALUE_LENGTH} characters ('bytes')"
+      raise StudentFacingError.new(:MAX_VALUE_LENGTH_EXCEEDED), "The value is too large, it must be shorter than #{MAX_VALUE_LENGTH} bytes ('characters')"
     end
   end
 end

--- a/dashboard/app/models/datablock_storage_record.rb
+++ b/dashboard/app/models/datablock_storage_record.rb
@@ -28,7 +28,7 @@ class DatablockStorageRecord < ApplicationRecord
 
   private def max_record_length
     if record_json.to_json.bytesize > MAX_RECORD_LENGTH
-      raise StudentFacingError.new(:MAX_RECORD_LENGTH_EXCEEDED), "The record is too large. The maximum allowable size is #{DatablockStorageRecord::MAX_RECORD_LENGTH} bytes"
+      raise StudentFacingError.new(:MAX_RECORD_LENGTH_EXCEEDED), "The record is too large. The maximum allowable size is #{DatablockStorageRecord::MAX_RECORD_LENGTH} characters ('bytes')"
     end
   end
 end

--- a/dashboard/app/models/datablock_storage_record.rb
+++ b/dashboard/app/models/datablock_storage_record.rb
@@ -28,7 +28,7 @@ class DatablockStorageRecord < ApplicationRecord
 
   private def max_record_length
     if record_json.to_json.bytesize > MAX_RECORD_LENGTH
-      raise StudentFacingError.new(:MAX_RECORD_LENGTH_EXCEEDED), "The record is too large. The maximum allowable size is #{DatablockStorageRecord::MAX_RECORD_LENGTH} characters ('bytes')"
+      raise StudentFacingError.new(:MAX_RECORD_LENGTH_EXCEEDED), "The record is too large. The maximum allowable size is #{DatablockStorageRecord::MAX_RECORD_LENGTH} bytes ('characters')"
     end
   end
 end


### PR DESCRIPTION
Fixes #58674 raised by honeybadger

<img width="725" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/bc3727c5-7d17-44be-a1b2-c8c22a279b19">

Also rewords two other length-related StudentFacingError messages to refer to "bytes ('characters')", whereas previously they'd just referred to the limit being in bytes. While bytes is more technically correct (e.g. in languages where UTF-8 uses more than one byte for some or all characters), this is hopefully provides a clearer hint for the many many cases where characters is the clearer way to understand the limit.