### PR TITLE
Fix null pointer exception from progress v1

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
@@ -210,8 +210,12 @@ class ProgressTableView extends React.Component {
   syncScrollTop() {
     clearTimeout(this.timeout);
     this.timeout = setTimeout(() => {
-      this.setScrollState(this.contentView.bodyComponent);
-      this.setScrollState(this.studentList.bodyComponent);
+      if (this.contentView?.bodyComponent) {
+        this.setScrollState(this.contentView.bodyComponent);
+      }
+      if (this.studentList?.bodyComponent) {
+        this.setScrollState(this.studentList.bodyComponent);
+      }
     }, 200);
   }
 


### PR DESCRIPTION
Fixes a null pointer exception from progress v1 when switching from v2 to v1 table.

This bug does not seem to cause any bad behavior other than showing a console error. This PR just prevents the null pointer from being hit.

My assumption is that this is a race condition for the `this.bodyComponent` reference to get set and the first on-scroll event. This is likely an issue even when loading the v1 table originally, but because data is already loaded when switching between v2 and v1 we are hitting a race condition.

No bad behavior seems to be present with the fix in place. 

Before:

https://github.com/code-dot-org/code-dot-org/assets/25193259/5eb452ff-76e5-495c-bc01-faeea17f5899



After:

https://github.com/code-dot-org/code-dot-org/assets/25193259/6841c513-1ca4-49f0-be2a-d5991332cee4
Note that the scrollbar is still consistent between lesson and level views.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
