### PR TITLE
Add age to CPA amplitude events in state modal

### DIFF
--- a/apps/src/sites/studio/pages/layouts/_student_information_interstitial.js
+++ b/apps/src/sites/studio/pages/layouts/_student_information_interstitial.js
@@ -9,6 +9,7 @@ const userId = getScriptData('userId');
 const inSection = getScriptData('inSection');
 const previousStateValue = getScriptData('currentUsState');
 const selectedLanguage = getScriptData('selectedLanguage');
+const studentAge = getScriptData('studentAge');
 const forceStudentInterstitial = queryParams('forceStudentInterstitial');
 
 $(document).ready(function () {
@@ -23,11 +24,13 @@ $(document).ready(function () {
         user_id: userId,
         in_section: inSection,
         selected_language: selectedLanguage,
+        age: studentAge,
       });
   }
 
   form.on('ajax:success', () => {
     const newStateValue = $('#user_us_state').val();
+    const newAge = $('#user_age').val();
     if (newStateValue && (retrieveInfoForCap || forceStudentInterstitial))
       analyticsReporter.sendEvent(EVENTS.CAP_STATE_FORM_PROVIDED, {
         user_id: userId,
@@ -35,6 +38,7 @@ $(document).ready(function () {
         us_state: newStateValue,
         previous_us_state: previousStateValue,
         selected_language: selectedLanguage,
+        age: newAge ? newAge : studentAge,
       });
 
     retrieveInfoForCap || forceStudentInterstitial
@@ -48,6 +52,7 @@ $(document).ready(function () {
         user_id: userId,
         in_section: inSection,
         selected_language: selectedLanguage,
+        age: studentAge,
       });
   });
 });

--- a/dashboard/app/views/layouts/_student_information_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_student_information_interstitial.html.haml
@@ -29,5 +29,5 @@
         - haml_tag :hr, class: 'header-divider'
         .form-group#information_form_buttons
           = link_to t('nav.user.logout'), destroy_user_session_url, class: 'btn primary-button', id: 'sign-out-btn'
-          = f.submit t('continue'), class: 'btn primary-button', id: 'submit-btn'
-%script{src: webpack_asset_path('js/layouts/_student_information_interstitial.js'), data: {retrieveInfoForCap: cap_user_info_required?(student, country).to_json, userId: student.id.to_json, inSection: (!student.sections_as_student.empty?).to_json, currentUsState: student.us_state.to_json, selectedLanguage: request.locale.to_json}}
+          = f.submit request.language.downcase == 'en' ? t('submit') : t('continue'), class: 'btn primary-button', id: 'submit-btn'
+%script{src: webpack_asset_path('js/layouts/_student_information_interstitial.js'), data: {retrieveInfoForCap: cap_user_info_required?(student, country).to_json, userId: student.id.to_json, inSection: (!student.sections_as_student.empty?).to_json, currentUsState: student.us_state.to_json, selectedLanguage: request.locale.to_json, studentAge: student.age.to_json}}

--- a/dashboard/app/views/layouts/_student_information_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_student_information_interstitial.html.haml
@@ -29,5 +29,5 @@
         - haml_tag :hr, class: 'header-divider'
         .form-group#information_form_buttons
           = link_to t('nav.user.logout'), destroy_user_session_url, class: 'btn primary-button', id: 'sign-out-btn'
-          = f.submit request.language.downcase == 'en' ? t('submit') : t('continue'), class: 'btn primary-button', id: 'submit-btn'
+          = f.submit I18n.locale == :'en-US' ? t('submit') : t('continue'), class: 'btn primary-button', id: 'submit-btn'
 %script{src: webpack_asset_path('js/layouts/_student_information_interstitial.js'), data: {retrieveInfoForCap: cap_user_info_required?(student, country).to_json, userId: student.id.to_json, inSection: (!student.sections_as_student.empty?).to_json, currentUsState: student.us_state.to_json, selectedLanguage: request.locale.to_json, studentAge: student.age.to_json}}


### PR DESCRIPTION
Adds the Student Age to all amplitude events within the CPA State modal.
Also includes a small edit to the submit button:
For English users change the button from "Continue" to "Submit"
<img width="566" alt="Screenshot 2024-05-16 at 1 33 27 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/e523c803-9915-4d28-a031-63b445a9d73a">


## Amplitude Event Console Logs
<img width="1792" alt="Screenshot 2024-05-16 at 1 35 13 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/31c2cd84-6832-46a8-a776-ccd24f8326a5">

<img width="1792" alt="Screenshot 2024-05-16 at 1 31 03 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/f170ef43-0be1-4771-9a04-8901ae576a23">

## If Age was null before, updates the value if found when submitted
<img width="1792" alt="Screenshot 2024-05-16 at 1 33 37 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/0a3fed69-3fdc-4822-9406-761c308df167">



## Links

- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/P20/boards/69?assignee=712020%3Af0e2716f-09f9-4686-8490-9f1f9a08bb06&selectedIssue=P20-934)

## Testing story
Local amplitude console logs
