### PR TITLE
Using us ip and persisting school data

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -268,7 +268,7 @@ $(document).ready(() => {
       if (isInSchoolAssociationExperiment) {
         ReactDOM.render(
           <div style={{padding: 10}}>
-            <SchoolDataInputs />
+            <SchoolDataInputs usIp={usIp} />
           </div>,
           schoolInfoMountPoint
         );

--- a/apps/src/templates/SchoolDataInputs.jsx
+++ b/apps/src/templates/SchoolDataInputs.jsx
@@ -12,7 +12,11 @@ import i18n from '@cdo/locale';
 
 import style from './school-association.module.scss';
 
+const SCHOOL_COUNTRY = 'schoolCountry';
+const US_COUNTRY_CODE = 'US';
+
 export default function SchoolDataInputs({
+  usIp,
   includeHeaders = true,
   fieldNames = {
     country: 'user[school_info_attributes][country]',
@@ -21,18 +25,25 @@ export default function SchoolDataInputs({
     schoolZip: 'user[school_info_attributes][school_zip]',
   },
 }) {
-  const [askForZip, setAskForZip] = useState(false);
-  const [isOutsideUS, setIsOutsideUS] = useState(false);
-  const [country, setCountry] = useState('');
+  // If the user filled out country before or we are detecting a US IP address
+  const detectedCountry =
+    sessionStorage.getItem(SCHOOL_COUNTRY) || (usIp ? US_COUNTRY_CODE : '');
+  const [country, setCountry] = useState(detectedCountry);
+  const [askForZip, setAskForZip] = useState(
+    detectedCountry === US_COUNTRY_CODE
+  );
+  const [isOutsideUS, setIsOutsideUS] = useState(
+    detectedCountry && detectedCountry !== US_COUNTRY_CODE
+  );
 
   // Add 'Select a country' and 'United States' to the top of the country list
   let COUNTRY_ITEMS = [
     {value: 'selectCountry', text: i18n.selectCountry()},
-    {value: 'US', text: i18n.unitedStates()},
+    {value: US_COUNTRY_CODE, text: i18n.unitedStates()},
   ];
   // Pull in the rest of the countries after/below
   const nonUsCountries = Object.values(COUNTRIES).filter(
-    item => item.label !== 'US'
+    item => item.label !== US_COUNTRY_CODE
   );
   for (const item of nonUsCountries) {
     COUNTRY_ITEMS.push({value: item.label, text: item.value});
@@ -41,6 +52,7 @@ export default function SchoolDataInputs({
   const onCountryChange = e => {
     const country = e.target.value;
     setCountry(country);
+    sessionStorage.setItem(SCHOOL_COUNTRY, country);
     analyticsReporter.sendEvent(
       EVENTS.COUNTRY_SELECTED,
       {country: country},
@@ -48,7 +60,7 @@ export default function SchoolDataInputs({
     );
     // We don't want to display any fields to start that won't eventually be
     // necessary, so updating both of these any time country changes
-    if (country === 'US') {
+    if (country === US_COUNTRY_CODE) {
       setAskForZip(true);
       setIsOutsideUS(false);
     } else {
@@ -103,6 +115,7 @@ export default function SchoolDataInputs({
 }
 
 SchoolDataInputs.propTypes = {
+  usIp: PropTypes.bool,
   includeHeaders: PropTypes.bool,
   fieldNames: PropTypes.object,
 };

--- a/apps/src/templates/SchoolNameInput.jsx
+++ b/apps/src/templates/SchoolNameInput.jsx
@@ -6,8 +6,10 @@ import i18n from '@cdo/locale';
 
 import style from './school-association.module.scss';
 
+const SCHOOL_NAME = 'schoolName';
 export default function SchoolNameInput({fieldNames}) {
-  const [schoolName, setSchoolName] = useState('');
+  const detectedName = sessionStorage.getItem(SCHOOL_NAME) || '';
+  const [schoolName, setSchoolName] = useState(detectedName);
 
   return (
     <label>
@@ -19,6 +21,7 @@ export default function SchoolNameInput({fieldNames}) {
         name={fieldNames.schoolName}
         onChange={e => {
           setSchoolName(e.target.value);
+          sessionStorage.setItem(SCHOOL_NAME, e.target.value);
         }}
         value={schoolName}
       />

--- a/apps/src/templates/SchoolZipSearch.jsx
+++ b/apps/src/templates/SchoolZipSearch.jsx
@@ -23,18 +23,24 @@ const SEARCH_DEFAULTS = [
   {value: NO_SCHOOL_SETTING, text: i18n.noSchoolSetting()},
 ];
 const ZIP_REGEX = new RegExp(/(^\d{5}$)/);
+const SCHOOL_ZIP = 'schoolZip';
+const SCHOOL_ID = 'schoolId';
 
 // Controls the logic and components surrounding a zip input box and its error
 // messaging, the api school search filtered on zip, and the school dropdown
 // that search populates.
 export default function SchoolZipSearch({fieldNames}) {
-  const [selectedSchoolNcesId, setSelectedSchoolNcesId] =
-    useState(SELECT_A_SCHOOL);
+  const detectedSchoolId = sessionStorage.getItem(SCHOOL_ID);
+  const detectedZip = sessionStorage.getItem(SCHOOL_ZIP);
+  const [selectedSchoolNcesId, setSelectedSchoolNcesId] = useState(
+    detectedSchoolId || SELECT_A_SCHOOL
+  );
   const [inputManually, setInputManually] = useState(false);
   const [dropdownSchools, setDropdownSchools] = useState([]);
-  const [zip, setZip] = useState('');
-  const [isSchoolDropdownDisabled, setIsSchoolDropdownDisabled] =
-    useState(true);
+  const [zip, setZip] = useState(detectedZip || '');
+  const [isSchoolDropdownDisabled, setIsSchoolDropdownDisabled] = useState(
+    !detectedZip
+  );
 
   const labelClassName = isSchoolDropdownDisabled
     ? classNames(style.padding, style.disabledLabel)
@@ -43,7 +49,11 @@ export default function SchoolZipSearch({fieldNames}) {
   useEffect(() => {
     const isValidZip = ZIP_REGEX.test(zip);
     if (isValidZip) {
-      setSelectedSchoolNcesId(SELECT_A_SCHOOL);
+      if (zip !== sessionStorage.getItem(SCHOOL_ZIP)) {
+        // Clear out school from dropdown if zip has changed
+        setSelectedSchoolNcesId(SELECT_A_SCHOOL);
+      }
+      sessionStorage.setItem(SCHOOL_ZIP, zip);
       const searchUrl = `/dashboardapi/v1/schoolzipsearch/${zip}`;
       fetch(searchUrl, {headers: {'X-Requested-With': 'XMLHttpRequest'}})
         .then(response => (response.ok ? response.json() : []))
@@ -67,6 +77,10 @@ export default function SchoolZipSearch({fieldNames}) {
       setIsSchoolDropdownDisabled(true);
     }
   }, [zip]);
+
+  useEffect(() => {
+    sessionStorage.setItem(SCHOOL_ID, selectedSchoolNcesId);
+  }, [selectedSchoolNcesId]);
 
   const sendAnalyticsEvent = (eventName, data) => {
     analyticsReporter.sendEvent(eventName, data, PLATFORMS.BOTH);


### PR DESCRIPTION
This PR combines two upgrades: detecting US IP addresses to prepopulate country, and saving school selections in session storage so if a user tries to save with other form errors, their fields will keep the information they entered in their prior attempt. 

I tried to cover as many edge cases in one round as I could think of (while utilizing attempts to save incomplete registration fields to show the most common use case of this work). 


https://github.com/code-dot-org/code-dot-org/assets/37230822/5779dcd7-feea-4797-8fd7-4c6628e98caa


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1905
- https://codedotorg.atlassian.net/browse/ACQ-1906

## Testing story

See screen recording above!

Additionally, I added tests to the schoolDataInputs test file so that I could check the functionality of School Association on the whole.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
