### PR TITLE
Add DCDO Flag to Disable Session Migration

### DIFF
--- a/dashboard/config/custom_session_store/migrate_cookies_to_redis_store.rb
+++ b/dashboard/config/custom_session_store/migrate_cookies_to_redis_store.rb
@@ -30,6 +30,10 @@ module ActionDispatch
       # If the cookie does not contain any existing session data, do nothing
       # and return nothing.
       private def migrate_session_data(request)
+        # In preparation for eventually removing this module entirely and
+        # switching to use an unmodified RedisStore instance, add a DCDO flag
+        # to dynamically disable the custom functionality this module provides.
+        return if DCDO.get('disable-migrate_session_data', false)
         stale_session_check! do
           session_data = unpacked_cookie_data(request)
           if session_data.is_a?(Hash) && !session_data.empty?


### PR DESCRIPTION
In preparation for eventually removing this code entirely, add a DCDO flag that will allow us to dynamically disable the custom functionality provided by this code, to build our confidence that removal will be safe.

Note this is probably not strictly necessary; my expectation is that we should be able to just switch to the generic RedisStore implementation directly without any user disruption. This flag represents an abundance of caution, and I don't think there's any reason not to move cautiously.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
