### PR TITLE
Minecraft: limit mute button clicks while updating

### DIFF
--- a/apps/src/templates/instructions/BackgroundMusicMuteButton.jsx
+++ b/apps/src/templates/instructions/BackgroundMusicMuteButton.jsx
@@ -30,9 +30,15 @@ function BackgroundMusicMuteButton({
 
   const [isBackgroundMusicMuted, setIsBackgroundMusicMuted] =
     useState(initialMuteState);
+  const [isSavingMutePreference, setIsSavingMutePreference] = useState(false);
 
   const updateMuteMusic = updatedMuteValue => {
-    signedIn ? new UserPreferences().setMuteMusic(updatedMuteValue) : {};
+    if (signedIn) {
+      setIsSavingMutePreference(true);
+      new UserPreferences()
+        .setMuteMusic(updatedMuteValue)
+        .always(() => setIsSavingMutePreference(false));
+    }
     setMuteMusic(updatedMuteValue);
   };
 
@@ -84,7 +90,8 @@ function BackgroundMusicMuteButton({
       }
       isRtl={isRtl}
       isMinecraft={isMinecraft}
-      onClick={handleMuteMusicTabClick}
+      isDisabled={isSavingMutePreference}
+      onClick={isSavingMutePreference ? () => {} : handleMuteMusicTabClick}
       style={{
         ...styles.button,
         ...(!isMinecraft

--- a/apps/test/unit/templates/instructions/BackgroundMusicMuteButtonTest.jsx
+++ b/apps/test/unit/templates/instructions/BackgroundMusicMuteButtonTest.jsx
@@ -25,6 +25,14 @@ describe('SignedInUser', () => {
     return mount(<BackgroundMusicMuteButton {...props} />);
   };
 
+  let server;
+  beforeEach(() => {
+    server = sinon.fakeServer.create();
+    server.respondWith('POST', '/api/v1/users/me/mute_music', 'ok');
+  });
+
+  afterEach(() => server.restore());
+
   it('switches label and icon when button is pressed', () => {
     const wrapper = setUp();
     assert(wrapper.text() === i18n.backgroundMusicOn());
@@ -33,8 +41,6 @@ describe('SignedInUser', () => {
   });
 
   it('calls mute and unmute functions accordingly', () => {
-    const server = sinon.fakeServer.create();
-    server.respondWith('POST', '/api/v1/users/me/mute_music', 'ok');
     let onMuteSpy = sinon.spy();
     let onUnmuteSpy = sinon.spy();
     const wrapper = setUp({
@@ -46,8 +52,6 @@ describe('SignedInUser', () => {
     expect(onMuteSpy).to.have.been.calledOnce;
     wrapper.find('.uitest-mute-music-button').simulate('click');
     expect(onUnmuteSpy).to.have.been.calledOnce;
-
-    server.restore();
   });
 
   describe('minecraft vs starwars styling', () => {

--- a/apps/test/unit/templates/instructions/BackgroundMusicMuteButtonTest.jsx
+++ b/apps/test/unit/templates/instructions/BackgroundMusicMuteButtonTest.jsx
@@ -33,6 +33,8 @@ describe('SignedInUser', () => {
   });
 
   it('calls mute and unmute functions accordingly', () => {
+    const server = sinon.fakeServer.create();
+    server.respondWith('POST', '/api/v1/users/me/mute_music', 'ok');
     let onMuteSpy = sinon.spy();
     let onUnmuteSpy = sinon.spy();
     const wrapper = setUp({
@@ -40,9 +42,12 @@ describe('SignedInUser', () => {
       unmuteBackgroundMusic: onUnmuteSpy,
     });
     wrapper.find('.uitest-mute-music-button').simulate('click');
+    server.respond();
     expect(onMuteSpy).to.have.been.calledOnce;
     wrapper.find('.uitest-mute-music-button').simulate('click');
     expect(onUnmuteSpy).to.have.been.calledOnce;
+
+    server.restore();
   });
 
   describe('minecraft vs starwars styling', () => {


### PR DESCRIPTION
Disables the mute/unmute button in Minecraft levels until we've received a response from the server that a user's mute preferences have been saved.

**New behavior** (button disabled during request -- response time for saving user preference exaggerated for demonstration purposes)

https://github.com/code-dot-org/code-dot-org/assets/25372625/993e0eca-c1d6-451b-98d9-305f9c563c48

## Links

- jira ticket: [LABS-543](https://codedotorg.atlassian.net/browse/LABS-543)

## Testing story

Tested manually that I couldn't make additional requests to update my mute preferences until we had received a response from the server. Also updated existing unit test.