### PR TITLE
Python Lab: reset globals on each run

### DIFF
--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -1,6 +1,7 @@
 import {
   getUpdatedSourceAndDeleteFiles,
   importPackagesFromFiles,
+  resetGlobals,
   writeSource,
 } from './pythonHelpers/pythonScriptUtils';
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
@@ -20,11 +21,13 @@ async function loadPyodideAndPackages() {
 }
 
 let pyodideReadyPromise = null;
+let pyodideGlobals = null;
 async function initializePyodide() {
   if (pyodideReadyPromise === null) {
     pyodideReadyPromise = loadPyodideAndPackages();
   }
   await pyodideReadyPromise;
+  pyodideGlobals = self.pyodide.globals.toJs();
 }
 
 // Get pyodide ready as soon as possible.
@@ -49,6 +52,7 @@ self.onmessage = async event => {
     self.postMessage
   );
   self.postMessage({type: 'updated_source', message: updatedSource, id});
+  resetGlobals(self.pyodide, pyodideGlobals);
   self.postMessage({type: 'run_complete', message: results, id});
 };
 

--- a/apps/src/pythonlab/pythonHelpers/pythonScriptUtils.ts
+++ b/apps/src/pythonlab/pythonHelpers/pythonScriptUtils.ts
@@ -210,6 +210,21 @@ export async function importPackagesFromFiles(
   }
 }
 
+// Delete any python globals that were not present in
+// the original globals on pyodide start (originalGlobals param).
+// This allows us to ensure each pyodide run has a clean state.
+export function resetGlobals(
+  pyodide: PyodideInterface,
+  originalGlobals: Map<string, string>
+) {
+  const newGlobals = pyodide.globals.toJs();
+  newGlobals.forEach((_value: string, key: string) => {
+    if (!originalGlobals.has(key)) {
+      pyodide.globals.delete(key);
+    }
+  });
+}
+
 // For the given fileId, return the module version of the file. For example, a file at
 // path folder1/folder2/file.py would have a module name of "folder1.folder2.file".
 function getModuleName(fileId: string, source: MultiFileSource) {


### PR DESCRIPTION
Pyodide has a single interpreter for its lifetime, so we could get some inconsistent results in some programs. For example, before this change, the below code would print `x is not in locals` on first run, but `x is in locals` on subsequent runs.
```
if 'x' in locals():
  print("x is in locals")
else:
  print("x is not in locals")

x = 5
```

The fix for this is to save the python globals we see on pyodide load, and delete any globals that were not in that original list after each run.

## Links

- jira ticket: [CT-505](https://codedotorg.atlassian.net/browse/CT-505)


## Testing story
Tested locally. The above test code now always prints `x is not in locals`, and other code still works as expected.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
