### PR TITLE
[CodeBridge] "For Teachers Only" (Teacher Markdown Instructions)

### DIFF
--- a/apps/src/codebridge/InfoPanel/ForTeachersOnly.tsx
+++ b/apps/src/codebridge/InfoPanel/ForTeachersOnly.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import TeacherOnlyMarkdown from '@cdo/apps/templates/instructions/TeacherOnlyMarkdown';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+const ForTeachersOnly: React.FunctionComponent = () => {
+  const teacherMarkdown = useAppSelector(
+    state => state.lab.levelProperties?.teacherMarkdown
+  );
+  return <TeacherOnlyMarkdown content={teacherMarkdown} hideContainer={true} />;
+};
+
+export default ForTeachersOnly;

--- a/apps/src/codebridge/InfoPanel/index.tsx
+++ b/apps/src/codebridge/InfoPanel/index.tsx
@@ -32,6 +32,7 @@ export const InfoPanel = React.memo(() => {
   const teacherMarkdown = useAppSelector(
     state => state.lab.levelProperties?.teacherMarkdown
   );
+  const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
   const [currentPanel, setCurrentPanel] = useState(Panels.Instructions);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [panelOptions, setPanelOptions] = useState<Panels[]>([
@@ -42,7 +43,7 @@ export const InfoPanel = React.memo(() => {
     // For now, always include Instructions panel.
     // TODO: support hiding this panel completely if there are no instructions.
     const options = [Panels.Instructions];
-    if (teacherMarkdown) {
+    if (isUserTeacher && teacherMarkdown) {
       options.push(Panels.ForTeachersOnly);
     }
     if (mapReference || referenceLinks) {
@@ -51,7 +52,7 @@ export const InfoPanel = React.memo(() => {
     setPanelOptions(options);
     // Close the dropdown if we change levels.
     setIsDropdownOpen(false);
-  }, [mapReference, referenceLinks, teacherMarkdown]);
+  }, [isUserTeacher, mapReference, referenceLinks, teacherMarkdown]);
 
   useEffect(() => {
     // If we change levels and were on a panel that no longer exists,

--- a/apps/src/codebridge/InfoPanel/index.tsx
+++ b/apps/src/codebridge/InfoPanel/index.tsx
@@ -5,6 +5,7 @@ import InstructionsView from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import ForTeachersOnly from './ForTeachersOnly';
 import HelpAndTips from './HelpAndTips';
 
 import moduleStyles from './styles/info-panel.module.scss';
@@ -12,11 +13,13 @@ import moduleStyles from './styles/info-panel.module.scss';
 enum Panels {
   Instructions = 'Instructions',
   HelpAndTips = 'Help and Tips',
+  ForTeachersOnly = 'For Teachers Only',
 }
 
 const panelMap = {
   [Panels.Instructions]: InstructionsView,
   [Panels.HelpAndTips]: HelpAndTips,
+  [Panels.ForTeachersOnly]: ForTeachersOnly,
 };
 
 export const InfoPanel = React.memo(() => {
@@ -25,6 +28,9 @@ export const InfoPanel = React.memo(() => {
   );
   const referenceLinks = useAppSelector(
     state => state.lab.levelProperties?.referenceLinks
+  );
+  const teacherMarkdown = useAppSelector(
+    state => state.lab.levelProperties?.teacherMarkdown
   );
   const [currentPanel, setCurrentPanel] = useState(Panels.Instructions);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -36,13 +42,16 @@ export const InfoPanel = React.memo(() => {
     // For now, always include Instructions panel.
     // TODO: support hiding this panel completely if there are no instructions.
     const options = [Panels.Instructions];
+    if (teacherMarkdown) {
+      options.push(Panels.ForTeachersOnly);
+    }
     if (mapReference || referenceLinks) {
       options.push(Panels.HelpAndTips);
     }
     setPanelOptions(options);
     // Close the dropdown if we change levels.
     setIsDropdownOpen(false);
-  }, [mapReference, referenceLinks]);
+  }, [mapReference, referenceLinks, teacherMarkdown]);
 
   useEffect(() => {
     // If we change levels and were on a panel that no longer exists,

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -148,6 +148,8 @@ export interface LevelProperties {
   // Help and Tips values
   mapReference?: string;
   referenceLinks?: string[];
+  // For Teachers Only value
+  teacherMarkdown?: string;
 }
 
 // Level configuration data used by project-backed labs that don't require

--- a/apps/src/templates/CurrentUserState.ts
+++ b/apps/src/templates/CurrentUserState.ts
@@ -23,6 +23,7 @@ export interface CurrentUserState {
   isSortedByFamilyName: boolean;
   under13: boolean;
   over21: boolean;
+  isTeacher: boolean | undefined;
   showProgressTableV2: boolean;
   progressTableV2ClosedBeta: boolean;
   childAccountComplianceState: string | null;

--- a/apps/src/templates/instructions/TeacherOnlyMarkdown.jsx
+++ b/apps/src/templates/instructions/TeacherOnlyMarkdown.jsx
@@ -13,6 +13,15 @@ export default class TeacherOnlyMarkdown extends Component {
     hideContainer: PropTypes.bool,
   };
 
+  renderMarkdownContent() {
+    const {content} = this.props;
+    return (
+      <div style={styles.content}>
+        <SafeMarkdown markdown={content} />
+      </div>
+    );
+  }
+
   render() {
     const {content, hideContainer} = this.props;
 
@@ -22,19 +31,13 @@ export default class TeacherOnlyMarkdown extends Component {
 
     // CodeBridge does not use the teal container/header, so we just render the content.
     if (hideContainer) {
-      return (
-        <div style={styles.content}>
-          <SafeMarkdown markdown={content} />
-        </div>
-      );
+      return this.renderMarkdownContent();
     }
 
     return (
       <div style={styles.container}>
         <div style={styles.header}>{i18n.forTeachersOnly()}</div>
-        <div style={styles.content}>
-          <SafeMarkdown markdown={content} />
-        </div>
+        {this.renderMarkdownContent()}
       </div>
     );
   }

--- a/apps/src/templates/instructions/TeacherOnlyMarkdown.jsx
+++ b/apps/src/templates/instructions/TeacherOnlyMarkdown.jsx
@@ -10,13 +10,23 @@ import color from '../../util/color';
 export default class TeacherOnlyMarkdown extends Component {
   static propTypes = {
     content: PropTypes.string,
+    hideContainer: PropTypes.bool,
   };
 
   render() {
-    const {content} = this.props;
+    const {content, hideContainer} = this.props;
 
     if (!content) {
       return null;
+    }
+
+    // CodeBridge does not use the teal container/header, so we just render the content.
+    if (hideContainer) {
+      return (
+        <div style={styles.content}>
+          <SafeMarkdown markdown={content} />
+        </div>
+      );
     }
 
     return (

--- a/dashboard/app/views/levels/editors/_pythonlab.html.haml
+++ b/dashboard/app/views/levels/editors/_pythonlab.html.haml
@@ -1,4 +1,5 @@
 = render partial: 'levels/editors/fields/long_instructions', locals: {f: f}
+= render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
 = render partial: 'levels/editors/fields/help_and_tips', locals: {f: f}
 = render partial: 'levels/editors/fields/pythonlab_fields', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}

--- a/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 1.level
+++ b/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 1.level
@@ -2,7 +2,7 @@
   <config><![CDATA[{
   "published": true,
   "game_id": 72,
-  "created_at": "2024-04-30T03:00:53.000Z",
+  "created_at": "2024-01-03T20:01:05.000Z",
   "level_num": "custom",
   "user_id": 6959,
   "properties": {
@@ -33,8 +33,9 @@
     "reference_links": [
       "/courses/csa-2023/guides/instantiating-objects"
     ],
-    "map_reference": "/docs/concepts/html/"
+    "map_reference": "/docs/concepts/html/",
+    "teacher_markdown": "Teachers should see this extra info."
   },
-  "audit_log": "[{\"changed_at\":\"2024-05-08 10:58:39 -0700\",\"changed\":[\"source\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-08 11:24:52 -0700\",\"changed\":[\"source\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-10 09:11:05 -0700\",\"changed\":[\"source\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-10 09:11:27 -0700\",\"changed\":[\"source\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-15 10:24:36 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-15 10:52:58 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-15 16:23:46 -0700\",\"changed\":[\"map_reference\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]"
+  "audit_log": "[{\"changed_at\":\"2024-05-08 10:58:39 -0700\",\"changed\":[\"source\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-08 11:24:52 -0700\",\"changed\":[\"source\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-10 09:11:05 -0700\",\"changed\":[\"source\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-10 09:11:27 -0700\",\"changed\":[\"source\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-15 10:24:36 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-15 10:52:58 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-15 16:23:46 -0700\",\"changed\":[\"map_reference\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-05-23 14:13:27 -0400\",\"changed\":[],\"changed_by_id\":1,\"changed_by_email\":\"mike@code.org\"},{\"changed_at\":\"2024-05-23 15:01:14 -0400\",\"changed\":[\"teacher_markdown\"],\"changed_by_id\":1,\"changed_by_email\":\"mike@code.org\"}]"
 }]]></config>
 </Pythonlab>


### PR DESCRIPTION
Similar to:
- https://github.com/code-dot-org/code-dot-org/pull/58684

This adds levelbuilder support for defining teacher-only markdown instructions, and adds a "For Teachers Only" option to the Code Bridge info panel for showing that content.

For now, we're using the same `TeacherOnlyMarkdown` component used outside of Lab2. I modified this component to supporting hiding a teal container/header that normally surround the content. [[Relevant Slack thread](https://codedotorg.slack.com/archives/C05DK21DAHK/p1716489343362349)]

New teacher instructions in Pyhon Lab:
<img width="639" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/48953d15-6572-404f-90f6-66b570f3dfb6">

Unchanged teacher instructions in Java Lab:
<img width="531" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/c2c75c9b-20d6-413b-91cc-f359409e3a63">


## Links

Jira: https://codedotorg.atlassian.net/browse/CT-594
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally. 
- The panel is added to the dropdown options and can be viewed for a signed in teacher user.
- The panel is not added to the options for signed out users or students
- Basic markdown text is rendered correctly, included headings (not shown in screenshot)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
