### PR TITLE
LTI account linking page

### DIFF
--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ExistingAccountCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ExistingAccountCard/index.tsx
@@ -16,12 +16,11 @@ import {LtiProviderContext} from '../../context';
 const ExistingAccountCard = () => {
   const {ltiProvider, ltiProviderName, existingAccountUrl} =
     useContext(LtiProviderContext)!;
-  const callToActionUrl = new URL(existingAccountUrl);
   const urlParams = new URLSearchParams({
     lms_name: ltiProviderName,
     lti_provider: ltiProvider,
   });
-  callToActionUrl.search = urlParams.toString();
+  existingAccountUrl.search = urlParams.toString();
 
   return (
     <Card data-testid={'existing-account-card'}>
@@ -45,7 +44,7 @@ const ExistingAccountCard = () => {
           color={buttonColors.purple}
           type={'primary'}
           size="l"
-          href={callToActionUrl.href}
+          href={existingAccountUrl.href}
           text={i18n.ltiLinkAccountExistingAccountCardActionLabel()}
         />
       </CardActions>

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ExistingAccountCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ExistingAccountCard/index.tsx
@@ -16,10 +16,12 @@ import {LtiProviderContext} from '../../context';
 const ExistingAccountCard = () => {
   const {ltiProvider, ltiProviderName, existingAccountUrl} =
     useContext(LtiProviderContext)!;
+  const callToActionUrl = new URL(existingAccountUrl);
   const urlParams = new URLSearchParams({
     lms_name: ltiProviderName,
     lti_provider: ltiProvider,
   });
+  callToActionUrl.search = urlParams.toString();
 
   return (
     <Card data-testid={'existing-account-card'}>
@@ -43,7 +45,7 @@ const ExistingAccountCard = () => {
           color={buttonColors.purple}
           type={'primary'}
           size="l"
-          href={`${existingAccountUrl}?${urlParams.toString()}`}
+          href={callToActionUrl.href}
           text={i18n.ltiLinkAccountExistingAccountCardActionLabel()}
         />
       </CardActions>

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ExistingAccountCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ExistingAccountCard/index.tsx
@@ -14,7 +14,12 @@ import i18n from '@cdo/locale';
 import {LtiProviderContext} from '../../context';
 
 const ExistingAccountCard = () => {
-  const {ltiProviderName, existingAccountUrl} = useContext(LtiProviderContext)!;
+  const {ltiProvider, ltiProviderName, existingAccountUrl} =
+    useContext(LtiProviderContext)!;
+  const urlParams = new URLSearchParams({
+    lms_name: ltiProviderName,
+    lti_provider: ltiProvider,
+  });
 
   return (
     <Card data-testid={'existing-account-card'}>
@@ -38,7 +43,7 @@ const ExistingAccountCard = () => {
           color={buttonColors.purple}
           type={'primary'}
           size="l"
-          href={existingAccountUrl}
+          href={`${existingAccountUrl}?${urlParams.toString()}`}
           text={i18n.ltiLinkAccountExistingAccountCardActionLabel()}
         />
       </CardActions>

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/context.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/context.tsx
@@ -5,7 +5,7 @@ export interface LtiProviderContextProps {
   ltiProvider: LtiProvider;
   ltiProviderName: string;
   newAccountUrl: string;
-  existingAccountUrl: string;
+  existingAccountUrl: URL;
 }
 
 export const LtiProviderContext = createContext<

--- a/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
+++ b/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const ltiProvider = scriptData['lti_provider'];
   const ltiProviderName = scriptData['lti_provider_name'];
   const newAccountUrl = scriptData['new_account_url'];
-  const existingAccountUrl = scriptData['existing_account_url'];
+  const existingAccountUrl = new URL(scriptData['existing_account_url']);
 
   const ltiProviderContext = {
     ltiProvider,

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -12,7 +12,7 @@ const DEFAULT_CONTEXT: LtiProviderContextProps = {
   ltiProvider: 'canvas_cloud',
   ltiProviderName: 'Canvas',
   newAccountUrl: '/new-account',
-  existingAccountUrl: '/existing-account',
+  existingAccountUrl: 'https://example.com/existing-account',
 };
 
 describe('LTI Link Account Page Tests', () => {
@@ -41,7 +41,7 @@ describe('LTI Link Account Page Tests', () => {
           .getByText(i18n.ltiLinkAccountExistingAccountCardActionLabel())
           .closest('a')!
           .getAttribute('href')
-      ).to.equal('/existing-account?lms_name=Canvas&lti_provider=canvas_cloud');
+      ).to.equal('https://example.com/existing-account?lms_name=Canvas&lti_provider=canvas_cloud');
     });
   });
 

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -41,7 +41,7 @@ describe('LTI Link Account Page Tests', () => {
           .getByText(i18n.ltiLinkAccountExistingAccountCardActionLabel())
           .closest('a')!
           .getAttribute('href')
-      ).to.equal('/existing-account');
+      ).to.equal('/existing-account?lms_name=Canvas&lti_provider=canvas_cloud');
     });
   });
 

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -41,7 +41,9 @@ describe('LTI Link Account Page Tests', () => {
           .getByText(i18n.ltiLinkAccountExistingAccountCardActionLabel())
           .closest('a')!
           .getAttribute('href')
-      ).to.equal('https://example.com/existing-account?lms_name=Canvas&lti_provider=canvas_cloud');
+      ).to.equal(
+        'https://example.com/existing-account?lms_name=Canvas&lti_provider=canvas_cloud'
+      );
     });
   });
 

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -12,7 +12,7 @@ const DEFAULT_CONTEXT: LtiProviderContextProps = {
   ltiProvider: 'canvas_cloud',
   ltiProviderName: 'Canvas',
   newAccountUrl: '/new-account',
-  existingAccountUrl: 'https://example.com/existing-account',
+  existingAccountUrl: new URL('https://example.com/existing-account'),
 };
 
 describe('LTI Link Account Page Tests', () => {

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/WelcomeBanner/WelcomeBannerTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/WelcomeBanner/WelcomeBannerTest.tsx
@@ -10,7 +10,7 @@ const getContext = (ltiProvider: LtiProvider) => {
     ltiProvider,
     ltiProviderName: 'LMS',
     newAccountUrl: '/new-account',
-    existingAccountUrl: '/existing-account',
+    existingAccountUrl: new URL('https://test.com/existing-account'),
   };
 };
 

--- a/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
+++ b/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
@@ -1,0 +1,33 @@
+#linking-page-header {
+  text-align: center;
+  margin-bottom: 10px;
+  margin-top: 10px;
+}
+
+#linking-page-description {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+#oauth-side {
+  flex-grow: 0;
+  margin-left: auto;
+}
+
+#email-side {
+  margin-right: auto;
+}
+
+#signin-connect-button {
+  background: #8C52BA;
+  color: white;
+}
+
+.go-back-link {
+  display: block;
+  margin-top: 60px;
+}
+
+.oauth-sign-in {
+  padding-right: 20px;
+}

