### PR TITLE
Update at a glance section on code.org/tools/musiclab

### DIFF
--- a/pegasus/sites.v3/code.org/public/tools/musiclab.haml
+++ b/pegasus/sites.v3/code.org/public/tools/musiclab.haml
@@ -23,7 +23,7 @@ theme: responsive_full_width
 %section.bg-neutral-light
   .wrapper.centered
     %h2=hoc_s("music_lab.tools_page.glance.heading")
-    = view :"tools/tools_glance", ages: hoc_s("music_lab.tools_page.glance.ages"), level: hoc_s("music_lab.tools_page.glance.level"), make: hoc_s("music_lab.tools_page.glance.make"), devices: hoc_s("music_lab.tools_page.glance.devices"), browsers: hoc_s("music_lab.tools_page.glance.browsers"), languages: "العربية, Español (España), Español (LATAM), Filipino, Français, हिन्दी, Bahasa Indonesia, Italiano, 日本語, 한국어, فارسی, Polski, Português (Brasil), Português (Portugal), Slovenčina, ภาษาไทย, Türkçe, Tiếng Việt, 繁體字", accessibility: hoc_s("music_lab.tools_page.glance.accessibility")
+    = view :"tools/tools_glance", ages: hoc_s("music_lab.tools_page.glance.ages"), level: hoc_s("music_lab.tools_page.glance.level"), make: hoc_s("music_lab.tools_page.glance.make"), devices: hoc_s("music_lab.tools_page.glance.devices"), browsers: hoc_s("music_lab.tools_page.glance.browsers"), languages: "العربية, Español (España), Español (LATAM), Filipino, Français, हिन्दी, Bahasa Indonesia, Italiano, 日本語, 한국어, فارسی, Polski, Português (Brasil), Português (Portugal), Slovenčina, ภาษาไทย, Türkçe, Tiếng Việt, 繁體字", accessibility: nil
     %p.body-two.wrap-pretty
       =hoc_s("music_lab.tutorial.desc")
     %a.link-button.secondary{href: CDO.studio_url("/s/music-tutorial-2024")}

--- a/pegasus/sites.v3/code.org/public/tools/musiclab.haml
+++ b/pegasus/sites.v3/code.org/public/tools/musiclab.haml
@@ -24,10 +24,10 @@ theme: responsive_full_width
   .wrapper.centered
     %h2=hoc_s("music_lab.tools_page.glance.heading")
     = view :"tools/tools_glance", ages: hoc_s("music_lab.tools_page.glance.ages"), level: hoc_s("music_lab.tools_page.glance.level"), make: hoc_s("music_lab.tools_page.glance.make"), devices: hoc_s("music_lab.tools_page.glance.devices"), browsers: hoc_s("music_lab.tools_page.glance.browsers"), languages: "العربية, Español (España), Español (LATAM), Filipino, Français, हिन्दी, Bahasa Indonesia, Italiano, 日本語, 한국어, فارسی, Polski, Português (Brasil), Português (Portugal), Slovenčina, ภาษาไทย, Türkçe, Tiếng Việt, 繁體字", accessibility: hoc_s("music_lab.tools_page.glance.accessibility")
-    %p.body-two
-      =hoc_s("music_lab.tools_page.glance.teachers_guide_desc")
+    %p.body-two.wrap-pretty
+      =hoc_s("music_lab.tutorial.desc")
     %a.link-button.secondary{href: CDO.studio_url("/s/music-tutorial-2024")}
-      =hoc_s("music_lab.button.get_teachers_guide")
+      =hoc_s("music_lab.tutorial.button")
 
 %section.student-projects
   .wrapper

--- a/pegasus/sites.v3/code.org/views/tools/tools_glance.haml
+++ b/pegasus/sites.v3/code.org/views/tools/tools_glance.haml
@@ -15,9 +15,10 @@
 .at-a-glance{style: "margin-block: 2rem"}
   %ul.two-col
     - items_index.times do |index|
-      %li
-        %i{class: "#{icons[index]}"}
-        %p
-          %strong
-            = labels[index]
-          #{descriptions[index]}
+      - unless descriptions[index].nil?
+        %li
+          %i{class: "#{icons[index]}"}
+          %p
+            %strong
+              = labels[index]
+            #{descriptions[index]}


### PR DESCRIPTION
Updates the following in the _Music Lab at a glance_ section on https://code.org/tools/musiclab:
- Hide `Accessibility` string
- Update bottom desc and button label

## Link
Jira ticket: [ACQ-1898](https://codedotorg.atlassian.net/browse/ACQ-1898)
Figma mock: [here](https://www.figma.com/design/2WMErkWkUqY8DNxPCa5hXB/Music-Lab-Launch?node-id=2425%3A1727&t=TehcIgBK1xKdDebw-1)

## Testing story
Tested locally to make sure the new `tools_glance.haml` view logic works when a description is `nil`

----

| Before | After | 
| ---- | ---- |
| <img width="1058" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/00e3cefa-69fe-47ea-8427-cc8f9cb0d5c3"> | <img width="1058" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/cf7eea8b-8f69-492c-9534-21b9d780d6bd"> |

