### PR TITLE
PL Launch 2024 post-launch - Take down PL skinny banners around the site

### DIFF
--- a/pegasus/sites.v3/code.org/public/professional-learning/self-paced.haml
+++ b/pegasus/sites.v3/code.org/public/professional-learning/self-paced.haml
@@ -20,7 +20,7 @@ theme: responsive_full_width
         =hoc_s(:self_paced_pl_hero_desc)
     %img{src: "../shared/images/banners/self-paced-pl-hero.png", alt: ""}
 
-%section
+%section.bg-neutral-light
   .wrapper
     %h2=hoc_s(:self_paced_pl_intro_heading)
     %p=hoc_s(:self_paced_pl_intro_desc)

--- a/pegasus/sites.v3/code.org/views/professional_learning_skinny_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_skinny_banner.haml
@@ -1,4 +1,4 @@
-- display_professional_learning_banners = true
+- display_professional_learning_banners = false
 - if request.locale == "en-US" && display_professional_learning_banners
   = inline_css 'professional_learning_marketing_banner.css'
   - header_text = hoc_s(:pl_superhero_title)


### PR DESCRIPTION
Sets the logic showing the PL skinny banners to `false` so the banners are removed on this following pages:
- [code.org/teach](http://code.org/teach)
- [code.org/csp](http://code.org/csp)
- [code.org/csa](http://code.org/csa)
- [code.org/csd](http://code.org/csd)
- [code.org/curriculum/computer-vision](http://code.org/curriculum/computer-vision)
- [code.org/educate/professional-development-online](http://code.org/educate/professional-development-online)

## Links
Jira ticket: [ACQ-1826](https://codedotorg.atlassian.net/browse/ACQ-1826)
Related PR: https://github.com/code-dot-org/code-dot-org/pull/55780

## Testing story
Tested locally