### PR TITLE
Handle no project identifier in aichat request

### DIFF
--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -117,9 +117,11 @@ class AichatController < ApplicationController
       return false
     end
 
-    _, project_id = storage_decrypt_channel_id(context[:channelId])
-    if session.project_id != project_id
-      return false
+    if context[:channelId]
+      _, project_id = storage_decrypt_channel_id(context[:channelId])
+      if session.project_id != project_id
+        return false
+      end
     end
 
     if params[:aichatModelCustomizations] != JSON.parse(session.model_customizations) ||
@@ -138,7 +140,11 @@ class AichatController < ApplicationController
 
   private def create_session(new_messages)
     context = params[:aichatContext]
-    _, project_id = storage_decrypt_channel_id(context[:channelId])
+
+    project_id = nil
+    if context[:channelId]
+      _, project_id = storage_decrypt_channel_id(context[:channelId])
+    end
 
     AichatSession.create(
       user_id: current_user.id,


### PR DESCRIPTION
We saw Honeybadger errors come in for a missing channel ID yesterday. I repro this situation if a teacher views a student's work via the teacher panel but the student hasn't actually viewed the level (ie, has no channel ID).

The change here is to handle if no channel ID is provided (ie, don't include it in the stored session).

## Links

- honeybadger error: https://app.honeybadger.io/projects/3240/faults/108087043

## Testing story

Tested manually that the observed repro case does not fail any more (and logs successfully) with this change in place.