### PR TITLE
Music: fix typo in skip dialog

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2612,7 +2612,7 @@
   "signingInWord3": "3. Type in their secret words and hit 'sign in'.",
   "skipPuzzle": "Skip puzzle",
   "skipTitle": "Are you sure you want to skip the tutorial?",
-  "skipBody": "This will skip the tutorial and take you the project.",
+  "skipBody": "This will skip the tutorial and take you to the project.",
   "skipToProject": "Skip to project",
   "slideDecks": "Slide Decks",
   "slowLoading": "This is taking longer than usual...",


### PR DESCRIPTION
Fix a typo in the skip confirmation dialog.  Thanks to @castro-jorge for catching.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/57844.
