### PR TITLE
Code Bridge: small console updates

### DIFF
--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -15,6 +15,7 @@ const Console: React.FunctionComponent = () => {
   const previousLevelId = useRef(levelId);
   const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
+  // TODO: Update this with other apps that use the console as needed.
   const systemMessagePrefix = appName === 'pythonlab' ? '[PYTHON LAB] ' : '';
 
   useEffect(() => {

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -13,6 +13,9 @@ const Console: React.FunctionComponent = () => {
   const dispatch = useDispatch();
   const levelId = useAppSelector(state => state.lab.levelProperties?.id);
   const previousLevelId = useRef(levelId);
+  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+
+  const systemMessagePrefix = appName === 'pythonlab' ? '[PYTHON LAB] ' : '';
 
   useEffect(() => {
     // If the level changes, clear the console.
@@ -31,7 +34,7 @@ const Console: React.FunctionComponent = () => {
       <Button
         isIconOnly
         color={'black'}
-        icon={{iconStyle: 'solid', iconName: 'broom'}}
+        icon={{iconStyle: 'solid', iconName: 'eraser'}}
         ariaLabel="clear console"
         onClick={clearOutput}
         size={'xs'}
@@ -68,7 +71,12 @@ const Console: React.FunctionComponent = () => {
               </div>
             );
           } else {
-            return <div key={index}>[PYTHON LAB] {outputLine.contents}</div>;
+            return (
+              <div key={index}>
+                {systemMessagePrefix}
+                {outputLine.contents}
+              </div>
+            );
           }
         })}
       </div>

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -1,5 +1,5 @@
 import {resetOutput} from '@codebridge/redux/consoleRedux';
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import {useDispatch} from 'react-redux';
 
 import Button from '@cdo/apps/componentLibrary/button';
@@ -11,6 +11,16 @@ import moduleStyles from './console.module.scss';
 const Console: React.FunctionComponent = () => {
   const codeOutput = useAppSelector(state => state.codebridgeConsole.output);
   const dispatch = useDispatch();
+  const levelId = useAppSelector(state => state.lab.levelProperties?.id);
+  const previousLevelId = useRef(levelId);
+
+  useEffect(() => {
+    // If the level changes, clear the console.
+    if (previousLevelId.current !== levelId) {
+      dispatch(resetOutput());
+      previousLevelId.current = levelId;
+    }
+  }, [dispatch, levelId]);
 
   const clearOutput = () => {
     dispatch(resetOutput());


### PR DESCRIPTION
A couple updates to the code bridge console:
- On level change, reset the console. Previously the contents would stick around until you manually clicked the clear button, which is a bit confusing when all your code changes
- Change the clear console button from a broom to an eraser, to match current mocks.
- Remove the hard-coded `[PYTHON LAB]` prefix from the start of every system message, and instead make the prefix dependent on the lab app name. For now only python lab adds a system message prefix, as it's the only one that uses this console.

For the clear console logic, I did something similar to #58967 so that the console wouldn't be cleared on hot reload. This has an interesting side effect that is only present if you are in a level progression that switches from Python Lab to another lab2 lab (and therefore never reload the page). In this case the console contents persist, because the level never changed from the console's point of view. This seems fine to me as the console contents were for that level anyway, and this is probably a very rare situation to come across. 

## Links

- jira ticket: [CT-614](https://codedotorg.atlassian.net/browse/CT-614)

## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
