### PR TITLE
[Python Lab] Add bubble choice fields to level edit page

### DIFF
--- a/dashboard/app/views/levels/editors/_pythonlab.html.haml
+++ b/dashboard/app/views/levels/editors/_pythonlab.html.haml
@@ -1,5 +1,6 @@
 = render partial: 'levels/editors/fields/long_instructions', locals: {f: f}
 = render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
+= render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/help_and_tips', locals: {f: f}
 = render partial: 'levels/editors/fields/pythonlab_fields', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}


### PR DESCRIPTION
Adds bubble choice fields to the level edit view. 
Task from ticket:
> Add support for making bubble choice levels in python lab, and ensure they work as expected. This may just be a matter of adding the `bubble_choice_sublevel` field to the edit page, as https://studio.code.org/s/allthethings/lessons/52/levels/8?section_id=1  is able to add a Python Lab level as a sub-level already.

<img width="788" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/fee4440b-2287-4a76-9449-a424d44a8e8f">
<img width="758" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/8b70c5cb-e615-4044-bfc9-1629893bc3da">
<img width="450" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/e20d1bef-1033-489f-a7c0-40d1517b0bac">


## Links

Jira - https://codedotorg.atlassian.net/browse/CT-619
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
