### PR TITLE
Speculative fix for flaky hamburger.feature UI test

### DIFF
--- a/dashboard/test/ui/features/foundations/hamburger.feature
+++ b/dashboard/test/ui/features/foundations/hamburger.feature
@@ -5,6 +5,7 @@ Feature: Hamburger dropdown
   Scenario: Signed out user in English should not see hamburger on large desktop
     Given I am on "http://code.org/"
     And I dismiss the language selector
+    And I change the browser window size to 1300 by 768
     Then I wait to see ".header_button"
     Then element "#hamburger-icon" is not visible
 


### PR DESCRIPTION
This is a speculative fix for the `Signed out user in English should not see hamburger on large desktop` test on `hamburger.feature` UI test. I think what's happening is that the desktop breakpoint might be `1024px` for UI tests, and at this breakpoint the hamburger should show up, so I made the breakpoint larger for this test specifically. 

See the passing tests on SauceLabs:
- [Firefox](https://app.saucelabs.com/tests/de944a92023e4f6fb18a2c6a05e53178)
- [Safari](https://app.saucelabs.com/tests/795228b804fe4001b3251e74db2a1e4d) 
- [Chrome](https://app.saucelabs.com/tests/df8212d4a7034b139a23d9e37584b50c)

## Links
Jira ticket: [ACQ-1976](https://codedotorg.atlassian.net/browse/ACQ-1976)
Slack convo: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1717734374429929?thread_ts=1717716553.954559&cid=C0T0PNTM3)
Failing test: [here](https://cucumber-logs.s3.amazonaws.com/test/test/Firefox_foundations_hamburger_output.html?versionId=y5SakbqSY5C1kAqwEJ.aJmccCfDWcr7s)

## Testing story
Tested locally on SauceLabs