### PR TITLE
Fix sad bee on My Professional Learning page when a workshop has no sessions

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -683,6 +683,7 @@ class Pd::Workshop < ApplicationRecord
   end
 
   def workshop_date_range_string
+    return "N/A" if sessions.empty?
     if workshop_starting_date == workshop_ending_date
       workshop_starting_date.strftime('%B %e, %Y')
     else

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -683,7 +683,7 @@ class Pd::Workshop < ApplicationRecord
   end
 
   def workshop_date_range_string
-    return "N/A" if sessions.empty?
+    return I18n.t('not_applicable_abbreviation') if sessions.empty?
     if workshop_starting_date == workshop_ending_date
       workshop_starting_date.strftime('%B %e, %Y')
     else

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1489,3 +1489,4 @@ en:
         invalid_parent_email: The parent/guardian's email address is invalid
         parent_email_is_own: A request cannot be sent to your own email address
         resend_limit_reached: The limit for resend requests has been reached
+  not_applicable_abbreviation: "N/A"

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1587,6 +1587,11 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     Pd::Workshop.send_automated_emails
   end
 
+  test 'workshop date range string is NA when no sessions' do
+    workshop = create :workshop, num_sessions: 0
+    assert_equal 'N/A', workshop.workshop_date_range_string
+  end
+
   private def session_on_day(day_offset)
     # 9am-5pm
     session_on(day_offset, 9.hours, 17.hours)


### PR DESCRIPTION
We got a report that the My Professional Learning page was showing a sad bee to a long time regional partner. I found the corresponding [Honeybadger error](https://app.honeybadger.io/projects/3240/faults/105696509), which looks like we're not handling a start and end time of null, which this PR handles.

I dug into our database a bit and it looks like in 2015 fifteen workshops were created without sessions. There were over 100 enrollments across these workshops, but I assume the vast majority of those users are no longer active. 

## Testing story

I did not explicitly test this case on the My Professional Learning page, instead relying on the added unit test. I confirmed that the added test threw and error before this change and passed after.





## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
