### PR TITLE
Navigation updates - Shrink the size of the help icon

### DIFF
--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -599,7 +599,7 @@ nav.main .help_button .help_icon {
 }
 
 nav.main .help_button .help_contents {
-  top: 46px;
+  top: 44px;
 }
 
 nav.main #hamburger #hamburger-icon {

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -122,8 +122,8 @@
   position: relative;
 
   .help_icon {
-    padding: 9px 0 16px 0;
-    font-size: 26px;
+    padding: 11px 0 16px 0;
+    font-size: 22px;
     color: $white;
     cursor: pointer;
     height: 20px;


### PR DESCRIPTION
Shrinks the size of the help icon `(?)` by 2px to make room for additional updates and the "Create account" button A/B test.

🚨 **DOTD note:** this will result in a ton of Eyes diffs.

## Links
Jira ticket: [ACQ-1781](https://codedotorg.atlassian.net/browse/ACQ-1781)
Figma mock: [here](https://www.figma.com/design/88sbry7xnl1wcyrOgbgFtn/Sign-Up-Flow?node-id=2913-4091&t=oVC4MmQYoo53ewAp-1)

## Testing story
Tested locally on both logged out (code.org) and logged in (studio.code.org) Teacher and Student headers. This icon does not show up on tablet or mobile sizes so I made sure that maintained its invisibility. 

## Followup
Additional Navigation updates:
- Update nav breakpoints - [ACQ-1510](https://codedotorg.atlassian.net/browse/ACQ-1510)
- Update Create menu to be called New project - [ACQ-1780](https://codedotorg.atlassian.net/browse/ACQ-1780)
- A/B Test: Adding Create Account button - [ACQ-1545](https://codedotorg.atlassian.net/browse/ACQ-1545)

----

## Logged out (code.org)
| Before | After | 
| ---- | ---- |
| <img width="1308" alt="Logged_out_full_before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/08b39b7b-77b3-4196-a957-9aecfc9c3f6c"> | <img width="1308" alt="Logged_out_full_after" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/2207b136-530b-4364-a618-bc5dc536a942"> |
| <img width="324" alt="Logged_out_before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/84c6177a-c63f-40bc-93f1-38b35dca25a0"> | <img width="324" alt="Logged_out_after" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/ab109867-f751-42a3-9ed6-3efa59ec0b7c"> |
| <img width="324" alt="Logged_out_menu_open_before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/9a6edbed-9ea7-41ab-a881-02c2de575da8"> | <img width="324" alt="Logged_out_menu_open_after" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/d1193a5f-7672-4f88-a389-95369c1e4f18"> |

## Logged in (studio.code.org) 
| Before | After | 
| ---- | ---- |
| <img width="1308" alt="Logged_in_full_before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/ba49157b-ea5e-4a32-805d-abd1b69e5244"> | <img width="1308" alt="Logged_in_full_after" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/e082d554-0725-4aec-aa53-e27c5e1d1140"> |
| <img width="324" alt="Logged_in_before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/54456a96-5aec-440d-afe0-781caa7a52fa"> | <img width="324" alt="Logged_in_after" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/c9bedc31-997a-4cb4-8fea-a7dcdd3febfe"> |
| <img width="324" alt="Logged_in_menu_open_before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/ec1c5364-1649-4808-87ac-a134a9c8a3ab"> | <img width="324" alt="Logged_in_menu_open_after" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/e2cd4987-5012-429f-a27e-9e8bce3b66db"> |