### PR TITLE
[Sprite Lab] use generator getName

### DIFF
--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -350,12 +350,7 @@ const customInputTypes = {
     generateCode(block, arg) {
       const fieldValue = block.getFieldValue(arg.name);
       const invalidBehavior = fieldValue === NO_OPTIONS_MESSAGE;
-      // variableDB_ was deprecated in Google Blockly but exists up to v9 and in CDO Blockly.
-      // TODO: After Sprite Lab has migrated to mainline, and before updating to v10,
-      // use nameDB_ exclusively.
-      const variableNameDB =
-        Blockly.JavaScript.nameDB_ || Blockly.JavaScript.variableDB_;
-      const behaviorId = variableNameDB.getName(fieldValue, 'PROCEDURE');
+      const behaviorId = Blockly.JavaScript.getName(fieldValue, 'PROCEDURE');
       if (invalidBehavior) {
         console.warn('No behaviors available');
         return undefined;


### PR DESCRIPTION
Sprite Lab's behavior picker has an edit button which opens the modal function editor for the currently selected behavior. To determine the correct behavior/procedure to use, we need to access the JavaScript generator's `nameDB_` (formerly `variableDB_`). This was renamed between v9 and v10. In anticipation of the rename, we simply started checking for either name and left ourselves a note to clean it up. This is that clean up. :)
However, instead of simply calling `nameDB_` directly (which works fine), I realized we can use the base generator class's `getName` to save ourselves a step. See here: https://github.com/google/blockly/blob/6e4ba00be52da2102516b48ab9a704236a93b0cd/core/generator.ts#L539-L546

Unfortunately, CDO Blockly doesn't have an equivalent method in the base generator class. This just means we'll continue to see and support `JavaScript.variableDB_` across non-migrated labs.) [This PR](https://github.com/code-dot-org/code-dot-org/pull/58939) handle assigning the new database value to the old label so that we don't actually need to touch those files during the migration effort. However, once an upcoming lab (Maze, Artist, Play Lab) is fully migrated, we can perform a similar clean-up to this branch, if desired.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I confirmed that the edit button on a behavior picker block still works as expected.

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/acfab7ed-82a5-4149-b13d-d4aa13f5e8c6)Clicking "edit" opens the modal:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/9834b11e-9390-4445-a12e-e9620353172b)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
