### PR TITLE
Add Project Template Level support to Python Lab

### DIFF
--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -4,16 +4,26 @@ import {FileTabs} from '@codebridge/FileTabs';
 import React from 'react';
 
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import ProjectTemplateWorkspaceIcon from '@cdo/apps/templates/ProjectTemplateWorkspaceIcon';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import HeaderButtons from './HeaderButtons';
 
 import moduleStyles from './workspace.module.scss';
 const Workspace = () => {
   const {config} = useCodebridgeContext();
+  const isProjectTemplateLevel = useAppSelector(
+    state => state.lab.levelProperties?.isProjectTemplateLevel
+  );
+
+  const headerContent = (
+    <>Workspace {isProjectTemplateLevel && <ProjectTemplateWorkspaceIcon />}</>
+  );
+
   return (
     <PanelContainer
       id="editor-workspace"
-      headerContent={'Workspace'}
+      headerContent={headerContent}
       rightHeaderContent={<HeaderButtons />}
       className={moduleStyles.workspace}
     >

--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -3,6 +3,7 @@ import {Editor} from '@codebridge/Editor';
 import {FileTabs} from '@codebridge/FileTabs';
 import React from 'react';
 
+import {isProjectTemplateLevel} from '@cdo/apps/lab2/lab2Redux';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import ProjectTemplateWorkspaceIcon from '@cdo/apps/templates/ProjectTemplateWorkspaceIcon';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -12,12 +13,10 @@ import HeaderButtons from './HeaderButtons';
 import moduleStyles from './workspace.module.scss';
 const Workspace = () => {
   const {config} = useCodebridgeContext();
-  const isProjectTemplateLevel = useAppSelector(
-    state => state.lab.levelProperties?.isProjectTemplateLevel
-  );
+  const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
 
   const headerContent = (
-    <>Workspace {isProjectTemplateLevel && <ProjectTemplateWorkspaceIcon />}</>
+    <>Workspace {projectTemplateLevel && <ProjectTemplateWorkspaceIcon />}</>
   );
 
   return (

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -1,4 +1,4 @@
-import {useMemo, useEffect, useCallback, useRef} from 'react';
+import {useMemo, useEffect, useCallback, useRef, useState} from 'react';
 
 import header from '@cdo/apps/code-studio/header';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
@@ -30,6 +30,7 @@ export const useSource = (defaultSources: ProjectSources) => {
   );
   const previousChannelIdRef = useRef<string | null>(null);
   const levelId = useAppSelector(state => state.lab.levelProperties?.id);
+  const [hasSetInitialSource, setHasSetInitialSource] = useState(false);
 
   const setSource = useMemo(
     () => (newSource: MultiFileSource) => {
@@ -57,15 +58,22 @@ export const useSource = (defaultSources: ProjectSources) => {
   }, [isStartMode, isEditingExemplarMode, levelId, source]);
 
   useEffect(() => {
-    if (channelId && previousChannelIdRef.current !== channelId) {
+    // It's possible to not have a channel id if we are in start or exemplar mode.
+    if (
+      !hasSetInitialSource ||
+      (channelId && previousChannelIdRef.current !== channelId)
+    ) {
       // We reset the project when the channelId changes, as this means we are on a new level
       // with a new project.
       if (initialSources) {
         dispatch(setAndSaveProjectSource(initialSources));
       }
-      previousChannelIdRef.current = channelId;
+      if (channelId) {
+        previousChannelIdRef.current = channelId;
+      }
+      setHasSetInitialSource(true);
     }
-  }, [channelId, initialSources, dispatch]);
+  }, [channelId, initialSources, dispatch, hasSetInitialSource]);
 
   return {source, setSource, resetToStartSource};
 };

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -1,4 +1,4 @@
-import {useMemo, useEffect, useCallback, useRef, useState} from 'react';
+import {useMemo, useEffect, useCallback, useRef} from 'react';
 
 import header from '@cdo/apps/code-studio/header';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
@@ -21,16 +21,14 @@ export const useSource = (defaultSources: ProjectSources) => {
     state => state.lab2Project.projectSource
   );
   const source = projectSource?.source as MultiFileSource;
-  const channelId = useAppSelector(state => state.lab.channel?.id);
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const isEditingExemplarMode = getAppOptionsEditingExemplar();
   const initialSources = useInitialSources(defaultSources);
   const levelStartSource = useAppSelector(
     state => state.lab.levelProperties?.source
   );
-  const previousChannelIdRef = useRef<string | null>(null);
+  const previousLevelIdRef = useRef<number | null>(null);
   const levelId = useAppSelector(state => state.lab.levelProperties?.id);
-  const [hasSetInitialSource, setHasSetInitialSource] = useState(false);
 
   const setSource = useMemo(
     () => (newSource: MultiFileSource) => {
@@ -58,22 +56,16 @@ export const useSource = (defaultSources: ProjectSources) => {
   }, [isStartMode, isEditingExemplarMode, levelId, source]);
 
   useEffect(() => {
-    // It's possible to not have a channel id if we are in start or exemplar mode.
-    if (
-      !hasSetInitialSource ||
-      (channelId && previousChannelIdRef.current !== channelId)
-    ) {
-      // We reset the project when the channelId changes, as this means we are on a new level
-      // with a new project.
+    if (levelId && previousLevelIdRef.current !== levelId) {
+      // We reset the project when the levelId changes, as this means we are on a new level.
       if (initialSources) {
         dispatch(setAndSaveProjectSource(initialSources));
       }
-      if (channelId) {
-        previousChannelIdRef.current = channelId;
+      if (levelId) {
+        previousLevelIdRef.current = levelId;
       }
-      setHasSetInitialSource(true);
     }
-  }, [channelId, initialSources, dispatch, hasSetInitialSource]);
+  }, [initialSources, dispatch, levelId]);
 
   return {source, setSource, resetToStartSource};
 };

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -153,6 +153,7 @@ export interface LevelProperties {
   exemplarSources?: MultiFileSource;
   // For Teachers Only value
   teacherMarkdown?: string;
+  isProjectTemplateLevel?: boolean;
 }
 
 // Level configuration data used by project-backed labs that don't require

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -153,7 +153,6 @@ export interface LevelProperties {
   exemplarSources?: MultiFileSource;
   // For Teachers Only value
   teacherMarkdown?: string;
-  isProjectTemplateLevel?: boolean;
 }
 
 // Level configuration data used by project-backed labs that don't require

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -15,6 +15,7 @@ $default-spacing: 2px;
   min-height: 30px;
   margin-bottom: $default-spacing;
   position: relative;
+  z-index: 1;
 }
 
 .panelContainerHeader-dark {

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -844,7 +844,6 @@ class Level < ApplicationRecord
     properties_camelized[:appName] = game&.app
     properties_camelized[:useRestrictedSongs] = game.use_restricted_songs?
     properties_camelized[:usesProjects] = try(:is_project_level) || channel_backed?
-    properties_camelized[:isProjectTemplateLevel] = project_template_level_name.present?
     # Localized properties
     properties_camelized["validations"] = localized_validations if properties_camelized["validations"]
     properties_camelized["panels"] = localized_panels if properties_camelized["panels"]

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -844,6 +844,7 @@ class Level < ApplicationRecord
     properties_camelized[:appName] = game&.app
     properties_camelized[:useRestrictedSongs] = game.use_restricted_songs?
     properties_camelized[:usesProjects] = try(:is_project_level) || channel_backed?
+    properties_camelized[:isProjectTemplateLevel] = project_template_level_name.present?
     # Localized properties
     properties_camelized["validations"] = localized_validations if properties_camelized["validations"]
     properties_camelized["panels"] = localized_panels if properties_camelized["panels"]

--- a/dashboard/app/views/levels/editors/_pythonlab.html.haml
+++ b/dashboard/app/views/levels/editors/_pythonlab.html.haml
@@ -3,4 +3,5 @@
 = render partial: 'levels/editors/fields/help_and_tips', locals: {f: f}
 = render partial: 'levels/editors/fields/pythonlab_fields', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
+= render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
@@ -26,7 +26,7 @@
         %li For users: The coding workspace, design mode, data mode, the reset button, and sharing are all disabled.
         %li For levelbuilders: The coding workspace and design mode are available in start mode.
 
-  - if (@level.is_a?(Blockly) || @level.is_a?(Weblab) || @level.is_a?(Javalab) || @level.is_a?(Aichat))
+  - if (@level.is_a?(Blockly) || @level.is_a?(Weblab) || @level.is_a?(Javalab) || @level.is_a?(Aichat)) || @level.is_a?(Pythonlab)
     .field
       = f.label :project_template_level_name, 'Project Template Level Name'
       %p What this does:

--- a/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 3.level
+++ b/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 3.level
@@ -1,0 +1,15 @@
+<Pythonlab>
+  <config><![CDATA[{
+  "game_id": 72,
+  "created_at": "2024-06-03T17:54:37.000Z",
+  "level_num": "custom",
+  "user_id": 2,
+  "properties": {
+    "encrypted": "false",
+    "project_template_level_name": "pythonlab_test_project_template",
+    "long_instructions": "## Project-backed level\r\nThis level shares a project with level 4 in the progression.",
+    "hide_share_and_remix": "false"
+  },
+  "published": true
+}]]></config>
+</Pythonlab>

--- a/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 4.level
+++ b/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 4.level
@@ -1,0 +1,16 @@
+<Pythonlab>
+  <config><![CDATA[{
+  "published": true,
+  "game_id": 72,
+  "created_at": "2024-06-04T00:54:53.000Z",
+  "level_num": "custom",
+  "user_id": 2,
+  "properties": {
+    "encrypted": "false",
+    "project_template_level_name": "pythonlab_test_project_template",
+    "long_instructions": "## Project-backed level\r\nThis level shares a project with level 3 in the progression.",
+    "hide_share_and_remix": "false"
+  },
+  "audit_log": "[{\"changed_at\":\"2024-06-03T10:54:53.225-07:00\",\"changed\":[\"cloned from \\\"Allthethings Python Lab 3\\\"\"],\"cloned_from\":\"Allthethings Python Lab 3\"},{\"changed_at\":\"2024-06-03 10:55:00 -0700\",\"changed\":[\"long_instructions\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]"
+}]]></config>
+</Pythonlab>

--- a/dashboard/config/levels/custom/pythonlab/pythonlab_test_project_template.level
+++ b/dashboard/config/levels/custom/pythonlab/pythonlab_test_project_template.level
@@ -1,0 +1,30 @@
+<Pythonlab>
+  <config><![CDATA[{
+  "game_id": 72,
+  "created_at": "2024-06-04T00:43:47.000Z",
+  "level_num": "custom",
+  "user_id": 2,
+  "properties": {
+    "encrypted": "false",
+    "long_instructions": "## Sample Python Lab Project Template Level",
+    "hide_share_and_remix": "false",
+    "source": {
+      "files": {
+        "0": {
+          "id": "0",
+          "name": "main.py",
+          "language": "py",
+          "contents": "print(\"Hello from sample project template level!\")",
+          "folderId": "0",
+          "active": true,
+          "open": true
+        }
+      },
+      "folders": {
+      }
+    }
+  },
+  "published": true,
+  "audit_log": "[{\"changed_at\":\"2024-06-03 10:53:25 -0700\",\"changed\":[],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]"
+}]]></config>
+</Pythonlab>

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2024-05-09 17:50:07 UTC",
+    "serialized_at": "2024-06-03 17:55:32 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -3137,6 +3137,9 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "courseF_firstFunctions_map"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6466,6 +6469,48 @@
     },
     {
       "chapter": 179,
+      "position": 3,
+      "activity_section_position": 3,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Allthethings Python Lab 3"
+        ],
+        "lesson.key": "lesson-53",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "465bc905-13b5-487c-8fd6-8043676ee607"
+      },
+      "level_keys": [
+        "Allthethings Python Lab 3"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 4,
+      "activity_section_position": 4,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Allthethings Python Lab 4"
+        ],
+        "lesson.key": "lesson-53",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "465bc905-13b5-487c-8fd6-8043676ee607"
+      },
+      "level_keys": [
+        "Allthethings Python Lab 4"
+      ]
+    },
+    {
+      "chapter": 181,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6489,7 +6534,7 @@
       ]
     },
     {
-      "chapter": 180,
+      "chapter": 182,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6513,11 +6558,14 @@
       ]
     },
     {
-      "chapter": 181,
+      "chapter": 183,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Music Lab2 Showcase"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6534,11 +6582,14 @@
       ]
     },
     {
-      "chapter": 182,
+      "chapter": 184,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "AI Chat Lab2 Showcase"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6555,11 +6606,14 @@
       ]
     },
     {
-      "chapter": 183,
+      "chapter": 185,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Python Lab2 Showcase"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6576,11 +6630,14 @@
       ]
     },
     {
-      "chapter": 184,
+      "chapter": 186,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Weblab2 Lab2 Showcase"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6597,11 +6654,14 @@
       ]
     },
     {
-      "chapter": 185,
+      "chapter": 187,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Dance Lab2 Showcase"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6618,11 +6678,14 @@
       ]
     },
     {
-      "chapter": 186,
+      "chapter": 188,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Panels Lab2 Showcase"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6639,11 +6702,14 @@
       ]
     },
     {
-      "chapter": 187,
+      "chapter": 189,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "StandaloneVideo Lab2 Showcase"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6660,11 +6726,14 @@
       ]
     },
     {
-      "chapter": 188,
+      "chapter": 190,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Lab2 BubbleChoice Showcase"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -7962,19 +8031,6 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Artist 1 new",
-        "script_level.level_keys": [
-          "2-3 Artist 1 new",
-          "ramp_video_artistIntro"
-        ],
-        "lesson.key": "Swapped Levels",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
-      }
-    },
-    {
-      "seeding_key": {
         "level.key": "ramp_video_artistIntro",
         "script_level.level_keys": [
           "2-3 Artist 1 new",
@@ -7988,7 +8044,20 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Artist Loops 2",
+        "level.key": "2-3 Artist 1 new",
+        "script_level.level_keys": [
+          "2-3 Artist 1 new",
+          "ramp_video_artistIntro"
+        ],
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
         "script_level.level_keys": [
           "2-3 Artist Loops 2",
           "ramp_video_loopsArtist"
@@ -8001,7 +8070,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "ramp_video_loopsArtist",
+        "level.key": "2-3 Artist Loops 2",
         "script_level.level_keys": [
           "2-3 Artist Loops 2",
           "ramp_video_loopsArtist"
@@ -8937,6 +9006,30 @@
         "level.key": "Allthethings Python Lab 2",
         "script_level.level_keys": [
           "Allthethings Python Lab 2"
+        ],
+        "lesson.key": "lesson-53",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "465bc905-13b5-487c-8fd6-8043676ee607"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Allthethings Python Lab 3",
+        "script_level.level_keys": [
+          "Allthethings Python Lab 3"
+        ],
+        "lesson.key": "lesson-53",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "465bc905-13b5-487c-8fd6-8043676ee607"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Allthethings Python Lab 4",
+        "script_level.level_keys": [
+          "Allthethings Python Lab 4"
         ],
         "lesson.key": "lesson-53",
         "lesson_group.key": "",


### PR DESCRIPTION
Add project template-backed level support to Python Lab (adding support for Web Lab 2 will be just be a matter of updating the level edit page). 

This was a pretty straightforward change! Just marking the level as template backed did the main portion of the work, because our channel id fetching per-level still worked, if we are moving between two project-backed levels we will fetch the same channel as the previous level and re-load the same contents. The only other piece of work was adding the icon to the header to indicate the level is project backed. In order to get this to show up properly I had to add a `z-index` to the panel container header div. I verified this did not cause any change for any lab2 lab.

As I was working on this I noticed I broke start mode in #58967. I fixed this by updating the check to be against levelId rather than channelId (all the changes in `useSource` are to fix this issue).

I think it would be similarly straightforward to bring project-backed levels to other lab2 labs. Tagging student labs as an fyi.

### Project template backed level
Screenshot taken while hovering over the workspace header icon.
![Screenshot 2024-06-03 at 2 06 37 PM](https://github.com/code-dot-org/code-dot-org/assets/33666587/ca204f33-4483-4610-bb68-69753da90354)

## Links

- jira ticket: [CT-618](https://codedotorg.atlassian.net/browse/CT-618)


## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
