### PR TITLE
Datablock Storage: rename_column creates a new column if the old column doesn't exist

### DIFF
--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -281,7 +281,11 @@ class DatablockStorageTable < ApplicationRecord
     end
 
     # Second rename the column in the table definition
-    self.columns = columns.map {|column| column == old_column_name ? new_column_name : column}
+    if columns.include? old_column_name
+      self.columns = columns.map {|column| column == old_column_name ? new_column_name : column}
+    else
+      self.columns << new_column_name
+    end
   end
 
   # Convert all values in a column to a new type

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -321,6 +321,20 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     assert_equal [{"first_name" => 'bob', "age" => 8, "id" => 1}], JSON.parse(@response.body)
   end
 
+  test "rename_column creates a new column if the old column doesn't exist" do
+    create_bob_record
+
+    put _url(:rename_column), params: {
+      table_name: 'mytable',
+      old_column_name: 'nonexistent',
+      new_column_name: 'newcol'
+    }
+    assert_response :success
+
+    get _url(:get_columns_for_table), params: {table_name: 'mytable'}
+    assert_equal ['id', 'name', 'age', 'newcol'], JSON.parse(@response.body)
+  end
+
   test "get_column" do
     create_bob_record
     get _url(:get_column), params: {table_name: 'mytable', column_name: 'name'}


### PR DESCRIPTION
Fixes: [#56734](https://github.com/code-dot-org/code-dot-org/issues/56734)

Firebase Storage had a weird behavior where rename_column was used to create a new column (basically if the old_column_name doesn't exist, it creates a new column). Because the databrowser UX relied on this behavior, this PR adds the same behavior to datablock storage.

Co-authored-by: Cassi Brenci <cnbrenci@users.noreply.github.com>