### PR TITLE
Add ssl flag to thin during local https development

### DIFF
--- a/bin/dashboard-server
+++ b/bin/dashboard-server
@@ -15,8 +15,11 @@ def main
     pids.push spawn("rerun -x -d #{apps_dir}/src --background -n apps-watcher -- rake package:apps")
   end
 
+  thin_args = "-a #{CDO.dashboard_host} -p #{CDO.dashboard_port}"
+  thin_args += " --ssl" if CDO.rack_env == :development && CDO.https_development
+
   Dir.chdir(dashboard_dir) do
-    system "RAILS_ENV=#{CDO.rack_env} bundle exec #{rerun} thin start -a #{CDO.dashboard_host} -p #{CDO.dashboard_port}"
+    system "RAILS_ENV=#{CDO.rack_env} bundle exec #{rerun} thin start #{thin_args}"
   end
 
   pids.each do |pid|

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -136,3 +136,9 @@ use_my_apps: true
 # instance of Javabuilder. This will likely be 'javabuilder-dev-<your_branch_name>'
 # use_localhost_javabuilder: true
 # local_javabuilder_stack_name: javabuilder-dev-<your_branch_name>
+
+# Configuration for local development with HTTPS. Setting https_development to true will
+# also cause the bin/dashboard-server script to start with SSL enabled.
+#https_development: true
+#default_scheme: 'https:'
+#dashboard_port: 443


### PR DESCRIPTION
Sometimes it's necessary to use https for local development. Even with the `https_development` flag set to true, the `ssl` option still has to be passed to `thin` when running the server locally. This changes `bin/dashboard-server` to automatically append --ssl if `https_development` is true and the environment is `:development`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally. If there are already tests in place for the bin directory, let me know.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
