### PR TITLE
[Google Blockly] fix empty dynamic category bug

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -595,7 +595,7 @@ export function getSimplifiedStateForFlyout(
   const blocksCopy = {...blocks};
 
   // Replace variable ids with names and simplify state for flyout.
-  blocksCopy.blocks.forEach(block => {
+  blocksCopy.blocks?.forEach(block => {
     updateVariableFields(block, serializedVariableMap);
     blocksList.push(simplifyBlockState(block));
   });

--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.ts
@@ -245,12 +245,14 @@ export function flyoutCategory(
     blockList.push(newBehaviorButton);
   }
 
+  // Add blocks from the level toolbox XML, if present.
+  const levelToolboxBlocks = Blockly.cdoUtils.getLevelToolboxBlocks('Behavior');
+  if (!levelToolboxBlocks?.querySelector('xml')?.hasChildNodes()) {
+    return blockList;
+  }
+
   // Blockly supports XML or JSON, but not a combination of both.
   // We convert to JSON here because the behavior_get blocks are JSON.
-  const levelToolboxBlocks = Blockly.cdoUtils.getLevelToolboxBlocks('Behavior');
-  if (!levelToolboxBlocks) {
-    return [];
-  }
   const blocksConvertedJson = convertXmlToJson(
     levelToolboxBlocks.documentElement
   );

--- a/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.ts
@@ -16,10 +16,15 @@ export function flyoutCategory(workspace: WorkspaceSvg) {
 
   const categoryBlocks = flyoutCategoryBlocks(workspace);
   blockList.push(...categoryBlocks);
+
+  // Add blocks from the level toolbox XML, if present.
   const levelToolboxBlocks = Blockly.cdoUtils.getLevelToolboxBlocks('VARIABLE');
-  if (!levelToolboxBlocks) {
-    return [];
+  if (!levelToolboxBlocks?.querySelector('xml')?.hasChildNodes()) {
+    return blockList;
   }
+
+  // Blockly supports XML or JSON, but not a combination of both.
+  // We convert to JSON here because the behavior_get blocks are JSON.
   const blocksConvertedJson = convertXmlToJson(
     levelToolboxBlocks.documentElement
   );
@@ -28,7 +33,7 @@ export function flyoutCategory(workspace: WorkspaceSvg) {
 
   blockList.push(...flyoutJson);
 
-  // The may include "change [var] by" blocks with custom default values.
+  // The toolox may include "change [var] by" blocks with custom default values.
   // If any of these blocks are found, we can remove the auto-generated block.
   // Count the 'math_change' blocks in blockList.
   const mathChangeBlocksCount = blockList.filter(


### PR DESCRIPTION
Unlike standard toolbox categories which are static based on level XML, Blockly also supports dynamic/auto-populated categories which are populated with a custom callback. Two our auto-populated categories, Behaviors and Variables, also support merging in the static blocks that may have been set by a levelbuilder.

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/1e093db1-ef0a-43a0-b925-b1967d8b0d1d)

The Star Wars project level includes the variables category but without any static blocks and it is failing to open.
<img width="1323" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/fd57097c-4518-4394-8e37-68704979f1f7">
 
_Why haven't we encountered this bug yet?_
The simplest explanation is that all migrated levels with variables and/or behaviors (Poetry/Dance/Sprite Lab) always include some static blocks in each category.

**Changes proposed:**

* The immediate bug is that `getSimplifiedStateForFlyout`  doesn't check that we have a list of blocks before iterating over them. Added `?` to check for this.
* We don't really need to try converting the blocks if there aren't any so I updated the early return to check that the toolbox XML for the given category actually contains children.
* Corrected the early return to `blocksList` instead of `[]` because we always want the auto-populated contents.
* Applied the same fix to the behavior category


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested that the variable category can now be opened in Star Wars:
<img width="642" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/20dd9775-f269-4b7b-8843-3e1925b7473d">
After creating a variable:
<img width="816" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/5b7b2f35-5ad5-494e-8a13-1150d37e00cf">

Also tested that Behaviors and Variables in Sprite Lab still work as expected:

|<img width="402" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/d9d80b85-5bf3-4226-b2ec-2a190facc86a">|<img width="387" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/d2241c06-51da-4963-ad6c-bd6f20994596">|
|-|-|



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
