### PR TITLE
Music: sounds panel preview variant update

### DIFF
--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -158,6 +158,8 @@ class FieldSounds extends GoogleBlockly.Field {
   }
 
   dropdownDispose_() {
+    this.options.cancelPreviews();
+
     this.newDiv_ = null;
     this.showingEditor = false;
   }

--- a/apps/src/music/blockly/fields.js
+++ b/apps/src/music/blockly/fields.js
@@ -38,6 +38,7 @@ export const fieldSoundsDefinition = {
   playPreview: (id, onStop) => {
     Globals.getPlayer().previewSound(id, onStop);
   },
+  cancelPreviews: () => Globals.getPlayer().cancelPreviews(),
   currentValue: null,
   getShowSoundFilters: () => Globals.getShowSoundFilters(),
 };

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -182,6 +182,7 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
       className={classNames(
         'sounds-panel-sound-row',
         styles.soundRow,
+        useSoundsPanelPreview && styles.soundRowExtraHeight,
         isSelected && styles.soundRowSelected
       )}
       onClick={onSoundClick}
@@ -218,20 +219,27 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
         </div>
       )}
       <div className={styles.soundRowRight}>
-        <div className={styles.length}>
+        <div
+          className={classNames(
+            styles.length,
+            useSoundsPanelPreview && styles.lengthNoMarginRight
+          )}
+        >
           {getLengthRepresentation(sound.length)}
         </div>
-        <div className={styles.previewContainer}>
-          <FontAwesome
-            title={undefined}
-            icon={'play-circle'}
-            className={classNames(
-              styles.preview,
-              isPlayingPreview && styles.previewPlaying
-            )}
-            onClick={onPreviewClick}
-          />
-        </div>
+        {!useSoundsPanelPreview && (
+          <div className={styles.previewContainer}>
+            <FontAwesome
+              title={undefined}
+              icon={'play-circle'}
+              className={classNames(
+                styles.preview,
+                isPlayingPreview && styles.previewPlaying
+              )}
+              onClick={onPreviewClick}
+            />
+          </div>
+        )}
       </div>
     </div>
   );
@@ -343,7 +351,14 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
 
   return (
     <FocusLock>
-      <div id="sounds-panel" className={styles.soundsPanel} aria-modal>
+      <div
+        id="sounds-panel"
+        className={classNames(
+          styles.soundsPanel,
+          useSoundsPanelPreview && styles.soundsPanelExtraHeight
+        )}
+        aria-modal
+      >
         <div id="hidden-item" tabIndex={0} role="button" />
         {showSoundFilters && (
           <div id="sounds-panel-top" className={styles.soundsPanelTop}>

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -8,6 +8,10 @@
   flex-direction: column;
   gap: 5px;
 
+  &ExtraHeight {
+    height: 340px;
+  }
+
   &Top {
     display: flex;
     justify-content: space-between;
@@ -103,6 +107,10 @@
     align-items: center;
     cursor: pointer;
 
+    &ExtraHeight {
+      padding: 6px 0;
+    }
+
     &:hover {
       background-color: $neutral_dark90;
     }
@@ -156,6 +164,10 @@
     margin-right: 10px;
     color: $neutral_dark50;
     text-align: right;
+
+    &NoMarginRight {
+      margin-right: 0;
+    }
   }
 
   .previewContainer {

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -54,8 +54,14 @@ const optionsList = [
     name: 'sounds-panel-1-preview',
     type: 'radio',
     values: [
-      {value: 'false', description: 'Use original sounds panel (default).'},
-      {value: 'true', description: 'Use original sounds panel with preview.'},
+      {
+        value: 'false',
+        description: 'Use original sounds panel with preview (default).',
+      },
+      {
+        value: 'true',
+        description: 'Use original sounds panel with preview on select.',
+      },
     ],
   },
   {


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/58746.

This makes some updates to the new sounds panel variant, still shown with the `sounds-panel-1-preview=true` URL parameter.  The variant now doesn't show the preview icon, rows have extra height, and the panel is taller.  Both the original and the variant now cancel preview sounds when dismissed.

### variant

<img width="1512" alt="Screenshot 2024-05-31 at 10 51 26 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/2e157c39-9549-4662-8a41-2b460a1efcf6">

### original

<img width="1512" alt="Screenshot 2024-05-31 at 10 51 33 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/862beaa4-0bc4-4596-972e-662c890a18d8">
