### PR TITLE
[Google Blockly] Block.interpolateMsg

### DIFF
--- a/apps/src/blockly/addons/cdoGenerator.ts
+++ b/apps/src/blockly/addons/cdoGenerator.ts
@@ -49,6 +49,7 @@ export default function initializeGenerator(
     }
     const generator = blocklyWrapper.getGenerator();
     generator.init(blocklyWrapper.getMainWorkspace());
+    generator.variableDB_ = generator.nameDB_;
     const code: string[] = [];
     blocksToGenerate.forEach(block => {
       code.push(blocklyWrapper.JavaScript.blockToCode(block));

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -102,6 +102,7 @@ import {
   LOOP_HIGHLIGHT,
   handleCodeGenerationFailure,
   strip,
+  interpolateMsg,
 } from './utils';
 
 const options = {
@@ -459,6 +460,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
 
   const extendedBlock = blocklyWrapper.Block.prototype as ExtendedBlock;
 
+  extendedBlock.interpolateMsg = interpolateMsg;
   extendedBlock.setStrictOutput = function (isOutput, check) {
     return this.setOutput(isOutput, check);
   };

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -203,12 +203,9 @@ export interface ExtendedInput extends Input {
 
 export interface ExtendedBlock extends Block {
   interpolateMsg: (
+    this: ExtendedBlock,
     msg: string,
-    ...var_args: (
-      | number
-      | [string, string | number, string | number]
-      | (() => void)
-    )[]
+    ...inputArgs: [...([string, string, number] | (() => void))[], number]
   ) => void;
   setStrictOutput: (isOutput: boolean, check: string | string[] | null) => void;
   // Blockly uses any for value.

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -202,6 +202,14 @@ export interface ExtendedInput extends Input {
 }
 
 export interface ExtendedBlock extends Block {
+  interpolateMsg: (
+    msg: string,
+    ...var_args: (
+      | number
+      | [string, string | number, string | number]
+      | (() => void)
+    )[]
+  ) => void;
   setStrictOutput: (isOutput: boolean, check: string | string[] | null) => void;
   // Blockly uses any for value.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -211,6 +211,8 @@ export function strip(code: string) {
  *     The last parameter is not a tuple, but just an alignment for any trailing
  *     dummy input.  This last parameter is mandatory; there may be any number
  *     of tuples (though the number of tuples must match the symbols in msg).
+ * This was copied and modernized from the original CDO Blockly version:
+ * https://github.com/code-dot-org/blockly/blob/v4.1.0/core/ui/block.js#L2632-L2692
  */
 export function interpolateMsg(
   this: ExtendedBlock,

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -198,7 +198,7 @@ export function strip(code: string) {
 }
 
 /**
- * Interpolate a message string, creating titles and inputs.
+ * Interpolate a message string, creating fields and inputs.
  * @param {string} msg The message string to parse.  %1, %2, etc. are symbols
  *     for value inputs.
  * @param {!Array.<string|number>|number} inputArgs A series of tuples or
@@ -207,7 +207,7 @@ export function strip(code: string) {
  *     three values:
  *       the input name
  *       its check type
- *       its title's alignment.
+ *       its field's alignment.
  *     The last parameter is not a tuple, but just an alignment for any trailing
  *     dummy input.  This last parameter is mandatory; there may be any number
  *     of tuples (though the number of tuples must match the symbols in msg).

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -254,11 +254,12 @@ export function interpolateMsg(
   }
 
   // Verify that all inputs were used.
-  for (let i = 0; i < usedArgs.length; i++) {
-    if (!usedArgs[i]) {
-      const formattedMessage = `Input "${i + 1}" not used in message: "${msg}"`;
-      throw new Error(formattedMessage);
-    }
+  const unusedArgIndex = usedArgs.findIndex(used => !used);
+  if (unusedArgIndex !== -1) {
+    const formattedMessage = `Input "${
+      unusedArgIndex + 1
+    }" not used in message: "${msg}"`;
+    throw new Error(formattedMessage);
   }
 
   // Make the inputs inline unless there is only one input and no text follows it.


### PR DESCRIPTION
The block method `interpolateMsg` is defined in the CDO Blockly repo and used to define various blocks for Bee (Maze), Play Lab, and Artist. It interpolates a message string to create fields and inputs based on the provided parameters. It parses the message (e.g. `'make %1 honey'`) to replace symbols (like %1, %2) with specific value inputs. These value inputs are specified in a number of additional parameters, which can be a series of tuples or callbacks. As there is no compatible method in core Google Blockly, I suggest we port it into our utils.

## Approach
Because the source comes from a different file/repo, Github can't really provide a clear diff. To make reviewing a little easier, here is a line-by-line diff: https://www.diffchecker.com/jgDOHreF/

I started by copying the original method from CDO Blockly here:
- https://github.com/code-dot-org/blockly/blob/v4.1.0/core/ui/block.js#L2632-L2692

This function utilized Google's Closure library (`goog.asserts`, `goog.string`), which is a set of utilities for JavaScript, including assertions for type checking and validating conditions during development.
- https://google.github.io/closure-library/api/goog.asserts.html
- https://google.github.io/closure-library/api/goog.string.html

Since we are not using the closure library, `goog` is undefined. I replaced each of these calls with some standard error throwing and string trimming that should be functionally equivalent. 

The old function utilizes the `arguments` object, which provides a way to access all arguments passed to the function. For TypeScript, we use the [rest parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) syntax to define the types of each argument explicitly.

The old function checks that all inputs have been used by resetting the value to `null`. To avoid assigning `null` to the typed argument, I instead created a `usedArgs` array to track which inputs have been completed.

Several instances of `appendTitle` have been updated to `appendField` which is supported by the mainline API.

One traditional for loop has been modernized to use `Array.findIndex` instead.


## Manual testing

The `Bee` variant of Maze defines a few blocks using this method that are actually not found in any levels. However, I was able to add them to a toolbox and confirm that they work as expected. These blocks are shown below with logged arguments for the first block:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/20e2cdb4-4c4a-4289-a7a1-141515ee1e90)![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/7fc377a1-4c0c-4219-b5fe-23ed4340a889)


These blocks only have a single input and use tuples exclusively, I wanted to test additional blocks. Play Lab has a block with multiple inputs defined with callback functions. This block can be found at `/s/playlab/lessons/1/levels/10`, however there are additional local changes needed to get that level to load without crashing. (Stay tuned for that PR.) In any case, by including all needed changes, I was able to confirm that we could define and create the blocks using callbacks for the inputs too:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/71a1ced9-2a6c-4557-89bb-69b3396cba78)
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/edd24e8b-cd49-496a-834a-3e36133af430)


## Generator update
Blockly's generators work with a database of names/variables, which was renamed for v10. For the Sprite Lab migration, we checked for the existence of either name:
https://github.com/code-dot-org/code-dot-org/blob/mike/interpolateMsg/apps/src/p5lab/spritelab/blocks.js#L353-L357

Rather than re-using the same band-aid in other places where we access the database, I also implemented a quick fix to assign the new `nameDB_` value to the old `variableDB_` after initializing the generator. This was necessary to get the Bee blocks to actually generate code and will also be important as we work migrate Artist.

The snippet below is the helper method used to create these Bee blocks. You'll notice that the block's `init` function calls `interpolateMsg` while the generator function accesses a function on the old `variableDB_` name:

https://github.com/code-dot-org/code-dot-org/blob/mike/interpolateMsg/apps/src/maze/beeBlocks.js#L255-L293

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
