### PR TITLE
Clear chat history when switching user views of aichat level

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -34,6 +34,8 @@ import moduleStyles from './aichatView.module.scss';
 const AichatView: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
 
+  const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
+
   const beforeNextLevel = useCallback(() => {
     dispatch(sendSuccessReport('aichat'));
   }, [dispatch]);
@@ -69,10 +71,11 @@ const AichatView: React.FunctionComponent = () => {
     );
   }, [dispatch, initialSources, levelAichatSettings]);
 
-  // When the level changes, clear the chat message history and start a new session.
+  // When the level changes or if we are viewing aichat level as a different user
+  // (e.g., teacher viewing student work), clear the chat message history and start a new session.
   useEffect(() => {
     dispatch(clearChatMessages());
-  }, [currentLevelId, dispatch]);
+  }, [currentLevelId, viewAsUserId, dispatch]);
 
   // Showing presentation view when:
   // 1) levelbuilder hasn't explicitly configured the toggle to be hidden, and

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useRef, useEffect} from 'react';
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {useSelector} from 'react-redux';
 import ChatWarningModal from '@cdo/apps/aichat/views/ChatWarningModal';
 import ChatMessage from './ChatMessage';
@@ -7,7 +7,6 @@ import UserChatMessageEditor from './UserChatMessageEditor';
 import moduleStyles from './chatWorkspace.module.scss';
 import {
   AichatState,
-  clearChatMessages,
   setShowWarningModal,
 } from '@cdo/apps/aichat/redux/aichatRedux';
 
@@ -29,8 +28,6 @@ const ChatWorkspace: React.FunctionComponent = () => {
 
   const conversationContainerRef = useRef<HTMLDivElement>(null);
 
-  const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
-
   useEffect(() => {
     if (conversationContainerRef.current) {
       conversationContainerRef.current.scrollTo({
@@ -41,11 +38,6 @@ const ChatWorkspace: React.FunctionComponent = () => {
   }, [conversationContainerRef, storedMessages, isWaitingForChatResponse]);
 
   const dispatch = useAppDispatch();
-
-  // Clear chat history if we are viewing aichat level as a different user (e.g., teacher viewing student work)
-  useEffect(() => {
-    dispatch(clearChatMessages());
-  }, [dispatch, viewAsUserId]);
 
   const onCloseWarningModal = useCallback(
     () => dispatch(setShowWarningModal(false)),

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useRef, useEffect} from 'react';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {useSelector} from 'react-redux';
 import ChatWarningModal from '@cdo/apps/aichat/views/ChatWarningModal';
 import ChatMessage from './ChatMessage';
@@ -7,6 +7,7 @@ import UserChatMessageEditor from './UserChatMessageEditor';
 import moduleStyles from './chatWorkspace.module.scss';
 import {
   AichatState,
+  clearChatMessages,
   setShowWarningModal,
 } from '@cdo/apps/aichat/redux/aichatRedux';
 
@@ -28,6 +29,8 @@ const ChatWorkspace: React.FunctionComponent = () => {
 
   const conversationContainerRef = useRef<HTMLDivElement>(null);
 
+  const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
+
   useEffect(() => {
     if (conversationContainerRef.current) {
       conversationContainerRef.current.scrollTo({
@@ -38,6 +41,11 @@ const ChatWorkspace: React.FunctionComponent = () => {
   }, [conversationContainerRef, storedMessages, isWaitingForChatResponse]);
 
   const dispatch = useAppDispatch();
+
+  // Clear chat history if we are viewing aichat level as a different user (e.g., teacher viewing student work)
+  useEffect(() => {
+    dispatch(clearChatMessages());
+  }, [dispatch, viewAsUserId]);
 
   const onCloseWarningModal = useCallback(
     () => dispatch(setShowWarningModal(false)),


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates aichat so that when a teacher switches the user view of an aichat level via the teacher channel, the chat history is cleared.

## After update


https://github.com/code-dot-org/code-dot-org/assets/107423305/5ea4aa03-650f-488f-ab87-ffea27761c58

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-787)


<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally in /allthethings aichat levels with a teacher account with a section that has two student accounts.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
- Investigate 'strange behavior' when teacher views student aichat levels [Slack thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1716218408274659?thread_ts=1716215584.783499&cid=C06FELVTV0Q)
- Update read-only view of aichat level https://codedotorg.atlassian.net/browse/LABS-758 
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
