### PR TITLE
Add Code bridge section to new level page

### DIFF
--- a/dashboard/app/views/levels/new.html.haml
+++ b/dashboard/app/views/levels/new.html.haml
@@ -60,8 +60,12 @@
   %li= link_to 'Build an External Link Level', new_level_path(type: 'ExternalLink')
   %li= link_to 'Build a Java Lab level', new_level_path(type: 'Javalab')
   %li= link_to 'Build a Music Lab level', new_level_path(type: 'Music')
-  %li= link_to 'Build a Python Lab level', new_level_path(type: 'Pythonlab')
   %li= link_to 'Build a Panels level', new_level_path(type: 'Panels')
+
+%h2 Code Bridge
+%p These level types are still in development (expect breaking changes), and are not yet localized (en_us only!)
+%ul
+  %li= link_to 'Build a Python Lab level', new_level_path(type: 'Pythonlab')
   %li= link_to 'Build a Web Lab 2 level', new_level_path(type: 'Weblab2')
 
 %h2 Your Levels


### PR DESCRIPTION
Small update to the new level page to add a Code Bridge section with Web Lab 2 and Python Lab listed in it.

## Screenshot
![Screenshot 2024-05-22 at 10 55 30 AM](https://github.com/code-dot-org/code-dot-org/assets/33666587/56196077-3014-497a-8c5f-8f62b244387b)


## Links

- jira ticket: [CT-460](https://codedotorg.atlassian.net/browse/CT-460)

## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
