### PR TITLE
Add experiment for allowing bigger playspace in Sprite Lab

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -99,8 +99,11 @@ var copyrightStrings;
  */
 const MIN_WIDTH = 1400;
 const DEFAULT_MOBILE_NO_PADDING_SHARE_WIDTH = 400;
-// export const MAX_VISUALIZATION_WIDTH = 800;
-export const MAX_VISUALIZATION_WIDTH = 0.75 * window.innerHeight;
+export const MAX_VISUALIZATION_WIDTH = experiments.isEnabled(
+  experiments.BIG_PLAYSPACE
+)
+  ? 0.75 * window.innerHeight
+  : 400;
 export const MIN_VISUALIZATION_WIDTH = 200;
 
 /**
@@ -2009,8 +2012,10 @@ StudioApp.prototype.setConfigValues_ = function (config) {
   this.startBlocks_ =
     config.level.lastAttempt || config.level.startBlocks || '';
   this.vizAspectRatio = config.vizAspectRatio || 1.0;
-  // this.nativeVizWidth = config.nativeVizWidth || this.maxVisualizationWidth;
-  this.nativeVizWidth = 400;
+  this.nativeVizWidth = config.nativeVizWidth || this.maxVisualizationWidth;
+  if (experiments.isEnabled(experiments.BIG_PLAYSPACE)) {
+    this.nativeVizWidth = 400;
+  }
 
   if (config.level.initializationBlocks) {
     var xml = parseXmlElement(config.level.initializationBlocks);

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -99,7 +99,7 @@ var copyrightStrings;
  */
 const MIN_WIDTH = 1400;
 const DEFAULT_MOBILE_NO_PADDING_SHARE_WIDTH = 400;
-export const MAX_VISUALIZATION_WIDTH = 400;
+export const MAX_VISUALIZATION_WIDTH = 800;
 export const MIN_VISUALIZATION_WIDTH = 200;
 
 /**
@@ -2004,7 +2004,8 @@ StudioApp.prototype.setConfigValues_ = function (config) {
   this.startBlocks_ =
     config.level.lastAttempt || config.level.startBlocks || '';
   this.vizAspectRatio = config.vizAspectRatio || 1.0;
-  this.nativeVizWidth = config.nativeVizWidth || this.maxVisualizationWidth;
+  // this.nativeVizWidth = config.nativeVizWidth || this.maxVisualizationWidth;
+  this.nativeVizWidth = 400;
 
   if (config.level.initializationBlocks) {
     var xml = parseXmlElement(config.level.initializationBlocks);

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1525,6 +1525,10 @@ StudioApp.prototype.resizeVisualization = function (width) {
   visualizationColumn.style.maxWidth = newVizWidth + vizSideBorderWidth + 'px';
   visualization.style.maxWidth = newVizWidthString;
   visualization.style.maxHeight = newVizHeightString;
+  if (experiments.isEnabled(experiments.BIG_PLAYSPACE)) {
+    visualization.style.width = newVizWidthString;
+    visualization.style.height = newVizHeightString;
+  }
 
   var scale = newVizWidth / this.nativeVizWidth;
   getStore().dispatch(setVisualizationScale(scale));

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -99,7 +99,8 @@ var copyrightStrings;
  */
 const MIN_WIDTH = 1400;
 const DEFAULT_MOBILE_NO_PADDING_SHARE_WIDTH = 400;
