### PR TITLE
Write UI tests for My Professional Learning page

### DIFF
--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -510,15 +510,6 @@ def create_facilitator(course)
   facilitator
 end
 
-# workshop = Retryable.retryable(on: [ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid], tries: 5) do
-#   FactoryBot.create(:workshop, :self_paced,
-#     title: course,
-#     current_lesson_name: current_lesson_name,
-#     percent_completed: percent_completed
-#     finish_url:
-#   )
-# end
-
 And(/^I create a workshop for course "([^"]*)" ([a-z]+) by "([^"]*)" with (\d+) (people|facilitators)(.*)$/) do |course, role, name, number, number_type, post_create_actions|
   # Organizer
   organizer =

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -119,6 +119,16 @@ Given(/^I am an organizer with started and completed courses$/) do
   GHERKIN
 end
 
+Given(/^I am a program manager with started and completed courses$/) do
+  random_name = "TestProgramManager" + SecureRandom.hex[0..9]
+  steps <<~GHERKIN
+    And I am a program manager named "#{random_name}" for regional partner "Test Partner"
+    And I create a workshop for course "CS Fundamentals" organized by "#{random_name}" with 5 people and start it
+    And I create a workshop for course "CS Fundamentals" organized by "#{random_name}" with 5 people and end it
+    And I create a workshop for course "CS Fundamentals" organized by "#{random_name}" with 5 people
+  GHERKIN
+end
+
 Given(/^I am a teacher who has just followed a workshop certificate link$/) do
   test_teacher_name = "TestTeacher - Certificate Test"
   require_rails_env
@@ -499,6 +509,15 @@ def create_facilitator(course)
 
   facilitator
 end
+
+# workshop = Retryable.retryable(on: [ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid], tries: 5) do
+#   FactoryBot.create(:workshop, :self_paced,
+#     title: course,
+#     current_lesson_name: current_lesson_name,
+#     percent_completed: percent_completed
+#     finish_url:
+#   )
+# end
 
 And(/^I create a workshop for course "([^"]*)" ([a-z]+) by "([^"]*)" with (\d+) (people|facilitators)(.*)$/) do |course, role, name, number, number_type, post_create_actions|
   # Organizer

--- a/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
@@ -111,12 +111,12 @@ Feature: Professional Learning landing page
     And the href of selector "a:contains(Start professional learning courses)" contains "/educate/professional-development-online"
 
     # Starts a self-paced PL course
-    Then I am on "http://studio.code.org/s/self-paced-pl-csd-unit2-1-2024"
-    And I wait until element "span:contains(Try Now)" is visible
-    Then I click selector "span:contains(Try Now)"
-    Then I am on "http://studio.code.org/s/self-paced-pl-csd-unit2-1-2024/lessons/1/levels/1"
-    And I wait until element "button:contains(Continue)" is visible
-    Then I click selector "button:contains(Continue)"
+    Then I am on "http://studio.code.org/s/alltheselfpacedplthings/lessons/1/levels/1"
+    And I wait until element "a[aria-label='Level 3 Lesson Instructor In Training Levels']" is visible
+    Then I click selector "a[aria-label='Level 3 Lesson Instructor In Training Levels']"
+    Then I am on "http://studio.code.org/s/alltheselfpacedplthings/lessons/1/levels/3"
+    And I wait until element "a:contains(Submit)" is visible
+    Then I click selector "a:contains(Submit)"
     Then I am on "http://studio.code.org/my-professional-learning"
 
     # Sees Self-Paced Professional Learning Courses table

--- a/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
@@ -1,6 +1,6 @@
 Feature: Professional Learning landing page
 
-  # @eyes
+  @eyes
   Scenario: New teacher without PL history sees relevant content sections
     Given I create a teacher named "New Teacher"
     And I sign in as "New Teacher" and go home
@@ -14,7 +14,7 @@ Feature: Professional Learning landing page
 
     # Sees Joined Professional Learning Sections section
     And element "button.ui-test-join-section" is visible
-    And I see no difference for "Joined PL Sections without sections"
+    And I see no difference for "Joined PL Sections section"
 
     # Sees Recommended for you section
     And element "a:contains(Learn more about workshops)" is visible
@@ -22,6 +22,29 @@ Feature: Professional Learning landing page
     And element "a:contains(Start professional learning courses)" is visible
     And the href of selector "a:contains(Start professional learning courses)" contains "/educate/professional-development-online"
     And I see no difference for "PL Recommended for you section"
+    And I close my eyes
+
+  @eyes
+  Scenario: Facilitator sees relevant content sections
+    Given I am a facilitator with started and completed courses
+    And I am on "http://studio.code.org/my-professional-learning"
+    And I open my eyes to test "Facilitator Professional Learning page"
+
+    # Go to the right My PL page tab
+    And I wait until element "button:contains(Facilitator Center)" is visible
+    Then I click selector "button:contains(Facilitator Center)"
+    And I see no difference for "Facilitator Center tab"
+
+    # # Sees Facilitator Resources section
+    And I wait until element "a:contains(View workshop dashboard)" is visible
+    And the href of selector "a:contains(View workshop dashboard)" contains "/pd/workshop_dashboard"
+    And I wait until element "a:contains(View CSF Facilitator Landing page)" is visible
+    And the href of selector "a:contains(View CSF Facilitator Landing page)" contains "/educate/facilitator-landing/CSF"
+    And I see no difference for "Facilitator Resources section"
+
+    # Sees Workshops table
+    And I wait until element "button:contains(Workshop Details)" is visible
+    And I see no difference for "Facilitator workshops table"
     And I close my eyes
 
   Scenario: Instructor sees relevant content sections

--- a/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
@@ -48,7 +48,7 @@ Feature: Professional Learning landing page
     And I see no difference for "Facilitator workshops table"
     And I close my eyes
 
-  Scenario: Instructor sees relevant content sections
+  Scenario: Universal Instructor sees relevant content sections
     Given I create a teacher named "PL Instructor"
     And I sign in as "PL Instructor" and go home
     And I get universal instructor access

--- a/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
@@ -1,6 +1,6 @@
 Feature: Professional Learning landing page
 
-  @eyes
+  # @eyes
   Scenario: New teacher without PL history sees relevant content sections
     Given I create a teacher named "New Teacher"
     And I sign in as "New Teacher" and go home
@@ -53,3 +53,18 @@ Feature: Professional Learning landing page
     And the href of selector "a:contains(View workshop dashboard)" contains "/pd/workshop_dashboard"
     And element "a:contains(View playbook)" is visible
     And the href of selector "a:contains(View playbook)" contains "/educate/regional-partner/playbook"
+
+  Scenario: Workshop Organizer sees relevant content sections
+    Given I am an organizer with started and completed courses
+    And I am on "http://studio.code.org/my-professional-learning"
+
+    # Go to the right My PL page tab
+    And I wait until element "button:contains(Workshop Organizer)" is visible
+    Then I click selector "button:contains(Workshop Organizer)"
+
+    # Sees Workshop Organizer Resources section
+    And I wait until element "a:contains(View workshop dashboard)" is visible
+    And the href of selector "a:contains(View workshop dashboard)" contains "/pd/workshop_dashboard"
+
+    # Sees Workshops table
+    And I wait until element "button:contains(Workshop Details)" is visible

--- a/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
@@ -115,6 +115,7 @@ Feature: Professional Learning landing page
     And I wait until element "a:contains(Try Now)" is visible
     Then I click selector "a:contains(Try Now)"
     Then I am on "http://studio.code.org/s/self-paced-pl-csd-unit2-1-2024/lessons/1/levels/1"
+    And I wait until element "button:contains(Continue)" is visible
     Then I click selector "button:contains(Continue)"
     Then I am on "http://studio.code.org/my-professional-learning"
 

--- a/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
@@ -112,8 +112,8 @@ Feature: Professional Learning landing page
 
     # Starts a self-paced PL course
     Then I am on "http://studio.code.org/s/self-paced-pl-csd-unit2-1-2024"
-    And I wait until element "a:contains(Try Now)" is visible
-    Then I click selector "a:contains(Try Now)"
+    And I wait until element "span:contains(Try Now)" is visible
+    Then I click selector "span:contains(Try Now)"
     Then I am on "http://studio.code.org/s/self-paced-pl-csd-unit2-1-2024/lessons/1/levels/1"
     And I wait until element "button:contains(Continue)" is visible
     Then I click selector "button:contains(Continue)"

--- a/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
@@ -1,0 +1,19 @@
+Feature: Professional Learning landing page
+
+  Scenario: New teacher without PL history sees relevant content sections
+    Given I create a teacher named "New Teacher"
+    And I sign in as "New Teacher" and go home
+    Then I am on "http://studio.code.org/my-professional-learning"
+
+    # Sees Getting Started banner
+    And I wait until element "a:contains(Learn about professional learning)" is visible
+    And the href of selector "a:contains(Learn about professional learning)" contains "/educate/professional-learning"
+
+    # Sees Joined Professional Learning Sections section
+    And element "button.ui-test-join-section" is visible
+
+    # Sees Recommended for you section
+    And element "a:contains(Learn more about workshops)" is visible
+    And the href of selector "a:contains(Learn more about workshops)" contains "/professional-learning/middle-high"
+    And element "a:contains(Start professional learning courses)" is visible
+    And the href of selector "a:contains(Start professional learning courses)" contains "/educate/professional-development-online"

--- a/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
@@ -36,7 +36,7 @@ Feature: Professional Learning landing page
     Then I click selector "button:contains(Facilitator Center)"
     And I see no difference for "Facilitator Center tab"
 
-    # # Sees Facilitator Resources section
+    # Sees Facilitator Resources section
     And I wait until element "a:contains(View workshop dashboard)" is visible
     And the href of selector "a:contains(View workshop dashboard)" contains "/pd/workshop_dashboard"
     And I wait until element "a:contains(View CSF Facilitator Landing page)" is visible
@@ -78,7 +78,7 @@ Feature: Professional Learning landing page
     And element "a:contains(View playbook)" is visible
     And the href of selector "a:contains(View playbook)" contains "/educate/regional-partner/playbook"
 
-    # # Sees Workshops table
+    # Sees Workshops table
     And I wait until element "button:contains(Workshop Details)" is visible
 
   Scenario: Workshop Organizer sees relevant content sections
@@ -96,7 +96,7 @@ Feature: Professional Learning landing page
     # Sees Workshops table
     And I wait until element "button:contains(Workshop Details)" is visible
 
-  Scenario: Teacher with self-paced PL courses sees relevant content sections
+  Scenario: Teacher with Self-paced PL courses sees relevant content sections
     Given I create a teacher named "Self-paced Teacher"
     And I sign in as "Self-paced Teacher" and go home
     Then I am on "http://studio.code.org/my-professional-learning"

--- a/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
@@ -95,3 +95,28 @@ Feature: Professional Learning landing page
 
     # Sees Workshops table
     And I wait until element "button:contains(Workshop Details)" is visible
+
+  Scenario: Teacher with self-paced PL courses sees relevant content sections
+    Given I create a teacher named "Self-paced Teacher"
+    And I sign in as "Self-paced Teacher" and go home
+    Then I am on "http://studio.code.org/my-professional-learning"
+
+    # Sees Joined Professional Learning Sections section
+    And element "button.ui-test-join-section" is visible
+
+    # Sees Recommended for you section
+    And element "a:contains(Learn more about workshops)" is visible
+    And the href of selector "a:contains(Learn more about workshops)" contains "/professional-learning/middle-high"
+    And element "a:contains(Start professional learning courses)" is visible
+    And the href of selector "a:contains(Start professional learning courses)" contains "/educate/professional-development-online"
+
+    # Starts a self-paced PL course
+    Then I am on "http://studio.code.org/s/self-paced-pl-csd-unit2-1-2024"
+    And I wait until element "a:contains(Try Now)" is visible
+    Then I click selector "a:contains(Try Now)"
+    Then I am on "http://studio.code.org/s/self-paced-pl-csd-unit2-1-2024/lessons/1/levels/1"
+    Then I click selector "button:contains(Continue)"
+    Then I am on "http://studio.code.org/my-professional-learning"
+
+    # Sees Self-Paced Professional Learning Courses table
+    And I wait until element "a:contains(Continue course)" is visible

--- a/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
@@ -1,19 +1,55 @@
 Feature: Professional Learning landing page
 
+  @eyes
   Scenario: New teacher without PL history sees relevant content sections
     Given I create a teacher named "New Teacher"
     And I sign in as "New Teacher" and go home
     Then I am on "http://studio.code.org/my-professional-learning"
+    And I open my eyes to test "New teacher Professional Learning page"
 
     # Sees Getting Started banner
     And I wait until element "a:contains(Learn about professional learning)" is visible
     And the href of selector "a:contains(Learn about professional learning)" contains "/educate/professional-learning"
+    And I see no difference for "PL Getting Started banner"
 
     # Sees Joined Professional Learning Sections section
     And element "button.ui-test-join-section" is visible
+    And I see no difference for "Joined PL Sections without sections"
 
     # Sees Recommended for you section
     And element "a:contains(Learn more about workshops)" is visible
     And the href of selector "a:contains(Learn more about workshops)" contains "/professional-learning/middle-high"
     And element "a:contains(Start professional learning courses)" is visible
     And the href of selector "a:contains(Start professional learning courses)" contains "/educate/professional-development-online"
+    And I see no difference for "PL Recommended for you section"
+    And I close my eyes
+
+  Scenario: Instructor sees relevant content sections
+    Given I create a teacher named "PL Instructor"
+    And I sign in as "PL Instructor" and go home
+    And I get universal instructor access
+    And I reload the page
+    Then I am on "http://studio.code.org/my-professional-learning"
+
+    # Go to the right My PL page tab
+    And I wait until element "button:contains(Instructor Center)" is visible
+    Then I click selector "button:contains(Instructor Center)"
+
+    # Sees Instructor Professional Learning Sections section
+    And I wait until element "button:contains(Create a section)" is visible
+
+  Scenario: Regional Partner sees relevant content sections
+    Given I am a program manager
+    And I am on "http://studio.code.org/my-professional-learning"
+
+    # Go to the right My PL page tab
+    And I wait until element "button:contains(Regional Partner)" is visible
+    Then I click selector "button:contains(Regional Partner)"
+
+    # Sees Regional Partner Resources section
+    And I wait until element "a:contains(Manage applications)" is visible
+    And the href of selector "a:contains(Manage applications)" contains "/pd/application_dashboard"
+    And element "a:contains(View workshop dashboard)" is visible
+    And the href of selector "a:contains(View workshop dashboard)" contains "/pd/workshop_dashboard"
+    And element "a:contains(View playbook)" is visible
+    And the href of selector "a:contains(View playbook)" contains "/educate/regional-partner/playbook"

--- a/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_landing_page.feature
@@ -1,3 +1,4 @@
+@no_mobile
 Feature: Professional Learning landing page
 
   @eyes
@@ -62,7 +63,7 @@ Feature: Professional Learning landing page
     And I wait until element "button:contains(Create a section)" is visible
 
   Scenario: Regional Partner sees relevant content sections
-    Given I am a program manager
+    Given I am a program manager with started and completed courses
     And I am on "http://studio.code.org/my-professional-learning"
 
     # Go to the right My PL page tab
@@ -76,6 +77,9 @@ Feature: Professional Learning landing page
     And the href of selector "a:contains(View workshop dashboard)" contains "/pd/workshop_dashboard"
     And element "a:contains(View playbook)" is visible
     And the href of selector "a:contains(View playbook)" contains "/educate/regional-partner/playbook"
+
+    # # Sees Workshops table
+    And I wait until element "button:contains(Workshop Details)" is visible
 
   Scenario: Workshop Organizer sees relevant content sections
     Given I am an organizer with started and completed courses

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -234,16 +234,3 @@ Feature: Professional learning Sections
     And I enter the section code into "input.ui-test-join-section"
     And I click selector "button.ui-test-join-section"
     Then the professional learning joined sections table should have 1 row
-
-  @eyes
-  Scenario: Teacher without current application, workshops, or self-paced courses sees Getting Started banner
-    Given I create a teacher named "New Teacher"
-    And I sign in as "New Teacher" and go home
-    Then I am on "http://studio.code.org/my-professional-learning"
-
-    # Sees Getting Started banner
-    And I wait until element "a:contains(Learn about professional learning)" is visible
-    And the href of selector "a:contains(Learn about professional learning)" contains "/educate/professional-learning"
-    And I open my eyes to test "New teacher My PL page"
-    And I see no difference in "New teacher My PL page"
-    And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -234,3 +234,16 @@ Feature: Professional learning Sections
     And I enter the section code into "input.ui-test-join-section"
     And I click selector "button.ui-test-join-section"
     Then the professional learning joined sections table should have 1 row
+
+  @eyes
+  Scenario: Teacher without current application, workshops, or self-paced courses sees Getting Started banner
+    Given I create a teacher named "New Teacher"
+    And I sign in as "New Teacher" and go home
+    Then I am on "http://studio.code.org/my-professional-learning"
+
+    # Sees Getting Started banner
+    And I wait until element "a:contains(Learn about professional learning)" is visible
+    And the href of selector "a:contains(Learn about professional learning)" contains "/educate/professional-learning"
+    And I open my eyes to test "New teacher My PL page"
+    And I see no difference in "New teacher My PL page"
+    And I close my eyes


### PR DESCRIPTION
Adds UI and two Eyes tests to https://studio.code.org/my-professional-learning page. These are testing that the correct sections show for each tab:
- New teacher w/o PL history (home page) - has Eyes test
- Facilitator Center - has Eyes test
- Instructor Center
- Regional Partner Center
- Workshop Organizer Center
- Teacher w/ self-paced PL (home page)

_Note:_ The Upcoming workshop banners seen in the Figma mocks were never built, and I'm not UI testing the Workshop Feedback banners because these are already tested for in Unit tests, and the Getting Started banner on the `New teacher…` test uses the same component.

## Links
Jira ticket: [ACQ-1824](https://codedotorg.atlassian.net/browse/ACQ-1824)
Figma mocks: [No PL History](https://www.figma.com/design/sZ6d1uhJWFksJ6j3Fnmbnc/PL-Flow-Improvements?node-id=1958-10453&t=L1bVFX6fF9P3qg6h-1) • [Managing PL Views](https://www.figma.com/design/sZ6d1uhJWFksJ6j3Fnmbnc/PL-Flow-Improvements?node-id=2041-3394&t=L1bVFX6fF9P3qg6h-1) • [Self-paced](https://www.figma.com/design/sZ6d1uhJWFksJ6j3Fnmbnc/PL-Flow-Improvements?node-id=1958-10169&t=L1bVFX6fF9P3qg6h-1) 

## Testing story
Tested locally on SauceLabs