### PR TITLE
disable iPad_teacher_tools_level_types_multi

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/multi.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multi.feature
@@ -51,7 +51,7 @@ Scenario: Can render without a question
   When element ".submitButton" is visible
   Then element ".multi-question" is not visible
 
-@no_phone
+@no_mobile
 Scenario: Standalone level without retries locks after answer is submitted
   Given I create a student named "Sally Student"
   And I sign in as "Sally Student"


### PR DESCRIPTION
I could not get this test to pass today after 5 manual reruns. Disabling so that we do not get interrupted on every subsequent DTT this week.

the work to re-enable this is tracked in https://codedotorg.atlassian.net/browse/TEACH-1150