### PR TITLE
Fix extra links on prod (again)

### DIFF
--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -341,6 +341,11 @@ class Ability
       end
     end
 
+    # We allow loading extra links on non-levelbuilder environments (such as prod)
+    if user.persisted? && user.permission?(UserPermission::LEVELBUILDER)
+      can :extra_links, Level
+    end
+
     # In order to accommodate the possibility of there being no database, we
     # need to check that the user is persisted before checking the user
     # permissions.


### PR DESCRIPTION
#58644 did not fix the entire issue of the new extra links box not showing up on prod. I also needed to update `ability.rb` to allow getting extra links on any environment.

## Links

- jira ticket: [CT-606](https://codedotorg.atlassian.net/browse/CT-606)


## Testing story
Tested locally. I was able to reproduce the error by turning levelbuilder off of my local environment. This fix allowed me to load extra links again.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
