### PR TITLE
Manage MySQL Version in Cookbooks via Chef Attribute

### DIFF
--- a/cookbooks/cdo-mysql/attributes/default.rb
+++ b/cookbooks/cdo-mysql/attributes/default.rb
@@ -1,4 +1,5 @@
 default['cdo-mysql'] = {
+  target_version: '5.7',
   proxy: {
     # Enable ProxySQL on non-daemon app-servers by default.
     enabled: node['cdo-apps'] && !node['cdo-apps']['daemon'],

--- a/cookbooks/cdo-mysql/attributes/default.rb
+++ b/cookbooks/cdo-mysql/attributes/default.rb
@@ -1,5 +1,5 @@
 default['cdo-mysql'] = {
-  target_version: '8.0',
+  target_version: '5.7',
   proxy: {
     # Enable ProxySQL on non-daemon app-servers by default.
     enabled: node['cdo-apps'] && !node['cdo-apps']['daemon'],

--- a/cookbooks/cdo-mysql/attributes/default.rb
+++ b/cookbooks/cdo-mysql/attributes/default.rb
@@ -1,5 +1,5 @@
 default['cdo-mysql'] = {
-  target_version: '5.7',
+  target_version: '8.0',
   proxy: {
     # Enable ProxySQL on non-daemon app-servers by default.
     enabled: node['cdo-apps'] && !node['cdo-apps']['daemon'],

--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -6,6 +6,6 @@ apt_package 'mysql-client' do
   if node['cdo-mysql']['target_version'] == '5.7'
     version '5.7.42-1ubuntu18.04'
   elsif node['cdo-mysql']['target_version'] == '8.0'
-    version '8.0.37-1ubuntu20.04'
+    version '8.0.36-0ubuntu0.22.04.1'
   end
 end

--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -2,4 +2,10 @@ include_recipe 'cdo-mysql::repo'
 
 apt_package 'libmysqlclient-dev'
 
-apt_package 'mysql-client'
+apt_package 'mysql-client' do
+  if node['cdo-mysql']['target_version'] == '5.7'
+    version '5.7.42-1ubuntu18.04'
+  elsif node['cdo-mysql']['target_version'] == '8.0'
+    version '8.0.36-0ubuntu0.22.04.1'
+  end
+end

--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -6,6 +6,6 @@ apt_package 'mysql-client' do
   if node['cdo-mysql']['target_version'] == '5.7'
     version '5.7.42-1ubuntu18.04'
   elsif node['cdo-mysql']['target_version'] == '8.0'
-    version '8.0.36-0ubuntu0.22.04.1'
+    version '8.0.36-0ubuntu0.20.04.1'
   end
 end

--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -6,6 +6,6 @@ apt_package 'mysql-client' do
   if node['cdo-mysql']['target_version'] == '5.7'
     version '5.7.42-1ubuntu18.04'
   elsif node['cdo-mysql']['target_version'] == '8.0'
-    version '8.0.36-0ubuntu0.22.04.1'
+    version '8.0.37-1ubuntu20.04'
   end
 end

--- a/cookbooks/cdo-mysql/recipes/repo.rb
+++ b/cookbooks/cdo-mysql/recipes/repo.rb
@@ -1,10 +1,26 @@
 apt_repository 'mysql' do
   uri 'http://repo.mysql.com/apt/ubuntu'
-  distribution node['lsb']['codename']
-  components ['mysql-8.0']
 
-  # https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
-  key '3A79BD29'
+  if node['cdo-mysql']['target_version'] == '5.7'
+    # hardcode the distribution we target to Ubuntu 18 rather than whatever our
+    # current is, since that's the last LTS for which a MySQL 5.7 package was
+    # distributed. Once we update to MySQL 8+, this can be restored.
+    #distribution node['lsb']['codename']
+    distribution 'bionic'
+
+    # Pin to MySQL 5.7 until we're ready to update to MySQL 8
+    components ['mysql-5.7']
+
+    # https://dev.mysql.com/doc/refman/5.7/en/checking-gpg-signature.html
+    key 'B7B3B788A8D3785C'
+  elsif node['cdo-mysql']['target_version'] == '8.0'
+    distribution node['lsb']['codename']
+    components ['mysql-8.0']
+
+    # https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html
+    key '3A79BD29'
+  end
+
   keyserver 'keyserver.ubuntu.com'
   retries 3
 end

--- a/cookbooks/cdo-mysql/recipes/server.rb
+++ b/cookbooks/cdo-mysql/recipes/server.rb
@@ -6,7 +6,7 @@ apt_package 'mysql-server' do
   if node['cdo-mysql']['target_version'] == '5.7'
     version '5.7.42-1ubuntu18.04'
   elsif node['cdo-mysql']['target_version'] == '8.0'
-    version '8.0.37-1ubuntu20.04'
+    version '8.0.36-0ubuntu0.22.04.1'
   end
 
   notifies :create, 'template[cdo.cnf]', :immediately

--- a/cookbooks/cdo-mysql/recipes/server.rb
+++ b/cookbooks/cdo-mysql/recipes/server.rb
@@ -2,6 +2,13 @@ include_recipe 'cdo-mysql::repo'
 
 apt_package 'mysql-server' do
   action :upgrade
+
+  if node['cdo-mysql']['target_version'] == '5.7'
+    version '5.7.42-1ubuntu18.04'
+  elsif node['cdo-mysql']['target_version'] == '8.0'
+    version '8.0.36-0ubuntu0.22.04.1'
+  end
+
   notifies :create, 'template[cdo.cnf]', :immediately
   notifies :start, 'service[mysql]', :immediately
   notifies :run, 'execute[mysql-upgrade]', :immediately

--- a/cookbooks/cdo-mysql/recipes/server.rb
+++ b/cookbooks/cdo-mysql/recipes/server.rb
@@ -6,7 +6,7 @@ apt_package 'mysql-server' do
   if node['cdo-mysql']['target_version'] == '5.7'
     version '5.7.42-1ubuntu18.04'
   elsif node['cdo-mysql']['target_version'] == '8.0'
-    version '8.0.36-0ubuntu0.22.04.1'
+    version '8.0.37-1ubuntu20.04'
   end
 
   notifies :create, 'template[cdo.cnf]', :immediately

--- a/cookbooks/cdo-mysql/recipes/server.rb
+++ b/cookbooks/cdo-mysql/recipes/server.rb
@@ -6,7 +6,7 @@ apt_package 'mysql-server' do
   if node['cdo-mysql']['target_version'] == '5.7'
     version '5.7.42-1ubuntu18.04'
   elsif node['cdo-mysql']['target_version'] == '8.0'
-    version '8.0.36-0ubuntu0.22.04.1'
+    version '8.0.36-0ubuntu0.20.04.1'
   end
 
   notifies :create, 'template[cdo.cnf]', :immediately

--- a/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
+++ b/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
@@ -39,7 +39,7 @@ mysql_variables=
 
   # The server version with which the proxy will respond to the clients.
   # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-server_version
-  server_version="8.0.35-proxysql"
+  server_version="<%=node['cdo-mysql']['target_version'] == '5.7' ? '5.7.12-proxysql' : '8.0.36-proxysql'%>"
 
   # The user needs only USAGE privileges to connect, ping and check read_only.
   # The user needs also REPLICATION CLIENT if it needs to monitor replication lag.


### PR DESCRIPTION
Small update to https://github.com/code-dot-org/code-dot-org/pull/56386 so that we can manage the installed version environment-by-environment via Chef Attributes (specifically, we'd like to be able to upgrade our non-production servers in advance of upgrading production).

## Testing story

Tested on an adhoc. First, spun up an adhoc with a default of 5.7 and verified that it installed correctly. Then, manually modified the cookbook on the adhoc so it defaults to 8.0 and executed `sudo chef-client` from `/var/chef` to rerun the chef build. Verified that the build completed successfully and upgraded the local install to version 8.0.

I also verified that we can create a new adhoc from scratch with 8.0 as the default.

## Deployment strategy

Deploying this as-is should be a no-op, since all of our servers are currently using 5.7. Once deployed, we can selectively update the `target_version` attribute to 8.0 for any server environments we want to get upgraded, and they should do so the next time they run a build.

## Follow-up work

Once we're fully updated to MySQL 8.0 everywhere, we can remove this temporary attribute and simplify the logic.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
