### PR TITLE
Fix /catalog for when device compatibility is (None)

### DIFF
--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -53,6 +53,7 @@ class CourseEditor extends Component {
     courseVersionId: PropTypes.number,
     coursePath: PropTypes.string.isRequired,
     courseOfferingEditorLink: PropTypes.string,
+    isMissingRequiredDeviceCompatibilities: PropTypes.bool,
 
     // Provided by redux
     teacherResources: PropTypes.arrayOf(resourceShape),
@@ -142,6 +143,18 @@ class CourseEditor extends Component {
       this.setState({
         isSaving: false,
         error: 'Please set both version year and family name.',
+      });
+      return;
+    } else if (
+      [PublishedState.preview, PublishedState.stable].includes(
+        this.state.publishedState
+      ) &&
+      this.props.isMissingRequiredDeviceCompatibilities
+    ) {
+      this.setState({
+        isSaving: false,
+        error:
+          'Please set all device compatibilities in order to save with published state as preview or stable.',
       });
       return;
     }

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -94,6 +94,7 @@ class UnitEditor extends React.Component {
     scriptPath: PropTypes.string.isRequired,
     courseOfferingEditorLink: PropTypes.string,
     isCSDCourseOffering: PropTypes.bool,
+    courseOfferingDeviceCompatibilities: PropTypes.string,
 
     // from redux
     lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
@@ -154,6 +155,23 @@ class UnitEditor extends React.Component {
       participantAudience: this.props.initialParticipantAudience,
     };
   }
+
+  // Return if the given course offering's device compatibilities JSON string either:
+  // - Is null
+  // - Contains a device compatibility mapping to the (None) option
+  //   (which would appear like `{tablet: ""}`)
+  isMissingDeviceCompatibility = deviceCompatibilities => {
+    if (!deviceCompatibilities) {
+      return true;
+    }
+
+    const deviceCompatibilitiesValues = Object.values(
+      JSON.parse(deviceCompatibilities)
+    );
+    return deviceCompatibilitiesValues.some(
+      compatibility => compatibility === ''
+    );
+  };
 
   handleUpdateAnnouncements = newAnnouncements => {
     this.setState({announcements: newAnnouncements});
@@ -245,6 +263,20 @@ class UnitEditor extends React.Component {
       this.setState({
         isSaving: false,
         error: 'Please set both version year and family name.',
+      });
+      return;
+    } else if (
+      [PublishedState.preview, PublishedState.stable].includes(
+        this.state.publishedState
+      ) &&
+      this.isMissingDeviceCompatibility(
+        this.props.courseOfferingDeviceCompatibilities
+      )
+    ) {
+      this.setState({
+        isSaving: false,
+        error:
+          'Please set all device compatibilities in order to save with published state as preview or stable.',
       });
       return;
     }

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -94,7 +94,7 @@ class UnitEditor extends React.Component {
     scriptPath: PropTypes.string.isRequired,
     courseOfferingEditorLink: PropTypes.string,
     isCSDCourseOffering: PropTypes.bool,
-    courseOfferingDeviceCompatibilities: PropTypes.string,
+    isMissingRequiredDeviceCompatibilities: PropTypes.bool,
 
     // from redux
     lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
@@ -155,23 +155,6 @@ class UnitEditor extends React.Component {
       participantAudience: this.props.initialParticipantAudience,
     };
   }
-
-  // Return if the given course offering's device compatibilities JSON string either:
-  // - Is null
-  // - Contains a device compatibility mapping to the (None) option
-  //   (which would appear like `{tablet: ""}`)
-  isMissingDeviceCompatibility = deviceCompatibilities => {
-    if (!deviceCompatibilities) {
-      return true;
-    }
-
-    const deviceCompatibilitiesValues = Object.values(
-      JSON.parse(deviceCompatibilities)
-    );
-    return deviceCompatibilitiesValues.some(
-      compatibility => compatibility === ''
-    );
-  };
 
   handleUpdateAnnouncements = newAnnouncements => {
     this.setState({announcements: newAnnouncements});
@@ -265,14 +248,7 @@ class UnitEditor extends React.Component {
         error: 'Please set both version year and family name.',
       });
       return;
-    } else if (
-      [PublishedState.preview, PublishedState.stable].includes(
-        this.state.publishedState
-      ) &&
-      this.isMissingDeviceCompatibility(
-        this.props.courseOfferingDeviceCompatibilities
-      )
-    ) {
+    } else if (this.props.isMissingRequiredDeviceCompatibilities) {
       this.setState({
         isSaving: false,
         error:

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -248,7 +248,12 @@ class UnitEditor extends React.Component {
         error: 'Please set both version year and family name.',
       });
       return;
-    } else if (this.props.isMissingRequiredDeviceCompatibilities) {
+    } else if (
+      [PublishedState.preview, PublishedState.stable].includes(
+        this.state.publishedState
+      ) &&
+      this.props.isMissingRequiredDeviceCompatibilities
+    ) {
       this.setState({
         isSaving: false,
         error:

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -81,6 +81,9 @@ function showCourseEditor() {
         courseOfferingEditorLink={
           courseEditorData.course_summary.course_offering_edit_path
         }
+        isMissingRequiredDeviceCompatibilities={
+          courseEditorData.missing_required_device_compatibilities
+        }
       />
     </Provider>,
     document.getElementById('course_editor')

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -96,8 +96,8 @@ export default function initPage(unitEditorData) {
         scriptPath={scriptData.scriptPath}
         courseOfferingEditorLink={scriptData.courseOfferingEditPath}
         isCSDCourseOffering={scriptData.isCSDCourseOffering}
-        courseOfferingDeviceCompatibilities={
-          scriptData.courseOfferingDeviceCompatibilities
+        isMissingRequiredDeviceCompatibilities={
+          scriptData.missingRequiredDeviceCompatibilities
         }
       />
     </Provider>,

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -96,6 +96,9 @@ export default function initPage(unitEditorData) {
         scriptPath={scriptData.scriptPath}
         courseOfferingEditorLink={scriptData.courseOfferingEditPath}
         isCSDCourseOffering={scriptData.isCSDCourseOffering}
+        courseOfferingDeviceCompatibilities={
+          scriptData.courseOfferingDeviceCompatibilities
+        }
       />
     </Provider>,
     document.querySelector('.edit_container')

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -62,7 +62,7 @@ const ExpandedCurriculumCatalogCard = ({
     },
   };
 
-  const devices = JSON.parse(deviceCompatibility);
+  const devices = deviceCompatibility ? JSON.parse(deviceCompatibility) : {};
 
   const resoucesOrder = [
     'Lesson Plan',
@@ -233,22 +233,29 @@ const ExpandedCurriculumCatalogCard = ({
               </div>
               <hr className={style.horizontalDivider} />
               <div className={style.compatibilityContainer}>
-                {Object.keys(devices).map(device => (
-                  <div key={device} className={style.iconWithDescription}>
-                    <FontAwesome
-                      icon={iconData[devices[device]].icon}
-                      className={`fa-solid ${iconData[devices[device]].color}`}
-                    />
-                    <BodyTwoText>
-                      {device !== 'no_device'
-                        ? translatedCourseOfferingDeviceTypes[device]
-                            .charAt(0)
-                            .toUpperCase() +
-                          translatedCourseOfferingDeviceTypes[device].slice(1)
-                        : i18n.offline()}
-                    </BodyTwoText>
-                  </div>
-                ))}
+                {Object.keys(devices).map(
+                  device =>
+                    devices[device] !== '' && (
+                      <div key={device} className={style.iconWithDescription}>
+                        <FontAwesome
+                          icon={iconData[devices[device]].icon}
+                          className={`fa-solid ${
+                            iconData[devices[device]].color
+                          }`}
+                        />
+                        <BodyTwoText>
+                          {device !== 'no_device'
+                            ? translatedCourseOfferingDeviceTypes[device]
+                                .charAt(0)
+                                .toUpperCase() +
+                              translatedCourseOfferingDeviceTypes[device].slice(
+                                1
+                              )
+                            : i18n.offline()}
+                        </BodyTwoText>
+                      </div>
+                    )
+                )}
               </div>
               <hr className={style.horizontalDivider} />
               <div className={style.buttonsContainer}>

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
@@ -375,4 +375,79 @@ describe('CourseEditor', () => {
 
     $.ajax.restore();
   });
+
+  it('shows error when published state is preview or stable and device compatibility JSON is null', () => {
+    sinon.stub($, 'ajax');
+    const wrapper = createWrapper({
+      isMissingRequiredDeviceCompatibilities: true,
+    });
+
+    const courseEditor = wrapper.find('CourseEditor');
+    courseEditor.setState({
+      publishedState: PublishedState.preview,
+      courseOfferingDeviceCompatibilities: null,
+    });
+
+    const saveBar = wrapper.find('SaveBar');
+
+    const saveAndKeepEditingButton = saveBar.find('button').at(1);
+    expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+      .true;
+    saveAndKeepEditingButton.simulate('click');
+
+    expect($.ajax).to.not.have.been.called;
+
+    expect(courseEditor.state().isSaving).to.equal(false);
+    expect(courseEditor.state().error).to.equal(
+      'Please set all device compatibilities in order to save with published state as preview or stable.'
+    );
+
+    expect(
+      wrapper
+        .find('.saveBar')
+        .contains(
+          'Error Saving: Please set all device compatibilities in order to save with published state as preview or stable.'
+        )
+    ).to.be.true;
+
+    $.ajax.restore();
+  });
+
+  it('shows error when published state is preview or stable and at least one device compatibility is not set', () => {
+    sinon.stub($, 'ajax');
+    const wrapper = createWrapper({
+      isMissingRequiredDeviceCompatibilities: true,
+    });
+
+    const courseEditor = wrapper.find('CourseEditor');
+    courseEditor.setState({
+      publishedState: PublishedState.stable,
+      courseOfferingDeviceCompatibilities:
+        '{"computer":"","chromebook":"ideal","tablet":"ideal","mobile":"not_recommended","no_device":"incompatible"}',
+    });
+
+    const saveBar = wrapper.find('SaveBar');
+
+    const saveAndKeepEditingButton = saveBar.find('button').at(1);
+    expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+      .true;
+    saveAndKeepEditingButton.simulate('click');
+
+    expect($.ajax).to.not.have.been.called;
+
+    expect(courseEditor.state().isSaving).to.equal(false);
+    expect(courseEditor.state().error).to.equal(
+      'Please set all device compatibilities in order to save with published state as preview or stable.'
+    );
+
+    expect(
+      wrapper
+        .find('.saveBar')
+        .contains(
+          'Error Saving: Please set all device compatibilities in order to save with published state as preview or stable.'
+        )
+    ).to.be.true;
+
+    $.ajax.restore();
+  });
 });

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -492,6 +492,77 @@ describe('UnitEditor', () => {
       $.ajax.restore();
     });
 
+    it('shows error when published state is preview or stable and device compatibility JSON is null', () => {
+      sinon.stub($, 'ajax');
+      const wrapper = createWrapper({hasCourse: true});
+
+      const unitEditor = wrapper.find('UnitEditor');
+      unitEditor.setState({
+        publishedState: PublishedState.stable,
+        courseOfferingDeviceCompatibilities: null,
+      });
+
+      const saveBar = wrapper.find('SaveBar');
+
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
+      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+        .true;
+      saveAndKeepEditingButton.simulate('click');
+
+      expect($.ajax).to.not.have.been.called;
+
+      expect(unitEditor.state().isSaving).to.equal(false);
+      expect(unitEditor.state().error).to.equal(
+        'Please set all device compatibilities in order to save with published state as preview or stable.'
+      );
+
+      expect(
+        wrapper
+          .find('.saveBar')
+          .contains(
+            'Error Saving: Please set all device compatibilities in order to save with published state as preview or stable.'
+          )
+      ).to.be.true;
+
+      $.ajax.restore();
+    });
+
+    it('shows error when published state is preview or stable and at least one device compatibility is not set', () => {
+      sinon.stub($, 'ajax');
+      const wrapper = createWrapper({hasCourse: true});
+
+      const unitEditor = wrapper.find('UnitEditor');
+      unitEditor.setState({
+        publishedState: PublishedState.stable,
+        courseOfferingDeviceCompatibilities:
+          '{"computer":"","chromebook":"ideal","tablet":"ideal","mobile":"not_recommended","no_device":"incompatible"}',
+      });
+
+      const saveBar = wrapper.find('SaveBar');
+
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
+      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+        .true;
+      saveAndKeepEditingButton.simulate('click');
+
+      expect($.ajax).to.not.have.been.called;
+
+      expect(unitEditor.state().isSaving).to.equal(false);
+      expect(unitEditor.state().error).to.equal(
+        'Please set all device compatibilities in order to save with published state as preview or stable.'
+      );
+
+      expect(
+        wrapper
+          .find('.saveBar')
+          .contains(
+            'Error Saving: Please set all device compatibilities in order to save with published state as preview or stable.'
+          )
+      ).to.be.true;
+
+      $.ajax.restore();
+    });
+
     it('saves successfully if unit is not a course and only version year is set', () => {
       const wrapper = createWrapper({initialIsCourse: false});
 

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -88,6 +88,7 @@ describe('UnitEditor', () => {
       scriptPath: '/s/test-unit',
       initialProfessionalLearningCourse: '',
       isCSDCourseOffering: false,
+      isMissingRequiredDeviceCompatibilities: false,
     };
   });
 
@@ -494,11 +495,14 @@ describe('UnitEditor', () => {
 
     it('shows error when published state is preview or stable and device compatibility JSON is null', () => {
       sinon.stub($, 'ajax');
-      const wrapper = createWrapper({hasCourse: true});
+      const wrapper = createWrapper({
+        isMissingRequiredDeviceCompatibilities: true,
+        hasCourse: true,
+      });
 
       const unitEditor = wrapper.find('UnitEditor');
       unitEditor.setState({
-        publishedState: PublishedState.stable,
+        publishedState: PublishedState.preview,
         courseOfferingDeviceCompatibilities: null,
       });
 
@@ -529,7 +533,10 @@ describe('UnitEditor', () => {
 
     it('shows error when published state is preview or stable and at least one device compatibility is not set', () => {
       sinon.stub($, 'ajax');
-      const wrapper = createWrapper({hasCourse: true});
+      const wrapper = createWrapper({
+        isMissingRequiredDeviceCompatibilities: true,
+        hasCourse: true,
+      });
 
       const unitEditor = wrapper.find('UnitEditor');
       unitEditor.setState({

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogExpandedCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogExpandedCardTest.jsx
@@ -226,6 +226,20 @@ describe('CurriculumCatalogExpandedCard', () => {
     });
   });
 
+  it('does not render a device if their compatibility is not set', () => {
+    renderCurriculumExpandedCard({
+      ...defaultProps,
+      deviceCompatibility:
+        '{"computer":"","chromebook":"ideal","tablet":"ideal","mobile":"not_recommended","no_device":"incompatible"}',
+    });
+
+    expect(screen.queryByText('Computer')).to.be.null;
+    screen.getByText('Chromebook');
+    screen.getByText('Tablet');
+    screen.getByText('Mobile');
+    screen.getByText('Offline');
+  });
+
   it('clicking assign button triggers onAssign function', () => {
     const onAssign = sinon.spy();
     renderCurriculumExpandedCard({

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -99,7 +99,8 @@ class CoursesController < ApplicationController
       course_summary: @unit_group.summarize(@current_user, for_edit: true),
       script_names: Unit.all.select {|unit| unit.is_course? == false}.map(&:name),
       course_families: UnitGroup.family_names,
-      version_year_options: UnitGroup.get_version_year_options
+      version_year_options: UnitGroup.get_version_year_options,
+      missing_required_device_compatibilities: @unit_group&.course_version&.course_offering&.missing_required_device_compatibility?
     }
     render 'edit', locals: {unit_group: @unit_group}
   end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -240,19 +240,14 @@ class CourseOffering < ApplicationRecord
     false
   end
 
-  # Return if the course offering's device compatibilities JSON string either:
-  # - Is null
-  # - Contains a device compatibility mapping to the (None) option (which would appear like `{tablet: ""}`)
-  def missing_device_compatibility?
-    return true unless device_compatibility
+  # Checks if the course offering requires device compatibilities and is missing any.
+  def missing_required_device_compatibility?
+    # Only student course offerings require device compatibilites to be published.
+    return false if get_participant_audience != 'student'
+    return true if device_compatibility.nil?
 
     device_compatibility_values = JSON.parse(device_compatibility).values
     device_compatibility_values.any?(&:blank?)
-  end
-
-  def missing_required_device_compatibility?
-    # Course offering device compatibilites are required to publish student courses that are assignable.
-    assignable? && get_participant_audience == 'student' && missing_device_compatibility?
   end
 
   def summarize_for_assignment_dropdown(user, locale_code)

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -240,6 +240,21 @@ class CourseOffering < ApplicationRecord
     false
   end
 
+  # Return if the course offering's device compatibilities JSON string either:
+  # - Is null
+  # - Contains a device compatibility mapping to the (None) option (which would appear like `{tablet: ""}`)
+  def missing_device_compatibility?
+    return true unless device_compatibility
+
+    device_compatibility_values = JSON.parse(device_compatibility).values
+    device_compatibility_values.any?(&:blank?)
+  end
+
+  def missing_required_device_compatibility?
+    # Course offering device compatibilites are required to publish student courses that are assignable.
+    assignable? && get_participant_audience == 'student' && missing_device_compatibility?
+  end
+
   def summarize_for_assignment_dropdown(user, locale_code)
     [
       id,

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -184,14 +184,6 @@ class CourseOffering < ApplicationRecord
     course_versions.any? {|cv| published_states.include?(cv.published_state)}
   end
 
-  # Returns true if:
-  # - Assignable (course offering 'assignable' setting is true)
-  # - Published (associated unit group or unit 'published_state' setting is 'preview' or 'stable')
-  # - For students (associated unit group or unit 'participant_audience' setting is student)
-  def assignable_published_for_students?
-    assignable? && any_version_is_in_published_state? && get_participant_audience == 'student'
-  end
-
   def self.all_course_offerings
     if should_cache?
       @@course_offerings ||= CourseOffering.all.includes(course_versions: :content_root)
@@ -205,7 +197,7 @@ class CourseOffering < ApplicationRecord
   # - Published (associated unit group or unit 'published_state' setting is 'preview' or 'stable')
   # - For students (associated unit group or unit 'participant_audience' setting is student)
   def self.assignable_published_for_students_course_offerings
-    all_course_offerings.select(&:assignable_published_for_students?)
+    all_course_offerings.select {|co| co.assignable? && co.any_version_is_in_published_state? && co.get_participant_audience == 'student'}
   end
 
   def self.assignable_course_offerings(user)

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -184,6 +184,14 @@ class CourseOffering < ApplicationRecord
     course_versions.any? {|cv| published_states.include?(cv.published_state)}
   end
 
+  # Returns true if:
+  # - Assignable (course offering 'assignable' setting is true)
+  # - Published (associated unit group or unit 'published_state' setting is 'preview' or 'stable')
+  # - For students (associated unit group or unit 'participant_audience' setting is student)
+  def assignable_published_for_students?
+    assignable? && any_version_is_in_published_state? && get_participant_audience == 'student'
+  end
+
   def self.all_course_offerings
     if should_cache?
       @@course_offerings ||= CourseOffering.all.includes(course_versions: :content_root)
@@ -197,7 +205,7 @@ class CourseOffering < ApplicationRecord
   # - Published (associated unit group or unit 'published_state' setting is 'preview' or 'stable')
   # - For students (associated unit group or unit 'participant_audience' setting is student)
   def self.assignable_published_for_students_course_offerings
-    all_course_offerings.select {|co| co.assignable? && co.any_version_is_in_published_state? && co.get_participant_audience == 'student'}
+    all_course_offerings.select(&:assignable_published_for_students?)
   end
 
   def self.assignable_course_offerings(user)

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1618,6 +1618,7 @@ class Unit < ApplicationRecord
     summary = summarize(include_lessons)
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_unit_edit)
     summary[:courseOfferingEditPath] = edit_course_offering_path(course_version.course_offering.key) if course_version
+    summary[:courseOfferingDeviceCompatibilities] = course_version&.course_offering&.device_compatibility
     summary[:coursePublishedState] = unit_group ? unit_group.published_state : published_state
     summary[:unitPublishedState] = unit_group ? published_state : nil
     summary[:isCSDCourseOffering] = unit_group&.course_version&.course_offering&.csd?

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1629,9 +1629,9 @@ class Unit < ApplicationRecord
     include_lessons = false
     summary = summarize(include_lessons)
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_unit_edit)
-    summary[:courseOfferingEditPath] = edit_course_offering_path(co.key) if course_version
+    summary[:courseOfferingEditPath] = edit_course_offering_path(co&.key) if course_version
     # Course offering device compatibilites are required to publish student courses that are assignable.
-    summary[:missingRequiredDeviceCompatibilities] = co.assignable? && co.get_participant_audience == 'student' && missing_device_compatibility?
+    summary[:missingRequiredDeviceCompatibilities] = co&.assignable? && co&.get_participant_audience == 'student' && missing_device_compatibility?
     summary[:coursePublishedState] = unit_group ? unit_group.published_state : published_state
     summary[:unitPublishedState] = unit_group ? published_state : nil
     summary[:isCSDCourseOffering] = unit_group&.course_version&.course_offering&.csd?

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1629,8 +1629,8 @@ class Unit < ApplicationRecord
     summary = summarize(include_lessons)
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_unit_edit)
     summary[:courseOfferingEditPath] = edit_course_offering_path(co.key) if course_version
-    # Course offering device compatibilites are required for student courses that are assignable and published.
-    summary[:missingRequiredDeviceCompatibilities] = co&.assignable_published_for_students? && missing_device_compatibility?(co&.device_compatibility)
+    # Course offering device compatibilites are required to publish student courses that are assignable.
+    summary[:missingRequiredDeviceCompatibilities] = co.assignable? && co.get_participant_audience == 'student' && missing_device_compatibility?(co&.device_compatibility)
     summary[:coursePublishedState] = unit_group ? unit_group.published_state : published_state
     summary[:unitPublishedState] = unit_group ? published_state : nil
     summary[:isCSDCourseOffering] = unit_group&.course_version&.course_offering&.csd?

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1488,17 +1488,6 @@ class Unit < ApplicationRecord
     get_published_state == Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
   end
 
-  # Return if the unit's course offering's device compatibilities JSON string either:
-  # - Is null
-  # - Contains a device compatibility mapping to the (None) option (which would appear like `{tablet: ""}`)
-  def missing_device_compatibility?
-    device_compatibilities = course_version&.course_offering&.device_compatibility
-    return true unless device_compatibilities
-
-    device_compatibilities_values = JSON.parse(device_compatibilities).values
-    device_compatibilities_values.any?(&:blank?)
-  end
-
   def summarize(include_lessons = true, user = nil, include_bonus_levels = false, locale_code = 'en-us')
     ActiveRecord::Base.connected_to(role: :reading) do
       # TODO: Set up peer reviews to be more consistent with the rest of the system
@@ -1625,13 +1614,11 @@ class Unit < ApplicationRecord
   end
 
   def summarize_for_unit_edit
-    co = course_version&.course_offering
     include_lessons = false
     summary = summarize(include_lessons)
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_unit_edit)
-    summary[:courseOfferingEditPath] = edit_course_offering_path(co&.key) if course_version
-    # Course offering device compatibilites are required to publish student courses that are assignable.
-    summary[:missingRequiredDeviceCompatibilities] = co&.assignable? && co&.get_participant_audience == 'student' && missing_device_compatibility?
+    summary[:courseOfferingEditPath] = edit_course_offering_path(course_version&.course_offering&.key) if course_version
+    summary[:missingRequiredDeviceCompatibilities] = course_version&.course_offering&.missing_required_device_compatibility?
     summary[:coursePublishedState] = unit_group ? unit_group.published_state : published_state
     summary[:unitPublishedState] = unit_group ? published_state : nil
     summary[:isCSDCourseOffering] = unit_group&.course_version&.course_offering&.csd?

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1488,10 +1488,11 @@ class Unit < ApplicationRecord
     get_published_state == Curriculum::SharedCourseConstants::PUBLISHED_STATE.in_development
   end
 
-  # Return if the given unit's course offering's device compatibilities JSON string either:
+  # Return if the unit's course offering's device compatibilities JSON string either:
   # - Is null
   # - Contains a device compatibility mapping to the (None) option (which would appear like `{tablet: ""}`)
-  def missing_device_compatibility?(device_compatibilities)
+  def missing_device_compatibility?
+    device_compatibilities = course_version&.course_offering&.device_compatibility
     return true unless device_compatibilities
 
     device_compatibilities_values = JSON.parse(device_compatibilities).values
@@ -1630,7 +1631,7 @@ class Unit < ApplicationRecord
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_unit_edit)
     summary[:courseOfferingEditPath] = edit_course_offering_path(co.key) if course_version
     # Course offering device compatibilites are required to publish student courses that are assignable.
-    summary[:missingRequiredDeviceCompatibilities] = co.assignable? && co.get_participant_audience == 'student' && missing_device_compatibility?(co&.device_compatibility)
+    summary[:missingRequiredDeviceCompatibilities] = co.assignable? && co.get_participant_audience == 'student' && missing_device_compatibility?
     summary[:coursePublishedState] = unit_group ? unit_group.published_state : published_state
     summary[:unitPublishedState] = unit_group ? published_state : nil
     summary[:isCSDCourseOffering] = unit_group&.course_version&.course_offering&.csd?

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -674,14 +674,23 @@ class CourseOfferingTest < ActiveSupport::TestCase
     Unit.clear_cache
   end
 
-  test 'missing_device_compatibility?' do
+  test 'missing_required_device_compatibility? returns false for pl course offerings' do
+    pl_co = create :course_offering
+    pl_unit = create :script, participant_audience: 'teacher', instructor_audience: 'facilitator'
+    create :course_version, content_root: pl_unit, course_offering: pl_co
+    co = create :course_offering, self_paced_pl_course_offering: pl_co
+
+    refute(co.missing_required_device_compatibility?)
+  end
+
+  test 'missing_required_device_compatibility? returns if device compatibilities are missing for student course offerings' do
     co_device_comp_nil = create :course_offering, key: 'course-offering-dc-nil', device_compatibility: nil
     co_device_comp_missing_one = create :course_offering, key: 'course-offering-dc-missing-one', device_compatibility: '{"computer":"","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
     co_device_comp_full = create :course_offering, key: 'course-offering-dc-full', device_compatibility: '{"computer":"ideal","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
 
-    assert(co_device_comp_nil.missing_device_compatibility?)
-    assert(co_device_comp_missing_one.missing_device_compatibility?)
-    refute(co_device_comp_full.missing_device_compatibility?)
+    assert(co_device_comp_nil.missing_required_device_compatibility?)
+    assert(co_device_comp_missing_one.missing_required_device_compatibility?)
+    refute(co_device_comp_full.missing_required_device_compatibility?)
   end
 
   test 'duration returns nil if latest_published_version does not exist' do

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -675,19 +675,13 @@ class CourseOfferingTest < ActiveSupport::TestCase
   end
 
   test 'missing_device_compatibility?' do
-    unit = create :script, family_name: 'fake', version_year: '2017', is_course: true
-    co = CourseOffering.add_course_offering(unit)
-    device_compatibilities_missing_one = '{"computer":"","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
-    device_compatibilities_full = '{"computer":"ideal","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
+    co_device_comp_nil = create :course_offering, key: 'course-offering-dc-nil', device_compatibility: nil
+    co_device_comp_missing_one = create :course_offering, key: 'course-offering-dc-missing-one', device_compatibility: "{'computer':'','chromebook':'not_recommended','tablet':'incompatible','mobile':'incompatible','no_device':'incompatible'}"
+    co_device_comp_full = create :course_offering, key: 'course-offering-dc-full', device_compatibility: "{'computer':'ideal','chromebook':'not_recommended','tablet':'incompatible','mobile':'incompatible','no_device':'incompatible'}"
 
-    co.update!(device_compatibility: nil)
-    assert(unit.missing_device_compatibility?)
-
-    co.update!(device_compatibility: device_compatibilities_missing_one)
-    assert(unit.missing_device_compatibility?)
-
-    co.update!(device_compatibility: device_compatibilities_full)
-    refute(unit.missing_device_compatibility?)
+    assert(co_device_comp_nil.missing_device_compatibility?)
+    assert(co_device_comp_missing_one.missing_device_compatibility?)
+    refute(co_device_comp_full.missing_device_compatibility?)
   end
 
   test 'duration returns nil if latest_published_version does not exist' do

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -674,6 +674,22 @@ class CourseOfferingTest < ActiveSupport::TestCase
     Unit.clear_cache
   end
 
+  test 'missing_device_compatibility?' do
+    unit = create :script, family_name: 'fake', version_year: '2017', is_course: true
+    co = CourseOffering.add_course_offering(unit)
+    device_compatibilities_missing_one = '{"computer":"","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
+    device_compatibilities_full = '{"computer":"ideal","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
+
+    co.update!(device_compatibility: nil)
+    assert(unit.missing_device_compatibility?)
+
+    co.update!(device_compatibility: device_compatibilities_missing_one)
+    assert(unit.missing_device_compatibility?)
+
+    co.update!(device_compatibility: device_compatibilities_full)
+    refute(unit.missing_device_compatibility?)
+  end
+
   test 'duration returns nil if latest_published_version does not exist' do
     unit = create(:script, family_name: 'test-duration', version_year: '1997', is_course: true, published_state: 'in_development')
     co = CourseOffering.add_course_offering(unit)

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -683,14 +683,28 @@ class CourseOfferingTest < ActiveSupport::TestCase
     refute(co.missing_required_device_compatibility?)
   end
 
-  test 'missing_required_device_compatibility? returns if device compatibilities are missing for student course offerings' do
-    co_device_comp_nil = create :course_offering, key: 'course-offering-dc-nil', device_compatibility: nil
-    co_device_comp_missing_one = create :course_offering, key: 'course-offering-dc-missing-one', device_compatibility: '{"computer":"","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
-    co_device_comp_full = create :course_offering, key: 'course-offering-dc-full', device_compatibility: '{"computer":"ideal","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
+  test 'missing_required_device_compatibility? returns true for student course offering with nil device_compatibility' do
+    co = create :course_offering, device_compatibility: nil
+    unit = create :script, participant_audience: 'student', instructor_audience: 'teacher'
+    create :course_version, content_root: unit, course_offering: co
 
-    assert(co_device_comp_nil.missing_required_device_compatibility?)
-    assert(co_device_comp_missing_one.missing_required_device_compatibility?)
-    refute(co_device_comp_full.missing_required_device_compatibility?)
+    assert(co.missing_required_device_compatibility?)
+  end
+
+  test 'missing_required_device_compatibility? returns true for student course offering missing a device_compatibility' do
+    co = create :course_offering, device_compatibility: '{"computer":"","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
+    unit = create :script, participant_audience: 'student', instructor_audience: 'teacher'
+    create :course_version, content_root: unit, course_offering: co
+
+    assert(co.missing_required_device_compatibility?)
+  end
+
+  test 'missing_required_device_compatibility? returns false for student course offering not missing any device_compatibility' do
+    co = create :course_offering, device_compatibility: '{"computer":"ideal","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
+    unit = create :script, participant_audience: 'student', instructor_audience: 'teacher'
+    create :course_version, content_root: unit, course_offering: co
+
+    refute(co.missing_required_device_compatibility?)
   end
 
   test 'duration returns nil if latest_published_version does not exist' do

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -676,8 +676,8 @@ class CourseOfferingTest < ActiveSupport::TestCase
 
   test 'missing_device_compatibility?' do
     co_device_comp_nil = create :course_offering, key: 'course-offering-dc-nil', device_compatibility: nil
-    co_device_comp_missing_one = create :course_offering, key: 'course-offering-dc-missing-one', device_compatibility: "{'computer':'','chromebook':'not_recommended','tablet':'incompatible','mobile':'incompatible','no_device':'incompatible'}"
-    co_device_comp_full = create :course_offering, key: 'course-offering-dc-full', device_compatibility: "{'computer':'ideal','chromebook':'not_recommended','tablet':'incompatible','mobile':'incompatible','no_device':'incompatible'}"
+    co_device_comp_missing_one = create :course_offering, key: 'course-offering-dc-missing-one', device_compatibility: '{"computer":"","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
+    co_device_comp_full = create :course_offering, key: 'course-offering-dc-full', device_compatibility: '{"computer":"ideal","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
 
     assert(co_device_comp_nil.missing_device_compatibility?)
     assert(co_device_comp_missing_one.missing_device_compatibility?)

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -679,22 +679,6 @@ class UnitTest < ActiveSupport::TestCase
     assert Unit.find_by_name('ECSPD').old_professional_learning_course?
   end
 
-  test 'missing_device_compatibility?' do
-    unit = create :script, family_name: 'fake', version_year: '2017', is_course: true
-    co = CourseOffering.add_course_offering(unit)
-    device_compatibilities_missing_one = '{"computer":"","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
-    device_compatibilities_full = '{"computer":"ideal","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
-
-    co.update!(device_compatibility: nil)
-    assert(unit.missing_device_compatibility?)
-
-    co.update!(device_compatibility: device_compatibilities_missing_one)
-    assert(unit.missing_device_compatibility?)
-
-    co.update!(device_compatibility: device_compatibilities_full)
-    refute(unit.missing_device_compatibility?)
-  end
-
   test 'should summarize migrated unit' do
     unit = create(:script, name: 'single-lesson-script', instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student)
     lesson_group = create(:lesson_group, key: 'key1', script: unit)

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -679,6 +679,22 @@ class UnitTest < ActiveSupport::TestCase
     assert Unit.find_by_name('ECSPD').old_professional_learning_course?
   end
 
+  test 'missing_device_compatibility?' do
+    unit = create :script, family_name: 'fake', version_year: '2017', is_course: true
+    co = CourseOffering.add_course_offering(unit)
+    device_compatibilities_missing_one = "{'computer':'','chromebook':'not_recommended','tablet':'incompatible','mobile':'incompatible','no_device':'incompatible'}"
+    device_compatibilities_full = "{'computer':'ideal','chromebook':'not_recommended','tablet':'incompatible','mobile':'incompatible','no_device':'incompatible'}"
+
+    co.update!(device_compatibility: nil)
+    assert(co.missing_device_compatibility?)
+
+    co.update!(device_compatibility: device_compatibilities_missing_one)
+    assert(co.missing_device_compatibility?)
+
+    co.update!(device_compatibility: device_compatibilities_full)
+    assert(co.missing_device_compatibility?)
+  end
+
   test 'should summarize migrated unit' do
     unit = create(:script, name: 'single-lesson-script', instruction_type: Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.teacher_led, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student)
     lesson_group = create(:lesson_group, key: 'key1', script: unit)

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -682,17 +682,17 @@ class UnitTest < ActiveSupport::TestCase
   test 'missing_device_compatibility?' do
     unit = create :script, family_name: 'fake', version_year: '2017', is_course: true
     co = CourseOffering.add_course_offering(unit)
-    device_compatibilities_missing_one = "{'computer':'','chromebook':'not_recommended','tablet':'incompatible','mobile':'incompatible','no_device':'incompatible'}"
-    device_compatibilities_full = "{'computer':'ideal','chromebook':'not_recommended','tablet':'incompatible','mobile':'incompatible','no_device':'incompatible'}"
+    device_compatibilities_missing_one = '{"computer":"","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
+    device_compatibilities_full = '{"computer":"ideal","chromebook":"not_recommended","tablet":"incompatible","mobile":"incompatible","no_device":"incompatible"}'
 
     co.update!(device_compatibility: nil)
-    assert(co.missing_device_compatibility?)
+    assert(unit.missing_device_compatibility?)
 
     co.update!(device_compatibility: device_compatibilities_missing_one)
-    assert(co.missing_device_compatibility?)
+    assert(unit.missing_device_compatibility?)
 
     co.update!(device_compatibility: device_compatibilities_full)
-    assert(co.missing_device_compatibility?)
+    refute(unit.missing_device_compatibility?)
   end
 
   test 'should summarize migrated unit' do


### PR DESCRIPTION
Last week, [Dan found a bug](https://codedotorg.slack.com/archives/C04540KNGDQ/p1716219131534839) where if a new student course offering is created without setting the device compatibilities (at least , when its associated Curriculum Catalog expanded card is opened it will break the page.

This PR fixes this both on the side of the unit + course editors and on the Curriculum Catalog. In the unit + course editors now, a unit/course that will go on the catalog page (assignable and for students) can't be published (set to "preview" or "stable") without setting all device compatibilities. On the Curriculum Catalog, expanded card device compatibilities are only listed if a valid answer is provided to avoid the page breaking.

## Demos
### For unit/course editor
#### Unit editor
Does not allow editors to publish (i.e. put into "preview" or "stable" state) if at least one of the device compatibility dropdowns is still set to "(None)":

https://github.com/code-dot-org/code-dot-org/assets/56283563/686dcc5f-6ec8-4823-b58e-1ba4b16835a9

Allows editors to publish once all device compatibility dropdowns are set:

https://github.com/code-dot-org/code-dot-org/assets/56283563/14f3b8e6-ba44-48ce-8399-be8e0b8e3361

#### Course editor has the same behavior

https://github.com/code-dot-org/code-dot-org/assets/56283563/048d2a06-11c0-4a7c-b530-94f9cbeabf7b

### For [/catalog](https://studio.code.org/catalog) page
#### Regular view with all device compatibilities set remains unchanged
For a unit course offering:
![regular is unchanged](https://github.com/code-dot-org/code-dot-org/assets/56283563/0a79647f-666e-4981-a5aa-f5b3e3045024)

For a unit group course offering:
![looks normal](https://github.com/code-dot-org/code-dot-org/assets/56283563/9153dbec-a82b-4c20-a9fa-199b6b755b8f)

#### If one device compatibility is not set, will not show that device
For a unit course offering:
![one dc is still None](https://github.com/code-dot-org/code-dot-org/assets/56283563/8c5014e9-e911-4884-865d-34e88f1a7df6)

For a unit group course offering:
![Doesnt show Null device for edited course](https://github.com/code-dot-org/code-dot-org/assets/56283563/fe502bba-60c2-4270-aa1f-278def9d5488)

#### If no device compatibilities are set, will not show any of them
For a unit course offering:
![null dc](https://github.com/code-dot-org/code-dot-org/assets/56283563/748ce3cd-9826-4296-9411-cb9df09ec3f2)

For a unit group course offering:
![csd no devices](https://github.com/code-dot-org/code-dot-org/assets/56283563/613423d4-9de5-46bd-8e64-6518e084acdb)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1907)
Slack discussion where Dan found the bug: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1716219131534839)

## Testing story
Local testing and updating unit tests.
