### PR TITLE
Music: bypass cache for new library version

### DIFF
--- a/apps/src/music/utils/Loader.ts
+++ b/apps/src/music/utils/Loader.ts
@@ -8,6 +8,10 @@ import MusicLibrary, {
 const AppConfig = require('../appConfig').default;
 import {getBaseAssetUrl} from '../appConfig';
 
+// This value can be modifed each time we know that there is an important new version
+// of the library on S3, to help bypass any caching of an older version.
+const requestVersion = 'launch2024-0';
+
 /**
  * Loads a sound library JSON file.
  *
@@ -29,7 +33,10 @@ export const loadLibrary = async (
     );
   } else {
     const libraryJsonResponse = await HttpClient.fetchJson<LibraryJson>(
-      getBaseAssetUrl() + libraryFilename + '.json',
+      getBaseAssetUrl() +
+        libraryFilename +
+        '.json' +
+        (requestVersion ? `?version=${requestVersion}` : ''),
       {},
       LibraryValidator
     );


### PR DESCRIPTION
Some browsers are caching an older version of the library file that comes from S3.  This change appends a URL parameter to retrieve the new version.  The value can be modified in code each time there is an important new version of the library on S3.

We can consider more comprehensive solutions later, but this should be useful for the short term at least.

