### PR TITLE
Music: increase timeline rows

### DIFF
--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -14,6 +14,10 @@ import {
 import {useMusicSelector} from './types';
 import usePlaybackUpdate from './hooks/usePlaybackUpdate';
 
+// The height of the primary timeline area for drawing events.  This is the height of each measure's
+// vertical bar.
+const timelineHeight = 130;
+// The width of one measure.
 const barWidth = 60;
 // Leave some vertical space between each event block.
 const eventVerticalSpace = 2;
@@ -22,7 +26,10 @@ const paddingOffset = 10;
 // Start scrolling the playhead when it's more than this percentage of the way across the timeline area.
 const playheadScrollThreshold = 0.75;
 
-const getEventHeight = (numUniqueRows: number, availableHeight = 130) => {
+const getEventHeight = (
+  numUniqueRows: number,
+  availableHeight = timelineHeight
+) => {
   // While we might not actually have this many rows to show,
   // we will limit each row's height to the size that would allow
   // this many to be shown at once.

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -22,13 +22,13 @@ const paddingOffset = 10;
 // Start scrolling the playhead when it's more than this percentage of the way across the timeline area.
 const playheadScrollThreshold = 0.75;
 
-const getEventHeight = (numUniqueRows: number, availableHeight = 110) => {
+const getEventHeight = (numUniqueRows: number, availableHeight = 130) => {
   // While we might not actually have this many rows to show,
   // we will limit each row's height to the size that would allow
   // this many to be shown at once.
   const minVisible = 5;
 
-  const maxVisible = 10;
+  const maxVisible = 26;
 
   // We might not actually have this many rows to show, but
   // we will size the bars so that this many rows would show.


### PR DESCRIPTION
Previously, the timeline showed a maximum of 12½ rows.  Now, it can show up to 27½.

### before

<img width="1186" alt="Screenshot 2024-05-27 at 10 45 50 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/dd48004c-03d5-4da1-bc07-fa94c0146137">
<img width="1186" alt="Screenshot 2024-05-27 at 10 45 55 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/b0e59305-ae0a-4078-b73b-01cd247c253e">
<img width="1186" alt="Screenshot 2024-05-27 at 10 45 58 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/efe384a9-0e13-410c-87b0-ec8730039154">

### after

<img width="1186" alt="Screenshot 2024-05-27 at 10 44 35 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/83417f07-1499-4933-912c-e5b1913163d0">
<img width="1186" alt="Screenshot 2024-05-27 at 10 44 39 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/1f97b3be-03f7-4519-9d84-3ff48efb7860">
<img width="1186" alt="Screenshot 2024-05-27 at 10 44 43 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/d2f6518d-288a-49c7-b00a-0151a8f65d64">
<img width="1186" alt="Screenshot 2024-05-27 at 10 44 49 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/607f8d78-8ba8-4ecd-a45e-6d0e8a2829d8">
<img width="1186" alt="Screenshot 2024-05-27 at 10 44 53 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/58d9eacb-0b27-4426-96e3-db6081934ac9">
<img width="1186" alt="Screenshot 2024-05-27 at 10 44 56 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/4909ced7-15ff-461a-94d9-93ea8a733e68">
<img width="1186" alt="Screenshot 2024-05-27 at 10 44 59 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/47057280-2d97-4a08-a3f9-3e0da1d7deb9">
