### PR TITLE
Add bubble choice editor to AI Chat

### DIFF
--- a/dashboard/app/views/levels/editors/_aichat.html.haml
+++ b/dashboard/app/views/levels/editors/_aichat.html.haml
@@ -1,4 +1,5 @@
 = render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/aichat_settings', locals: {f: f}
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
+= render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}


### PR DESCRIPTION
Add the "Bubble Choice & Lesson Extras" editor to AI Chat levels. This allows level editors to specify the display name, description, and image when an AI Chat level appears as a bubble choice sublevel.

Only adding this to AI Chat for now to limit the impact scope, but we'd likely want to add this to other Lab2 level types as we start including them in more curriculum.

Example on allthethings (AI Chat has the editor enabled, but Music Lab does not):
![Screenshot 2024-05-21 at 2 19 48 PM](https://github.com/code-dot-org/code-dot-org/assets/85528507/45f6e093-6e47-4127-9e8f-88f2175a76ba)

## Links

https://codedotorg.atlassian.net/browse/LABS-824

## Testing story

Tested locally with allthethings