### PR TITLE
fix(sms): stub Gatekeeper to prevent race condition

### DIFF
--- a/dashboard/test/controllers/sms_controller_test.rb
+++ b/dashboard/test/controllers/sms_controller_test.rb
@@ -77,7 +77,7 @@ class SmsControllerTest < ActionController::TestCase
   end
 
   test "send to phone with project pretends to succeed when twilio is disabled by gatekeeper flag" do
-    Gatekeeper.set('twilio', where: {}, value: false)
+    Gatekeeper.stubs(:allows).with('twilio', default: true).returns(false)
 
     channel_id = "xxproject_channelxx"
 


### PR DESCRIPTION
The SMS controller uses Gatekeeper to enable/disable twilio sms. However, if a different test clears Gatekeeper after Gatekeeper was populated by this test, the test will fail. Instead, use a stub to prevent the cross-test state side effect.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-928)

## Testing story

Ran unit tests

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