-export const MAX_VISUALIZATION_WIDTH = 800;
+// export const MAX_VISUALIZATION_WIDTH = 800;
+export const MAX_VISUALIZATION_WIDTH = 0.75 * window.innerHeight;
 export const MIN_VISUALIZATION_WIDTH = 200;
 
 /**

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -4,8 +4,18 @@ import classNames from 'classnames';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
-import AnimationTab from './AnimationTab/AnimationTab';
+
+import experiments from '@cdo/apps/util/experiments';
 import StudioAppWrapper from '@cdo/apps/templates/StudioAppWrapper';
+import InstructionsWithWorkspace from '@cdo/apps/templates/instructions/InstructionsWithWorkspace';
+import {isResponsiveFromState} from '@cdo/apps/templates/ProtectedVisualizationDiv';
+import CodeWorkspace from '@cdo/apps/templates/CodeWorkspace';
+import {getManifest} from '@cdo/apps/assetManagement/animationLibraryApi';
+import ModalFunctionEditor from '@cdo/apps/blockly/components/ModalFunctionEditor';
+import IFrameEmbedOverlay from '@cdo/apps/templates/IFrameEmbedOverlay';
+import VisualizationResizeBar from '@cdo/apps/lib/ui/VisualizationResizeBar';
+
+import AnimationTab from './AnimationTab/AnimationTab';
 import ErrorDialogStack from './ErrorDialogStack';
 import AnimationJsonViewer from './AnimationJsonViewer';
 import {
@@ -16,15 +26,8 @@ import {
 } from './constants';
 import P5LabVisualizationHeader from './P5LabVisualizationHeader';
 import P5LabVisualizationColumn from './P5LabVisualizationColumn';
-import InstructionsWithWorkspace from '@cdo/apps/templates/instructions/InstructionsWithWorkspace';
-import {isResponsiveFromState} from '@cdo/apps/templates/ProtectedVisualizationDiv';
-import CodeWorkspace from '@cdo/apps/templates/CodeWorkspace';
 import {allowAnimationMode} from './stateQueries';
-import IFrameEmbedOverlay from '@cdo/apps/templates/IFrameEmbedOverlay';
-import VisualizationResizeBar from '@cdo/apps/lib/ui/VisualizationResizeBar';
 import AnimationPicker, {PICKER_TYPE} from './AnimationPicker/AnimationPicker';
-import {getManifest} from '@cdo/apps/assetManagement/animationLibraryApi';
-import ModalFunctionEditor from '@cdo/apps/blockly/components/ModalFunctionEditor';
 
 /**
  * Top-level React wrapper for GameLab
@@ -138,7 +141,11 @@ class P5LabView extends React.Component {
         <div
           id="visualizationColumn"
           className={visualizationColumnClassNames}
-          style={visualizationColumnStyle}
+          style={
+            experiments.isEnabled(experiments.BIG_PLAYSPACE)
+              ? {}
+              : visualizationColumnStyle
+          }
         >
           <P5LabVisualizationHeader labType={this.props.labType} />
           <P5LabVisualizationColumn

--- a/apps/src/p5lab/constants.js
+++ b/apps/src/p5lab/constants.js
@@ -15,7 +15,7 @@ export const P5LabType = utils.makeEnum('GAMELAB', 'SPRITELAB', 'POETRY');
 export const CURRENT_ANIMATION_TYPE = utils.makeEnum('default', 'background');
 
 /** @const {number} */
-export const APP_WIDTH = 400;
+export const APP_WIDTH = 800;
 
 /** @const {number} */
 export const APP_HEIGHT = 400;

--- a/apps/src/p5lab/constants.js
+++ b/apps/src/p5lab/constants.js
@@ -15,7 +15,7 @@ export const P5LabType = utils.makeEnum('GAMELAB', 'SPRITELAB', 'POETRY');
 export const CURRENT_ANIMATION_TYPE = utils.makeEnum('default', 'background');
 
 /** @const {number} */
-export const APP_WIDTH = 800;
+export const APP_WIDTH = 400;
 
 /** @const {number} */
 export const APP_HEIGHT = 400;

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -60,6 +60,8 @@ experiments.KEYBOARD_NAVIGATION = 'blockly_keyboard';
 experiments.SECTION_PROGRESS_V2 = 'section_progress_v2';
 // Enables a user to utilize the new school association flow
 experiments.SCHOOL_ASSOCIATION_V2 = 'school_association_v2';
+// Allows the playspace to be dragged to take up a larger portion of the screen
+experiments.BIG_PLAYSPACE = 'bigPlayspace';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -427,7 +427,7 @@ html[dir="rtl"] div#visualizationResizeBar {
 
 #visualization {
   position: relative;
-  height: 800px;
+  height: 400px;
   margin-bottom: 5px;
 }
 

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -427,7 +427,7 @@ html[dir="rtl"] div#visualizationResizeBar {
 
 #visualization {
   position: relative;
-  height: 400px;
+  height: 800px;
   margin-bottom: 5px;
 }
 


### PR DESCRIPTION
Adds an experiment flag (`?enableExperiments=bigPlayspace`) that allows the playspace to be expanded up to a width of 75% of the viewport height (assumes that the limiting/smaller screen dimension in a visualization where height and width are the same is the height).

This is definitely still rough around the edges (eg, if you enable this experiment and view other lab types like App Lab, you get funky behavior), but the goal here is get something in front of curriculum and design folks to critique and see if it fits their needs.

https://github.com/code-dot-org/code-dot-org/assets/25372625/71e8c113-7041-4a9d-9ef9-06d34bff9033

## Links

- jira: https://codedotorg.atlassian.net/browse/LABS-858

## Testing story

I tested manually on a Sprite Lab allthethings level as well as two levels that were called out by curriculum as potentially being positively impacted by this change:
- /s/allthethings/lessons/36/levels/4
- /s/k5-ai-data-2024/lessons/1/levels/2
- /s/coursee-2023/lessons/5/levels/1

## Follow-up work

We'll need to do a lot more experimentation across device types, screen sizes, labs, etc. before we would ship a change this this without an experiment flag. I'm also not super happy with the scaling/resolution of the playspace at larger widths, so that's something else we'd want to look at. We'd maybe want a better experience for what happens to the workspace/instructions at these larger sizes (eg, full collapse button?) as well. This is probably not a comprehensive list of things we'd want to follow up on before making this change broadly :).
