### PR TITLE
feat(email): POST the email address for LMS account linking scenarions

### DIFF
--- a/apps/src/dcdo.js
+++ b/apps/src/dcdo.js
@@ -29,7 +29,7 @@ export class DCDO {
   /**
    * Sets the DCDO configs. Tests only! This has no affect on the backend.
    * @param {string} key The key for the DCDO config to set.
-   * @param {object} value The value to store for the given key.
+   * @param {object | boolean} value The value to store for the given key.
    */
   set(key, value) {
     if (key) {

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/NewAccountCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/NewAccountCard/index.tsx
@@ -7,13 +7,31 @@ import {
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';
 import classNames from 'classnames';
 import styles from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/link-account.module.scss';
-import {buttonColors, LinkButton} from '@cdo/apps/componentLibrary/button';
-import React, {useContext} from 'react';
+import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
+import React, {useContext, useRef} from 'react';
 import i18n from '@cdo/locale';
 import {LtiProviderContext} from '../../context';
+import DCDO from '@cdo/apps/dcdo';
+import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
+import {navigateToHref} from '@cdo/apps/utils';
 
 const NewAccountCard = () => {
-  const {ltiProviderName, newAccountUrl} = useContext(LtiProviderContext)!;
+  const {ltiProviderName, newAccountUrl, emailAddress} =
+    useContext(LtiProviderContext)!;
+  const finishSignupFormRef = useRef<HTMLFormElement>(null);
+  const isStudentEmailPostEnabled = DCDO.get(
+    'student-email-post-enabled',
+    false
+  );
+
+  const handleNewAccountSubmit = () => {
+    if (isStudentEmailPostEnabled) {
+      finishSignupFormRef.current?.submit();
+    } else {
+      navigateToHref(newAccountUrl);
+    }
+  };
+
   return (
     <Card data-testid={'new-account-card'}>
       <CardHeader
@@ -29,14 +47,25 @@ const NewAccountCard = () => {
         {i18n.ltiLinkAccountNewAccountCardContent({
           providerName: ltiProviderName,
         })}
+
+        <form
+          data-testid={'new-account-form'}
+          action={newAccountUrl}
+          ref={finishSignupFormRef}
+          method="post"
+          className={styles.newAccountForm}
+        >
+          <RailsAuthenticityToken />
+          <input type="hidden" value={emailAddress} name={'user[email]'} />
+        </form>
       </CardContent>
       <CardActions>
-        <LinkButton
+        <Button
           className={classNames(styles.button, styles.cardSecondaryButton)}
           color={buttonColors.white}
           size="l"
-          href={newAccountUrl}
           text={i18n.ltiLinkAccountNewAccountCardActionLabel()}
+          onClick={handleNewAccountSubmit}
         />
       </CardActions>
     </Card>

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/context.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/context.tsx
@@ -6,6 +6,7 @@ export interface LtiProviderContextProps {
   ltiProviderName: string;
   newAccountUrl: string;
   existingAccountUrl: URL;
+  emailAddress: string;
 }
 
 export const LtiProviderContext = createContext<

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/link-account.module.scss
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/link-account.module.scss
@@ -41,3 +41,7 @@
 .exchangeIcon {
   color: #7F8286;
 }
+
+.newAccountForm {
+  display: none;
+}

--- a/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
+++ b/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
@@ -17,12 +17,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const ltiProviderName = scriptData['lti_provider_name'];
   const newAccountUrl = scriptData['new_account_url'];
   const existingAccountUrl = new URL(scriptData['existing_account_url']);
+  const emailAddress = scriptData['email'];
 
   const ltiProviderContext = {
     ltiProvider,
     ltiProviderName,
     newAccountUrl,
     existingAccountUrl,
+    emailAddress,
   };
 
   ReactDOM.render(

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -1,4 +1,4 @@
-import {render, screen, within} from '@testing-library/react';
+import {fireEvent, render, screen, within} from '@testing-library/react';
 import {
   LtiProviderContext,
   LtiProviderContextProps,
@@ -7,15 +7,27 @@ import React from 'react';
 import i18n from '@cdo/locale';
 import {expect} from '../../../../../../util/reconfiguredChai';
 import LtiLinkAccountPage from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage';
+import sinon from 'sinon';
+import * as utils from '@cdo/apps/utils';
+import DCDO from '@cdo/apps/dcdo';
 
 const DEFAULT_CONTEXT: LtiProviderContextProps = {
   ltiProvider: 'canvas_cloud',
   ltiProviderName: 'Canvas',
   newAccountUrl: '/new-account',
   existingAccountUrl: new URL('https://example.com/existing-account'),
+  emailAddress: 'test@code.org',
 };
 
 describe('LTI Link Account Page Tests', () => {
+  beforeEach(() => {
+    sinon.stub(utils, 'navigateToHref');
+  });
+
+  afterEach(() => {
+    (utils.navigateToHref as sinon.SinonStub).restore();
+  });
+
   describe('LTI Link Account Existing Account Card Tests', () => {
     it('should render an existing account card', () => {
       render(
@@ -67,12 +79,43 @@ describe('LTI Link Account Page Tests', () => {
         i18n.ltiLinkAccountNewAccountCardContent({providerName: 'Canvas'})
       );
       // Should have button to link new account
-      expect(
-        withinNewAccountCard
-          .getByText(i18n.ltiLinkAccountNewAccountCardActionLabel())
-          .closest('a')!
-          .getAttribute('href')
-      ).to.equal('/new-account');
+      const newAccountButton = withinNewAccountCard.getByText(
+        i18n.ltiLinkAccountNewAccountCardActionLabel()
+      );
+
+      fireEvent.click(newAccountButton);
+
+      expect(utils.navigateToHref).to.have.been.calledWith('/new-account');
+    });
+
+    it('should render a new account card - student email post enabled', () => {
+      DCDO.set('student-email-post-enabled', true);
+
+      render(
+        <LtiProviderContext.Provider value={DEFAULT_CONTEXT}>
+          <LtiLinkAccountPage />
+        </LtiProviderContext.Provider>
+      );
+
+      const newAccountCard = screen.getByTestId('new-account-card');
+      const withinNewAccountCard = within(newAccountCard);
+
+      // Should render header
+      withinNewAccountCard.getByText(
+        i18n.ltiLinkAccountNewAccountCardHeaderLabel()
+      );
+      // Should render card content
+      withinNewAccountCard.getByText(
+        i18n.ltiLinkAccountNewAccountCardContent({providerName: 'Canvas'})
+      );
+      const newAccountForm: HTMLFormElement =
+        screen.getByTestId('new-account-form');
+
+      const formValues = new FormData(newAccountForm);
+
+      expect(formValues.get('user[email]')).to.equal(
+        DEFAULT_CONTEXT.emailAddress
+      );
     });
   });
 });

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/WelcomeBanner/WelcomeBannerTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/WelcomeBanner/WelcomeBannerTest.tsx
@@ -11,6 +11,7 @@ const getContext = (ltiProvider: LtiProvider) => {
     ltiProviderName: 'LMS',
     newAccountUrl: '/new-account',
     existingAccountUrl: new URL('https://test.com/existing-account'),
+    emailAddress: 'test@code.org',
   };
 };
 

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -196,12 +196,23 @@ class LtiV1Controller < ApplicationController
         redirect_to destination_url
       else
         user = Services::Lti.initialize_lti_user(decoded_jwt)
+        # PartialRegistration removes the email address, so store it in a local variable first
+        email_address = Services::Lti.get_claim(decoded_jwt, :email)
         PartialRegistration.persist_attributes(session, user)
         session[:user_return_to] = destination_url
         if DCDO.get('lti_account_linking_enabled', false)
-          redirect_to lti_v1_account_linking_landing_path lti_provider: integration[:platform_name] and return
+          render 'lti/v1/account_linking/landing', locals: {lti_provider: integration[:platform_name], email: email_address} and return
         end
-        redirect_to new_user_registration_url
+
+        if DCDO.get('student-email-post-enabled', false)
+          @form_data = {
+            email: email_address
+          }
+
+          render 'omniauth/redirect', {layout: false}
+        else
+          redirect_to new_user_registration_url
+        end
       end
     else
       jwt_error_message = jwt_verifier.errors.empty? ? 'Invalid JWT' : jwt_verifier.errors.join(', ')

--- a/dashboard/app/views/lti/v1/account_linking/landing.haml
+++ b/dashboard/app/views/lti/v1/account_linking/landing.haml
@@ -5,6 +5,7 @@
     script_data[:lti_provider_name] = Policies::Lti::LMS_PLATFORMS[params[:lti_provider].to_sym][:name]
     script_data[:new_account_url] = new_user_registration_url
     script_data[:existing_account_url] = CDO.studio_url(user_session_path, CDO.default_scheme)
+    script_data[:email] = email
 
   %script{src: webpack_asset_path('js/lti/v1/account_linking/landing.js'), data: {json: script_data.to_json}}}
 %body

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -574,6 +574,22 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to '/users/sign_up'
   end
 
+  test 'auth - should render oauth redirector if student-email-post-enabled' do
+    Cpa.stubs(:cpa_experience).with(any_parameters).returns(false)
+    SignUpTracking.stubs(:begin_sign_up_tracking).returns(false)
+    DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
+    DCDO.stubs(:get).with('lti_account_linking_enabled', false).returns(false)
+    DCDO.stubs(:get).with('student-email-post-enabled', false).returns(true)
+    payload = {**get_valid_payload, Policies::Lti::LTI_ROLES_KEY => [Policies::Lti::CONTEXT_LEARNER_ROLE]}
+    jwt = create_jwt_and_stub(payload)
+
+    deployment = LtiDeployment.create(deployment_id: @deployment_id, lti_integration_id: @integration.id)
+    assert deployment
+    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
+
+    assert_template 'omniauth/redirect'
+  end
+
   test 'sync - should redirect students to homepage without syncing' do
     user = create :student
     sign_in user

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -52,6 +52,7 @@ class DCDOBase < DynamicConfigBase
       'music-lab-samples-report': DCDO.get('music-lab-samples-report', true),
       'disable-try-new-progress-view-modal': DCDO.get('disable-try-new-progress-view-modal', false),
       'music-lab-existing-projects-default-sounds': DCDO.get('music-lab-existing-projects-default-sounds', true),
+      'student-email-post-enabled': DCDO.get('student-email-post-enabled', false),
     }
   end
 end


### PR DESCRIPTION
With the upcoming student email posting feature, the LMS account link needs to post to the finish sign up page as the email will not be available in the partial registration cache anymore.

This change will read the DCDO flag for student email, 

### if enabled:

A hidden form is created and will be submitted when the user wants to create a new account. This will POST the user to the finish sign up page.

### if disabled:

The user is redirected to the finish sign up page.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. Verified behavior in both enabled and disabled scenarios

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
