### PR TITLE
Music: new timeline order

### DIFF
--- a/apps/src/music/views/TimelineSimple2Events.tsx
+++ b/apps/src/music/views/TimelineSimple2Events.tsx
@@ -116,7 +116,28 @@ interface TimelineSimple2EventsProps {
 const TimelineSimple2Events: React.FunctionComponent<
   TimelineSimple2EventsProps
 > = ({paddingOffset, barWidth, eventVerticalSpace, getEventHeight}) => {
-  const soundEvents = useMusicSelector(state => state.music.playbackEvents);
+  const soundEventsOrig = [
+    ...useMusicSelector(state => state.music.playbackEvents),
+  ];
+  const soundEvents = soundEventsOrig.sort((a, b) => {
+    if (a.triggered && b.triggered) {
+      const name1 = a.functionContext?.name || '';
+      const name2 = b.functionContext?.name || '';
+      if (name1 < name2) {
+        return -1;
+      } else if (name1 > name2) {
+        return 1;
+      } else {
+        return 0;
+      }
+    } else if (a.triggered && !b.triggered) {
+      return 1;
+    } else if (!a.triggered && b.triggered) {
+      return -1;
+    } else {
+      return a.when - b.when;
+    }
+  });
   const orderedFunctions = useMusicSelector(
     state => state.music.orderedFunctions
   );
@@ -135,6 +156,7 @@ const TimelineSimple2Events: React.FunctionComponent<
         uniqueSounds.push(id);
       }
     }
+    console.log(uniqueSounds);
     return uniqueSounds;
   }, [soundEvents]);
 
@@ -144,7 +166,7 @@ const TimelineSimple2Events: React.FunctionComponent<
   // Each timeline extent has left/right position in measures, and
   // top/bottom position in rows.
   const uniqueFunctionExtentsArray = useMemo(() => {
-    return orderedFunctions
+    const funcs = orderedFunctions
       .map(orderedFunction =>
         getFunctionExtents(
           orderedFunction,
@@ -153,6 +175,7 @@ const TimelineSimple2Events: React.FunctionComponent<
         )
       )
       .filter(orderedFunction => orderedFunction);
+    return funcs;
   }, [orderedFunctions, currentUniqueSounds]);
 
   const eventHeight = useMemo(

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -115,6 +115,14 @@ const optionsList = [
       },
     ],
   },
+  {
+    name: 'timeline-layout-2',
+    type: 'radio',
+    values: [
+      {value: 'false', description: 'Original timeline (default).'},
+      {value: 'true', description: 'New timeline.'},
+    ],
+  },
 ];
 
 export default class MusicMenu extends React.Component {


### PR DESCRIPTION
This adds a new idea for the timeline ordering, behind the `?timeline-layout-2=true` URL parameter.  

Until now, sounds have been grouped by the function that directly generates them, in adjacent rows. 

In this new ordering, all sounds generated somewhere under `when run` are ordered in rows by their play time.

### before

<img width="1512" alt="Screenshot 2024-05-28 at 10 45 50 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/87fefab6-62f7-4545-b505-060e3b101424">

### after

<img width="1512" alt="Screenshot 2024-05-28 at 10 46 19 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/d5aa9c8b-c8e6-460b-85e4-c7089e477238">
