### PR TITLE
[Google Blockly] cleanup level methods

### DIFF
--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -57,10 +57,6 @@ class Dancelab < GamelabJr
     )
   end
 
-  def uses_google_blockly?
-    true
-  end
-
   def common_blocks(type)
   end
 

--- a/dashboard/app/models/levels/gamelab.rb
+++ b/dashboard/app/models/levels/gamelab.rb
@@ -97,6 +97,10 @@ class Gamelab < Blockly
     true
   end
 
+  def uses_google_blockly?
+    true
+  end
+
   def age_13_required?
     true
   end

--- a/dashboard/app/models/levels/gamelab_jr.rb
+++ b/dashboard/app/models/levels/gamelab_jr.rb
@@ -183,10 +183,6 @@ class GamelabJr < Gamelab
     false
   end
 
-  def uses_google_blockly?
-    true
-  end
-
   def age_13_required?
     false
   end

--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -106,10 +106,6 @@ class Poetry < GamelabJr
     )
   end
 
-  def uses_google_blockly?
-    true
-  end
-
   def common_blocks(type)
   end
 


### PR DESCRIPTION
As of the Sprite Lab migration, all Blockly labs in the Game Lab "branch" of our level models structure are now on Google Blockly. Rather than continue to define the `uses_google_blockly?` method in each Game Lab child, we can do this just one in the parent. See diagram:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/04c98d64-b266-4ab7-a4b8-0454e214dd55)

Poetry, Dance, and Sprite Lab will now inherit the same method from the Game Lab class. It may be worth pointing out that Game Lab proper level use Droplet and not Blockly (all Droplet levels are technically considered "Blockly"). This method doesn't cause any problems since it's only used to inform which version of Blockly we would use if it was needed. The GamelabJr class also explicitly states that Droplet isn't used (including for its children Poetry and Dancelab).

This is just clean up; there are no functional changes.


## Testing story

I confirmed that Sprite Lab, Dance, and Poetry project still load with Google Blockly. I also confirmed that Game Lab projects still load without error and that Blockly never gets set to the global scope.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
