### PR TITLE
Music: Show music thumbnail for music labs projects in the "My Projects" list

### DIFF
--- a/apps/src/templates/projects/PersonalProjectsTable.jsx
+++ b/apps/src/templates/projects/PersonalProjectsTable.jsx
@@ -23,6 +23,9 @@ import {personalProjectDataPropType} from './projectConstants';
 import {PROJECT_TYPE_MAP} from './projectTypeMap';
 
 const PROJECT_DEFAULT_IMAGE = '/blockly/media/projects/project_default.png';
+const PROJECT_DEFAULT_IMAGE_OVERRIDE = {
+  music: '/shared/images/fill-70x70/courses/logo_music.png',
+};
 
 const THUMBNAIL_SIZE = 65;
 
@@ -308,7 +311,10 @@ export const styles = {
 // Cell formatters.
 const thumbnailFormatter = function (thumbnailUrl, {rowData}) {
   const projectUrl = `/projects/${rowData.type}/${rowData.channel}/edit`;
-  thumbnailUrl = thumbnailUrl || PROJECT_DEFAULT_IMAGE;
+  thumbnailUrl =
+    thumbnailUrl ||
+    PROJECT_DEFAULT_IMAGE_OVERRIDE[rowData.type] ||
+    PROJECT_DEFAULT_IMAGE;
   return (
     <a
       style={tableLayoutStyles.link}


### PR DESCRIPTION
Update the thumbnail for Music Lab projects on the "My Projects" list! 

## Links

[Music: custom thumbnail for My Projects lists](https://codedotorg.atlassian.net/browse/LABS-839)

## Testing story

Tested locally that Music Lab projects use the new thumbnail, but other project types still have their thumbnails.

![image](https://github.com/code-dot-org/code-dot-org/assets/24951544/b8e50aef-a418-4b79-8d1d-951ec2de97f3)
