### PR TITLE
Modify script for adding users to V2 pilot to address errors encountered

### DIFF
--- a/bin/oneoff/add_progress_v2_closed_beta_users
+++ b/bin/oneoff/add_progress_v2_closed_beta_users
@@ -30,7 +30,6 @@ CSV.table(teacher_id_csv, encoding: 'iso-8859-1:utf-8').by_col[:id].each do |id|
     count += 1
   rescue ActiveRecord::RecordInvalid
     puts "RecordInvalid error #{id}"
-    next
   end
 end
 

--- a/bin/oneoff/add_progress_v2_closed_beta_users
+++ b/bin/oneoff/add_progress_v2_closed_beta_users
@@ -24,9 +24,13 @@ CSV.table(teacher_id_csv, encoding: 'iso-8859-1:utf-8').by_col[:id].each do |id|
     next
   end
 
-  if user.teacher?
+  next unless user.teacher?
+  begin
     user.update!(progress_table_v2_closed_beta: true)
     count += 1
+  rescue ActiveRecord::RecordInvalid
+    puts "RecordInvalid error #{id}"
+    next
   end
 end
 


### PR DESCRIPTION
Modified Ruby Script for adding new teachers to the closed beta. 

Based on when we used the script last time, we got an `ActiveRecord::RecordInvalid` error.  This addresses the error.  We tested this out when we modified the file on production.