### PR TITLE
Fix: Readd toolTipContainer styles to sections-refresh

### DIFF
--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -219,3 +219,14 @@ button.advancedSettingsButton {
 .textPopUp {
   cursor: pointer;
 }
+
+.toolTipContainer {
+  display: flex;
+  align-items: center;
+
+  button {
+    .toggle-display {
+      margin-left: 5px;
+    }
+  }
+}


### PR DESCRIPTION
When PR https://github.com/code-dot-org/code-dot-org/pull/58038/files was merged, the sections-refresh module was imported into the `SectionAccessToggle.tsx` and had unintended consequences in the teacher dashboard because it has some very broad CSS selectors. 

The Slack thread on the original issue was: https://codedotorg.slack.com/archives/C045UAX4WKH/p1715806578458379?thread_ts=1715803641.843369&cid=C045UAX4WKH

When I put up the revert of the revert, I moved the CSS for the tooltips into a dedicated `access-controls.module.scss`, which kept the overly scoped `sections-refresh` rules from applying across the teacher dashboard: https://github.com/code-dot-org/code-dot-org/pull/58659/files/a681e72105862d5b78068298fe4bbd66267b5f46..67852a06652225a93a2c4e5e47a2bb54ca788335

BUT, I made a mistake by removing the toolTipContainer from the `sections-refresh` container https://github.com/code-dot-org/code-dot-org/pull/58659/files/a681e72105862d5b78068298fe4bbd66267b5f46..67852a06652225a93a2c4e5e47a2bb54ca788335#diff-e26532ee34fdf045c225c00b1fd13d15158929aba3b198ee9711b5e1f994806dL182 because I assumed it had been added by @kakiha11 in the original PR. 

It is necessary for the other Advanced Settings tooltips, and wasn't caught by existing UI tests. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I confirmed locally that the appearance and CSS being applied here now match what they were before yesterday night.

[
<img width="430" alt="Screenshot 2024-05-16 at 2 06 35 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/f664c7e2-e76a-4be9-880a-629a4068dcf3">
<img width="461" alt="Screenshot 2024-05-16 at 2 06 42 PM" src="https://github.com/code-dot-org/code-dot-org/assets/26844240/f9d691c9-4738-4ff0-af23-93249ca99d5d">
](url)

## Deployment strategy

## Follow-up work

Added a task to add UI tests for Advanced Settings section toggles: https://codedotorg.atlassian.net/browse/TEACH-1113

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
