### PR TITLE
P20 941/instrument registration events

### DIFF
--- a/apps/src/lib/ui/lti/registration/LtiDynamicRegistrationPage.tsx
+++ b/apps/src/lib/ui/lti/registration/LtiDynamicRegistrationPage.tsx
@@ -37,7 +37,6 @@ export const LtiDynamicRegistrationPage = ({
         window.parent.postMessage({subject: 'org.imsglobal.lti.close'}, '*');
       },
       error: xhr => {
-        console.log(JSON.stringify(xhr));
         setHasError(true);
         setErrorMsg(JSON.parse(xhr.responseText).error);
       },

--- a/apps/src/lib/ui/lti/registration/LtiDynamicRegistrationPage.tsx
+++ b/apps/src/lib/ui/lti/registration/LtiDynamicRegistrationPage.tsx
@@ -37,6 +37,7 @@ export const LtiDynamicRegistrationPage = ({
         window.parent.postMessage({subject: 'org.imsglobal.lti.close'}, '*');
       },
       error: xhr => {
+        console.log(JSON.stringify(xhr));
         setHasError(true);
         setErrorMsg(JSON.parse(xhr.responseText).error);
       },

--- a/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
+++ b/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
@@ -1,5 +1,6 @@
 require 'clients/cache_client'
 require 'clients/lti_dynamic_registration_client'
+require 'metrics/events'
 
 module Lti
   module V1
@@ -67,7 +68,7 @@ module Lti
         end
 
         begin
-          dynamic_registration_client = Lti::DynamicRegistration.new(registration_data[:registration_token], registration_data[:registration_endpoint])
+          dynamic_registration_client = LtiDynamicRegistrationClient.new(registration_data[:registration_token], registration_data[:registration_endpoint])
           registration_response = dynamic_registration_client.make_registration_request
         rescue => exception
           message = 'Error creating registration'
@@ -87,6 +88,16 @@ module Lti
             access_token_url: platform[:access_token_url],
             admin_email: admin_email,
           )
+          metadata = {
+            lms_name: platform[:name],
+          }
+          fake_user = {id: 1234, user_type: 'teacher'}
+          Metrics::Events.log_event(
+            fake_user,
+            'lti_dynamic_registration_completed',
+            metadata
+          )
+
           return render status: :created, json: {}
         else
           return render status: :conflict, json: {error: I18n.t('lti.integration.exists_error')}

--- a/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
+++ b/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
@@ -91,11 +91,9 @@ module Lti
           metadata = {
             lms_name: platform[:name],
           }
-          fake_user = {id: 1234, user_type: 'teacher'}
           Metrics::Events.log_event(
-            fake_user,
-            'lti_dynamic_registration_completed',
-            metadata
+            event_name: 'lti_dynamic_registration_completed',
+            metadata: metadata,
           )
 
           return render status: :created, json: {}

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -397,6 +397,14 @@ class LtiV1Controller < ApplicationController
 
       @integration_status = :created
       LtiMailer.lti_integration_confirmation(admin_email).deliver_now
+
+      metadata = {
+        lms_name: platform_name,
+      }
+      Metrics::Events.log_event(
+        event_name: 'lti_portal_registration_completed',
+        metadata: metadata,
+      )
     end
     render 'lti/v1/integration_status'
   end

--- a/dashboard/lib/clients/lti_dynamic_registration_client.rb
+++ b/dashboard/lib/clients/lti_dynamic_registration_client.rb
@@ -1,20 +1,18 @@
-module Lti
-  class DynamicRegistration
-    def initialize(registration_token, registration_endpoint)
-      raise ArgumentError unless registration_token && registration_endpoint
-      @registration_token = registration_token
-      @registration_endpoint = registration_endpoint
-    end
+class LtiDynamicRegistrationClient
+  def initialize(registration_token, registration_endpoint)
+    raise ArgumentError unless registration_token && registration_endpoint
+    @registration_token = registration_token
+    @registration_endpoint = registration_endpoint
+  end
 
-    def make_registration_request
-      body = Policies::Lti::DYNAMIC_REGISTRATION_CONFIG.to_json
-      headers = {
-        'Content-Type' => 'application/json',
-        'Authorization' => "Bearer #{@registration_token}"
-      }
-      res = HTTParty.post(@registration_endpoint, body: body, headers: headers)
-      raise "Error making registration request: #{res.code} #{res.body}" unless res.code == HTTP::Status::OK
-      return JSON.parse(res.body, symbolize_names: true)
-    end
+  def make_registration_request
+    body = Policies::Lti::DYNAMIC_REGISTRATION_CONFIG.to_json
+    headers = {
+      'Content-Type' => 'application/json',
+      'Authorization' => "Bearer #{@registration_token}"
+    }
+    res = HTTParty.post(@registration_endpoint, body: body, headers: headers)
+    raise "Error making registration request: #{res.code} #{res.body}" unless res.code == HTTP::Status::OK
+    return JSON.parse(res.body, symbolize_names: true)
   end
 end

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -1,13 +1,36 @@
 require 'cdo/statsig'
 
+# This is a wrapper for the Statsig SDK.
+#
+# Example Usage:
+#
+# Specify any (optional) metadata relevant to the event
+# metadata = {
+#   foo: 'bar',
+#   fizz: 'buzz',
+# }
+#
+# Metrics::Events.log_event('some_event_name')
+# Metrics::Events.log_event(current_user, 'some_event_name', metadata)
+# Metrics::Events.log_event(current_user, 'some_event_name', 'some_event_value', metadata)
+# Metrics::Events.log_event(current_user, 'some_event_name', true)
+
 module Metrics
   module Events
     class << self
       # Logs an event, delegating to the appropriate handler based on environment
-      def log_event(user:, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false)
+      #
+      # Parameters:
+      # @user - a logged in user instance (optional)
+      # @event_name - the name of the event to be logged (required)
+      # @event_value - the value of the event (optional)
+      # @metadata - a metadata hash with relevant data (optional)
+      # @get_enabled_experiments - include list of experiements the user is enrolled in (optional)
+      def log_event(user: nil, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false)
         event_value = event_name if event_value.nil?
-        enabled_experiments = get_enabled_experiments ? user.get_active_experiment_names : nil
+        enabled_experiments = get_enabled_experiments && user.present? ? user.get_active_experiment_names : nil
         managed_test_environment = CDO.running_web_application? && CDO.test_system?
+        user = '' if user.nil?
 
         if CDO.rack_env?(:development)
           log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments)
