### PR TITLE
Music: timeline cursor

### DIFF
--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import TimelineSampleEvents from './TimelineSampleEvents';
 import TimelineTrackEvents from './TimelineTrackEvents';
 import TimelineSimple2Events from './TimelineSimple2Events';
-import appConfig, {getBlockMode} from '../appConfig';
+import {getBlockMode} from '../appConfig';
 import {BlockMode, MIN_NUM_MEASURES} from '../constants';
 import {useDispatch} from 'react-redux';
 import {
@@ -89,8 +89,7 @@ const Timeline: React.FunctionComponent = () => {
 
   const onMeasuresBackgroundClick = useCallback(
     (event: MouseEvent) => {
-      // Ignore if playing unless using ToneJS player
-      if (isPlaying && appConfig.getValue('player') !== 'tonejs') {
+      if (isPlaying) {
         return;
       }
       const offset =
@@ -98,7 +97,7 @@ const Timeline: React.FunctionComponent = () => {
         (event.target as Element).getBoundingClientRect().x -
         paddingOffset;
       const exactMeasure = offset / barWidth + 1;
-      // Round measure to the nearest beat (1/4 note)
+      // Round measure to the nearest beat (1/4 note).
       const roundedMeasure = Math.round(exactMeasure * 4) / 4;
       dispatch(setStartPlayheadPosition(roundedMeasure));
     },
@@ -155,7 +154,8 @@ const Timeline: React.FunctionComponent = () => {
         id="timeline-measures-background"
         className={classNames(
           moduleStyles.measuresBackground,
-          moduleStyles.fullWidthOverlay
+          moduleStyles.fullWidthOverlay,
+          !isPlaying && moduleStyles.measuresBackgroundClickable
         )}
         style={{width: paddingOffset + measuresToDisplay * barWidth}}
         onClick={onMeasuresBackgroundClick}
@@ -174,7 +174,8 @@ const Timeline: React.FunctionComponent = () => {
                 className={classNames(
                   moduleStyles.barNumber,
                   measure === Math.floor(currentPlayheadPosition) &&
-                    moduleStyles.barNumberCurrent
+                    moduleStyles.barNumberCurrent,
+                  !isPlaying && moduleStyles.barNumberClickable
                 )}
                 onClick={() => onMeasureNumberClick(measure)}
               >

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -27,7 +27,10 @@
     background-color: $neutral_dark90;
     height: 24px;
     border-bottom: solid $default-spacing $dark_black;
-    cursor: pointer;
+
+    &Clickable {
+      cursor: pointer;
+    }
   }
 
   .barLineContainer {
@@ -41,10 +44,13 @@
       top: 4px;
       left: 6px;
       color: $neutral_dark20;
-      cursor: pointer;
 
       &Current {
         color: $neutral_light;
+      }
+
+      &Clickable {
+        cursor: pointer;
       }
     }
 


### PR DESCRIPTION
The updates the top bar of the timeline to only show the `pointer` mouse cursor when not playing, corresponding to when it handles clicks. 
