### PR TITLE
Set different breakpoints for Create menu on pegasus and dashboard headers

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -230,6 +230,12 @@ img.video_thumbnail {
     }
   }
 
+  @media screen and (max-width: 1120px) {
+    .create_menu {
+      display: none !important;
+    }
+  }
+
   .headerlinks {
     margin-inline-start: 1rem;
     display: flex;

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -611,6 +611,12 @@ nav.main #hamburger #hamburger-icon {
   margin-inline-start: 6px;
 }
 
+@media (max-width: 1023px) {
+  nav.main .create_menu {
+    display: none !important;
+  }
+}
+
 /* Show the hamburger on small desktop
   with appropriate links hidden */
 @media (min-width: 1024px) and (max-width: 1268px) {

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -193,8 +193,4 @@
       padding-left: 10px;
     }
   }
-
-  @media (max-width: 1023px) {
-    display: none !important;
-  }
 }


### PR DESCRIPTION
Forward fixes an issue from [this PR](https://github.com/code-dot-org/code-dot-org/pull/59016) that caused overlap in the header when translations are longer than English. 

- Puts the original `1120px` breakpoint back on studio.code.org
- Keeps the new `1023px` breakpoint on code.org
- Removes the shared breakpoint introduced [here](https://github.com/code-dot-org/code-dot-org/pull/59016/files#diff-ea5be2e2714a72efacd3ccb32d99e8a95695269b8e3335eee11572bfeb60d27a) on line 197 

## Links
Slack convo: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1717717958498509?thread_ts=1717716553.954559&cid=C0T0PNTM3)

## Testing story
Tested locally to make sure the header breakpoints still worked when signed out, signed in as a student, and signed in as a teacher

----

## Before
![screenshot_2024-06-06_at_4 51 40___pm_720](https://github.com/code-dot-org/code-dot-org/assets/9256643/230be15d-32ae-45cd-bd0f-1dcf317f920d)

## After
https://github.com/code-dot-org/code-dot-org/assets/9256643/a394d4d8-bf68-47fd-9ead-b31d7eee5783

