### PR TITLE
fix(statsig): add statsig stable id to the rails session

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -29,6 +29,8 @@ class ApplicationController < ActionController::Base
 
   before_action :clear_sign_up_session_vars
 
+  before_action :initialize_statsig_session
+
   def fix_crawlers_with_bad_accept_headers
     # append text/html as an acceptable response type for Edmodo and weebly-agent's malformed HTTP_ACCEPT header.
     if request.formats.include?("image/*") &&
@@ -352,6 +354,12 @@ class ApplicationController < ActionController::Base
     ].include?(request.path)
 
     redirect_to lockout_path if Policies::ChildAccount.locked_out?(current_user)
+  end
+
+  # Creates a stable statsig id for use of session tracking (whether the user is logged in or not)
+  # Use this session variable when you want to track the user journey when the user is not logged in.
+  protected def initialize_statsig_session
+    session[:statsig_stable_id] ||= SecureRandom.uuid
   end
 
   private def pairing_still_enabled

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -17,6 +17,7 @@ class HomeController < ApplicationController
   # The terms_and_privacy page gets loaded in an iframe on the signup page, so skip
   # clearing the sign up tracking variables
   skip_before_action :clear_sign_up_session_vars, only: [:terms_and_privacy]
+  skip_before_action :initialize_statsig_session, only: [:health_check]
 
   def set_locale
     set_locale_cookie(params[:locale]) if params[:locale]

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -377,7 +377,8 @@ Devise.setup do |config|
   end
 
   OmniAuth.config.before_request_phase do |env|
-    Metrics::Events.log_event(
+    Metrics::Events.log_event_with_session(
+      session: env['rack.session'],
       event_name: "#{env['omniauth.strategy'].options[:name]}-begin-auth",
       )
   end

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -48,6 +48,7 @@ module Metrics
 
       def log_event_with_session(session:, event_name:, event_value: nil, metadata: {})
         event_value = event_name if event_value.nil?
+        managed_test_environment = CDO.running_web_application? && CDO.test_system?
         statsig_user = StatsigUser.new({'userID' => session[:statsig_stable_id]})
 
         if CDO.rack_env?(:development)

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -34,7 +34,7 @@ module Metrics
         if CDO.rack_env?(:development)
           log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments)
         elsif CDO.rack_env?(:production) || managed_test_environment
-          log_event_with_statsig(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments)
+          log_statsig_event_with_cdo_user(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments)
         else
           # We don't want to log in other environments, just return silently
           return
@@ -46,11 +46,21 @@ module Metrics
       )
       end
 
+      def log_event_with_session(session:, event_name:, event_value: nil, metadata: {})
+        statsig_user = StatsigUser.new({'userID' => session[:statsig_stable_id]})
+
+        log_statsig_event(statsig_user: statsig_user, event_name: event_name, event_value: event_value, metadata: metadata)
+      end
+
       # Logs an event to Statsig
-      private def log_event_with_statsig(user:, event_name:, event_value:, metadata:, enabled_experiments:)
-        # Re-initialize Statsig to make sure it's avaiable in current thread.
-        Cdo::StatsigInitializer.init
+      private def log_statsig_event_with_cdo_user(user:, event_name:, event_value:, metadata:, enabled_experiments:)
         statsig_user = build_statsig_user(user: user, enabled_experiments: enabled_experiments)
+        log_statsig_event(statsig_user: statsig_user, event_name: event_name, event_value: event_value, metadata: metadata)
+      end
+
+      private def log_statsig_event(statsig_user:, event_name:, event_value:, metadata:)
+        # Re-initialize Statsig to make sure it's available in current thread.
+        Cdo::StatsigInitializer.init
         Statsig.log_event(statsig_user, event_name, event_value, metadata)
       end
 

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -57,7 +57,8 @@ module SignUpTracking
       }
     )
 
-    Metrics::Events.log_event(
+    Metrics::Events.log_event_with_session(
+      session: session,
       event_name: event_name,
       metadata: {
         study: STUDY_NAME,
@@ -80,7 +81,8 @@ module SignUpTracking
     }
     FirehoseClient.instance.put_record(:analysis, tracking_data)
 
-    Metrics::Events.log_event(
+    Metrics::Events.log_event_with_session(
+      session: session,
       event_name: "begin-sign-up-#{result}",
       metadata: {
         study: STUDY_NAME,
@@ -100,7 +102,8 @@ module SignUpTracking
       }
     )
 
-    Metrics::Events.log_event(
+    Metrics::Events.log_event_with_session(
+      session: session,
       event_name: "#{provider}-load-finish-sign-up",
       metadata: {
         study: STUDY_NAME,
@@ -120,7 +123,8 @@ module SignUpTracking
       }
     )
 
-    Metrics::Events.log_event(
+    Metrics::Events.log_event_with_session(
+      session: session,
       event_name: "#{provider}-cancel-finish-sign-up",
       metadata: {
         study: STUDY_NAME,
@@ -145,7 +149,8 @@ module SignUpTracking
       )
     end
 
-    Metrics::Events.log_event(
+    Metrics::Events.log_event_with_session(
+      session: session,
       event_name: event_name,
       metadata: {
         study: STUDY_NAME,
@@ -166,7 +171,8 @@ module SignUpTracking
       }
       FirehoseClient.instance.put_record(:analysis, tracking_data)
 
-      Metrics::Events.log_event(
+      Metrics::Events.log_event_with_session(
+        session: session,
         event_name: "#{provider}-sign-in",
         metadata: {
           study: STUDY_NAME,
@@ -194,7 +200,8 @@ module SignUpTracking
     }
     FirehoseClient.instance.put_record(:analysis, tracking_data)
 
-    Metrics::Events.log_event(
+    Metrics::Events.log_event_with_session(
+      session: session,
       event_name: "#{sign_up_type}-sign-up-#{result}",
       metadata: {
         study: STUDY_NAME,

--- a/dashboard/test/integration/session_cookie_test.rb
+++ b/dashboard/test/integration/session_cookie_test.rb
@@ -12,12 +12,6 @@ class SessionCookieTest < ActionDispatch::IntegrationTest
     assert cookies['_learn_session_test']
   end
 
-  test 'no cookies if you do not do anything' do
-    get '/'
-
-    assert_nil cookies['_learn_session_test']
-  end
-
   test 'session cookie not set over insecure HTTP' do
     https! false
     get '/reset_session'


### PR DESCRIPTION
Normally, statsig requires a user id to track a user's journey. However, anonymous users will inherently not have a user id because the user has not yet been created. Instead, use the 'stable id' feature which is a random uuid generated alongside the rails session. The reason why a new uuid is generated is to prevent leaking the rails session id to external parties.

A new method `log_statsig_event_with_session` has been created to ensure most calls are made with the user and only in unique circumstances (such as tracking an anonymous user) should this method be used.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-986)

## Testing story

![Screenshot from 2024-06-06 14-42-05](https://github.com/code-dot-org/code-dot-org/assets/538214/c89774e6-4e0f-49e9-80ac-8e5aa87dcace)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

- [change frontend statsig sdk to initialize with the same stable id as the backend](https://codedotorg.atlassian.net/browse/P20-985)

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
