### PR TITLE
[Levelbuilder] Use key for levels list

### DIFF
--- a/dashboard/app/views/levels/_list.html.haml
+++ b/dashboard/app/views/levels/_list.html.haml
@@ -88,9 +88,9 @@
         -# Level name column, linked to view action if permitted
         %td
           - if can? :show, level
-            = link_to level.name, level, title: t('crud.show')
+            = link_to level.key, level, title: t('crud.show')
           - else
-            = level.name
+            = level.key
 
         -# Level type column
         %td= level.class.name


### PR DESCRIPTION
At `/levels`, we show a filterable table of all levels by name. Many old levels of type "Blockly" share the same name "blockly". There are many pages of these levels which makes the list impossible to navigate.
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/05f0337a-6b4e-4591-821b-5b04ee0c4ddc)

In other places, such as the Extra links box, we use the level key instead of name to show a more helpful label. 
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/a9f96e92-e710-4581-919d-7326cd664c00)

I propose that we do the same thing to the levels list to make the list possible to navigate when perusing Blockly levels.

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/6c35d7a8-e789-43f5-a9fb-0aa37820e090)

For most (all?) other level types, there's no difference between `name` and `key` so these changes shouldn't be noticeable except for Blockly levels. Note that child types related to Blockly (e.g. GamelabJr) have descriptive names. These also won't be affected.
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/a810e908-e882-4010-8fb0-75bfb3af391a)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
