### PR TITLE
[Lab2] update styles for instructions code

### DIFF
--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -186,9 +186,7 @@
   }
 
   code {
-    // Color copied for consistency with bootstrap styles auto-applied to SafeMarkdown component
-    background-color: #f7f7f9;
-    color: $purple;
+    color: $light_primary_700;
   }
 
   p {

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -155,7 +155,8 @@
   border-radius: 4px;
   height: 38px;
   margin: 0 0 10px 0;
-  &:disabled, &[aria-disabled="true"] {
+  &:disabled,
+  &[aria-disabled='true'] {
     cursor: not-allowed;
     border-color: $light_gray_200;
     background-color: $light_gray_200;
@@ -166,7 +167,10 @@
 .markdownText {
   line-height: 0;
 
-  h1, h2, h3, h4 {
+  h1,
+  h2,
+  h3,
+  h4 {
     margin: 0 0 10px 0;
     font-family: $barlowSemiCondensed-semibold;
     font-size: 1.75em;
@@ -182,7 +186,9 @@
   }
 
   code {
-    color: $neutral_light;
+    // Color copied for consistency with bootstrap styles auto-applied to SafeMarkdown component
+    background-color: #f7f7f9;
+    color: $purple;
   }
 
   p {


### PR DESCRIPTION
Now that an upper lab sample progression has been shared, I decided to quickly check how well the instruction panel component would render the type of text found. 

This helped me realize that we're not correctly styling `code` text in the instructions: 
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/86dab95a-23c9-4002-b8c4-ec23058f37c1)

I compared the styles with a published lab (Java Lab): 
<img width="418" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/ae2b8e95-8166-422d-91ad-2ce4cfdaaed4">

Assuming we'd like consistency here, this PR provides the needed color and background color. For the background color, I followed a precedent I found for a recent similar fix for AI Tutor: https://github.com/code-dot-org/code-dot-org/pull/58364

This results in our familiar purple being used for code text in this CodeBridge level:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/dc390a36-d0b7-4c11-a9c8-de0fc43d12ca)


## Links

Slack thread: https://codedotorg.slack.com/archives/C06JELCAPT9/p1715895412065549
Data Science Sample progression: https://docs.google.com/document/d/1gE8tuXM2g5ZqsbomSWC0AvU5EJSvDuc7xICHwsdTHUc/edit#heading=h.w7zi4jv346jl

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

It looks like the original color was added intentionally based on this commit: https://github.com/code-dot-org/code-dot-org/commit/6e10321bb2d288f2d976f37f9e2f1431ddb092fc

However, I tested that this bug existed in Python Lab as well as Music Lab (where I'm guessing we must not be using this formatting anywhere). It looks like the new Music Lab tutorial uses separate styles for its callout links It would be good to confirm that changing this wouldn't cause any problems.
DOM view of clickable text element in Music Lab tutorial level:
<img width="252" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/9d93f132-03e6-41d9-b9b5-31d346a030ba">


## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
