### PR TITLE
P20-987: Add ability to set DCDO via cookie for testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -258,6 +258,7 @@ end
 # Reduce volume of production logs
 # Ref: https://github.com/roidrage/lograge/pull/252
 gem 'lograge', github: 'code-dot-org/lograge', ref: 'debug_exceptions'
+gem 'request_store', '~> 1.6.0', require: false
 
 # Enforce SSL
 gem 'rack-ssl-enforcer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1115,6 +1115,7 @@ DEPENDENCIES
   redis (~> 4.8.1)
   redis-actionpack (~> 5.4.0)
   redis-slave-read!
+  request_store (~> 1.6.0)
   require_all
   rerun
   responders (~> 3.0)

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -330,6 +330,9 @@ netsim_shard_expiry_seconds: 7200
 dcdo_table_name:       dcdo_<%=env%>
 gatekeeper_table_name: gatekeeper_<%=env%>
 
+# Allows DCDO settings via cookies. See: 'dashboard/test/ui/features/cookie_dcdo.rb'
+cookie_dcdo: false
+
 # Poste (internal transactional email processing framework)
 poste_host: '<%= code_org_url.sub('//', '') %>'
 poste_attachment_dir:

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -73,3 +73,6 @@ openai_evaluate_rubric_api_key:
 
 # Mapbox
 mapbox_upload_tileset:    'censustiles-dev'
+
+# Enables DCDO settings via cookies
+cookie_dcdo: true

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -66,3 +66,6 @@ statsig_api_client_key: !Secret
 statsig_server_secret_key: 'secret-fake-key'
 statsig_api_client_key: 'client-fake-key'
 <% end -%>
+
+# Enables DCDO settings via cookies
+cookie_dcdo: true

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -90,6 +90,12 @@ module Dashboard
     require 'cdo/rack/upgrade_insecure_requests'
     config.middleware.use ::Rack::UpgradeInsecureRequests
 
+    if CDO.cookie_dcdo
+      # Enables the setting of DCDO via cookies for testing purposes.
+      require 'cdo/rack/cookie_dcdo'
+      config.middleware.insert_after ActionDispatch::RequestId, Rack::CookieDCDO
+    end
+
     config.encoding = 'utf-8'
 
     Rails.application.routes.default_url_options[:host] = CDO.canonical_hostname('studio.code.org')

--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -83,7 +83,4 @@ Dashboard::Application.configure do
   # queue adapter in development, comment out this line and make sure you have
   # run `bin/delayed_job start` or rake build.
   config.active_job.queue_adapter = :async
-
-  require 'cdo/rack/cookie_dcdo'
-  config.middleware.insert_after ActionDispatch::RequestId, Rack::CookieDCDO
 end

--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -83,4 +83,7 @@ Dashboard::Application.configure do
   # queue adapter in development, comment out this line and make sure you have
   # run `bin/delayed_job start` or rake build.
   config.active_job.queue_adapter = :async
+
+  require 'cdo/rack/cookie_dcdo'
+  config.middleware.insert_after ActionDispatch::RequestId, Rack::CookieDCDO
 end

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -91,4 +91,7 @@ Dashboard::Application.configure do
   end
 
   config.experiment_cache_time_seconds = 0
+
+  require 'cdo/rack/cookie_dcdo'
+  config.middleware.insert_after ActionDispatch::RequestId, Rack::CookieDCDO
 end

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -91,7 +91,4 @@ Dashboard::Application.configure do
   end
 
   config.experiment_cache_time_seconds = 0
-
-  require 'cdo/rack/cookie_dcdo'
-  config.middleware.insert_after ActionDispatch::RequestId, Rack::CookieDCDO
 end

--- a/dashboard/test/ui/features/cookie_dcdo.feature
+++ b/dashboard/test/ui/features/cookie_dcdo.feature
@@ -1,0 +1,19 @@
+Feature: Cookie DCDO
+  Scenario: Cookie DCDO flag is set
+    Given I am on "http://studio.code.org/users/sign_in"
+    Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":null"
+
+    # Tests assigning of a cookie DCDO flag
+    When I set the DCDO key "cookie_dcdo_test" to "Cookie DCDO assigning works"
+    And I reload the page
+    Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":"Cookie DCDO assigning works""
+
+    # Tests re-assigning of a cookie DCDO flag
+    When I set the DCDO key "cookie_dcdo_test" to "{"Cookie DCDO re-assigning":"works"}"
+    And I reload the page
+    Then element "script[data-dcdo]" attr "data-dcdo" includes ""Cookie DCDO re-assigning":"works""
+
+    # Tests cleaning of a cookie DCDO flag
+    When I delete the cookie named "DCDO"
+    And I reload the page
+    Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":null"

