### PR TITLE
P20-903: Display U13 Warning on Section Creation to USA teachers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'sinatra', '2.2.3', require: 'sinatra/base'
 
 gem 'mysql2', '>= 0.4.1'
 
+gem 'city-state', '~> 1.1.0'
 gem 'dalli' # memcached
 gem 'dalli-elasticache' # ElastiCache Auto Discovery memcached nodes
 gem 'google_drive'

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ gem 'sinatra', '2.2.3', require: 'sinatra/base'
 
 gem 'mysql2', '>= 0.4.1'
 
-gem 'city-state', '~> 1.1.0'
 gem 'dalli' # memcached
 gem 'dalli-elasticache' # ElastiCache Auto Discovery memcached nodes
 gem 'google_drive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,8 +287,6 @@ GEM
     cgi (0.3.6)
     chronic (0.10.2)
     chunky_png (1.3.6)
-    city-state (1.1.0)
-      rubyzip (>= 2.3)
     cld (0.11.0)
       ffi
     climate_control (0.0.3)
@@ -1011,7 +1009,6 @@ DEPENDENCIES
   cancancan (~> 3.5.0)
   cgi (~> 0.3.6)
   chronic (~> 0.10.2)
-  city-state (~> 1.1.0)
   cld
   colorize
   composite_primary_keys (~> 13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,8 @@ GEM
     cgi (0.3.6)
     chronic (0.10.2)
     chunky_png (1.3.6)
+    city-state (1.1.0)
+      rubyzip (>= 2.3)
     cld (0.11.0)
       ffi
     climate_control (0.0.3)
@@ -1009,6 +1011,7 @@ DEPENDENCIES
   cancancan (~> 3.5.0)
   cgi (~> 0.3.6)
   chronic (~> 0.10.2)
+  city-state (~> 1.1.0)
   cld
   colorize
   composite_primary_keys (~> 13.0)

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -114,6 +114,8 @@ const initialState = {
   under13: true,
   over21: false,
   childAccountComplianceState: null,
+  countryCode: null,
+  usStateCode: null,
 };
 
 export default function currentUser(state = initialState, action) {
@@ -230,6 +232,8 @@ export default function currentUser(state = initialState, action) {
       date_progress_table_invitation_last_delayed,
       has_seen_progress_table_v2_invitation,
       child_account_compliance_state,
+      country_code,
+      us_state_code,
     } = action.serverUser;
     analyticsReport.setUserProperties(
       id,
@@ -262,6 +266,8 @@ export default function currentUser(state = initialState, action) {
         date_progress_table_invitation_last_delayed,
       hasSeenProgressTableInvite: has_seen_progress_table_v2_invitation,
       childAccountComplianceState: child_account_compliance_state,
+      countryCode: country_code,
+      usStateCode: us_state_code,
     };
   }
 

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -12,6 +12,7 @@ import StylizedBaseDialog from '@cdo/apps/componentLibrary/StylizedBaseDialog';
 import fontConstants from '@cdo/apps/fontConstants';
 import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {getStore} from '@cdo/apps/redux';
 import color from '@cdo/apps/util/color';
 import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
@@ -88,6 +89,13 @@ class LoginTypePicker extends Component {
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
+    const currentUser = getStore().getState().currentUser;
+    const inUSA =
+      ['US', 'RD'].includes(currentUser.countryCode) ||
+      !!currentUser.usStateCode;
+    const showStudentsToSectionPermissionWarning =
+      (inUSA && currentUser.isTeacher) ||
+      experiments.isEnabledAllowingQueryString(experiments.CPA_EXPERIENCE);
 
     const style = {
       container: {
@@ -137,9 +145,7 @@ class LoginTypePicker extends Component {
       <div style={style.container}>
         <Heading3 isRebranded>{title}</Heading3>
         <p>{i18n.addStudentsToSectionInstructionsUpdated()}</p>
-        {experiments.isEnabledAllowingQueryString(
-          experiments.CPA_EXPERIENCE
-        ) && (
+        {showStudentsToSectionPermissionWarning && (
           <p>
             <span
               className="fa fa-exclamation-triangle"

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.story.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.story.jsx
@@ -1,5 +1,13 @@
 import {action} from '@storybook/addon-actions';
 import React from 'react';
+import {Provider} from 'react-redux';
+import sinon from 'sinon';
+
+import {getStore, registerReducers} from '@cdo/apps/redux';
+import currentUser, {
+  setInitialData,
+} from '@cdo/apps/templates/currentUserRedux';
+import experiments from '@cdo/apps/util/experiments';
 
 import {UnconnectedLoginTypePicker as LoginTypePicker} from './LoginTypePicker';
 
@@ -7,34 +15,62 @@ export default {
   component: LoginTypePicker,
 };
 
-const Template = args => (
-  <LoginTypePicker
-    title="New section"
-    handleImportOpen={action('handleImportOpen')}
-    setLoginType={action('setLoginType')}
-    handleCancel={action('handleCancel')}
-    {...args}
-  />
+const store = getStore();
+registerReducers({currentUser});
+store.dispatch(
+  setInitialData({
+    id: 1,
+    user_type: 'teacher',
+    us_state_code: 'CO',
+  })
 );
 
-export const Basic = Template.bind({});
+const setCpaExperienceEnabled = enabled => {
+  experiments.isEnabledAllowingQueryString.restore &&
+    experiments.isEnabledAllowingQueryString.restore();
 
-export const Google = Template.bind({});
+  sinon
+    .stub(experiments, 'isEnabledAllowingQueryString')
+    .withArgs(experiments.CPA_EXPERIENCE)
+    .callsFake(() => enabled);
+};
+
+const Template = (withCpaExperience, args) => {
+  setCpaExperienceEnabled(withCpaExperience);
+
+  return (
+    <Provider store={store}>
+      <LoginTypePicker
+        title="New section"
+        handleImportOpen={action('handleImportOpen')}
+        setLoginType={action('setLoginType')}
+        handleCancel={action('handleCancel')}
+        {...args}
+      />
+    </Provider>
+  );
+};
+
+export const Basic = Template.bind({}, false);
+
+export const BasicWithCPAWarning = Template.bind({}, true);
+
+export const Google = Template.bind({}, false);
 Google.args = {
   providers: ['google_classroom'],
 };
 
-export const Clever = Template.bind({});
+export const Clever = Template.bind({}, false);
 Clever.args = {
   providers: ['clever'],
 };
 
-export const Microsoft = Template.bind({});
+export const Microsoft = Template.bind({}, false);
 Microsoft.args = {
   providers: ['microsoft_classroom'],
 };
 
-export const Multiple = Template.bind({});
+export const Multiple = Template.bind({}, false);
 Multiple.args = {
   providers: ['google_classroom', 'clever'],
 };

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -42,6 +42,8 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         has_seen_progress_table_v2_invitation: current_user.has_seen_progress_table_v2_invitation?,
         date_progress_table_invitation_last_delayed: current_user.date_progress_table_invitation_last_delayed,
         child_account_compliance_state: current_user.child_account_compliance_state,
+        country_code: helpers.country_code(current_user, request),
+        us_state_code: current_user.us_state_code,
       }
     else
       render json: {

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -6,7 +6,7 @@ class SectionsController < ApplicationController
 
   def new
     redirect_to '/home' unless params[:loginType] && params[:participantType]
-    @user_country = request.country.to_s.upcase
+    @user_country = helpers.country_code(current_user, request)
     @is_users_first_section = current_user.sections_instructed.empty?
   end
 

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -527,4 +527,10 @@ module UsersHelper
 
     Policies::Lti.lti?(current_user)
   end
+
+  def country_code(user, request)
+    return user.country_code if user.student?
+
+    user.country_code.presence || request.country.to_s.upcase
+  end
 end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2740,7 +2740,7 @@ class User < ApplicationRecord
 
   # @return [String, nil] the user's US state code in the ISO 3166-2:US standard
   def us_state_code
-    state = student? ? us_state : school_info&.state
+    state = student? ? us_state : school_info&.usa? && school_info&.state
     return if state.blank?
 
     # Returns `state` if it is a US state code

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -70,6 +70,7 @@
 #
 
 require 'digest/md5'
+require 'state_abbr'
 require 'cdo/aws/metrics'
 require 'cdo/shared_constants'
 require_relative '../../legacy/middleware/helpers/user_helpers'
@@ -2742,13 +2743,11 @@ class User < ApplicationRecord
     state = student? ? us_state : school_info&.state
     return if state.blank?
 
-    # {CO: 'Colorado', DC: 'District Of Columbia', ...}
-    state_code_to_name_map = CS.states(:US)
     # Returns `state` if it is a US state code
-    return state.upcase if state_code_to_name_map.key?(state.upcase.to_sym)
+    return state.upcase if us_state_abbr?(state, include_dc: true)
 
     # Returns the code of `state` if it is a US state name
-    state_code_to_name_map.transform_values(&:downcase).key(state.downcase)&.to_s
+    get_us_state_abbr_from_name(state, include_dc: true)
   end
 
   private def account_age_in_years

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2737,6 +2737,20 @@ class User < ApplicationRecord
     id && Digest::UUID.uuid_v5(Dashboard::Application.config.secret_key_base, id.to_s)
   end
 
+  # @return [String, nil] the user's US state code in the ISO 3166-2:US standard
+  def us_state_code
+    state = student? ? us_state : school_info&.state
+    return if state.blank?
+
+    # {CO: 'Colorado', DC: 'District Of Columbia', ...}
+    state_code_to_name_map = CS.states(:US)
+    # Returns `state` if it is a US state code
+    return state.upcase if state_code_to_name_map.key?(state.upcase.to_sym)
+
+    # Returns the code of `state` if it is a US state name
+    state_code_to_name_map.transform_values(&:downcase).key(state.downcase)&.to_s
+  end
+
   private def account_age_in_years
     ((Time.now - created_at.to_time) / 1.year).round
   end

--- a/dashboard/test/helpers/users_helper_test.rb
+++ b/dashboard/test/helpers/users_helper_test.rb
@@ -5,6 +5,41 @@ class UsersHelperTest < ActionView::TestCase
   include UsersHelper
   include SharedConstants
 
+  class CountryCodeTest < ActionView::TestCase
+    setup do
+      @country_code = 'US'
+      @request = ActionDispatch::Request.new({'HTTP_CLOUDFRONT_VIEWER_COUNTRY' => @country_code.downcase})
+    end
+
+    test 'returns country code of student' do
+      student_country_code = 'UA'
+
+      student = build(:student, country_code: student_country_code)
+
+      assert_equal student_country_code, country_code(student, @request)
+    end
+
+    test 'returns nil if country code of student is not set' do
+      student = build(:student, country_code: nil)
+
+      assert_nil country_code(student, @request)
+    end
+
+    test 'returns country code of teacher' do
+      teacher_country_code = 'UA'
+
+      teacher = build(:teacher, country_code: teacher_country_code)
+
+      assert_equal teacher_country_code, country_code(teacher, @request)
+    end
+
+    test 'returns request country code when teacher country_code is not set' do
+      teacher = build(:teacher, country_code: '')
+
+      assert_equal @country_code, country_code(teacher, @request)
+    end
+  end
+
   def test_summarize_user_progress
     script = create(:script, :with_levels, levels_count: 3)
     user = create :user

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -24,7 +24,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     test 'returns teacher school US state code when state is name' do
-      teacher = create(:teacher, school_info: create(:school_info, state: 'district of Columbia'))
+      teacher = create(:teacher, school_info: create(:school_info, state: 'washington dc'))
       assert_equal 'DC', teacher.us_state_code
     end
   end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -13,19 +13,29 @@ class UserTest < ActiveSupport::TestCase
       assert_equal 'CO', student.us_state_code
     end
 
-    test 'returns nil if student us_state is "??"' do
+    test 'returns nil if student us_state is unknown' do
       student = create(:student, :unknown_us_region)
       assert_nil student.us_state_code
     end
 
     test 'returns teacher school US state code' do
-      teacher = create(:teacher, school_info: create(:school_info, state: 'ny'))
+      teacher = create(:teacher, school_info: create(:school_info, country: 'US', state: 'ny'))
       assert_equal 'NY', teacher.us_state_code
     end
 
     test 'returns teacher school US state code when state is name' do
-      teacher = create(:teacher, school_info: create(:school_info, state: 'washington dc'))
+      teacher = create(:teacher, school_info: create(:school_info, country: 'USA', state: 'washington dc'))
       assert_equal 'DC', teacher.us_state_code
+    end
+
+    test 'returns nil if teacher school state is not set' do
+      teacher = create(:teacher, school_info: create(:school_info, :skip_validation, state: ''))
+      assert_nil teacher.us_state_code
+    end
+
+    test 'returns nil if teacher school is not in USA' do
+      teacher = create(:teacher, school_info: create(:school_info, :skip_validation, country: 'CA', state: 'AL')) # Alberta, Canada
+      assert_nil teacher.us_state_code
     end
   end
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -7,6 +7,28 @@ class UserTest < ActiveSupport::TestCase
   include ProjectsTestUtils
   self.use_transactional_test_case = true
 
+  class UsStateCodeTest < ActiveSupport::TestCase
+    test 'returns student us_state if present' do
+      student = create(:student, :in_colorado)
+      assert_equal 'CO', student.us_state_code
+    end
+
+    test 'returns nil if student us_state is "??"' do
+      student = create(:student, :unknown_us_region)
+      assert_nil student.us_state_code
+    end
+
+    test 'returns teacher school US state code' do
+      teacher = create(:teacher, school_info: create(:school_info, state: 'ny'))
+      assert_equal 'NY', teacher.us_state_code
+    end
+
+    test 'returns teacher school US state code when state is name' do
+      teacher = create(:teacher, school_info: create(:school_info, state: 'district of Columbia'))
+      assert_equal 'DC', teacher.us_state_code
+    end
+  end
+
   setup_all do
     @good_data = {
       email: 'foo@bar.com',


### PR DESCRIPTION
## Error
```
==============[0m[1000D[KERROR["test_returns_nil_if_student_us_state_is_\"??\"", "UserTest::UsStateCodeTest", 56.4121803099988]
 test_returns_nil_if_student_us_state_is_"??"#UserTest::UsStateCodeTest (56.41s)
Minitest::UnexpectedError:         Errno::EACCES: Permission denied @ rb_sysopen - /usr/local/lib/ruby/gems/3.0.0/gems/city-state-1.1.0/lib/db/states.us
            app/models/user.rb:2746:in `us_state_code'
            test/models/user_test.rb:18:in `block in <class:UsStateCodeTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'
```
## Links
- JIRA ticket: [P20-903](https://codedotorg.atlassian.net/browse/P20-903)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/58497
- Revert PR: https://github.com/code-dot-org/code-dot-org/pull/58670
