### PR TITLE
[Google Blockly] Prevent infinite mirroring of variable events

### DIFF
--- a/apps/src/blockly/addons/functionEditor.ts
+++ b/apps/src/blockly/addons/functionEditor.ts
@@ -491,8 +491,7 @@ export default class FunctionEditor {
       }
     });
 
-    // Mirror variable events from main workspace to editor workspace and the
-    // hidden procedure definition workspace.
+    // Mirror variable events from main workspace to the hidden workspace.
     // This is allows newly created/renamed/deleted variables to propogate
     // to the other workspaces.
     this.primaryWorkspace?.addChangeListener(e => {
@@ -500,13 +499,8 @@ export default class FunctionEditor {
         return;
       }
       if (e instanceof Blockly.Events.VarBase) {
-        let newEditorWorkspaceEvent;
         let newHiddenWorkspaceEvent;
         try {
-          newEditorWorkspaceEvent = Blockly.Events.fromJson(
-            e.toJson(),
-            this.editorWorkspace
-          );
           newHiddenWorkspaceEvent = Blockly.Events.fromJson(
             e.toJson(),
             Blockly.getHiddenDefinitionWorkspace()
@@ -517,7 +511,6 @@ export default class FunctionEditor {
           // cannot be deserialized into the original workspace.
           return;
         }
-        newEditorWorkspaceEvent.run(true);
         newHiddenWorkspaceEvent.run(true);
 
         // Update the toolbox in case this change is happening


### PR DESCRIPTION
In order to make our 3 (main, editor, and hidden) workspaces  stay in sync, we mirror events related to procedures and variables. Variable mirroring was only added last week and it unfortunately included the potential for an infinite loop.
- https://github.com/code-dot-org/code-dot-org/pull/58780

The current state is as follows:

- Procedure and variable events on the ***editor*** workspace are mirrored to the ***main*** workspace. _(We need this so that procedure call blocks work and to keep variables in sync.)_
- All non ui-events (including proc/var) on the ***editor*** workspace are mirrored to the ***hidden*** workspace. _(We need this so that all changes made in the modal editor are copied to the hidden workspace (ie. our source of truth))_
- All variable events on the ***main*** workspace are mirrored to the the ***hidden*** workspace. _(We need this so that changes to variables will trigger the hidden workspace to update accordingly.)_
- All variables events on the ***main*** workspace are mirrored to the ***editor*** workspace.

The last bullet is not needed and is causing the infinite loop. (See scratch paper diagram)
![IMG_7950](https://github.com/code-dot-org/code-dot-org/assets/43474485/85f6f0b1-5c84-491f-9f03-0f6b7609c62c)

At the time, I thought that this was needed to keep the editor's variable toolbox up to date, but it's not. When we open the editor with a function from the hidden workspace, we already bring the needed variable info over from the hidden workspace (ie. our source of truth). It's sufficient to mirror variable events to the hidden workspace and stop there.

**The proposed fix is to stop mirroring variable events from the main workspace to the editor workspace, which is something we started doing last week.**

This task was taken on because of a bug that was causing toolbox blocks to be created incorrectly. I'm not totally sure how these issues are linked, but resolving the infinite loop does solve the problem that was reported. 

## Links

Slack thread: https://codedotorg.slack.com/archives/C03DBDN67B7/p1717092734528559

## Testing story

I used console logging to confirm that no infinite loops are present. I also checked that the odd toolbox behavior was resolved. Finally, I confirmed that there are no regressions related to variables when using the function editor. Specifically, I defined new variables from within the main workspace and the modal editor workspace and confirmed that they were propagated correctly between the workspaces.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
