### PR TITLE
Prevent deletion of programming expressions referenced from existing lessons

### DIFF
--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionsTable.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionsTable.jsx
@@ -57,10 +57,16 @@ export default function ProgrammingExpressionsTable({
           style={{margin: 0}}
         />
         <Button
+          disabled={!rowData.deletable}
           onClick={() => setItemToDelete(rowData)}
           text=""
           icon="trash"
           color="red"
+          title={
+            rowData.deletable
+              ? null
+              : 'Programming expressions referenced from lessons cannot be deleted.'
+          }
           style={{margin: 0}}
         />
       </div>

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionsTableTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionsTableTest.jsx
@@ -30,6 +30,7 @@ describe('ProgrammingExpressionsTable', () => {
           environmentTitle: 'App Lab',
           categoryName: 'UI Controls',
           editPath: '/programming_expressions/2/edit',
+          deletable: true,
         },
         {
           id: 3,
@@ -39,6 +40,7 @@ describe('ProgrammingExpressionsTable', () => {
           environmentTitle: 'Game Lab',
           categoryName: 'Sprites',
           editPath: '/programming_expressions/3/edit',
+          deletable: false,
         },
         {
           id: 4,
@@ -185,6 +187,22 @@ describe('ProgrammingExpressionsTable', () => {
       const destroyButton = wrapper.find('BodyRow').at(1).find('Button').at(2);
       destroyButton.simulate('click');
       expect(wrapper.find('StylizedBaseDialog').length).to.equal(1);
+      expect(fetchStub.callCount).to.equal(fetchCount);
+    });
+  });
+
+  it('does not show confirmation dialog for disabled destroy button', () => {
+    fetchStub
+      .withArgs('/programming_expressions/get_filtered_results?page=1')
+      .returns(Promise.resolve({ok: true, json: () => returnData}));
+    const wrapper = mount(<ProgrammingExpressionsTable {...defaultProps} />);
+    return new Promise(resolve => setImmediate(resolve)).then(() => {
+      const fetchCount = fetchStub.callCount;
+      expect(fetchCount).to.equal(1);
+      wrapper.update();
+      const destroyButton = wrapper.find('BodyRow').at(2).find('Button').at(2);
+      destroyButton.simulate('click');
+      expect(wrapper.find('StylizedBaseDialog').length).to.equal(0);
       expect(fetchStub.callCount).to.equal(fetchCount);
     });
   });

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -111,7 +111,7 @@ class ProgrammingExpressionsController < ApplicationController
   def destroy
     return render :not_found unless @programming_expression
     begin
-      @programming_expression.destroy
+      @programming_expression.destroy!
       render(status: :ok, plain: "Destroyed #{@programming_expression.name}")
     rescue
       render(status: :not_acceptable, plain: @programming_expression.errors.full_messages.join('. '))

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -35,6 +35,7 @@ class ProgrammingExpression < ApplicationRecord
   validate :validate_key_format
 
   after_destroy :remove_serialization
+  before_destroy :check_unused
 
   serialized_attrs %w(
     color
@@ -371,6 +372,12 @@ class ProgrammingExpression < ApplicationRecord
   def remove_serialization
     return unless Rails.application.config.levelbuilder_mode
     FileUtils.rm_f(file_path)
+  end
+
+  def check_unused
+    return if lessons.empty?
+    errors.add(:base, 'Cannot delete programming expressions that are introduced in existing lessons')
+    throw(:abort)
   end
 
   def clone_to_programming_environment(environment_name, new_category_key = nil)

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -252,6 +252,7 @@ class ProgrammingExpression < ApplicationRecord
       environmentId: programming_environment.id,
       environmentTitle: programming_environment.title,
       categoryName: programming_environment_category&.name,
+      deletable: lessons.empty?,
       editPath: edit_programming_expression_path(self)
     }
   end

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -497,16 +497,17 @@ module Services
       # or resources, the seed process will not re-create the programming expression for us.
       # choose a key later in the sort order than existing keys.
       new_programming_expression = create :programming_expression, key: 'xyz'
+      old_programming_expression = script.lessons.first.programming_expressions.last
 
       expected_keys = [
-        script.lessons.first.programming_expressions.last.key,
+        old_programming_expression.key,
         new_programming_expression.key
       ]
       assert_equal expected_keys, expected_keys.sort
 
       script_with_changes, json = get_script_and_json_with_change_and_rollback(script) do
         lesson = script.lessons.first
-        lesson.programming_expressions.first.destroy
+        lesson.programming_expressions = [old_programming_expression]
         lesson.programming_expressions.push(new_programming_expression)
       end
 
@@ -525,16 +526,17 @@ module Services
       # or resources, the seed process will not re-create the programming expression for us.
       # choose a key earlier in the sort order than existing keys.
       new_programming_expression = create :programming_expression, key: 'abc'
+      old_programming_expression = script.lessons.first.programming_expressions.last
 
       expected_keys = [
-        script.lessons.first.programming_expressions.last.key,
+        old_programming_expression.key,
         new_programming_expression.key
       ]
       refute_equal expected_keys, expected_keys.sort
 
       script_with_changes, json = get_script_and_json_with_change_and_rollback(script) do
         lesson = script.lessons.first
-        lesson.programming_expressions.first.destroy
+        lesson.programming_expressions = [old_programming_expression]
         lesson.programming_expressions.push(new_programming_expression)
       end
 

--- a/dashboard/test/models/programming_expression_test.rb
+++ b/dashboard/test/models/programming_expression_test.rb
@@ -14,6 +14,12 @@ class ProgrammingExpressionTest < ActiveSupport::TestCase
     assert_equal 1, lesson.programming_expressions.length
   end
 
+  test 'programming expression in lesson cannot be destroyed' do
+    lesson = create :lesson
+    programming_expression = create :programming_expression, lessons: [lesson]
+    refute programming_expression.destroy
+  end
+
   class KeyConstraintTests < ActiveSupport::TestCase
     setup do
       @programming_environment = create :programming_environment


### PR DESCRIPTION
A while ago we had an incident where a levelbuilder inadvertently broke the build by deleting a programming expression documentation object. This caused lesson seeding to fail because one or more lessons referenced the now-deleted document and could not find it (exception thrown [here](https://github.com/code-dot-org/code-dot-org/blob/0084f3cff6ad0efa071e58bcfbebab21880f66ac/dashboard/lib/services/script_seed.rb#L606)).

This PR puts safeguards in place to ensure that programming expressions included in lessons cannot be deleted.

![image](https://github.com/code-dot-org/code-dot-org/assets/4108328/091878c6-c706-40cc-85c6-7c2911e09727)

## Links

- [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1711725765489529)
- [JIRA](https://codedotorg.atlassian.net/browse/TEACH-980)

## Testing story

Unit test included for backend deletion check

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
