### PR TITLE
Add LTI account linking metrics

### DIFF
--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ExistingAccountCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ExistingAccountCard/index.tsx
@@ -8,10 +8,13 @@ import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';
 import classNames from 'classnames';
 import styles from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/link-account.module.scss';
 import cardStyles from '@cdo/apps/componentLibrary/card/Card/card.module.scss';
-import {buttonColors, LinkButton} from '@cdo/apps/componentLibrary/button';
+import {buttonColors, Button} from '@cdo/apps/componentLibrary/button';
 import React, {useContext} from 'react';
 import i18n from '@cdo/locale';
 import {LtiProviderContext} from '../../context';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {navigateToHref} from '@cdo/apps/utils';
 
 const ExistingAccountCard = () => {
   const {ltiProvider, ltiProviderName, existingAccountUrl, emailAddress} =
@@ -22,6 +25,19 @@ const ExistingAccountCard = () => {
     email: emailAddress,
   });
   existingAccountUrl.search = urlParams.toString();
+
+  const handleExistingAccountSubmit = () => {
+    const eventPayload = {
+      lms_name: ltiProvider,
+    };
+    analyticsReporter.sendEvent(
+      'lti_existing_account_click',
+      eventPayload,
+      PLATFORMS.STATSIG
+    );
+
+    navigateToHref(existingAccountUrl.href);
+  };
 
   return (
     <Card data-testid={'existing-account-card'}>
@@ -40,12 +56,12 @@ const ExistingAccountCard = () => {
         })}
       </CardContent>
       <CardActions>
-        <LinkButton
+        <Button
           className={styles.button}
           color={buttonColors.purple}
           type={'primary'}
           size="l"
-          href={existingAccountUrl.href}
+          onClick={handleExistingAccountSubmit}
           text={i18n.ltiLinkAccountExistingAccountCardActionLabel()}
         />
       </CardActions>

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/NewAccountCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/NewAccountCard/index.tsx
@@ -14,6 +14,8 @@ import {LtiProviderContext} from '../../context';
 import DCDO from '@cdo/apps/dcdo';
 import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
 import {navigateToHref} from '@cdo/apps/utils';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 const NewAccountCard = () => {
   const {ltiProviderName, newAccountUrl, emailAddress} =
@@ -25,6 +27,14 @@ const NewAccountCard = () => {
   );
 
   const handleNewAccountSubmit = () => {
+    const eventPayload = {
+      lms_name: ltiProviderName,
+    };
+    analyticsReporter.sendEvent(
+      'lti_new_account_click',
+      eventPayload,
+      PLATFORMS.STATSIG
+    );
     if (isStudentEmailPostEnabled) {
       finishSignupFormRef.current?.submit();
     } else {

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -53,12 +53,15 @@ describe('LTI Link Account Page Tests', () => {
         i18n.ltiLinkAccountExistingAccountCardContent({providerName: 'Canvas'})
       );
       // Should have button to link new account
-      expect(
-        withinExistingAccountCard
-          .getByText(i18n.ltiLinkAccountExistingAccountCardActionLabel())
-          .closest('a')!
-          .getAttribute('href')
-      ).to.equal(`https://example.com/existing-account?${urlParams}`);
+      const existingAccountButton = withinExistingAccountCard.getByText(
+        i18n.ltiLinkAccountExistingAccountCardActionLabel()
+      );
+
+      fireEvent.click(existingAccountButton);
+
+      expect(utils.navigateToHref).to.have.been.calledWith(
+        `https://example.com/existing-account?${urlParams}`
+      );
     });
   });
 

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -199,6 +199,15 @@ class LtiV1Controller < ApplicationController
         PartialRegistration.persist_attributes(session, user)
         session[:user_return_to] = destination_url
         if DCDO.get('lti_account_linking_enabled', false)
+          metadata = {
+            'user_type' => user.user_type,
+            'lms_name' => integration[:platform_name],
+          }
+          Metrics::Events.log_event(
+            user: user,
+            event_name: 'lti_account_linking_page_visit',
+            metadata: metadata,
+          )
           render 'lti/v1/account_linking/landing', locals: {lti_provider: integration[:platform_name], email: email_address} and return
         end
 

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -200,7 +200,6 @@ class LtiV1Controller < ApplicationController
         session[:user_return_to] = destination_url
         if DCDO.get('lti_account_linking_enabled', false)
           metadata = {
-            'user_type' => user.user_type,
             'lms_name' => integration[:platform_name],
           }
           Metrics::Events.log_event(

--- a/dashboard/lib/services/lti/account_linker.rb
+++ b/dashboard/lib/services/lti/account_linker.rb
@@ -20,7 +20,6 @@ module Services
 
         lti_integration = user.lti_user_identities.first.lti_integration
         metadata = {
-          'user_type' => user.user_type,
           'lms_name' => lti_integration[:platform_name],
           'lms_client_id' => lti_integration[:client_id],
           'login_type' => user.primary_contact_info&.credential_type,

--- a/dashboard/lib/services/lti/account_linker.rb
+++ b/dashboard/lib/services/lti/account_linker.rb
@@ -1,3 +1,5 @@
+require 'metrics/events'
+
 module Services
   module Lti
     class AccountLinker < Services::Base
@@ -15,6 +17,19 @@ module Services
           user.lti_roster_sync_enabled = true if user.teacher?
           PartialRegistration.delete(session)
         end
+
+        lti_integration = user.lti_user_identities.first.lti_integration
+        metadata = {
+          'user_type' => user.user_type,
+          'lms_name' => lti_integration[:platform_name],
+          'lms_client_id' => lti_integration[:client_id],
+          'login_type' => user.primary_contact_info&.credential_type,
+        }
+        Metrics::Events.log_event(
+          user: user,
+          event_name: 'lti_account_linked',
+          metadata: metadata,
+        )
       end
 
       private def rehydrated_user


### PR DESCRIPTION
Adds some new metrics for LTI account linking:

- `lti_account_linking_page_visit` - when the user is sent to the new account landing/disambiguation page
- `lti_existing_account_click` - when the user clicks the button to link an existing account instead of creating a new account
- `lti_new_account_click` - when the user clicks the button to create a fresh account instead of linking
- `lti_account_linked` - after a successful account linking operation

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-921)

## Testing story

Tested locally and observed statsig output to stdout and to the browser console.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Two metrics from the ticket still need to be implemented:

- Clicks for the individual oauth linking buttons. Currently these are wired up the same as the normal oauth login buttons, so they'll publish the usual oauth events. Will have to circle back with Ali on whether or not we need to do special instrumentation of the buttons.
- Successfully creating an LTI account. Not sure how this differs from normal account creation metrics and doesn't seem directly related to account linking.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
