### PR TITLE
Removed iPhone from testing 

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/instructor_in_training.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructor_in_training.feature
@@ -1,3 +1,4 @@
+@no_phone
 Feature: Self Paced PL Instructor in Training
 
   Scenario: View Instructor In Training Applab Level as Universal Instructor


### PR DESCRIPTION
Removed test from iPhone given flaky issues, and the fact the teacher tools generally doesn't require iPhone compatibility.  

## Links
[
Convo](https://codedotorg.slack.com/archives/C045UAX4WKH/p1715968071966789)