--- a/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
+++ b/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
@@ -1,3 +1,5 @@
+@import 'color';
+
 #linking-page-header {
   text-align: center;
   margin-bottom: 10px;
@@ -19,8 +21,8 @@
 }
 
 #signin-connect-button {
-  background: #8C52BA;
-  color: white;
+  background: $purple;
+  color: $white;
 }
 
 .go-back-link {

--- a/dashboard/app/views/devise/sessions/_login.html.haml
+++ b/dashboard/app/views/devise/sessions/_login.html.haml
@@ -1,0 +1,57 @@
+%h2= t('signin_form.title')
+
+.flex-container
+  #signin
+    = form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
+      = show_flashes.html_safe
+      = f.hidden_field :hashed_email
+
+      / Email
+      .field
+        = label_tag t('signin_form.login_username')
+        - email = @email || ''
+        = f.text_field :login, value: email, autofocus: email == ''
+
+      / Password
+      .field#password_field
+        = f.label :password
+        = f.password_field :password, autofocus: email != ''
+
+        / Forgot password?
+      - if devise_mapping.recoverable?
+        %div.field-aligned.password_help_link
+          = link_to t('auth.forgot_password'), new_password_path(resource_name), id: 'forgot-password'
+
+      / Sign in button
+      %button#signin-button= t('signin_form.submit')
+
+    / Not yet signed up? Sign up
+    - if devise_mapping.registerable?
+      = link_to new_user_registration_path, class: 'field-aligned' do
+        %button.neutral-button{:id => 'user_signup'}= t('nav.user.signup')
+
+  %div.vertical-or
+    %hr
+    = t("or").upcase
+    %hr
+
+  = render "devise/shared/oauth_links"
+
+%h4#code_without_signing_in= t('signin.try_heading')
+
+.row
+  - if @is_english
+    - course_blocks = [Unit::DANCE_PARTY_2019_NAME, Unit::MINECRAFT_AQUATIC_NAME, Unit::OCEANS_NAME, Unit::FLAPPY_NAME]
+  - else
+    - course_blocks = [Unit::DANCE_PARTY_2019_NAME, Unit::MINECRAFT_AQUATIC_NAME, Unit::FROZEN_NAME, Unit::HOC_NAME]
+
+  - course_blocks.each do |course_id|
+    = render partial: 'shared/course_tall_block', locals: { id: course_id }
+
+
+%br/
+%br/
+%br/
+%br/
+%br/
+%br/

--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -1,0 +1,46 @@
+%link{href: "/shared/css/phase1-design-system.css", rel: "stylesheet"}
+
+%h2#linking-page-header= t('lti.account_linking.linking_page_header', provider: params[:lms_name])
+%p#linking-page-description= t('lti.account_linking.linking_page_description')
+
+.flex-container
+  #oauth-side.devise-links
+    %h3= t('lti.account_linking.connect_with')
+    - [:google_oauth2, :microsoft_v2_auth, :facebook].each do |provider|
+      = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
+        = image_tag("oauth/#{provider}.svg")
+        = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))
+    %a.go-back-link{href: lti_v1_account_linking_landing_path(lti_provider: params[:lti_provider])}
+      %i.fa.fa-arrow-left
+      = t('lti.account_linking.go_back')
+  %div.vertical-or
+    %hr
+    = t("or").upcase
+    %hr
+
+  #email-side
+    %h3= t('lti.account_linking.connect_with_email')
+    = form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
+      = show_flashes.html_safe
+      = f.hidden_field :hashed_email
+
+      / Email
+      .field
+        = f.label :email
+        - email = @email || ''
+        = f.text_field :login, value: email, autofocus: email == '', required: true
+
+      / Password
+      .field#password_field
+        = f.label :password
+        = f.password_field :password, autofocus: email != '', required: true
+
+      / Sign in button
+      %button#signin-connect-button= t('lti.account_linking.sign_in_and_connect')
+
+%br/
+%br/
+%br/
+%br/
+%br/
+%br/

