### PR TITLE
Update CSD text on MS and HS pages

### DIFF
--- a/pegasus/sites.v3/code.org/views/high_school_curricula_video.haml
+++ b/pegasus/sites.v3/code.org/views/high_school_curricula_video.haml
@@ -4,7 +4,7 @@
 
 - video_curricula_title = [hoc_s(:curriculum_name_csd), hoc_s(:curriculum_name_csp), hoc_s(:curriculum_name_csa), hoc_s(:curriculum_name_artificial_intelligence), hoc_s(:curriculum_name_maker), hoc_s(:hour_of_code)]
 
-- video_curricula_desc = [hoc_s(:csf_page_top_desc), hoc_s(:csp_page_top_desc), hoc_s(:curriculum_desc_csa),  hoc_s(:ai_hero_desc), hoc_s(:curriculum_desc_maker), hoc_s(:hoc_homepage_what_is_hoc_subhead)]
+- video_curricula_desc = [hoc_s(:csd_page_top_desc), hoc_s(:csp_page_top_desc), hoc_s(:curriculum_desc_csa),  hoc_s(:ai_hero_desc), hoc_s(:curriculum_desc_maker), hoc_s(:hoc_homepage_what_is_hoc_subhead)]
 
 - video_id = ["cs_discoveries", "cs_principles", "ai_intelligence", "courses_maker", "hour_of_code"]
 - video_link = ["/csd", "/csp", "/csa", "/ai", "/maker", "/hourofcode"]

--- a/pegasus/sites.v3/code.org/views/middle_school_curricula_video.haml
+++ b/pegasus/sites.v3/code.org/views/middle_school_curricula_video.haml
@@ -4,7 +4,7 @@
 
 - video_curricula_title = [hoc_s(:curriculum_name_csd), hoc_s(:curriculum_name_artificial_intelligence), hoc_s(:curriculum_name_maker), hoc_s(:hour_of_code)]
 
-- video_curricula_desc = [hoc_s(:csf_page_top_desc), hoc_s(:ai_hero_desc), hoc_s(:curriculum_desc_maker), hoc_s(:hoc_homepage_what_is_hoc_subhead)]
+- video_curricula_desc = [hoc_s(:csd_page_top_desc), hoc_s(:ai_hero_desc), hoc_s(:curriculum_desc_maker), hoc_s(:hoc_homepage_what_is_hoc_subhead)]
 
 - video_id = ["cs_discoveries", "ai_intelligence", "courses_maker", "hour_of_code"]
 - video_link = ["/csd", "/ai", "/maker", "/hourofcode"]


### PR DESCRIPTION
Updates the CSD description text on https://code.org/curriculum/middle-school and https://code.org/curriculum/high-school to the correct string. It's replacing the CSF string, and the correct string already exists (yay!). 

## Links
Jira ticket: [ACQ-1932](https://codedotorg.atlassian.net/browse/ACQ-1932)

## Testing story
Tested locally

----

## Middle School page
| Before | After |
| ---- | ---- |
| <img width="1019" alt="Before_Mid" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/6798cc0f-f0c6-42e1-ae14-ebd752fb568f"> | <img width="1019" alt="After_Mid" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/6dc8bbc1-fcc6-4894-af17-b1e88b728893"> |

## High School page
| Before | After |
| ---- | ---- |
| <img width="1019" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/f6813030-1a1a-4679-bc16-c70039c9f6c2"> | <img width="1019" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/b4fe6b67-e9db-41e7-8733-eef07d53a0bb"> |
