### PR TITLE
Fix Violations of and Reenable `Style/IfWithBooleanLiteralBranches`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -225,13 +225,6 @@ Style/GlobalVars:
 Style/HashLikeCase:
   Enabled: false
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: nonzero?
-Style/IfWithBooleanLiteralBranches:
-  Enabled: false
-
 # Offense count: 21
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: InverseMethods, InverseBlocks.

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -207,7 +207,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
       workshop = if Pd::Workshop::ACADEMIC_YEAR_WORKSHOP_SUBJECTS.include?(test_case[:subject])
                    create :academic_year_workshop, course: test_case[:course], subject: test_case[:subject]
                  else
-                   suppress_email = Pd::Workshop::MUST_SUPPRESS_EMAIL_SUBJECTS.include?(test_case[:subject]) ? true : false
+                   suppress_email = Pd::Workshop::MUST_SUPPRESS_EMAIL_SUBJECTS.include?(test_case[:subject])
                    create :workshop, course: test_case[:course], subject: test_case[:subject], suppress_email: suppress_email
                  end
 


### PR DESCRIPTION
> Checks for redundant `if` with boolean literal branches. It checks only conditions to return boolean value (`true` or `false`) for safe detection. The conditions to be checked are comparison methods, predicate methods, and double negation (!!). `nonzero?` method is allowed by default. These are customizable with `AllowedMethods` option.

This is a pretty straightforward one! We only have a single violation, and I'd say the fix makes it more readable. It's also in a test file, so it's about as safe as changes get.

Fix applied automatically with `bundle exec rubocop --autocorrect-all --only Style/IfWithBooleanLiteralBranches`

## Links

- https://docs.rubocop.org/rubocop/cops_style.html#styleifwithbooleanliteralbranches
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfWithBooleanLiteralBranches

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
