### PR TITLE
[Google Blockly] keep variables in sync between workspaces

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -1,12 +1,17 @@
 import {unregisterProcedureBlocks} from '@blockly/block-shareable-procedures';
 import {Block, BlockSvg, Field, Theme, WorkspaceSvg} from 'blockly';
-import {ToolboxItemInfo, BlockInfo} from 'blockly/core/utils/toolbox';
+import {
+  ToolboxItemInfo,
+  BlockInfo,
+  ToolboxDefinition,
+} from 'blockly/core/utils/toolbox';
 import _ from 'lodash';
 
 import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
 import {
   getProjectXml,
   processIndividualBlock,
+  removeIdsFromBlocks,
 } from '@cdo/apps/blockly/addons/cdoXml';
 import {APP_HEIGHT} from '@cdo/apps/p5lab/constants';
 import experiments from '@cdo/apps/util/experiments';
@@ -712,4 +717,16 @@ export function highlightBlock(id: string, spotlight: boolean) {
     Blockly.selected.unselect();
   }
   Blockly.getMainWorkspace().highlightBlock(id, spotlight);
+}
+
+// Removes block ids from an XML string toolbox
+export function toolboxWithoutIds(
+  toolbox: string | Element | ToolboxDefinition | undefined
+) {
+  if (typeof toolbox !== 'string') {
+    return toolbox;
+  }
+  const toolboxDom = Blockly.Xml.textToDom(toolbox);
+  removeIdsFromBlocks(toolboxDom);
+  return Blockly.Xml.domToText(toolboxDom);
 }

--- a/apps/src/blockly/addons/functionEditor.ts
+++ b/apps/src/blockly/addons/functionEditor.ts
@@ -625,6 +625,8 @@ export default class FunctionEditor {
     // procedure definition.
     Blockly.Events.disable();
     this.editorWorkspace.clear();
+    // The previous line also clears the variable map. We need to manually rebuild it
+    // so that student variables continue to be defined on the editor workspace.
     const primaryWorkspaceVariableMap = this.primaryWorkspace?.getVariableMap();
     const functionEditorVariableMap = this.editorWorkspace.getVariableMap();
     if (primaryWorkspaceVariableMap) {

--- a/apps/src/blockly/addons/functionEditor.ts
+++ b/apps/src/blockly/addons/functionEditor.ts
@@ -491,9 +491,10 @@ export default class FunctionEditor {
       }
     });
 
-    // Mirror variable events from main workspace to editor workspace.
+    // Mirror variable events from main workspace to editor workspace and the
+    // hidden procedure definition workspace.
     // This is allows newly created/renamed/deleted variables to propogate
