### PR TITLE
AI Tutor: 🎨 change color of code in AI response from purple to dark teal

### DIFF
--- a/apps/src/aiTutor/views/chat-workspace.module.scss
+++ b/apps/src/aiTutor/views/chat-workspace.module.scss
@@ -142,9 +142,9 @@ $default-spacing: 2px;
 }
 
 .aiTutorMarkdown {
-  pre {
+  pre, code {
     // Color copied for consistency with bootstrap styles auto-applied to SafeMarkdown component
     background-color: #f7f7f9;
-    color: $purple;
+    color: $light_primary_700;
   }
 }


### PR DESCRIPTION
[CT-596](https://codedotorg.atlassian.net/browse/CT-596)

Small design update for cross-AI-component style consistency. The color of code in the AI response is dark teal rather than purple now.

BEFORE 

![ai-tutor-purple-code](https://github.com/code-dot-org/code-dot-org/assets/12300669/bc5b4ed6-4ae8-43d4-bfdc-736063ba2966)

AFTER 

![ai-tutor-teal-code](https://github.com/code-dot-org/code-dot-org/assets/12300669/ab5f3d3f-25e0-45d8-b60d-6d66ed61e437)

