### PR TITLE
LTI account linking for roster sync users

### DIFF
--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -212,11 +212,6 @@ class Policies::Lti
 
   # Check if a partial registration is in progress for an LTI user.
   def self.lti_registration_in_progress?(session)
-    puts 'CHECKING'
-    if PartialRegistration.in_progress?(session)
-      puts 'IN PROGRESS'
-      return PartialRegistration.get_provider(session) == AuthenticationOption::LTI_V1
-    end
-    return false
+    PartialRegistration.in_progress?(session) && PartialRegistration.get_provider(session) == AuthenticationOption::LTI_V1
   end
 end

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -212,6 +212,11 @@ class Policies::Lti
 
   # Check if a partial registration is in progress for an LTI user.
   def self.lti_registration_in_progress?(session)
-    PartialRegistration.in_progress?(session) && PartialRegistration.get_provider(session) == AuthenticationOption::LTI_V1
+    puts 'CHECKING'
+    if PartialRegistration.in_progress?(session)
+      puts 'IN PROGRESS'
+      return PartialRegistration.get_provider(session) == AuthenticationOption::LTI_V1
+    end
+    return false
   end
 end

--- a/dashboard/lib/services/lti/account_linker.rb
+++ b/dashboard/lib/services/lti/account_linker.rb
@@ -23,9 +23,9 @@ module Services
         @rehydrated_user ||= find_cached_user || ::User.new_with_session(ActionController::Parameters.new, session)
       end
 
-      # The user with the auth option being linked might be in sections, if they were
-      # created via a roster sync. In this case, we need to swap the existing user into these
-      # sections to avoid the roster being in a bad state.
+      # The new user might already be in sections, if the account was created
+      # via a roster sync. In this case, we need to swap the pre-existing user
+      # into these sections to avoid the roster being in a bad state.
       private def handle_sections(user_to_remove, user_to_add)
         return if user_to_remove.sections_as_student.empty?
         user_to_remove.sections_as_student.each do |section|
@@ -34,8 +34,9 @@ module Services
         end
       end
 
-      # A cached user should be referenced in the session. If the user was created via
-      # roster sync, there might be a fully-created user with an ID. Use this user if it exists.
+      # A cached user should be referenced in the session. If the user was
+      # created via roster sync, there might be a fully-created user with an ID.
+      # Prefer this user if it exists.
       private def find_cached_user
         cache_key = session[PartialRegistration::SESSION_KEY]
         user_attrs = CDO.shared_cache.read(cache_key)

--- a/dashboard/lib/services/lti/account_linker.rb
+++ b/dashboard/lib/services/lti/account_linker.rb
@@ -12,13 +12,39 @@ module Services
         ActiveRecord::Base.transaction do
           user.authentication_options << rehydrated_user.authentication_options.first
           Services::Lti.create_lti_user_identity(user)
+          handle_sections(rehydrated_user, user)
           user.lti_roster_sync_enabled = true if user.teacher?
           PartialRegistration.delete(session)
+          rehydrated_user.destroy if rehydrated_user.id
         end
       end
 
       private def rehydrated_user
-        @rehydrated_user ||= ::User.new_with_session(ActionController::Parameters.new, session)
+        @rehydrated_user ||= find_cached_user || ::User.new_with_session(ActionController::Parameters.new, session)
+      end
+
+      # The user with the auth option being linked might be in sections, if they were
+      # created via a roster sync. In this case, we need to swap the existing user into these
+      # sections to avoid the roster being in a bad state.
+      private def handle_sections(user_to_remove, user_to_add)
+        return if user_to_remove.sections_as_student.empty?
+        user_to_remove.sections_as_student.each do |section|
+          section.students << user_to_add
+          section.students.destroy(user_to_remove)
+        end
+      end
+
+      # A cached user should be referenced in the session. If the user was created via
+      # roster sync, there might be a fully-created user with an ID. Use this user if it exists.
+      private def find_cached_user
+        cache_key = session[PartialRegistration::SESSION_KEY]
+        user_attrs = CDO.shared_cache.read(cache_key)
+        return unless user_attrs
+
+        user_id = JSON.parse(user_attrs).symbolize_keys[:id]
+        return unless user_id
+
+        ::User.find(user_id)
       end
     end
   end


### PR DESCRIPTION
Currently, users are only put into the account linking flow if the LTI login route doesn't find a user based on the info from their ID token. This means that users who were provisioned via a roster sync, who actually have full users created for them, aren't sent into the flow.

This PR fixes this issue by also including LTI users who exist, but have a sign-in count of 0. These should be users who were provisioned via roster sync, but are logging in for the first time.

This also adds functionality to swap the newly-linked user into the sections that the synced user used to be in. Otherwise, the teacher would have to re-sync their classes to avoid having out of sync rosters after their students go through the account linking flow.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-945)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
