### PR TITLE
fixed student selector styling

### DIFF
--- a/apps/src/templates/rubrics/StudentSelector.jsx
+++ b/apps/src/templates/rubrics/StudentSelector.jsx
@@ -84,9 +84,16 @@ function StudentSelector({
           label: (
             <div className={style.studentDropdownOptionContainer}>
               <div className={style.studentDropdownOption}>
-                <BodyThreeText className={style.submitStatusText}>{`${
-                  student.name
-                } ${student.familyName || ''}`}</BodyThreeText>
+                <BodyThreeText className={style.submitStatusText}>
+                  {student.familyName
+                    ? student.familyName.length < 10
+                      ? `${student.name} ${student.familyName}`
+                      : `${student.name} ${student.familyName.substring(
+                          0,
+                          7
+                        )}...`
+                    : `${student.name}`}
+                </BodyThreeText>
                 {!!levelsWithProgress && (
                   <StudentProgressStatus
                     level={levelsWithProgress.find(

--- a/apps/src/templates/rubrics/StudentSelector.jsx
+++ b/apps/src/templates/rubrics/StudentSelector.jsx
@@ -22,6 +22,7 @@ import {reportingDataShape} from './rubricShapes';
 import style from './rubrics.module.scss';
 
 const NO_SELECTED_SECTION_VALUE = '';
+const MAX_NAME_LENGTH = 20;
 
 function StudentSelector({
   styleName,
@@ -86,10 +87,11 @@ function StudentSelector({
               <div className={style.studentDropdownOption}>
                 <BodyThreeText className={style.submitStatusText}>
                   {student.familyName
-                    ? student.familyName.length + student.name.length < 15
+                    ? student.familyName.length + student.name.length <
+                      MAX_NAME_LENGTH
                       ? `${student.name} ${student.familyName}`
                       : `${student.name} ${student.familyName}`
-                          .substring(0, 12)
+                          .substring(0, MAX_NAME_LENGTH - 1)
                           .concat('', '...')
                     : `${student.name}`}
                 </BodyThreeText>

--- a/apps/src/templates/rubrics/StudentSelector.jsx
+++ b/apps/src/templates/rubrics/StudentSelector.jsx
@@ -86,12 +86,11 @@ function StudentSelector({
               <div className={style.studentDropdownOption}>
                 <BodyThreeText className={style.submitStatusText}>
                   {student.familyName
-                    ? student.familyName.length < 10
+                    ? student.familyName.length + student.name.length < 15
                       ? `${student.name} ${student.familyName}`
-                      : `${student.name} ${student.familyName.substring(
-                          0,
-                          7
-                        )}...`
+                      : `${student.name} ${student.familyName}`
+                          .substring(0, 12)
+                          .concat('', '...')
                     : `${student.name}`}
                 </BodyThreeText>
                 {!!levelsWithProgress && (

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -855,7 +855,7 @@ em.aiFeedbackReceived {
 }
 
 .studentSelector {
-  width: 240px;
+  width: 300px;
 }
 
 .learningGoalsContainer {

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -1234,12 +1234,13 @@ p.detailsHidden {
 .studentDropdownOptionContainer {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-between;
 }
 
 .studentDropdownOption {
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
   gap: 5px;
   margin-top: 3px;
   height: 26px;
@@ -1250,6 +1251,7 @@ p.detailsHidden {
   border-radius: 20px;
   padding: 4px 10px 0;
   height: 22px;
+  min-width: 80px;
   display: inline;
   p {
     margin-bottom: 0;
@@ -1261,6 +1263,7 @@ p.detailsHidden {
   border-radius: 20px;
   padding: 5px 10px 0;
   height: 22px;
+  min-width: 80px;
   display: inline;
   p {
     margin: 0, 0, 0, 0;
@@ -1272,6 +1275,7 @@ p.detailsHidden {
   border-radius: 20px;
   padding: 5px 10px 0;
   height: 22px;
+  min-width: 80px;
   display: inline;
   p {
     margin: 0, 0, 0, 0;


### PR DESCRIPTION
Fixed issue causing options in the student selector dropdown to be misaligned when a student has a long name.
- Set minimum width for status bubble to prevent text dropping to a second line
- Truncate last names of students with long names

Before:
![image](https://github.com/code-dot-org/code-dot-org/assets/5552007/46c90ea2-ad43-4d1f-aada-fc5fd9d65e64)

After:
![Screenshot 2024-06-03 160009](https://github.com/code-dot-org/code-dot-org/assets/5552007/a3eb42c2-4740-4037-a7b2-56ee37942f0e)

## Links
[AITT-632](https://codedotorg.atlassian.net/browse/AITT-632)

## Testing story
Manually tested

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
