### PR TITLE
Gen AI: basic error handling

### DIFF
--- a/apps/src/aichat/aichatCompletionApi.ts
+++ b/apps/src/aichat/aichatCompletionApi.ts
@@ -6,7 +6,6 @@ import {
   AichatModelCustomizations,
 } from './types';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 
 const CHAT_COMPLETION_URL = '/aichat/chat_completion';
 
@@ -36,26 +35,16 @@ export async function postAichatCompletionMessage(
     aichatContext,
     ...(sessionId ? {sessionId} : {}),
   };
-  try {
-    const response = await HttpClient.post(
-      CHAT_COMPLETION_URL,
-      JSON.stringify(payload),
-      true,
-      {
-        'Content-Type': 'application/json; charset=UTF-8',
-      }
-    );
-    // For now, response will be null if there was an error.
-    if (response.ok) {
-      return await response.json();
-    } else {
-      return null;
+  const response = await HttpClient.post(
+    CHAT_COMPLETION_URL,
+    JSON.stringify(payload),
+    true,
+    {
+      'Content-Type': 'application/json; charset=UTF-8',
     }
-  } catch (error) {
-    Lab2Registry.getInstance()
-      .getMetricsReporter()
-      .logError('Error in aichat completion request', error as Error);
-  }
+  );
+
+  return await response.json();
 }
 
 const formatMessagesForAichatCompletion = (

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -339,21 +339,7 @@ export const submitChatContents = createAsyncThunk(
         .getMetricsReporter()
         .logError('Error in aichat completion request', error as Error);
 
-      const assistantChatMessage: ChatCompletionMessage = {
-        id: getNewMessageId(),
-        role: Role.ASSISTANT,
-        status: Status.ERROR,
-        chatMessageText: 'error',
-        timestamp: getCurrentTimestamp(),
-      };
-      thunkAPI.dispatch(addChatMessage(assistantChatMessage));
-
-      thunkAPI.dispatch(
-        updateUserChatMessageStatus({
-          id: newMessage.id,
-          status: Status.ERROR,
-        })
-      );
+      updateMessagesOnError(newMessage, thunkAPI.dispatch);
 
       return;
     }
@@ -400,21 +386,7 @@ export const submitChatContents = createAsyncThunk(
 
       // error state #1: model generated profanity
     } else if (chatApiResponse?.status === AichatErrorType.PROFANITY_MODEL) {
-      const assistantChatMessage: ChatCompletionMessage = {
-        id: getNewMessageId(),
-        role: Role.ASSISTANT,
-        status: Status.ERROR,
-        chatMessageText: 'error',
-        timestamp: getCurrentTimestamp(),
-      };
-      thunkAPI.dispatch(addChatMessage(assistantChatMessage));
-
-      thunkAPI.dispatch(
-        updateUserChatMessageStatus({
-          id: newMessage.id,
-          status: Status.ERROR,
-        })
-      );
+      updateMessagesOnError(newMessage, thunkAPI.dispatch);
 
       // error state #2: user message contained profanity
     } else if (chatApiResponse?.status === AichatErrorType.PROFANITY_USER) {
@@ -630,6 +602,27 @@ const allFieldsHidden = (fieldVisibilities: AichatState['fieldVisibilities']) =>
   getTypedKeys(fieldVisibilities).every(
     key => fieldVisibilities[key] === Visibility.HIDDEN
   );
+
+const updateMessagesOnError = (
+  newMessage: ChatCompletionMessage,
+  dispatch: ThunkDispatch<unknown, unknown, AnyAction>
+) => {
+  const assistantChatMessage: ChatCompletionMessage = {
+    id: getNewMessageId(),
+    role: Role.ASSISTANT,
+    status: Status.ERROR,
+    chatMessageText: 'error',
+    timestamp: getCurrentTimestamp(),
+  };
+  dispatch(addChatMessage(assistantChatMessage));
+
+  dispatch(
+    updateUserChatMessageStatus({
+      id: newMessage.id,
+      status: Status.ERROR,
+    })
+  );
+};
 
 // Selectors
 export const selectHasFilledOutModelCard = createSelector(

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -611,7 +611,7 @@ const updateMessagesOnError = (
     id: getNewMessageId(),
     role: Role.ASSISTANT,
     status: Status.ERROR,
-    chatMessageText: 'error',
+    chatMessageText: 'There was an error getting a response. Please try again.',
     timestamp: getCurrentTimestamp(),
   };
   dispatch(addChatMessage(assistantChatMessage));

--- a/apps/src/aichat/views/ChatMessage.tsx
+++ b/apps/src/aichat/views/ChatMessage.tsx
@@ -81,10 +81,10 @@ const displayAssistantMessage = (status: string, chatMessageText: string) => {
         className={classNames(
           moduleStyles.message,
           moduleStyles.assistantMessage,
-          moduleStyles.errorMessage
+          moduleStyles.dangerContainer
         )}
       >
-        {'There was an error getting a response. Please try again.'}
+        {chatMessageText}
       </div>
     );
   }

--- a/apps/src/aichat/views/chatMessage.module.scss
+++ b/apps/src/aichat/views/chatMessage.module.scss
@@ -37,7 +37,7 @@
   font-size: 16px;
 }
 
-.dangerContainer {
+div.dangerContainer {
   background-color: #FBE0DD;
 }
 
@@ -50,8 +50,4 @@
 
 .inappropriateMessage {
   background-color: $lightest_red;
-}
-
-.errorMessage {
-  background-color: $lightest_yellow;
 }


### PR DESCRIPTION
Makes an initial attempt at broadening error handling on the front end -- ie, if we receive any error from Rails/submitting a request/etc, we display a generic error response:

![image](https://github.com/code-dot-org/code-dot-org/assets/25372625/b67d9373-dea3-4a5d-818d-6dc4e04b6566)

This case is the same as what we do when we receive profanity generated by the model, so I've reused that logic here. I haven't done any special casing to handle different errors, as I don't see much differentiation currently needed from a user perpsective whether we receive a failure from WebPurify, Sagemaker, or Rails.

## Links

- jira ticket: [LABS-820](https://codedotorg.atlassian.net/browse/LABS-820)

## Testing story

Tested manually that:
- I saw the error response pictured above when I intentionally threw an error or hard-coded profanity to be returned by the controller. 
- I was able to make the usual successful requests when no intentional error states were put in place. 
- I saw the appropriate messages being logged to our conversation history after this change.