### PR TITLE
[Python Lab] Add support for scipy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,9 @@ pegasus/sites.v3/** filter=lfs diff=lfs merge=lfs -text
 pegasus/sites/** filter=lfs diff=lfs merge=lfs -text
 shared/images/** filter=lfs diff=lfs merge=lfs -text
 
+# INCLUDE any .zip files that appear in the pyodide folder.
+apps/lib/pyodide/*.zip filter=lfs diff=lfs merge=lfs -text
+
 # HOW TO EXCLUDE A FILE/FILES FROM GIT LFS:
 #
 # 1. Add a new exclusion pattern in the immediately following section

--- a/.gitattributes
+++ b/.gitattributes
@@ -22,9 +22,6 @@ pegasus/sites.v3/** filter=lfs diff=lfs merge=lfs -text
 pegasus/sites/** filter=lfs diff=lfs merge=lfs -text
 shared/images/** filter=lfs diff=lfs merge=lfs -text
 
-# INCLUDE any .zip files that appear in the pyodide folder.
-apps/lib/pyodide/*.zip filter=lfs diff=lfs merge=lfs -text
-
 # HOW TO EXCLUDE A FILE/FILES FROM GIT LFS:
 #
 # 1. Add a new exclusion pattern in the immediately following section
@@ -60,6 +57,7 @@ pegasus/sites*/**/*.scss !text !filter !merge !diff
 *.png filter=lfs diff=lfs merge=lfs -text
 *.ttf filter=lfs diff=lfs merge=lfs -text
 *.whl filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
 
 # Small list of very common text file types to EXCLUDE from Git LFS:
 *.css !text !filter !merge !diff

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -233,7 +233,7 @@ module.exports = function (grunt) {
         {
           expand: true,
           cwd: 'lib/pyodide',
-          src: ['*.whl'],
+          src: ['*.whl', '*.zip'],
           dest: `build/package/js/pyodide/${pyodide.version}`,
         },
       ],

--- a/apps/lib/pyodide/openblas-0.3.23.zip
+++ b/apps/lib/pyodide/openblas-0.3.23.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd4867ee63ad4e9c250faa2ade932ebe0513a99da1368ac77b155a116a4aa55e
+size 5920280

--- a/apps/lib/pyodide/scipy-1.11.2-cp311-cp311-emscripten_3_1_46_wasm32.whl
+++ b/apps/lib/pyodide/scipy-1.11.2-cp311-cp311-emscripten_3_1_46_wasm32.whl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20fb3193b0444614045692c6f3bddfe33dea155d7b2797c779f4079fe0f4fb86
+size 42661491


### PR DESCRIPTION
Add support for scipy in our self-hosted version of pyodide. Scipy required us to add a `.zip` file for its `openblas` dependency, so I updated our `.gitattributes` to include any `zip` files in the `pyodide` folder in LFS. We have some other zip files in the repo that are not in LFS so I didn't include zip more broadly.

## Links

- jira ticket: [https://codedotorg.atlassian.net/browse/CT-447](https://codedotorg.atlassian.net/browse/CT-447) This ticket was for scipy, math and pandas. I already added pandas, and math is included by default.

## Testing story
Tested locally that you can now import and use scipy in Python Lab.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
