### PR TITLE
Music: sounds panel preview variant

### DIFF
--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -11,6 +11,10 @@ import AppConfig from '../appConfig';
 const FIELD_HEIGHT = 20;
 const FIELD_PADDING = 2;
 
+// A variant for SoundsPanel that plays previews as sounds are selected.
+const useSoundsPanelPreview =
+  AppConfig.getValue('sounds-panel-1-preview') === 'true';
+
 // Default to using SoundsPanel, unless a URL parameter forces the use of
 // the newer SoundsPanel2.
 const useSoundsPanel2 = AppConfig.getValue('sounds-panel-2') === 'true';
@@ -144,7 +148,7 @@ class FieldSounds extends GoogleBlockly.Field {
         }}
         onSelect={value => {
           this.setValue(value);
-          if (!useSoundsPanel2) {
+          if (!useSoundsPanelPreview && !useSoundsPanel2) {
             this.hide_();
           }
         }}

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import classNames from 'classnames';
-import {getBaseAssetUrl} from '../appConfig';
+import AppConfig, {getBaseAssetUrl} from '../appConfig';
 import styles from './soundsPanel.module.scss';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
@@ -13,6 +13,10 @@ import SoundStyle from '../utils/SoundStyle';
 import FocusLock from 'react-focus-lock';
 import SegmentedButtons from '@cdo/apps/componentLibrary/segmentedButtons';
 import musicI18n from '../locale';
+
+// A variant for SoundsPanel that plays previews as sounds are selected.
+const useSoundsPanelPreview =
+  AppConfig.getValue('sounds-panel-1-preview') === 'true';
 
 /*
  * Renders a UI for previewing and choosing samples. This is currently used within a
@@ -145,6 +149,24 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
   const soundPath = folder.id + '/' + sound.src;
   const isSelected = soundPath === currentValue;
   const isPlayingPreview = playingPreview === soundPath;
+
+  const onSoundSelect = useCallback(() => {
+    if (useSoundsPanelPreview) {
+      if (!isPlayingPreview) {
+        onPreview(soundPath);
+      }
+    }
+    onSelect(soundPath);
+  }, [isPlayingPreview, onPreview, onSelect, soundPath]);
+
+  const onSoundClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      onSoundSelect();
+    },
+    [onSoundSelect]
+  );
+
   const onPreviewClick = useCallback(
     (e: Event) => {
       if (!isPlayingPreview) {
@@ -162,10 +184,10 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
         styles.soundRow,
         isSelected && styles.soundRowSelected
       )}
-      onClick={() => onSelect(folder.id + '/' + sound.src)}
+      onClick={onSoundClick}
       onKeyDown={event => {
         if (event.key === 'Enter') {
-          onSelect(folder.id + '/' + sound.src);
+          onSoundSelect();
         }
       }}
       ref={isSelected ? currentSoundRefCallback : null}

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -52,6 +52,14 @@ const optionsList = [
     ],
   },
   {
+    name: 'sounds-panel-1-preview',
+    type: 'radio',
+    values: [
+      {value: 'false', description: 'Use original sounds panel (default).'},
+      {value: 'true', description: 'Use original sounds panel with preview.'},
+    ],
+  },
+  {
     name: 'sounds-panel-2',
     type: 'radio',
     values: [


### PR DESCRIPTION
This is a new variant of the original `SoundsPanel` which borrows one idea from `SoundsPanel2`: when a sound is clicked, it plays a preview and changes the selection, but doesn't dismiss the panel.  It can be tried using the `sounds-panel-1-preview=true` URL parameter.
