### PR TITLE
feat(lms): show the school info popup if lms user

### DIFF
--- a/dashboard/app/helpers/school_info_interstitial_helper.rb
+++ b/dashboard/app/helpers/school_info_interstitial_helper.rb
@@ -3,7 +3,7 @@ module SchoolInfoInterstitialHelper
     return false if user.nil?
     return false unless user.teacher?
 
-    return false if user.account_age_days < 7
+    return false if user.account_age_days < 7 && !Policies::Lti.lti?(user)
 
     # Interstitial should pop up the first time for the teacher if it has been at least 7 days since the teacher signed
     # up for an account AND the teacher hasn’t previously filled out all the fields already (e.g. as part

--- a/dashboard/test/lib/school_info_interstitial_helper_test.rb
+++ b/dashboard/test/lib/school_info_interstitial_helper_test.rb
@@ -171,4 +171,15 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
     refute SchoolInfoInterstitialHelper.show? user
   end
+
+  test 'shows school info interstitial if account has no school info even if created recently if LTI user' do
+    user = create :teacher, created_at: 5.minutes.ago
+    create :lti_authentication_option, user: user
+
+    assert_nil user.school_info
+    assert_empty user.user_school_infos
+
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    assert SchoolInfoInterstitialHelper.show? user
+  end
 end


### PR DESCRIPTION
Normally, the school info popup is displayed if the teacher account is > 7 days old, however for LMS we want to collect the information regardless of account age.

The other school info popup rules still apply, including making sure the user doesn't see the popup again for another 7 days, and the popup lasting one year.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-890)

## Testing story

Created teacher account via roster sync, logged in as user

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
