### PR TITLE
Fix Go back link on LTI linking page

### DIFF
--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -10,7 +10,7 @@
       = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
         = image_tag("oauth/#{provider}.svg")
         = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))
-    %a.go-back-link{href: lti_v1_account_linking_landing_path(lti_provider: params[:lti_provider])}
+    %a.go-back-link{href: lti_v1_account_linking_landing_path(lti_provider: params[:lti_provider], email: params[:email])}
       %i.fa.fa-arrow-left
       = t('lti.account_linking.go_back')
   %div.vertical-or

--- a/dashboard/app/views/lti/v1/account_linking/landing.haml
+++ b/dashboard/app/views/lti/v1/account_linking/landing.haml
@@ -1,6 +1,8 @@
 - content_for(:head) do
   :ruby
     script_data = {}
+    lti_provider ||= params[:lti_provider]
+    email ||= params[:email]
     script_data[:lti_provider] = lti_provider
     script_data[:lti_provider_name] = Policies::Lti::LMS_PLATFORMS[lti_provider.to_sym][:name]
     script_data[:new_account_url] = new_user_registration_url


### PR DESCRIPTION
The account linking login page has a "Go back" link that takes the user back to the landing page where decide whether to create a fresh account or link an old one. We recently changed the lti_provider and email variables in the landing page template to local variables, which are set directly by the controller when rendering the page, instead of grabbing these values from params. This breaks the "Go back" link, which just links back with params. To fix this, this PR changes the landing page to fall back on params if the locals aren't present.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-988)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
