### PR TITLE
CodeBridge: move console buttons and improve console styling

### DIFF
--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -16,6 +16,7 @@ import React from 'react';
 
 import './styles/cdoIDE.scss';
 import Console from './Console';
+import ControlButtons from './ControlButtons';
 import Workspace from './Workspace';
 
 type CodebridgeProps = {
@@ -50,6 +51,7 @@ export const Codebridge = React.memo(
       'info-panel': config.Instructions || InfoPanel,
       workspace: Workspace,
       console: Console,
+      'control-buttons': ControlButtons,
     };
 
     return (

--- a/apps/src/codebridge/Console/console.module.scss
+++ b/apps/src/codebridge/Console/console.module.scss
@@ -12,4 +12,5 @@
 .console {
   font-family:'Courier New', Courier, monospace;
   overflow-y: scroll;
+  user-select: text;
 }

--- a/apps/src/codebridge/Console/console.module.scss
+++ b/apps/src/codebridge/Console/console.module.scss
@@ -3,10 +3,13 @@
 .consoleContainer {
   grid-area: console;
   color: $white;
-  overflow-y: scroll;
-  border: 1px solid $white;
   margin: 0 5px 10px 0;
+  overflow: hidden;
   height: 100%;
-  font-family:'Courier New', Courier, monospace;
   white-space: pre;
+}
+
+.console {
+  font-family:'Courier New', Courier, monospace;
+  overflow-y: scroll;
 }

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -2,7 +2,8 @@ import {resetOutput} from '@codebridge/redux/consoleRedux';
 import React from 'react';
 import {useDispatch} from 'react-redux';
 
-import Button from '@cdo/apps/templates/Button';
+import Button from '@cdo/apps/componentLibrary/button';
+import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import moduleStyles from './console.module.scss';
@@ -15,12 +16,27 @@ const Console: React.FunctionComponent = () => {
     dispatch(resetOutput());
   };
 
+  const headerButton = () => {
+    return (
+      <Button
+        isIconOnly
+        color={'black'}
+        icon={{iconStyle: 'solid', iconName: 'broom'}}
+        ariaLabel="clear console"
+        onClick={clearOutput}
+        size={'xs'}
+      />
+    );
+  };
+
   return (
-    <div className={moduleStyles.consoleContainer}>
-      <div>
-        <Button type={'button'} text="Clear output" onClick={clearOutput} />
-      </div>
-      <div>
+    <PanelContainer
+      id="codebridge-console"
+      className={moduleStyles.consoleContainer}
+      headerContent={'Console'}
+      rightHeaderContent={headerButton()}
+    >
+      <div className={moduleStyles.console}>
         {codeOutput.map((outputLine, index) => {
           if (outputLine.type === 'img') {
             return (
@@ -40,7 +56,7 @@ const Console: React.FunctionComponent = () => {
           }
         })}
       </div>
-    </div>
+    </PanelContainer>
   );
 };
 

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -1,38 +1,15 @@
-import {useCodebridgeContext} from '@codebridge/codebridgeContext';
-import {appendSystemMessage, resetOutput} from '@codebridge/redux/consoleRedux';
+import {resetOutput} from '@codebridge/redux/consoleRedux';
 import React from 'react';
 import {useDispatch} from 'react-redux';
 
-import {MultiFileSource} from '@cdo/apps/lab2/types';
 import Button from '@cdo/apps/templates/Button';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {useFetch} from '@cdo/apps/util/useFetch';
 
 import moduleStyles from './console.module.scss';
 
-interface PermissionResponse {
-  permissions: string[];
-}
-
 const Console: React.FunctionComponent = () => {
-  const {onRun} = useCodebridgeContext();
-  const source = useAppSelector(
-    state => state.lab2Project.projectSource?.source
-  ) as MultiFileSource | undefined;
   const codeOutput = useAppSelector(state => state.codebridgeConsole.output);
-  const {loading, data} = useFetch('/api/v1/users/current/permissions');
   const dispatch = useDispatch();
-
-  const handleRun = (runTests: boolean) => {
-    if (onRun) {
-      const parsedPermissions = data
-        ? (data as PermissionResponse)
-        : {permissions: []};
-      onRun(runTests, dispatch, parsedPermissions.permissions, source);
-    } else {
-      dispatch(appendSystemMessage("We don't know how to run your code."));
-    }
-  };
 
   const clearOutput = () => {
     dispatch(resetOutput());
@@ -41,18 +18,6 @@ const Console: React.FunctionComponent = () => {
   return (
     <div className={moduleStyles.consoleContainer}>
       <div>
-        <Button
-          type={'button'}
-          text="Run"
-          onClick={() => handleRun(false)}
-          disabled={loading}
-        />
-        <Button
-          type={'button'}
-          text="Test"
-          onClick={() => handleRun(true)}
-          disabled={loading}
-        />
         <Button type={'button'} text="Clear output" onClick={clearOutput} />
       </div>
       <div>

--- a/apps/src/codebridge/ControlButtons/control-buttons.module.scss
+++ b/apps/src/codebridge/ControlButtons/control-buttons.module.scss
@@ -1,0 +1,4 @@
+.controlButtonsContainer {
+  grid-area: control-buttons;
+  text-align: center;
+}

--- a/apps/src/codebridge/ControlButtons/control-buttons.module.scss
+++ b/apps/src/codebridge/ControlButtons/control-buttons.module.scss
@@ -1,4 +1,16 @@
+@import 'color.scss';
+
 .controlButtonsContainer {
   grid-area: control-buttons;
-  text-align: center;
+  display: flex;
+  padding: 8px 0;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+  background-color: $neutral_dark80;
+}
+
+.controlButton {
+  margin-left: 8px;
+  margin-right: 8px;
 }

--- a/apps/src/codebridge/ControlButtons/index.tsx
+++ b/apps/src/codebridge/ControlButtons/index.tsx
@@ -3,8 +3,8 @@ import {appendSystemMessage} from '@codebridge/redux/consoleRedux';
 import React from 'react';
 import {useDispatch} from 'react-redux';
 
+import Button from '@cdo/apps/componentLibrary/button';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
-import Button from '@cdo/apps/templates/Button';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {useFetch} from '@cdo/apps/util/useFetch';
 
@@ -37,16 +37,21 @@ const ControlButtons: React.FunctionComponent = () => {
   return (
     <div className={moduleStyles.controlButtonsContainer}>
       <Button
-        type={'button'}
         text="Run"
         onClick={() => handleRun(false)}
         disabled={loading}
+        iconLeft={{iconStyle: 'solid', iconName: 'play'}}
+        className={moduleStyles.controlButton}
+        size={'s'}
       />
       <Button
-        type={'button'}
         text="Test"
         onClick={() => handleRun(true)}
         disabled={loading}
+        iconLeft={{iconStyle: 'solid', iconName: 'flask'}}
+        color={'black'}
+        className={moduleStyles.controlButton}
+        size={'s'}
       />
     </div>
   );

--- a/apps/src/codebridge/ControlButtons/index.tsx
+++ b/apps/src/codebridge/ControlButtons/index.tsx
@@ -1,0 +1,55 @@
+import {useCodebridgeContext} from '@codebridge/codebridgeContext';
+import {appendSystemMessage} from '@codebridge/redux/consoleRedux';
+import React from 'react';
+import {useDispatch} from 'react-redux';
+
+import {MultiFileSource} from '@cdo/apps/lab2/types';
+import Button from '@cdo/apps/templates/Button';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useFetch} from '@cdo/apps/util/useFetch';
+
+import moduleStyles from './control-buttons.module.scss';
+
+interface PermissionResponse {
+  permissions: string[];
+}
+
+const ControlButtons: React.FunctionComponent = () => {
+  const {onRun} = useCodebridgeContext();
+  const {loading, data} = useFetch('/api/v1/users/current/permissions');
+  const dispatch = useDispatch();
+
+  const source = useAppSelector(
+    state => state.lab2Project.projectSource?.source
+  ) as MultiFileSource | undefined;
+
+  const handleRun = (runTests: boolean) => {
+    if (onRun) {
+      const parsedPermissions = data
+        ? (data as PermissionResponse)
+        : {permissions: []};
+      onRun(runTests, dispatch, parsedPermissions.permissions, source);
+    } else {
+      dispatch(appendSystemMessage("We don't know how to run your code."));
+    }
+  };
+
+  return (
+    <div className={moduleStyles.controlButtonsContainer}>
+      <Button
+        type={'button'}
+        text="Run"
+        onClick={() => handleRun(false)}
+        disabled={loading}
+      />
+      <Button
+        type={'button'}
+        text="Test"
+        onClick={() => handleRun(true)}
+        disabled={loading}
+      />
+    </div>
+  );
+};
+
+export default ControlButtons;

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -61,7 +61,7 @@ const defaultConfig: ConfigType = {
       action: () => window.alert('You are already on the file browser'),
     },
   ],
-  gridLayoutRows: '1fr 1fr 1fr 50px',
+  gridLayoutRows: '1fr 1fr 1fr 48px',
   gridLayoutColumns: '300px minmax(0, 1fr)',
   gridLayout: `
     "info-panel workspace"

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -22,18 +22,12 @@ const defaultProject: ProjectSources = {
         name: MAIN_PYTHON_FILE,
         language: 'py',
         contents: 'print("Hello world!")',
-        folderId: '1',
+        folderId: '0',
         active: true,
         open: true,
       },
     },
-    folders: {
-      '1': {
-        id: '1',
-        name: 'src',
-        parentId: '0',
-      },
-    },
+    folders: {},
   },
 };
 
@@ -67,12 +61,13 @@ const defaultConfig: ConfigType = {
       action: () => window.alert('You are already on the file browser'),
     },
   ],
-  gridLayoutRows: '1fr 1fr 1fr',
+  gridLayoutRows: '1fr 1fr 1fr 50px',
   gridLayoutColumns: '300px minmax(0, 1fr)',
   gridLayout: `
     "info-panel workspace"
     "file-browser workspace"
     "file-browser console"
+    "file-browser control-buttons"
   `,
 };
 


### PR DESCRIPTION
Previously the run/test/clear console buttons were at the top of the console and could be scrolled out of view. This PR aligns these buttons with the figma and improves the console styling a bit:
- The console now has a "Console" header
- There is a clear console icon-only button in the new header
- The run and text buttons are centered below the console
- The console text is selectable

## Screenshots
(Ignore the extra links button being in one but not the other)
### Before
![Screenshot 2024-05-22 at 9 58 08 AM](https://github.com/code-dot-org/code-dot-org/assets/33666587/c3384670-00d3-48ef-b2a4-2df901d2e2e0)

### After
![Screenshot 2024-05-22 at 9 57 41 AM](https://github.com/code-dot-org/code-dot-org/assets/33666587/0016f0a6-a743-4606-a7a5-c78bd5e9eada)


## Links
- jira ticket: [CT-595](https://codedotorg.atlassian.net/browse/CT-595)
- [figma](https://www.figma.com/design/vcNGOFsIks0HhRk6GEOfZf/Upper-Lab?node-id=3049-3362&m=dev)


## Testing story
Tested locally.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
