### PR TITLE
fix(selenium): use sauce labs regionalized US endpoint

### DIFF
--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -21,7 +21,7 @@ def saucelabs_browser(test_run_name)
   raise "Please define CDO.saucelabs_authkey"  if CDO.saucelabs_authkey.blank?
 
   is_tunnel = ENV['CIRCLE_BUILD_NUM']
-  url = "http://#{CDO.saucelabs_username}:#{CDO.saucelabs_authkey}@#{is_tunnel ? 'localhost:4445' : 'ondemand.saucelabs.com:80'}/wd/hub"
+  url = "http://#{CDO.saucelabs_username}:#{CDO.saucelabs_authkey}@#{is_tunnel ? 'localhost:4445' : 'ondemand.us-west-1.saucelabs.com:80'}/wd/hub"
 
   capabilities = Selenium::WebDriver::Remote::Capabilities.new($browser_config.except('name'))
 


### PR DESCRIPTION
Currently, code.org uses the global endpoint for saucelabs to create selenium sessions. However, starting around late last week, the global endpoint started to return non-session data on its 303 session endpoint for iPad and iPhone simulator tests. The regionalized endpoint does not appear to be affected.

Switching to the regionalized endpoint seems to make sense anyway to ensure our tests run in the US on the closest possible servers.

---

## Debugging

I first noticed that our sauce labs setup has no issues with WebdriverIO (a popular javascript version to connect to sauce labs) but failed when using our own setup. Using wireshark, I did a packet dump of WDIO vs our custom selenium connector. With the same session API payload and HTTP headers we continued to receive the unexpected response on the 303 follow. However, upon further inspection, the side by side wireshark analysis revealed that the hostnames were different. When switching to the regionalized endpoint, the appropriate response was returned.

## Global Endpoint

Notice the unexpected response from the global endpoint (namely no session id)

```
curl -vvv -L  -H "Content-Type: application/json; charset=utf-8" -H "Connection: keep-alive" -H "Accept: application/json" -H "User-Agent: webdriver/8.38.0" -L --retry 3 -d '{"capabilities":{"alwaysMatch":{"platformName":"iOS","browserName":"Safari","appium:deviceName":"iPad Simulator","appium:platformVersion":"15.4","appium:automationName":"XCUITest","sauce:options":{"appiumVersion":"1.22.3","build":"<your build id>","name":"<your test name>","deviceOrientation":"PORTRAIT"}},"firstMatch":[{}]},"desiredCapabilities":{"platformName":"iOS","browserName":"Safari","appium:deviceName":"iPad Simulator","appium:platformVersion":"15.4","appium:automationName":"XCUITest","sauce:options":{"appiumVersion":"1.22.3","build":"<your build id>","name":"<your test name>","deviceOrientation":"PORTRAIT"}}}' http://[redacted]@ondemand.saucelabs.com/wd/hub/session
*   Trying 66.85.49.22:80...
* TCP_NODELAY set
* Connected to ondemand.saucelabs.com (66.85.49.22) port 80 (#0)
* Server auth using Basic with user 'redacted'
> POST /wd/hub/session HTTP/1.1
> Host: ondemand.saucelabs.com
> Authorization: Basic [redacted]
> Content-Type: application/json; charset=utf-8
> Connection: keep-alive
> Accept: application/json
> User-Agent: webdriver/8.38.0
> Content-Length: 624
>
* upload completely sent off: 624 out of 624 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 303 See Other
< X-Please-Hold: ...
< Location: /wd/hub/session/dda7d948a67c408496c1ed4f4a68e5e3
< Content-Length: 0
< Connection: close
<
* Closing connection 0
* Issue another request to this URL: 'http://[redacted]@ondemand.saucelabs.com/wd/hub/session/dda7d948a67c408496c1ed4f4a68e5e3'
* Disables POST, goes with GET
*   Trying 66.85.49.22:80...
* TCP_NODELAY set
* Connected to ondemand.saucelabs.com (66.85.49.22) port 80 (#1)
* Server auth using Basic with user 'redacted'
> GET /wd/hub/session/dda7d948a67c408496c1ed4f4a68e5e3 HTTP/1.1
> Host: ondemand.saucelabs.com
> Authorization: Basic [redacted]
> Content-Type: application/json; charset=utf-8
> Connection: keep-alive
> Accept: application/json
> User-Agent: webdriver/8.38.0
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-length: 1467
< content-type: application/json;charset=UTF-8
< date: Wed, 29 May 2024 14:43:15 GMT
< server: monocle/0.42
< x-sauce-session-id: dda7d948a67c408496c1ed4f4a68e5e3
<
{"value": {"deviceName": "iPad (5th generation)", "orientation": "PORTRAIT", "noReset": true, "selenium:webdriver.remote.quietExceptions": false, "CFBundleIdentifier": "com.apple.mobilesafari", "device": "ipad", "bootstrapPath": "/Volumes/Sauce/wda/wda-v1.22.3-xcode13.0/WebDriverAgent", "newCommandTimeout": 0, "preventWDAAttachments": true, "sauce:options": {}, "viewportRect": {"width": 1536, "top": 40, "height": 2008, "left": 0}, "derivedDataPath": "/Volumes/Sauce/wda/wda-v1.22.3-xcode13.0/WebDriverAgent/DerivedData/WebdriverAgent", "webdriver.remote.sessionid": "dda7d948a67c408496c1ed4f4a68e5e3", "maxTypingFrequency": 8, "platformName": "iOS", "showIOSLog": false, "pixelRatio": 2, "automationName": "XCUITest", "usePrebuiltWDA": true, "browserName": "Safari", "hasMetadata": true, "platformVersion": "15.4", "eventTimings": true, "keepKeyChains": true, "sdkVersion": "15.4", "launchTimeout": 240000, "udid": "2D4B1D88-8C08-457A-85B4-50C32CAA31F9", "statBarHeight": 20, "events": {"xcodeDetailsRetrieved": [1716993* Connection #1 to host ondemand.saucelabs.com left intact
754096], "orientationSet": [1716993785753], "commands": [], "initialWebviewNavigated": [1716993794027], "wdaStarted": [1716993785598], "resetComplete": [1716993754098], "appConfigured": [1716993754098], "logCaptureStarted": [1716993756424], "wdaSessionStarted": [1716993785588], "wdaSessionAttempted": [1716993778297], "simStarted": [1716993758755], "wdaStartAttempted": [1716993758845], "resetStarted": [1716993754098]}, "backendRetries": 4}}
```

