### PR TITLE
only find unit by name on script and script level paths

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -11,6 +11,7 @@ class ScriptLevelsController < ApplicationController
   before_action :disable_session_for_cached_pages
   before_action :redirect_admin_from_labs, only: [:reset, :next, :show, :lesson_extras]
   before_action :set_redirect_override, only: [:show]
+  before_action :check_script_id_is_name, only: [:show, :lesson_extras]
 
   # Return true if request is one that can be publicly cached.
   def cachable_request?(request)
@@ -594,6 +595,13 @@ class ScriptLevelsController < ApplicationController
     if params[:script_id] && params[:no_redirect]
       VersionRedirectOverrider.set_unit_redirect_override(session, params[:script_id])
     end
+  end
+
+  # showing script levels by script id is no longer supported.
+  private def check_script_id_is_name
+    script_id = request.params[:script_id]
+    is_id = script_id.to_i.to_s == script_id.to_s
+    raise ActiveRecord::RecordNotFound if is_id
   end
 
   private def redirect_script(script, locale)

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -597,7 +597,10 @@ class ScriptLevelsController < ApplicationController
     end
   end
 
-  # showing script levels by script id is no longer supported.
+  # showing script levels by script id is no longer supported. Other codepaths
+  # still need underlying helper methods to support lookup by id, so we filter
+  # out numerical ids on a per-action basis rather than removing support for
+  # ids from those methods.
   private def check_script_id_is_name
     script_id = request.params[:script_id]
     is_id = script_id.to_i.to_s == script_id.to_s

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -602,6 +602,8 @@ class ScriptLevelsController < ApplicationController
   # out numerical ids on a per-action basis rather than removing support for
   # ids from those methods.
   private def check_script_id_is_name
+    # Unfortunately, scripts routes sometimes pass the name and sometimes pass
+    # the id, making params[:script_id] a misnomer when passing the name.
     script_id = request.params[:script_id]
     is_id = script_id.to_i.to_s == script_id.to_s
     raise ActiveRecord::RecordNotFound if is_id

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -264,7 +264,10 @@ class ScriptsController < ApplicationController
   private def get_unit_by_name
     unit_id = params[:id]
 
-    # showing scripts by id is no longer supported.
+    # Showing scripts by id is no longer supported. Other codepaths still need
+    # get_without_cache and get_from_cache to support lookup by id, so we filter
+    # out numerical ids here rather than removing support for them from those
+    # methods.
     is_id = unit_id.to_i.to_s == unit_id.to_s
     raise ActiveRecord::RecordNotFound if is_id
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -263,6 +263,8 @@ class ScriptsController < ApplicationController
 
   private def get_unit_by_name
     unit_id = params[:id]
+
+    # showing scripts by id is no longer supported.
     is_id = unit_id.to_i.to_s == unit_id.to_s
     raise ActiveRecord::RecordNotFound if is_id
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -6,10 +6,10 @@ class ScriptsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :vocab, :resources, :code, :standards]
   check_authorization
   before_action :set_unit_by_name, only: [:show, :vocab, :resources, :code, :standards, :edit]
-  before_action :set_unit_by_id, only: [:update, :destroy]
   before_action :render_no_access, only: [:show]
   before_action :set_redirect_override, only: [:show]
-  authorize_resource class: 'Unit'
+  authorize_resource class: 'Unit', except: [:update, :destroy]
+  load_and_authorize_resource class: 'Unit', only: [:update, :destroy]
 
   use_reader_connection_for_route(:show)
 
@@ -284,11 +284,6 @@ class ScriptsController < ApplicationController
 
   private def set_unit_by_name
     @script = get_unit_by_name
-    raise ActiveRecord::RecordNotFound unless @script
-  end
-
-  private def set_unit_by_id
-    @script = Unit.find(params[:id])
     raise ActiveRecord::RecordNotFound unless @script
   end
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -262,25 +262,27 @@ class ScriptsController < ApplicationController
   end
 
   private def get_unit_by_name
-    unit_id = params[:id]
+    # Unfortunately, scripts routes sometimes pass the name and sometimes pass
+    # the id, making params[:id] a misnomer when passing the name.
+    unit_name = params[:id]
 
     # Showing scripts by id is no longer supported. Other codepaths still need
     # get_without_cache and get_from_cache to support lookup by id, so we filter
     # out numerical ids here rather than removing support for them from those
     # methods.
-    is_id = unit_id.to_i.to_s == unit_id.to_s
+    is_id = unit_name.to_i.to_s == unit_name.to_s
     raise ActiveRecord::RecordNotFound if is_id
 
     script = params[:action] == "edit" ?
-      Unit.get_without_cache(unit_id, with_associated_models: true) :
-      Unit.get_from_cache(unit_id, raise_exceptions: false)
+      Unit.get_without_cache(unit_name, with_associated_models: true) :
+      Unit.get_from_cache(unit_name, raise_exceptions: false)
 
     return script if script
 
-    if Unit.family_names.include?(unit_id)
-      script = Unit.get_unit_family_redirect_for_user(unit_id, user: current_user, locale: request.locale)
+    if Unit.family_names.include?(unit_name)
+      script = Unit.get_unit_family_redirect_for_user(unit_name, user: current_user, locale: request.locale)
       session[:show_unversioned_redirect_warning] = true
-      Unit.log_redirect(unit_id, script.redirect_to, request, 'unversioned-script-redirect', current_user&.user_type) if script.present?
+      Unit.log_redirect(unit_name, script.redirect_to, request, 'unversioned-script-redirect', current_user&.user_type) if script.present?
       return script
     end
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -5,6 +5,7 @@ class ScriptsController < ApplicationController
   before_action :require_levelbuilder_mode_or_test_env, only: [:edit, :update, :new, :create]
   before_action :authenticate_user!, except: [:show, :vocab, :resources, :code, :standards]
   check_authorization