-    // to the modal function editor workspace.
+    // to the other workspaces.
     this.primaryWorkspace?.addChangeListener(e => {
       if (!this.editorWorkspace) {
         return;
@@ -624,13 +625,13 @@ export default class FunctionEditor {
     // procedure definition.
     Blockly.Events.disable();
     this.editorWorkspace.clear();
-    const primaryVariableMap = this.primaryWorkspace?.getVariableMap();
-    const modalVariableMap = this.editorWorkspace.getVariableMap();
-    if (primaryVariableMap) {
-      const variables = primaryVariableMap.getAllVariables();
+    const primaryWorkspaceVariableMap = this.primaryWorkspace?.getVariableMap();
+    const functionEditorVariableMap = this.editorWorkspace.getVariableMap();
+    if (primaryWorkspaceVariableMap) {
+      const variables = primaryWorkspaceVariableMap.getAllVariables();
 
       variables.forEach(variable => {
-        modalVariableMap.createVariable(
+        functionEditorVariableMap.createVariable(
           variable.name,
           variable.type,
           variable.getId()

--- a/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor.feature
+++ b/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor.feature
@@ -2,7 +2,7 @@
 Feature: Modal Function Editor
 
 Background:
-  Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/3?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/3?noautoplay=true"
   And I wait for the page to fully load
   And I wait for 3 seconds
   And I wait until I don't see selector "#p5_loading"
@@ -30,8 +30,8 @@ Scenario: Can edit a function
   And element "#modalFunctionEditor" is visible
   # Open Sprites flyout
   And I press "blockly-d"
-  # Drag block to top of function
-  And I drag block "new-sprite-block" to offset "40, 100"
+  # Drag new sprite block to top of function
+  And I drag block number "3" to offset "40, 100"
   # Close function
   And I press "closeModalFunctionEditor"
   And element "#modalFunctionEditor" is not visible

--- a/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor.feature
+++ b/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor.feature
@@ -31,7 +31,7 @@ Scenario: Can edit a function
   # Open Sprites flyout
   And I press "blockly-d"
   # Drag new sprite block to top of function
-  And I drag block number "3" to offset "40, 100"
+  And I drag block number 3 to offset "40, 100"
   # Close function
   And I press "closeModalFunctionEditor"
   And element "#modalFunctionEditor" is not visible

--- a/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor_eyes.feature
+++ b/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor_eyes.feature
@@ -3,7 +3,7 @@
 Feature: Modal Function Editor Eyes
 
 Background:
-  Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/3?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/3?noautoplay=true"
   And I wait for the page to fully load
   And I wait for 3 seconds
   And I wait until I don't see selector "#p5_loading"

--- a/dashboard/test/ui/features/code_tools/google_blockly/spritelab_eyes.feature
+++ b/dashboard/test/ui/features/code_tools/google_blockly/spritelab_eyes.feature
@@ -3,7 +3,7 @@
 Feature: Google Blockly Sprite Lab Eyes
 
 Background:
-  Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/4?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/4?noautoplay=true"
   And I wait for the page to fully load
   And I wait for 3 seconds
   And I wait until I don't see selector "#p5_loading"

--- a/dashboard/test/ui/features/star_labs/spritelab/spritelab.feature
+++ b/dashboard/test/ui/features/star_labs/spritelab/spritelab.feature
@@ -1,7 +1,7 @@
 Feature: Sprite Lab
 
 Background:
-  Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/1?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/1?noautoplay=true"
   And I wait for the page to fully load
   And I wait for 3 seconds
   And I wait until I don't see selector "#p5_loading"

--- a/dashboard/test/ui/features/step_definitions/blockly.rb
+++ b/dashboard/test/ui/features/step_definitions/blockly.rb
@@ -70,6 +70,11 @@ When /^I drag block "([^"]*)" into first position in repeat block "([^"]*)"$/ do
   @browser.execute_script code
 end
 
+When /^I drag block number (\d+) to offset "([^"]*), ([^"]*)"$/ do |index, dx, dy|
+  block_selector = get_indexed_blockly_draggable_selector(index.to_i)
+  drag_indexed_block_to_offset(block_selector, dx, dy)
+end
+
 Then /^block "([^"]*)" is near offset "([^"]*), ([^"]*)"$/ do |block, x, y|
   point = get_block_coordinates(get_block_id(block))
   expect(point.x).to be_within(3).of(x.to_i)

--- a/dashboard/test/ui/features/support/blockly_helpers.rb
+++ b/dashboard/test/ui/features/support/blockly_helpers.rb
@@ -28,6 +28,16 @@ module BlocklyHelpers
         "$(\"[#{id_selector}='#{from}']\").simulate( 'drag', {justDrag: true, handle: 'corner', dx: drag_dx + #{target_dx}, dy: drag_dy + #{target_dy}, moves: 5});"
   end
 
+  def get_indexed_blockly_draggable_selector(index)
+    ".blocklyDraggable:visible:eq(#{index - 1})"
+  end
+
+  def drag_indexed_block_to_offset(block_selector, dx, dy)
+    target_selector = block_selector # Using the same block as target for relative drag
+    code = generate_selector_drag_code(block_selector, target_selector, dx.to_i, dy.to_i)
+    @browser.execute_script(code)
+  end
+
   def generate_offset_code(selector)
     # Only get offset for non-hidden elements. We have to check the parent tree
     # for any hidden parents, because blocks will not be "hidden" per jquery's logic


### PR DESCRIPTION
Recently, two related bug reports came in where Sprite Lab projects were behaving strangely due to variable blocks.  My investigation led to the discovery of a few related bugs:


1. We were not using our custom flyout callback for the Variables category on the modal editor workspace - just on the main workspace. 
2. When variables are created/renamed/deleted in one workspace, we did not mirror the events to the other workspaces. This could cause a student to create a `score` in on the main workspace, then not find it on the modal workspace. If they created it a second time there, it would conflict and throw an error.
3. If a toolbox block with a set id is dragged into a workspace, the new block has the same id, unless it's already used. However, Blockly only checks the target workspace. If a block was created on the modal workspace but the id was already in use on the hidden workspace, it would cause problems. If you opened the original function with this block, it was no longer there (because it had been moved to the new function).

### Custom Variables Category
We customize the variable category to provide our own button/prompt for creating variables and to make sure that blocks from the level XML get merged with the auto-populated blocks driven by the variable map. When we added this to Google Blockly, we only added it to the main workspace, which resulted in this inconsistent experience:

Main Workspace: 
<img width="363" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/bab1f833-4df4-4ce0-b5c2-ca4839158d80">
Editor workspace: 
<img width="351" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/b9916420-d17d-4003-971a-618a76b01f01">
Expected custom prompt: 
<img width="670" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/b1109639-24dc-4689-8254-38c8fcbc15be">
Unexpected prompt: 
<img width="458" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/19c87ee5-f890-455d-82fa-7ec7ba1c2e65">

Fixing this was just a matter of calling `registerToolboxCategoryCallback` on the editor workspace.

### Duplicate block ids from toolbox blocks
If the toolbox XML for a block includes an ID, Blockly will try to give preserve it for the first block created on that workspace. Once the id is in use on that workspace, it will randomly generate new ones. We needed Blockly to preserve this functionality for us because we use these hard-coded block ids for UI tests that involve dragging blocks out of the toolbox. However, if this is done in the modal editor it has the potential to cause problems. Steps:
1. Open the modal editor.
2. Drag out a block with a hard-coded id.
3. Close the modal editor and re-open it with a different function
4. Drag out the same block

Because the block from step 2 is no longer on the editor workspace, Blockly doesn't detect the conflict so it allow the id to be used. The block create event is then mirrored to the hidden workspace, which fails because a block with that id already exists. The subsequent block event is also mirror to the hidden workspace, which "succeeds" by moving the first block into the new position intended for the second block. Now, if you re-open the first function, the expected block has disappeared.

I considered several alternatives here, but ultimately what worked was just to strip block ids out of the toolbox string before injecting the editor workspace. This should be fine because we don't have any UI tests for the modal editor that rely upon the static block id.

### Mirroring variable events

Currently, on staging, we mirror events in the following ways:
* Procedure events are mirrored from the modal editor workspace to the main workspace
* All non-UI events are mirrored from the modal editor workspace to the hidden definition workspace

The first rule is needed so that we can create the right procedure call blocks and so that functions and behaviors are still defined on the main workspace. The second rule is needed so that our source of truth for definitions (ie. the hidden workspace) is always kept up to date.

What's missing from the system is proper mirroring of variable events. With Blockly, all variables are created within the global scope. We concatenate the generated code from the main and hidden workspace, so it shouldn't matter which workspace is active when a variable is created. If a variable is created (or renamed or deleted) from the main workspace, we should do the same thing on both the editor and hidden workspaces (and vice versa).

To solve this problem, we need mirror these events from the main workspace to both other workspaces. I did this via a new change listener. We also need to mirror from the modal editor workspace to both the main and hidden workspaces. For the first case, I just latched onto where we were already mirroring procedure events. For the second case, we were already handling this sufficiently because variable events are non-UI events.

The results of the changes here are variables can now be managed on either workspace and will stay in sync. If blocks are dragged out which reference a certain variable, it will either be found on that workspace's map (and all of them) or it will be created. And toolboxes will be stripped of block ids so that we don't continue having issues with duplicate block ids being used on the hidden workspace.


## Full Bug Reports

The first was reported by @cnbrenci. From the [ticket](https://codeorg.zendesk.com/agent/tickets/496608):
> Probable Bug in Sprite Lab.
In project I create Variables “score”. After I create function “score+” and try to call variable “score” in function “score+”, variable is not there. Then I create variable with same name “score” and exit function. Use that function with variable included and save the project. Exit project and after I again enter that project my variable “score” used in function change name to “i”.
https://studio.code.org/projects/spritelab/6bBUKGra5IGR_JIpK8I-tr5Fvc-CUjGwoDkCzOzczMQ/edit

Cassi added on [Slack](https://codedotorg.slack.com/archives/C03DBDN67B7/p1715286123330839?thread_ts=1715284795.658849&cid=C03DBDN67B7):
> Seems like there's also bug(s) around creating vars with the same name as ones in main scope too, I'm seeing uncaught errors in console about conflicting names that aren't showing any indication in UI, and sometimes reverts the var back and sometimes doesn't.
(errors like
Uncaught Error: Variable "mainScope" is already in use and its id is "9?(dNoz*5BTN%k%n)0K1" which conflicts with the passed in id, "(|5Et68[=ZwMGs$s`:4)".)

_This screenshot shows a reproduction of the affected user's project, now working as expected:_
<img width="900" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/51615297-f711-407f-87e7-3a648e8278f6">

The second was reported by @molly-moen. From the [ticket](https://codeorg.zendesk.com/agent/users/26672271907725):
>In Sprite Lab, adding “location of” block to a function causes the “location of” block to not save when the function is closed. This happens in the second function that uses the “location of” block.
Repro steps:
> - Create a new SpriteLab project
> - Create a new function “do something” and edit it
> - Add a “Make new sprite at” block to the function.
> - Add a “location of” block to the “Make new sprite at” block
> - Close the “do something” function
> - Create another new function “do something2” and edit it
> - Add a “Make new sprite at” block to the function
> - Add a “location of” block to the “Make new sprite at” block
> - Close the “do something2” function
> - Edit the “do something2” function again
Expected results:
“do something2” should contain the “location of” block added in step 8. The code should look like this:
>```
>function do_something2() {
>  makeNewSpriteAnon("purple bunny", locationOf({name: 'mySprite'}));
>}
>```
>Actual results:
>“do something2” has no “location of” block. The code looks like this:
>```
>function do_something2() {
>  makeNewSpriteAnon("purple bunny", undefined);
>}
>```
>In the dev console, I see this exception as soon as I add the “location of” block to the second function:
>```
>Uncaught Error: Variable "mySprite" is already in use and its id is "I59!Ry8~_7B$y(:#eF)j" which conflicts with the passed in id, "c6;ZQ]cqk;j|Vo]!pnI+".
>   at t.createVariable (external var "$":1:18)
>   at i.createVariable (external var "$":1:18)
>   at T.run (external var "$":1:18)
>   at external var "$":1:18
>   at i.fireChangeListener (external var "$":1:18)
>   at y (external var "$":1:18)
>   at nrWrapper (edit:16:17823)
>```

_This screenshot demonstrates that the bug described above has been fixed:_
<img width="653" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/40b788c1-f0e2-4d85-b9d2-58c952983b13">


## Links

Jira: https://codedotorg.atlassian.net/browse/CT-573
Slack thread: https://codedotorg.slack.com/archives/C05DK21DAHK/p1715971343769239
Zendesk tickets:
1. https://codeorg.zendesk.com/agent/tickets/496608
6. https://codeorg.zendesk.com/agent/tickets/496843
Broken user project: https://studio.code.org/projects/spritelab/6bBUKGra5IGR_JIpK8I-tr5Fvc-CUjGwoDkCzOzczMQ/view


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  7.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