--- a/dashboard/app/views/devise/sessions/new.html.haml
+++ b/dashboard/app/views/devise/sessions/new.html.haml
@@ -1,60 +1,8 @@
+- require 'policies/lti'
 %link{href: "/shared/css/phase1-design-system.css", rel: "stylesheet"}
 %script{src: webpack_asset_path('js/devise/sessions/new.js')}
 
-%h2= t('signin_form.title')
-
-.flex-container
-  #signin
-    = form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
-      = show_flashes.html_safe
-      = f.hidden_field :hashed_email
-
-      / Email
-      .field
-        = label_tag t('signin_form.login_username')
-        - email = @email || ''
-        = f.text_field :login, value: email, autofocus: email == ''
-
-      / Password
-      .field#password_field
-        = f.label :password
-        = f.password_field :password, autofocus: email != ''
-
-        / Forgot password?
-      - if devise_mapping.recoverable?
-        %div.field-aligned.password_help_link
-          = link_to t('auth.forgot_password'), new_password_path(resource_name), id: 'forgot-password'
-
-      / Sign in button
-      %button#signin-button= t('signin_form.submit')
-
-    / Not yet signed up? Sign up
-    - if devise_mapping.registerable?
-      = link_to new_user_registration_path, class: 'field-aligned' do
-        %button.neutral-button{:id => 'user_signup'}= t('nav.user.signup')
-
-  %div.vertical-or
-    %hr
-    = t("or").upcase
-    %hr
-
-  = render "devise/shared/oauth_links"
-
-%h4#code_without_signing_in= t('signin.try_heading')
-
-.row
-  - if @is_english
-    - course_blocks = [Unit::DANCE_PARTY_2019_NAME, Unit::MINECRAFT_AQUATIC_NAME, Unit::OCEANS_NAME, Unit::FLAPPY_NAME]
-  - else
-    - course_blocks = [Unit::DANCE_PARTY_2019_NAME, Unit::MINECRAFT_AQUATIC_NAME, Unit::FROZEN_NAME, Unit::HOC_NAME]
-
-  - course_blocks.each do |course_id|
-    = render partial: 'shared/course_tall_block', locals: { id: course_id }
-
-
-%br/
-%br/
-%br/
-%br/
-%br/
-%br/
+- if DCDO.get('lti_account_linking_enabled', false) && Policies::Lti.lti_registration_in_progress?(session)
+  = render 'login_lti_account_linking', lms_name: params[:lms_name]
+- else
+  = render 'login'

