### PR TITLE
Datablock Storage: use UX expected enum values for StudentFacingError(:VALUE)

### DIFF
--- a/dashboard/app/models/datablock_storage_kvp.rb
+++ b/dashboard/app/models/datablock_storage_kvp.rb
@@ -46,7 +46,7 @@ class DatablockStorageKvp < ApplicationRecord
       DatablockStorageKvp.insert_all(kvps)
     end
   rescue ActiveRecord::ValueTooLong
-    raise StudentFacingError.new(:MAX_KEY_LENGTH_EXCEEDED), "The key is too large, it must be shorter than #{columns_hash['key'].limit} bytes ('characters')"
+    raise StudentFacingError.new(:KEY_INVALID), "The key is too large, it must be shorter than #{columns_hash['key'].limit} bytes ('characters')"
   end
 
   def self.set_kvp(project_id, key, value)

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -245,7 +245,7 @@ class DatablockStorageTable < ApplicationRecord
 
     create_records(new_records)
   rescue CSV::MalformedCSVError => exception
-    raise StudentFacingError.new(:INVALID_CSV), "Could not import CSV as it was not in the format we expected: #{exception.message}"
+    raise StudentFacingError.new(:IMPORT_FAILED), "Could not import CSV as it was not in the format we expected: #{exception.message}"
   end
 
   def add_column(column_name)


### PR DESCRIPTION
Fixes #58762 

1. Raise UX errors on import_csv:
<img width="701" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/1a88538c-9fc9-474f-8e18-5af702dd96c6">

2. Raise UX errors when set_key_value key is too long:
<img width="799" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/60941f9c-bbde-479b-a285-5033fcc7d68e">