### PR TITLE
[Sprite Lab] use new bitmap field config options

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -176,7 +176,7 @@
     "@amplitude/analytics-browser": "^1.5.4",
     "@blockly/block-shareable-procedures": "~4.0.5",
     "@blockly/field-angle": "^4.0.0",
-    "@blockly/field-bitmap": "^4.0.18",
+    "@blockly/field-bitmap": "^4.1.0",
     "@blockly/field-colour": "^4.0.0",
     "@blockly/field-grid-dropdown": "~4.0.9",
     "@blockly/keyboard-navigation": "~0.5.6",

--- a/apps/src/blockly/addons/cdoFieldBitmap.ts
+++ b/apps/src/blockly/addons/cdoFieldBitmap.ts
@@ -1,11 +1,5 @@
 import {FieldBitmap} from '@blockly/field-bitmap';
 
-import {commonI18n} from '@cdo/apps/types/locale';
-
-// The parent class sets a static pixel size and calculate the field size dymanically.
-// We set a static height for the field and calculate the pixel size based on available space.
-const FIELD_HEIGHT = 42;
-
 /**
  * Custom FieldBitmap class with additional hooks for XML serialization.
  */
@@ -24,88 +18,6 @@ export class CdoFieldBitmap extends FieldBitmap {
     super(value, options, config);
   }
 
-  /**
-   * Show the bitmap editor dialog. The parent class provides two buttons labeled
-   * "Randomize" and "Clear". In our version, we remove the randomize button and
-   * replace the clear button text with a translation string.
-   * @param {!Event=} e Optional mouse event that triggered the field to
-   *     open, or undefined if triggered programmatically.
-   * @param {boolean=} _quietInput Quiet input.
-   * @override
-   * @protected
-   */
-  showEditor_(e = undefined, _quietInput = undefined) {
-    super.showEditor_(e, _quietInput);
-
-    // Find the buttons inside the dropdown editor.
-    const buttons: NodeListOf<HTMLButtonElement> = document.querySelectorAll(
-      '.dropdownEditor .controlButton'
-    );
-
-    // Remove the button or update its text to use our translations.
-    buttons.forEach(button => {
-      switch (button.innerHTML.trim()) {
-        case 'Randomize':
-          button.remove();
-          break;
-        case 'Clear':
-          button.innerHTML = commonI18n.blocklyClear();
-          break;
-      }
-    });
-  }
-
-  /**
-   * Initializes the on-block display.
-   * In the parent class, each pixel is 15x15. In our version, we dynamically
-   * set the size based on a static field height. See updateSize_() for more.
-   * @override
-   */
-  initView() {
-    this.blockDisplayPixels = [];
-    this.pixelSize = FIELD_HEIGHT / this.imgHeight;
-    for (let r = 0; r < this.imgHeight; r++) {
-      const row = [];
-      for (let c = 0; c < this.imgWidth; c++) {
-        const square = Blockly.utils.dom.createSvgElement(
-          'rect',
-          {
-            x: c * this.pixelSize,
-            y: r * this.pixelSize,
-            width: this.pixelSize,
-            height: this.pixelSize,
-            fill: '#fff',
-            fill_opacity: 1,
-          },
-          this.fieldGroup_
-        );
-        row.push(square);
-      }
-      this.blockDisplayPixels.push(row);
-    }
-  }
-
-  /**
-   * Updates the size of the block based on the size of the underlying image.
-   * In the parent class, the field size is always sized dynamically based on the
-   * number of pixels, each being 15x15. In our version, the height of the field
-   * static to prevent the blocks from becoming to large. The width of the field
-   * is calculated based on the number of pixels horizontally, each being sized
-   * dynamically according to the fixed field height. See initView() for more.
-   * @override
-   */
-  protected updateSize_() {
-    {
-      const newWidth = this.pixelSize * this.imgWidth;
-      if (this.borderRect_) {
-        this.borderRect_.setAttribute('width', String(newWidth));
-        this.borderRect_.setAttribute('height', String(FIELD_HEIGHT));
-      }
-
-      this.size_.width = newWidth;
-      this.size_.height = FIELD_HEIGHT;
-    }
-  }
   /**
    * Converts the field's value to XML representation.
    * @param {Element} fieldElement - The XML element to populate with field data.

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -434,6 +434,8 @@ const customInputTypes = {
       const config = {
         height: 8,
         width: 8,
+        fieldHeight: 42,
+        buttons: {randomize: false},
       };
       currentInputRow
         .appendField(inputConfig.label)

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3042,12 +3042,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@blockly/field-bitmap@npm:^4.0.18":
-  version: 4.0.18
-  resolution: "@blockly/field-bitmap@npm:4.0.18"
+"@blockly/field-bitmap@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@blockly/field-bitmap@npm:4.1.0"
   peerDependencies:
     blockly: ^10.0.0
-  checksum: 1e03b7bdd775479893959eee2b4a9aa65982cb4278658c6be3f29592367edcd9ed2a6339ce927683a0ab014ddea37a58e59a00e7933cefe900dfc57e26d6c7a4
+  checksum: 0e1daf5180f54e1d65e7834bee8c5cf95a85a6edbaa15fe283bead84efe10f181107740df425c6bd9179a2ab40248e4aa91229ce3c91221f53f5733f7d0eac8a
   languageName: node
   linkType: hard
 
@@ -8041,7 +8041,7 @@ __metadata:
     "@babel/preset-react": ^7.24.1
     "@blockly/block-shareable-procedures": ~4.0.5
     "@blockly/field-angle": ^4.0.0
-    "@blockly/field-bitmap": ^4.0.18
+    "@blockly/field-bitmap": ^4.1.0
     "@blockly/field-colour": ^4.0.0
     "@blockly/field-grid-dropdown": ~4.0.9
     "@blockly/keyboard-navigation": ~0.5.6


### PR DESCRIPTION
A new version of the bitmap field plugin has been published which includes new customization options:
* https://github.com/google/blockly-samples/pull/2351

These options allow for customization that was previously only possible by extending some fairly major methods in the class. Now we can simply indicate that we want a fixed height and to hide the "Randomize" button when we create in the field instance.

**Before and after** _No differences_

<img width="416" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/286252a5-52d6-44ed-b405-904ac951624c">



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
