### PR TITLE
hide param label

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
@@ -228,6 +228,12 @@ GoogleBlockly.Extensions.register(
   function (this: ProcedureBlock) {
     const mixin = {
       /**
+       * Adds or removes the parameter label to match the state of the data model.
+       * No-op to avoid adding "with:" label to the block.
+       */
+      addParametersLabel__: function () {},
+
+      /**
        * Updates the shape of this block to reflect the state of the data model.
        */
       doProcedureUpdate: function (this: ProcedureBlock) {


### PR DESCRIPTION
When Blockly creates call blocks for functions with parameters, a label 'with:' is added to the top input row:
<img width="286" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/1275dbad-3551-4703-a08f-0dd1c9b59f33">
 With CDO Blockly, we do not add this label:
<img width="232" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/2f67b73a-a589-4917-964f-bff7c5c3f41e">

With the shareable procedures plugin, this field is handled by `addParametersLabel__`:

https://github.com/google/blockly-samples/blob/@blockly/block-shareable-procedures@5.0.0/plugins/block-shareable-procedures/src/blocks.ts#L1157-L1173

We can override and no-op this function to produce the desired result:

<img width="253" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/b77abbe2-d1f3-416b-ac08-fa74bb674130">


## Links

https://codedotorg.atlassian.net/browse/CT-625

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
