### PR TITLE
Gen AI: Hide profanity when copying chat history

### DIFF
--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -6,6 +6,7 @@ import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import {AichatState} from '@cdo/apps/aichat/redux/aichatRedux';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
 const CopyButton: React.FunctionComponent = () => {
   const storedMessages = useSelector(
@@ -17,7 +18,9 @@ const CopyButton: React.FunctionComponent = () => {
       .map(
         message =>
           `[${message.timestamp || 'XXXX-XX-XX XX:XX'} - ${message.role}] ${
-            message.chatMessageText
+            message.status === Status.PROFANITY_VIOLATION
+              ? '[FLAGGED AS PROFANITY]'
+              : message.chatMessageText
           }`
       )
       .join('\n');


### PR DESCRIPTION
Replaces content marked with profanity with a placeholder when using the copy chat button.

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-775

## Testing story

Observed the appropriate placeholder when copying a message with profanity, and the actual content of a message that doesn't contain profanity.