### PR TITLE
Explicitly Install `mysql-client-8.0` Package

### DIFF
--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -2,10 +2,19 @@ include_recipe 'cdo-mysql::repo'
 
 apt_package 'libmysqlclient-dev'
 
-apt_package 'mysql-client' do
-  if node['cdo-mysql']['target_version'] == '5.7'
-    version '5.7.42-1ubuntu18.04'
-  elsif node['cdo-mysql']['target_version'] == '8.0'
-    version '8.0.36-0ubuntu0.20.04.1'
-  end
+mysql_client_packages = ['mysql-client']
+mysql_client_versions = ['5.7.42-1ubuntu18.04']
+
+# It's not entirely clear why this needs to be explicitly installed; for some
+# reason, `sudo apt install mysql-client=8.0.36-0ubuntu0.20.04.1` fails with
+# `mysql-client : Depends: mysql-client-8.0 but it is not going to be
+# installed`, even though I would expect it to be able to install that
+# dependency automatically.
+if node['cdo-mysql']['target_version'] == '8.0'
+  mysql_client_packages << 'mysql-client-8.0'
+  mysql_client_versions = ['8.0.36-0ubuntu0.20.04.1', '8.0.36-0ubuntu0.20.04.1']
+end
+
+apt_package mysql_client_packages do
+  version mysql_client_versions
 end


### PR DESCRIPTION
For some reason, when trying to install v8.0 of mysql-client our managed servers fail with

```
The following packages have unmet dependencies:
     mysql-client : Depends: mysql-client-8.0 but it is not going to be installed
    STDERR: E: Unable to correct problems, you have held broken packages.
```

Manually executing `sudo apt install mysql-client-8.0 mysql-client=8.0.36-0ubuntu0.20.04.1` on the staging server worked to get it to install everything correctly, so doing the same thing via cookbooks for our other servers. 

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