@@ -34,18 +57,22 @@ module Metrics
 
       # Builds a StatsigUser object from a user entity
       private def build_statsig_user(user:, enabled_experiments:)
-        custom_ids = {
-          user_type: user.user_type,
-          enabled_experiments: enabled_experiments,
-        }.compact
-
-        StatsigUser.new({'userID' => user.id.to_s, 'custom_ids' => custom_ids})
+        if user.present?
+          custom_ids = {
+            user_type: user.user_type,
+            enabled_experiments: enabled_experiments,
+          }.compact
+          StatsigUser.new({'userID' => user.id.to_s, 'custom_ids' => custom_ids})
+        else
+          StatsigUser.new({'userID' => ''})
+        end
       end
 
       # Logs an event to stdout, useful for development and debugging
       private def log_event_to_stdout(user:, event_name:, event_value:, metadata:, enabled_experiments:)
+        user_id = user.present? ? user.id : ''
         event_details = {
-          user_id: user.id,
+          user_id: user_id,
           custom_ids: {
             user_type: user.user_type,
             enabled_experiments: enabled_experiments,

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -10,10 +10,10 @@ require 'cdo/statsig'
 #   fizz: 'buzz',
 # }
 #
-# Metrics::Events.log_event('some_event_name')
-# Metrics::Events.log_event(current_user, 'some_event_name', metadata)
-# Metrics::Events.log_event(current_user, 'some_event_name', 'some_event_value', metadata)
-# Metrics::Events.log_event(current_user, 'some_event_name', true)
+# Metrics::Events.log_event(event_name: 'some_event_name')
+# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', metadata: metadata)
+# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', event_value: 'some_event_value', metadata: metadata)
+# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', get_enabled_experiments: true)
 
 module Metrics
   module Events

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -71,10 +71,11 @@ module Metrics
       # Logs an event to stdout, useful for development and debugging
       private def log_event_to_stdout(user:, event_name:, event_value:, metadata:, enabled_experiments:)
         user_id = user.present? ? user.id : ''
+        user_type = user.present? ? user.user_type : ''
         event_details = {
           user_id: user_id,
           custom_ids: {
-            user_type: user.user_type,
+            user_type: user_type,
             enabled_experiments: enabled_experiments,
           }.compact,
           event_name: event_name,

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -30,7 +30,6 @@ module Metrics
         event_value = event_name if event_value.nil?
         enabled_experiments = get_enabled_experiments && user.present? ? user.get_active_experiment_names : nil
         managed_test_environment = CDO.running_web_application? && CDO.test_system?
-        user = '' if user.nil?
 
         if CDO.rack_env?(:development)
           log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments)

--- a/dashboard/test/controllers/lti/v1/dynamic_registration_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/dynamic_registration_controller_test.rb
@@ -37,7 +37,7 @@ class Lti::V1::DynamicRegistrationControllerTest < ActionController::TestCase
     }
     CacheClient.any_instance.stubs(:read).with(registration_id).returns(registration_data)
     response = {client_id: client_id}
-    Lti::DynamicRegistration.any_instance.stubs(:make_registration_request).returns(response)
+    LtiDynamicRegistrationClient.any_instance.stubs(:make_registration_request).returns(response)
 
     post :create_registration, params: {email: email, registration_id: registration_id}
     assert_response :created
@@ -83,7 +83,7 @@ class Lti::V1::DynamicRegistrationControllerTest < ActionController::TestCase
       lms_account_name: name,
     }
     CacheClient.any_instance.stubs(:read).with(registration_id).returns(registration_data)
