### PR TITLE
Provision New Production Database Cluster via CloudFormation for MySQL 8 Cutover

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -318,14 +318,16 @@
       # Credentials (username and password) for the SQL User this Resource is provisioning.
       DBCredentialSecret: !Ref DatabaseSecretReader
       Privileges: ['SELECT']
-
-# We don't provision these in production via CloudFormation ... yet!
-<%  unless rack_env?(:production)%>
   AuroraCluster:
     Type: AWS::RDS::DBCluster
     Properties:
       DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
       DBClusterParameterGroupName: !Ref AuroraClusterDBParameters
+<%  if rack_env?(:production) -%>
+      SourceDBClusterIdentifier: <%=PRODUCTION_DB_CLUSTER_ID %>
+      RestoreType: copy-on-write
+      UseLatestRestorableTime: true
+<%  end -%>
       Engine: aurora-mysql
       # Updating a Stack with a change to EngineVersion causes "Some Interruption".
       # Each Database Instance in the cluster is restarted.
@@ -343,7 +345,7 @@
         - slowquery
       DeletionProtection: <%= rack_env?(:adhoc) ? false : true %>
       BackupRetentionPeriod: !Ref DBBackupRetention
-<%    DB_INSTANCE_RANGE.each do |i| %>
+<%  DB_INSTANCE_RANGE.each do |i| %>
   Aurora<%=i%>:
     Type: AWS::RDS::DBInstance
     Properties:
@@ -354,11 +356,11 @@
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
       DBParameterGroupName: default.aurora-mysql5.7 #Explicitly stop setting a custom Instance ParameterGroup.
-<%      if rack_env?(:production) || rack_env?(:test) -%>
+<%    if rack_env?(:production) || rack_env?(:test) -%>
       EnablePerformanceInsights: true
       PerformanceInsightsRetentionPeriod: <%= rack_env?(:production) ? 465 : 7 %>
-<%      end -%>
 <%    end -%>
+<%  end -%>
   DBProxy:
     Type: AWS::RDS::DBProxy
     DependsOn: [WriterSQLUser, ReaderSQLUser]
@@ -389,5 +391,4 @@
       TargetGroupName: default
       ConnectionPoolConfigurationInfo:
         ConnectionBorrowTimeout: 10
-<%  end -%>
-<%end -%>
+<% end -%>


### PR DESCRIPTION
One possible mechanism for cutting over our production database to MySQL 8 would be to start provisioning the production database cluster via CloudFormation (production is the only environment where the cluster was provisioned manually via the web console). None of our applications would use this new cluster because all of the settings and configuration for production ignore the `AuroraCluster` Stack Resource. This change would also provision the reader and writer RDS Proxies for production.

An alternative would be to provision the new production cluster manually via the web console and then later Import it into the Stack.

## Testing story

``` bash
code-dot-org $ export AWS_PROFILE=codeorg-admin
code-dot-org $ bin/aws_access
AWS access: GoogleSignInAdmin/suresh@code.org
code-dot-org $ bundle exec rake stack:validate RAILS_ENV=production VERBOSE=veryMuchSo

Pending update for stack `autoscale-prod`:
Add Aurora0 [AWS::RDS::DBInstance]
Add Aurora1 [AWS::RDS::DBInstance]
Add AuroraCluster [AWS::RDS::DBCluster]
Add DBProxyTargetGroup [AWS::RDS::DBProxyTargetGroup]
Add DBProxy [AWS::RDS::DBProxy]
Add ReaderDBProxyEndpoint [AWS::RDS::DBProxyEndpoint]
Finished stack:validate (less than a minute)
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
