### PR TITLE
Prevent "skip" messages from appearing in CI

### DIFF
--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -10,7 +10,7 @@ Minitest.load_plugins
 Minitest.extensions.delete('rails')
 Minitest.extensions.unshift('rails')
 
-reporters = [CowReporter.new]
+reporters = [CowReporter.new(detailed_skip: !ENV['CI'])]
 if ENV['CIRCLECI']
   reporters << Minitest::Reporters::JUnitReporter.new("#{ENV['CIRCLE_TEST_REPORTS']}/dashboard")
 end


### PR DESCRIPTION
Improves the CI log analysis experience by omitting "skip" messages, such as:
```bash
SKIP["test_0009_filter by end date", "Api::V1::Pd::TeacherAttendanceReportControllerTest", 1312.8364090719842]
--
4221 | test_0009_filter by end date#Api::V1::Pd::TeacherAttendanceReportControllerTest (1312.84s)
4222 | test is flaky for 6 hours per day due to time zone differences
4223 | test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb:209:in `block in <class:TeacherAttendanceReportControllerTest>'
4224 | test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

