### PR TITLE
[i18n-sync] Retry Crowdin request on error "409 This file is currently being updated"

### DIFF
--- a/bin/i18n/utils/crowdin_client.rb
+++ b/bin/i18n/utils/crowdin_client.rb
@@ -18,6 +18,7 @@ module I18n
       REQUEST_RETRY_DELAY = 2 # Number of seconds to wait before retrying a failed request
       RETRIABLE_ERRORS = [
         '408 Request Timeout',
+        '409 This file is currently being updated',
         '429 Too Many Requests',
         '500 Internal Server Error',
         '503 Service Unavailable',


### PR DESCRIPTION
## Error
```
bundler: failed to load command: ./bin/i18n/sync-all.rb (./bin/i18n/sync-all.rb)
/home/ubuntu/code-dot-org/bin/i18n/utils/crowdin_client.rb:274:in `request': 409 This file is currently being updated (I18n::Utils::CrowdinClient::RequestError)
Project:  hour-of-code
Endpoint: update_or_restore_file
Params:   [595, {:storageId=>2131009580}]
Attempt:  2
```