### PR TITLE
feat(clever): add clever as a login and signup option

### DIFF
--- a/dashboard/app/assets/images/oauth/clever.svg
+++ b/dashboard/app/assets/images/oauth/clever.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6b6c64fb39a7573429af39ba40e15ddcd52bc54ba59ba46b5138c282ff3983f
+size 1565

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2423,6 +2423,12 @@ a.download-video {
       background-color: $microsoft_brand_color;
       border-color: $microsoft_brand_color;
     }
+
+    &.with-clever {
+      background-color: $clever_brand_color;
+      border-color: $clever_brand_color;
+      color: $neutral_white;
+    }
   }
 }
 

--- a/dashboard/app/views/devise/shared/_oauth_links.haml
+++ b/dashboard/app/views/devise/shared/_oauth_links.haml
@@ -21,7 +21,7 @@
         = "#{Rails.env},"
         consult the "Developer OAuth Setup on Localhost" doc in the Engineering drive folder
 
-    - [:google_oauth2, :microsoft_v2_auth, :facebook].each do |provider|
+    - [:google_oauth2, :microsoft_v2_auth, :facebook, :clever].each do |provider|
       = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
         = image_tag("oauth/#{provider}.svg")
         = t('auth.continue_with', provider: t("auth.#{provider}"))

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -376,6 +376,12 @@ Devise.setup do |config|
     end
   end
 
+  OmniAuth.config.before_request_phase do |env|
+    Metrics::Events.log_event(
+      event_name: "#{env['omniauth.strategy'].options[:name]}-begin-auth",
+      )
+  end
+
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -81,7 +81,7 @@ module SignUpTracking
     FirehoseClient.instance.put_record(:analysis, tracking_data)
 
     Metrics::Events.log_event(
-      event_name: "#{provider}-begin-sign-up-#{result}",
+      event_name: "begin-sign-up-#{result}",
       metadata: {
         study: STUDY_NAME,
         study_group: study_group(session),

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -184,6 +184,7 @@ $neutral_dark: #292F36;
 $google_brand_color: #0F9D58;
 $microsoft_brand_color: #FFB900;
 $facebook_brand_color: #3B5998;
+$clever_brand_color: #1464FF;
 
 // ===----===----===---- Design system colors: ----===----===----===
 


### PR DESCRIPTION
This change exposes the existing Clever login omniauth callbacks to the sign in page. Previously, these weren't exposed due to the potential confusion caused by the district picker on Clever however this login pattern might be well known to  schools as other companies use the same mechanism for signin with Clever.

## Links

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-957)

## Testing story

Tested with student and teacher login


https://github.com/code-dot-org/code-dot-org/assets/538214/a1425d16-3173-477e-8468-749535bdf596


https://github.com/code-dot-org/code-dot-org/assets/538214/22483938-1bcc-43a7-b18a-6958914125d6


## Statsig Instrumentation

To test the Statsig instrumentation, I ran through sign up and sign in procedures for all providers, the output is attached:

```
I, [2024-06-03T15:01:59.961661 #177122]  INFO -- omniauth: (clever) Request phase initiated.
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"clever-begin-auth","event_value":"clever-begin-auth","metadata":{}}
I, [2024-06-03T15:02:00.285819 #177122]  INFO -- omniauth: (clever) Callback phase initiated.
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"clever-callback","event_value":"clever-callback","metadata":{"study":"account-sign-up-v5","study_group":"not-in-study"}}
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
I, [2024-06-03T15:02:18.415442 #177122]  INFO -- omniauth: (facebook) Request phase initiated.
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"facebook-begin-auth","event_value":"facebook-begin-auth","metadata":{}}
I, [2024-06-03T15:02:23.680874 #177122]  INFO -- omniauth: (google_oauth2) Setup endpoint detected, running now.
I, [2024-06-03T15:02:23.681514 #177122]  INFO -- omniauth: (google_oauth2) Request phase initiated.
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"google_oauth2-begin-auth","event_value":"google_oauth2-begin-auth","metadata":{}}
I, [2024-06-03T15:02:27.020300 #177122]  INFO -- omniauth: (microsoft_v2_auth) Request phase initiated.
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"microsoft_v2_auth-begin-auth","event_value":"microsoft_v2_auth-begin-auth","metadata":{}}
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"load-sign-up-page","event_value":"load-sign-up-page","metadata":{"study":"account-sign-up-v5","study_group":"control-v4"}}
I, [2024-06-03T15:02:43.621483 #177122]  INFO -- omniauth: (clever) Request phase initiated.
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"clever-begin-auth","event_value":"clever-begin-auth","metadata":{}}
I, [2024-06-03T15:02:43.835093 #177122]  INFO -- omniauth: (clever) Callback phase initiated.
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"clever-signup-callback","event_value":"clever-signup-callback","metadata":{"study":"account-sign-up-v5","study_group":"control-v4"}}
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"clever-sign-in","event_value":"clever-sign-in","metadata":{"study":"account-sign-up-v5","study_group":"control-v4"}}
I, [2024-06-03T15:03:36.480637 #177122]  INFO -- omniauth: (clever) Request phase initiated.
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"clever-begin-auth","event_value":"clever-begin-auth","metadata":{}}
I, [2024-06-03T15:03:49.468307 #177122]  INFO -- omniauth: (clever) Callback phase initiated.
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"clever-signup-callback","event_value":"clever-signup-callback","metadata":{"study":"account-sign-up-v5","study_group":"not-in-study"}}
Logging Event: {"user_id":"","custom_ids":{"user_type":""},"event_name":"clever-sign-up-success","event_value":"clever-sign-up-success","metadata":{"study":"account-sign-up-v5","study_group":"not-in-study"}}
```

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

No net new feature, we already have Clever as a login option but was not exposed as a public facing signin option.

## Security

No net new feature, we already have Clever as a login option but was not exposed as a public facing signin option.

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
