### PR TITLE
Lab2: force refresh if saving project returns 401

### DIFF
--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -363,10 +363,7 @@ export default class ProjectManager {
       // We set forceReloading to true so the client can skip
       // showing the user a dialog before reload.
       this.forceReloading = true;
-      this.metricsReporter.logWarning({
-        event: 'Conflict on save, reloading page',
-        details: error.message,
-      });
+      this.metricsReporter.logWarning(`${error.message}. Reloading page.`);
       reload();
     } else {
       // Otherwise, we log the error.

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -357,12 +357,16 @@ export default class ProjectManager {
   private onSaveFail(errorMessage: string, error: Error) {
     this.saveInProgress = false;
     this.executeSaveFailListeners(error);
-    if (error.message.includes('409')) {
-      // If this is a conflict, we need to reload the page.
+    if (error.message.includes('409') || error.message.includes('401')) {
+      // If this is a conflict or the user has somehow become unauthorized,
+      // we need to reload the page.
       // We set forceReloading to true so the client can skip
       // showing the user a dialog before reload.
       this.forceReloading = true;
-      this.metricsReporter.logWarning('Conflict on save, reloading page');
+      this.metricsReporter.logWarning({
+        event: 'Conflict on save, reloading page',
+        details: error.message,
+      });
       reload();
     } else {
       // Otherwise, we log the error.


### PR DESCRIPTION
Force a refresh if we receive a 401 Unauthorized from the server while attempting to save a student's project (similar to what we do if we receive a 409 Conflict). We've seen a small but steady number of these errors in Music Lab, including a few in a small group during a play session recently. It's not immediately clear how standard users would end up in this scenario, but an easy way to repro this is to start a new Music Lab project signed out, then sign in to Code.org on another tab, and go back to the Music Lab project and try to Run/save code. The server returns an error because the now signed in user's cookie doesn't have permissions to the signed out user's channel ID. In other labs, we also just a force a refresh if we hit this scenario, so we can just do the same here.

## Links

https://codedotorg.atlassian.net/browse/LABS-831

## Testing story

Tested locally with a standalone project, 1) creating a project signed out and signing in on another tab and 2) creating a project signed in, and signing out on another tab.