--- a/dashboard/app/views/lti/v1/account_linking/landing.haml
+++ b/dashboard/app/views/lti/v1/account_linking/landing.haml
@@ -4,7 +4,7 @@
     script_data[:lti_provider] = params[:lti_provider]
     script_data[:lti_provider_name] = Policies::Lti::LMS_PLATFORMS[params[:lti_provider].to_sym][:name]
     script_data[:new_account_url] = new_user_registration_url
-    script_data[:existing_account_url] = user_session_path
+    script_data[:existing_account_url] = CDO.studio_url(user_session_path, CDO.default_scheme)
 
   %script{src: webpack_asset_path('js/lti/v1/account_linking/landing.js'), data: {json: script_data.to_json}}}
 %body

--- a/dashboard/app/views/lti/v1/account_linking/landing.haml
+++ b/dashboard/app/views/lti/v1/account_linking/landing.haml
@@ -4,7 +4,7 @@
     script_data[:lti_provider] = params[:lti_provider]
     script_data[:lti_provider_name] = Policies::Lti::LMS_PLATFORMS[params[:lti_provider].to_sym][:name]
     script_data[:new_account_url] = new_user_registration_url
-    script_data[:existing_account_url] = lti_v1_account_linking_existing_account_path
+    script_data[:existing_account_url] = user_session_path
 
   %script{src: webpack_asset_path('js/lti/v1/account_linking/landing.js'), data: {json: script_data.to_json}}}
 %body

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1422,6 +1422,14 @@ en:
     founder: "Founder, Code.org"
     your_friends: "Your Friends at Code.org"
   lti:
+    account_linking:
+      connect_button: "Connect with %{provider}"
+      connect_with: "Connect with..."
+      connect_with_email: "Connect with personal login"
+      go_back: "Go back"
+      linking_page_header: "Link your %{provider} account to your existing Code.org account"
+      linking_page_description: "Choose the sign-in method you normally use to access Code.org"
+      sign_in_and_connect: "Sign in and connect"
     create_integration_success: "Successfully created your LTI integration"
     dynamic_registration_title: "Code.org Dynamic Registration"
     error:

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -231,4 +231,9 @@ class Policies::Lti
   def self.feedback_available?(user)
     user.teacher? && lti?(user) && user.created_at <= 2.days.ago
   end
+
+  # Check if a partial registration is in progress for an LTI user.
+  def self.lti_registration_in_progress?(session)
+    PartialRegistration.in_progress?(session) && PartialRegistration.get_provider(session) == AuthenticationOption::LTI_V1
+  end
 end

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1601,7 +1601,6 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
     # Pre-existing Google account that we want the new LTI auth option to be linked to
     existing_user = create :teacher, :with_google_authentication_option
-    puts existing_user.authentication_options.inspect
     auth = generate_auth_user_hash provider: AuthenticationOption::GOOGLE, uid: existing_user.authentication_options[1].authentication_id
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -9,6 +9,8 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     @request.env["devise.mapping"] = Devise.mappings[:user]
     @request.host = CDO.dashboard_hostname
     CDO.stubs(:properties_encryption_key).returns(STUB_ENCRYPTION_KEY)
+    DCDO.stubs(:get)
+    DCDO.stubs(:get).with('sign_up_split_test', 0).returns(0)
   end
 
   test "login: authorizing with known facebook account signs in" do
@@ -1591,6 +1593,36 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal 1, account.authentication_options.count
 
     assert_nil signed_in_user_id
