### PR TITLE
Music: dismiss chaff on start over

### DIFF
--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -111,6 +111,9 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
   );
 
   const onClickStartOver = useCallback(() => {
+    // Hide any custom fields that are showing.
+    Blockly.getMainWorkspace().hideChaff();
+
     if (dialogControl) {
       dialogControl.showDialog(DialogType.StartOver, clearCode);
     }


### PR DESCRIPTION
Dismiss Blockly [chaff](https://developers.google.com/blockly/reference/js/blockly.hidechaff_1_function), including custom fields, when the `Start Over` button is pressed.  

Thanks to @mikeharv for discovering and suggesting the fix for this issue, in which the confirmation dialog could be overlapped by some remaining chaff such as a custom field like this:

<img width="1512" alt="Screenshot 2024-05-31 at 9 34 51 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/ee8f3d27-a9c5-45bf-8209-8fbe63798404">
