### PR TITLE
Add dotd flaky test tracking reminders

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -181,7 +181,7 @@ def main
       if CDO.test_system?
         DevelopersTopic.set_dtt 'no (robo-DTT failed)'
         ChatClient.log "*** Before you manually re-run a test, please ensure that the team who owns that test is actively tracking de-flaking. ***", color: 'yellow'
-        ChatClient.log "*** Please update the <https://docs.google.com/spreadsheets/d/1DD6ebHM-2fsiMxxYCzhJYd1DzA69Z20qrCItaER9vto|Flaky Test Tracker> ***", color: 'red'
+        ChatClient.log "*** Please update the <https://docs.google.com/spreadsheets/d/1DD6ebHM-2fsiMxxYCzhJYd1DzA69Z20qrCItaER9vto|Flaky Test Tracker> with any failing tests. ***", color: 'red'
       end
     end
 

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -160,6 +160,8 @@ def main
 
         # Schedule a reminder for the dotd to check Zendesk in 2 hours
         Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 7200, 'Reminder: check <https://codeorg.zendesk.com/agent/filters/44863373|Zendesk>')
+        # Remind dotd to update the flaky test tracker on DTP as a once-ish a day reminder.
+        Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i, 'Please update the <https://docs.google.com/spreadsheets/d/1DD6ebHM-2fsiMxxYCzhJYd1DzA69Z20qrCItaER9vto|Flaky Test Tracker>')
 
         # Check hoc_mode and hoc_launch only on successful DTPs, so that we get about 1 reminder per
         # day to bring staging, test and production to the same hoc_mode and hoc_launch after a
@@ -179,6 +181,7 @@ def main
       if CDO.test_system?
         DevelopersTopic.set_dtt 'no (robo-DTT failed)'
         ChatClient.log "*** Before you manually re-run a test, please ensure that the team who owns that test is actively tracking de-flaking. ***", color: 'yellow'
+        ChatClient.log "*** Please update the <https://docs.google.com/spreadsheets/d/1DD6ebHM-2fsiMxxYCzhJYd1DzA69Z20qrCItaER9vto|Flaky Test Tracker> ***", color: 'red'
       end
     end
 

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -160,8 +160,6 @@ def main
 
         # Schedule a reminder for the dotd to check Zendesk in 2 hours
         Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 7200, 'Reminder: check <https://codeorg.zendesk.com/agent/filters/44863373|Zendesk>')
-        # Remind dotd to update the flaky test tracker on DTP as a once-ish a day reminder.
-        Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i, 'Please update the <https://docs.google.com/spreadsheets/d/1DD6ebHM-2fsiMxxYCzhJYd1DzA69Z20qrCItaER9vto|Flaky Test Tracker>')
 
         # Check hoc_mode and hoc_launch only on successful DTPs, so that we get about 1 reminder per
         # day to bring staging, test and production to the same hoc_mode and hoc_launch after a

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -178,8 +178,10 @@ def main
 
       if CDO.test_system?
         DevelopersTopic.set_dtt 'no (robo-DTT failed)'
-        ChatClient.log "*** Before you manually re-run a test, please ensure that the team who owns that test is actively tracking de-flaking. ***", color: 'yellow'
-        ChatClient.log "*** Please update the <https://docs.google.com/spreadsheets/d/1DD6ebHM-2fsiMxxYCzhJYd1DzA69Z20qrCItaER9vto|Flaky Test Tracker> with any failing tests. ***", color: 'red'
+        msg = "*** <@#{DevelopersTopic.dotd}> Please update the " \
+          "<https://docs.google.com/spreadsheets/d/1DD6ebHM-2fsiMxxYCzhJYd1DzA69Z20qrCItaER9vto|Flaky Test Tracker>. " \
+          "See instructions in the tracker for more info. ***"
+        ChatClient.log msg, color: 'yellow'
       end
     end
 

--- a/bin/cron/update_dotd
+++ b/bin/cron/update_dotd
@@ -24,11 +24,7 @@ def main
 
   # Set the new developers room topic
   new_topic = current_topic.sub(/^.+?;/, "DOTD: @#{primary_dotd_user};")
-  unless new_topic == current_topic
-    Slack.update_topic('developers', new_topic)
-
-    Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 3600, msg)
-  end
+  Slack.update_topic('developers', new_topic) unless new_topic == current_topic
 end
 
 main

--- a/bin/cron/update_dotd
+++ b/bin/cron/update_dotd
@@ -24,10 +24,15 @@ def main
 
   # Set the new developers room topic
   new_topic = current_topic.sub(/^.+?;/, "DOTD: @#{primary_dotd_user};")
-  Slack.update_topic('developers', new_topic) unless new_topic == current_topic
+  unless new_topic == current_topic
+    Slack.update_topic('developers', new_topic)
 
-  # Remind dotd to update the flaky test tracker at 8am PST.
-  Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 3600, 'Please update the <https://docs.google.com/spreadsheets/d/1DD6ebHM-2fsiMxxYCzhJYd1DzA69Z20qrCItaER9vto|Flaky Test Tracker>')
+    # Remind dotd to update the flaky test tracker at 8am PST.
+    msg = "Please update the " \
+      "<https://docs.google.com/spreadsheets/d/1DD6ebHM-2fsiMxxYCzhJYd1DzA69Z20qrCItaER9vto|Flaky Test Tracker> " \
+      "See instructions in the tracker for more info."
+    Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 3600, msg)
+  end
 end
 
 main

--- a/bin/cron/update_dotd
+++ b/bin/cron/update_dotd
@@ -25,6 +25,9 @@ def main
   # Set the new developers room topic
   new_topic = current_topic.sub(/^.+?;/, "DOTD: @#{primary_dotd_user};")
   Slack.update_topic('developers', new_topic) unless new_topic == current_topic
+
+  # Remind dotd to update the flaky test tracker at 8am PST.
+  Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 3600, 'Please update the <https://docs.google.com/spreadsheets/d/1DD6ebHM-2fsiMxxYCzhJYd1DzA69Z20qrCItaER9vto|Flaky Test Tracker>')
 end
 
 main

--- a/bin/cron/update_dotd
+++ b/bin/cron/update_dotd
@@ -27,10 +27,6 @@ def main
   unless new_topic == current_topic
     Slack.update_topic('developers', new_topic)
 
-    # Remind dotd to update the flaky test tracker at 8am PST.
-    msg = "Please update the " \
-      "<https://docs.google.com/spreadsheets/d/1DD6ebHM-2fsiMxxYCzhJYd1DzA69Z20qrCItaER9vto|Flaky Test Tracker> " \
-      "See instructions in the tracker for more info."
     Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 3600, msg)
   end
 end


### PR DESCRIPTION
Adds two reminders:

When a DTT fails, it posts a new message with a link to the flaky test tracker
Every day at 8:00 AM PT, the DOTD will get a DM from the DOTD app

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
