### PR TITLE
Update Configuration Settings to Point to New MySQL 8 Database

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -1,5 +1,5 @@
 <%
-  PRODUCTION_DB_CLUSTER_ID = 'production-aurora-cluster'.freeze
+  PRODUCTION_DB_CLUSTER_ID = 'autoscale-prod-cluster'.freeze
   # If an adhoc environment is using MySQL server installed on the app server EC2 Instance instead of an AWS RDS Cluster
   # use default credentials and hostname.
   MYSQL_DAEMON_DEFAULT_CREDENTIALS = '{"username":"root", "password":""}'.freeze


### PR DESCRIPTION
Merge and release this change to production after manually cutting over to the new MySQL 8 production database cluster. This change will ensure that the production Reporting RDS Proxy and other components are updated to point to the new MySQL 8 cluster.

## Testing story

Possibly:
```
bundle exec rake stack:validate RAILS_ENV=production ADMIN=true VERBOSE=mostDefinitelyYes
```

## Deployment strategy



## Follow-up work

Import the new database cluster into the Stack using the changes in [#upgrade database cl](https://github.com/code-dot-org/code-dot-org/pull/58882)

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
