### PR TITLE
Skip applab versions test on phone

### DIFF
--- a/dashboard/test/ui/features/star_labs/applab/versions.feature
+++ b/dashboard/test/ui/features/star_labs/applab/versions.feature
@@ -1,6 +1,7 @@
 @as_student
 Feature: App Lab Versions
 
+@no_phone
 Scenario: Script Level Versions
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1?noautoplay=true"
   And I wait for the page to fully load


### PR DESCRIPTION
This skips the first scenario of the `applab/versions` UI test on the phone simulator, due to a very high failure rate in recent days.  

Lots of detail captured in this [ticket](https://codedotorg.atlassian.net/browse/LABS-828).  The video of each test run shows that the final step should succeed, despite it failing with one of these two errors:

```
Original error: null is not an object (evaluating '__TestInterface.getDroplet().aceEditor')
```

```
Then ace editor code is equal to "// comment 2// comment 1"
expected: "// comment 2// comment 1"
got: "// comment 1"
(compared using ==)
(RSpec:: Expectations:: ExpectationNotMetError)
```

Related: https://github.com/code-dot-org/code-dot-org/pull/23500