### PR TITLE
Instructions to reach reference guide editing pages for any standalone unit

### DIFF
--- a/dashboard/app/views/helpful_links/index.html.haml
+++ b/dashboard/app/views/helpful_links/index.html.haml
@@ -5,10 +5,10 @@
   %li= link_to 'CSD', '/courses/csd/guides/'
   %li= link_to 'CSP', '/courses/csp/guides/'
   %li= link_to 'CSA', '/courses/csa/guides/'
-%p 
-  To edit reference guides for standalone units (with /s/ links), use: 
+%p
+  To edit reference guides for standalone units (with /s/ links), use:
   %b "/courses/[unit_name]/guides/edit"
-  %br For ex, to edit guides for gen-ai-customizing-pilot-v1 unit,  
+  %br For ex, to edit guides for gen-ai-customizing-pilot-v1 unit,
   = link_to 'https://levelbuilder-studio.code.org/courses/gen-ai-customizing-pilot-v1/guides/edit', '/courses/gen-ai-customizing-pilot-v1/guides/edit'
 
 %h2 Miscellaneous

--- a/dashboard/app/views/helpful_links/index.html.haml
+++ b/dashboard/app/views/helpful_links/index.html.haml
@@ -5,6 +5,11 @@
   %li= link_to 'CSD', '/courses/csd/guides/'
   %li= link_to 'CSP', '/courses/csp/guides/'
   %li= link_to 'CSA', '/courses/csa/guides/'
+%p 
+  To edit reference guides for standalone units (with /s/ links), use: 
+  %b "/courses/[unit_name]/guides/edit"
+  %br For ex, to edit guides for gen-ai-customizing-pilot-v1 unit,  
+  = link_to 'https://levelbuilder-studio.code.org/courses/gen-ai-customizing-pilot-v1/guides/edit', '/courses/gen-ai-customizing-pilot-v1/guides/edit'
 
 %h2 Miscellaneous
 %ul


### PR DESCRIPTION
With the new set of curriculum for genai, there is a new requirement to have reference guides that are associated with standalone units. Although the framework supports having a collection of reference guides given a standalone unit, accessing that in levelbuilder isn't readily available, like it is for CSD, CSP or CSA (through the helpful links page).

This change includes instructions on how to get to the reference guides editing page for any standalone unit. 

**Before the change**
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/412ebc30-33b7-4ab7-9040-bf0d6c54af32)

**After the change**
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/4685f341-3623-4200-a28c-44e2a499bb60)

## Links

Slack conversation:  https://codedotorg.slack.com/archives/CFGAVL2CA/p1715975771354139?thread_ts=1715806904.889559&cid=CFGAVL2CA
Fix to cloning script discussed in slack conversation https://github.com/code-dot-org/code-dot-org/pull/58686

## Testing story

Local environment and drone

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
