### PR TITLE
Create code.org/tools/musiclab

### DIFF
--- a/pegasus/helpers/analytics_constants.rb
+++ b/pegasus/helpers/analytics_constants.rb
@@ -38,6 +38,7 @@ module AnalyticsConstants
     VIDEO_LIBRARY_PAGE_VISIT_EVENT = 'Video Library Page Visited'.freeze,
     INTL_PL_PAGE_VISIT_EVENT = 'International Professional Learning Page Visited'.freeze,
     INTL_PL_PARTNERS_PAGE_VISIT_EVENT = 'International Professional Learning Partners Page Visited'.freeze,
-    MUSIC_PAGE_VISITED_EVENT = 'Music Lab Marketing Page Visited'.freeze
+    MUSIC_PAGE_VISITED_EVENT = 'Music Lab Marketing Page Visited'.freeze,
+    MUSIC_LAB_PAGE_VISITED_EVENT = 'Music Lab Tools Page Visited'.freeze
   ].freeze
 end

--- a/pegasus/sites.v3/code.org/public/tools/musiclab.haml
+++ b/pegasus/sites.v3/code.org/public/tools/musiclab.haml
@@ -1,0 +1,53 @@
+---
+title: Music Lab
+theme: responsive_full_width
+---
+
+%link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
+%link{href: "/css/generated/page/music-styles.css", rel: "stylesheet"}
+
+%section
+  .wrapper
+    .text-wrapper.col-50
+      %h1 Music Lab
+      %p.body-one
+        =hoc_s("music_lab.tools_page.top.subheading")
+      %p.body-two
+        =hoc_s("music_lab.tools_page.top.desc")
+      %a.link-button{href: CDO.studio_url("/s/music-intro-2024/reset")}
+        =hoc_s("music_lab.button.try_music_lab")
+    %figure.col-45{style: "float: right; margin-top: 1.25rem;"}
+      = view :display_video_thumbnail, id: "music_lab", video_code: "GqlP5s7KTl4", play_button: 'center', letterbox: 'false', download_path: "//videos.code.org/music_lab/Music_Lab_Make_Music_Learn_Code.mp4"
+    .clear
+
+%section.bg-neutral-light
+  .wrapper.centered
+    %h2=hoc_s("music_lab.tools_page.glance.heading")
+    = view :"tools/tools_glance", ages: hoc_s("music_lab.tools_page.glance.ages"), level: hoc_s("music_lab.tools_page.glance.level"), make: hoc_s("music_lab.tools_page.glance.make"), devices: hoc_s("music_lab.tools_page.glance.devices"), browsers: hoc_s("music_lab.tools_page.glance.browsers"), languages: "العربية, Español (España), Español (LATAM), Filipino, Français, हिन्दी, Bahasa Indonesia, Italiano, 日本語, 한국어, فارسی, Polski, Português (Brasil), Português (Portugal), Slovenčina, ภาษาไทย, Türkçe, Tiếng Việt, 繁體字", accessibility: hoc_s("music_lab.tools_page.glance.accessibility")
+    %p.body-two
+      =hoc_s("music_lab.tools_page.glance.teachers_guide_desc")
+    %a.link-button.secondary{href: CDO.studio_url("/s/music-tutorial-2024")}
+      =hoc_s("music_lab.button.get_teachers_guide")
+
+%section.student-projects
+  .wrapper
+    %h2=hoc_s("music_lab.student_projects.heading")
+    = view :"music/music_lab_student_projects"
+
+%section.bg-neutral-light
+  .wrapper
+    %h2.centered
+      =hoc_s("music_lab.tools_page.videos.heading")
+    = view :"tools/music_lab/music_lab_videos"
+
+-# TODO - Add resources view once this ticket is done ACQ-1621
+-# %section
+-#   .wrapper
+
+%section
+  .wrapper
+    = view :afe_partnership_block
+    %p.body-four.centered
+      =hoc_s(:dance_afe_disclaimer)
+
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::MUSIC_PAGE_VISITED_EVENT

