### PR TITLE
use useRef in for blockRef in EmbeddedBlock

### DIFF
--- a/apps/src/templates/codeDocs/EmbeddedBlock.jsx
+++ b/apps/src/templates/codeDocs/EmbeddedBlock.jsx
@@ -1,12 +1,12 @@
 import {Link} from '@dsco_/link';
 import PropTypes from 'prop-types';
-import React, {createRef, useEffect} from 'react';
+import React, {useRef, useEffect} from 'react';
 
 import {shrinkBlockSpaceContainer} from '@cdo/apps/templates/instructions/utils';
 import {parseElement} from '@cdo/apps/xml';
 
 export default function EmbeddedBlock({blockName, link, ariaLabel}) {
-  const blockRef = createRef();
+  const blockRef = useRef();
 
   useEffect(() => {
     if (blockName && blockRef.current) {
@@ -21,8 +21,7 @@ export default function EmbeddedBlock({blockName, link, ariaLabel}) {
       );
       shrinkBlockSpaceContainer(blockSpace, true);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockName]);
+  }, [blockName, blockRef]);
 
   return (
     <div>

--- a/apps/src/templates/codeDocs/EmbeddedBlock.jsx
+++ b/apps/src/templates/codeDocs/EmbeddedBlock.jsx
@@ -11,10 +11,6 @@ export default function EmbeddedBlock({blockName, link, ariaLabel}) {
   useEffect(() => {
     if (blockName && blockRef.current) {
       const blocksDom = parseElement(`<block type='${blockName}' />`);
-      const previousBlockSpace = blockRef.current.querySelector(
-        'svg.readOnlyBlockSpace'
-      );
-      previousBlockSpace?.remove();
       const blockSpace = Blockly.createEmbeddedWorkspace(
         blockRef.current,
         blocksDom,
@@ -26,7 +22,7 @@ export default function EmbeddedBlock({blockName, link, ariaLabel}) {
       shrinkBlockSpaceContainer(blockSpace, true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockRef]);
+  }, [blockName]);
 
   return (
     <div>


### PR DESCRIPTION
Alternative/Follow-up to:
- https://github.com/code-dot-org/code-dot-org/pull/59017

On Friday we observed that a lesson plan was crashing due to a Sprite Lab block failing to render with CDO Blockly. After updating lessons to use Google Blockly, the block rendered correctly - but it rendered four times. As a quick fix, I updated the steps of the `useEffect` to check for an existing workspace SVG and remove it.

~~As an alternative, we could consider updating the dependency array to only include `blockName`. This change makes it so that `useEffect` hook runs once instead of four times.~~

In the component, `blockRef` was created using `createRef()`, which returns a new/different object each time the component is remounted. By switching to the more appropirate `useRef()`, we can keep the reference stable which avoid running the hook multiple times. We can also remove the manual SVG removal and the eslint disable rule. :tada:

## Links

https://codedotorg.atlassian.net/browse/CT-622

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
