### PR TITLE
Use /blockly url to serve pyodide files

### DIFF
--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -8,9 +8,10 @@ import {loadPyodide, version} from 'pyodide';
 
 async function loadPyodideAndPackages() {
   self.pyodide = await loadPyodide({
-    indexURL: `https://cdn.jsdelivr.net/pyodide/v${version}/full`,
-    // This URL is not working on prod, so we will use the CDN for now.
-    // indexURL: `/assets/js/pyodide/${version}/`,
+    // /assets does not serve unhashed files, so we load from /blockly instead,
+    // which does serve the unhashed files. We need to serve the unhashed files because
+    // pyodide controls adding the filenames to the url we provide here.
+    indexURL: `/blockly/js/pyodide/${version}/`,
     // pre-load numpy as it will frequently be used, and matplotlib as we patch it.
     packages: ['numpy', 'matplotlib'],
   });


### PR DESCRIPTION
We couldn't serve the pyodide files from the `/assets/js` path on prod because only the hashed version of the files was hosted there. However, the unhashed files are available via `/blockly/js`. After discussing with infra we decided this was a reasonable url to use instead, as we are already referencing this path in other labs, and using it unblocks us from hosting pyodide from our server.

## Links
- [slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1713201165878559)
- jira ticket: [CT-512](https://codedotorg.atlassian.net/browse/CT-512)


## Testing story
Tested that you can access pyodide locally with this configuration. This url already works on production, so we are reasonably confident this will work end to end on production.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