+  end
+
+  test 'Google SSO: links an LTI auth option to an existing account' do
+    DCDO.stubs(:get).with('lti_account_linking_enabled', false).returns(true)
+    lti_integration = create :lti_integration
+
+    # Pre-existing Google account that we want the new LTI auth option to be linked to
+    existing_user = create :teacher, :with_google_authentication_option
+    puts existing_user.authentication_options.inspect
+    auth = generate_auth_user_hash provider: AuthenticationOption::GOOGLE, uid: existing_user.authentication_options[1].authentication_id
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+
+    # Teacher that is going through the account linking flow
+    partial_lti_teacher = create :teacher
+    fake_id_token = {iss: lti_integration.issuer, aud: lti_integration.client_id, sub: 'foo'}
+    auth_id = Services::Lti::AuthIdGenerator.new(fake_id_token).call
+    ao = AuthenticationOption.new(
+      authentication_id: auth_id,
+      credential_type: AuthenticationOption::LTI_V1,
+      email: existing_user.email,
+    )
+    partial_lti_teacher.authentication_options = [ao]
+    PartialRegistration.persist_attributes session, partial_lti_teacher
+
+    get :google_oauth2
+    # The user factory automatically creates an email auth option,
+    # so this includes 1 email, 1 google, and 1 LTI auth option
+    assert_equal 3, existing_user.reload.authentication_options.count
+    assert_includes existing_user.authentication_options, ao
   end
 
   # Try to link a credential to the provided user

--- a/dashboard/test/controllers/sessions_controller_test.rb
+++ b/dashboard/test/controllers/sessions_controller_test.rb
@@ -325,4 +325,31 @@ class SessionsControllerTest < ActionController::TestCase
       end
     end
   end
+
+  class LtiAccountLinkingSignInPageTest < ActionDispatch::IntegrationTest
+    test 'renders alternative account linking login page during LTI registration' do
+      DCDO.stubs(:get)
+      DCDO.stubs(:get).with('lti_account_linking_enabled', false).returns(true)
+      Policies::Lti.stubs(:lti_registration_in_progress?).returns(true)
+
+      get user_session_path
+      assert_template partial: 'devise/sessions/_login_lti_account_linking'
+    end
+
+    test 'renders normal login page if the account linking DCDO flag is disabled' do
+      Policies::Lti.stubs(:lti_registration_in_progress?).returns(true)
+
+      get user_session_path
+      assert_template partial: 'devise/sessions/_login'
+    end
+
+    test 'renders normal login page for non-LTI/non-partial registrations' do
+      DCDO.stubs(:get)
+      DCDO.stubs(:get).with('lti_account_linking_enabled', false).returns(true)
+      Policies::Lti.stubs(:lti_registration_in_progress?).returns(false)
+
+      get user_session_path
+      assert_template partial: 'devise/sessions/_login'
+    end
+  end
 end


### PR DESCRIPTION

<img width="852" alt="Screenshot 2024-05-21 at 1 48 47 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/8ae3be17-0710-4afb-8901-c126de6bf5b5">

Adds some more of the LTI account linking functionality:
- Links a new LTI auth option to an existing account when a new LTI user successfully auths via Google during the registration flow.
- Adds a new version of the login page for the account linking flow. This page conditionally renders instead of the normal login page when the DCDO flag for account linking is enabled, and there is an in-progress partial registration for an LTI user.

Out of scope for this PR:
- Support for Microsoft and Facebook auth. If the users clicks those buttons, they will log the user in as usual but no account linking will happen.
- Support for users created via roster sync. Right now, they skip the account linking flow.

## Links

- [JIRA](https://codedotorg.atlassian.net/browse/P20-917)
- [JIRA](https://codedotorg.atlassian.net/browse/P20-910)
- [Figma](https://www.figma.com/design/88sbry7xnl1wcyrOgbgFtn/Sign-Up-Flow?node-id=2667-8615&t=Xs9sYUrsM92VQJzf-0)

## Testing story

To test this locally, some extra configuration is required. Google oauth requires https to work with non-localhost domains, such as `localhost-studio.code.org`. Since Canvas launches need to work as well, Canvas also needs to be configured to launch into a local Code.org server using https. Steps are as follows:
1. Configure locals.yml to run https:
```
https_development: true
default_scheme: 'https:'
dashboard_port: 443
```
2. Run dashboard-server while passing the --ssl flag to `thin`. This can be accomplished by adding `--ssl` to the arguments to thin start on [line 19 of the dashboard-server script](https://github.com/code-dot-org/code-dot-org/blob/staging/bin/dashboard-server#L19). There's also a [PR up](https://github.com/code-dot-org/code-dot-org/pull/58821) to make this happen automatically.
3. Configure your Canvas developer key with the proper https URLs:
```
Redirect URI: https://localhost-studio.code.org/lti/v1/authenticate
Target Link URI: https://localhost-studio.code.org/lti/v1/sync_course
OIDC Initiation URI: https://localhost-studio.code.org/lti/v1/login
```
4. GCP has already been configured to work with the localhost https URL. As long as your local server is listening on port 443, it should work.


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
