### PR TITLE
Music: callouts updates

### DIFF
--- a/apps/src/music/views/Callouts.tsx
+++ b/apps/src/music/views/Callouts.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 import {MusicState} from '../redux/musicRedux';
 import moduleStyles from './callouts.module.scss';
@@ -8,7 +8,7 @@ import {Triggers} from '../constants';
 const arrowImage = require(`@cdo/static/music/music-callout-arrow.png`);
 
 const availableCallouts: {
-  [key: string]: {selector: string};
+  [key: string]: {openToolboxCategory?: number; selector: string};
 } = {
   'play-sound-block': {
     selector: `.blocklyFlyout g[data-id="${BlockTypes.PLAY_SOUND_AT_CURRENT_LOCATION_SIMPLE2}"]`,
@@ -44,6 +44,7 @@ const availableCallouts: {
   'trigger-button-1': {selector: `#${Triggers[0].id}`},
   'toolbox-first-row': {selector: '.blocklyTreeRow'},
   'toolbox-second-block': {
+    openToolboxCategory: 0,
     selector:
       '.blocklyFlyout:not([style*="display: none;"]) .blocklyDraggable:nth-of-type(3)',
   },
@@ -60,14 +61,29 @@ const Callouts: React.FunctionComponent = () => {
     (state: {music: MusicState}) => state.music.currentCallout
   );
 
-  if (!callout.id) {
-    return null;
-  }
+  const availableCallout = callout.id
+    ? availableCallouts[callout.id]
+    : undefined;
 
-  const availableCallout = availableCallouts[callout.id];
+  const calloutIndex = callout.index;
+
+  useEffect(() => {
+    const toolbox = Blockly.getMainWorkspace()?.getToolbox();
+    if (availableCallout?.openToolboxCategory !== undefined) {
+      // Open toolbox category if a position is specified.
+      // This actually toggles whether a toolbox category is selected.  Ideally, we would only call
+      // this if the correct category isn't yet selected, but IToolbox doesn't expose the necessary
+      // functionality.
+      toolbox?.selectItemByPosition(availableCallout.openToolboxCategory);
+    } else {
+      toolbox?.clearSelection();
+    }
+  }, [availableCallout, calloutIndex]);
+
   if (!availableCallout) {
     return null;
   }
+
   const element = document.querySelector(availableCallout.selector);
   if (!element) {
     return null;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -28,7 +28,6 @@ import {
   getCurrentlyPlayingBlockIds,
   setSoundLoadingProgress,
   setUndoStatus,
-  showCallout,
   clearCallout,
   setSelectedTriggerId,
   clearSelectedTriggerId,
@@ -104,7 +103,6 @@ class UnconnectedMusicView extends React.Component {
     isReadOnlyWorkspace: PropTypes.bool,
     updateLoadProgress: PropTypes.func,
     setUndoStatus: PropTypes.func,
-    showCallout: PropTypes.func,
     clearCallout: PropTypes.func,
     isPlayView: PropTypes.bool,
   };
@@ -770,7 +768,6 @@ const MusicView = connect(
     setPageError: pageError => dispatch(setPageError(pageError)),
     updateLoadProgress: value => dispatch(setSoundLoadingProgress(value)),
     setUndoStatus: value => dispatch(setUndoStatus(value)),
-    showCallout: id => dispatch(showCallout(id)),
     clearCallout: id => dispatch(clearCallout()),
   })
 )(UnconnectedMusicView);

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -123,6 +123,17 @@ const optionsList = [
       {value: 'true', description: 'New timeline.'},
     ],
   },
+  {
+    name: 'clickable-text-with-glow',
+    type: 'radio',
+    values: [
+      {
+        value: 'false',
+        description: 'No glow for clickable text in instructions (default).',
+      },
+      {value: 'true', description: 'Glow for clickable text in instructions.'},
+    ],
+  },
 ];
 
 export default class MusicMenu extends React.Component {

--- a/apps/src/templates/EnhancedSafeMarkdown.jsx
+++ b/apps/src/templates/EnhancedSafeMarkdown.jsx
@@ -87,10 +87,14 @@ export class ClickableTextWrapper extends React.Component {
 
   renderClickableText(node) {
     const clickableTextAll = node.querySelectorAll('b.clickable-text');
-    for (const clickableText of clickableTextAll) {
+    clickableTextAll.forEach((clickableText, index) => {
       const id = clickableText.dataset.id;
+      const extraClass = ` clickable-text-${index}`;
+      if (!clickableText.className.includes(extraClass)) {
+        clickableText.className += extraClass;
+      }
       clickableText.onclick = () => this.props.handleInstructionsTextClick(id);
-    }
+    });
   }
 
   render() {

--- a/apps/src/templates/EnhancedSafeMarkdown.jsx
+++ b/apps/src/templates/EnhancedSafeMarkdown.jsx
@@ -3,10 +3,15 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {connect} from 'react-redux';
 
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import {openDialog} from '@cdo/apps/redux/instructionsDialog';
 
 import SafeMarkdown from './SafeMarkdown';
 import {renderExpandableImages} from './utils/expandableImages';
+
+// A variant for clickable text that shows a glow on hover and appearance.
+const showClickableTextWithGlow =
+  queryParams('clickable-text-with-glow') === 'true';
 
 export class UnconnectedExpandableImagesWrapper extends React.Component {
   static propTypes = {
@@ -89,9 +94,11 @@ export class ClickableTextWrapper extends React.Component {
     const clickableTextAll = node.querySelectorAll('b.clickable-text');
     clickableTextAll.forEach((clickableText, index) => {
       const id = clickableText.dataset.id;
-      const extraClass = ` clickable-text-${index}`;
-      if (!clickableText.className.includes(extraClass)) {
-        clickableText.className += extraClass;
+      if (showClickableTextWithGlow) {
+        const extraClass = ` clickable-text-with-glow clickable-text-${index}`;
+        if (!clickableText.className.includes(extraClass)) {
+          clickableText.className += extraClass;
+        }
       }
       clickableText.onclick = () => this.props.handleInstructionsTextClick(id);
     });

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -4135,20 +4135,10 @@ $clickable-text-glow: 0 0 1px $realyellow,
     }
   }
 
-  .clickable-text-0 {
-    animation-delay: 1s;
-  }
-  .clickable-text-1 {
-    animation-delay: 2s;
-  }
-  .clickable-text-2 {
-    animation-delay: 3s;
-  }
-  .clickable-text-3 {
-    animation-delay: 4s;
-  }
-  .clickable-text-4 {
-    animation-delay: 5s;
+  @for $i from 0 through 4 {
+    .clickable-text-#{$i} {
+      animation-delay: #{$i + 1}s;
+    }
   }
 }
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -4099,9 +4099,50 @@ a {
   }
 }
 
+@keyframes clickable-text-glow {
+  0% {
+    text-shadow: none;
+  }
+  50% {
+    text-shadow: 0 0 1px $realyellow,
+      0 0 2px $realyellow,
+      0 0 3px $realyellow,
+      0 0 4px $realyellow,
+      0 0 5px $realyellow,
+      0 0 6px $realyellow,
+      0 0 7px $realyellow,
+      0 0 8px $realyellow,
+      0 0 9px $realyellow;
+  }
+  100% {
+    text-shadow: none;
+  }
+}
+
 #instructions {
   .clickable-text {
     cursor: pointer;
+    position: relative;
+  }
+
+  .clickable-text {
+    animation: clickable-text-glow 2s ease-in-out;
+  }
+
+  .clickable-text-0 {
+    animation-delay: 1s;
+  }
+  .clickable-text-1 {
+    animation-delay: 2s;
+  }
+  .clickable-text-2 {
+    animation-delay: 3s;
+  }
+  .clickable-text-3 {
+    animation-delay: 4s;
+  }
+  .clickable-text-4 {
+    animation-delay: 5s;
   }
 }
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -4099,20 +4099,22 @@ a {
   }
 }
 
-@keyframes clickable-text-glow {
+$clickable-text-glow: 0 0 1px $realyellow,
+  0 0 2px $realyellow,
+  0 0 3px $realyellow,
+  0 0 4px $realyellow,
+  0 0 5px $realyellow,
+  0 0 6px $realyellow,
+  0 0 7px $realyellow,
+  0 0 8px $realyellow,
+  0 0 9px $realyellow;
+
+@keyframes clickable-text-glow-keyframes {
   0% {
     text-shadow: none;
   }
   50% {
-    text-shadow: 0 0 1px $realyellow,
-      0 0 2px $realyellow,
-      0 0 3px $realyellow,
-      0 0 4px $realyellow,
-      0 0 5px $realyellow,
-      0 0 6px $realyellow,
-      0 0 7px $realyellow,
-      0 0 8px $realyellow,
-      0 0 9px $realyellow;
+    text-shadow: $clickable-text-glow;
   }
   100% {
     text-shadow: none;
@@ -4123,10 +4125,11 @@ a {
   .clickable-text {
     cursor: pointer;
     position: relative;
-  }
+    animation: clickable-text-glow-keyframes 2s ease-in-out;
 
-  .clickable-text {
-    animation: clickable-text-glow 2s ease-in-out;
+    &:hover {
+      text-shadow: $clickable-text-glow;
+    }
   }
 
   .clickable-text-0 {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -4125,10 +4125,13 @@ $clickable-text-glow: 0 0 1px $realyellow,
   .clickable-text {
     cursor: pointer;
     position: relative;
-    animation: clickable-text-glow-keyframes 2s ease-in-out;
 
-    &:hover {
-      text-shadow: $clickable-text-glow;
+    &-with-glow {
+      animation: clickable-text-glow-keyframes 2s ease-in-out;
+
+      &:hover {
+        text-shadow: $clickable-text-glow;
+      }
     }
   }
 


### PR DESCRIPTION
This makes some updates to the Music Labs callouts.  

When the `clickable-text-with-glow=true` URL parameter is provided, a glow now plays behind each item of clickable text in instructions and feedback when it first appears, designed as a hint that it's clickable.  The same glow shows on hover, too.  

The goal is that it doesn't interfere with regular instruction reading, but still suggests there is something to do.  The yellow color is chosen to match the arrow that will show upon click.

Thanks to @snickell for revitalizing this effort with a prototype. 

Also, a callout can now open a toolbox category.

### Glow sequence

https://github.com/code-dot-org/code-dot-org/assets/2205926/830e0a98-2450-4c04-a8da-0fb34a1dd785

### Glow on hover

https://github.com/code-dot-org/code-dot-org/assets/2205926/d2536e33-6692-40ab-af8f-7fa8349a4697

### Opening a toolbox category

https://github.com/code-dot-org/code-dot-org/assets/2205926/4699b28c-8668-4db4-8935-302fdc792bc6

