### PR TITLE
Unit cloning fails when the destination is a stand alone unit and has reference guides to be cloned

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1238,7 +1238,7 @@ class Unit < ApplicationRecord
         end
 
         source_course_version&.reference_guides&.each do |reference_guide|
-          reference_guide.copy_to_course_version(destination_unit_group.course_version)
+          reference_guide.copy_to_course_version(copied_unit.get_course_version)
         end
 
         if destination_professional_learning_course.nil?

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -2326,12 +2326,31 @@ class UnitTest < ActiveSupport::TestCase
       assert_equal @unit_in_course.student_resources[0], cloned_unit.student_resources[0]
     end
 
-    test 'can copy reference guides' do
+    test 'can copy reference guides when cloning unit in unit group' do
       Rails.application.config.stubs(:levelbuilder_mode).returns true
       ReferenceGuide.any_instance.expects(:write_serialization).once
       File.stubs(:write)
-      @unit_in_course.unit_group.course_version.reference_guides = [create(:reference_guide)]
-      cloned_unit = @unit_in_course.clone_migrated_unit('coursename3-2021', destination_unit_group_name: @unit_group.name)
+      cloned_unit = @unit_in_course.clone_migrated_unit('refguidetest-ug-coursename-2021', destination_unit_group_name: @unit_group.name)
+      assert_equal cloned_unit.unit_group, @unit_group
+      assert_equal 1, @unit_group.course_version.reference_guides.count
+    end
+
+    test 'can copy reference guides when cloning unit from unit group to stand alone' do
+      Rails.application.config.stubs(:levelbuilder_mode).returns true
+      ReferenceGuide.any_instance.expects(:write_serialization).once
+      File.stubs(:write)
+      cloned_unit = @unit_in_course.clone_migrated_unit('refguidetest-ugsa-coursename-2021', version_year: '2021', family_name: 'csf')
+      assert_equal cloned_unit.unit_group, @unit_group
+      assert_equal 1, cloned_unit.course_version.reference_guides.count
+    end
+
+    test 'can copy reference guides when cloning stand alone' do
+      Rails.application.config.stubs(:levelbuilder_mode).returns true
+      ReferenceGuide.any_instance.expects(:write_serialization).once
+      File.stubs(:write)
+      @standalone_unit.course_version.reference_guides = [create(:reference_guide)]
+
+      cloned_unit = @standalone_unit.clone_migrated_unit('refguidetest-sa-coursename-2022', version_year: '2022', family_name: 'csf')
       assert_equal cloned_unit.unit_group, @unit_group
       assert_equal 1, @unit_group.course_version.reference_guides.count
     end

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -2332,7 +2332,7 @@ class UnitTest < ActiveSupport::TestCase
       File.stubs(:write)
       cloned_unit = @unit_in_course.clone_migrated_unit('refguidetest-ug-coursename-2021', destination_unit_group_name: @unit_group.name)
       assert_equal cloned_unit.unit_group, @unit_group
-      assert_equal 1, @unit_group.course_version.reference_guides.count
+      assert_equal 1, cloned_unit.get_course_version.reference_guides.count
     end
 
     test 'can copy reference guides when cloning unit from unit group to stand alone' do
@@ -2340,8 +2340,7 @@ class UnitTest < ActiveSupport::TestCase
       ReferenceGuide.any_instance.expects(:write_serialization).once
       File.stubs(:write)
       cloned_unit = @unit_in_course.clone_migrated_unit('refguidetest-ugsa-coursename-2021', version_year: '2021', family_name: 'csf')
-      assert_equal cloned_unit.unit_group, @unit_group
-      assert_equal 1, cloned_unit.course_version.reference_guides.count
+      assert_equal 1, cloned_unit.get_course_version.reference_guides.count
     end
 
     test 'can copy reference guides when cloning stand alone' do
@@ -2351,8 +2350,7 @@ class UnitTest < ActiveSupport::TestCase
       @standalone_unit.course_version.reference_guides = [create(:reference_guide)]
 
       cloned_unit = @standalone_unit.clone_migrated_unit('refguidetest-sa-coursename-2022', version_year: '2022', family_name: 'csf')
-      assert_equal cloned_unit.unit_group, @unit_group
-      assert_equal 1, @unit_group.course_version.reference_guides.count
+      assert_equal 1, cloned_unit.get_course_version.reference_guides.count
     end
 
     test 'can copy a script without a course version' do

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -2160,7 +2160,9 @@ class UnitTest < ActiveSupport::TestCase
       @deeper_learning_unit = create :script, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer, professional_learning_course: 'DLP 2021'
 
       @unit_group = create :unit_group
-      create :course_version, content_root: @unit_group
+      @ug_course_version = create :course_version, content_root: @unit_group
+      create :reference_guide, course_version: @ug_course_version
+
       @unit_in_course = create :script, is_migrated: true, name: 'coursename1-2021'
       create :unit_group_unit, unit_group: @unit_group, script: @unit_in_course, position: 1
       @unit_group.reload


### PR DESCRIPTION
**Issue**: When a unit is cloned and the destination is a standalone unit, the cloning script fails with a null reference exception at the step of cloning reference guides.

**Root cause**: The cloning step assumes that the destination unit is part of a unit group.  As part of cloning reference guides, the course version is accessed through the unit group, which is null in case of standalone courses.

**Fix**: Leverage an already existing in-built function that has logic to determine course version for both stand alone and units that are part of unit groups.

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1109

## Testing story

Added unit tests and drone

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
