### PR TITLE
Revert "P20-548: Fix translation of `Level#available_callouts`"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,6 @@ group :development, :test do
   gem 'minitest-around'
   gem 'minitest-reporters', '~> 1.2.0.beta3'
   gem 'minitest-spec-context', '~> 0.0.3'
-  gem 'minitest-spec-rails', '~> 7.2', require: false
   gem 'minitest-stub-const', '~> 0.6'
   gem 'net-http-persistent'
   gem 'rinku'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -570,9 +570,6 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     minitest-spec-context (0.0.5)
-    minitest-spec-rails (7.2.0)
-      minitest (>= 5.0)
-      railties (>= 4.1)
     minitest-stub-const (0.6)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
@@ -1068,7 +1065,6 @@ DEPENDENCIES
   minitest-around
   minitest-reporters (~> 1.2.0.beta3)
   minitest-spec-context (~> 0.0.3)
-  minitest-spec-rails (~> 7.2)
   minitest-stub-const (~> 0.6)
   mocha
   mysql2 (>= 0.4.1)

--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -26,7 +26,7 @@ module PartialRegistration
 
   def self.can_finish_signup?(params, session)
     if DCDO.get('student-email-post-enabled', false)
-      params&.dig(:user, :email).present? && in_progress?(session)
+      params[:user]&.dig(:email)&.present? && in_progress?(session)
     else
       in_progress?(session)
     end

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -203,13 +203,16 @@ class Level < ApplicationRecord
   def available_callouts(script_level)
     if custom?
       if callout_json.present?
-        callouts_i18n = should_localize? ? I18n.t(name, scope: %i[data callouts], default: {}).with_indifferent_access : {}
-
         return JSON.parse(callout_json).map do |callout_definition|
+          i18n_key = "data.callouts.#{name}.#{callout_definition['localization_key']}"
+          callout_text = (should_localize? &&
+            I18n.t(i18n_key, default: nil)) ||
+              callout_definition['callout_text']
+
           Callout.new(
             element_id: callout_definition['element_id'],
             localization_key: callout_definition['localization_key'],
-            callout_text: callouts_i18n[callout_definition['localization_key']] || callout_definition['callout_text'],
+            callout_text: callout_text,
             qtip_config: callout_definition['qtip_config'].try(:to_json),
             on: callout_definition['on']
           )

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -113,7 +113,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     }.merge options
   end
 
-  def test_logged_in_milestone
+  test "logged in milestone" do
     # do all the logging
     @controller.expects :log_milestone
 

--- a/dashboard/test/models/concerns/partial_registration_test.rb
+++ b/dashboard/test/models/concerns/partial_registration_test.rb
@@ -60,11 +60,6 @@ class PartialRegistrationTest < ActiveSupport::TestCase
       refute PartialRegistration.can_finish_signup?({}, @session)
     end
 
-    it 'can_finish_signup? is false when user is nil' do
-      PartialRegistration.persist_attributes @session, build(:user)
-      refute PartialRegistration.can_finish_signup?(ActionController::Parameters.new({user: nil}), @session)
-    end
-
     it 'can_finish_signup? is false when email is not present' do
       PartialRegistration.persist_attributes @session, build(:user)
       refute PartialRegistration.can_finish_signup?({user: {}}, @session)

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -634,6 +634,89 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal right, level.ideal_level_source
   end
 
+  test 'localizes callouts' do
+    test_locale = :'te-ST'
+    level_name = 'test_localize_callouts'
+
+    I18n.locale = test_locale
+    custom_i18n = {
+      'data' => {
+        'callouts' => {
+          level_name => {
+            first: "first test markdown",
+            second: "second test markdown",
+          }
+        }
+      }
+    }
+
+    I18n.backend.store_translations test_locale, custom_i18n
+
+    level = Level.create(
+      name: level_name,
+      level_num: 'custom',
+      callout_json: JSON.generate(
+        [
+          {callout_text: "first english markdown", localization_key: "first"},
+          {callout_text: "second english markdown", localization_key: "second"},
+        ]
+      )
+    )
+
+    callouts = level.available_callouts nil
+
+    assert_equal callouts[0].callout_text, "first test markdown"
+    assert_equal callouts[1].callout_text, "second test markdown"
+  end
+
+  test 'handles bad callout localization data' do
+    test_locale = :'te-ST'
+    level_name = 'test_localize_callouts'
+    I18n.locale = test_locale
+
+    level = Level.create(
+      name: level_name,
+      level_num: 'custom',
+      callout_json: JSON.generate(
+        [
+          {callout_text: "first english markdown", localization_key: "first"},
+          {callout_text: "second english markdown", localization_key: "second"},
+        ]
+      )
+    )
+
+    custom_i18n = {
+      'data' => {
+        'callouts' => {
+          "#{level_name}_callout" => {
+            first: nil,
+            second: nil
+          }
+        }
+      }
+    }
+
+    I18n.backend.store_translations test_locale, custom_i18n
+
+    callouts = level.available_callouts nil
+
+    assert_equal callouts[0].callout_text, "first english markdown"
+    assert_equal callouts[1].callout_text, "second english markdown"
+
+    custom_i18n = {
+      'data' => {
+        'callouts' => {}
+      }
+    }
+
+    I18n.backend.store_translations test_locale, custom_i18n
+
+    callouts = level.available_callouts nil
+
+    assert_equal callouts[0].callout_text, "first english markdown"
+    assert_equal callouts[1].callout_text, "second english markdown"
+  end
+
   test 'localizes rubric properties' do
     test_locale = :'te-ST'
     level_name = 'test_localize_callouts'
