### PR TITLE
LTI account linking for existing Facebook logins

### DIFF
--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1624,6 +1624,35 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_includes existing_user.authentication_options, ao
   end
 
+  test 'Facebook SSO: links an LTI auth option to an existing account' do
+    DCDO.stubs(:get).with('lti_account_linking_enabled', false).returns(true)
+    lti_integration = create :lti_integration
+
+    # Pre-existing Facebook account that we want the new LTI auth option to be linked to
+    existing_user = create :teacher, :with_facebook_authentication_option
+    auth = generate_auth_user_hash provider: AuthenticationOption::FACEBOOK, uid: existing_user.authentication_options[1].authentication_id
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+
+    # Teacher that is going through the account linking flow
+    partial_lti_teacher = create :teacher
+    fake_id_token = {iss: lti_integration.issuer, aud: lti_integration.client_id, sub: 'foo'}
+    auth_id = Services::Lti::AuthIdGenerator.new(fake_id_token).call
+    ao = AuthenticationOption.new(
+      authentication_id: auth_id,
+      credential_type: AuthenticationOption::LTI_V1,
+      email: existing_user.email,
+    )
+    partial_lti_teacher.authentication_options = [ao]
+    PartialRegistration.persist_attributes session, partial_lti_teacher
+
+    get :facebook
+    # The user factory automatically creates an email auth option,
+    # so this includes 1 email, 1 Facebook, and 1 LTI auth option
+    assert_equal 3, existing_user.reload.authentication_options.count
+    assert_includes existing_user.authentication_options, ao
+  end
+
   # Try to link a credential to the provided user
   # @return [OmniAuth::AuthHash] the auth hash, useful for validating
   #   linked credentials with assert_auth_option

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -526,6 +526,23 @@ FactoryBot.define do
       provider {'windowslive'}
     end
 
+    trait :with_facebook_authentication_option do
+      after(:create) do |user|
+        create(:authentication_option,
+          user: user,
+          email: user.email,
+          hashed_email: user.hashed_email,
+          credential_type: AuthenticationOption::FACEBOOK,
+          authentication_id: SecureRandom.uuid,
+          data: {
+            oauth_token: 'some-facebook-token',
+            oauth_refresh_token: 'some-facebook-refresh-token',
+            oauth_token_expiration: '999999'
+          }.to_json
+        )
+      end
+    end
+
     trait :with_google_authentication_option do
       after(:create) do |user|
         create(:authentication_option,


### PR DESCRIPTION
Adds support for linking new LTI logins to existing Facebook accounts. Facebook was previously handled by the generic `:all` handler in the oauth callbacks controller. This PR breaks it out into its own handler, but the change feels low-risk for existing Facebook users because the method is nearly identical to the `:all` handler, just with the account linking logic added behind a DCDO flag.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-911)

## Testing story

1. [Enable https_development locally](https://github.com/code-dot-org/code-dot-org/blob/staging/locals.yml.default#L140-L144)
2. Create an account and link your Facebook login
3. Log out
4. Launch from an LMS and select "I have an existing account in the login page"
5. Login via the same Facebook credentials
6. Verify that your existing account now has your new LTI authentication_option added

## Deployment strategy

## Follow-up work

- [Microsoft oauth support](https://codedotorg.atlassian.net/browse/P20-912)
- [Graceful error handling](https://codedotorg.atlassian.net/browse/P20-947)

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