+  before_action :check_unit_param, only: [:show, :vocab, :resources, :code, :standards]
   before_action :set_unit, only: [:show, :vocab, :resources, :code, :standards, :edit, :update, :destroy]
   before_action :render_no_access, only: [:show]
   before_action :set_redirect_override, only: [:show]
@@ -282,6 +283,12 @@ class ScriptsController < ApplicationController
   private def set_unit
     @script = get_unit
     raise ActiveRecord::RecordNotFound unless @script
+  end
+
+  private def check_unit_param
+    unit_id = params[:id]
+    is_id = unit_id.to_i.to_s == unit_id.to_s
+    raise ActiveRecord::RecordNotFound if is_id
   end
 
   private def render_no_access

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -287,16 +287,8 @@ class ScriptsController < ApplicationController
     raise ActiveRecord::RecordNotFound unless @script
   end
 
-  private def get_unit_by_id
-    unit_id = params[:id]
-    is_id = unit_id.to_i.to_s == unit_id.to_s
-    raise ActiveRecord::RecordNotFound unless is_id
-
-    Unit.get_from_cache(unit_id, raise_exceptions: false)
-  end
-
   private def set_unit_by_id
-    @script = get_unit_by_id
+    @script = Unit.find(params[:id])
     raise ActiveRecord::RecordNotFound unless @script
   end
 

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -197,6 +197,27 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_equal @script_level, assigns(:script_level)
   end
 
+  test 'should show script level by script name' do
+    params = {
+      script_id: @script_level.script.name,
+      lesson_position: @script_level.lesson.absolute_position,
+      id: @script_level.position
+    }
+    get :show, params: params
+    assert_response :success
+  end
+
+  test 'should not show script level by script id' do
+    params = {
+      script_id: @script_level.script.id,
+      lesson_position: @script_level.lesson.absolute_position,
+      id: @script_level.position
+    }
+    assert_raises ActiveRecord::RecordNotFound do
+      get :show, params: params
+    end
+  end
+
   test 'should make script level pages uncachable by default' do
     get_show_script_level_page(@script_level)
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -366,14 +366,14 @@ class ScriptsControllerTest < ActionController::TestCase
   test "platformization partner cannot edit our units" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     sign_in create(:platformization_partner)
-    get :edit, params: {id: @coursez_2019.id}
+    get :edit, params: {id: @coursez_2019.name}
     assert_response :forbidden
   end
 
   test "platformization partner can edit their units" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     sign_in create(:platformization_partner)
-    get :edit, params: {id: @partner_unit.id}
+    get :edit, params: {id: @partner_unit.name}
     assert_response :success
   end
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -111,19 +111,9 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_select 'a', text: 'Overview of Courses 1, 2, and 3'
   end
 
-  test "should redirect to /s/course1" do
-    get :show, params: {id: Unit.find_by_name("course1").id}
-    assert_redirected_to "/s/course1"
-  end
-
   test "show of hourofcode redirects to hoc" do
     get :show, params: {id: 'hourofcode'}
     assert_response :success
-  end
-
-  test "show of hourofcode by id should redirect to hoc" do
-    get :show, params: {id: Unit.find_by_name('hourofcode').id}
-    assert_redirected_to '/s/hourofcode'
   end
 
   test "should get show if not signed in" do
@@ -411,20 +401,6 @@ class ScriptsControllerTest < ActionController::TestCase
       lesson_groups: '[]',
     }
     assert_response :success
-  end
-
-  # These two tests are the only remaining dependency on script seed order.  Check that /s/1 redirects to /s/20-hour in
-  # production. On a fresh db the only guarantee that '20-hour.script' has id:1 is by manually specifying ID in the DSL.
-
-  test "should redirect old k-8" do
-    get :show, params: {id: 1}
-    assert_redirected_to script_path(Unit.twenty_hour_unit)
-  end
-
-  test "show should redirect to flappy" do
-    flappy = Unit.find_by_name('flappy')
-    get :show, params: {id: flappy.id}
-    assert_redirected_to "/s/flappy"
   end
 
   test 'create' do

--- a/dashboard/test/integration/redirects_test.rb
+++ b/dashboard/test/integration/redirects_test.rb
@@ -118,18 +118,6 @@ class RedirectsTest < ActionDispatch::IntegrationTest
     assert_includes e.message, 'No route matches'
   end
 
-  test 'old script id paths redirect to named paths' do
-    {
-      'Hour of Code': 'Hour%20of%20Code',
-      events: 'events',
-      jigsaw: 'jigsaw'
-    }.each do |name, slug|
-      unit = Unit.find_by_name(name)
-      get "/s/#{unit.id}"
-      assert_redirected_to "/s/#{slug}"
-    end
-  end
-
   test 'redirects weblab code studio share link to codeprojects' do
     get "http://#{CDO.dashboard_hostname}/projects/weblab/abcdef"
     assert_redirected_to "http://#{CDO.codeprojects_hostname}/abcdef/"


### PR DESCRIPTION
Follow-up from https://github.com/code-dot-org/code-dot-org/pull/58951#pullrequestreview-2089216860 .

Remove deprecated routes, in part so that we can make our tests a bit less dependent on test fixtures.

We stopped using script and script level paths like /s/1/... in our product a long time ago: 
* https://github.com/code-dot-org/code-dot-org/pull/1295

There is a little bit of traffic to /s/1 and other numeric script id paths, likely because this path is showing up in google search results. Making these paths return 404 should be enough to make Google stop showing these pages in search results.

## Testing story

new + updated unit tests