### PR TITLE
Speculative de-flaking of useRegionalPartner apps test

### DIFF
--- a/apps/src/code-studio/pd/components/useRegionalPartner.jsx
+++ b/apps/src/code-studio/pd/components/useRegionalPartner.jsx
@@ -16,7 +16,7 @@ const COURSE_NAMES = {
 };
 
 // constructs query params and fetches the data, returning a promise
-const fetchRegionalPartner = ({
+const fetchRegionalPartner = async ({
   program,
   schoolZipCode,
   schoolState,
@@ -39,7 +39,7 @@ const fetchRegionalPartner = ({
     locationParams
   )}`;
 
-  return fetch(url).then(response => {
+  return await fetch(url).then(response => {
     if (!response.ok) {
       throw response.statusText;
     }

--- a/apps/src/code-studio/pd/components/useRegionalPartner.jsx
+++ b/apps/src/code-studio/pd/components/useRegionalPartner.jsx
@@ -16,7 +16,7 @@ const COURSE_NAMES = {
 };
 
 // constructs query params and fetches the data, returning a promise
-const fetchRegionalPartner = async ({
+const fetchRegionalPartner = ({
   program,
   schoolZipCode,
   schoolState,
@@ -39,7 +39,7 @@ const fetchRegionalPartner = async ({
     locationParams
   )}`;
 
-  return await fetch(url).then(response => {
+  return fetch(url).then(response => {
     if (!response.ok) {
       throw response.statusText;
     }

--- a/apps/src/code-studio/pd/components/useRegionalPartner.jsx
+++ b/apps/src/code-studio/pd/components/useRegionalPartner.jsx
@@ -82,10 +82,8 @@ export const useRegionalPartner = data => {
     let cancelled = false;
     fetchRegionalPartner(searchTerm)
       .then(partner => {
-        console.log('Fetched partner');
         // Update state with all the partner workshop data to display
         if (!cancelled) {
-          console.log('Not cancelled then');
           setLoadingPartner(false);
           setLoadError(false);
           // the api returns an object with all fields set to null if not found
@@ -99,21 +97,15 @@ export const useRegionalPartner = data => {
         }
       })
       .catch(() => {
-        console.log('Caught partner fetch');
         if (!cancelled) {
-          console.log('Not cancelled catch');
           setLoadingPartner(false);
           setLoadError(true);
         }
       });
     return () => {
-      console.log('Cancelled');
       cancelled = true;
     };
   }, [program, searchTerm]);
 
-  if (loadingPartner) {
-    console.log('Loading partner before return');
-  }
   return [loadingPartner ? undefined : partner, loadError];
 };

--- a/apps/src/code-studio/pd/components/useRegionalPartner.jsx
+++ b/apps/src/code-studio/pd/components/useRegionalPartner.jsx
@@ -82,8 +82,10 @@ export const useRegionalPartner = data => {
     let cancelled = false;
     fetchRegionalPartner(searchTerm)
       .then(partner => {
+        console.log('Fetched partner');
         // Update state with all the partner workshop data to display
         if (!cancelled) {
+          console.log('Not cancelled then');
           setLoadingPartner(false);
           setLoadError(false);
           // the api returns an object with all fields set to null if not found
@@ -97,15 +99,21 @@ export const useRegionalPartner = data => {
         }
       })
       .catch(() => {
+        console.log('Caught partner fetch');
         if (!cancelled) {
+          console.log('Not cancelled catch');
           setLoadingPartner(false);
           setLoadError(true);
         }
       });
     return () => {
+      console.log('Cancelled');
       cancelled = true;
     };
   }, [program, searchTerm]);
 
+  if (loadingPartner) {
+    console.log('Loading partner before return');
+  }
   return [loadingPartner ? undefined : partner, loadError];
 };

--- a/apps/test/unit/code-studio/pd/components/useRegionalPartnerTest.js
+++ b/apps/test/unit/code-studio/pd/components/useRegionalPartnerTest.js
@@ -117,8 +117,8 @@ describe('useRegionalPartner tests', () => {
           }}
         />
       );
-      await clock.runAllAsync();
     });
+    await clock.runAllAsync();
 
     const [regionalPartner, regionalPartnerError] =
       getRegionalPartnerData(rendered);
@@ -144,8 +144,8 @@ describe('useRegionalPartner tests', () => {
           }}
         />
       );
-      await clock.runAllAsync();
     });
+    await clock.runAllAsync();
 
     const [regionalPartner, regionalPartnerError] =
       getRegionalPartnerData(rendered);


### PR DESCRIPTION
This `useRegionalPartner` test has been flaky so this provides a speculative fix. The only way a regional partner can be set to `undefined` is if `useRegionalPartner` is still [waiting to load the partner](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/pd/components/useRegionalPartner.jsx#L110). So, seeing [these flaky results](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1887) where the test returns `undefined` rather than `null` means it needs to wait longer to receive the result.

Looking at [this non-flaky test](https://github.com/code-dot-org/code-dot-org/pull/58963/files#diff-53aea5c8be638597e9c6ca2ceac2ad31f07a6b6230e8e8641490ca6b8ed7bf00L83-L104) in the file, it has the `await clock.runAllAsync()` line after the `act` block rather than being inside of it. Since that test is not flaky and also checks for the regional partner to be `null`, I'm mirroring that structure with the flaky test (as well as the test after it to maintain consistency) to see if that buys more time to resolve the promise.

I was unable to reproduce the error locally or through drone so this fix is speculative. Even if this does not end up resolving the issue, the tests still pass locally so I'm pretty confident it will at the very least not make anything worse.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1887)

## Testing story
Updating the unit tests.

## Follow-up work
Monitor if this test continues to be flaky in test builds.
