### PR TITLE
LTI account linking for Clever

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -26,6 +26,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     user = find_user_by_credential
     if user
+      return link_accounts user if should_link_accounts?
       sign_in_clever user
     else
       sign_up_clever

--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -6,7 +6,7 @@
 .flex-container
   #oauth-side.devise-links
     %h3= t('lti.account_linking.connect_with')
-    - [:google_oauth2, :microsoft_v2_auth, :facebook].each do |provider|
+    - [:google_oauth2, :microsoft_v2_auth, :facebook, :clever].each do |provider|
       = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
         = image_tag("oauth/#{provider}.svg")
         = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))


### PR DESCRIPTION
Adds the Clever button to the linking page, and adds the call to the account linker to the Clever oauth callback.

<img width="896" alt="Screenshot 2024-06-07 at 1 09 09 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/8744ecd5-2174-4f47-b9a0-70835ff62bd7">

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-975)

## Testing story

```
bundle exec spring testunit test/**/*lti*_test.rb test/**/lti/**/*_test.rb
Running via Spring preloader in process 95252
Started with run options --seed 3053
  235/235: [================================================] 100% Time: 00:00:15, Time: 00:00:15

Finished in 15.26083s
235 tests, 1238 assertions, 0 failures, 0 errors, 0 skips
```

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
