### PR TITLE
Clean up files manually added to apps build by Storybook deploy

### DIFF
--- a/apps/script/deploy-storybook.sh
+++ b/apps/script/deploy-storybook.sh
@@ -67,5 +67,9 @@ echo "cleaning up!"
 # clean up after ourselves
 popd
 rm -rf $DIR_TO_DEPLOY
+# Remove these files manually copied over above
+# so they are not retained in our staging apps build package.
+rm ./build/package/css/application.css
+rm ./build/package/css/font-awesome.css
 
 echo "if everything worked, your changes should be up on https://code-dot-org.github.io/cdo-styleguide/"

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -11,6 +11,9 @@ namespace :build do
   desc 'Builds apps.'
   timed_task_with_logging :apps do
     Dir.chdir(apps_dir) do
+      commit_hash = apps_dir('build/commit_hash')
+
+      # This will never be hit in current configuration
       if apps_unchanged?
         ChatClient.log '<b>apps</b> unchanged since last build, skipping.'
         next
@@ -23,11 +26,6 @@ namespace :build do
       npm_target = CDO.optimize_webpack_assets ? 'build:dist' : 'build'
       RakeUtils.system "npm run #{npm_target}"
       File.write(commit_hash, calculate_apps_commit_hash)
-
-      if rack_env?(:staging) && DCDO.get('deploy_storybook', true)
-        ChatClient.log 'Deploying <b>storybook</b>...'
-        RakeUtils.system 'npm run storybook:deploy'
-      end
     end
   end
 
@@ -190,12 +188,14 @@ namespace :build do
     end
   end
 
+  apps_unchanged = apps_unchanged?
+
   tasks = []
-  tasks << :apps if CDO.build_apps
+  tasks << :apps if CDO.build_apps && !apps_unchanged
   tasks << :dashboard if CDO.build_dashboard
   tasks << :pegasus if CDO.build_pegasus
   tasks << :tools if rack_env?(:staging)
-  tasks << :storybook if rack_env?(:staging) && !apps_unchanged?
+  tasks << :storybook if rack_env?(:staging) && !apps_unchanged
   tasks << :i18n if CDO.build_i18n
   timed_task_with_logging all: tasks
 end
@@ -222,8 +222,10 @@ end
 
 # Only rebuild or deploy storybook if any of the apps_build_trigger_paths have changed since last build.
 def apps_unchanged?
-  commit_hash = apps_dir('build/commit_hash')
-  !RakeUtils.git_staged_changes?(*apps_build_trigger_paths) &&
-    File.exist?(commit_hash) &&
-    File.read(commit_hash) == calculate_apps_commit_hash
+  Dir.chdir(apps_dir) do
+    commit_hash = apps_dir('build/commit_hash')
+    return !RakeUtils.git_staged_changes?(*apps_build_trigger_paths) &&
+        File.exist?(commit_hash) &&
+        File.read(commit_hash) == calculate_apps_commit_hash
+  end
 end


### PR DESCRIPTION
[Stephen noted](https://codedotorg.slack.com/archives/C0T0PNTM3/p1716411724975939) that the difference between our staging and test builds that produce the "different package for same contents" that often blocks staging/test builds is a result of a couple of files being manually added to our staging build as part of our Storybook deploy process. This change cleans up that diff, which should reduce the frequency of these errors.

I pursued a "cleaner" approach of separating out and running the Storybook build after we do the S3 upload, but I felt it ended up a bit more complicated than it was worth. Here's the description for posterity:

The "upload to S3" step is actually a part of (really a prerequisite for) the "dashboard" build step ([the "package" dependency listed here](https://github.com/code-dot-org/code-dot-org/blob/0d63b81a4963a5fab567576dc6a1d87d86337937/lib/rake/build.rake#L48)), rather than the "apps" build step. I didn't feel confident messing with that setup (and it might make sense if you think of the apps build itself as "standalone" and the need for it to be on S3 as a requirement for our Rails app). As a result, I wanted to put the Storybook step after the dashboard build step. To do this, I needed to separate out the logic that determines when we build apps (ie, if there have been changes in the apps directory since the last build), and apply this to both the Storybook step and the main apps build step. [A rough draft of this is here for future reference](https://github.com/code-dot-org/code-dot-org/pull/58925).

## Testing story

I tested this script manually locally and saw that the two files no longer appeared in my build directory.