### PR TITLE
Default to MySQL 8 in Chef

### DIFF
--- a/cookbooks/cdo-mysql/attributes/default.rb
+++ b/cookbooks/cdo-mysql/attributes/default.rb
@@ -1,5 +1,5 @@
 default['cdo-mysql'] = {
-  target_version: '5.7',
+  target_version: '8.0',
   proxy: {
     # Enable ProxySQL on non-daemon app-servers by default.
     enabled: node['cdo-apps'] && !node['cdo-apps']['daemon'],


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/56386; now that all environments have been manually updated to target MySQL 8.0, update the default to also target 8.0.

After this change has been picked up by all environments, we can follow it up with a final change to eliminate the `if` statements and just install MySQL 8 everywhere.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
