### PR TITLE
Adding asterisks and bold to required fields in sign up

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1927,6 +1927,19 @@ a.download-video {
   display: flex;
   flex-wrap: wrap;
 
+  .required {
+    font-weight: 600;
+
+    & > * {
+      font-weight: 600;
+    }
+
+    &::after {
+      content: "*";
+      display: inline;
+    }
+  }
+
   .header {
     display: flex;
     flex-wrap: wrap;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1940,7 +1940,6 @@ a.download-video {
 
     &::after {
       content: "*";
-      display: inline;
     }
   }
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1930,6 +1930,10 @@ a.download-video {
   .required {
     font-weight: 600;
 
+    &.not-bold {
+      font-weight: normal;
+    }
+
     & > * {
       font-weight: 600;
     }

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -57,7 +57,7 @@
       = f.hidden_field :user_type, value: @user.user_type
     - else
       .row
-        .span3.signup-field-label{:id => 'signup-select-user-type-label'}
+        .span3.signup-field-label.required{:id => 'signup-select-user-type-label'}
           = f.label :user_type, t('signup_form.user_type_label')
           - if @user.errors[:user_type].present?
             %p.error= t('activerecord.errors.messages.blank')
@@ -92,14 +92,14 @@
           .row.parent-email-field
             .span3.signup-field-label
               = f.label :parent_email do
-                %span= t('signup_form.parent_account_email_label')
+                %span.required= t('signup_form.parent_account_email_label')
               - if @user.errors[:parent_email_preference_email].present?
                 %p.error= @user.errors[:parent_email_preference_email]&.first
             .span4.parent-email-field-input
               = f.email_field :parent_email_preference_email, maxlength: 255, value: @user.parent_email_preference_email || @user.email
           .row.parent-email-field
             .span6.signup-field-label
-              = t('signup_form.parent_account_email_progress_permission', privacy_policy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
+              .required= t('signup_form.parent_account_email_progress_permission', privacy_policy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
               - if @user.errors[:parent_email_preference_opt_in].present?
                 %p.error= t('signup_form.email_preference_required')
             .span1.parent-email-field-input{style:"display:block"}
@@ -124,9 +124,9 @@
 
     .row
       .span3.signup-field-label
-        #teacher-name-label{style: "display: none;"}
+        #teacher-name-label.required{style: "display: none;"}
           = f.label :name, t('activerecord.attributes.user.name').html_safe
-        #student-name-label{style: "display: none;"}
+        #student-name-label.required{style: "display: none;"}
           = f.label :name, t('activerecord.attributes.user.name_example')
         - if @user.errors[:name].present?
           %p.error= @user.errors[:name].join('\n')
@@ -134,7 +134,7 @@
         = f.text_field :name, maxlength: 255
 
     .row#age-dropdown{style: "display: none;"}
-      .span3.signup-field-label
+      .span3.signup-field-label.required
         = f.label :age
         - if @user.errors[:age].present?
           %p.error= @user.errors[:age].join('\n')
@@ -143,7 +143,7 @@
 
     - if us_ip && Cpa.cpa_experience(request)
       .row#us-state-dropdown{style: "display: none;"}
-        .span3.signup-field-label
+        .span3.signup-field-label.required
           = f.label :us_state
           - if @user.errors[:us_state].present?
             %p.error= @user.errors[:us_state].join('\n')
@@ -184,7 +184,7 @@
                   = t('signup_form.agree_us_data_transfer_student', markdown: :inline).html_safe
                 %span#teacher-gdpr{style: "display: none;"}
                   = t('signup_form.agree_us_data_transfer_teacher', markdown: :inline).html_safe
-                %span
+                %span.required
                   = t('signup_form.data_collection_us', markdown: :inline).html_safe
                   = t('signup_form.visit_privacy', privacy_url: CDO.code_org_url('/privacy'), markdown: :inline).html_safe
           - if @user.errors[:data_transfer_agreement_accepted].present?
@@ -192,7 +192,7 @@
 
     .row#email-preference-radio{style: "display: none;"}
       .span10.signup-field-label
-        %p
+        %p.required
           = t('signup_form.email_preference_question')
           = link_to t('signup_form.email_preference_privacy'), CDO.code_org_url('/privacy'), target: '_blank'
         - if @user.errors[:email_preference_opt_in].present?
@@ -206,7 +206,7 @@
           = f.label :email_preference_opt_in, t('signup_form.email_preference_no'), value: 'no'
 
     .row#share-email-reg-part-preference-radio{style: "display: none;"}
-      .span10.signup-field-label
+      .span10.signup-field-label.required
         %p
           = t('signup_form.share_teacher_email_reg_partner_question', cdo_regional_partner_desc: CDO.code_org_url('/educate/regional-partner'), markdown: true).html_safe
         - if @user.errors[:share_teacher_email_reg_partner_opt_in_radio_choice].present?

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -115,7 +115,7 @@
         - if ao_form.object.lti?
           .row
             .span3.signup-field-label
-              #teacher-email-label
+              #teacher-email-label.required
                 = ao_form.label :email, User.human_attribute_name(:email)
               - if @user.errors[:email].present?
                 %p.error= @user.errors[:email].join('\n')

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -184,7 +184,7 @@
                   = t('signup_form.agree_us_data_transfer_student', markdown: :inline).html_safe
                 %span#teacher-gdpr{style: "display: none;"}
                   = t('signup_form.agree_us_data_transfer_teacher', markdown: :inline).html_safe
-                %span.required
+                %span.required.not-bold
                   = t('signup_form.data_collection_us', markdown: :inline).html_safe
                   = t('signup_form.visit_privacy', privacy_url: CDO.code_org_url('/privacy'), markdown: :inline).html_safe
           - if @user.errors[:data_transfer_agreement_accepted].present?


### PR DESCRIPTION
I checked how this looks for all four different states:

Student (and parent signing up on behalf of student)
Teachers 

Folks in EU (dgpr)
Folks who are shown CPA

<img width="687" alt="Screenshot 2024-05-21 at 2 25 56 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/42f4b207-5a0d-47a5-ade1-e7a4628ba5df">
<img width="755" alt="Screenshot 2024-05-21 at 2 35 39 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/51236b70-f55b-4d93-81b2-29b72bee6de1">
<img width="665" alt="Screenshot 2024-05-21 at 2 37 33 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/6bd91e39-a0b7-4de7-9b0b-573382b7a15c">
<img width="643" alt="Screenshot 2024-05-21 at 2 25 47 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/0809b27d-ad24-4627-abd1-a136c73383dd">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1904

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