-    Lti::DynamicRegistration.any_instance.stubs(:make_registration_request).raises RuntimeError
+    LtiDynamicRegistrationClient.any_instance.stubs(:make_registration_request).raises RuntimeError
 
     post :create_registration, params: {email: email, registration_id: registration_id}
     assert_response :internal_server_error

--- a/dashboard/test/lib/clients/lti_dynamic_registration_client_test.rb
+++ b/dashboard/test/lib/clients/lti_dynamic_registration_client_test.rb
@@ -10,7 +10,7 @@ module Lti
       registration_token = SecureRandom.uuid
       @registration_endpoint = 'https://example.com'
       @client_id = SecureRandom.alphanumeric(10)
-      @registration_client = Lti::DynamicRegistration.new(registration_token, @registration_endpoint)
+      @registration_client = LtiDynamicRegistrationClient.new(registration_token, @registration_endpoint)
     end
 
     test 'Returns response body with client_id when successful response from the registration_endpoint' do
@@ -36,7 +36,7 @@ module Lti
 
     test 'throws an error if no registration_token or registration_endpoint is provided' do
       assert_raises ArgumentError do
-        Lti::DynamicRegistration.new(nil, nil)
+        LtiDynamicRegistrationClient.new(nil, nil)
       end
     end
   end


### PR DESCRIPTION
In order to add event metrics to registration events (portal and dynamic), it was necessary to change the Statsig wrapper to allow for a `nil` user, as these events happen outside of a logged in user session. This PR does the following:

* Changes Stagsig wrapper to allow for nil user
* Adds comments on Statsig wrapper with usage examples
* Instruments metrics for both portal and dynamic registration flows
* Standardizes Dynamic Registration client to a single Class, to align with other clients (technically out of scope with this PR, but I was already here and figured I'd make the improvement. The PR isn't that big so I think it's fine, but can move this to another PR if people want)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
