### PR TITLE
Music: triggered immediately sounds sometimes don't play

### DIFF
--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -281,20 +281,6 @@ class ToneJSPlayer implements AudioPlayer {
       player.toDestination();
     }
 
-    const startPosition = sample.playbackPosition;
-    const currentTime = this.getCurrentPlaybackPosition();
-    if (startPosition < currentTime && startPosition - currentTime > -0.01) {
-      console.log(`Offset: ${startPosition - currentTime}`);
-      console.log(
-        `Sample time ${startPosition}; Current time ${currentTime}. Adjusting start time.`
-      );
-      console.log(
-        `start transport time: ${this.playbackTimeToTransportTime(
-          startPosition
-        )}`
-      );
-      console.log(`current transport time: ${Transport.position}`);
-    }
     player
       .sync()
       .start(this.playbackTimeToTransportTime(sample.playbackPosition));

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -281,6 +281,20 @@ class ToneJSPlayer implements AudioPlayer {
       player.toDestination();
     }
 
+    const startPosition = sample.playbackPosition;
+    const currentTime = this.getCurrentPlaybackPosition();
+    if (startPosition < currentTime && startPosition - currentTime > -0.01) {
+      console.log(`Offset: ${startPosition - currentTime}`);
+      console.log(
+        `Sample time ${startPosition}; Current time ${currentTime}. Adjusting start time.`
+      );
+      console.log(
+        `start transport time: ${this.playbackTimeToTransportTime(
+          startPosition
+        )}`
+      );
+      console.log(`current transport time: ${Transport.position}`);
+    }
     player
       .sync()
       .start(this.playbackTimeToTransportTime(sample.playbackPosition));
@@ -375,8 +389,10 @@ class ToneJSPlayer implements AudioPlayer {
   ): BarsBeatsSixteenths {
     const bar = Math.floor(playbackPosition);
     const beat = Math.floor((playbackPosition - bar) * 4);
-    const sixteenths = Math.floor((playbackPosition - bar - beat / 4) * 16);
-    return `${bar - 1}:${beat}:${sixteenths}`;
+    const sixteenths = (playbackPosition - bar - beat / 4) * 16;
+    // Round sixteenths note value to 3 decimal places.
+    const sixteenthsRounded = Math.round(sixteenths * 1000) / 1000;
+    return `${bar - 1}:${beat}:${sixteenthsRounded}`;
   }
 
   private createPlayer(
@@ -405,6 +421,8 @@ class ToneJSPlayer implements AudioPlayer {
   }
 
   private generateEffectBusses() {
+    // Dispose of all existing effect busses
+    Object.values(this.effectBusses).forEach(node => node.dispose());
     BUS_EFFECT_COMBINATIONS.forEach(effects => {
       const {filter, delay} = effects;
       let firstNode, lastNode;


### PR DESCRIPTION
The issue here was just that we were rounding playback time to the nearest sixteenth when converting to ToneJS's transport time. Now, we'll convert to the nearest 1/1000 of a sixteenth note, which is the precision that the ToneJS Transport gives us when we ask for its current time.

Also includes a small optimization to make sure we clean up any existing effect busses when creating new ones.

https://github.com/code-dot-org/code-dot-org/assets/85528507/90b53908-eb25-4942-9537-c9d31d89f1d9

## Links

https://codedotorg.atlassian.net/browse/LABS-846

## Testing story

Tested locally on standalone projects with a few different songs of varying tempos.