### PR TITLE
Pass down less info about enrolled workshops

### DIFF
--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -80,7 +80,7 @@ function LandingPage({
   lastWorkshopSurveyCourse,
   deeperLearningCourseData,
   currentYearApplicationId,
-  workshopsAsParticipant,
+  hasEnrolledInWorkshop,
   workshopsAsFacilitator,
   workshopsAsOrganizer,
   workshopsAsRegionalPartner,
@@ -101,7 +101,7 @@ function LandingPage({
 
   const showGettingStartedBanner =
     !currentYearApplicationId &&
-    workshopsAsParticipant?.length === 0 &&
+    !hasEnrolledInWorkshop &&
     plCoursesStarted?.length === 0;
 
   const joinedPlSectionsStyling =
@@ -438,7 +438,7 @@ LandingPage.propTypes = {
   lastWorkshopSurveyCourse: PropTypes.string,
   deeperLearningCourseData: PropTypes.array,
   currentYearApplicationId: PropTypes.number,
-  workshopsAsParticipant: PropTypes.array,
+  hasEnrolledInWorkshop: PropTypes.bool,
   workshopsAsFacilitator: PropTypes.array,
   workshopsAsOrganizer: PropTypes.array,
   workshopsAsRegionalPartner: PropTypes.array,

--- a/apps/src/sites/studio/pages/pd/professional_learning_landing/index.js
+++ b/apps/src/sites/studio/pages/pd/professional_learning_landing/index.js
@@ -26,7 +26,7 @@ $(() => {
         currentYearApplicationId={
           landingPageData['current_year_application_id']
         }
-        workshopsAsParticipant={landingPageData['workshops_as_participant']}
+        hasEnrolledInWorkshop={landingPageData['has_enrolled_in_workshop']}
         workshopsAsFacilitator={landingPageData['workshops_as_facilitator']}
         workshopsAsOrganizer={landingPageData['workshops_as_organizer']}
         workshopsAsRegionalPartner={

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
@@ -39,7 +39,7 @@ const DEFAULT_PROPS = {
   lastWorkshopSurveyCourse: 'CS Fundamentals',
   deeperLearningCourseData: [{data: 'oh yeah'}],
   currentYearApplicationId: 2024,
-  workshopsAsParticipant: [{data: 'workshops'}],
+  hasEnrorolledInWorkshop: true,
   workshopsAsFacilitator: [],
   workshopsAsOrganizer: [],
   workshopsAsRegionalPartner: [],
@@ -79,7 +79,7 @@ describe('LandingPage', () => {
       lastWorkshopSurveyCourse: null,
       deeperLearningCourseData: null,
       currentYearApplicationId: null,
-      workshopsAsParticipant: [],
+      hasEnrolledInWorkshop: false,
       plCoursesStarted: [],
     });
     screen.getByText(i18n.plLandingGettingStartedHeading());

--- a/dashboard/app/controllers/pd/professional_learning_landing_controller.rb
+++ b/dashboard/app/controllers/pd/professional_learning_landing_controller.rb
@@ -16,11 +16,6 @@ class Pd::ProfessionalLearningLandingController < ApplicationController
       PLC_COURSE_ORDERING.index(enrollment[:courseName]) || PLC_COURSE_ORDERING.size
     end
 
-    workshops_as_participant_data = Pd::Enrollment.for_user(current_user).map do |enrollment|
-      workshop = enrollment.workshop
-      workshop.summarize_for_my_pl_page.merge({feedback_given: enrollments_with_pending_surveys.include?(enrollment)})
-    end
-
     workshops_as_facilitator = current_user.pd_workshops_facilitated
     workshops_as_facilitator_with_surveys_completed = Pd::WorkshopSurveyFoormSubmission.where(user: current_user, pd_workshop: workshops_as_facilitator).pluck(:pd_workshop_id).uniq
     workshops_as_facilitator_data = workshops_as_facilitator.map do |workshop|
@@ -36,7 +31,7 @@ class Pd::ProfessionalLearningLandingController < ApplicationController
       last_workshop_survey_course: last_enrollment_with_pending_survey.try(:workshop).try(:course),
       summarized_plc_enrollments: summarized_plc_enrollments,
       current_year_application_id: Pd::Application::TeacherApplication.find_by(user: current_user, application_year: Pd::SharedApplicationConstants::APPLICATION_CURRENT_YEAR)&.id,
-      workshops_as_participant: workshops_as_participant_data,
+      has_enrolled_in_workshop: Pd::Enrollment.for_user(current_user).any?,
       workshops_as_facilitator: workshops_as_facilitator_data,
       workshops_as_organizer: workshops_as_organizer_data,
       workshops_for_regional_partner: workshops_for_regional_partner_data,

--- a/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
@@ -193,14 +193,13 @@ class Pd::ProfessionalLearningLandingControllerTest < ActionController::TestCase
     assert_equal application.id, response[:current_year_application_id]
   end
 
-  test 'enrolled workshops are passed down' do
+  test 'has_enrolled_in_workshops is true when user is enrolled workshops' do
     prepare_scenario
 
     load_pl_landing @teacher
 
     response = assigns(:landing_page_data)
-    assert_equal 3, response[:workshops_as_participant].length
-    assert_equal([@csf_workshop, @csd_workshop, @csp_workshop].map(&:course_name), response[:workshops_as_participant].map {|workshop| workshop[:course]})
+    assert response[:has_enrolled_in_workshop]
   end
 
   test 'facilitated workshops are passed down' do


### PR DESCRIPTION
The `EnrolledWorkshops` component fetches info about enrolled workshops, so we were passing down a bunch of unnecessary data. In fact, we were only using `workshopsAsParticipant` to check if the user enrolled in any workshops, so this change passes down that info only. I'm hoping this cuts down on unnecessary queries and data transfer.