### PR TITLE
Delaying the CPA exception date because the DTP is delayed

### DIFF
--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -27,7 +27,7 @@ class Policies::ChildAccount
   # P20-937 - We had a regression which we have chosen to mitigate by allowing
   # accounts created before the below date to have their lock-out delayed until
   # the CAP policy is set to lockout all users.
-  CPA_CREATED_AT_EXCEPTION_DATE = Date.parse('2024-05-26T00:00:00MST')
+  CPA_CREATED_AT_EXCEPTION_DATE = Date.parse('2024-05-29T00:00:00MST')
 
   # The individual US State child account policy configuration
   # max_age: the oldest age of the child at which this policy applies.

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -146,7 +146,7 @@ And(/^I create( as a parent)? a (young )?student( in Colorado)?( who has never s
   end
 
   # See Policies::ChildAccount::CPA_CREATED_AT_EXCEPTION_DATE
-  cpa_exception_date = Date.parse('2024-05-26T00:00:00MST')
+  cpa_exception_date = Date.parse('2024-05-29T00:00:00MST')
 
   if after_cpa_exception
     user_opts[:created_at] = cpa_exception_date


### PR DESCRIPTION
The DTP was cancelled for today which means the next DTP will be after this exception date. The exception date needs to be  after the next DTP. If the DTP gets delayed again, I will use a DCDO value instead.

## Testing story
* Unit tests

