### PR TITLE
Fix weird wrapping on translated AWS section on code.org/music

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/page/music-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/page/music-styles.scss
@@ -94,6 +94,19 @@ section.student-projects {
   }
 }
 
+section.aws-career-tours {
+
+  @media (min-width: 993px) {
+    .text-wrapper {
+      max-width: 570px;
+    }
+
+    a.link-button {
+      max-width: 205px;
+    }
+  }
+}
+
 section.quote {
   background: url("/images/banners/banner-bg-music.png") center repeat-x;
   background-size: contain;

--- a/pegasus/sites.v3/code.org/public/music/index.haml
+++ b/pegasus/sites.v3/code.org/public/music/index.haml
@@ -40,7 +40,7 @@ theme: responsive_full_width
     %h2=hoc_s("music_lab.student_projects.heading")
     = view :"music/music_lab_student_projects"
 
-%section.bg-primary-light
+%section.bg-primary-light.aws-career-tours
   .wrapper.flex-container.justify-space-between.align-items-center.wrap.flex-direction-column-tablet.gap-1
     %figure
       %img{src: "/images/avatars/amazon-career-tours.png", alt: hoc_s("music_lab.amazon_future_engineer"), style: "width: 150px"}


### PR DESCRIPTION
Fixes weird wrapping in the translated AWS Career Tour section on https://code.org/music. I usually catch this stuff, but the button translations for this were extra long this time!

## Links
Jira ticket: [ACQ-1941](https://codedotorg.atlassian.net/browse/ACQ-1941)

## Testing story
Tested locally; has no effect on tablet or mobile styles

----

## English (no change)
<img width="1125" alt="English" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/d2675873-77d7-43a0-97e0-df59617a66fd">

## Spanish
| Before | After | 
| ---- | ---- |
| <img width="1125" alt="Spanish_Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/33975e73-0f0b-49aa-973b-e5592467fee9"> | <img width="1125" alt="Spanish_After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/5f14704e-f7f6-47a0-b142-8a933fd0d6e6"> |

## French
| Before | After | 
| ---- | ---- |
| <img width="1125" alt="French_Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/2f1d3cf3-8dcf-4455-89eb-65514af834a4"> | <img width="1125" alt="French_After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/e29fa4bf-5f26-4e39-bbd7-23be4fc570cc"> |
