### PR TITLE
Reverting link to csc-ecosystem to latest version in CSC curriculum page.

### DIFF
--- a/pegasus/sites.v3/code.org/views/carousel_csc_week_long.haml
+++ b/pegasus/sites.v3/code.org/views/carousel_csc_week_long.haml
@@ -29,7 +29,7 @@
       title: hoc_s(:module_name_simulating_marine_ecosystem),
       image: "/images/csc-module-simulating-marine-ecosystem.png",
       desc: hoc_s(:module_desc_simulating_marine_ecosystem),
-      url: CDO.studio_url("/s/csc-ecosystems-2023?viewAs=Instructor"),
+      url: CDO.studio_url("/s/csc-ecosystems?viewAs=Instructor"),
       aria_label: hoc_s(:aria_label_call_to_action_module_simulating_marine_ecosystem),
     },
     {


### PR DESCRIPTION
The link to various CSC modules in the carousal at https://code.org/curriculum/csc#csc-week-long-modules use the family name of the course as it redirects to the latest version of the course. But, this link was broken for csc-ecosystems module and as a stop gap, the link to specific 2023 version of the course was put in place.

The underlying redirect issue has since been fixed https://codedotorg.atlassian.net/browse/TEACH-872

This change reverts the stop gap to again use the course family name in the URL and hence redirect to the latest version of the course.

## Links

Don't have a ticket for this.

## Testing story

Local testing and drone

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