--- a/dashboard/test/ui/features/cookie_dcdo.feature
+++ b/dashboard/test/ui/features/cookie_dcdo.feature
@@ -4,14 +4,14 @@ Feature: Cookie DCDO
     Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":null"
 
     # Tests assigning of a cookie DCDO flag
-    When I set the DCDO key "cookie_dcdo_test" to "Cookie DCDO assigning works"
+    When I set the DCDO key "cookie_dcdo_test" to "assigning_works"
     And I reload the page
-    Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":"Cookie DCDO assigning works""
+    Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":"assigning_works""
 
     # Tests re-assigning of a cookie DCDO flag
-    When I set the DCDO key "cookie_dcdo_test" to "{"Cookie DCDO re-assigning":"works"}"
+    When I set the DCDO key "cookie_dcdo_test" to "{"re-assigning":"works"}"
     And I reload the page
-    Then element "script[data-dcdo]" attr "data-dcdo" includes ""Cookie DCDO re-assigning":"works""
+    Then element "script[data-dcdo]" attr "data-dcdo" includes ""cookie_dcdo_test":{"re-assigning":"works"}"
 
     # Tests cleaning of a cookie DCDO flag
     When I delete the cookie named "DCDO"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1048,27 +1048,10 @@ def set_cookie(key, value)
   @browser.manage.add_cookie params
 end
 
-def set_cookie_dcdo(key, value)
-  cookie_dcdo =
-    begin
-      JSON.parse(@browser.manage.cookie_named('DCDO').try(:[], :value).presence || '{}')
-    rescue Selenium::WebDriver::Error::NoSuchCookieError
-      {}
-    end
-
-  cookie_dcdo[key] = value
-
-  set_cookie('DCDO', cookie_dcdo.to_json)
-end
-
 Given(/^I set the DCDO key "([^"]*)" to "(.*)"$/) do |key, json|
-  begin
-    value = JSON.parse(json)
-  rescue JSON::ParserError
-    value = json
-  end
-
-  set_cookie_dcdo(key, value)
+  set_dcdo(key, JSON.parse(json))
+rescue JSON::ParserError
+  set_dcdo(key, json)
 end
 
 And(/^I set the language cookie$/) do

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -844,6 +844,22 @@ Then /^element "([^"]*)" is (not )?displayed$/ do |selector, negation|
   expect(element_displayed?(selector)).to eq(negation.nil?)
 end
 
