### PR TITLE
Raise StudentFacingError.new(:TABLE_NAME_INVALID) if table name is too long

### DIFF
--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -334,6 +334,8 @@ class DatablockStorageController < ApplicationController
 
   private def table_or_create
     where_table.first_or_create
+  rescue ActiveRecord::ValueTooLong
+    raise StudentFacingError.new(:TABLE_NAME_INVALID), "The table name is too long, it must be shorter than #{DatablockStorageTable.columns_hash['table_name'].limit} bytes ('characters')"
   rescue ActiveRecord::RecordNotUnique
     # first_or_create() is not atomic, retry in case a create was done in parallel
     where_table.first_or_create

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -214,6 +214,19 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     assert_equal ['👁️👄👁️'], JSON.parse(@response.body)
   end
 
+  test "create_table enforces max table_name length" do
+    max_table_name_length = 700
+    not_too_many_bees = 'b' * (max_table_name_length - 1) # 1 less 'b' chars than max
+    post _url(:create_table), params: {table_name: not_too_many_bees}
+    assert_response :success
+
+    too_many_bees = 'b' * (max_table_name_length + 1) # 1 more 'b' char than max
+    post _url(:create_table), params: {table_name: too_many_bees}
+    assert_response :bad_request
+
+    assert_equal 'TABLE_NAME_INVALID', JSON.parse(@response.body)['type']
+  end
+
   test "get_key_values" do
     post _url(:set_key_value), params: {
       key: 'name',


### PR DESCRIPTION
Fixes [#58763](https://github.com/code-dot-org/code-dot-org/issues/58763)

Fixes Honeybadger Error: https://app.honeybadger.io/projects/3240/faults/107904108

Tested by:
- Manually trying to use the data browser add table button to add a table_name > 800 chars. Confirm it brings up a UX error when it fails: 
<img width="789" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/300fb7c5-9686-4a87-8fcd-3252e8e43903">
- Adds an integration test that the correct error is thrown to trigger the UX error.