### PR TITLE
Music: use callouts updates

### DIFF
--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -137,17 +137,6 @@ const optionsList = [
       {value: 'true', description: 'Original timeline.'},
     ],
   },
-  {
-    name: 'clickable-text-with-glow',
-    type: 'radio',
-    values: [
-      {
-        value: 'false',
-        description: 'No glow for clickable text in instructions (default).',
-      },
-      {value: 'true', description: 'Glow for clickable text in instructions.'},
-    ],
-  },
 ];
 
 export default class MusicMenu extends React.Component {

--- a/apps/src/templates/EnhancedSafeMarkdown.jsx
+++ b/apps/src/templates/EnhancedSafeMarkdown.jsx
@@ -3,15 +3,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {connect} from 'react-redux';
 
-import {queryParams} from '@cdo/apps/code-studio/utils';
 import {openDialog} from '@cdo/apps/redux/instructionsDialog';
 
 import SafeMarkdown from './SafeMarkdown';
 import {renderExpandableImages} from './utils/expandableImages';
-
-// A variant for clickable text that shows a glow on hover and appearance.
-const showClickableTextWithGlow =
-  queryParams('clickable-text-with-glow') === 'true';
 
 export class UnconnectedExpandableImagesWrapper extends React.Component {
   static propTypes = {
@@ -94,11 +89,9 @@ export class ClickableTextWrapper extends React.Component {
     const clickableTextAll = node.querySelectorAll('b.clickable-text');
     clickableTextAll.forEach((clickableText, index) => {
       const id = clickableText.dataset.id;
-      if (showClickableTextWithGlow) {
-        const extraClass = ` clickable-text-with-glow clickable-text-${index}`;
-        if (!clickableText.className.includes(extraClass)) {
-          clickableText.className += extraClass;
-        }
+      const extraClass = ` clickable-text-with-glow clickable-text-${index}`;
+      if (!clickableText.className.includes(extraClass)) {
+        clickableText.className += extraClass;
       }
       clickableText.onclick = () => this.props.handleInstructionsTextClick(id);
     });

--- a/apps/static/music/music-callout-arrow.png
+++ b/apps/static/music/music-callout-arrow.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2877c4c1f66db135a26ddec49571756c2be5617403dad996c037dab010e75928
-size 4697
+oid sha256:d01fbda4a8e0ca50c085697077d8c33f4af97ba17e34c7639a26a21cba00e403
+size 5268

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -4109,25 +4109,15 @@ a {
   }
 }
 
-$clickable-text-glow: 0 0 1px $realyellow,
-  0 0 2px $realyellow,
-  0 0 3px $realyellow,
-  0 0 4px $realyellow,
-  0 0 5px $realyellow,
-  0 0 6px $realyellow,
-  0 0 7px $realyellow,
-  0 0 8px $realyellow,
-  0 0 9px $realyellow;
-
 @keyframes clickable-text-glow-keyframes {
   0% {
-    text-shadow: none;
+    color: initial;
   }
   50% {
-    text-shadow: $clickable-text-glow;
+    color: $light_primary_500;
   }
   100% {
-    text-shadow: none;
+    color: initial;
   }
 }
 
@@ -4140,7 +4130,7 @@ $clickable-text-glow: 0 0 1px $realyellow,
       animation: clickable-text-glow-keyframes 2s ease-in-out;
 
       &:hover {
-        text-shadow: $clickable-text-glow;
+        color: $light_primary_500;
       }
     }
   }


### PR DESCRIPTION
This uses the callouts updates added in https://github.com/code-dot-org/code-dot-org/pull/59026, though instead of a yellow glow, it uses a brand-colour for the text itself, and updates the arrow to match.

https://github.com/code-dot-org/code-dot-org/assets/2205926/3ef3f3a2-9f31-487a-b802-989fe5800e29