## Regionalized

Notice the inclusion of the session id

```
 curl -vvv -L  -H "Content-Type: application/json; charset=utf-8" -H "Connection: keep-alive" -H "Accept: application/json" -H "User-Agent: webdriver/8.38.0" -L --retry 3 -d '{"capabilities":{"alwaysMatch":{"platformName":"iOS","browserName":"Safari","appium:deviceName":"iPad Simulator","appium:platformVersion":"15.4","appium:automationName":"XCUITest","sauce:options":{"appiumVersion":"1.22.3","build":"<your build id>","name":"<your test name>","deviceOrientation":"PORTRAIT"}},"firstMatch":[{}]},"desiredCapabilities":{"platformName":"iOS","browserName":"Safari","appium:deviceName":"iPad Simulator","appium:platformVersion":"15.4","appium:automationName":"XCUITest","sauce:options":{"appiumVersion":"1.22.3","build":"<your build id>","name":"<your test name>","deviceOrientation":"PORTRAIT"}}}' http://[redacted]@ondemand.us-west-1.saucelabs.com/wd/hub/session
*   Trying 66.85.52.224:80...
* TCP_NODELAY set
* Connected to ondemand.us-west-1.saucelabs.com (66.85.52.224) port 80 (#0)
* Server auth using Basic with user 'redacted'
> POST /wd/hub/session HTTP/1.1
> Host: ondemand.us-west-1.saucelabs.com
> Authorization: Basic [redacted]
> Content-Type: application/json; charset=utf-8
> Connection: keep-alive
> Accept: application/json
> User-Agent: webdriver/8.38.0
> Content-Length: 624
>
* upload completely sent off: 624 out of 624 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 303 See Other
< content-length: 0
< content-type: text/html
< date: Wed, 29 May 2024 14:46:03 GMT
< location: /wd/hub/session/b815ce7d19604e5bb6280d16ad51f96b
< server: monocle/0.42
< x-request-id: b815ce7d-1960-4e5b-b628-0d16ad51f96b
<
* Connection #0 to host ondemand.us-west-1.saucelabs.com left intact
* Issue another request to this URL: 'http://[redacted]@ondemand.us-west-1.saucelabs.com/wd/hub/session/b815ce7d19604e5bb6280d16ad51f96b'
* Disables POST, goes with GET
* Found bundle for host ondemand.us-west-1.saucelabs.com: 0x559e9c634e70 [serially]
* Can not multiplex, even if we wanted to!
* Re-using existing connection! (#0) with host ondemand.us-west-1.saucelabs.com
* Connected to ondemand.us-west-1.saucelabs.com (66.85.52.224) port 80 (#0)
* Server auth using Basic with user 'redacted'
> GET /wd/hub/session/b815ce7d19604e5bb6280d16ad51f96b HTTP/1.1
> Host: ondemand.us-west-1.saucelabs.com
> Authorization: Basic [redacted]
> Content-Type: application/json; charset=utf-8
> Connection: keep-alive
> Accept: application/json
> User-Agent: webdriver/8.38.0
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-length: 1064
< content-type: application/json;charset=UTF-8
< date: Wed, 29 May 2024 14:46:59 GMT
< server: monocle/0.42
< x-request-id: 38f9e4a2-e0fd-43aa-9651-010493f745bc
<
{"value": {"sessionId": "b815ce7d19604e5bb6280d16ad51f96b", "webdriver.remote.sessionid": "b815ce7d19604e5bb6280d16ad51f96b", "hasMetadata": true, "capabilities": {"deviceName": "iPad (5th generation)", "takesScreenshot": true, "orientation": "PORTRAIT", "networkConnectionEnabled": false, "selenium:webdriver.remote.quietExceptions": false, "bootstrapPath": "/Volumes/Sauce/wda/wda-v1.22.3-xcode13.0/WebDriverAgent", "newCommandTimeout": 0, "preventWDAAttachments": true, "sauce:options": {}, "derivedDataPath": "/Volumes/Sauce/wda/wda-v1.22.3-xcode13.0/WebDriverAgent/DerivedData/WebdriverAgent", "locationContextEnabled": false, "platform": "MAC", "maxTypingFrequency": 8, "platformName": "iOS", "showIOSLog": false, "javascriptEnabled": true, "automationName": "XCUITest", "databaseEnabled": false, "noReset": true, "usePrebuiltWDA": true, "browserName": "Safari", "platformVersion": "15.4", "webStorageEnabled": false, "eventTimings": true, "keepKeyChains": true, "launchTimeout": 240000, "udid": "2D4B1D88-8C08-457A-85* Connection #0 to host ondemand.us-west-1.saucelabs.com left intact
B4-50C32CAA31F9", "backendRetries": 4}}}⏎
```

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1716557833547009)

## Testing story

I did a quick edit on test and rebuilt DTT. This resulted in all tests to pass except for a potentially flaky firefox one and some eyes mismatches.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
