### PR TITLE
fix(lms): allow duplicate user accounts to be created for LMS users

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -816,6 +816,8 @@ class User < ApplicationRecord
   def email_and_hashed_email_must_be_unique
     # skip the db lookup if we are already invalid
     return if errors.present?
+    # allow duplicate accounts to be created for LMS users that are unlinked
+    return if authentication_options.length == 1 && authentication_options.first&.credential_type == AuthenticationOption::LTI_V1
 
     if ((email.present? && (other_user = User.find_by_email_or_hashed_email(email))) ||
         (hashed_email.present? && (other_user = User.find_by_hashed_email(hashed_email)))) &&

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -817,7 +817,7 @@ class User < ApplicationRecord
     # skip the db lookup if we are already invalid
     return if errors.present?
     # allow duplicate accounts to be created for LMS users that are unlinked
-    return if authentication_options.length == 1 && authentication_options.first&.credential_type == AuthenticationOption::LTI_V1
+    return if authentication_options.length == 1 && authentication_options.first&.lti?
 
     if ((email.present? && (other_user = User.find_by_email_or_hashed_email(email))) ||
         (hashed_email.present? && (other_user = User.find_by_hashed_email(hashed_email)))) &&

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -516,6 +516,38 @@ class UserTest < ActiveSupport::TestCase
     cannot_create_multi_auth_users_with_email COLLISION_EMAIL
   end
 
+  test "can create multi-auth LTI user with duplicate of multi-auth user's second email" do
+    create :student, email: COLLISION_EMAIL
+    # trigger the email validation by changing the email (partial registration has email as "" which becomes the actual
+    # email in the finish sign up flow)
+    user = create :student
+    user.authentication_options.destroy_all
+
+    lti_authentication_option = create(:lti_authentication_option, user: user, email: COLLISION_EMAIL)
+    user.authentication_options << lti_authentication_option
+    user.email = COLLISION_EMAIL
+
+    user.save!
+
+    user.valid?
+  end
+
+  test "cannot create multi-auth LTI user multiple auth options and duplicate of multi-auth user's second email" do
+    create :student, email: COLLISION_EMAIL
+    # trigger the email validation by changing the email (partial registration has email as "" which becomes the actual
+    # email in the finish sign up flow)
+    user = create :student
+    user.authentication_options.destroy_all
+
+    lti_authentication_option = create(:lti_authentication_option, user: user, email: COLLISION_EMAIL)
+    user.authentication_options << lti_authentication_option
+    user.email = COLLISION_EMAIL
+
+    user.save!
+    user.authentication_options << create(:lti_authentication_option, user: user, email: COLLISION_EMAIL)
+    cannot_create_user_with_email :google_authentication_option, user: user, email: COLLISION_EMAIL
+  end
+
   def cannot_create_multi_auth_users_with_email(email)
     cannot_create_user_with_email :teacher, email: email
     cannot_create_user_with_email :student, email: email


### PR DESCRIPTION
Currently, Code.org allows duplicate accounts with the same email address to be created due to the partial registration cache allowing the rehydration of invalid users. When the student email remediation DCDO was enabled, the rehydration of the email address allowed for the email uniqueness validation to occur (which was previously bypassed) and prevented LMS accounts from being created. 

Per the [slack discussion](https://codedotorg.slack.com/archives/C032LKQL53Q/p1717613645457869), we will be allowing duplicate accounts to be created for LMS users that are unlinked.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [slack thread](https://codedotorg.slack.com/archives/C032LKQL53Q/p1717613645457869)
- [jira ticket](https://codedotorg.atlassian.net/browse/P20-984)

## Testing story

1. Added unit tests for this scenario
2. Created an email account user, then went to Canvas and created a fresh account with the same user. Previously, this would error out but now a duplicate account is created.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  3.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
