### PR TITLE
change seed order to fix intermittent contained level seeding problems

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -7,9 +7,6 @@
 # build dependency accounting stuff
 /config/scripts/.dropbox
 /config/scripts/.hints_imported
-/config/scripts/.matches_seeded
-/config/scripts/.multis_seeded
-/config/scripts/.dsls_seeded
 /config/scripts/.seeded
 
 # unit test and ui test artifacts

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -232,7 +232,10 @@ namespace :seed do
 
   timed_task_with_logging child_dsls: :environment do
     DSLDefined.transaction do
+      # Allow developers to seed just one dsl-defined level, e.g.
+      # rake seed:child_dsls DSL_FILENAME=k-1_Artistloops_multi1.multi
       dsl_files = override_dsl_filenames(ENV['DSL_FILENAME'], CHILD_DSL_FILES)
+
       parse_dsl_files(dsl_files, CHILD_DSL_TYPES)
     end
   end
@@ -244,13 +247,14 @@ namespace :seed do
 
   timed_task_with_logging parent_dsls: :environment do
     DSLDefined.transaction do
+      # Allow developers to seed just one dsl-defined level, e.g.
+      # rake seed:parent_dsls DSL_FILENAME=csa_unit_6_assessment_2023.level_group
       dsl_files = override_dsl_filenames(ENV['DSL_FILENAME'], PARENT_DSL_FILES)
+
       parse_dsl_files(dsl_files, PARENT_DSL_TYPES)
     end
   end
 
-  # Allow developers to seed just one dsl-defined level, e.g.
-  # rake seed:dsls DSL_FILENAME=k-1_Artistloops_multi1.multi
   def override_dsl_filenames(filename_override, dsl_files)
     dsl_files = filename_override ? Dir.glob("config/scripts/**/#{filename_override}") : dsl_files
 

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -232,11 +232,7 @@ namespace :seed do
 
   timed_task_with_logging child_dsls: :environment do
     DSLDefined.transaction do
-      # Allow developers to seed just one dsl-defined level, e.g.
-      # rake seed:child_dsls DSL_FILENAME=k-1_Artistloops_multi1.multi
-      dsl_files = override_dsl_filenames(ENV['DSL_FILENAME'], CHILD_DSL_FILES)
-
-      parse_dsl_files(dsl_files, CHILD_DSL_TYPES)
+      parse_dsl_files(CHILD_DSL_FILES, CHILD_DSL_TYPES)
     end
   end
 
@@ -247,24 +243,25 @@ namespace :seed do
 
   timed_task_with_logging parent_dsls: :environment do
     DSLDefined.transaction do
-      # Allow developers to seed just one dsl-defined level, e.g.
-      # rake seed:parent_dsls DSL_FILENAME=csa_unit_6_assessment_2023.level_group
-      dsl_files = override_dsl_filenames(ENV['DSL_FILENAME'], PARENT_DSL_FILES)
-
-      parse_dsl_files(dsl_files, PARENT_DSL_TYPES)
+      parse_dsl_files(PARENT_DSL_FILES, PARENT_DSL_TYPES)
     end
   end
 
-  def override_dsl_filenames(filename_override, dsl_files)
-    dsl_files = filename_override ? Dir.glob("config/scripts/**/#{filename_override}") : dsl_files
+  # Allow developers to seed just one dsl-defined level, e.g.
+  # rake seed:single_dsl DSL_FILENAME=k-1_Artistloops_multi1.multi
+  # rake seed:single_dsl DSL_FILENAME=csa_unit_6_assessment_2023.level_group
+  timed_task_with_logging single_dsl: :environment do
+    DSLDefined.transaction do
+      dsl_files = Dir.glob("config/scripts/**/#{ENV['DSL_FILENAME']}")
 
