### PR TITLE
Fix Progress v2 UI test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
@@ -151,6 +151,7 @@ Scenario: Teacher can view student work, ask student to keep working, on rubric 
   And I wait to see "#ui-test-feedback-input"
   And I click selector "#keep-working" once I see it
   And I press "#ui-test-submit-feedback" using jQuery
+  And I wait for 3 seconds
 
   # Teacher can see keep working icon
   Given I am on "http://studio.code.org/"
@@ -194,53 +195,3 @@ Scenario: Teacher can view choice levels
   # View expanded choice level
   And I click selector "button:contains(b)"
   And I see no difference for "unexpanded choice level - closed"
-
-# The test requires java-lab which does not run on correctly on drone
-@eyes @no_circle @skip
-Scenario: Teacher can view validated level
-  And I open my eyes to test "V2 Progress - Validated Levels"
-
-  # Student must be in CSA to run java lab
-  # Teacher for this step is named `Dumbledore`
-  Given I create a student named "Sally" in a CSA section
-
-  # Student makes progress in validated level
-  Given I am on "http://studio.code.org/s/allthethings/lessons/44/levels/11?noautoplay=true"
-  And I wait until I see selector "button:contains(Commit Code)"
-  And I click selector "button:contains(Commit Code)"
-  And I wait to see "#commit-notes"
-  And I press the first "#commit-notes" element
-  And I press keys "Commit message" for element "#commit-notes"
-  And I wait until "#confirmationButton" is not disabled
-  And I press "confirmationButton"
-  And I wait for 5 seconds
-
-  # Student submits validated level
-  Given I am on "http://studio.code.org/s/allthethings/lessons/44/levels/12?noautoplay=true"
-  And I wait to see "#finishButton"
-  And I press "testButton"
-  And I wait until element ".javalab-console" contains text "[JAVALAB] Program completed."
-  And I wait until "#finishButton" is enabled
-  And I press "finishButton"
-
-  Given I am assigned to unit "allthethings"
-
-  When I sign in as "Dumbledore" and go home
-  And I get levelbuilder access
-  And I navigate to the V2 progress dashboard for "New Section"
-
-  # Navigate to the right course on the progress page
-  And I wait until element "#unit-selector-v2" is visible
-  And I click selector "#unit-selector-v2"
-  And I click selector "option:contains(All the Things!)"
-
-  # eyes test for unexpanded lessons
-  And I wait until element "#ui-test-lesson-header-1" is visible
-  And I scroll to "#ui-test-lesson-header-44"
-  And I see no difference for "unexpanded lessons"
-
-  # eyes test for expanded lessons with in progress and completed validated levels
-  And I click selector "#ui-test-lesson-header-44"
-  And I wait until I see selector "div:contains('44.12')"
-  And I scroll to "#ui-test-lesson-header-45"
-  And I see no difference for "expanded lesson"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
@@ -137,6 +137,7 @@ Scenario: Teacher can view student work, ask student to keep working, on rubric 
   And I press keys "Nice!" for element "#ui-test-feedback-input"
   And I press "#ui-test-submit-feedback" using jQuery
   And element ".editor-column" contains text "Nice!"
+  And I wait for 3 seconds
 
   # Teacher can see feedback given icon
   Given I am on "http://studio.code.org/"


### PR DESCRIPTION
Fix a flaky progress test `Teacher can view student work, ask student to keep working, on rubric level`
This was caused because the test was leaving a page after submitting feedback too quickly. This caused a popup for `Are you sure you want to leave`. By waiting an extra three seconds, we should remove this popup.

This also removes the test `Teacher can view validated level`
This functionality is covered by unit tests [here](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/test/unit/templates/sectionProgressV2/LevelDataCellTest.jsx#L95). All ui except for the validated checkmark is also covered by other UI tests
This test can't be tested on Drone because it uses java lab. This makes it very hard to debug now and in the future. This test was not working when merged, even after a couple rounds of fixes and is currently disabled. I don't think that the minimal coverage is worth the effort to fix the test to work or continue to maintain it in the future.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
