### PR TITLE
P20-987: Add ability to set DCDO via cookie for testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,7 @@ group :development, :test do
   gem 'minitest-spec-context', '~> 0.0.3'
   gem 'minitest-stub-const', '~> 0.6'
   gem 'net-http-persistent'
+  gem 'request_store', '~> 1.6.0', require: false
   gem 'rinku'
   gem 'rspec', require: false
   gem 'selenium-webdriver', '~> 4.0'

--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,6 @@ group :development, :test do
   gem 'minitest-spec-context', '~> 0.0.3'
   gem 'minitest-stub-const', '~> 0.6'
   gem 'net-http-persistent'
-  gem 'request_store', '~> 1.6.0', require: false
   gem 'rinku'
   gem 'rspec', require: false
   gem 'selenium-webdriver', '~> 4.0'
@@ -259,6 +258,7 @@ end
 # Reduce volume of production logs
 # Ref: https://github.com/roidrage/lograge/pull/252
 gem 'lograge', github: 'code-dot-org/lograge', ref: 'debug_exceptions'
+gem 'request_store', '~> 1.6.0', require: false
 
 # Enforce SSL
 gem 'rack-ssl-enforcer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1115,6 +1115,7 @@ DEPENDENCIES
   redis (~> 4.8.1)
   redis-actionpack (~> 5.4.0)
   redis-slave-read!
+  request_store (~> 1.6.0)
   require_all
   rerun
   responders (~> 3.0)

--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -83,4 +83,7 @@ Dashboard::Application.configure do
   # queue adapter in development, comment out this line and make sure you have
   # run `bin/delayed_job start` or rake build.
   config.active_job.queue_adapter = :async
+
+  require 'cdo/rack/cookie_dcdo'
+  config.middleware.insert_after ActionDispatch::RequestId, Rack::CookieDCDO
 end

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -91,4 +91,7 @@ Dashboard::Application.configure do
   end
 
   config.experiment_cache_time_seconds = 0
+
+  require 'cdo/rack/cookie_dcdo'
+  config.middleware.insert_after ActionDispatch::RequestId, Rack::CookieDCDO
 end

--- a/dashboard/test/ui/features/cookie_dcdo.feature
+++ b/dashboard/test/ui/features/cookie_dcdo.feature
@@ -4,12 +4,12 @@ Feature: Cookie DCDO
     Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":null"
 
     # Tests assigning of a cookie DCDO flag
-    When I set the DCDO flag "cookie_dcdo_test" to "Cookie DCDO assigning works"
+    When I set the DCDO key "cookie_dcdo_test" to "Cookie DCDO assigning works"
     And I reload the page
     Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":"Cookie DCDO assigning works""
 
     # Tests re-assigning of a cookie DCDO flag
-    When I set the DCDO flag "cookie_dcdo_test" to "{"Cookie DCDO re-assigning":"works"}"
+    When I set the DCDO key "cookie_dcdo_test" to "{"Cookie DCDO re-assigning":"works"}"
     And I reload the page
     Then element "script[data-dcdo]" attr "data-dcdo" includes ""Cookie DCDO re-assigning":"works""
 

--- a/dashboard/test/ui/features/cookie_dcdo.feature
+++ b/dashboard/test/ui/features/cookie_dcdo.feature
@@ -1,0 +1,19 @@
+Feature: Cookie DCDO
+  Scenario: Cookie DCDO flag is set
+    Given I am on "http://studio.code.org/users/sign_in"
+    Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":null"
+
+    # Tests assigning of a cookie DCDO flag
+    When I set the DCDO flag "cookie_dcdo_test" to "Cookie DCDO assigning works"
+    And I reload the page
+    Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":"Cookie DCDO assigning works""
+
+    # Tests re-assigning of a cookie DCDO flag
+    When I set the DCDO flag "cookie_dcdo_test" to "{"Cookie DCDO re-assigning":"works"}"
+    And I reload the page
+    Then element "script[data-dcdo]" attr "data-dcdo" includes ""Cookie DCDO re-assigning":"works""
+
+    # Tests cleaning of a cookie DCDO flag
+    When I delete the cookie named "DCDO"
+    And I reload the page
+    Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":null"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1066,7 +1066,7 @@ def set_cookie_dcdo(key, value)
   end
 end
 
-Given(/^I set the DCDO flag "([^"]*)" to "(.*)"$/) do |key, json|
+Given(/^I set the DCDO key "([^"]*)" to "(.*)"$/) do |key, json|
   begin
     value = JSON.parse(json)
   rescue JSON::ParserError

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1058,12 +1058,7 @@ def set_cookie_dcdo(key, value)
 
   cookie_dcdo[key] = value
 
