### PR TITLE
Fixed play sound block in french

### DIFF
--- a/apps/i18n/music/fr_fr.json
+++ b/apps/i18n/music/fr_fr.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2828f2ddc1b2118e3b1ffd73a68b6b5d2e5a635c10df0e424f8e3d9d800a9b4b
-size 4390
+oid sha256:cac5d677c5f27e7675c0237a85a01f69ebe8766bde5c19fcd628d667a6ee4156
+size 4392

--- a/dashboard/config/locales/long_instructions.fr-FR.json
+++ b/dashboard/config/locales/long_instructions.fr-FR.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5687a6b2e252f9c6d38b57b8772a7f5f7e112bf0d18a8e5be80495722ce4e2b4
+oid sha256:305aafe3f93bbcf496e7a4b7cd4c9e19974e9a98c3afd9c457514305bd87cb1d
 size 1861998


### PR DESCRIPTION
During the translation process, the `play sound {sound}` block got the variable translated into French.

This PR restores the correct variable name:
Before:
  `"blockly_blockPlaySound": "jouer le {son}",`
After
  `"blockly_blockPlaySound": "jouer le {sound}",`

Also changes the translation of `[Run]` from `[Exécuter]` to `[Démarrer]`

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
