### PR TITLE
Reset `dashboard/config` On Staging Branch to Match Levelbuilder

### DIFF
--- a/dashboard/config/levels/custom/spritelab/game_new3_environment_choice2_2024.level
+++ b/dashboard/config/levels/custom/spritelab/game_new3_environment_choice2_2024.level
@@ -1,6 +1,5 @@
 <GamelabJr>
   <config><![CDATA[{
-  "published": true,
   "game_id": 64,
   "created_at": "2024-05-07T21:28:11.000Z",
   "level_num": "custom",
@@ -72,11 +71,9 @@
     "short_instructions": "Try out this game! Use the arrows to pig to get the corn.",
     "standalone_app_name": "game_design",
     "long_instructions": "**Try it out!**\r\n\r\n- Move the pig to get the corn\r\n\r\n- The grass sprites block the pig so you will have to stay on the dirt path\r\n\r\n- Press `Finish` when you are ready to move on",
-    "preload_asset_list": null,
-    "encrypted_examples": [
-
-    ]
+    "preload_asset_list": null
   },
+  "published": true,
   "notes": "",
   "audit_log": "[{\"changed_at\":\"2024-05-07T21:28:11.059+00:00\",\"changed\":[\"cloned from \\\"game_new3_environment_choice2\\\"\"],\"cloned_from\":\"game_new3_environment_choice2\"},{\"changed_at\":\"2024-05-15 22:19:32 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1196,\"changed_by_email\":\"amy.woodman@code.org\"},{\"changed_at\":\"2024-05-16 15:36:06 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"start_animations\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":18605,\"changed_by_email\":\"katie.frank+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-16 15:36:34 +0000\",\"changed\":[\"start_blocks\"],\"changed_by_id\":18605,\"changed_by_email\":\"katie.frank+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-16 15:37:15 +0000\",\"changed\":[\"start_blocks\"],\"changed_by_id\":18605,\"changed_by_email\":\"katie.frank+levelbuilder@code.org\"}]",
   "level_concept_difficulty": {

--- a/dashboard/config/scripts_json/k5-ai-data-2024.script_json
+++ b/dashboard/config/scripts_json/k5-ai-data-2024.script_json
@@ -1088,26 +1088,14 @@
     },
     {
       "seeding_key": {
-        "level.key": "k5_ai_sorting_markdown_level",
+        "level.key": "sorting_items_wings",
         "script_level.level_keys": [
-          "k5_ai_sorting_markdown_level"
+          "sorting_items_wings"
         ],
         "lesson.key": "Sorting Data",
         "lesson_group.key": "",
         "script.name": "k5-ai-data-2024",
-        "activity_section.key": "4d4a5dd9-6bae-44b3-8137-b6a76d67fbe3"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "k5_ai_sorting_choice_level",
-        "script_level.level_keys": [
-          "k5_ai_sorting_choice_level"
-        ],
-        "lesson.key": "Sorting Data",
-        "lesson_group.key": "",
-        "script.name": "k5-ai-data-2024",
-        "activity_section.key": "e5b0e9d8-a9af-4ebe-aea8-1ed630257a0d"
+        "activity_section.key": "dc798ba9-8a3f-4eac-9fea-9bf01b5fa054"
       }
     },
     {


### PR DESCRIPTION
We're not exactly sure what happened, but we had a couple of merge conflicts that resulted in some levelbuilder content having changes on the staging branch that did not actually come from the levelbuilder branch.

To resolve, we manually executed `git checkout levelbuilder -- dashboard/config` on the staging branch.


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- https://github.com/code-dot-org/code-dot-org/pull/58678
- https://github.com/code-dot-org/code-dot-org/commit/166e2f5156c0192a74494047fbac96cda28c9046

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
