### PR TITLE
Remove /poetry skinny banner

### DIFF
--- a/pegasus/sites.v3/code.org/public/poetry.haml
+++ b/pegasus/sites.v3/code.org/public/poetry.haml
@@ -11,8 +11,6 @@ set_dir: true
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/poetry-styles.css", rel: "stylesheet"}
 
-= view :top_skinny_banner, banner_id: "banner-poetry", banner_url: nil, banner_icon: "fa fa-pen-nib", banner_text: hoc_s('poetry_page.skinny_banner'), external_link: false, light_theme: true
-
 %section.hero-banner-basic
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper


### PR DESCRIPTION
Remove the skinny banner on the [/poetry](https://code.org/poetry) page now that it's no longer Poetry Month.

Before:
![with skinny banner](https://github.com/code-dot-org/code-dot-org/assets/56283563/0acf9f01-df16-4a67-8fe5-18db7a1202dc)

After:
![without banner](https://github.com/code-dot-org/code-dot-org/assets/56283563/5b631cbd-2353-4eb2-b282-fa3fffd16f3d)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1888)

## Testing story
Local testing.

## Followup work
Let DOTD know about eyes diffs for poetry page.
