### PR TITLE
Allowing Google accounts to delay CPA lockout until July 1st 2024

### DIFF
--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -76,7 +76,10 @@ class Policies::ChildAccount
   # Checks if a user is affected by a state policy but was created prior to the
   # policy going into effect.
   def self.user_predates_policy?(user)
-    parent_permission_required?(user) && user.created_at < STATE_POLICY[user.us_state][:start_date]
+    parent_permission_required?(user) && (
+      user.created_at < STATE_POLICY[user.us_state][:start_date] ||
+      user.authentication_options.any?(&:google?)
+    )
   end
 
   # The date on which the student's account will be locked if the account is not compliant.

--- a/dashboard/test/controllers/application_controller_test.rb
+++ b/dashboard/test/controllers/application_controller_test.rb
@@ -11,8 +11,6 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     # Test matrix for the user states which require parent permission.
     [
       [:U13, :in_colorado, :without_parent_permission],
-      [:U13, :in_colorado, :without_parent_permission, :google_sso_provider],
-      [:U13, :in_colorado, :migrated_imported_from_clever, :with_google_authentication_option],
     ].each do |traits|
       user = create(:student, *traits)
       sign_in user
@@ -36,6 +34,8 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
       [:student, :U13, :in_colorado, :migrated_imported_from_clever],
       [:student, :U13, :unknown_us_region],
       [:student, :not_U13, :in_colorado],
+      [:student, :U13, :in_colorado, :without_parent_permission, :google_sso_provider],
+      [:student, :U13, :in_colorado, :migrated_imported_from_clever, :with_google_authentication_option],
     ].each do |traits|
       user = create(*traits)
       sign_in user

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -49,7 +49,7 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
     end
   end
 
-  test 'show_cap_state_modal??' do
+  test 'show_cap_state_modal?' do
     test_matrix = [
       {rollout: 10, user_id: 9, expected: true},
       {rollout: 10, user_id: 101, expected: true},
@@ -67,6 +67,29 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       DCDO.stubs(:get).with('cap-state-modal-rollout', 0).returns(test_case[:rollout])
       actual = Policies::ChildAccount.show_cap_state_modal? user
       assert_equal test_case[:expected], actual, "Testcase #{test_case} failed"
+    end
+  end
+
+  test 'user_predates_policy?' do
+    # [User traits, Expected result from compliant?]
+    test_matrix = [
+      [[:student], false],
+      [[:student, :U13], false],
+      [[:student, :U13, :unknown_us_region], false],
+      [[:non_compliant_child, {created_at: '2023-06-29T23:59:59Z'}], true],
+      [[:non_compliant_child, {created_at: '2023-07-01T00:00:00Z'}], false],
+      [[:non_compliant_child, {created_at: '2024-06-29T23:59:59Z'}], false],
+      [[:non_compliant_child, :migrated_imported_from_clever, {created_at: '2023-06-29T23:59:59Z'}], false],
+      [[:non_compliant_child, :migrated_imported_from_clever, {created_at: '2024-06-29T23:59:59Z'}], false],
+      [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2023-06-29T23:59:59Z'}], true],
+      [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2024-06-29T23:59:59Z'}], true],
+      [[:non_compliant_child, :with_google_authentication_option, {created_at: '2024-06-29T23:59:59Z'}], true],
+    ]
+    test_matrix.each do |traits, compliance|
+      user = create(*traits)
+      actual = Policies::ChildAccount.user_predates_policy?(user)
+      failure_msg = "Expected user_predates_policy?(#{traits}) to be #{compliance} but it was #{actual}"
+      assert_equal compliance, actual, failure_msg
     end
   end
 end


### PR DESCRIPTION
We discovered that Google accounts created by students were being blocked as soon as they defined their US state in a  pop-up. This is happening because we thought all "new" (after July 1st, 2023) accounts would have defined their "US State" during account creation. Unfortunately we didn't realize Google classroom accounts would skip the account signup step where US state is defined. Interrupting classrooms this way is unacceptable, so we are going to make an exception for "new" Google accounts to not be locked out until July 1st, 2024.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/P20-936)

## Testing story
* Unit tests (please look carefully)
* On localhost I setup a Age 9 student Google account. I confirmed I wasn't locked out. Then I set my us_state and country_code to 'CO' and 'US' respectively. I confirmed I was not locked out.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
