### PR TITLE
Add low-cap "New project" string

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -442,6 +442,7 @@ en:
       navigator: 'Partner'
       create: 'Create'
       new_project: "New Project"
+      new_project_low_cap: "New project"
       algebra_game: 'Algebra'
       applab: 'App Lab'
       artist: 'Artist'


### PR DESCRIPTION
Adds a `New project` sentence-case string to eventually replace the `New Project` title-case string that will be used in upcoming header updates. Also added to the [i18n ghseet](https://docs.google.com/spreadsheets/d/1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU/edit#gid=0&range=1558:1558).

## Links
Jira ticket: [ACQ-1933](https://codedotorg.atlassian.net/browse/ACQ-1933)
Slack convo: [here](https://codedotorg.slack.com/archives/C0T0UQH0R/p1712677145809799)