### PR TITLE
P20-954: Add warning icon to the Parent Permission Banner

### DIFF
--- a/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
+++ b/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
@@ -7,7 +7,7 @@ import {useSelector} from 'react-redux';
 import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {ParentalPermissionRequest} from '@cdo/apps/redux/parentalPermissionRequestReducer';
-import Notification from '@cdo/apps/templates/Notification';
+import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
 import ParentalPermissionModal from '@cdo/apps/templates/policy_compliance/ParentalPermissionModal';
 import {RootState} from '@cdo/apps/types/redux';
 import color from '@cdo/apps/util/color';
@@ -134,6 +134,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
         />
 
         <Notification
+          type={NotificationType.warning}
           colors={{backgroundColor: color.orange, borderColor: color.orange}}
           notice={i18n.policyCompliance_parentalPermissionBanner_title()}
           details={i18n.policyCompliance_parentalPermissionBanner_desc({


### PR DESCRIPTION
## Screenshot
<img src="https://github.com/code-dot-org/code-dot-org/assets/11708250/80c63307-ae47-43f5-9a2f-be0bea12e58f">

## Links
- JIRA ticket: [P20-954](https://codedotorg.atlassian.net/browse/P20-954)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/58434