### PR TITLE
Updating Sauce Labs tunnel instructions

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -215,6 +215,7 @@ azure_content_moderation_key:
 # multiple browsers
 saucelabs_username:
 saucelabs_authkey:
+saucelabs_tunnel_name:
 
 # Credentials for applitools.com, used for running automated visual tests
 applitools_eyes_api_key:      !Secret

--- a/dashboard/test/ui/README.md
+++ b/dashboard/test/ui/README.md
@@ -55,7 +55,7 @@ If you want to run tests on Sauce Labs against localhost you need to set up your
 4. Start the sauce labs tunnel
     - `sc run -u <saucelabs_username> -k <saucelabs_authkey> -r us-west --tunnel-name <saucelabs_tunnel_name>`
 5. Run your UI test
-    - `./runner.rb -l -f features/platform/policy_compliance.feature -c Chrome --html`
+    - `./runner.rb -l -c Chrome --html -f features/platform/policy_compliance.feature`
         - The log output can be found in `log/*.html`
 #### Older versions of Sauce Connect Proxy CLI
 1. Login to Sauce Labs and download the [tunnel](https://app.saucelabs.com/tunnels).

--- a/dashboard/test/ui/README.md
+++ b/dashboard/test/ui/README.md
@@ -47,6 +47,17 @@ You can find the values for these settings in your saucelabs account settings (`
 
 If you want to run tests on Sauce Labs against localhost you need to set up your tunnel:
 
+#### Latest version of Sauce Labs tunnel
+1. Login to Sauce Labs and download the [tunnel](https://app.saucelabs.com/tunnels).
+2. Uncomment and fill out the values for the "saucelabs_" properties in `locals.yml`
+   - `saucelabs_tunnel_name` can be an arbitrary name, but it needs to match what you pass as an argument to `sc run...`
+3. (Re)start your dashboard-server `./bin/dashboard-server`.
+4. Start the sauce labs tunnel
+    - `sc run -u <saucelabs_username> -k <saucelabs_authkey> -r us-west --tunnel-name <saucelabs_tunnel_name>`
+5. Run your UI test
+    - `./runner.rb -l -f features/platform/policy_compliance.feature -c Chrome --html`
+        - The log output can be found in `log/*.html`
+#### Older versions of Sauce Labs tunnel
 1. Login to Sauce Labs and download the [tunnel](https://app.saucelabs.com/tunnels).
    - If you work on a Linux EC2 instance:
      - Download the Linux version (will end in .tar.gz)

--- a/dashboard/test/ui/README.md
+++ b/dashboard/test/ui/README.md
@@ -47,7 +47,7 @@ You can find the values for these settings in your saucelabs account settings (`
 
 If you want to run tests on Sauce Labs against localhost you need to set up your tunnel:
 
-#### Latest version of Sauce Labs tunnel
+#### Latest version of Sauce Connect Proxy CLI (5.1.0)
 1. Login to Sauce Labs and download the [tunnel](https://app.saucelabs.com/tunnels).
 2. Uncomment and fill out the values for the "saucelabs_" properties in `locals.yml`
    - `saucelabs_tunnel_name` can be an arbitrary name, but it needs to match what you pass as an argument to `sc run...`
@@ -57,7 +57,7 @@ If you want to run tests on Sauce Labs against localhost you need to set up your
 5. Run your UI test
     - `./runner.rb -l -f features/platform/policy_compliance.feature -c Chrome --html`
         - The log output can be found in `log/*.html`
-#### Older versions of Sauce Labs tunnel
+#### Older versions of Sauce Connect Proxy CLI
 1. Login to Sauce Labs and download the [tunnel](https://app.saucelabs.com/tunnels).
    - If you work on a Linux EC2 instance:
      - Download the Linux version (will end in .tar.gz)

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -32,7 +32,8 @@ def saucelabs_browser(test_run_name)
     idleTimeout: 60,
     seleniumVersion: Selenium::WebDriver::VERSION
   }
-  sauce_options[:tunnelIdentifier] = CDO.circle_run_identifier if CDO.circle_run_identifier
+  tunnel_name = CDO.circle_run_identifier || CDO.saucelabs_tunnel_name
+  sauce_options[:tunnelIdentifier] = tunnel_name if tunnel_name
   sauce_options[:priority] = ENV['PRIORITY'].to_i if ENV['PRIORITY']
   capabilities["sauce:options"] ||= {}
   capabilities["sauce:options"].merge!(sauce_options)

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -32,6 +32,10 @@ def saucelabs_browser(test_run_name)
     idleTimeout: 60,
     seleniumVersion: Selenium::WebDriver::VERSION
   }
+
+  # CDO.saucelabs_tunnel_name is only intended to be used by developers doing
+  # local testing. This alternative name was chosen to make the developer's
+  # locals.yml easier to understand.
   tunnel_name = CDO.circle_run_identifier || CDO.saucelabs_tunnel_name
   sauce_options[:tunnelIdentifier] = tunnel_name if tunnel_name
   sauce_options[:priority] = ENV['PRIORITY'].to_i if ENV['PRIORITY']

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -71,6 +71,7 @@ use_my_apps: true
 # multiple browsers
 #saucelabs_username: ''
 #saucelabs_authkey: ''
+#saucelabs_tunnel_name: ''
 
 
 # Credentails for applitools.com, used for running automated visual tests


### PR DESCRIPTION
I wanted to setup Sauce Labs tunnel for the first time on my laptop but I ran into problems because the commands didn't match what we have documented. It looks like the `sc` Sauce Connect Proxy CLI has been updated to require more arguments:
* `region` e.g. "us-west"
* `tunnel-name` e.g. "dayne_localhost"
  * The important part of the tunnel name is that it has to matches what you use when running `sc run --tunnel-name`

This PR:
* Creates a new config value `CDO.saucelabs_tunnel_name` so the UI tests can find the tunnel `sc` has started.
* Update the README file related to running the Sauce Labs tunnel.

An alternative to creating the config property `CDO.saucelabs_tunnel_name` is to set `CDO.circle_run_identifier` in your locals.yml. However, I think creating a new config value is more readable.

## Testing story
* Started the tunnel and successfully ran UI tests.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