+Then /^element "([^"]*)" attr "([^"]*)" includes (no )?"(.*)"$/ do |selector, attr, negation, attr_json|
+  actual_attr_value = @browser.find_element(:css, selector).attribute(attr)
+  expected_attr_value =
+    begin
+      JSON.parse(attr_json)
+    rescue JSON::ParserError
+      attr_json
+    end
+
+  if negation
+    expect(actual_attr_value).not_to include(expected_attr_value)
+  else
+    expect(actual_attr_value).to include(expected_attr_value)
+  end
+end
+
 And(/^I select age (\d+) in the age dialog/) do |age|
   dropdown_selection = age
   if age == 21
@@ -1030,6 +1046,29 @@ def set_cookie(key, value)
   end
 
   @browser.manage.add_cookie params
+end
+
+def set_cookie_dcdo(key, value)
+  cookie_dcdo =
+    begin
+      JSON.parse(@browser.manage.cookie_named('DCDO').try(:[], :value).presence || '{}')
+    rescue Selenium::WebDriver::Error::NoSuchCookieError
+      {}
+    end
+
+  cookie_dcdo[key] = value
+
+  set_cookie('DCDO', cookie_dcdo.to_json)
+end
+
+Given(/^I set the DCDO key "([^"]*)" to "(.*)"$/) do |key, json|
+  begin
+    value = JSON.parse(json)
+  rescue JSON::ParserError
+    value = json
+  end
+
+  set_cookie_dcdo(key, value)
 end
 
 And(/^I set the language cookie$/) do

--- a/dashboard/test/ui/features/support/dashboard_helpers.rb
+++ b/dashboard/test/ui/features/support/dashboard_helpers.rb
@@ -9,6 +9,19 @@ module DashboardHelpers
     puts "Requiring rails env took #{finish - start} seconds"
     @rails_loaded = true
   end
+
+  def set_dcdo(key, value)
+    cookie_dcdo =
+      begin
+        JSON.parse(@browser.manage.cookie_named('DCDO').try(:[], :value).presence || '{}')
+      rescue Selenium::WebDriver::Error::NoSuchCookieError
+        {}
+      end
+
+    cookie_dcdo[key] = value
+
+    @browser.manage.add_cookie(name: 'DCDO', value: cookie_dcdo.to_json)
+  end
 end
 
 World(DashboardHelpers)

--- a/dashboard/test/ui/features/support/dashboard_helpers.rb
+++ b/dashboard/test/ui/features/support/dashboard_helpers.rb
@@ -10,8 +10,7 @@ module DashboardHelpers
     @rails_loaded = true
   end
 
-  # Allows setting DCDO values per test scenario
-  # @see 'dashboard/test/ui/features/cookie_dcdo.rb'
+  # Sets DCDO for a test scenario.
   # @see Rack::CookieDCDO
   def set_dcdo(key, value)
     cookie_dcdo =

--- a/dashboard/test/ui/features/support/dashboard_helpers.rb
+++ b/dashboard/test/ui/features/support/dashboard_helpers.rb
@@ -10,6 +10,9 @@ module DashboardHelpers
     @rails_loaded = true
   end
 
+  # Allows setting DCDO values per test scenario
+  # @see 'dashboard/test/ui/features/cookie_dcdo.rb'
+  # @see Rack::CookieDCDO
   def set_dcdo(key, value)
     cookie_dcdo =
       begin

--- a/lib/cdo/rack/cookie_dcdo.rb
+++ b/lib/cdo/rack/cookie_dcdo.rb
@@ -1,0 +1,32 @@
+require 'json'
+require 'request_store'
+require 'dynamic_config/dcdo'
+
+# This middleware enables the setting of DCDO via cookies for testing purposes.
+# See: 'dashboard/test/ui/features/cookie_dcdo.rb'
+module Rack
+  class CookieDCDO
+    def initialize(app)
+      modify_dcdo
+
+      @app = app
+    end
+
+    def call(env)
+      # Stores the cookie DCDO data per request.
+      RequestStore.store[:DCDO] = JSON.parse(Rack::Request.new(env).cookies['DCDO'] || '{}')
+
+      @app.call(env)
+    ensure
+      # Clears the cookie DCDO after the request to avoid data leaking.
+      RequestStore.store[:DCDO] = nil
+    end
+
+    # Redefines `DCDO#get` to return the cookie DCDO value if it exists;
+    private def modify_dcdo
+      DCDO.define_singleton_method(:get) do |key, *args|
+        RequestStore.store[:DCDO]&.key?(key) ? RequestStore.store[:DCDO][key] : super(key, *args)
+      end
+    end
+  end
+end

--- a/lib/cdo/rack/cookie_dcdo.rb
+++ b/lib/cdo/rack/cookie_dcdo.rb
@@ -14,27 +14,30 @@ module Rack
       # Stores the cookie DCDO data per request.
       RequestStore.store[:DCDO] = JSON.parse(Rack::Request.new(env).cookies['DCDO'] || '{}')
 
-      Rails.logger.info "\n" * 2
-      Rails.logger.info "=" * 80
-      Rails.logger.info "Request Cookies: #{Rack::Request.new(env).cookies.inspect}"
-      Rails.logger.info '-' * 80
-      Rails.logger.info "RequestStore ID: #{RequestStore.store.object_id}"
-      Rails.logger.info "RequestStore DCDO: #{RequestStore.store[:DCDO].inspect}"
-      Rails.logger.info "=" * 80
-      Rails.logger.info "\n" * 2
+      if Rack::Request.new(env).cookies['DCDO']
+        Rails.logger.info "\n"
+        Rails.logger.info "=" * 80
+        Rails.logger.info "Request Cookies: #{Rack::Request.new(env).cookies.inspect}"
+        Rails.logger.info '-' * 80
+        Rails.logger.info "request_store_dcdo[#{RequestStore.store.object_id}]: #{RequestStore.store[:DCDO].inspect}"
+        Rails.logger.info "=" * 80
+        Rails.logger.info "\n"
+      end
 
       unless DCDO.instance_variable_get(:@_redefined)
         # Redefines `DCDO#get` to return the cookie DCDO value if it exists.
         DCDO.define_singleton_method(:get) do |key, *args|
-          Rails.logger.info "\n" * 2
-          Rails.logger.info '*' * 80
-          Rails.logger.info "DCDO INSTANCE ID: #{object_id.inspect}"
-          Rails.logger.info "DCDO KEY: #{key.inspect}"
-          Rails.logger.info '-' * 80
-          Rails.logger.info "RequestStore ID: #{RequestStore.store.object_id}"
-          Rails.logger.info "RequestStore DCDO: #{RequestStore.store[:DCDO].inspect}"
-          Rails.logger.info '*' * 80
-          Rails.logger.info "\n" * 2
+          if key == 'cookie_dcdo_test'
+            Rails.logger.info "\n" * 2
+            Rails.logger.info '*' * 80
+            Rails.logger.info "DCDO INSTANCE ID: #{object_id.inspect}"
+            Rails.logger.info "DCDO KEY: #{key.inspect}"
+            Rails.logger.info '-' * 80
+            Rails.logger.info "Request key: request_store_dcdo[#{RequestStore.store.object_id}]"
+            Rails.logger.info "RequestStore DCDO: #{RequestStore.store[:DCDO].inspect}"
+            Rails.logger.info '*' * 80
+            Rails.logger.info "\n" * 2
+          end
 
           RequestStore.store[:DCDO]&.key?(key) ? RequestStore.store[:DCDO][key] : super(key, *args)
         end

--- a/lib/cdo/rack/cookie_dcdo.rb
+++ b/lib/cdo/rack/cookie_dcdo.rb
@@ -14,9 +14,28 @@ module Rack
       # Stores the cookie DCDO data per request.
       RequestStore.store[:DCDO] = JSON.parse(Rack::Request.new(env).cookies['DCDO'] || '{}')
 
+      Rails.logger.info "\n" * 2
+      Rails.logger.info "=" * 80
+      Rails.logger.info "Request Cookies: #{Rack::Request.new(env).cookies.inspect}"
+      Rails.logger.info '-' * 80
+      Rails.logger.info "RequestStore ID: #{RequestStore.store.object_id}"
+      Rails.logger.info "RequestStore DCDO: #{RequestStore.store[:DCDO].inspect}"
+      Rails.logger.info "=" * 80
+      Rails.logger.info "\n" * 2
+
       unless DCDO.instance_variable_get(:@_redefined)
         # Redefines `DCDO#get` to return the cookie DCDO value if it exists.
         DCDO.define_singleton_method(:get) do |key, *args|
+          Rails.logger.info "\n" * 2
+          Rails.logger.info '*' * 80
+          Rails.logger.info "DCDO INSTANCE ID: #{object_id.inspect}"
+          Rails.logger.info "DCDO KEY: #{key.inspect}"
+          Rails.logger.info '-' * 80
+          Rails.logger.info "RequestStore ID: #{RequestStore.store.object_id}"
+          Rails.logger.info "RequestStore DCDO: #{RequestStore.store[:DCDO].inspect}"
+          Rails.logger.info '*' * 80
+          Rails.logger.info "\n" * 2
+
           RequestStore.store[:DCDO]&.key?(key) ? RequestStore.store[:DCDO][key] : super(key, *args)
         end
 

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -55,6 +55,8 @@ class DCDOBase < DynamicConfigBase
       'student-email-post-enabled': DCDO.get('student-email-post-enabled', false),
       'progress-v2-metadata-enabled': DCDO.get('progress-v2-metadata-enabled', false),
       'show-updated-lms-content': DCDO.get('show-updated-lms-content', false),
+      # Used to test DCDO setting via cookie. See: 'dashboard/test/ui/features/cookie_dcdo.rb'
+      cookie_dcdo_test: DCDO.get('cookie_dcdo_test', nil),
     }
   end
 end

