### PR TITLE
Music: update UI test

### DIFF
--- a/apps/src/music/views/PackDialog.tsx
+++ b/apps/src/music/views/PackDialog.tsx
@@ -220,7 +220,7 @@ const PackDialog: React.FunctionComponent<PackDialogProps> = ({player}) => {
           <div className={styles.buttonContainer}>
             <button
               onClick={setPackToDefault}
-              className={styles.skip}
+              className={classNames('skip-button', styles.skip)}
               type="button"
             >
               Skip

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
@@ -8,6 +8,9 @@ Scenario Outline: Dragging play sound block
   Given I am on "<url>"
   And I rotate to landscape
 
+  # Skip the pack dialog if it is showing.
+  Then I click selector ".skip-button" if it exists
+
   # Wait until we see the first category.
   And I wait until element ".blocklyTreeRow" is visible
 


### PR DESCRIPTION
Update UI test to skip the pack dialog when viewing a standalone Music Lab project. 