### PR TITLE
Lab2: tidy up types

### DIFF
--- a/apps/src/lab2/constants.ts
+++ b/apps/src/lab2/constants.ts
@@ -27,3 +27,6 @@ export enum PERMISSIONS {
 export const START_SOURCES = 'start_sources';
 
 export const LABS_USING_NEW_SHARE_DIALOG = ['music', 'pythonlab'];
+
+// Text-based labs that are currently supported by lab2.
+export const TEXT_BASED_LABS: AppName[] = ['aichat', 'pythonlab', 'weblab2'];

--- a/apps/src/lab2/progress/ProgressContainer.tsx
+++ b/apps/src/lab2/progress/ProgressContainer.tsx
@@ -8,7 +8,6 @@ import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import React, {useCallback, useEffect, useRef} from 'react';
 import {useSelector} from 'react-redux';
 import {setValidationState} from '../lab2Redux';
-import {ProjectLevelData} from '../types';
 
 interface ProgressContainerProps {
   children: React.ReactNode;
@@ -43,21 +42,13 @@ const ProgressContainer: React.FunctionComponent<ProgressContainerProps> = ({
     new ProgressManager(onProgressChange)
   );
 
-  const levelDataValidations = useAppSelector(
-    state =>
-      (state.lab.levelProperties?.levelData as ProjectLevelData | undefined)
-        ?.validations
-  );
   const levelValidations = useAppSelector(
     state => state.lab.levelProperties?.validations
   );
 
   useEffect(() => {
-    // Use validations on level properties if present, otherwise fallback to validations in level data.
-    progressManager.current.onLevelChange(
-      levelValidations || levelDataValidations
-    );
-  }, [levelValidations, levelDataValidations]);
+    progressManager.current.onLevelChange(levelValidations);
+  }, [levelValidations]);
 
   return (
     <ProgressManagerContext.Provider value={progressManager.current}>

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -12,7 +12,7 @@
  */
 import {SourcesStore} from './SourcesStore';
 import {ChannelsStore} from './ChannelsStore';
-import {Channel, Project, ProjectSources} from '../types';
+import {Channel, ProjectAndSources, ProjectSources} from '../types';
 import {currentLocation} from '@cdo/apps/utils';
 import LabMetricsReporter from '../Lab2MetricsReporter';
 import {ValidationError} from '../responseValidators';
@@ -72,7 +72,7 @@ export default class ProjectManager {
   }
 
   // Load the project from the sources and channels store.
-  async load(): Promise<Project> {
+  async load(): Promise<ProjectAndSources> {
     if (this.destroyed) {
       this.throwErrorIfDestroyed('load');
     }

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -143,8 +143,6 @@ export interface LevelProperties {
   toolboxBlocks?: string;
   source?: MultiFileSource;
   sharedBlocks?: BlockDefinition[];
-  // We are moving level validations out of level data and into level properties.
-  // Temporarily keeping them in both places to avoid breaking existing code.
   validations?: Validation[];
   // An optional URL that allows the user to skip the progression.
   skipUrl?: string;

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -8,8 +8,10 @@
 // The library data should definitely live elsewhere.
 
 import {BlockDefinition} from '@cdo/apps/blockly/types';
-import {PanelsLevelData} from '@cdo/apps/panels/types';
 
+/// ------ PROJECTS ------ ///
+
+/** Identifies a project. Corresponds to the "value" JSON column for the entry in the projects table. */
 export interface Channel {
   id: string;
   name: string;
@@ -28,6 +30,15 @@ export interface Channel {
 
 export type DefaultChannel = Pick<Channel, 'name'>;
 
+/** A project and its corresponding sources if present, fetched together when loading a level. */
+export interface ProjectAndSources {
+  // When projects are loaded for the first time, sources may not be present
+  sources?: ProjectSources;
+  channel: Channel;
+}
+
+/// ------ SOURCES ------ ///
+
 // Represents the structure of the full project sources object (i.e. the main.json file)
 export interface ProjectSources {
   // Source code can either be a string or a nested JSON object (for multi-file).
@@ -38,7 +49,7 @@ export interface ProjectSources {
 }
 
 // We will eventually make this a union type to include other source types.
-export type Source = BlocklySource;
+export type Source = BlocklySource | MultiFileSource;
 
 export interface SourceUpdateOptions {
   currentVersion: string;
@@ -47,11 +58,7 @@ export interface SourceUpdateOptions {
   tabId: string | null;
 }
 
-export interface Project {
-  // When projects are loaded for the first time, sources may not be present
-  sources?: ProjectSources;
-  channel: Channel;
-}
+// -- BLOCKLY -- //
 
 export interface BlocklySource {
   blocks: {
@@ -60,6 +67,23 @@ export interface BlocklySource {
   };
   variables: BlocklyVariable[];
 }
+
+export interface BlocklyBlock {
+  type: string;
+  id: string;
+  x: number;
+  y: number;
+  next: {
+    block: BlocklyBlock;
+  };
+}
+
+export interface BlocklyVariable {
+  name: string;
+  id: string;
+}
+
+// -- MULTI-FILE -- //
 
 export type FileId = string;
 export type FolderId = string;
@@ -98,34 +122,7 @@ export interface ProjectFolder {
   open?: boolean;
 }
 
-export interface BlocklyBlock {
-  type: string;
-  id: string;
-  x: number;
-  y: number;
-  next: {
-    block: BlocklyBlock;
-  };
-}
-
-export interface BlocklyVariable {
-  name: string;
-  id: string;
-}
-
-// TODO: these are not all the properties of the level.
-// Fill this in as we need them.
-export interface Level {
-  projectType: ProjectType;
-  isK1: boolean;
-  standaloneAppName: StandaloneAppName;
-  useContractEditor: boolean;
-  // Minecraft specific properties
-  isAgentLevel: boolean;
-  isEventLevel: boolean;
-  isConnectionLevel: boolean;
-  isAquaticLevel: boolean;
-}
+/// ------ LEVELS ------ ///
 
 /**
  * Labs may extend this type to add lab-specific properties.
@@ -166,8 +163,6 @@ export interface LevelProperties {
 // Level configuration data used by project-backed labs that don't require
 // reloads between levels. Labs may define more specific fields.
 export interface ProjectLevelData {
-  text?: string;
-  validations?: Validation[];
   startSources: Source;
 }
 
@@ -178,38 +173,7 @@ export interface VideoLevelData {
   download: string;
 }
 
-// TODO: Add AichatLevelData.
-
-export type LevelData = ProjectLevelData | VideoLevelData | PanelsLevelData;
-
-// A validation condition.
-export interface Condition {
-  name: string;
-  value?: string | number;
-}
-
-export interface ConditionType {
-  name: string;
-  valueType?: 'string' | 'number';
-}
-
-// Validation in the level.
-export interface Validation {
-  conditions: Condition[];
-  message: string;
-  next: boolean;
-  key: string;
-}
-
-// TODO: these are not all the properties of app options.
-// Fill this in as we need them.
-export interface AppOptions {
-  app: AppName;
-  level: Level;
-  skinId: string;
-  droplet: boolean;
-  channel: string;
-}
+export type LevelData = ProjectLevelData | VideoLevelData;
 
 export type ProjectType =
   | AppName
@@ -265,6 +229,29 @@ export type StandaloneAppName =
   | 'time_capsule'
   | 'dance';
 
+/// ------ VALIDATIONS ------ ///
+
+// A validation condition.
+export interface Condition {
+  name: string;
+  value?: string | number;
+}
+
+export interface ConditionType {
+  name: string;
+  valueType?: 'string' | 'number';
+}
+
+// Validation in the level.
+export interface Validation {
+  conditions: Condition[];
+  message: string;
+  next: boolean;
+  key: string;
+}
+
+/// ------ MISC ------ ///
+
 export enum ProjectManagerStorageType {
   LOCAL = 'LOCAL',
   REMOTE = 'REMOTE',
@@ -280,6 +267,3 @@ export interface ExtraLinksData {
     path: string;
   }[];
 }
-
-// Text-based labs that are currently supported by lab2.
-export const TEXT_BASED_LABS: AppName[] = ['aichat', 'pythonlab', 'weblab2'];

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -47,7 +47,6 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   imagePopOutDirection,
   handleInstructionsTextClick,
 }) => {
-  // Prefer using long instructions if available, otherwise fall back to level data text.
   const instructionsText = useSelector(
     (state: {lab: LabState}) => state.lab.levelProperties?.longInstructions
   );

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -8,7 +8,6 @@ import {nextLevelId} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import {LabState} from '../../lab2Redux';
-import {ProjectLevelData} from '../../types';
 import {ThemeContext} from '../ThemeWrapper';
 const commonI18n = require('@cdo/locale');
 
@@ -50,10 +49,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
 }) => {
   // Prefer using long instructions if available, otherwise fall back to level data text.
   const instructionsText = useSelector(
-    (state: {lab: LabState}) =>
-      state.lab.levelProperties?.longInstructions ||
-      (state.lab.levelProperties?.levelData as ProjectLevelData | undefined)
-        ?.text
+    (state: {lab: LabState}) => state.lab.levelProperties?.longInstructions
   );
   const hasNextLevel = useSelector(state => nextLevelId(state) !== undefined);
   const {hasConditions, message, satisfied, index} = useSelector(

--- a/apps/src/lab2/views/dialogs/StartOverDialog.tsx
+++ b/apps/src/lab2/views/dialogs/StartOverDialog.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import {BaseDialogProps} from './DialogManager';
 import moduleStyles from './confirm-dialog.module.scss';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {TEXT_BASED_LABS} from '@cdo/apps/lab2/types';
-const commonI18n = require('@cdo/locale');
+import {TEXT_BASED_LABS} from '../../constants';
+import {commonI18n} from '@cdo/apps/types/locale';
 
 // Lab-specific messages for starting over.
 const LAB_SPECIFIC_MESSAGES: {[key: string]: string} = {

--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -9,7 +9,7 @@ import {
   sendSuccessReport,
   navigateToNextLevel,
 } from '@cdo/apps/code-studio/progressRedux';
-import {PanelsLevelData, PanelsLevelProperties} from './types';
+import {PanelsLevelProperties} from './types';
 import PanelsView from './PanelsView';
 import useWindowSize from '../util/hooks/useWindowSize';
 import {
@@ -24,9 +24,7 @@ const PanelsLabView: React.FunctionComponent = () => {
 
   const panels = useAppSelector(
     state =>
-      (state.lab.levelProperties as PanelsLevelProperties | undefined)
-        ?.panels ||
-      (state.lab.levelProperties?.levelData as PanelsLevelData)?.panels
+      (state.lab.levelProperties as PanelsLevelProperties | undefined)?.panels
   );
   const currentAppName = useAppSelector(
     state => state.lab.levelProperties?.appName

--- a/apps/src/panels/types.ts
+++ b/apps/src/panels/types.ts
@@ -1,11 +1,5 @@
 import {LevelProperties} from '../lab2/types';
 
-// The level data for a panels level that doesn't require
-// reloads between levels.
-export interface PanelsLevelData {
-  panels: Panel[];
-}
-
 export interface PanelsLevelProperties extends LevelProperties {
   panels: Panel[];
 }


### PR DESCRIPTION
Quick cleanup of Lab2 types. Changes include:
- Grouping types in lab2/types.ts by category
- Removing redundant/unused types
- Removing deprecated fields from level data, like text, validations, and panels (these should be coming from the level properties directly).

Of these, only the third makes changes to existing behavior; now instead of falling back to level data validations, text, or panels, we will just ignore it. This should **only** affect levels that were created **before** we added custom GUI editors for these fields in the level edit page (i.e. validations and panels) and **have not** been updated since. I manually tested our production scripts that have these fields to make sure nothing was broken (see Testing Story below).

I was originally thinking of splitting the types.ts file up according to the various sections but held off on this for now to avoid having to change a bunch of imports.

## Testing story

Locally verified that music-intro-2024, music-tutorial-2024, and gen-ai-customizing-pilot-v1 were unchanged. I also checked music-accessibility, which does have one level which will need to be updated. I will manually update that level in levelbuilder before merging this (just need to open re-save the level without making changes).

## Follow-up work

- Update https://levelbuilder-studio.code.org/s/music-accessibility/lessons/1/levels/7 on levelbuilder before merging.