### PR TITLE
Update some stats and links

### DIFF
--- a/i18n/locales/source/hourofcode/en.yml
+++ b/i18n/locales/source/hourofcode/en.yml
@@ -10808,7 +10808,7 @@
 
   about_us_page_title: "About Us"
   about_us_page_hero_description: "Code.org® is an education innovation nonprofit dedicated to the vision that every student in every school has the opportunity to learn computer science as part of their core K-12 education. We expand access to computer science in schools, with a focus on increasing participation by young women and students from other underrepresented groups.  The leading provider of K-12 computer science curriculum in the largest school districts in the United States, Code.org also organizes the annual [Hour of Code](%{hour_url}) campaign, which has engaged more than 15% of all students in the world. Code.org is supported by generous donors including Microsoft, Amazon, Google and [many others.](%{others_url})"
-  about_us_page_section_title_1: "Over 80 million students and 2 million teachers on Code.org"
+  about_us_page_section_title_1: "Over 92 million students and 2.7 million teachers on Code.org"
   about_us_page_statistic_figcaption: "Code.org participation from the 2021-2022 school year. [See disaggregated data.](%{data_url})"
   about_us_page_statistic_description: "Code.org increases diversity in computer science by reaching students of all backgrounds where they are — at their skill-level, in their schools, and in ways that inspire them to keep learning. The vast majority of the students on Code.org are from student groups historically underrepresented in computer science. Increasing diversity in computer science is foundational to our work, and [we encourage you to read more about our efforts](%{diversity_url})."
   about_us_page_section_title_2: "Code.org in the News"

--- a/pegasus/sites.v3/code.org/public/about/index.haml
+++ b/pegasus/sites.v3/code.org/public/about/index.haml
@@ -33,7 +33,7 @@ set_dir: true
       %img{src: "/images/marketing/diversity/code_frl.png", style:"max-width: 100%"}
 .div{style:"clear: both;"}
   %figcaption{style: "text-align: center; font-size: 13px"}
-    =hoc_s(:about_us_page_statistic_figcaption, markdown: :inline, locals: {data_url: "/promote/diversitydata"})
+    =hoc_s(:about_us_page_statistic_figcaption, markdown: :inline, locals: {data_url: "/diversity"})
   %br
     =hoc_s(:about_us_page_statistic_description, markdown: :inline, locals: {diversity_url: "/diversity"})
 

--- a/pegasus/sites.v3/code.org/views/stats_homepage.haml
+++ b/pegasus/sites.v3/code.org/views/stats_homepage.haml
@@ -3,7 +3,7 @@
   female_students = "39M"
   project_count = fetch_project_count['rounded_down_millions']
   project_count = project_count.to_s + "M"
-  teacher_users = "2M"
+  teacher_users = "2.7M"
   states_policy_change = "50"
 
   top_statistic_number = student_accounts


### PR DESCRIPTION
Update student and teacher number on /about
![Screenshot 2024-05-23 at 11 42 05 AM](https://github.com/code-dot-org/code-dot-org/assets/208083/14435d6e-450e-444e-8ea9-d4b3c450c1db)

Homepage move teachers from 2M to 2.7M
![Screenshot 2024-05-23 at 11 34 18 AM](https://github.com/code-dot-org/code-dot-org/assets/208083/e297d2f6-8248-40d2-80ca-7abe9e62e624)

got rid of /diversitydata links because we deprecated that page