-  begin
-    set_cookie('DCDO', cookie_dcdo.to_json)
-  rescue Selenium::WebDriver::Error::InvalidCookieDomainError
-    navigate_to replace_hostname('http://studio.code.org')
-    retry
-  end
+  set_cookie('DCDO', cookie_dcdo.to_json)
 end
 
 Given(/^I set the DCDO key "([^"]*)" to "(.*)"$/) do |key, json|

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -844,6 +844,22 @@ Then /^element "([^"]*)" is (not )?displayed$/ do |selector, negation|
   expect(element_displayed?(selector)).to eq(negation.nil?)
 end
 
+Then /^element "([^"]*)" attr "([^"]*)" includes (no )?"(.*)"$/ do |selector, attr, negation, attr_json|
+  actual_attr_value = @browser.find_element(:css, selector).attribute(attr)
+  expected_attr_value =
+    begin
+      JSON.parse(attr_json)
+    rescue JSON::ParserError
+      attr_json
+    end
+
+  if negation
+    expect(actual_attr_value).not_to include(expected_attr_value)
+  else
+    expect(actual_attr_value).to include(expected_attr_value)
+  end
+end
+
 And(/^I select age (\d+) in the age dialog/) do |age|
   dropdown_selection = age
   if age == 21
@@ -1030,6 +1046,34 @@ def set_cookie(key, value)
   end
 
   @browser.manage.add_cookie params
+end
+
+def set_cookie_dcdo(key, value)
+  cookie_dcdo =
+    begin
+      JSON.parse(@browser.manage.cookie_named('DCDO').try(:[], :value).presence || '{}')
+    rescue Selenium::WebDriver::Error::NoSuchCookieError
+      {}
+    end
+
+  cookie_dcdo[key] = value
+
+  begin
+    set_cookie('DCDO', cookie_dcdo.to_json)
+  rescue Selenium::WebDriver::Error::InvalidCookieDomainError
+    navigate_to replace_hostname('http://studio.code.org')
+    retry
+  end
+end
+
+Given(/^I set the DCDO flag "([^"]*)" to "(.*)"$/) do |key, json|
+  begin
+    value = JSON.parse(json)
+  rescue JSON::ParserError
+    value = json
+  end
+
+  set_cookie_dcdo(key, value)
 end
 
 And(/^I set the language cookie$/) do

--- a/lib/cdo/rack/cookie_dcdo.rb
+++ b/lib/cdo/rack/cookie_dcdo.rb
@@ -1,0 +1,32 @@
+require 'json'
+require 'request_store'
+require 'dynamic_config/dcdo'
+
+# This middleware enables the setting of DCDO via cookies for testing purposes.
+# See: 'dashboard/test/ui/features/cookie_dcdo.rb'
+module Rack
+  class CookieDCDO
+    def initialize(app)
+      modify_dcdo
+
+      @app = app
+    end
+
+    def call(env)
+      # Stores the cookie DCDO data per request.
+      RequestStore.store[:DCDO] = JSON.parse(Rack::Request.new(env).cookies['DCDO'] || '{}')
+
+      @app.call(env)
+    ensure
+      # Clears the cookie DCDO after the request to avoid data leaking.
+      RequestStore.store[:DCDO] = nil
+    end
+
+    # Redefines `DCDO#get` to return the cookie DCDO value if it exists;
+    private def modify_dcdo
+      DCDO.define_singleton_method(:get) do |key, *args|
+        RequestStore.store[:DCDO]&.key?(key) ? RequestStore.store[:DCDO][key] : super(key, *args)
+      end
+    end
+  end
+end

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -55,6 +55,8 @@ class DCDOBase < DynamicConfigBase
       'student-email-post-enabled': DCDO.get('student-email-post-enabled', false),
       'progress-v2-metadata-enabled': DCDO.get('progress-v2-metadata-enabled', false),
       'show-updated-lms-content': DCDO.get('show-updated-lms-content', false),
+      # Used to test DCDO setting via cookie. See: 'dashboard/test/ui/features/cookie_dcdo.rb'
+      cookie_dcdo_test: DCDO.get('cookie_dcdo_test', nil),
     }
   end
 end

--- a/lib/dynamic_config/dynamic_config_base.rb
+++ b/lib/dynamic_config/dynamic_config_base.rb
@@ -16,6 +16,8 @@ class DynamicConfigBase
   # @param key [String]
   # @param default
   # @returns the stored value at key
+  # @note This method is redefined in Rack::CookieDCDO to return the cookie DCDO value for testing, if it exists
+  # @see Rack::CookieDCDO#modify_dcdo
   def get(key, default)
     raise ArgumentError unless key.is_a? String
     value = @datastore_cache.get(key)


### PR DESCRIPTION
## Summary
Allows us to set DCDO via cookies for testing purposes in the `test` and `development` environments:
https://github.com/code-dot-org/code-dot-org/blob/79996e15f334d4ce49bda676ee8482a615696621/dashboard/test/ui/features/cookie_dcdo.feature#L7

## Links
- JIRA task: [P20-987](https://codedotorg.atlassian.net/browse/P20-987)