### PR TITLE
Music: adjust pack dialog

### DIFF
--- a/apps/src/music/views/PackDialog.module.scss
+++ b/apps/src/music/views/PackDialog.module.scss
@@ -90,13 +90,15 @@
           }
 
           &Footer {
-            margin-top: 10px;
+            margin-top: 8px;
             display: flex;
             justify-content: space-between;
             align-items: center;
 
             &Name {
-              font-size: 16px;
+              font-size: 18px;
+              font-weight: 600;
+              line-height: 1.3;
             }
 
             &Artist {


### PR DESCRIPTION
Small adjustment to the Music Lab pack dialog to make the pack titles a little bigger and bolder.

### before
<img width="1512" alt="Screenshot 2024-05-18 at 2 07 32 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/cb75b308-c9b5-4dfd-a681-5a13b0637a95">

### after
<img width="1512" alt="Screenshot 2024-05-18 at 2 07 12 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/c99d5eaa-363b-45e1-b956-832594d0f0e9">
