### PR TITLE
Gen AI: export chat history to CSV on sublevels

### DIFF
--- a/bin/oneoff/aichat_logs_to_csv
+++ b/bin/oneoff/aichat_logs_to_csv
@@ -16,7 +16,7 @@ def main
 
   CSV.open("aichat_logs_#{options[:section_id]}_#{options[:date]}.csv", "w") do |csv|
     headers = %w[
-      session_id user_id username name path level_name created_at updated_at
+      session_id user_id username name path created_at updated_at
       selectedModelId temperature systemPrompt retrievalContexts
       status role content
     ]
@@ -63,7 +63,6 @@ def main
         user.username,
         user.name,
         path,
-        level.name,
         session.created_at,
         session.updated_at,
         model_customizations["selectedModelId"],

--- a/bin/oneoff/aichat_logs_to_csv
+++ b/bin/oneoff/aichat_logs_to_csv
@@ -16,7 +16,7 @@ def main
 
   CSV.open("aichat_logs_#{options[:section_id]}_#{options[:date]}.csv", "w") do |csv|
     headers = %w[
-      session_id user_id username name path created_at updated_at
+      session_id user_id username name path level_name created_at updated_at
       selectedModelId temperature systemPrompt retrievalContexts
       status role content
     ]
@@ -35,7 +35,11 @@ def main
 
       level = Level.find(session.level_id)
       script_level = level.script_levels.find_by_script_id(session.script_id)
-      path = script_level.path
+      path = ""
+      if script_level
+        path = script_level.path
+      end
+      level_name = level.name
 
       base_row = [
         session.id,
@@ -43,6 +47,7 @@ def main
         user.username,
         user.name,
         path,
+        level_name,
         session.created_at,
         session.updated_at,
         model_customizations["selectedModelId"],

--- a/bin/oneoff/aichat_logs_to_csv
+++ b/bin/oneoff/aichat_logs_to_csv
@@ -34,12 +34,28 @@ def main
       user = session.user
 
       level = Level.find(session.level_id)
-      script_level = level.script_levels.find_by_script_id(session.script_id)
       path = ""
+
+      script_level = level.script_levels.find_by_script_id(session.script_id)
       if script_level
+        # This handles chat history that occurred on standard levels in a progression
         path = script_level.path
+      else
+        # This handles chat history that occurred on a sublevel
+        parent_levels = BubbleChoice.parent_levels(level.name)
+        parent_levels_in_script = parent_levels.filter do |pl|
+          pl.script_levels.any? {|sl| sl.script_id == session.script_id}
+        end
+
+        if parent_levels_in_script
+          parent_level = parent_levels_in_script.first
+          sublevel_position = parent_level.sublevel_position(level)
+          path = parent_level.build_script_level_path(
+            parent_level.script_levels.first,
+            {sublevel_position: sublevel_position}
+          )
+        end
       end
-      level_name = level.name
 
       base_row = [
         session.id,
@@ -47,7 +63,7 @@ def main
         user.username,
         user.name,
         path,
-        level_name,
+        level.name,
         session.created_at,
         session.updated_at,
         model_customizations["selectedModelId"],


### PR DESCRIPTION
Fixes the chat history CSV export script to handle progress that occurred on a sublevel (eg, `/s/gen-ai-customizing-pilot-v1/lessons/6/levels/9/sublevel/2`). Follow-up to https://github.com/code-dot-org/code-dot-org/pull/58850.

## Testing story

Tested manually/locally that chat history generated on a sublevel appeared appropriately in the generated CSV, with an appropriate path. Also tested that chat history that occurred on a normal level continued to export appropriately.