### PR TITLE
remove calc and eval lessons from events script

### DIFF
--- a/dashboard/config/scripts_json/events.script_json
+++ b/dashboard/config/scripts_json/events.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": "events",
-    "serialized_at": "2022-04-08 15:40:28 UTC",
+    "serialized_at": "2024-06-04 11:36:50 UTC",
     "published_state": "beta",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -62,36 +62,6 @@
         "lesson_group.key": "",
         "script.name": "events"
       }
-    },
-    {
-      "key": "Calc",
-      "name": "Calc",
-      "absolute_position": 3,
-      "lockable": false,
-      "has_lesson_plan": false,
-      "relative_position": 3,
-      "properties": {
-      },
-      "seeding_key": {
-        "lesson.key": "Calc",
-        "lesson_group.key": "",
-        "script.name": "events"
-      }
-    },
-    {
-      "key": "Eval",
-      "name": "Eval",
-      "absolute_position": 4,
-      "lockable": false,
-      "has_lesson_plan": false,
-      "relative_position": 4,
-      "properties": {
-      },
-      "seeding_key": {
-        "lesson.key": "Eval",
-        "lesson_group.key": "",
-        "script.name": "events"
-      }
     }
   ],
   "lesson_activities": [
@@ -120,32 +90,6 @@
         "lesson_group.key": "",
         "script.name": "events"
       }
-    },
-    {
-      "key": "deb7a5d8-03f7-4827-99c7-35253777c80d",
-      "position": 1,
-      "properties": {
-        "name": "Levels"
-      },
-      "seeding_key": {
-        "lesson_activity.key": "deb7a5d8-03f7-4827-99c7-35253777c80d",
-        "lesson.key": "Calc",
-        "lesson_group.key": "",
-        "script.name": "events"
-      }
-    },
-    {
-      "key": "9451b66f-6867-4a87-837c-db45a423921a",
-      "position": 1,
-      "properties": {
-        "name": "Levels"
-      },
-      "seeding_key": {
-        "lesson_activity.key": "9451b66f-6867-4a87-837c-db45a423921a",
-        "lesson.key": "Eval",
-        "lesson_group.key": "",
-        "script.name": "events"
-      }
     }
   ],
   "activity_sections": [
@@ -167,26 +111,6 @@
       "seeding_key": {
         "activity_section.key": "86d47c94-ba3d-4329-8467-c5bbb5f2f813",
         "lesson_activity.key": "2ad4d234-7415-4d96-a615-38f17d236b32"
-      }
-    },
-    {
-      "key": "9882a2a7-85b8-4f9a-bd0b-e595e34f1ef0",
-      "position": 1,
-      "properties": {
-      },
-      "seeding_key": {
-        "activity_section.key": "9882a2a7-85b8-4f9a-bd0b-e595e34f1ef0",
-        "lesson_activity.key": "deb7a5d8-03f7-4827-99c7-35253777c80d"
-      }
-    },
-    {
-      "key": "c6ac7afb-c9c5-44fe-93e6-108a5818872a",
-      "position": 1,
-      "properties": {
-      },
-      "seeding_key": {
-        "activity_section.key": "c6ac7afb-c9c5-44fe-93e6-108a5818872a",
-        "lesson_activity.key": "9451b66f-6867-4a87-837c-db45a423921a"
       }
     }
   ],
@@ -478,54 +402,6 @@
       "level_keys": [
         "blockly:Studio:full_sandbox_infinity"
       ]
-    },
-    {
-      "chapter": 13,
-      "position": 1,
-      "activity_section_position": 1,
-      "assessment": false,
-      "properties": {
-        "level_keys": [
-          "blockly:Calc:example1"
-        ]
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Calc:example1"
-        ],
-        "lesson.key": "Calc",
-        "lesson_group.key": "",
-        "script.name": "events",
-        "activity_section.key": "9882a2a7-85b8-4f9a-bd0b-e595e34f1ef0"
-      },
-      "level_keys": [
-        "blockly:Calc:example1"
-      ]
-    },
-    {
-      "chapter": 14,
-      "position": 1,
-      "activity_section_position": 1,
-      "assessment": false,
-      "properties": {
-        "level_keys": [
-          "blockly:Eval:eval1"
-        ]
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Eval:eval1"
-        ],
-        "lesson.key": "Eval",
-        "lesson_group.key": "",
-        "script.name": "events",
-        "activity_section.key": "c6ac7afb-c9c5-44fe-93e6-108a5818872a"
-      },
-      "level_keys": [
-        "blockly:Eval:eval1"
-      ]
     }
   ],
   "levels_script_levels": [
@@ -672,30 +548,6 @@
         "script.name": "events",
         "activity_section.key": "86d47c94-ba3d-4329-8467-c5bbb5f2f813"
       }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Calc:example1",
-        "script_level.level_keys": [
-          "blockly:Calc:example1"
-        ],
-        "lesson.key": "Calc",
-        "lesson_group.key": "",
-        "script.name": "events",
-        "activity_section.key": "9882a2a7-85b8-4f9a-bd0b-e595e34f1ef0"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Eval:eval1",
-        "script_level.level_keys": [
-          "blockly:Eval:eval1"
-        ],
-        "lesson.key": "Eval",
-        "lesson_group.key": "",
-        "script.name": "events",
-        "activity_section.key": "c6ac7afb-c9c5-44fe-93e6-108a5818872a"
-      }
     }
   ],
   "resources": [
@@ -726,6 +578,15 @@
 
   ],
   "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+
+  ],
+  "learning_goals": [
+
+  ],
+  "learning_goal_evidence_levels": [
 
   ]
 }


### PR DESCRIPTION
Yesterday an attempt was made to intentionally delete Calc and Eval as part of the CS in Algebra deprecation. Unfortunately, this resulted in a new Honeybadger error for a Calc level that was available on production in the `s/events` script. This script houses levels that are needed for UI tests of lab features and isn't part of an established course or curriculum. This branch updates that script to remove the two Calc/Eval lessons. Should a user attempt to https://studio.code.org/s/events/lessons/3/levels/1 or https://studio.code.org/s/events/lessons/4/levels/1 after this change goes live, they will see the expected 404 page instead of the current 500 internal server error. This is consistent with what is shown to users for other non-existent script levels URLs.

500 error: 
<img width="962" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/f6eedd58-13b5-4ad0-9a1c-7c4bba448c66">
<img width="491" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/8e193fa1-5b2e-4b2f-96f8-42ca53efd88b">

400 error:
<img width="1019" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/1acc7e91-8795-4c81-ae25-f9a201d216ef">
<img width="491" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/18f4c169-268c-450c-a6d9-48690e4f0b85">



## Links

Slack thread: https://codedotorg.slack.com/archives/C0T0PNTM3/p1717477684239169
Honeybadger error: https://app.honeybadger.io/projects/3240/faults/108378421

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Other UI tests will continue to use `/s/events` but none are using the deleted lessons.

## Deployment strategy


PR history:
- https://github.com/code-dot-org/code-dot-org/pull/58956
- https://github.com/code-dot-org/code-dot-org/pull/59050
- https://github.com/code-dot-org/code-dot-org/pull/59053

Following
## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
