### PR TITLE
Ceara/aitt 493 analytics for rubric open on load

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -157,6 +157,8 @@ const EVENTS = {
   // Rubrics
   TA_RUBRIC_OPENED_FROM_FAB_EVENT: 'TA Rubric Opened From FAB',
   TA_RUBRIC_CLOSED_FROM_FAB_EVENT: 'TA Rubric Closed From FAB',
+  TA_RUBRIC_OPEN_ON_PAGE_LOAD: 'TA Rubric Open on Page Load',
+  TA_RUBRIC_CLOSED_ON_PAGE_LOAD: 'TA Rubric Closed on Page Load',
   TA_RUBRIC_LEARNING_GOAL_EXPANDED_EVENT: 'TA Rubric Learning Goal Expanded',
   TA_RUBRIC_LEARNING_GOAL_COLLAPSED_EVENT: 'TA Rubric Learning Goal Collapsed',
   TA_RUBRIC_ON_STUDENT_WORK_LOADED: 'TA Rubric On Student Work Loaded',

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -77,6 +77,16 @@ function RubricFloatingActionButton({
   }, [eventData, studentLevelInfo]); // Neither of these should change, so this should run once
 
   useEffect(() => {
+    analyticsReporter.sendEvent(
+      isOpen
+        ? EVENTS.TA_RUBRIC_OPEN_ON_PAGE_LOAD
+        : EVENTS.TA_RUBRIC_CLOSED_ON_PAGE_LOAD,
+      eventData
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // disabling isOpen dependency because we only want this to report the initial open state once
+
+  useEffect(() => {
     trySetSessionStorage(sessionStorageKey, isOpen);
   }, [isOpen]);
 

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -455,7 +455,6 @@ describe('RubricContainer', () => {
       8. Calls refreshAiEvaluations
     */
     clock = sinon.useFakeTimers();
-    // const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
     stubFetchEvalStatusForUser(readyJson);
     stubFetchEvalStatusForAll(readyJsonAll);
     stubFetchTeacherEvaluations(noEvals);
@@ -535,7 +534,6 @@ describe('RubricContainer', () => {
     expect(wrapper.find('RubricContent').props().aiEvaluations).to.eql(
       mockAiEvaluations
     );
-    // sendEventSpy.restore();
   });
 
   it('shows general error message for status 1000', async () => {

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -29,6 +29,7 @@ describe('RubricContainer', () => {
   let store;
   let fetchStub;
   let ajaxStub;
+  let sendEventSpy;
 
   async function wait() {
     for (let _ = 0; _ < 10; _++) {
@@ -93,6 +94,7 @@ describe('RubricContainer', () => {
         new Response(JSON.stringify({}), {status: 200, statusText: 'OK'})
       )
     );
+    sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
     sinon.stub(utils, 'queryParams').withArgs('section_id').returns('1');
     stubRedux();
     registerReducers({teacherSections, teacherPanel, currentUser});
@@ -107,6 +109,7 @@ describe('RubricContainer', () => {
     utils.queryParams.restore();
     fetchStub.restore();
     ajaxStub.restore();
+    sendEventSpy.restore();
   });
 
   const notAttemptedJson = {
@@ -452,7 +455,7 @@ describe('RubricContainer', () => {
       8. Calls refreshAiEvaluations
     */
     clock = sinon.useFakeTimers();
-    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
+    // const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
     stubFetchEvalStatusForUser(readyJson);
     stubFetchEvalStatusForAll(readyJsonAll);
     stubFetchTeacherEvaluations(noEvals);
@@ -532,7 +535,7 @@ describe('RubricContainer', () => {
     expect(wrapper.find('RubricContent').props().aiEvaluations).to.eql(
       mockAiEvaluations
     );
-    sendEventSpy.restore();
+    // sendEventSpy.restore();
   });
 
   it('shows general error message for status 1000', async () => {
@@ -740,7 +743,6 @@ describe('RubricContainer', () => {
   });
 
   it('sends event when window is dragged', async function () {
-    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
     stubFetchEvalStatusForUser(readyJson);
     stubFetchEvalStatusForAll(readyJsonAll);
     stubFetchAiEvaluations(mockAiEvaluations);
@@ -779,7 +781,6 @@ describe('RubricContainer', () => {
       EVENTS.TA_RUBRIC_WINDOW_MOVE_END,
       {window_x_end: 0, window_y_end: 0}
     );
-    sendEventSpy.restore();
   });
 
   it('renders a RubricSubmitFooter if student data for an evaluation level', () => {
@@ -928,7 +929,6 @@ describe('RubricContainer', () => {
   });
 
   it('sends event when tour is started for the first time', async function () {
-    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
     stubFetchEvalStatusForUser(readyJson);
     stubFetchEvalStatusForAll(readyJsonAll);
     stubFetchAiEvaluations(mockAiEvaluations);
@@ -954,12 +954,9 @@ describe('RubricContainer', () => {
         {}
       )
     );
-
-    sendEventSpy.restore();
   });
 
   it('sends event when user clicks next and back buttons', async function () {
-    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
     stubFetchEvalStatusForUser(readyJson);
     stubFetchEvalStatusForAll(readyJsonAll);
     stubFetchAiEvaluations(mockAiEvaluations);
@@ -1000,12 +997,9 @@ describe('RubricContainer', () => {
         nextStep: 0,
       })
     );
-
-    sendEventSpy.restore();
   });
 
   it('sends event when user exits the tour', async function () {
-    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
     stubFetchEvalStatusForUser(readyJson);
     stubFetchEvalStatusForAll(readyJsonAll);
     stubFetchAiEvaluations(mockAiEvaluations);
@@ -1037,12 +1031,9 @@ describe('RubricContainer', () => {
         }
       )
     );
-
-    sendEventSpy.restore();
   });
 
   it('sends event when user completes the tour', async function () {
-    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
     stubFetchEvalStatusForUser(readyJson);
     stubFetchEvalStatusForAll(readyJsonAll);
     stubFetchAiEvaluations(mockAiEvaluations);
@@ -1082,12 +1073,9 @@ describe('RubricContainer', () => {
         {}
       )
     );
-
-    sendEventSpy.restore();
   });
 
   it('sends event when tour is restarted from ? button', async function () {
-    const sendEventSpy = sinon.spy(analyticsReporter, 'sendEvent');
     stubFetchEvalStatusForUser(readyJson);
     stubFetchEvalStatusForAll(readyJsonAll);
     stubFetchAiEvaluations(mockAiEvaluations);
@@ -1122,7 +1110,5 @@ describe('RubricContainer', () => {
         {}
       )
     );
-
-    sendEventSpy.restore();
   });
 });

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -56,17 +56,25 @@ describe('RubricFloatingActionButton - React Testing Library', () => {
     });
 
     afterEach(() => {
+      sessionStorage.getItem.withArgs('RubricFabOpenStateKey').returns(null);
       sessionStorage.getItem.restore();
     });
 
     it('renders pulse animation when session storage is empty', () => {
+      const sendEventSpy = sinon.stub(analyticsReporter, 'sendEvent');
       sessionStorage.getItem.withArgs('RubricFabOpenStateKey').returns(null);
       render(
         <Provider store={getStore()}>
           <RubricFloatingActionButton {...defaultProps} />
         </Provider>
       );
-
+      expect(sendEventSpy).to.have.been.calledWith(
+        EVENTS.TA_RUBRIC_CLOSED_ON_PAGE_LOAD,
+        {
+          viewingStudentWork: false,
+          viewingEvaluationLevel: true,
+        }
+      );
       const fab = screen.getByRole('button', {name: 'AI bot'});
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.false;
 
@@ -77,19 +85,51 @@ describe('RubricFloatingActionButton - React Testing Library', () => {
       const taImage = screen.getByRole('img', {name: 'TA overlay'});
       fireEvent.load(taImage);
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.true;
+      sendEventSpy.restore();
+    });
+
+    it('sends open on page load event when open state is true in session storage', () => {
+      const sendEventSpy = sinon.stub(analyticsReporter, 'sendEvent');
+      sessionStorage.getItem.withArgs('RubricFabOpenStateKey').returns(true);
+      render(
+        <Provider store={getStore()}>
+          <RubricFloatingActionButton {...defaultProps} />
+        </Provider>
+      );
+      expect(sendEventSpy).to.have.been.calledWith(
+        EVENTS.TA_RUBRIC_OPEN_ON_PAGE_LOAD,
+        {
+          viewingStudentWork: false,
+          viewingEvaluationLevel: true,
+        }
+      );
+      const image = screen.getByRole('img', {name: 'AI bot'});
+      fireEvent.load(image);
+      const fab = screen.getByRole('button', {name: 'AI bot'});
+      expect(fab.classList.contains('unittest-fab-pulse')).to.be.false;
+      sendEventSpy.restore();
     });
 
     it('does not render pulse animation when open state is present in session storage', () => {
+      const sendEventSpy = sinon.stub(analyticsReporter, 'sendEvent');
       sessionStorage.getItem.withArgs('RubricFabOpenStateKey').returns(false);
       render(
         <Provider store={getStore()}>
           <RubricFloatingActionButton {...defaultProps} />
         </Provider>
       );
+      expect(sendEventSpy).to.have.been.calledWith(
+        EVENTS.TA_RUBRIC_CLOSED_ON_PAGE_LOAD,
+        {
+          viewingStudentWork: false,
+          viewingEvaluationLevel: true,
+        }
+      );
       const image = screen.getByRole('img', {name: 'AI bot'});
       fireEvent.load(image);
       const fab = screen.getByRole('button', {name: 'AI bot'});
       expect(fab.classList.contains('unittest-fab-pulse')).to.be.false;
+      sendEventSpy.restore();
     });
   });
 });


### PR DESCRIPTION
Adds amplitude events for FAB open/closed state on a page load. This should only be sent once on the initial FAB render. 

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/AITT-493
Relevant previous PR where the issue was created: https://github.com/code-dot-org/code-dot-org/pull/56888

## Testing story

Added unit tests to the the Rubric floating action button tests, and did some incidental maintenance on the Rubric container tests to avoid subsequent "attempted to wrap sendEvent which is already wrapped" errors after one test failure.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