-    # This is only expected to happen when DSL_FILENAME is set and the
-    # filename is not found
-    unless dsl_files.count > 0
-      raise 'no matching dsl-defined level files found. please check filename for exact case and spelling.'
+      unless dsl_files.count > 0
+        raise 'no matching dsl-defined level files found. please check filename for exact case and spelling.'
+      end
+
+      puts "seeding dsl files:\n#{dsl_files.join("\n")}"
+
+      parse_dsl_files(dsl_files, CHILD_DSL_TYPES + PARENT_DSL_TYPES)
     end
-
-    dsl_files
   end
 
   # Parse each .[dsl] file and setup its model.

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -274,6 +274,9 @@ namespace :seed do
         contents = File.read(filename)
         md5 = Digest::MD5.hexdigest(contents)
         data, _i18n = dsl_class.parse(contents, filename)
+
+        # Skip any files which have not been updated since last seed. To force a
+        # a level to be reseeded, clear its md5 field in the database.
         unless md5 == level_md5s_by_name[data[:name]]
           dsl_class.setup(data, md5)
         end

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -229,10 +229,6 @@ namespace :seed do
   # LevelGroup must be last here so that LevelGroups are seeded after all levels that they can contain
   DSL_TYPES = %w(TextMatch ContractMatch External Match Multi EvaluationMulti BubbleChoice LevelGroup).freeze
   DSL_FILES = DSL_TYPES.map {|x| Dir.glob("config/scripts/**/*.#{x.underscore}*").sort}.flatten.freeze
-  file 'config/scripts/.dsls_seeded' => DSL_FILES do |t|
-    Rake::Task['seed:dsls'].invoke
-    FileUtils.touch(t.name)
-  end
 
   # explicit execution of "seed:dsls"
   timed_task_with_logging dsls: :environment do

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -237,8 +237,6 @@ namespace :seed do
   # explicit execution of "seed:dsls"
   timed_task_with_logging dsls: :environment do
     DSLDefined.transaction do
-      level_md5s_by_name = DSLDefined.pluck(:name, :md5).to_h
-
       # Allow developers to seed just one dsl-defined level, e.g.
       # rake seed:dsls DSL_FILENAME=k-1_Artistloops_multi1.multi
       dsls_glob = ENV['DSL_FILENAME'] ? Dir.glob("config/scripts/**/#{ENV['DSL_FILENAME']}") : DSLS_GLOB
@@ -250,19 +248,25 @@ namespace :seed do
       end
 
       # Parse each .[dsl] file and setup its model.
-      dsls_glob.each do |filename|
-        dsl_class = DSL_TYPES.detect {|type| filename.include?(".#{type.underscore}")}.try(:constantize)
-        begin
-          contents = File.read(filename)
-          md5 = Digest::MD5.hexdigest(contents)
-          data, _i18n = dsl_class.parse(contents, filename)
-          unless md5 == level_md5s_by_name[data[:name]]
-            dsl_class.setup(data, md5)
-          end
-        rescue Exception
-          puts "Error parsing #{filename}"
-          raise
+      parse_dsl_files(dsls_glob)
+    end
+  end
+
+  def parse_dsl_files(dsls_glob)
+    level_md5s_by_name = DSLDefined.pluck(:name, :md5).to_h
+
+    dsls_glob.each do |filename|
+      dsl_class = DSL_TYPES.detect {|type| filename.include?(".#{type.underscore}")}.try(:constantize)
+      begin
+        contents = File.read(filename)
+        md5 = Digest::MD5.hexdigest(contents)
+        data, _i18n = dsl_class.parse(contents, filename)
+        unless md5 == level_md5s_by_name[data[:name]]
+          dsl_class.setup(data, md5)
         end
+      rescue Exception
+        puts "Error parsing #{filename}"
+        raise
       end
     end
   end

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -237,18 +237,23 @@ namespace :seed do
   # explicit execution of "seed:dsls"
   timed_task_with_logging dsls: :environment do
     DSLDefined.transaction do
