### PR TITLE
Fix project row data for lab2 projects

### DIFF
--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -301,7 +301,7 @@ module ProjectsList
         name: project_value['name'],
         studentName: student&.name,
         thumbnailUrl: project_value['thumbnailUrl'],
-        type: project_type(project_value['level']),
+        type: project_type(project_value['level']) || project_value['projectType'],
         updatedAt: project_value['updatedAt'],
         publishedAt: project[:published_at],
         frozen: project_value['frozen'],

--- a/dashboard/test/lib/projects_list_test.rb
+++ b/dashboard/test/lib/projects_list_test.rb
@@ -27,7 +27,18 @@ class ProjectsListTest < ActionController::TestCase
       updatedAt: '2017-01-01T00:00:00.000-08:00',
       hidden: true
     }.to_json
+
     @hidden_project = {id: 33, value: hidden_project_value}
+
+    # lab2 projects rely on the projectType field to determine type.
+    lab2_project_value = {
+      name: 'Lab2 Project',
+      createdAt: '2024-01-24T16:41:08.000-08:00',
+      updatedAt: '2024-01-25T17:48:12.358-08:00',
+      projectType: 'pythonlab',
+      hidden: false,
+    }.to_json
+    @lab2_project = {id: 44, value: lab2_project_value}
   end
 
   test 'get_project_row_data correctly parses student and project data' do
@@ -38,6 +49,16 @@ class ProjectsListTest < ActionController::TestCase
     assert_equal @student.name, project_row['studentName']
     assert_equal 'applab', project_row['type']
     assert_equal '2017-01-25T17:48:12.358-08:00', project_row['updatedAt']
+  end
+
+  test 'get_project_row_data correctly parses lab2 project data' do
+    project_row = ProjectsList.send(:get_project_row_data, @lab2_project, @channel_id, @student)
+    assert_nil @channel_id
+    assert_nil project_row['channel']
+    assert_equal 'Lab2 Project', project_row['name']
+    assert_equal @student.name, project_row['studentName']
+    assert_equal 'pythonlab', project_row['type']
+    assert_equal '2024-01-25T17:48:12.358-08:00', project_row['updatedAt']
   end
 
   test 'get_project_row_data ignores hidden projects' do

--- a/dashboard/test/lib/projects_list_test.rb
+++ b/dashboard/test/lib/projects_list_test.rb
@@ -27,7 +27,6 @@ class ProjectsListTest < ActionController::TestCase
       updatedAt: '2017-01-01T00:00:00.000-08:00',
       hidden: true
     }.to_json
-
     @hidden_project = {id: 33, value: hidden_project_value}
 
     # lab2 projects rely on the projectType field to determine type.


### PR DESCRIPTION
The project type on the personal projects page is [derived](https://github.com/code-dot-org/code-dot-org/blob/8e4547f0fafbcaa050cb1b29646d7b11329cf565/dashboard/lib/projects_list.rb#L304) from the “level” field on the project rather than getting the project type directly. This causes an issue for lab2 projects that are remixed from a level, as that field is not set as expected, and their project type will be `null` in the projects table. However, all lab2 projects do have the `projectType` set as expected in the project data, so we can fall back to that if the original method returns `null`. 

I tagged both student labs and code tools in this PR because it is a general lab2 bug.
## Links

- jira ticket: [CT-601](https://codedotorg.atlassian.net/browse/CT-601)


## Testing story
Tested that after this change, lab2 projects that are remixed from a level now show up with the correct project type in the projects table, and other projects still show their type correctly. I also updated and added tests to cover this scenario.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
