### PR TITLE
Nicklathe/fix dynamic registration

### DIFF
--- a/apps/src/lib/ui/lti/registration/styles.module.scss
+++ b/apps/src/lib/ui/lti/registration/styles.module.scss
@@ -38,7 +38,6 @@ body {
 }
 
 .formLabel {
-  margin-right: 10px; /* Adds space between the label and the input field */
   white-space: nowrap; /* Prevents the label from wrapping */
 }
 
@@ -49,6 +48,7 @@ body {
 }
 
 .input {
+  margin-left: 10px;
   padding: 8px 12px;
   width: 300px; /* Responsive width */
   font-size: 16px; /* Sufficiently large font size for readability */

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -4,10 +4,8 @@ require "services/lti"
 require "policies/lti"
 require "concerns/partial_registration"
 require "clients/lti_advantage_client"
-require 'clients/lti_dynamic_registration_client'
 require "cdo/honeybadger"
 require 'metrics/events'
-require 'securerandom'
 
 class LtiV1Controller < ApplicationController
   before_action -> {redirect_to lti_v1_integrations_path, alert: I18n.t('lti.integration.early_access.closed')},

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -86,15 +86,15 @@ class Policies::Lti
     grant_types: ["client_credentials", "implicit"],
     initiate_login_uri: CDO.studio_url('/lti/v1/login', CDO.default_scheme),
     redirect_uris: [CDO.studio_url('/lti/v1/authenticate', CDO.default_scheme)],
-    client_name: "Code.org",
+    client_name: "Code.org - Nick Dynamic",
     jwks_uri: CDO.studio_url('/oauth/jwks', CDO.default_scheme),
     token_endpoint_auth_method: "private_key_jwt",
     contacts: ["platform@code.org"],
     scope: "https://purl.imsglobal.org/spec/lti-ags/scope/score https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
     "https://purl.imsglobal.org/spec/lti-tool-configuration" => {
-      domain: "studio.code.org",
-      description: "Code.org",
-      target_link_uri: "https://studio.code.org/lti/v1/sync_course",
+      domain: CDO.studio_url('', CDO.default_scheme),
+      description: "Code.org - Nick Dynamic",
+      target_link_uri: CDO.studio_url('/lti/v1/sync_course', CDO.default_scheme),
       custom_parameters: {
         email: "$Person.email.primary",
         full_name: "$Person.name.full",
@@ -108,38 +108,15 @@ class Policies::Lti
       messages: [
         {
           type: "LtiResourceLinkRequest",
-          label: "Launch Code.org",
-          placements: ["course_navigation"],
-        },
-        {
-          type: "LtiResourceLinkRequest",
-          label: "Launch Code.org",
-          placements: ["account_navigation"],
-        },
-        {
-          type: "LtiResourceLinkRequest",
-          label: "Launch Code.org",
+          label: "Launch Code.org - Nick Dynamic",
           placements: ["link_selection"],
+          icon_uri: CDO.studio_url('/images/logo.svg', CDO.default_scheme),
         },
         {
           type: "LtiResourceLinkRequest",
-          label: "Launch Code.org",
+          label: "Launch Code.org - Nick Dynamic",
           placements: ["assignment_selection"],
-        },
-        {
-          type: "LtiResourceLinkRequest",
-          label: "Launch Code.org",
-          placements: ["assignment_menu"],
-        },
-        {
-          type: "LtiResourceLinkRequest",
-          label: "Launch Code.org",
-          placements: ["assignment_view"],
-        },
-        {
-          type: "LtiResourceLinkRequest",
-          label: "Launch Code.org",
-          placements: ["submission_type_selection"],
+          icon_uri: CDO.studio_url('/images/logo.svg', CDO.default_scheme),
         }
       ]
     }

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -92,7 +92,7 @@ class Policies::Lti
     contacts: ["platform@code.org"],
     scope: ALL_SCOPES.join(' '),
     "https://purl.imsglobal.org/spec/lti-tool-configuration" => {
-      domain: CDO.studio_url('', CDO.default_scheme),
+      domain: CDO.dashboard_site_host,
       description: "Code.org LTI Integration",
       target_link_uri: CDO.studio_url('/lti/v1/sync_course', CDO.default_scheme),
       custom_parameters: {

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -86,14 +86,14 @@ class Policies::Lti
     grant_types: ["client_credentials", "implicit"],
     initiate_login_uri: CDO.studio_url('/lti/v1/login', CDO.default_scheme),
     redirect_uris: [CDO.studio_url('/lti/v1/authenticate', CDO.default_scheme)],
-    client_name: "Code.org - Nick Dynamic",
+    client_name: "Code.org",
     jwks_uri: CDO.studio_url('/oauth/jwks', CDO.default_scheme),
     token_endpoint_auth_method: "private_key_jwt",
     contacts: ["platform@code.org"],
     scope: ALL_SCOPES.join(' '),
     "https://purl.imsglobal.org/spec/lti-tool-configuration" => {
       domain: CDO.studio_url('', CDO.default_scheme),
-      description: "Code.org LTI Integration (Nick)",
+      description: "Code.org LTI Integration",
       target_link_uri: CDO.studio_url('/lti/v1/sync_course', CDO.default_scheme),
       custom_parameters: {
         email: "$Person.email.primary",
@@ -108,13 +108,13 @@ class Policies::Lti
       messages: [
         {
           type: "LtiResourceLinkRequest",
-          label: "Launch Code.org - Nick Dynamic",
+          label: "Launch Code.org",
           placements: ["link_selection"],
           icon_uri: CDO.studio_url('/images/logo.svg', CDO.default_scheme),
         },
         {
           type: "LtiResourceLinkRequest",
-          label: "Launch Code.org - Nick Dynamic",
+          label: "Launch Code.org",
           placements: ["assignment_selection"],
           icon_uri: CDO.studio_url('/images/logo.svg', CDO.default_scheme),
         }

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -90,10 +90,10 @@ class Policies::Lti
     jwks_uri: CDO.studio_url('/oauth/jwks', CDO.default_scheme),
     token_endpoint_auth_method: "private_key_jwt",
     contacts: ["platform@code.org"],
-    scope: "https://purl.imsglobal.org/spec/lti-ags/scope/score https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
+    scope: ALL_SCOPES.join(' '),
     "https://purl.imsglobal.org/spec/lti-tool-configuration" => {
       domain: CDO.studio_url('', CDO.default_scheme),
-      description: "Code.org - Nick Dynamic",
+      description: "Code.org LTI Integration (Nick)",
       target_link_uri: CDO.studio_url('/lti/v1/sync_course', CDO.default_scheme),
       custom_parameters: {
         email: "$Person.email.primary",

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -21,6 +21,7 @@ class Policies::Lti
   NAMESPACE = 'lti_v1_controller'.freeze
   JWT_CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'.freeze
   JWT_ISSUER = CDO.studio_url('', CDO.default_scheme).freeze
+  DEFAULT_TARGET_LINK_URI = CDO.studio_url('/lti/v1/sync_course', CDO.default_scheme).freeze
 
   MEMBERSHIP_CONTAINER_CONTENT_TYPE = 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json'.freeze
   TEACHER_ROLES = Set.new(['http://purl.imsglobal.org/vocab/lis/v1/institution/person#Instructor',
@@ -94,7 +95,7 @@ class Policies::Lti
     "https://purl.imsglobal.org/spec/lti-tool-configuration" => {
       domain: CDO.dashboard_site_host,
       description: "Code.org LTI Integration",
-      target_link_uri: CDO.studio_url('/lti/v1/sync_course', CDO.default_scheme),
+      target_link_uri: DEFAULT_TARGET_LINK_URI,
       custom_parameters: {
         email: "$Person.email.primary",
         full_name: "$Person.name.full",


### PR DESCRIPTION
This PR address a few Dynamic Registration improvements and bug fixes.

Fixes:
* Specifies the same scopes in registration as we request with the authentication token. This was preventing course syncing from working, as we were requesting different scopes in our authentication token request than we were specifying during the registration step.

Enhancements:
* Adds padding between the email label in the input text box
* Adds icon URL
* Removes undesirable placements
* Uses the `CDO.studio_url` and `CDO.dashboard_site_host` helper to set dynamic domain based on environment

Cleanup:
* Removes unused imports left over from a previous dynamic registration PR

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
