### PR TITLE
Remove Studio (Play Lab) share/remix/Add to Projects buttons

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -578,13 +578,14 @@ var projects = (module.exports = {
   // Hide Share/Remix for Play Lab because converting Play Lab level to standalone project
   // is problematic.
   shouldHideShareAndRemix() {
+    const appType = appOptions.app;
     return (
       (appOptions.level && appOptions.level.hideShareAndRemix) ||
       (appOptions.embed &&
-        (appOptions.app === 'applab' ||
-          appOptions.app === 'gamelab' ||
-          appOptions.app === 'spritelab')) ||
-      appOptions.app === 'studio'
+        (appType === 'applab' ||
+          appType === 'gamelab' ||
+          appType === 'spritelab')) ||
+      (appType === 'studio' && appOptions.skinId === 'studio')
     );
   },
 

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -575,7 +575,7 @@ var projects = (module.exports = {
 
   // Students should not be able to easily see source for embedded applab or
   // gamelab levels.
-  // Hide Share/Remix for Play Lab because converting Play Lab level to standalone project
+  // Hide Share/Remix for studio app because converting studio level to standalone project
   // is problematic.
   shouldHideShareAndRemix() {
     const appType = appOptions.app;
@@ -585,7 +585,7 @@ var projects = (module.exports = {
         (appType === 'applab' ||
           appType === 'gamelab' ||
           appType === 'spritelab')) ||
-      (appType === 'studio' && appOptions.skinId === 'studio')
+      appType === 'studio'
     );
   },
 

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -575,13 +575,16 @@ var projects = (module.exports = {
 
   // Students should not be able to easily see source for embedded applab or
   // gamelab levels.
+  // Hide Share/Remix for Play Lab because converting Play Lab level to standalone project
+  // is problematic.
   shouldHideShareAndRemix() {
     return (
       (appOptions.level && appOptions.level.hideShareAndRemix) ||
       (appOptions.embed &&
         (appOptions.app === 'applab' ||
           appOptions.app === 'gamelab' ||
-          appOptions.app === 'spritelab'))
+          appOptions.app === 'spritelab')) ||
+      appOptions.app === 'studio'
     );
   },
 

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -118,13 +118,7 @@ let level;
 let skin;
 
 // These skins can be published as projects.
-const PUBLISHABLE_SKINS = [
-  'gumball',
-  'studio',
-  'iceage',
-  'infinity',
-  'hoc2015',
-];
+const PUBLISHABLE_SKINS = ['gumball', 'iceage', 'infinity', 'hoc2015'];
 
 //TODO: Make configurable.
 studioApp().setCheckForEmptyBlocks(true);
@@ -3081,6 +3075,7 @@ Studio.displayFeedback = function () {
   };
 
   if (!Studio.waitingForReport) {
+    const saveToProjectGallery = PUBLISHABLE_SKINS.includes(skin.id);
     const isSignedIn =
       getStore().getState().currentUser.signInState === SignInState.SignedIn;
     studioApp().displayFeedback({
@@ -3097,13 +3092,12 @@ Studio.displayFeedback = function () {
         !level.projectTemplateLevelName,
       feedbackImage: Studio.feedbackImage,
       twitter: skin.twitterOptions || twitterOptions,
-      // Do not save to the project gallery because converting Play Lab level to
-      // standalone project is problematic.
-      saveToProjectGallery: false,
+      // Save to the project gallery unless 'studio' skin.
+      saveToProjectGallery: saveToProjectGallery,
       disableSaveToGallery: !isSignedIn,
       message: Studio.message,
       appStrings: appStrings,
-      // Currently only true for Artist levels
+      // Currently only true for Artist levels.
       enablePrinting: level.enablePrinting,
     });
   }

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -3081,7 +3081,6 @@ Studio.displayFeedback = function () {
   };
 
   if (!Studio.waitingForReport) {
-    const saveToProjectGallery = PUBLISHABLE_SKINS.includes(skin.id);
     const isSignedIn =
       getStore().getState().currentUser.signInState === SignInState.SignedIn;
     studioApp().displayFeedback({

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -117,9 +117,6 @@ const EdgeClassNames = ['top', 'left', 'bottom', 'right'];
 let level;
 let skin;
 
-// These skins can be published as projects.
-const PUBLISHABLE_SKINS = ['gumball', 'iceage', 'infinity', 'hoc2015'];
-
 //TODO: Make configurable.
 studioApp().setCheckForEmptyBlocks(true);
 
@@ -3075,7 +3072,6 @@ Studio.displayFeedback = function () {
   };
 
   if (!Studio.waitingForReport) {
-    const saveToProjectGallery = PUBLISHABLE_SKINS.includes(skin.id);
     const isSignedIn =
       getStore().getState().currentUser.signInState === SignInState.SignedIn;
     studioApp().displayFeedback({
@@ -3092,8 +3088,9 @@ Studio.displayFeedback = function () {
         !level.projectTemplateLevelName,
       feedbackImage: Studio.feedbackImage,
       twitter: skin.twitterOptions || twitterOptions,
-      // Save to the project gallery unless 'studio' skin.
-      saveToProjectGallery: saveToProjectGallery,
+      // Do not allow saving to the project gallery because converting from level to standalone
+      // project is problematic.
+      saveToProjectGallery: false,
       disableSaveToGallery: !isSignedIn,
       message: Studio.message,
       appStrings: appStrings,

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -3098,8 +3098,9 @@ Studio.displayFeedback = function () {
         !level.projectTemplateLevelName,
       feedbackImage: Studio.feedbackImage,
       twitter: skin.twitterOptions || twitterOptions,
-      // save to the project gallery
-      saveToProjectGallery: saveToProjectGallery,
+      // Do not save to the project gallery because converting Play Lab level to
+      // standalone project is problematic.
+      saveToProjectGallery: false,
       disableSaveToGallery: !isSignedIn,
       message: Studio.message,
       appStrings: appStrings,

--- a/dashboard/app/views/levels/editors/_studio.html.haml
+++ b/dashboard/app/views/levels/editors/_studio.html.haml
@@ -13,7 +13,6 @@
 = render partial: 'levels/editors/fields/control_buttons', locals: {f: f}
 = render partial: 'levels/editors/fields/studio_fields', locals: {f: f}
 
-= render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
 = render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
@@ -52,8 +52,7 @@
         locals: {f: f, field_name: :free_play, description: "Free Play"}
       %p
         Free Play levels are not checked for correctness (any solution is
-        accepted), can be shared, and can be saved to the public and private
-        gallery
+        accepted), can be shared, and depending on the app type can be saved to the personal project gallery.
   - if @level.respond_to? :validation_enabled
     .field
       = render partial: 'levels/editors/fields/checkboxes',

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
@@ -175,23 +175,6 @@ Feature: Using the teacher dashboard
     And I press the first ".project_remix" element to load a new page
     And I wait for the page to fully load
 
-    # Create a playlab project level and generate a thumbnail.
-
-    # We don't want to have to write the code by dragging blocks, so just remix
-    # an existing project-backed level, and then run the project.
-
-    When I am on "http://studio.code.org/s/allthethings/lessons/5/levels/5"
-    And I wait for the page to fully load
-    And I press the first ".project_remix" element to load a new page
-    And I wait for the page to fully load
-    And I press "runButton"
-    And I wait until element ".project_updated_at" contains text "Saved"
-    And I wait until initial thumbnail capture is complete
-    And I press "resetButton"
-    And I click selector "#runButton" once I see it
-    # Wait for the thumbnail URL to be sent to the server.
-    And I wait until element ".project_updated_at" contains text "Saved"
-
     # Create a dance party project level and generate a thumbnail.
 
     # We don't want to have to write the code by dragging blocks, so just remix

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
@@ -208,7 +208,6 @@ Feature: Using the teacher dashboard
     And I wait until the image within element "tr:eq(2)" has loaded
     And I wait until the image within element "tr:eq(3)" has loaded
     And I wait until the image within element "tr:eq(4)" has loaded
-    And I wait until the image within element "tr:eq(5)" has loaded
 
     Then I see no difference for "projects list view"
     And I close my eyes


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR:
- removes the 'Add to Projects' button that is displayed when a user is on a studio (e.g., Play Lab) free-play level and clicks on the 'Finish' button,
- removes the Share/Remix buttons for studio project-template levels,
- updates the level edit page for 'studio' levels.

These buttons are removed because the conversion from a studio level to a studio standalone project is problematic.
The reason is that studio (Play Lab) includes a levelbuilder editable property called ‘Grid’ or `maze` in the .level file which is converted to a map [here](https://github.com/code-dot-org/code-dot-org/blob/bfbc037478ca5cd29e8feeea52660effb88a1b84/apps/src/studio/studio.js#L377-L392). This 2D array is not copied over when a level such as https://studio.code.org/s/coursec-2023/lessons/13/levels/13 is converted to a [standalone project](https://github.com/code-dot-org/code-dot-org/blob/bfbc037478ca5cd29e8feeea52660effb88a1b84/dashboard/config/levels/custom/studio/New%20Play%20Lab%20Project.level). 

This mismatch can cause additional blocks to appear (32 blocks in example above), and the actors to disappear, example at https://studio.code.org/s/courseb-2023/lessons/12/levels/8.

More details in [this Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1716479316907339).

Note that the 'Copy link to project' included in the Finish dialog does work because it copies a url that pulls from [level sources](https://github.com/code-dot-org/code-dot-org/blob/8ed4afada78c9061fbe14e4720a1f97bb23cf0a0/dashboard/config/routes.rb#L156), e.g. 'https://studio.code.org/c/1983708489'. 

## Before update

Play Lab project template level:
<img width="927" alt="Screenshot 2024-05-23 at 3 04 49 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/6a59b1f8-866c-4544-b6f1-d6fe5c9015d6">


Play Lab free-play level:
<img width="839" alt="Screenshot 2024-05-23 at 3 06 13 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/2ef56ed5-6b6b-4190-9da8-28e619c8a6f0">


## After update

Play Lab project template level:
<img width="843" alt="Screenshot 2024-05-23 at 3 08 52 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/67d30372-327f-497c-ab85-29505fee8c6e">



Play Lab free-play level:
<img width="838" alt="Screenshot 2024-05-23 at 3 09 10 PM" src="https://github.com/code-dot-org/code-dot-org/assets/107423305/a074ac2f-7d26-44ca-bb09-75764ec79bdc">

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-690)


<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally on Play Lab levels - both free play and project template levels. Also tested an Ice Age free-play level to ensure 'Add to Project' is still displayed. 's/iceage/lessons/1/levels/11'
Also checked the studio level edit page.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
