### PR TITLE
Delete Manual DB_CLUSTER_ID Configuration Setting

### DIFF
--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -20,7 +20,6 @@ db_credential_admin: {"username":"ACCESS_DISABLED", "password":"ACCESS_DISABLED"
 newrelic_logging: true
 stack_name: autoscale-prod
 firebase_name: cdo-v3-prod
-db_cluster_id: production-aurora-cluster
 solr_server:                            solr.code.org
 use_pusher:                             true
 


### PR DESCRIPTION
In preparation for upgrade to MySQL 8, remove manual setting of `CDO.db_cluster_id` for production so that cutover from the existing MySQL 5.7 cluster (`production-aurora-cluster`) to the new production MySQL 8 cluster (`autoscale-prod-cluster`) can be configured easily.

`CDO.db_cluster_id` is now set uniformly for all CloudFormation-provisioned environments [here](https://github.com/code-dot-org/code-dot-org/blob/478de6f89be9d4c3a3c55a0b8fd1e128145d3a3e/config.yml.erb#L561), and is configured manually for production [here](https://github.com/code-dot-org/code-dot-org/blob/478de6f89be9d4c3a3c55a0b8fd1e128145d3a3e/aws/cloudformation/components/database.yml.erb#L2) and [here](https://github.com/code-dot-org/code-dot-org/blob/478de6f89be9d4c3a3c55a0b8fd1e128145d3a3e/aws/cloudformation/components/database.yml.erb#L82-L87).


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

- [x] Remove the `db_cluster_id` entry in `locals.yml` on `production-daemon`
- [x] Verify that `CDO.db_cluster_id` resolves correctly to `production-aurora-cluster`
- [ ] Release this change to production.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
