### PR TITLE
[Levelbuilder] show block name field for programming expressions

### DIFF
--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -179,7 +179,7 @@ class ProgrammingExpression < ApplicationRecord
       blockName: block_name,
       categoryKey: programming_environment_category&.key,
       programmingEnvironmentName: programming_environment.name,
-      environmentEditorLanguage: programming_environment.editor_language,
+      environmentLanguageType: programming_environment.editor_language,
       imageUrl: image_url,
       videoKey: video_key,
       shortDescription: short_description || '',


### PR DESCRIPTION
Our block documentation editor should have a field for specifying the block name. It looks like it used to be there, but a regression was introduced with this commit: https://github.com/code-dot-org/code-dot-org/commit/9ee5bc33ab0388d4f4b1b969cc120f83edb64ce3

Nobody has been actively working on block documentation over the last two years so it hadn't be noticed until now.

The cause of the bug is a simple key mismatch: https://github.com/code-dot-org/code-dot-org/blob/c0cc3aa6cf0dcdc64931456e9cb0767bdddd8578/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx#L154

By renaming the key, the block name field comes back.

|Before|After|
|-|-|
|<img width="585" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/5f57bba8-42a6-4e48-943e-86cab4e19066">|<img width="586" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/fdadc659-cd9e-4a38-8191-5f6f2d2d0bca">|





## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
