### PR TITLE
delete programming expression from lesson

### DIFF
--- a/dashboard/config/scripts_json/coursee-2023.script_json
+++ b/dashboard/config/scripts_json/coursee-2023.script_json
@@ -32,7 +32,7 @@
     },
     "new_name": null,
     "family_name": "coursee",
-    "serialized_at": "2024-05-22 20:51:10 UTC",
+    "serialized_at": "2024-05-31 19:46:59 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -9987,13 +9987,6 @@
         "lesson.key": "Hello World",
         "programming_environment.name": "spritelab",
         "programming_expression.key": "gamelab_setBackgroundImage"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Hello World",
-        "programming_environment.name": "spritelab",
-        "programming_expression.key": "outbreak_layoutClusters"
       }
     }
   ],


### PR DESCRIPTION
Removes a programming expression key from a lesson plan that corresponds to documentation that was deleted.

See slack for additional context: https://codedotorg.slack.com/archives/C0T0PNTM3/p1717160381952269
