### PR TITLE
Speculative flaky test fix: waiting for elements to load over time-based pause

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -153,7 +153,8 @@ Scenario: congrats certificate pages
   Given I am on "http://studio.code.org/congrats"
   And I wait until element "#uitest-certificate" is visible
   And element "#uitest-certificate" is visible
-  And I wait for 5 seconds
+  And I wait until element ".fa-facebook" is visible
+  And I wait until element ".fa-twitter" is visible
   And I open my eyes to test "congrats certificate pages"
 
   When I am on "http://code.org/api/hour/finish/flappy"
@@ -161,7 +162,8 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait for 5 seconds
+  And I wait until element ".fa-facebook" is visible
+  And I wait until element ".fa-twitter" is visible
   And I see no difference for "uncustomized flappy certificate"
 
   When I type "Robo Códer" into "#name"
@@ -175,7 +177,8 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait for 5 seconds
+  And I wait until element ".fa-facebook" is visible
+  And I wait until element ".fa-twitter" is visible
   And I see no difference for "uncustomized oceans certificate"
 
   When I type "Robo Códer" into "#name"
@@ -189,7 +192,8 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait for 5 seconds
+  And I wait until element ".fa-facebook" is visible
+  And I wait until element ".fa-twitter" is visible
   And I see no difference for "uncustomized 20-hour certificate"
 
   When I type "Robo Códer" into "#name"
@@ -206,7 +210,8 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait for 5 seconds
+  And I wait until element ".fa-facebook" is visible
+  And I wait until element ".fa-twitter" is visible
   And I see no difference for "uncustomized Course A 2017 certificate"
 
   When I type "Robo Códer" into "#name"


### PR DESCRIPTION
Our favorite flaky eyes test failed again today waiting for the Facebook icon to load. Instead of bumping the number of seconds we wait again, I'm suggesting waiting for the Facebook icon itself to load. In this PR, I replaced most of the "wait 5 seconds" steps with steps to wait for the social media icons to load, except when we are trying to check personalized certificates as those icons should have already loaded. I assume in those cases there was a different flakiness we've observed, so I didn't touch that in this PR.


## Testing story

passed Drone. Will revert if flakiness gets worse on test.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
