### PR TITLE
Show tutorial section for all languages on code.org/music

### DIFF
--- a/pegasus/sites.v3/code.org/public/music/index.haml
+++ b/pegasus/sites.v3/code.org/public/music/index.haml
@@ -71,8 +71,6 @@ theme: responsive_full_width
         %h2=hoc_s("music_lab.tutorial.heading")
         %p.wrap-pretty
           =hoc_s("music_lab.tutorial.desc")
-        %p.body-three
-          =hoc_s("music_lab.tutorial.english_only")
         %a.link-button{href: CDO.studio_url("/s/music-tutorial-2024")}
           =hoc_s("music_lab.tutorial.button")
 

--- a/pegasus/sites.v3/code.org/public/music/index.haml
+++ b/pegasus/sites.v3/code.org/public/music/index.haml
@@ -62,20 +62,19 @@ theme: responsive_full_width
     %h2.white=hoc_s("music_lab.quotes.heading")
     = view :"music/music_lab_carousel_quotes"
 
-- if request.language == "en"
-  %section
-    .wrapper
-      .flex-container.justify-space-between.align-items-center.wrap.gap-2
-        %figure.col-45
-          %img.rounded-corners{src: "/images/music-lab/music-lab-tutorial.png", alt: "", style: "width: 100%;"}
-        .text-wrapper.col-50
-          %h2=hoc_s("music_lab.tutorial.heading")
-          %p.wrap-pretty
-            =hoc_s("music_lab.tutorial.desc")
-          %p.body-three
-            =hoc_s("music_lab.tutorial.english_only")
-          %a.link-button{href: CDO.studio_url("/s/music-tutorial-2024")}
-            =hoc_s("music_lab.tutorial.button")
+%section
+  .wrapper
+    .flex-container.justify-space-between.align-items-center.wrap.gap-2
+      %figure.col-45
+        %img.rounded-corners{src: "/images/music-lab/music-lab-tutorial.png", alt: "", style: "width: 100%;"}
+      .text-wrapper.col-50
+        %h2=hoc_s("music_lab.tutorial.heading")
+        %p.wrap-pretty
+          =hoc_s("music_lab.tutorial.desc")
+        %p.body-three
+          =hoc_s("music_lab.tutorial.english_only")
+        %a.link-button{href: CDO.studio_url("/s/music-tutorial-2024")}
+          =hoc_s("music_lab.tutorial.button")
 
 %section.bg-neutral-light
   .wrapper


### PR DESCRIPTION
Shows the tutorial section on https://code.org/music to all languages now that the https://studio.code.org/s/music-tutorial-2024 tutorial has been translated. 

## Links
Jira ticket: [ACQ-1895](https://codedotorg.atlassian.net/browse/ACQ-1895)
Related PR: https://github.com/code-dot-org/code-dot-org/pull/58700

## Testing story
Tested locally

----

## English
<img width="1065" alt="English" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/8d463c0e-8276-4795-9d5a-f20dda3848d0">


## Spanish
<img width="1065" alt="Spanish" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/0228e1a9-38c9-49de-8164-f7ac20ba8b3c">

## French
<img width="1065" alt="French" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/9731a479-a22d-4fd2-be6f-4fcc8b7ace74">