### PR TITLE
Show tutorial section for english only on code.org/music

### DIFF
--- a/pegasus/sites.v3/code.org/public/music/index.haml
+++ b/pegasus/sites.v3/code.org/public/music/index.haml
@@ -62,16 +62,20 @@ theme: responsive_full_width
     %h2.white=hoc_s("music_lab.quotes.heading")
     = view :"music/music_lab_carousel_quotes"
 
-%section
-  .wrapper
-    .flex-container.justify-space-between.align-items-center.wrap.gap-2
-      %figure.col-47
-        %img.rounded-corners{src: "/images/music-lab/music-lab-tutorial.png", alt: "", style: "width: 100%;"}
-      .text-wrapper.col-47
-        %h2=hoc_s("music_lab.tutorial.heading")
-        %p=hoc_s("music_lab.tutorial.desc")
-        %a.link-button{href: CDO.studio_url("/s/music-tutorial-2024")}
-          =hoc_s("music_lab.tutorial.button")
+- if request.language == "en"
+  %section
+    .wrapper
+      .flex-container.justify-space-between.align-items-center.wrap.gap-2
+        %figure.col-45
+          %img.rounded-corners{src: "/images/music-lab/music-lab-tutorial.png", alt: "", style: "width: 100%;"}
+        .text-wrapper.col-50
+          %h2=hoc_s("music_lab.tutorial.heading")
+          %p.wrap-pretty
+            =hoc_s("music_lab.tutorial.desc")
+          %p.body-three
+            =hoc_s("music_lab.tutorial.english_only")
+          %a.link-button{href: CDO.studio_url("/s/music-tutorial-2024")}
+            =hoc_s("music_lab.tutorial.button")
 
 %section.bg-neutral-light
   .wrapper

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -2073,6 +2073,7 @@
       heading: "Teach Music Lab in your Classroom"
       desc: "Use our Music Lab tutorial to unleash your students' musical creativity, combining the joy of music with the principles of coding."
       button: "Start tutorial"
+      english_only: "Available in English only"
     additional_resources:
       heading: "Additional resources"
       catalog:


### PR DESCRIPTION
Shows the Tutorial section for English-only on https://code.org/music.

## Links
Jira ticket: [ACQ-1894](https://codedotorg.atlassian.net/browse/ACQ-1894)
Slack convo: [here](https://codedotorg.slack.com/archives/C043WM7TCH3/p1715894733871249?thread_ts=1715883545.429449&cid=C043WM7TCH3)

## Testing story
Tested locally in English and French

## Followup
We will show this section to all languages once the "Available in English only" string translation comes in. See followup ticket: [ACQ-1895](https://codedotorg.atlassian.net/browse/ACQ-1895)

----

## English
<img width="1177" alt="English" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/da3a82e2-dcd2-4f5a-8df8-6192ed92bf0e">

## French
<img width="1177" alt="French" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/5a2bef41-be76-4e97-9eb1-f8a3007ced83">
