### PR TITLE
CAP State Policies now dynamic

### DIFF
--- a/dashboard/app/models/cap/user_event.rb
+++ b/dashboard/app/models/cap/user_event.rb
@@ -19,7 +19,7 @@
 #
 module CAP
   class UserEvent < ApplicationRecord
-    POLICIES = Policies::ChildAccount::STATE_POLICY.each_value.map {|policy| policy[:name]}.freeze
+    POLICIES = Policies::ChildAccount.state_policies.each_value.map {|policy| policy[:name]}.freeze
 
     NAMES = [
       PARENT_EMAIL_SUBMIT = 'parent_email_submit'.freeze,

--- a/dashboard/lib/cpa.rb
+++ b/dashboard/lib/cpa.rb
@@ -31,6 +31,8 @@ module Cpa
     #   “cpa_all_user_lockout”:         “2024-07-01T00:00:00MST”
     # }
     schedule = experiment_value('cpa_schedule', current_request)
+    # Ensure the schedule is a Hash
+    schedule = JSON.parse(schedule) unless schedule.nil? || schedule.is_a?(Hash)
     # override [String] configuration overrides if we are manually testing the
     # experiences. This parameter will default to the query string parameter or
     # cookie 'cpa_experience'.

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -27,19 +27,7 @@ class Policies::ChildAccount
   # P20-937 - We had a regression which we have chosen to mitigate by allowing
   # accounts created before the below date to have their lock-out delayed until
   # the CAP policy is set to lockout all users.
-  CPA_CREATED_AT_EXCEPTION_DATE = Date.parse('2024-05-26T00:00:00MST')
-
-  # The individual US State child account policy configuration
-  # max_age: the oldest age of the child at which this policy applies.
-  # start_date: the date on which this policy first went into effect.
-  STATE_POLICY = {
-    'CO' => {
-      name: 'CPA', # Colorado Privacy Act
-      max_age: 12,
-      lockout_date: DateTime.parse(DCDO.get('cpa_schedule', {Cpa::ALL_USER_LOCKOUT => Cpa::ALL_USER_LOCKOUT_DATE.iso8601})[Cpa::ALL_USER_LOCKOUT]),
-      start_date: DateTime.parse(DCDO.get('cpa_schedule', {Cpa::NEW_USER_LOCKOUT => Cpa::NEW_USER_LOCKOUT_DATE.iso8601})[Cpa::NEW_USER_LOCKOUT])
-    }
-  }.freeze
+  CPA_CREATED_AT_EXCEPTION_DATE = DateTime.parse('2024-05-26T00:00:00MST')
 
   # The delay is intended to provide notice to a parent
   # when a student may no longer be monitoring the "parent's email."
@@ -65,7 +53,7 @@ class Policies::ChildAccount
   # state missing
   # We use Colorado as it is the only start date we have for now
   def self.user_predates_state_collection?(user)
-    user.created_at < STATE_POLICY['CO'][:start_date]
+    user.created_at < state_policies['CO'][:start_date]
   end
 
   # 'cap-state-modal-rollout' should be a value in the range [0,100]
@@ -132,12 +120,29 @@ class Policies::ChildAccount
     end
   end
 
+  def self.state_policies
+    # The individual US State child account policy configuration
+    # name: the name of the policy
+    # max_age: the oldest age of the child at which this policy applies.
+    # lockout_date: the date at which we will begin to lockout all CPA users who
+    # are not in compliance with the policy.
+    # start_date: the date on which this policy first went into effect.
+    {
+      'CO' => {
+        name: 'CPA', # Colorado Privacy Act
+        max_age: 12,
+        lockout_date: DateTime.parse(DCDO.get('cpa_schedule', {Cpa::ALL_USER_LOCKOUT => Cpa::ALL_USER_LOCKOUT_DATE.iso8601})[Cpa::ALL_USER_LOCKOUT]),
+        start_date: DateTime.parse(DCDO.get('cpa_schedule', {Cpa::NEW_USER_LOCKOUT => Cpa::NEW_USER_LOCKOUT_DATE.iso8601})[Cpa::NEW_USER_LOCKOUT])
+      }
+    }
+  end
+
   def self.state_policy(user)
     # If the country_code is not set, then us_state value was inherited
     # from the teacher and we don't trust it.
     return unless user.country_code
     return unless user.us_state
-    STATE_POLICY[user.us_state]
+    state_policies[user.us_state]
   end
 
   # Check if parent permission is required for this account according to our

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -53,7 +53,7 @@ class Policies::ChildAccount
   # state missing
   # We use Colorado as it is the only start date we have for now
   def self.user_predates_state_collection?(user)
-    user.created_at < state_policies['CO'][:start_date]
+    user.created_at < state_policy(user)[:start_date]
   end
 
   # 'cap-state-modal-rollout' should be a value in the range [0,100]
@@ -131,8 +131,8 @@ class Policies::ChildAccount
       'CO' => {
         name: 'CPA', # Colorado Privacy Act
         max_age: 12,
-        lockout_date: DateTime.parse(DCDO.get('cpa_schedule', {Cpa::ALL_USER_LOCKOUT => Cpa::ALL_USER_LOCKOUT_DATE.iso8601})[Cpa::ALL_USER_LOCKOUT]),
-        start_date: DateTime.parse(DCDO.get('cpa_schedule', {Cpa::NEW_USER_LOCKOUT => Cpa::NEW_USER_LOCKOUT_DATE.iso8601})[Cpa::NEW_USER_LOCKOUT])
+        lockout_date: DateTime.parse(DCDO.get('cpa_schedule', {})[Cpa::ALL_USER_LOCKOUT] || Cpa::ALL_USER_LOCKOUT_DATE.iso8601),
+        start_date: DateTime.parse(DCDO.get('cpa_schedule', {})[Cpa::NEW_USER_LOCKOUT] || Cpa::NEW_USER_LOCKOUT_DATE.iso8601),
       }
     }
   end

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -53,7 +53,8 @@ class Policies::ChildAccount
   # state missing
   # We use Colorado as it is the only start date we have for now
   def self.user_predates_state_collection?(user)
