### PR TITLE
Music: use default pack if project has already been started

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -55,6 +55,7 @@ import {isEqual} from 'lodash';
 import MusicLibrary from '../player/MusicLibrary';
 import {TRIGGER_FIELD} from '../blockly/constants';
 import MusicLabView from './MusicLabView';
+import DCDO from '@cdo/apps/dcdo';
 
 const BLOCKLY_DIV_ID = 'blockly-div';
 
@@ -305,9 +306,16 @@ class UnconnectedMusicView extends React.Component {
     // specifically to handle the case where a user starts a project on a library
     // that does not have restricted packs (and is therefore using default),
     // and then later opens their project with a library that does have restricted packs.
-    if (codeChangedOnProjectLevel && !packId) {
+    if (
+      DCDO.get('music-lab-existing-projects-default-sounds', true) &&
+      codeChangedOnProjectLevel &&
+      !packId
+    ) {
       this.library.setCurrentPackId(DEFAULT_PACK);
       this.props.setPackId(DEFAULT_PACK);
+      Lab2Registry.getInstance()
+        .getMetricsReporter()
+        .logInfo('Setting existing project to default pack');
     }
 
     // Go ahead and compile and execute the initial song once code is loaded.

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -43,7 +43,12 @@ import {
 import Simple2Sequencer from '../player/sequencer/Simple2Sequencer';
 import AdvancedSequencer from '../player/sequencer/AdvancedSequencer';
 import MusicPlayerStubSequencer from '../player/sequencer/MusicPlayerStubSequencer';
-import {BlockMode, LEGACY_DEFAULT_LIBRARY, DEFAULT_LIBRARY} from '../constants';
+import {
+  BlockMode,
+  LEGACY_DEFAULT_LIBRARY,
+  DEFAULT_LIBRARY,
+  DEFAULT_PACK,
+} from '../constants';
 import {Key} from '../utils/Notes';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {isEqual} from 'lodash';
@@ -281,12 +286,28 @@ class UnconnectedMusicView extends React.Component {
     this.library.setCurrentPackId(packId);
     this.props.setPackId(packId);
 
+    // Check if the user has already made changes to the code on the project level.
+    let codeChangedOnProjectLevel = false;
     if (this.getStartSources() || initialSources) {
-      let codeToLoad = this.getStartSources();
+      const startSources = this.getStartSources();
+      let codeToLoad = startSources;
       if (initialSources?.source) {
         codeToLoad = JSON.parse(initialSources.source);
+        codeChangedOnProjectLevel =
+          this.props.isProjectLevel &&
+          !isEqual(codeToLoad?.blocks, startSources?.blocks);
       }
       this.loadCode(codeToLoad);
+    }
+
+    // If the user has made changes to the code on the project level but does
+    // not have a pack ID set, assume they are using the default pack. This is
+    // specifically to handle the case where a user starts a project on a library
+    // that does not have restricted packs (and is therefore using default),
+    // and then later opens their project with a library that does have restricted packs.
+    if (codeChangedOnProjectLevel && !packId) {
+      this.library.setCurrentPackId(DEFAULT_PACK);
+      this.props.setPackId(DEFAULT_PACK);
     }
 
     // Go ahead and compile and execute the initial song once code is loaded.

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -49,7 +49,8 @@ class DCDOBase < DynamicConfigBase
       'incubator-canvas-block-enabled': DCDO.get('incubator-canvas-block-enabled', true),
       'progress-table-v2-metadata-enabled': DCDO.get('progress-table-v2-metadata-enabled', false),
       'music-lab-launch-2024': DCDO.get('music-lab-launch-2024', false),
-      'music-lab-samples-report': DCDO.get('music-lab-samples-report', true)
+      'music-lab-samples-report': DCDO.get('music-lab-samples-report', true),
+      'music-lab-existing-projects-default-sounds': DCDO.get('music-lab-existing-projects-default-sounds', true),
     }
   end
 end


### PR DESCRIPTION
As we prepare for launch, we found a scenario where if a student has started a project with a library that doesn't have restricted sounds, and then opens their project later on a library that does have restricted sounds, they'll be prompted with the pack selection dialog. This may be confusing for users because once they select a pack, they are locked into the standard flow which means that if they want to change their pack, they need to start over, which is much more impactful if a student has already worked a lot on a project. This change sets the pack to the "default" Code.org pack if any changes have been made on an existing project, so when the library does update, they will be able to continue working on their project seamlessly.

## Testing story

Scenarios I tried:
- Open a project that was edited with the current (non-restricted library) with ?library=launch2024-prep. Pack dialog **does not** appear (automatically set to Code.org sounds).
- Starting a project and making changes on current (non-restricted) library. Refresh with ?library=launch2024-prep. Pack dialog **does not** appear (automatically set to Code.org sounds)
- Starting a project and saving, but making no changes. Refresh with ?library=launch2024-prep. Pack dialog **does** appear (because current code matches starter code).
- Open an existing project with edits, but then reverting back to blank (only when run block). Refresh with ?library=launch2024-prep. Pack dialog **does not** appear (pack ID has already been set to "default").
- Opening a blank project with ?library=launch2024-prep. Refreshing with the pack dialog still open. Pack dialog **does** appear since a pack has still not yet been selected.