### PR TITLE
Make a read-only version of Code Bridge

### DIFF
--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -13,13 +13,13 @@ import {
   shouldShowFile,
 } from '@codebridge/utils';
 import React, {useMemo} from 'react';
-import {useSelector} from 'react-redux';
 
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {ProjectFileType} from '@cdo/apps/lab2/types';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {FileBrowserHeaderPopUpButton} from './FileBrowserHeaderPopUpButton';
 import {
@@ -64,7 +64,7 @@ const InnerFileBrowser = React.memo(
     const hasValidationFile = Object.values(files).find(
       f => f.type === ProjectFileType.VALIDATION
     );
-    const isReadOnly = useSelector(isReadOnlyWorkspace);
+    const isReadOnly = useAppSelector(isReadOnlyWorkspace);
 
     const startModeFileDropdownOptions = (file: ProjectFile) => {
       // We only support one validation file per project, so if we already have one,
@@ -225,7 +225,7 @@ export const FileBrowser = React.memo(() => {
     newFolder,
     setFileType,
   } = useCodebridgeContext();
-  const isReadOnly = useSelector(isReadOnlyWorkspace);
+  const isReadOnly = useAppSelector(isReadOnlyWorkspace);
 
   const newFolderPrompt: FilesComponentProps['newFolderPrompt'] = useMemo(
     () =>

--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -13,8 +13,10 @@ import {
   shouldShowFile,
 } from '@codebridge/utils';
 import React, {useMemo} from 'react';
+import {useSelector} from 'react-redux';
 
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {ProjectFileType} from '@cdo/apps/lab2/types';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
@@ -62,6 +64,7 @@ const InnerFileBrowser = React.memo(
     const hasValidationFile = Object.values(files).find(
       f => f.type === ProjectFileType.VALIDATION
     );
+    const isReadOnly = useSelector(isReadOnlyWorkspace);
 
     const startModeFileDropdownOptions = (file: ProjectFile) => {
       // We only support one validation file per project, so if we already have one,
@@ -132,25 +135,28 @@ const InnerFileBrowser = React.memo(
                     </span>
                     <span>{f.name}</span>
                   </span>
-                  <PopUpButton
-                    iconName="ellipsis-v"
-                    className={moduleStyles['button-kebab']}
-                  >
-                    <span className={moduleStyles['button-bar']}>
-                      <span onClick={() => renameFolderPrompt(f.id)}>
-                        <i className="fa-solid fa-pencil" /> Rename folder
+                  {!isReadOnly && (
+                    <PopUpButton
+                      iconName="ellipsis-v"
+                      className={moduleStyles['button-kebab']}
+                    >
+                      <span className={moduleStyles['button-bar']}>
+                        <span onClick={() => renameFolderPrompt(f.id)}>
+                          <i className="fa-solid fa-pencil" /> Rename folder
+                        </span>
+                        <span onClick={() => newFolderPrompt(f.id)}>
+                          <i className="fa-solid fa-folder-plus" /> Add
+                          sub-folder
+                        </span>
+                        <span onClick={() => newFilePrompt(f.id)}>
+                          <i className="fa-solid fa-plus" /> Add file
+                        </span>
+                        <span onClick={() => deleteFolder(f.id)}>
+                          <i className="fa-solid fa-trash" /> Delete folder
+                        </span>
                       </span>
-                      <span onClick={() => newFolderPrompt(f.id)}>
-                        <i className="fa-solid fa-folder-plus" /> Add sub-folder
-                      </span>
-                      <span onClick={() => newFilePrompt(f.id)}>
-                        <i className="fa-solid fa-plus" /> Add file
-                      </span>
-                      <span onClick={() => deleteFolder(f.id)}>
-                        <i className="fa-solid fa-trash" /> Delete folder
-                      </span>
-                    </span>
-                  </PopUpButton>
+                    </PopUpButton>
+                  )}
                 </span>
                 {f.open && (
                   <ul>
@@ -180,24 +186,26 @@ const InnerFileBrowser = React.memo(
                   <i className={getFileIcon(f)} />
                   {f.name}
                 </span>
-                <PopUpButton
-                  iconName="ellipsis-v"
-                  className={moduleStyles['button-kebab']}
-                >
-                  <span className={moduleStyles['button-bar']}>
-                    <span onClick={() => moveFilePrompt(f.id)}>
-                      <i className="fa-solid fa-arrow-right" />
-                      Move file
+                {!isReadOnly && (
+                  <PopUpButton
+                    iconName="ellipsis-v"
+                    className={moduleStyles['button-kebab']}
+                  >
+                    <span className={moduleStyles['button-bar']}>
+                      <span onClick={() => moveFilePrompt(f.id)}>
+                        <i className="fa-solid fa-arrow-right" />
+                        Move file
+                      </span>
+                      <span onClick={() => renameFilePrompt(f.id)}>
+                        <i className="fa-solid fa-pencil" /> Rename file
+                      </span>
+                      <span onClick={() => deleteFile(f.id)}>
+                        <i className="fa-solid fa-trash" /> Delete file
+                      </span>
+                      {isStartMode && startModeFileDropdownOptions(f)}
                     </span>
-                    <span onClick={() => renameFilePrompt(f.id)}>
-                      <i className="fa-solid fa-pencil" /> Rename file
-                    </span>
-                    <span onClick={() => deleteFile(f.id)}>
-                      <i className="fa-solid fa-trash" /> Delete file
-                    </span>
-                    {isStartMode && startModeFileDropdownOptions(f)}
-                  </span>
-                </PopUpButton>
+                  </PopUpButton>
+                )}
               </span>
             </li>
           ))}
@@ -217,6 +225,7 @@ export const FileBrowser = React.memo(() => {
     newFolder,
     setFileType,
   } = useCodebridgeContext();
+  const isReadOnly = useSelector(isReadOnlyWorkspace);
 
   const newFolderPrompt: FilesComponentProps['newFolderPrompt'] = useMemo(
     () =>
@@ -369,10 +378,12 @@ export const FileBrowser = React.memo(() => {
       headerContent={'Files'}
       className={moduleStyles['file-browser']}
       rightHeaderContent={
-        <FileBrowserHeaderPopUpButton
-          newFolderPrompt={newFolderPrompt}
-          newFilePrompt={newFilePrompt}
-        />
+        !isReadOnly && (
+          <FileBrowserHeaderPopUpButton
+            newFolderPrompt={newFolderPrompt}
+            newFilePrompt={newFilePrompt}
+          />
+        )
       }
     >
       <ul>

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -21,7 +21,11 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
     }
   }, [dialogControl, resetProject]);
 
-  return !isReadOnly ? (
+  if (isReadOnly) {
+    return null;
+  }
+
+  return (
     <div>
       <Button
         icon={{iconStyle: 'solid', iconName: 'refresh'}}
@@ -32,7 +36,7 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
         size={'xs'}
       />
     </div>
-  ) : null;
+  );
 };
 
 export default WorkspaceHeaderButtons;

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -1,16 +1,19 @@
 import React, {useCallback, useContext} from 'react';
 
 import Button from '@cdo/apps/componentLibrary/button';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {
   DialogContext,
   DialogType,
 } from '@cdo/apps/lab2/views/dialogs/DialogManager';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {useCodebridgeContext} from '../codebridgeContext';
 
 const WorkspaceHeaderButtons: React.FunctionComponent = () => {
   const dialogControl = useContext(DialogContext);
   const {resetProject} = useCodebridgeContext();
+  const isReadOnly = useAppSelector(isReadOnlyWorkspace);
 
   const onClickStartOver = useCallback(() => {
     if (dialogControl) {
@@ -18,7 +21,7 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
     }
   }, [dialogControl, resetProject]);
 
-  return (
+  return !isReadOnly ? (
     <div>
       <Button
         icon={{iconStyle: 'solid', iconName: 'refresh'}}
@@ -29,7 +32,7 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
         size={'xs'}
       />
     </div>
-  );
+  ) : null;
 };
 
 export default WorkspaceHeaderButtons;

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -37,12 +37,10 @@ export const useSource = (defaultSources: ProjectSources) => {
 
   const setSourceHelper = useMemo(
     () => (newProjectSource: ProjectSources) => {
-      if (isReadOnly) {
-        // Don't attempt to save in read-only mode.
-        dispatch(setProjectSource(newProjectSource));
-      } else {
-        dispatch(setAndSaveProjectSource(newProjectSource));
-      }
+      const saveFunction = isReadOnly
+        ? setProjectSource
+        : setAndSaveProjectSource;
+      dispatch(saveFunction(newProjectSource));
     },
     [dispatch, isReadOnly]
   );

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -35,16 +35,23 @@ export const useSource = (defaultSources: ProjectSources) => {
   const levelId = useAppSelector(state => state.lab.levelProperties?.id);
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
 
-  const setSource = useMemo(
-    () => (newSource: MultiFileSource) => {
+  const setSourceHelper = useMemo(
+    () => (newProjectSource: ProjectSources) => {
       if (isReadOnly) {
-        dispatch(setProjectSource({source: newSource}));
+        // Don't attempt to save in read-only mode.
+        dispatch(setProjectSource(newProjectSource));
       } else {
-        // Only attempt to save in read-only mode.
-        dispatch(setAndSaveProjectSource({source: newSource}));
+        dispatch(setAndSaveProjectSource(newProjectSource));
       }
     },
     [dispatch, isReadOnly]
+  );
+
+  const setSource = useMemo(
+    () => (newSource: MultiFileSource) => {
+      setSourceHelper({source: newSource});
+    },
+    [setSourceHelper]
   );
 
   const resetToStartSource = useCallback(() => {
@@ -69,18 +76,13 @@ export const useSource = (defaultSources: ProjectSources) => {
     if (levelId && previousLevelIdRef.current !== levelId) {
       // We reset the project when the levelId changes, as this means we are on a new level.
       if (initialSources) {
-        if (isReadOnly) {
-          dispatch(setProjectSource(initialSources));
-        } else {
-          // Only attempt to save in read-only mode.
-          dispatch(setAndSaveProjectSource(initialSources));
-        }
+        setSourceHelper(initialSources);
       }
       if (levelId) {
         previousLevelIdRef.current = levelId;
       }
     }
-  }, [initialSources, dispatch, levelId, isReadOnly]);
+  }, [initialSources, levelId, setSourceHelper]);
 
   return {source, setSource, resetToStartSource};
 };

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -257,7 +257,11 @@ export const isLabLoading = (state: {lab: LabState}) =>
 
 // This may depend on more factors, such as share.
 export const isReadOnlyWorkspace = (state: {lab: LabState}) => {
-  return !state.lab.channel?.isOwner;
+  const isOwner = state.lab.channel?.isOwner;
+  const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
+  // We are in read-only mode if we are not the owner of the channel
+  // and we are not in start mode.
+  return !isStartMode && !isOwner;
 };
 
 // If there is an error present on the page.

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -8,6 +8,7 @@ import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 import Lab2Registry from '../Lab2Registry';
 import {
+  isReadOnlyWorkspace,
   setUpWithLevel,
   setUpWithoutLevel,
   shouldHideShareAndRemix,
@@ -49,6 +50,7 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
   const levelPropertiesPath = useSelector(getLevelPropertiesPath);
 
   const dispatch = useAppDispatch();
+  const isReadOnly = useAppSelector(isReadOnlyWorkspace);
 
   useEffect(() => {
     // The redux types are very complicated, so in order to re-use this variable
@@ -104,18 +106,20 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
       // Force a save before the page unloads, if there are unsaved changes.
       // If we need to force a save, prevent navigation so we can save first.
       // We skip this if we are already force reloading, as that will occur when
-      // saving already encountered an issue.
+      // saving already encountered an issue. We also can skip this in read only mode,
+      // as we never save in read only mode.
       if (
         projectManager &&
         !projectManager.isForceReloading() &&
-        projectManager.hasUnsavedChanges()
+        projectManager.hasUnsavedChanges() &&
+        !isReadOnly
       ) {
         projectManager.cleanUp();
         event.preventDefault();
         event.returnValue = '';
       }
     });
-  }, []);
+  }, [isReadOnly]);
 
   useEffect(() => {
     // Ensure the header is cleared when we have a change,

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import classNames from 'classnames';
 import {Compartment, EditorState, Extension} from '@codemirror/state';
 import {EditorView, ViewUpdate} from '@codemirror/view';
-import {useDispatch, useSelector} from 'react-redux';
+import {useDispatch} from 'react-redux';
 import {editorConfig} from './editorConfig';
 import {darkMode as darkModeTheme} from './editorThemes';
 import {autocompletion} from '@codemirror/autocomplete';
@@ -28,7 +28,7 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   const [didInit, setDidInit] = useState(false);
   const [editorView, setEditorView] = useState<EditorView | null>(null);
   const channelId = useAppSelector(state => state.lab.channel?.id);
-  const isReadOnly = useSelector(isReadOnlyWorkspace);
+  const isReadOnly = useAppSelector(isReadOnlyWorkspace);
 
   // These two compartments control read-only settings.
   // Controls if you can type in the editor or not.
@@ -54,8 +54,6 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
       autocompletion(),
       ...editorConfigExtensions,
     ];
-
-    console.log(`Setting editor read only to ${isReadOnly}`);
 
     editorExtensions.push(
       editorReadOnlyCompartment.of(EditorState.readOnly.of(isReadOnly)),
@@ -103,7 +101,6 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
 
   useEffect(() => {
     if (editorView) {
-      console.log(`Changing editor read only to ${isReadOnly}`);
       editorView.dispatch({
         effects: [
           editorReadOnlyCompartment.reconfigure(

--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -1,13 +1,14 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import classNames from 'classnames';
-import {EditorState, Extension} from '@codemirror/state';
+import {Compartment, EditorState, Extension} from '@codemirror/state';
 import {EditorView, ViewUpdate} from '@codemirror/view';
-import {useDispatch} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 import {editorConfig} from './editorConfig';
 import {darkMode as darkModeTheme} from './editorThemes';
 import {autocompletion} from '@codemirror/autocomplete';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import moduleStyles from './code-editor.module.scss';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 
 interface CodeEditorProps {
   onCodeChange: (code: string) => void;
@@ -27,6 +28,13 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
   const [didInit, setDidInit] = useState(false);
   const [editorView, setEditorView] = useState<EditorView | null>(null);
   const channelId = useAppSelector(state => state.lab.channel?.id);
+  const isReadOnly = useSelector(isReadOnlyWorkspace);
+
+  // These two compartments control read-only settings.
+  // Controls if you can type in the editor or not.
+  const editorReadOnlyCompartment = useMemo(() => new Compartment(), []);
+  // Controls if the dom is focusable or not (and therefore if a cursor is visible in the editor or not).
+  const editorEditableCompartment = useMemo(() => new Compartment(), []);
 
   useEffect(() => {
     if (editorRef.current === null || didInit) {
@@ -46,6 +54,13 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
       autocompletion(),
       ...editorConfigExtensions,
     ];
+
+    console.log(`Setting editor read only to ${isReadOnly}`);
+
+    editorExtensions.push(
+      editorReadOnlyCompartment.of(EditorState.readOnly.of(isReadOnly)),
+      editorEditableCompartment.of(EditorView.editable.of(!isReadOnly))
+    );
     if (darkMode) {
       editorExtensions.push(darkModeTheme);
     }
@@ -67,6 +82,9 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
     startCode,
     didInit,
     darkMode,
+    editorReadOnlyCompartment,
+    isReadOnly,
+    editorEditableCompartment,
   ]);
 
   // When we have a new channelId and/or start code, reset the editor with the start code.
@@ -82,6 +100,27 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
       });
     }
   }, [startCode, editorView, channelId]);
+
+  useEffect(() => {
+    if (editorView) {
+      console.log(`Changing editor read only to ${isReadOnly}`);
+      editorView.dispatch({
+        effects: [
+          editorReadOnlyCompartment.reconfigure(
+            EditorState.readOnly.of(isReadOnly)
+          ),
+          editorEditableCompartment.reconfigure(
+            EditorView.editable.of(!isReadOnly)
+          ),
+        ],
+      });
+    }
+  }, [
+    isReadOnly,
+    editorView,
+    editorReadOnlyCompartment,
+    editorEditableCompartment,
+  ]);
 
   return (
     <div


### PR DESCRIPTION
This PR enables Code Bridge to be in read only mode. It decides if it is in read-only mode based on the lab2 [isReadOnlyWorkspace](https://github.com/code-dot-org/code-dot-org/blob/047e757d09ffa022f28bf95cc79b338ca6f2de94/apps/src/lab2/lab2Redux.ts#L259) selector. The logic for this currently is if the level has a channel and the user is the owner of the channel, we are not in read-only mode. I updated this logic to also check that we are not in start mode (which has no channel) This turns exemplar and share modes in Code Bridge into view-only, which is what we want. As we add special level types (contained and submittable) we will need to update this selector.

The following happens in read only mode:
- The user cannot edit code
- The user cannot start over (button is gone)
- The user cannot do any file or folder operations (create, move, rename, delete) (the file menu is gone)
- The user can still open and close files in the editor, and expand and collapse folders in the file browser.
- We don't attempt to save to the project manager

Even after updating `useSource` to not save to the project manager while in read only mode, I saw a case where the project manager still attempted to save on reload (due to [this logic](https://github.com/code-dot-org/code-dot-org/blob/047e757d09ffa022f28bf95cc79b338ca6f2de94/apps/src/lab2/projects/ProjectContainer.tsx#L108-L116)). This causes a "you have unsaved changes" pop-up to appear every time you try to reload the page, because for some reason we think we have unsaved changes, but then when we try to save them we can't because the user doesn't own the channel. In order to avoid this I added a check in the project container to not execute that code if we are in read-only mode. This should not cause any issues besides avoiding an annoying pop-up.

## Links
- jira ticket: [CT-455](https://codedotorg.atlassian.net/browse/CT-455) covers making read-only mode. This work automatically completed [CT-608](https://codedotorg.atlassian.net/browse/CT-608), make exemplar view-only.

## Testing story
Tested that exemplars and share mode are read-only for python lab and exemplars are read only in web lab 2 (we haven't set up standalone projects in web lab 2 yet). I also verified other lab2 labs are unaffected.


## Follow-up work
This work was a prerequisite to getting contained and submittable levels working.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