-    user.created_at < state_policy(user)[:start_date]
+    # The date is the same as when CPA first started.
+    user.created_at < state_policies['CO'][:start_date]
   end
 
   # 'cap-state-modal-rollout' should be a value in the range [0,100]

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -107,6 +107,67 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
     assert failures.empty?, failures.join("\n")
   end
 
+  describe 'state_policies' do
+    let(:state_policies) {Policies::ChildAccount.state_policies}
+    let(:dcdo_cpa_schedule) {{}}
+
+    around do |test|
+      Timecop.freeze {test.call}
+    end
+
+    before do
+      DCDO.stubs(:get).with('cpa_schedule', {}).returns(dcdo_cpa_schedule)
+    end
+
+    describe 'for Colorado' do
+      let(:co_state_policy) {state_policies['CO']}
+      let(:default_start_date) {DateTime.parse('2023-07-01T00:00:00MST')}
+      let(:default_lockout_date) {DateTime.parse('2024-07-01T00:00:00MST')}
+
+      it 'contains expected max age' do
+        _(co_state_policy[:max_age]).must_equal 12
+      end
+
+      it 'contains expected name' do
+        _(co_state_policy[:name]).must_equal 'CPA'
+      end
+
+      it 'contains expected default start_date' do
+        _(co_state_policy[:start_date]).must_equal default_start_date
+      end
+
+      it 'contains expected default lockout_date' do
+        _(co_state_policy[:lockout_date]).must_equal default_lockout_date
+      end
+
+      context 'when DCDO cpa_schedule with only cpa_new_user_lockout is configured' do
+        let(:dcdo_cpa_schedule) do
+          {
+            'cpa_new_user_lockout' => cpa_new_user_lockout.iso8601
+          }
+        end
+        let(:cpa_new_user_lockout) {default_start_date.ago(100.days)}
+
+        it 'contains DCDO configured start_date' do
+          _(co_state_policy[:start_date]).must_equal cpa_new_user_lockout
+        end
+      end
+
+      context 'when DCDO cpa_schedule with only cpa_all_user_lockout is configured' do
+        let(:dcdo_cpa_schedule) do
+          {
+            'cpa_all_user_lockout' => cpa_all_user_lockout.iso8601
+          }
+        end
+        let(:cpa_all_user_lockout) {default_lockout_date.ago(21.days)}
+
+        it 'contains DCDO configured lockout_date' do
+          _(co_state_policy[:lockout_date]).must_equal cpa_all_user_lockout
+        end
+      end
+    end
+  end
+
   describe '.pre_lockout_user?' do
     let(:pre_lockout_user?) {Policies::ChildAccount.pre_lockout_user?(user)}
 

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -146,7 +146,7 @@ And(/^I create( as a parent)? a (young )?student( in Colorado)?( who has never s
   end
 
   # See Policies::ChildAccount::CPA_CREATED_AT_EXCEPTION_DATE
-  cpa_exception_date = Date.parse('2024-05-26T00:00:00MST')
+  cpa_exception_date = DateTime.parse('2024-05-26T00:00:00MST')
 
   if after_cpa_exception
     user_opts[:created_at] = cpa_exception_date


### PR DESCRIPTION
The Child Account Policy configuration for each US State was being frozen as a constant. This is a problem because some of the values are sourced from DCDO, so we expect these configurations to change if we change the DCDO value.

This fixes a few minor issues we noticed related to our Child Account Policy (CAP) code. 
* The CPA State Policies configuration now checks DCDO with every request.
* Use DateTime instead of Date because it can handle timezone names (We use MST for Colorado timezone).
* If an engineer uses the Query String or Cookie override for the `cpa_schedule` config, then it is a JSON serialized string and needs to be deserialized into an object.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