--- a/lib/dynamic_config/dynamic_config_base.rb
+++ b/lib/dynamic_config/dynamic_config_base.rb
@@ -16,6 +16,8 @@ class DynamicConfigBase
   # @param key [String]
   # @param default
   # @returns the stored value at key
+  # @note This method is redefined in Rack::CookieDCDO to return the cookie DCDO value for testing, if it exists
+  # @see Rack::CookieDCDO#modify_dcdo
   def get(key, default)
     raise ArgumentError unless key.is_a? String
     value = @datastore_cache.get(key)

--- a/lib/dynamic_config/dynamic_config_base.rb
+++ b/lib/dynamic_config/dynamic_config_base.rb
@@ -17,7 +17,7 @@ class DynamicConfigBase
   # @param default
   # @returns the stored value at key
   # @note This method is redefined in Rack::CookieDCDO to return the cookie DCDO value for testing, if it exists
-  # @see Rack::CookieDCDO#modify_dcdo
+  # @see Rack::CookieDCDO#call
   def get(key, default)
     raise ArgumentError unless key.is_a? String
     value = @datastore_cache.get(key)


### PR DESCRIPTION
## Summary
We have the ability to stub DCDO settings in a controller unit test.

But we don’t have a way to carry out a browser user interface test that checks how a feature behaves from the user’s perspective based on different values of a DCDO setting.

This change would allow a cookie to control that functionality for a single HTTP request or a sequence of HTTP requests without impacting how other endpoints behave in the web application server.

Allows us to set DCDO via cookies for testing purposes in the `test` and `development` environments:
https://github.com/code-dot-org/code-dot-org/blob/4117b99459d18cab0bb28dcffe844eecf0b10f6b/dashboard/test/ui/features/support/dashboard_helpers.rb#L15-L26

## Links
- JIRA task: [P20-987](https://codedotorg.atlassian.net/browse/P20-987)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/59142
- Revert PR: https://github.com/code-dot-org/code-dot-org/pull/59157
- Slack thread: https://codedotorg.slack.com/archives/C046G4TRLEN/p1717996253418919