@@ -1344,114 +1427,5 @@ class LevelTest < ActiveSupport::TestCase
     # Uses the localized form
     I18n.locale = test_locale
     assert_equal level.localized_teacher_markdown, "actual translated markdown"
-  end
-
-  describe '#available_callouts' do
-    let(:available_callouts) {level.available_callouts(script_level)}
-
-    let(:level) {build(:level)}
-    let(:script_level_callout) {build(:callout)}
-    let(:script_level) {build(:script_level)}
-
-    let(:level_is_custom) {false}
-    let(:level_is_localizable) {false}
-
-    before do
-      level.stubs(:custom?).returns(level_is_custom)
-      level.stubs(:should_localize?).returns(level_is_localizable)
-
-      script_level.callouts = [script_level_callout] if script_level
-    end
-
-    it 'returns script level callouts' do
-      _(available_callouts).must_equal [script_level_callout]
-    end
-
-    context 'when script level is not provided' do
-      let(:script_level) {nil}
-
-      it 'returns empty array' do
-        _(available_callouts).must_equal []
-      end
-    end
-
-    context 'when level is custom without callout_json' do
-      let(:level_is_custom) {true}
-
-      it 'returns empty array' do
-        _(available_callouts).must_equal []
-      end
-    end
-
-    context 'when level is custom with callout_json' do
-      let(:level_is_custom) {true}
-
-      let(:callout_element_id) {'expected_callout_element_id'}
-      let(:callout_localization_key) {'expected_callout_localization_json'}
-      let(:callout_text) {'expected_callout_text'}
-      let(:callout_qtip_config) {'expected_callout_qtip_config'}
-      let(:callout_on) {'expected_callout_on'}
-
-      before do
-        level.callout_json = JSON.dump(
-          [
-            element_id: callout_element_id,
-            localization_key: callout_localization_key,
-            callout_text: callout_text,
-            qtip_config: callout_qtip_config,
-            on: callout_on,
-          ]
-        )
-      end
-
-      it 'returns its callouts' do
-        _(available_callouts.size).must_equal 1
-        _(available_callouts.first).must_be_kind_of Callout
-        assert_attributes available_callouts.first, {
-          element_id: callout_element_id,
-          localization_key: callout_localization_key,
-          callout_text: callout_text,
-          qtip_config: callout_qtip_config.to_json,
-          on: callout_on,
-        }
-      end
-
-      context 'if it is localizable and i18n string exists' do
-        let(:level_is_localizable) {true}
-
-        let(:callout_localization_key) {''}
-        let(:callout_localized_text) {'expected_callout_localized_text'}
-
-        before do
-          I18n.backend.store_translations I18n.locale, {
-            data: {
-              callouts: {
-                level.name => {
-                  callout_localization_key => callout_localized_text
-                }
-              }
-            }
-          }
-        end
-
-        it 'returns its callout with localized text' do
-          assert_attributes available_callouts.first, {
-            localization_key: callout_localization_key,
-            callout_text: callout_localized_text,
-          }
-        end
-      end
-
-      context 'if it is localizable but i18n string does not exist' do
-        let(:level_is_localizable) {true}
-
-        it 'returns callout with original text' do
-          assert_attributes available_callouts.first, {
-            localization_key: callout_localization_key,
-            callout_text: callout_text,
-          }
-        end
-      end
-    end
   end
 end

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'test_reporter'
-require 'minitest-spec-rails'
+require 'rspec'
 
 if defined? ActiveRecord
   ActiveRecord::Migration&.check_pending!
@@ -30,7 +30,7 @@ ENV['TZ'] = 'UTC'
 require 'mocha/mini_test'
 
 CDO.stubs(:rack_env).returns(:test) if defined? CDO
-Rails.application&.reload_routes! if defined?(Rails) && defined?(Rails.application)
+Rails.application.reload_routes! if defined?(Rails) && defined?(Rails.application)
 
 require File.expand_path('../../config/environment', __FILE__)
 I18n.load_path += Dir[Rails.root.join('test', 'en.yml')]


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#58814 because it causes issues in `dashboard/test/lib/services/script_seed_test.rb`