### PR TITLE
[Google Blockly] check hidden workspace when executing student code

### DIFF
--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -1,4 +1,4 @@
-import {WorkspaceSvg} from 'blockly';
+import {Block, BlockSvg, WorkspaceSvg} from 'blockly';
 import _ from 'lodash';
 
 import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
@@ -14,6 +14,7 @@ type xmlAttribute = string | null;
 type InputTuple = [string, string, number];
 type InputCallback = () => void;
 type InputArgs = [...(InputTuple | InputCallback)[], number];
+type BlockList = [Block | BlockSvg];
 
 // Considers an attribute true only if it is explicitly set to 'true' (i.e. defaults to false if unset).
 export const FALSEY_DEFAULT = (attributeValue: xmlAttribute) =>
@@ -266,4 +267,22 @@ export function interpolateMsg(
 
   // Make the inputs inline unless there is only one input and no text follows it.
   this.setInputsInline(!msg.match(/%1\s*$/));
+}
+
+/**
+ * Retrieves the top-level Blockly blocks from the students Blockly workspace and
+ * potentially includes the top-level blocks from the hidden definition workspace.
+ *
+ * @returns {BlockList} An array of the top-level blocks.
+ */
+export function getCodeBlocks(): BlockList {
+  const codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true) as BlockList;
+  // The hidden workspace is only present in Google Blockly labs where the modal
+  // function editor is enabled.
+  if (Blockly.getHiddenDefinitionWorkspace()) {
+    const hiddenBlocks =
+      Blockly.getHiddenDefinitionWorkspace().getTopBlocks(true);
+    codeBlocks.push(...hiddenBlocks);
+  }
+  return codeBlocks;
 }

--- a/apps/src/craft/agent/craft.js
+++ b/apps/src/craft/agent/craft.js
@@ -10,6 +10,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 
+import {getCodeBlocks} from '@cdo/apps/blockly/utils';
 import PlayerSelectionDialog from '@cdo/apps/craft/PlayerSelectionDialog';
 import reducers from '@cdo/apps/craft/redux';
 import {ARROW_KEY_NAMES, handlePlayerSelection} from '@cdo/apps/craft/utils';
@@ -714,7 +715,7 @@ export default class Craft {
 
     // Run user generated code, calling appCodeOrgAPI
     let code = '';
-    let codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true);
+    let codeBlocks = getCodeBlocks();
     if (studioApp().initializationBlocks) {
       codeBlocks = studioApp().initializationBlocks.concat(codeBlocks);
     }

--- a/apps/src/craft/aquatic/craft.js
+++ b/apps/src/craft/aquatic/craft.js
@@ -7,6 +7,7 @@ import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import {getCodeBlocks} from '@cdo/apps/blockly/utils';
 import {TestResults} from '@cdo/apps/constants';
 import PlayerSelectionDialog from '@cdo/apps/craft/PlayerSelectionDialog';
 import reducers from '@cdo/apps/craft/redux';
@@ -582,7 +583,7 @@ Craft.executeUserCode = function () {
   };
 
   // Run user code.
-  let codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true);
+  let codeBlocks = getCodeBlocks();
   code += Blockly.Generator.blocksToCode('JavaScript', codeBlocks);
   interpreter = CustomMarshalingInterpreter.evalWith(
     code,

--- a/apps/src/craft/designer/craft.js
+++ b/apps/src/craft/designer/craft.js
@@ -10,6 +10,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 
+import {getCodeBlocks} from '@cdo/apps/blockly/utils';
 import PlayerSelectionDialog from '@cdo/apps/craft/PlayerSelectionDialog';
 import reducers from '@cdo/apps/craft/redux';
 import {ARROW_KEY_NAMES, handlePlayerSelection} from '@cdo/apps/craft/utils';
@@ -766,7 +767,7 @@ Craft.executeUserCode = function () {
   var appCodeOrgAPI = Craft.gameController.codeOrgAPI;
   appCodeOrgAPI.startCommandCollection();
   // Run user generated code, calling appCodeOrgAPI
-  let codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true);
+  let codeBlocks = getCodeBlocks();
   if (studioApp().initializationBlocks) {
     codeBlocks = studioApp().initializationBlocks.concat(codeBlocks);
   }

--- a/apps/src/craft/simple/craft.js
+++ b/apps/src/craft/simple/craft.js
@@ -7,6 +7,7 @@ import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import {getCodeBlocks} from '@cdo/apps/blockly/utils';
 import PlayerSelectionDialog from '@cdo/apps/craft/PlayerSelectionDialog';
 import reducers from '@cdo/apps/craft/redux';
 import {handlePlayerSelection} from '@cdo/apps/craft/utils';
@@ -774,7 +775,7 @@ Craft.executeUserCode = function () {
 
   // Run user generated code, calling appCodeOrgAPI
   let code = '';
-  let codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true);
+  let codeBlocks = getCodeBlocks();
   if (studioApp().initializationBlocks) {
     codeBlocks = studioApp().initializationBlocks.concat(codeBlocks);
   }

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -1,3 +1,4 @@
+import {getCodeBlocks} from '../blockly/utils';
 import {TestResults, ResultType} from '../constants';
 import AppView from '../templates/AppView';
 
@@ -309,9 +310,9 @@ module.exports = class Maze {
     this.beginAttempt();
     this.prepareForExecution_();
 
-    var code = '';
+    let code = '';
     if (studioApp().isUsingBlockly()) {
-      let codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true);
+      let codeBlocks = getCodeBlocks();
       if (studioApp().initializationBlocks) {
         codeBlocks = studioApp().initializationBlocks.concat(codeBlocks);
       }

--- a/apps/src/turtle/artist.js
+++ b/apps/src/turtle/artist.js
@@ -31,6 +31,7 @@ import {DEFAULT_EXECUTION_INFO} from '@cdo/apps/lib/tools/jsinterpreter/CustomMa
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 
 import {blockAsXmlNode, cleanBlocks} from '../block_utils';
+import {getCodeBlocks} from '../blockly/utils';
 import {TestResults} from '../constants';
 import {
   getContainedLevelResultInfo,
@@ -893,7 +894,7 @@ Artist.prototype.execute = function (executionInfo) {
   if (this.level.editCode) {
     this.initInterpreter();
   } else {
-    let codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true);
+    let codeBlocks = getCodeBlocks();
     if (this.studioApp_.initializationBlocks) {
       codeBlocks = this.studioApp_.initializationBlocks.concat(codeBlocks);
     }


### PR DESCRIPTION
When we execute student code in older Blockly labs, we only look at the main workspace. In order for the modal function editor to work as expected, we need to change this behavior. This change is necessary for the migration of both Maze and Artist to mainline. 

Technically, the change is not needed for Minecraft as those levels do not use the modal editor. However, using the proposed new utility doesn't cause harm and makes things a bit more consistent.
Unfortunately, we can't use this same approach for Play Lab as it apparently uses doesn't follow any of the same patterns for executing code. I suspect this was due to needing to support the paradigms of Calc/Eval, but haven't confirmed.

**Before:**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/4e883d31-e5eb-4b20-a92e-91d7c03ea677)

**After:**
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/a877709a-643f-44fc-b43b-c08f50c8ef34)

## Links

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
