### PR TITLE
LTI linking to existing Microsoft logins

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -12,7 +12,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   skip_before_action :verify_authenticity_token, only: :powerschool
 
   # Note: We can probably remove these once we've broken out all providers
-  BROKEN_OUT_TYPES = [AuthenticationOption::CLEVER, AuthenticationOption::GOOGLE, AuthenticationOption::FACEBOOK]
+  BROKEN_OUT_TYPES = [
+    AuthenticationOption::CLEVER,
+    AuthenticationOption::GOOGLE,
+    AuthenticationOption::FACEBOOK,
+    AuthenticationOption::MICROSOFT,
+  ]
   TYPES_ROUTED_TO_ALL = AuthenticationOption::OAUTH_CREDENTIAL_TYPES - BROKEN_OUT_TYPES
 
   # GET /users/auth/clever/callback
@@ -30,13 +35,9 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # GET /users/auth/facebook/callback
   def facebook
     user = find_user_by_credential
-    # If the user is in the LTI account linking flow, link the account before signing in.
-    if DCDO.get('lti_account_linking_enabled', false) && user && Policies::Lti.lti_registration_in_progress?(session)
-      user&.update_oauth_credential_tokens auth_hash
-      Services::Lti::AccountLinker.call(user: user, session: session)
-      sign_in_and_redirect user and return
-    end
+    user&.update_oauth_credential_tokens auth_hash
 
+    return link_accounts user if user && should_link_accounts?
     return connect_provider if should_connect_provider?
     login
   end
@@ -46,11 +47,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     user = find_user_by_credential
     user&.update_oauth_credential_tokens auth_hash
 
-    # If the user is in the LTI account linking flow, link the account before signing in.
-    if DCDO.get('lti_account_linking_enabled', false) && user && Policies::Lti.lti_registration_in_progress?(session)
-      Services::Lti::AccountLinker.call(user: user, session: session)
-      sign_in_and_redirect user and return
-    end
+    return link_accounts user if user && should_link_accounts?
 
     # Redirect to open roster dialog on home page if user just authorized access
     # to Google Classroom courses and rosters
@@ -62,6 +59,16 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     else
       sign_up_google_oauth2
     end
+  end
+
+  # GET /users/auth/microsoft_v2_auth/callback
+  def microsoft_v2_auth
+    user = find_user_by_credential
+    user&.update_oauth_credential_tokens auth_hash
+
+    return link_accounts user if user && should_link_accounts?
+    return connect_provider if should_connect_provider?
+    login
   end
 
   # All remaining providers
@@ -518,5 +525,17 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     return errors.first unless errors.empty?
     I18n.t('auth.unable_to_connect_provider', provider: I18n.t("auth.#{auth_option.credential_type}"))
+  end
+
+  # Determine whether to link a new LTI auth option to an existing account
+  # Not to be confused with the connect_provider flow
+  private def should_link_accounts?
+    DCDO.get('lti_account_linking_enabled', false) && Policies::Lti.lti_registration_in_progress?(session)
+  end
+
+  # For linking new LTI auth options to existing accounts
+  private def link_accounts(user)
+    Services::Lti::AccountLinker.call(user: user, session: session)
+    sign_in_and_redirect user and return
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -583,6 +583,23 @@ FactoryBot.define do
       end
     end
 
+    trait :with_microsoft_authentication_option do
+      after(:create) do |user|
+        create(:authentication_option,
+          user: user,
+          email: user.email,
+          hashed_email: user.hashed_email,
+          credential_type: AuthenticationOption::MICROSOFT,
+          authentication_id: SecureRandom.uuid,
+          data: {
+            oauth_token: 'some-microsoft-token',
+            oauth_refresh_token: 'some-microsoft-refresh-token',
+            oauth_token_expiration: '999999'
+          }.to_json
+        )
+      end
+    end
+
     trait :with_clever_authentication_option do
       after(:create) do |user|
         create(:authentication_option,


### PR DESCRIPTION
Adds support for linking new LTI accounts to existing Microsoft accounts. Also consolidates some of the repeat code into some private methods in the controller.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-912)

## Testing story

1. [Enable https_development locally](https://github.com/code-dot-org/code-dot-org/blob/staging/locals.yml.default#L140-L144)
2. Create an account and link your Microsoft login
3. Log out
4. Launch from an LMS and select "I have an existing account in the login page"
5. Login via the same Microsoft credentials
6. Verify that your existing account now has your new LTI authentication_option added

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
