### PR TITLE
Gen AI: chat logs to CSV script

### DIFF
--- a/bin/oneoff/aichat_logs_to_csv
+++ b/bin/oneoff/aichat_logs_to_csv
@@ -16,8 +16,8 @@ def main
 
   CSV.open("aichat_logs_#{options[:section_id]}_#{options[:date]}.csv", "w") do |csv|
     headers = %w[
-      session_id user_id username name level_id script_id project_id created_at
-      updated_at selectedModelId temperature systemPrompt retrievalContexts
+      session_id user_id username name path created_at updated_at
+      selectedModelId temperature systemPrompt retrievalContexts
       status role content
     ]
     csv << headers
@@ -33,14 +33,16 @@ def main
       messages = JSON.parse(session.messages)
       user = session.user
 
+      level = Level.find(session.level_id)
+      script_level = level.script_levels.find_by_script_id(session.script_id)
+      path = script_level.path
+
       base_row = [
         session.id,
         session.user_id,
         user.username,
         user.name,
-        session.level_id,
-        session.script_id,
-        session.project_id,
+        path,
         session.created_at,
         session.updated_at,
         model_customizations["selectedModelId"],

--- a/bin/oneoff/aichat_logs_to_csv
+++ b/bin/oneoff/aichat_logs_to_csv
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+
+require 'csv'
+require_relative '../../dashboard/config/environment'
+
+def main
+  CSV.open("output.csv", "w") do |csv|
+    headers = %w[
+      id user_id level_id script_id project_id created_at
+      updated_at selectedModelId temperature systemPrompt retrievalContexts
+      status role content
+    ]
+    csv << headers
+
+    AichatSession.last(10).each do |session|
+      model_customizations = JSON.parse(session.model_customizations)
+      messages = JSON.parse(session.messages)
+
+      base_row = [
+        session.id,
+        session.user_id,
+        session.level_id,
+        session.script_id,
+        session.project_id,
+        session.created_at,
+        session.updated_at,
+        model_customizations["selectedModelId"],
+        model_customizations["temperature"],
+        model_customizations["systemPrompt"],
+        model_customizations["retrievalContexts"],
+      ]
+
+      messages.each do |message|
+        row = [
+          *base_row,
+          message["status"],
+          message["role"],
+          message["content"]
+        ]
+        csv << row
+      end
+    end
+  end
+end
+
+main

--- a/bin/oneoff/aichat_logs_to_csv
+++ b/bin/oneoff/aichat_logs_to_csv
@@ -4,19 +4,28 @@ require 'csv'
 require_relative '../../dashboard/config/environment'
 
 def main
-  CSV.open("output.csv", "w") do |csv|
+  options = {}
+  OptionParser.new do |opts|
+    opts.on('--section_id SECTION_ID') do |section_id|
+      options[:section_id] = Integer(section_id)
+    end
+    opts.on('--date DATE') do |date|
+      options[:date] = Date.parse(date)
+    end
+  end.parse!
+
+  CSV.open("aichat_logs_#{options[:section_id]}_#{options[:date]}.csv", "w") do |csv|
     headers = %w[
-      id user_id username name level_id script_id project_id created_at
+      session_id user_id username name level_id script_id project_id created_at
       updated_at selectedModelId temperature systemPrompt retrievalContexts
       status role content
     ]
     csv << headers
 
-    student_users_in_section = Section.find(ARGV[0]).followers.map(&:student_user)
-    date = Date.parse(ARGV[1])
+    student_users_in_section = Section.find(options[:section_id]).followers.map(&:student_user)
     sessions = AichatSession.where(
       user: student_users_in_section,
-      created_at: date.beginning_of_day..date.end_of_day
+      created_at: options[:date].beginning_of_day..options[:date].end_of_day
     )
 
     sessions.each do |session|

--- a/bin/oneoff/aichat_logs_to_csv
+++ b/bin/oneoff/aichat_logs_to_csv
@@ -6,19 +6,29 @@ require_relative '../../dashboard/config/environment'
 def main
   CSV.open("output.csv", "w") do |csv|
     headers = %w[
-      id user_id level_id script_id project_id created_at
+      id user_id username name level_id script_id project_id created_at
       updated_at selectedModelId temperature systemPrompt retrievalContexts
       status role content
     ]
     csv << headers
 
-    AichatSession.last(10).each do |session|
+    student_users_in_section = Section.find(ARGV[0]).followers.map(&:student_user)
+    date = Date.parse(ARGV[1])
+    sessions = AichatSession.where(
+      user: student_users_in_section,
+      created_at: date.beginning_of_day..date.end_of_day
+    )
+
+    sessions.each do |session|
       model_customizations = JSON.parse(session.model_customizations)
       messages = JSON.parse(session.messages)
+      user = session.user
 
       base_row = [
         session.id,
         session.user_id,
+        user.username,
+        user.name,
         session.level_id,
         session.script_id,
         session.project_id,

--- a/dashboard/app/models/aichat_session.rb
+++ b/dashboard/app/models/aichat_session.rb
@@ -17,4 +17,5 @@
 #  index_acs_user_level_script  (user_id,level_id,script_id)
 #
 class AichatSession < ApplicationRecord
+  belongs_to :user
 end


### PR DESCRIPTION
Generates a CSV of chat logs for a given section on a given date. Plan for now would be to run this on `production-console`, then copy down the generated CSV to a dev machine to send to a teacher. Note that this is a placeholder for the pilot until we can build a more self-serve solution for teachers.

Here's an example of what the generated CSV would look like: [link](https://docs.google.com/spreadsheets/d/1u2oqHCMVRQWyLv-LuUVrIi5WfV23z256PCYMX2W60pU/edit#gid=1545249476)

To run: `./bin/oneoff/aichat_logs_to_csv --section_id 123 --date 2024-05-21`

## Links

- jira: https://codedotorg.atlassian.net/browse/LABS-843

## Testing story

Tested manually with two students in a section that I created that the CSV generated looked reasonable.

## Follow-up work

We will probably need to do a bit of follow-up work to support requests for a date range (rather than single date) or a single student (rather than a whole section), but this should work for the one request we've gotten for logging.