### PR TITLE
[AI Tutor] CT-603: Add flagged content to CloudWatch logs

### DIFF
--- a/apps/src/aiTutor/chatApi.ts
+++ b/apps/src/aiTutor/chatApi.ts
@@ -29,6 +29,7 @@ const logViolationDetails = (response: OpenaiChatCompletionMessage) => {
   });
   MetricsReporter.logWarning({
     event: MetricEvent.AI_TUTOR_CHAT_PROFANITY_PII_VIOLATION,
+    content: response.flagged_content,
   });
 };
 


### PR DESCRIPTION
We're seeing a lot of PII false positives in the AI Tutor pilot, where users are asking about code like
```
here's my player class again\n\nimport java.util.ArrayList;\nimport java.util.Scanner;\n\npublic class Player extends Dealer {\n\nprivate ArrayList<Card> playerCards;\n\npublic Player(ArrayList<Card> playerCards) {\n  super(playerCards);\n}\n public String showCards() {\n    String result = \" | \";\n    for(int i = 0; i<playerCards.size(); i++) {\n      result += playerCards.get(i) + \" | \";\n    }\n    return result;\n  }\n\n\n\n  \n}
```
And getting their questions flagged for PII. Adding flagged_content to our Cloudwatch dashboard will allow us to easily see what's causing the false positives here.

This PR was put up after a discussion with Travis and @cat5inthecradle. We have filed a follow-up task to add data retention limits to these logs.

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/CT-603

## Testing story

This change is largely untested (I'm unsure how to test Cloudwatch logging locally), but I don't expect issues based on other places we log custom fields, ex.
```
    MetricsReporter.logWarning({
      event: 'BLOCK_UNEXPECTED_ARGS',
      args,
      blockText: text,
    });
```

## Deployment strategy

## Follow-up work

We have filed a follow-up task to create a new log group for these with custom data retention windows, but it is considered non-blocking: https://codedotorg.atlassian.net/browse/CT-605. So far, we have only seen false positives from our PII filter and no true positives. 

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
