### PR TITLE
Add localhost.hourofcode.com to webpack.config.js

### DIFF
--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -699,7 +699,11 @@ function createWebpackConfig({
     ],
     devServer: envConstants.DEV
       ? {
-          allowedHosts: ['localhost-studio.code.org', 'localhost.code.org'],
+          allowedHosts: [
+            'localhost-studio.code.org',
+            'localhost.code.org',
+            'localhost.hourofcode.com',
+          ],
           client: {overlay: false},
           port: WEBPACK_DEV_SERVER_PORT,
           proxy: [


### PR DESCRIPTION
Adds `localhost.hourofcode.com` to the `webpack.config.js` file to reduce `Invalid Host/Origin header` console errors. 

Seth and Ben: adding y'all for visibility, and thanks @hannahbergam for helping with this!

## Links
Jira ticket: [ACQ-1910](https://codedotorg.atlassian.net/browse/ACQ-1910)
Slack convo inspiration: [here](https://codedotorg.slack.com/archives/C046G4TRLEN/p1710961384282119?thread_ts=1710959415.427739&cid=C046G4TRLEN)

## Testing story
Tested locally to make sure console errors are gone 

----

| Before | After | 
| ---- | ---- |
| <img width="351" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/8fa06764-3ffc-47c2-8d8c-3788d251ea06"> | <img width="351" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/f504b567-299d-480c-9503-ccdc5f4c98f5"> |