-      # Allow developers to seed just one dsl-defined level, e.g.
-      # rake seed:dsls DSL_FILENAME=k-1_Artistloops_multi1.multi
-      dsl_files = ENV['DSL_FILENAME'] ? Dir.glob("config/scripts/**/#{ENV['DSL_FILENAME']}") : DSL_FILES
-
-      # This is only expected to happen when DSL_FILENAME is set and the
-      # filename is not found
-      unless dsl_files.count > 0
-        raise 'no matching dsl-defined level files found. please check filename for exact case and spelling.'
-      end
-
+      dsl_files = override_dsl_filenames(ENV['DSL_FILENAME'], DSL_FILES)
       parse_dsl_files(dsl_files)
     end
+  end
+
+  # Allow developers to seed just one dsl-defined level, e.g.
+  # rake seed:dsls DSL_FILENAME=k-1_Artistloops_multi1.multi
+  def override_dsl_filenames(filename_override, dsl_files)
+    dsl_files = filename_override ? Dir.glob("config/scripts/**/#{filename_override}") : dsl_files
+
+    # This is only expected to happen when DSL_FILENAME is set and the
+    # filename is not found
+    unless dsl_files.count > 0
+      raise 'no matching dsl-defined level files found. please check filename for exact case and spelling.'
+    end
+
+    dsl_files
   end
 
   # Parse each .[dsl] file and setup its model.

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -247,11 +247,11 @@ namespace :seed do
         raise 'no matching dsl-defined level files found. please check filename for exact case and spelling.'
       end
 
-      # Parse each .[dsl] file and setup its model.
       parse_dsl_files(dsl_files)
     end
   end
 
+  # Parse each .[dsl] file and setup its model.
   def parse_dsl_files(dsl_files)
     level_md5s_by_name = DSLDefined.pluck(:name, :md5).to_h
 


### PR DESCRIPTION
## background

see https://codedotorg.slack.com/archives/C046G4TRLEN/p1716912073888199 for context. the current seeding problems were coming from this contained level not having been seeded before the containing level was seeded: https://github.com/code-dot-org/code-dot-org/blob/e914f6fe7ec3d5268420154aac3fb2d79bca5ad1/dashboard/config/levels/custom/spritelab/k5_ai_pilot_sorting_fruit_vegetables_2024.level#L57-L58

`k5_ai_pilot_sorting_fruit_vegetables_2024` is a custom level, and `k5_ai_sorting_food_question` is a DSLDefined level of type `Multi`.

The general problem is that seeding of multi levels happens after seeding the custom levels that may contain them: https://github.com/code-dot-org/code-dot-org/blob/11de383801f91f9e86c5ce67262517c1e4820304/dashboard/lib/tasks/seed.rake#L177-L178

there has not been a root cause analysis on why seeding NOT consistently fail during setup of new development or adhoc environments (some speculation in slack). however, this PR fixes the root cause for the case when seeding DOES fail, which seems like the right thing to focus on.

## description

the solution is to seed all levels that can be contained (multi, match, etc) before seeding custom levels, while still seeding bubble choice levels after custom levels: https://github.com/code-dot-org/code-dot-org/blob/7988d5b0759e4faa788f2baf0a09c0b43d855aad/dashboard/lib/tasks/seed.rake#L177-L179

this code change can be seen in 1aa43a5493802b3a3c801001cfc39042022f072e, and the rest of the commits are mostly refactoring or other cleanup.

### collateral damage

seeding a single DSLDefined level used to be:
```
rake seed:dsls DSL_FILENAME=...
```
and is now:
```
rake seed:single_dsl DSL_FILENAME=...
```

After merge, the Tips and Tricks doc will be updated to reflect this.

## Testing story

It's hard to verify this fix because I am not consistently able to reproduce the problem. after deleting containing and contained levels, `rake seed:custom_levels` succeeds in recreating the containing level even without the contained level in the database. So, all I can really show as verification steps are that nothing new is broken:
* `rake seed:scripts` passes locally after deleting contained and containing levels
* adhoc successfully starts (including seeding all levels from scratch)

That leaves this as a speculative fix, though I'd argue it is still worth doing since both my and Molly's issues were solved by creating the multi level first.
 