### PR TITLE
Music: add additional logging for sound load errors

### DIFF
--- a/apps/src/music/player/SoundCache.ts
+++ b/apps/src/music/player/SoundCache.ts
@@ -38,7 +38,7 @@ class SoundCache {
       updateLoadProgress?: (progress: number) => void;
     } = {}
   ): Promise<void> {
-    const failedSounds: string[] = [];
+    const failedSounds: {path: string; error: string}[] = [];
     const {onLoadFinished, updateLoadProgress} = callbacks;
     const startTime = Date.now();
 
@@ -53,15 +53,19 @@ class SoundCache {
     let loadCounter = 0;
     const loadPromises: Promise<void>[] = [];
 
+    if (paths.length > 0) {
+      this.metricsReporter.incrementCounter('SoundCache.LoadSoundsAttempt');
+    }
+
     for (const path of paths) {
       const loadPromise = this.loadSound(path)
         .then(sound => {
           if (!sound) {
-            failedSounds.push(path);
+            failedSounds.push({path, error: 'Error verifying URL'});
           }
         })
         .catch(err => {
-          failedSounds.push(path);
+          failedSounds.push({path, error: err.message});
         })
         .finally(() => {
           if (updateLoadProgress) {
@@ -82,9 +86,11 @@ class SoundCache {
 
     if (failedSounds.length > 0) {
       this.metricsReporter.logError('Error loading sounds', undefined, {
+        attempted: paths.length,
         count: failedSounds.length,
-        failedSounds: failedSounds.join(','),
+        failedSounds,
       });
+      this.metricsReporter.incrementCounter('SoundCache.LoadSoundsError');
     }
   }
 


### PR DESCRIPTION
Our largest error type by far is "Error loading sounds" but we currently don't have great insight into why these errors are occurring. This adds some more logging in the hopes of helping debug and ideally root cause any issues.

- The "Error loading sounds" log payload now includes an error message for each failed sound, as well as the overall number of sounds attempted, so we can get a better of idea of what fraction of sounds failed in a particular session.
- I also added counter metrics for load attempts and load failures, so we can get a better sense of overall error rate.

Example log payload in Cloudwatch
<img width="1136" alt="Screenshot 2024-05-23 at 2 54 32 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/0b047e46-ec92-4613-95fa-bc796573fc3b">

## Links

https://codedotorg.atlassian.net/browse/LABS-398

## Testing story

Tested locally using devtools to block URLs.