### PR TITLE
Music: update music test again

### DIFF
--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
@@ -6,10 +6,12 @@ Feature: Music Lab block can be dragged
 
 Scenario Outline: Dragging play sound block
   Given I am on "<url>"
-  And I rotate to landscape
 
-  # Skip the pack dialog if it is showing.
-  Then I click selector ".skip-button" if it exists
+  # Ensure that the pack dialog doesn't show by using a library with no restricted packs.
+  Then I append "?library=intro2024" to the URL
+
+  # Rotate to landscape.
+  And I rotate to landscape
 
   # Wait until we see the first category.
   And I wait until element ".blocklyTreeRow" is visible


### PR DESCRIPTION
Update UI test to not show the pack dialog.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/58797 which was a bit flaky due to sometimes trying to skip the pack dialog before it was showing.
