### PR TITLE
define parameters_get block and generator

### DIFF
--- a/apps/src/blockly/addons/cdoVariables.ts
+++ b/apps/src/blockly/addons/cdoVariables.ts
@@ -6,6 +6,8 @@ import {BlocklyWrapperType} from '../types';
 export default function initializeVariables(
   blocklyWrapper: BlocklyWrapperType
 ) {
+  blocklyWrapper.JavaScript.forBlock.parameters_get =
+    blocklyWrapper.JavaScript.forBlock.variables_get;
   blocklyWrapper.Variables.DEFAULT_CATEGORY = 'Default';
 
   // TODO: Removing support for sprite variables as a separate variable type is

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
@@ -97,6 +97,20 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
     ],
     mutator: 'procedure_caller_mutator',
   },
+  {
+    type: 'parameters_get',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_variable',
+        name: 'VAR',
+        variable: '%{BKY_VARIABLES_DEFAULT_NAME}',
+      },
+    ],
+    output: null,
+    style: 'sprite_blocks',
+    extensions: ['contextMenu_variableSetterGetter'],
+  },
 ]);
 
 // Respond to the click of a call block's edit button


### PR DESCRIPTION
Core Blockly uses the same `variables_get` block for global variables as well as parameters. However, our levels expect a similar `parameters_get` block, which is found in the modal function editor.  These blocks generate the same code but have a different appearance. Compare the `direction` parameter with the `left` variable:
<img width="416" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/b6b76cbf-70f9-4ad1-9f6e-3f242f4d4370">

Due to concerns about stretching an already thin palette of accessible block colors, I'm hesitant to define a new block style for this block. Instead, for now, I've opted to re-use our "sprite_blocks" style, because a) sprites and parameters are so far never both exposed within the same lab, and b) the color seems similar enough. 

<img width="425" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/59955829-f4a8-4153-9c71-47aaeb4a76a2">

Note that this branch just defines the block appearance and code generation. The work to actually add them to the mini-toolbox (as shown above) is in another branch: https://github.com/code-dot-org/code-dot-org/pull/59180 

## Links

https://codedotorg.atlassian.net/browse/CT-625

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
