### PR TITLE
Add time spent and last updated boxes to levels in new progress view

### DIFF
--- a/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
@@ -24,6 +24,7 @@ function ExpandedProgressDataColumn({
   sortedStudents,
   removeExpandedLesson,
   sectionId,
+  expandedMetadataStudentIds,
 }) {
   const [expandedChoiceLevels, setExpandedChoiceLevels] = React.useState([]);
 
@@ -52,11 +53,12 @@ function ExpandedProgressDataColumn({
           studentLevelProgress={levelProgressByStudent[studentId][level.id]}
           key={studentId + '.' + lesson.id + '.' + level.id}
           lessonId={lesson.id}
+          metadataExpanded={expandedMetadataStudentIds.includes(studentId)}
           {...propOverrides}
         />
       );
     },
-    [levelProgressByStudent, lesson]
+    [levelProgressByStudent, lesson, expandedMetadataStudentIds]
   );
 
   const getExpandedChoiceLevel = React.useCallback(
@@ -136,6 +138,7 @@ ExpandedProgressDataColumn.propTypes = {
   lesson: PropTypes.object.isRequired,
   removeExpandedLesson: PropTypes.func.isRequired,
   sectionId: PropTypes.number,
+  expandedMetadataStudentIds: PropTypes.array,
 };
 
 export const UnconnectedExpandedProgressDataColumn = ExpandedProgressDataColumn;
@@ -145,4 +148,5 @@ export default connect(state => ({
     state.sectionProgress.studentLevelProgressByUnit[
       state.unitSelection.scriptId
     ],
+  expandedMetadataStudentIds: state.sectionProgress.expandedMetadataStudentIds,
 }))(ExpandedProgressDataColumn);

--- a/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
@@ -13,6 +13,7 @@ import {commentLeft, studentNeedsFeedback} from '../progress/progressHelpers';
 import {studentLevelProgressType} from '../progress/progressTypes';
 
 import {ITEM_TYPE} from './ItemType';
+import {formatTimeSpent, formatLastUpdated} from './MetadataHelpers';
 import ProgressIcon from './ProgressIcon';
 
 import legendStyles from './progress-table-legend.module.scss';
@@ -73,6 +74,7 @@ function LevelDataCell({
   linkClassName,
   parentLevelId,
   lessonId,
+  metadataExpanded,
 }) {
   const itemType = React.useMemo(() => {
     if (expandedChoiceLevel) {
@@ -123,7 +125,7 @@ function LevelDataCell({
     }
   }, [studentLevelProgress, level, expandedChoiceLevel]);
 
-  return (
+  const levelCellUnexpanded = (
     <td
       className={classNames(
         styles.gridBox,
@@ -149,6 +151,22 @@ function LevelDataCell({
       </Link>
     </td>
   );
+
+  if (metadataExpanded) {
+    return (
+      <div className={styles.lessonDataCellExpanded}>
+        {levelCellUnexpanded}
+        <div className={classNames(styles.gridBox, styles.gridBoxMetadata)}>
+          {formatTimeSpent(studentLevelProgress)}
+        </div>
+        <div className={classNames(styles.gridBox, styles.gridBoxMetadata)}>
+          {formatLastUpdated(studentLevelProgress)}
+        </div>
+      </div>
+    );
+  }
+
+  return levelCellUnexpanded;
 }
 
 export const UnconnectedLevelDataCell = LevelDataCell;
@@ -167,4 +185,5 @@ LevelDataCell.propTypes = {
   lessonId: PropTypes.number.isRequired,
   className: PropTypes.string,
   linkClassName: PropTypes.string,
+  metadataExpanded: PropTypes.bool,
 };

--- a/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
@@ -156,11 +156,19 @@ function LevelDataCell({
     return (
       <div className={styles.lessonDataCellExpanded}>
         {levelCellUnexpanded}
-        <div className={classNames(styles.gridBox, styles.gridBoxMetadata)}>
-          {formatTimeSpent(studentLevelProgress)}
+        <div
+          className={classNames(styles.gridBox, styles.gridBoxMetadata, {
+            [styles.gridBoxChoiceSubLevel]: level.parentLevelId !== undefined,
+          })}
+        >
+          {!level.parentLevelId && formatTimeSpent(studentLevelProgress)}
         </div>
-        <div className={classNames(styles.gridBox, styles.gridBoxMetadata)}>
-          {formatLastUpdated(studentLevelProgress)}
+        <div
+          className={classNames(styles.gridBox, styles.gridBoxMetadata, {
+            [styles.gridBoxChoiceSubLevel]: level.parentLevelId !== undefined,
+          })}
+        >
+          {!level.parentLevelId && formatLastUpdated(studentLevelProgress)}
         </div>
       </div>
     );

--- a/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-table-v2.module.scss
@@ -1,4 +1,4 @@
-@import "color.scss";
+@import 'color.scss';
 
 .progressV2Page {
   background-color: white;
@@ -75,7 +75,7 @@ $level-cell-width: 52;
     height: 47px;
     line-height: 47px;
     padding-inline-start: 12px;
-    padding-inline-end: .5em;
+    padding-inline-end: 0.5em;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
@@ -87,7 +87,7 @@ $level-cell-width: 52;
   &Lesson {
     text-align: center;
     min-width: 52px;
-    max-width: 52px;  
+    max-width: 52px;
     height: 47px;
     line-height: 47px !important;
   }
@@ -102,12 +102,16 @@ $level-cell-width: 52;
   &Skeleton {
     vertical-align: middle;
   }
-  
+
   &Level {
     width: $level-cell-width + px;
     height: 47px;
     color: inherit !important;
     padding: 0;
+  }
+
+  &ChoiceSubLevel {
+    border-left: 0;
   }
 }
 
@@ -142,7 +146,7 @@ $level-cell-width: 52;
     flex-direction: column;
     justify-content: flex-end;
   }
-  
+
   &UnitSelector {
     display: flex;
     flex-direction: row;
@@ -190,7 +194,6 @@ $level-cell-width: 52;
     font-weight: 600;
   }
 
-  
   &HeaderTooltip {
     height: 18px;
     line-height: 18px;
@@ -248,7 +251,7 @@ $level-cell-width: 52;
         border: none !important;
       }
     }
-    
+
     &LessonText {
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -328,7 +331,7 @@ $level-cell-width: 52;
       }
     }
 
-    &ExpandedLevelCellFirst { 
+    &ExpandedLevelCellFirst {
       border-left: 1px solid $neutral_dark40;
       width: 52px;
     }
@@ -359,7 +362,7 @@ $level-cell-width: 52;
   &LevelLink {
     height: 100%;
     width: 100%;
-    text-align: center; 
+    text-align: center;
     line-height: 47px !important;
   }
 
@@ -427,7 +430,7 @@ $level-cell-width: 52;
   width: calc(100% - 20px);
   line-height: 47px;
   padding-inline-start: 12px;
-  padding-inline-end: .5em;
+  padding-inline-end: 0.5em;
   text-align: start;
   text-overflow: ellipsis;
   overflow: hidden;


### PR DESCRIPTION
Adds the row for time spent and last updated.

From tech spec:
<img width="1005" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/1c1ffe92-5024-4a37-a764-6d2d7af8c089">


What it looks like in this PR:

<img width="997" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/5f31b637-5f3f-4cd7-8846-268175af05ce">


Note that this has parity with the old view:
<img width="1014" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/8e19b339-b6fb-46cd-8027-db56bdda93cd">



## Links

[Jira Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1075)
[Tech spec](https://docs.google.com/document/d/1VgHhApGUMcCFLafL6KelrkonzO3MpYgIeRn6wD-Vrlo/edit#heading=h.qi8xxyq72bct)

## Testing story

Coming in future PR

