### PR TITLE
Replace AI 101 tile on How AI works page with AI 101 Self Paced

### DIFF
--- a/pegasus/sites.v3/code.org/views/how_ai_works_resources.haml
+++ b/pegasus/sites.v3/code.org/views/how_ai_works_resources.haml
@@ -11,7 +11,7 @@
         %strong
           =hoc_s(:module_label_duration)
         =hoc_s(:module_duration_5_hrs)
-      %a.link-button{href: CDO.studio_url("/courses/self-paced-pl-ai-101")}
+      %a.link-button{href: CDO.studio_url("/courses/self-paced-pl-ai-101"), aria:{label: hoc_s(:aria_label_call_to_action_ai_101)}}
         =hoc_s(:call_to_action_start_module)
   .action-block.action-block--one-col.flex-space-between
     .content-wrapper

--- a/pegasus/sites.v3/code.org/views/how_ai_works_resources.haml
+++ b/pegasus/sites.v3/code.org/views/how_ai_works_resources.haml
@@ -2,16 +2,17 @@
   .action-block.action-block--one-col.flex-space-between
     .content-wrapper
       %p.overline
-        =hoc_s(:teachers_label)
-      %h3=hoc_s(:ai_pl_101_hero_heading)
-      %img{src: "/shared/images/announcement/announcement_ai_pl_2023.png", alt: ""}
-      %p=hoc_s(:ai_pl_101_hero_desc)
+        =hoc_s(:module_label_self_paced)
+      %h3=hoc_s(:ai_pl_101_title)
+      %img{src: "/images/self-paced-pl-tile-ai-101.jpg", alt: ""}
+      %p=hoc_s(:ai_pl_101_desc)
     .content-footer
       %p
-        %strong=hoc_s(:module_label_duration)
+        %strong
+          =hoc_s(:module_label_duration)
         =hoc_s(:module_duration_5_hrs)
-      %a.link-button{href: "/ai/pl/101", aria:{label: hoc_s(:aria_label_call_to_action_ai_pl_101_videos)}}
-        =hoc_s(:call_to_action_watch_videos)
+      %a.link-button{href: CDO.studio_url("/courses/self-paced-pl-ai-101")}
+        =hoc_s(:call_to_action_start_module)
   .action-block.action-block--one-col.flex-space-between
     .content-wrapper
       %p.overline

--- a/pegasus/sites.v3/code.org/views/how_ai_works_resources.haml
+++ b/pegasus/sites.v3/code.org/views/how_ai_works_resources.haml
@@ -2,7 +2,7 @@
   .action-block.action-block--one-col.flex-space-between
     .content-wrapper
       %p.overline
-        =hoc_s(:module_label_self_paced)
+        =hoc_s(:teachers_label)
       %h3=hoc_s(:ai_pl_101_title)
       %img{src: "/images/self-paced-pl-tile-ai-101.jpg", alt: ""}
       %p=hoc_s(:ai_pl_101_desc)


### PR DESCRIPTION
Replaces the AI 101 for Teachers tile with the Self-Paced AI 101 for Teachers tile in the resources section on https://code.org/curriculum/how-ai-works.

## Links
Jira ticket: [ACQ-1915](https://codedotorg.atlassian.net/browse/ACQ-1915)
Slack convo: [here](https://codedotorg.slack.com/archives/C057CFC8W59/p1716391499655429?thread_ts=1716391499.655429&cid=C057CFC8W59)

## Testing story
Tested locally

----

## Before
<img width="1025" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/e5f4c1f0-68f7-4300-b433-762ac00de431">

## After
<img width="1025" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/d687c875-7071-4e60-90af-4edfbed93bc4">