### PR TITLE
Explicitly Specify MySQL 8.0 in Developer Setup Documentation

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -121,7 +121,7 @@ These steps are for Apple devices running **macOS 14.x**, including those runnin
 
 1. Install **brew packages**:
    ```
-   brew install rbenv ruby-build nvm mysql redis git-lfs enscript gs imagemagick coreutils parallel tidy-html5 openssl libffi pdftk-java
+   brew install rbenv ruby-build nvm mysql@8.0 redis git-lfs enscript gs imagemagick coreutils parallel tidy-html5 openssl libffi pdftk-java
    ```
 
 1. Initialize **Git LFS**:
@@ -138,10 +138,18 @@ These steps are for Apple devices running **macOS 14.x**, including those runnin
        ==> Successfully started `redis` (label: homebrew.mxcl.redis)
        ```
    3. macOS will notify you that `redis` has been configured to start automatically upon user login. Confirm this in System Settings --> General --> Login Items --> `redis-server` 
-1. Setup your local **MySql server**
-   1. Start mysql server:
+1. Setup your local **MySQL database server**
+   1. Link MySQL 8
         ```
-        brew services start mysql
+        brew link --force --overwrite mysql@8.0
+        ```
+   2. Verify Link
+        ```
+        mysql --version  # should show: mysql  Ver 8.0.[xx]
+        ```
+   3. Start mysql server:
+        ```
+        brew services start mysql # Should notify you that MySQL server has been added to Login Items
         ```
    2. Confirm that MySQL has started by running:
         ```


### PR DESCRIPTION
Explicitly specify MySQL 8.0 in developer setup documentation, particularly since newer releases are available (such as MySQL 8.2).

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
