### PR TITLE
Add index on user_id to pd_enrollments table

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -25,6 +25,7 @@
 #  index_pd_enrollments_on_code            (code) UNIQUE
 #  index_pd_enrollments_on_email           (email)
 #  index_pd_enrollments_on_pd_workshop_id  (pd_workshop_id)
+#  index_pd_enrollments_on_user_id         (user_id)
 #
 
 require 'cdo/code_generation'

--- a/dashboard/db/migrate/20240522163806_add_index_to_pd_enrollments_user_id.rb
+++ b/dashboard/db/migrate/20240522163806_add_index_to_pd_enrollments_user_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToPdEnrollmentsUserId < ActiveRecord::Migration[6.1]
+  def change
+    add_index :pd_enrollments, :user_id
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_14_181513) do
+ActiveRecord::Schema.define(version: 2024_05_22_163806) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1146,6 +1146,7 @@ ActiveRecord::Schema.define(version: 2024_05_14_181513) do
     t.index ["code"], name: "index_pd_enrollments_on_code", unique: true
     t.index ["email"], name: "index_pd_enrollments_on_email"
     t.index ["pd_workshop_id"], name: "index_pd_enrollments_on_pd_workshop_id"
+    t.index ["user_id"], name: "index_pd_enrollments_on_user_id"
   end
 
   create_table "pd_facilitator_program_registrations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
We've received reports of the My Professional Learning page loading slowly. I dug into New Relic data and confirmed that we have several instances of the page taking >10 seconds to load. I don't have a root cause of this slowness yet, but I did notice that we call a function `Pd::Enrollments.for_user` a couple of times, which isn't fully indexed. In particular, the email column does have an index, while the user_id column does not, but this method [queries on both](https://github.com/code-dot-org/code-dot-org/blob/5747cb43b611806d365d40ea77d16b80537936f6/dashboard/app/models/pd/enrollment.rb#L99). Given we are querying on this column frequently, adding an index seemed like low hanging fruit that may offer a modest improvement.

I did look into whether we could simply stop querying by `user_id` and found that about 12000 enrollments user a different email on the enrollment than on the user. This may be due to the fact that we allow teachers to supply an alternative email for PD in case they don't have access to their school email during the summer, but I didn't look too deeply and instead would like to stick with the conservative approach of not changing the logic of this method.


A git hook spit out this message:

```
Looks like you are adding a column, changing a column or adding an index in this migration:
dashboard/db/migrate/20240522163806_add_index_to_pd_enrollments_user_id.rb
Making these types of changes on a large table (>10M rows) needs to be reviewed and
tested with the Infrastructure team to avoid negatively impacting production database performance.
The may cause MySQL to rebuild the entire table.
For more information see https://dev.mysql.com/doc/refman/5.7/en/innodb-online-ddl-operations.html#online-ddl-column-operations.
```

The pd_enrollments table has just over 220,000 rows as of 5/22, so I believe this migration should be safe. That said, I'm tagging the infrastructure team just in case.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
