### PR TITLE
Music: increment counter metric on level load

### DIFF
--- a/apps/src/lab2/Lab2MetricsReporter.ts
+++ b/apps/src/lab2/Lab2MetricsReporter.ts
@@ -59,6 +59,16 @@ export default class LabMetricsReporter {
     ]);
   }
 
+  public incrementCounter(
+    metricName: string,
+    dimensions: MetricDimension[] = []
+  ) {
+    MetricsReporter.incrementCounter(metricName, [
+      ...dimensions,
+      ...this.getCommonDimensions(),
+    ]);
+  }
+
   public reportSevereError(dimensions: MetricDimension[] = []) {
     MetricsReporter.incrementCounter('SevereError', [
       ...dimensions,

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -327,6 +327,23 @@ class UnconnectedMusicView extends React.Component {
         (AppConfig.getValue('show-sound-filters') === 'true' ||
           levelData?.showSoundFilters)
     );
+
+    Lab2Registry.getInstance()
+      .getMetricsReporter()
+      .incrementCounter('LevelLoad', [
+        {
+          name: 'Type',
+          value: this.props.isProjectLevel ? 'Project' : 'Level',
+        },
+        {
+          name: 'Mode',
+          value: this.props.isPlayView
+            ? 'Share'
+            : this.props.isReadOnlyWorkspace
+            ? 'View'
+            : 'Edit',
+        },
+      ]);
   }
 
   // Load the library and initialize the music player, if not already loaded.


### PR DESCRIPTION
Add some more metric reporting so we can better track the number of loads. This metric is reported with a dimension that categorizes it as either a project or level load, and a dimension that identifies the "mode" in which the project/level is (edit, view/readonly, or share).

## Testing story

Tested locally with music intro script and standalone projects. Tried edit, view, and share modes, and teacher viewing student work on the intro script.