### PR TITLE
Remove public gallery has been updated banner

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2188,8 +2188,6 @@
   "publishToPublicGalleryWarning": "You are about to publish your project to the public gallery, meaning anyone in the world can view your project. Make sure your project does not contain any inappropriate content or personal information.",
   "published": "Published",
   "publicGallery": "Public Gallery",
-  "publicGalleryUpdatedInfo": "The public projects gallery has been updated.",
-  "publicGalleryUpdatedDetails": "The public projects gallery has been updated to display selected projects in the featured projects gallery. Users are no longer able to publish projects publicly but can still share and remix projects.",
   "publicProjects": "Public Projects",
   "purpose": "Purpose",
   "puzzle": "Puzzle",

--- a/apps/src/sites/studio/pages/projects/index.js
+++ b/apps/src/sites/studio/pages/projects/index.js
@@ -47,9 +47,6 @@ $(document).ready(() => {
         <ProjectHeader
           canViewAdvancedTools={projectsData.canViewAdvancedTools}
           projectCount={projectsData.projectCount}
-          showPublicGalleryUpdatedInfo={
-            projectsData.showPublicGalleryUpdatedInfo
-          }
         />
         <div className={'main container'}>
           <ProjectsGallery

--- a/apps/src/templates/projects/ProjectHeader.jsx
+++ b/apps/src/templates/projects/ProjectHeader.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import HeaderBanner from '@cdo/apps/templates/HeaderBanner';
-import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
 import StartNewProject from '@cdo/apps/templates/projects/StartNewProject';
 import i18n from '@cdo/locale';
 
@@ -13,7 +12,6 @@ export default class ProjectHeader extends React.Component {
   static propTypes = {
     canViewAdvancedTools: PropTypes.bool,
     projectCount: PropTypes.number,
-    showPublicGalleryUpdatedInfo: PropTypes.bool,
   };
 
   render() {
@@ -30,14 +28,6 @@ export default class ProjectHeader extends React.Component {
           backgroundImageStyling={{backgroundPosition: '90% 40%'}}
         />
         <div className={'container main'}>
-          {this.props.showPublicGalleryUpdatedInfo && (
-            <Notification
-              type={NotificationType.information}
-              notice={i18n.publicGalleryUpdatedInfo()}
-              details={i18n.publicGalleryUpdatedDetails()}
-              dismissible={true}
-            />
-          )}
           <ProjectsPromo />
           <StartNewProject
             canViewFullList

--- a/dashboard/app/views/projects/index.html.haml
+++ b/dashboard/app/views/projects/index.html.haml
@@ -11,7 +11,6 @@
   end
 
   projects_data[:specialAnnouncement] = Announcements.get_announcement_for_page("/projects")
-  projects_data[:showPublicGalleryUpdatedInfo] = !!current_user
   projects_data[:recaptchaSiteKey] = CDO.recaptcha_site_key
 
 %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR removes the banner on '/projects' for signed-in users that announced that the public gallery has been updated. It reverts the changes included in https://github.com/code-dot-org/code-dot-org/pull/57473.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