--- a/pegasus/sites.v3/code.org/public/tools/musiclab.haml
+++ b/pegasus/sites.v3/code.org/public/tools/musiclab.haml
@@ -50,4 +50,4 @@ theme: responsive_full_width
     %p.body-four.centered
       =hoc_s(:dance_afe_disclaimer)
 
-= view :analytics_event_log_helper, event_name: AnalyticsConstants::MUSIC_PAGE_VISITED_EVENT
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::MUSIC_LAB_PAGE_VISITED_EVENT

--- a/pegasus/sites.v3/code.org/views/tools/music_lab/music_lab_videos.haml
+++ b/pegasus/sites.v3/code.org/views/tools/music_lab/music_lab_videos.haml
@@ -1,0 +1,32 @@
+:ruby
+  videos = [
+    {
+      code: "oZhFQ1yjWhY",
+      download_path: "//videos.code.org/music_lab/Music_Lab_Aloe_Blacc.mp4",
+      caption: hoc_s("music_lab.artist.singer_songwriter", markdown: :inline, locals: {artist_name: "Aloe Blacc"}),
+    },
+    {
+      code: "Fysf1rD-RX0",
+      download_path: "//videos.code.org/music_lab/Music_Lab_Rosa_Linn.mp4",
+      caption: hoc_s("music_lab.artist.singer_songwriter", markdown: :inline, locals: {artist_name: "Rosa Linn"}),
+    },
+    {
+      code: "1TDma4wg3dE",
+      download_path: "//videos.code.org/music_lab/Music_Lab_Drew_Taggart_from_The_Chainsmokers.mp4",
+      caption: hoc_s("music_lab.artist.band", markdown: :inline, locals: {artist_name: "Drew Taggart", band_name: "The Chainsmokers"}),
+    },
+  ]
+
+.carousel-wrapper.video-carousel
+  %swiper-container.two-col.music-lab-tools-videos{navigation: "true", "navigation-next-el": ".nav-next-music-lab-tools-videos", "navigation-prev-el": ".nav-prev-music-lab-tools-videos", pagination: "true", init: "false", "allow-touch-move": "false"}
+    - videos.each do |video|
+      %swiper-slide
+        %figure
+          = view :video_with_fallback, video_code: video[:code], download_path: video[:download_path]
+          %figcaption.no-margin-bottom
+            = video[:caption]
+
+  %button.swiper-nav-prev.nav-prev-music-lab-tools-videos
+  %button.swiper-nav-next.nav-next-music-lab-tools-videos
+
+= view :swiper


### PR DESCRIPTION
Creates https://code.org/tools/musiclab. This is different than the https://code.org/music marketing page but shares similar content.
- Page is fully responsive and works with LTR and RTL languages
- Adds a new Amplitude event `MUSIC_LAB_PAGE_VISITED_EVENT`
- The embedded students projects section isn't working locally, asked about it [here](https://codedotorg.slack.com/archives/C04TH8400AU/p1715875067592109?thread_ts=1715713479.004789&cid=C04TH8400AU) 

## Links
Jira ticket: [ACQ-1679](https://codedotorg.atlassian.net/browse/ACQ-1679)
Figma mock: [here](https://www.figma.com/design/2WMErkWkUqY8DNxPCa5hXB/Music-Lab-Launch?node-id=2425%3A1727&t=H3fVJp5h6f2nSoY5-1)

## Testing story
Tested locally

## Followup
I'm going to create a new shared view for the "Additional resources" section in [this ticket ACQ-1621](https://codedotorg.atlassian.net/browse/ACQ-1621) that will be added to this page and https://code.org/applab.

----

![localhost code org_3000_tools_musiclab](https://github.com/code-dot-org/code-dot-org/assets/9256643/5aae73ad-e3fd-4252-8415-647d3a730337)