### PR TITLE
Show save indication while saving and error if save fails

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -77,7 +77,7 @@ const saveTypeToAnalyticsEvent: {[key in SaveType]: string} = {
   saveModelCard: EVENTS.SAVE_MODEL_CARD_INFO,
 };
 
-export type SaveType = 'updateChatbot' | 'publishModelCard' | 'saveModelCard';
+type SaveType = 'updateChatbot' | 'publishModelCard' | 'saveModelCard';
 
 export interface AichatState {
   // All user and assistant chat messages - includes too personal and inappropriate user messages.
@@ -269,7 +269,7 @@ export const onSaveFail = () => (dispatch: AppDispatch) => {
   dispatch(
     addChatMessage({
       id: getNewMessageId(),
-      role: Role.ERROR,
+      role: Role.ERROR_NOTIFICATION,
       chatMessageText: 'Error updating project. Please try again.',
       status: Status.ERROR,
       timestamp: getCurrentTime(),
@@ -401,13 +401,13 @@ const aichatSlice = createSlice({
     addChatMessage: (state, action: PayloadAction<ChatCompletionMessage>) => {
       state.chatMessages.push(action.payload);
     },
-    removeModelUpdateMessage: (state, action: PayloadAction<number>) => {
+    removeUpdateMessage: (state, action: PayloadAction<number>) => {
       const updatedMessages = [...state.chatMessages];
       const messageToRemovePosition = updatedMessages.findIndex(
         message => message.id === action.payload
       );
 
-      // Only allow removing individual messages that are model updates,
+      // Only allow removing individual messages that are model updates and error notifications,
       // as we want to retain user and bot message history
       // when requesting model responses within a chat session.
       // If we want to clear all history
@@ -415,7 +415,8 @@ const aichatSlice = createSlice({
       if (
         messageToRemovePosition < 0 ||
         (updatedMessages[messageToRemovePosition].role !== Role.MODEL_UPDATE &&
-          updatedMessages[messageToRemovePosition].role !== Role.ERROR)
+          updatedMessages[messageToRemovePosition].role !==
+            Role.ERROR_NOTIFICATION)
       ) {
         return;
       }
@@ -596,7 +597,7 @@ const {startSave} = aichatSlice.actions;
 registerReducers({aichat: aichatSlice.reducer});
 export const {
   addChatMessage,
-  removeModelUpdateMessage,
+  removeUpdateMessage,
   setNewChatSession,
   setChatSessionId,
   clearChatMessages,

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -36,6 +36,7 @@ import {
   Visibility,
 } from '../types';
 import {getTypedKeys} from '@cdo/apps/types/utils';
+import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 
 const haveDifferentValues = (
   value1: AiCustomizations[keyof AiCustomizations],
@@ -85,6 +86,10 @@ export interface AichatState {
   fieldVisibilities: {[key in keyof AiCustomizations]: Visibility};
   viewMode: ViewMode;
   currentSessionId?: number;
+  // If a save is currently in progress
+  saveInProgress: boolean;
+  // The type of save action being performed (customization update, publish, model card save, etc).
+  currentSaveType: string | undefined;
 }
 
 const initialState: AichatState = {
@@ -96,6 +101,8 @@ const initialState: AichatState = {
   savedAiCustomizations: EMPTY_AI_CUSTOMIZATIONS,
   fieldVisibilities: DEFAULT_VISIBILITIES,
   viewMode: ViewMode.EDIT,
+  saveInProgress: false,
+  currentSaveType: undefined,
 };
 
 // THUNKS
@@ -105,14 +112,9 @@ const initialState: AichatState = {
 // output a message to the chat window with the list of customizations that were updated.
 export const updateAiCustomization = createAsyncThunk(
   'aichat/updateAiCustomization',
-  async (_, thunkAPI) => {
-    const rootState = (await thunkAPI.getState()) as RootState;
-    const {currentAiCustomizations, savedAiCustomizations} = rootState.aichat;
-    const {dispatch} = thunkAPI;
-
+  async (_, {dispatch, getState}) => {
     await saveAiCustomization(
-      currentAiCustomizations,
-      savedAiCustomizations,
+      (getState() as RootState).aichat.currentAiCustomizations,
       EVENTS.UPDATE_CHATBOT,
       dispatch
     );
@@ -124,15 +126,10 @@ export const updateAiCustomization = createAsyncThunk(
 // and view its details (temperature, system prompt, etc) in a summary view.
 export const publishModel = createAsyncThunk(
   'aichat/publishModelCard',
-  async (_, thunkAPI) => {
-    const {dispatch} = thunkAPI;
+  async (_, {dispatch, getState}) => {
     dispatch(setModelCardProperty({property: 'isPublished', value: true}));
-
-    const rootState = thunkAPI.getState() as RootState;
-    const {currentAiCustomizations, savedAiCustomizations} = rootState.aichat;
     await saveAiCustomization(
-      currentAiCustomizations,
-      savedAiCustomizations,
+      (getState() as RootState).aichat.currentAiCustomizations,
       EVENTS.PUBLISH_MODEL_CARD_INFO,
       dispatch
     );
@@ -144,21 +141,15 @@ export const publishModel = createAsyncThunk(
 // in the "Publish" tab.
 export const saveModelCard = createAsyncThunk(
   'aichat/saveModelCard',
-  async (_, thunkAPI) => {
-    const {dispatch} = thunkAPI;
-    const rootState = (await thunkAPI.getState()) as RootState;
-    const modelCardInfo =
-      rootState.aichat.currentAiCustomizations.modelCardInfo;
+  async (_, {dispatch, getState}) => {
+    const {currentAiCustomizations} = (getState() as RootState).aichat;
+    const modelCardInfo = currentAiCustomizations.modelCardInfo;
     if (!hasFilledOutModelCard(modelCardInfo)) {
       dispatch(setModelCardProperty({property: 'isPublished', value: false}));
     }
 
-    const {currentAiCustomizations, savedAiCustomizations} = (
-      thunkAPI.getState() as RootState
-    ).aichat;
     await saveAiCustomization(
       currentAiCustomizations,
-      savedAiCustomizations,
       EVENTS.SAVE_MODEL_CARD_INFO,
       dispatch
     );
@@ -177,7 +168,6 @@ const getNewMessageId = () => {
 // model customizations (setup, retrieval, and "publish" tab)
 const saveAiCustomization = async (
   currentAiCustomizations: AiCustomizations,
-  savedAiCustomizations: AiCustomizations,
   eventDescription: string,
   dispatch: ThunkDispatch<unknown, unknown, AnyAction>
 ) => {
@@ -201,51 +191,81 @@ const saveAiCustomization = async (
     },
   };
 
+  // Notify the UI that a save is in progress.
+  dispatch(startSave(eventDescription));
+
   await Lab2Registry.getInstance()
     .getProjectManager()
     ?.save({source: JSON.stringify(trimmedCurrentAiCustomizations)}, true);
+};
 
-  dispatch(setSavedAiCustomizations(trimmedCurrentAiCustomizations));
+// Thunk called after a save has completed successfully.
+// Updates the chat window and reports analytics as necessary.
+export const onSaveComplete =
+  () => (dispatch: AppDispatch, getState: () => RootState) => {
+    const {savedAiCustomizations, currentAiCustomizations, currentSaveType} =
+      getState().aichat;
 
-  const changedProperties = findChangedProperties(
-    savedAiCustomizations,
-    trimmedCurrentAiCustomizations
-  );
-  if (
-    changedProperties.some(property =>
-      [
-        'selectedModelId',
-        'temperature',
-        'systemPrompt',
-        'retrievalContexts',
-      ].includes(property)
-    )
-  ) {
-    dispatch(setNewChatSession());
-  }
-
-  changedProperties.forEach(property => {
-    dispatch(
-      addChatMessage({
-        id: getNewMessageId(),
-        role: Role.MODEL_UPDATE,
-        chatMessageText:
-          AI_CUSTOMIZATIONS_LABELS[property as keyof AiCustomizations],
-        status: Status.OK,
-        timestamp: getCurrentTime(),
-      })
+    const changedProperties = findChangedProperties(
+      savedAiCustomizations,
+      currentAiCustomizations
     );
-    if (eventDescription) {
-      analyticsReporter.sendEvent(
-        eventDescription,
-        {
-          propertyUpdated: property,
-          levelPath: window.location.pathname,
-        },
-        PLATFORMS.BOTH
-      );
+    if (
+      changedProperties.some(property =>
+        [
+          'selectedModelId',
+          'temperature',
+          'systemPrompt',
+          'retrievalContexts',
+        ].includes(property)
+      )
+    ) {
+      dispatch(setNewChatSession());
     }
-  });
+
+    changedProperties.forEach(property => {
+      dispatch(
+        addChatMessage({
+          id: getNewMessageId(),
+          role: Role.MODEL_UPDATE,
+          chatMessageText:
+            AI_CUSTOMIZATIONS_LABELS[property as keyof AiCustomizations],
+          status: Status.OK,
+          timestamp: getCurrentTime(),
+        })
+      );
+
+      if (currentSaveType) {
+        analyticsReporter.sendEvent(
+          currentSaveType,
+          {
+            propertyUpdated: property,
+            levelPath: window.location.pathname,
+          },
+          PLATFORMS.BOTH
+        );
+      }
+    });
+
+    // Update our last saved customizations to match the current customizations
+    dispatch(setSavedAiCustomizations(currentAiCustomizations));
+    // Notify the UI that the save is complete.
+    dispatch(endSave());
+  };
+
+// Thunk called when a save has failed.
+export const onSaveFail = () => (dispatch: AppDispatch) => {
+  dispatch(
+    addChatMessage({
+      id: getNewMessageId(),
+      role: Role.ERROR,
+      chatMessageText: 'Error updating project. Please try again.',
+      status: Status.ERROR,
+      timestamp: getCurrentTime(),
+    })
+  );
+  // Notify the UI that the save is complete.
+  dispatch(endSave());
 };
 
 // This thunk's callback function submits a user's chat content and AI customizations to
@@ -383,7 +403,8 @@ const aichatSlice = createSlice({
       // and start a new session, see clearChatMessages.
       if (
         messageToRemovePosition < 0 ||
-        updatedMessages[messageToRemovePosition].role !== Role.MODEL_UPDATE
+        (updatedMessages[messageToRemovePosition].role !== Role.MODEL_UPDATE &&
+          updatedMessages[messageToRemovePosition].role !== Role.ERROR)
       ) {
         return;
       }
@@ -500,6 +521,14 @@ const aichatSlice = createSlice({
       };
       state.currentAiCustomizations.modelCardInfo = updatedModelCardInfo;
     },
+    startSave(state, action: PayloadAction<string>) {
+      state.saveInProgress = true;
+      state.currentSaveType = action.payload;
+    },
+    endSave(state) {
+      state.saveInProgress = false;
+      state.currentSaveType = undefined;
+    },
   },
   extraReducers: builder => {
     builder.addCase(submitChatContents.fulfilled, state => {
@@ -550,6 +579,9 @@ export const selectAllFieldsHidden = createSelector(
   allFieldsHidden
 );
 
+// Actions not to be used outside of this file
+const {startSave} = aichatSlice.actions;
+
 registerReducers({aichat: aichatSlice.reducer});
 export const {
   addChatMessage,
@@ -566,4 +598,5 @@ export const {
   setSavedAiCustomizations,
   setAiCustomizationProperty,
   setModelCardProperty,
+  endSave,
 } = aichatSlice.actions;

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -26,7 +26,7 @@ export enum Role {
   USER = 'user',
   SYSTEM = 'system',
   MODEL_UPDATE = 'update',
-  ERROR = 'error',
+  ERROR_NOTIFICATION = 'error_notification',
 }
 
 export enum ViewMode {

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -26,6 +26,7 @@ export enum Role {
   USER = 'user',
   SYSTEM = 'system',
   MODEL_UPDATE = 'update',
+  ERROR = 'error',
 }
 
 export enum ViewMode {

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -71,10 +71,11 @@ const AichatView: React.FunctionComponent = () => {
     if (!projectManager) {
       return;
     }
+    // No save occurred
     projectManager.addSaveNoopListener(() => {
-      // No save occurred
       dispatch(endSave());
     });
+
     projectManager.addSaveSuccessListener(() => {
       dispatch(onSaveComplete());
     });

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -14,14 +14,15 @@ import Button from '@cdo/apps/componentLibrary/button/Button';
 import ProjectTemplateWorkspaceIcon from '@cdo/apps/templates/ProjectTemplateWorkspaceIcon';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
-const commonI18n = require('@cdo/locale');
-const aichatI18n = require('@cdo/aichat/locale');
 
 import {
   setStartingAiCustomizations,
   setViewMode,
   clearChatMessages,
   selectAllFieldsHidden,
+  onSaveComplete,
+  onSaveFail,
+  endSave,
 } from '../redux/aichatRedux';
 import {AichatLevelProperties, ViewMode} from '../types';
 import {isDisabled} from './modelCustomization/utils';
@@ -30,6 +31,9 @@ import ModelCustomizationWorkspace from './ModelCustomizationWorkspace';
 import PresentationView from './presentation/PresentationView';
 import CopyButton from './CopyButton';
 import moduleStyles from './aichatView.module.scss';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {commonI18n} from '@cdo/apps/types/locale';
+import aichatI18n from '../locale';
 
 const AichatView: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
@@ -60,6 +64,24 @@ const AichatView: React.FunctionComponent = () => {
   const {botName, isPublished} = currentAiCustomizations.modelCardInfo;
 
   const allFieldsHidden = useAppSelector(selectAllFieldsHidden);
+
+  const projectManager = Lab2Registry.getInstance().getProjectManager();
+  // Attach save listeners whenever the project manager updates
+  useEffect(() => {
+    if (!projectManager) {
+      return;
+    }
+    projectManager.addSaveNoopListener(() => {
+      // No save occurred
+      dispatch(endSave());
+    });
+    projectManager.addSaveSuccessListener(() => {
+      dispatch(onSaveComplete());
+    });
+    projectManager.addSaveFailListener(() => {
+      dispatch(onSaveFail());
+    });
+  }, [projectManager, dispatch]);
 
   useEffect(() => {
     const studentAiCustomizations = JSON.parse(initialSources);

--- a/apps/src/aichat/views/ChatMessage.tsx
+++ b/apps/src/aichat/views/ChatMessage.tsx
@@ -23,6 +23,7 @@ const TOO_PERSONAL_MESSAGE = aichatI18n.tooPersonalUserMessage();
 const isAssistant = (role: string) => role === Role.ASSISTANT;
 const isUser = (role: string) => role === Role.USER;
 const isModelUpdate = (role: string) => role === Role.MODEL_UPDATE;
+const isError = (role: string) => role === Role.ERROR;
 
 const displayUserMessage = (status: string, chatMessageText: string) => {
   if (
@@ -113,6 +114,29 @@ const displayModelUpdateMessage = (
   );
 };
 
+const displayErrorMessage = (
+  message: ChatCompletionMessage,
+  onRemove: () => void
+) => {
+  const {chatMessageText} = message;
+
+  return (
+    <ChatNotificationMessage
+      onRemove={onRemove}
+      content={
+        <>
+          <span className={moduleStyles.modelUpdateMessageTextContainer}>
+            <StrongText>{chatMessageText}</StrongText>
+          </span>
+        </>
+      }
+      iconName="circle-xmark"
+      iconClass={moduleStyles.danger}
+      containerClass={moduleStyles.dangerContainer}
+    />
+  );
+};
+
 const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({message}) => {
   const dispatch = useAppDispatch();
 
@@ -130,6 +154,11 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({message}) => {
 
       {isModelUpdate(message.role) &&
         displayModelUpdateMessage(message, () =>
+          dispatch(removeModelUpdateMessage(message.id))
+        )}
+
+      {isError(message.role) &&
+        displayErrorMessage(message, () =>
           dispatch(removeModelUpdateMessage(message.id))
         )}
     </div>

--- a/apps/src/aichat/views/ChatMessage.tsx
+++ b/apps/src/aichat/views/ChatMessage.tsx
@@ -7,7 +7,7 @@ import aiBotIcon from '@cdo/static/aichat/ai-bot-icon.svg';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 
-import {removeModelUpdateMessage} from '../redux/aichatRedux';
+import {removeUpdateMessage} from '../redux/aichatRedux';
 import {ChatCompletionMessage, Role} from '../types';
 import aichatI18n from '../locale';
 import ChatNotificationMessage from './ChatNotificationMessage';
@@ -23,7 +23,7 @@ const TOO_PERSONAL_MESSAGE = aichatI18n.tooPersonalUserMessage();
 const isAssistant = (role: string) => role === Role.ASSISTANT;
 const isUser = (role: string) => role === Role.USER;
 const isModelUpdate = (role: string) => role === Role.MODEL_UPDATE;
-const isError = (role: string) => role === Role.ERROR;
+const isError = (role: string) => role === Role.ERROR_NOTIFICATION;
 
 const displayUserMessage = (status: string, chatMessageText: string) => {
   if (
@@ -154,12 +154,12 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({message}) => {
 
       {isModelUpdate(message.role) &&
         displayModelUpdateMessage(message, () =>
-          dispatch(removeModelUpdateMessage(message.id))
+          dispatch(removeUpdateMessage(message.id))
         )}
 
       {isError(message.role) &&
         displayErrorMessage(message, () =>
-          dispatch(removeModelUpdateMessage(message.id))
+          dispatch(removeUpdateMessage(message.id))
         )}
     </div>
   );

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -15,6 +15,8 @@ const UserChatMessageEditor: React.FunctionComponent = () => {
     state => state.aichat.isWaitingForChatResponse
   );
 
+  const saveInProgress = useAppSelector(state => state.aichat.saveInProgress);
+
   const dispatch = useAppDispatch();
 
   const handleSubmit = useCallback(() => {
@@ -39,7 +41,7 @@ const UserChatMessageEditor: React.FunctionComponent = () => {
           isIconOnly
           icon={{iconName: 'paper-plane'}}
           onClick={handleSubmit}
-          disabled={isWaitingForChatResponse || !userMessage}
+          disabled={isWaitingForChatResponse || !userMessage || saveInProgress}
         />
       </div>
     </div>

--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -20,6 +20,7 @@ import modelCustomizationStyles from '../model-customization-workspace.module.sc
 import {ModelCardInfo} from '../../types';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {useSelector} from 'react-redux';
+import {FontAwesomeV6IconProps} from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';
 
 const PublishNotes: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
@@ -33,6 +34,8 @@ const PublishNotes: React.FunctionComponent = () => {
   const hasFilledOutModelCard = useAppSelector(selectHasFilledOutModelCard);
 
   const isReadOnly = useSelector(isReadOnlyWorkspace) || isDisabled(visibility);
+  const saveInProgress = useAppSelector(state => state.aichat.saveInProgress);
+  const currentSaveType = useAppSelector(state => state.aichat.currentSaveType);
 
   const onSave = useCallback(() => {
     dispatch(saveModelCard());
@@ -41,6 +44,11 @@ const PublishNotes: React.FunctionComponent = () => {
   const onPublish = useCallback(() => {
     dispatch(publishModel());
   }, [dispatch]);
+
+  const spinnerIconProps: FontAwesomeV6IconProps = {
+    iconName: 'spinner',
+    animationType: 'spin',
+  };
 
   return (
     <div className={modelCustomizationStyles.verticalFlexContainer}>
@@ -92,17 +100,25 @@ const PublishNotes: React.FunctionComponent = () => {
       <div className={modelCustomizationStyles.footerButtonContainer}>
         <Button
           text="Save"
-          iconLeft={{iconName: 'download'}}
+          iconLeft={
+            saveInProgress && currentSaveType === 'saveModelCard'
+              ? spinnerIconProps
+              : {iconName: 'download'}
+          }
           type="secondary"
           color="black"
-          disabled={isReadOnly}
+          disabled={isReadOnly || saveInProgress}
           onClick={onSave}
           className={modelCustomizationStyles.updateButton}
         />
         <Button
           text="Publish"
-          iconLeft={{iconName: 'upload'}}
-          disabled={isReadOnly || !hasFilledOutModelCard}
+          iconLeft={
+            saveInProgress && currentSaveType === 'publishModelCard'
+              ? spinnerIconProps
+              : {iconName: 'upload'}
+          }
+          disabled={isReadOnly || !hasFilledOutModelCard || saveInProgress}
           onClick={onPublish}
           className={modelCustomizationStyles.updateButton}
         />

--- a/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
@@ -103,7 +103,7 @@ const RetrievalCustomization: React.FunctionComponent = () => {
         })}
       </div>
       <div className={modelCustomizationStyles.footerButtonContainer}>
-        <UpdateButton allFieldsDisabled={isReadOnly} />
+        <UpdateButton isDisabledDefault={isReadOnly} />
       </div>
     </div>
   );

--- a/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
@@ -7,12 +7,10 @@ import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElemen
 import modelCustomizationStyles from '../model-customization-workspace.module.scss';
 import styles from './retrieval-customization.module.scss';
 import {isDisabled} from './utils';
-import {
-  setAiCustomizationProperty,
-  updateAiCustomization,
-} from '@cdo/apps/aichat/redux/aichatRedux';
+import {setAiCustomizationProperty} from '@cdo/apps/aichat/redux/aichatRedux';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {useSelector} from 'react-redux';
+import UpdateButton from './UpdateButton';
 
 const RetrievalCustomization: React.FunctionComponent = () => {
   const [newRetrievalContext, setNewRetrievalContext] = useState('');
@@ -26,11 +24,6 @@ const RetrievalCustomization: React.FunctionComponent = () => {
   );
 
   const isReadOnly = useSelector(isReadOnlyWorkspace) || isDisabled(visibility);
-
-  const onUpdate = useCallback(
-    () => dispatch(updateAiCustomization()),
-    [dispatch]
-  );
 
   const onAdd = useCallback(() => {
     dispatch(
@@ -110,13 +103,7 @@ const RetrievalCustomization: React.FunctionComponent = () => {
         })}
       </div>
       <div className={modelCustomizationStyles.footerButtonContainer}>
-        <Button
-          text="Update"
-          onClick={onUpdate}
-          iconLeft={{iconName: 'edit'}}
-          className={modelCustomizationStyles.updateButton}
-          disabled={isReadOnly}
-        />
+        <UpdateButton allFieldsDisabled={isDisabled(visibility)} />
       </div>
     </div>
   );

--- a/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
@@ -103,7 +103,7 @@ const RetrievalCustomization: React.FunctionComponent = () => {
         })}
       </div>
       <div className={modelCustomizationStyles.footerButtonContainer}>
-        <UpdateButton allFieldsDisabled={isDisabled(visibility)} />
+        <UpdateButton allFieldsDisabled={isReadOnly} />
       </div>
     </div>
   );

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -168,7 +168,7 @@ const SetupCustomization: React.FunctionComponent = () => {
         )}
       </div>
       <div className={styles.footerButtonContainer}>
-        <UpdateButton allFieldsDisabled={allFieldsDisabled} />
+        <UpdateButton isDisabledDefault={allFieldsDisabled} />
       </div>
     </div>
   );

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -1,14 +1,11 @@
-import React, {useCallback, useState, useMemo} from 'react';
+import React, {useState, useMemo} from 'react';
 import classNames from 'classnames';
 
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
 import Button from '@cdo/apps/componentLibrary/button/Button';
 import SimpleDropdown from '@cdo/apps/componentLibrary/dropdown/simpleDropdown/SimpleDropdown';
-import {
-  setAiCustomizationProperty,
-  updateAiCustomization,
-} from '../../redux/aichatRedux';
+import {setAiCustomizationProperty} from '../../redux/aichatRedux';
 import styles from '../model-customization-workspace.module.scss';
 import {
   DEFAULT_VISIBILITIES,
@@ -22,6 +19,7 @@ import {modelDescriptions} from '../../constants';
 import {AichatLevelProperties, ModelDescription} from '@cdo/apps/aichat/types';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {useSelector} from 'react-redux';
+import UpdateButton from './UpdateButton';
 
 const SetupCustomization: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
@@ -69,15 +67,9 @@ const SetupCustomization: React.FunctionComponent = () => {
   const readOnlyWorkspace: boolean = useSelector(isReadOnlyWorkspace);
 
   const allFieldsDisabled =
-    (isDisabled(temperature) &&
-      isDisabled(systemPrompt) &&
-      isDisabled(selectedModelId)) ||
-    readOnlyWorkspace;
-
-  const onUpdate = useCallback(
-    () => dispatch(updateAiCustomization()),
-    [dispatch]
-  );
+    isDisabled(temperature) &&
+    isDisabled(systemPrompt) &&
+    isDisabled(selectedModelId);
 
   const renderChooseAndCompareModels = () => {
     return (
@@ -175,13 +167,7 @@ const SetupCustomization: React.FunctionComponent = () => {
         )}
       </div>
       <div className={styles.footerButtonContainer}>
-        <Button
-          text="Update"
-          disabled={allFieldsDisabled}
-          iconLeft={{iconName: 'edit'}}
-          onClick={onUpdate}
-          className={styles.updateButton}
-        />
+        <UpdateButton allFieldsDisabled={allFieldsDisabled} />
       </div>
     </div>
   );

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -67,9 +67,10 @@ const SetupCustomization: React.FunctionComponent = () => {
   const readOnlyWorkspace: boolean = useSelector(isReadOnlyWorkspace);
 
   const allFieldsDisabled =
-    isDisabled(temperature) &&
-    isDisabled(systemPrompt) &&
-    isDisabled(selectedModelId);
+    (isDisabled(temperature) &&
+      isDisabled(systemPrompt) &&
+      isDisabled(selectedModelId)) ||
+    readOnlyWorkspace;
 
   const renderChooseAndCompareModels = () => {
     return (

--- a/apps/src/aichat/views/modelCustomization/UpdateButton.tsx
+++ b/apps/src/aichat/views/modelCustomization/UpdateButton.tsx
@@ -17,13 +17,14 @@ const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
     [dispatch]
   );
   const saveInProgress = useAppSelector(state => state.aichat.saveInProgress);
+  const currentSaveType = useAppSelector(state => state.aichat.currentSaveType);
 
   return (
     <Button
       text="Update"
       disabled={allFieldsDisabled || saveInProgress}
       iconLeft={
-        saveInProgress
+        saveInProgress && currentSaveType === 'updateChatbot'
           ? {iconName: 'spinner', animationType: 'spin'}
           : {iconName: 'edit'}
       }

--- a/apps/src/aichat/views/modelCustomization/UpdateButton.tsx
+++ b/apps/src/aichat/views/modelCustomization/UpdateButton.tsx
@@ -5,11 +5,11 @@ import {Button} from '@cdo/apps/componentLibrary/button';
 import styles from '../model-customization-workspace.module.scss';
 
 interface UpdateButtonProps {
-  allFieldsDisabled: boolean;
+  isDisabledDefault: boolean;
 }
 
 const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
-  allFieldsDisabled,
+  isDisabledDefault,
 }) => {
   const dispatch = useAppDispatch();
   const onUpdate = useCallback(
@@ -22,7 +22,7 @@ const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
   return (
     <Button
       text="Update"
-      disabled={allFieldsDisabled || saveInProgress}
+      disabled={isDisabledDefault || saveInProgress}
       iconLeft={
         saveInProgress && currentSaveType === 'updateChatbot'
           ? {iconName: 'spinner', animationType: 'spin'}

--- a/apps/src/aichat/views/modelCustomization/UpdateButton.tsx
+++ b/apps/src/aichat/views/modelCustomization/UpdateButton.tsx
@@ -1,0 +1,36 @@
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import React, {useCallback} from 'react';
+import {updateAiCustomization} from '../../redux/aichatRedux';
+import {Button} from '@cdo/apps/componentLibrary/button';
+import styles from '../model-customization-workspace.module.scss';
+
+interface UpdateButtonProps {
+  allFieldsDisabled: boolean;
+}
+
+const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
+  allFieldsDisabled,
+}) => {
+  const dispatch = useAppDispatch();
+  const onUpdate = useCallback(
+    () => dispatch(updateAiCustomization()),
+    [dispatch]
+  );
+  const saveInProgress = useAppSelector(state => state.aichat.saveInProgress);
+
+  return (
+    <Button
+      text="Update"
+      disabled={allFieldsDisabled || saveInProgress}
+      iconLeft={
+        saveInProgress
+          ? {iconName: 'spinner', animationType: 'spin'}
+          : {iconName: 'edit'}
+      }
+      onClick={onUpdate}
+      className={styles.updateButton}
+    />
+  );
+};
+
+export default UpdateButton;


### PR DESCRIPTION
Two closely related updates to save/update behavior and UI
- while a save is in progress, disable Update/Save/Publish and chat submit buttons, and show spinners where appropriate. This is to prevent triggering another save while one is in progress, and gives the student some indication that a save is currently happening
- Show an error message if saving fails. Currently, we don't handle save failures and just show the success message ("XYZ updated at time"), even though we didn't successfully update the project. Instead now we'll just show a dismissible error message. 
  - Note that this error UI is temporary; guidance from design is to have an auto-dismissing toast notification (see [thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1716507981002499) for more details). However, since the experience is currently a little misleading if a save fails, I opted to go ahead with this temporary UI to at least have some indication in place, and follow-up later with a different UI.

Save in-progress (successful) UI:

https://github.com/code-dot-org/code-dot-org/assets/85528507/6244d399-e366-4d4b-89f3-87892a5e6f0b

Save error UI (manually blocked requests in devtools):

https://github.com/code-dot-org/code-dot-org/assets/85528507/786a20cc-0757-44ec-a9cb-ac2f7575e0fd

## Links

https://codedotorg.atlassian.net/browse/LABS-692

## Testing story

Tested locally on allthethings; manually blocked requests in devtools to simulate save errors.

## Follow-up work

Better error UI (auto-dismissing toast): https://codedotorg.atlassian.net/browse/LABS-853