### PR TITLE
Generate code for initialization blocks, including variables

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2015,11 +2015,13 @@ StudioApp.prototype.setConfigValues_ = function (config) {
 
     // Generate code for the initialization blocks. Used at execution time
     // for labs like Maze.
-    const generator = Blockly.getGenerator();
-    generator.init(this.initializationBlocks[0].workspace);
-    this.initializationCode = generator.finish(
-      Blockly.Generator.blocksToCode('JavaScript', this.initializationBlocks)
-    );
+    if (this.initializationBlocks.length) {
+      const generator = Blockly.getGenerator();
+      generator.init(this.initializationBlocks[0].workspace);
+      this.initializationCode = generator.finish(
+        Blockly.Generator.blocksToCode('JavaScript', this.initializationBlocks)
+      );
+    }
   }
 
   // enableShowCode defaults to true if not defined

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2012,6 +2012,14 @@ StudioApp.prototype.setConfigValues_ = function (config) {
       'JavaScript',
       xml
     );
+
+    // Generate code for the initialization blocks. Used at execution time
+    // for labs like Maze.
+    const generator = Blockly.getGenerator();
+    generator.init(this.initializationBlocks[0].workspace);
+    this.initializationCode = generator.finish(
+      Blockly.Generator.blocksToCode('JavaScript', this.initializationBlocks)
+    );
   }
 
   // enableShowCode defaults to true if not defined

--- a/apps/src/blockly/addons/cdoGenerator.ts
+++ b/apps/src/blockly/addons/cdoGenerator.ts
@@ -15,8 +15,8 @@ export default function initializeGenerator(
   // This function was a custom addition in CDO Blockly, so we need to add it here
   // so that our code generation logic still works with Google Blockly
   blocklyWrapper.Generator.xmlToBlocks = function (_name, xml) {
-    const div = document.createElement('div');
-    const workspace = blocklyWrapper.createEmbeddedWorkspace(div, xml, {});
+    const workspace = new Blockly.Workspace();
+    Blockly.Xml.domToBlockSpace(workspace, xml);
     return workspace.getTopBlocks(true);
   };
 
@@ -48,7 +48,9 @@ export default function initializeGenerator(
       );
     }
     const generator = blocklyWrapper.getGenerator();
-    generator.init(blocklyWrapper.getMainWorkspace());
+    if (blocklyWrapper.getMainWorkspace()) {
+      generator.init(blocklyWrapper.getMainWorkspace());
+    }
     generator.variableDB_ = generator.nameDB_;
     const code: string[] = [];
     blocksToGenerate.forEach(block => {

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -258,7 +258,7 @@ export interface ExtendedWorkspace extends Workspace {
 type CodeGeneratorType = typeof CodeGenerator;
 export interface ExtendedGenerator extends CodeGeneratorType {
   xmlToCode: (name: string, domBlocks: Element) => string;
-  xmlToBlocks: (name: string, xml: Node) => Block[];
+  xmlToBlocks: (name: string, xml: Element) => Block[];
   blockSpaceToCode: (
     name: string,
     opt_typeFilter?: string | string[]

--- a/apps/src/blockly/utils.ts
+++ b/apps/src/blockly/utils.ts
@@ -14,7 +14,7 @@ type xmlAttribute = string | null;
 type InputTuple = [string, string, number];
 type InputCallback = () => void;
 type InputArgs = [...(InputTuple | InputCallback)[], number];
-type BlockList = [Block | BlockSvg];
+type BlockList = Array<Block | BlockSvg>;
 
 // Considers an attribute true only if it is explicitly set to 'true' (i.e. defaults to false if unset).
 export const FALSEY_DEFAULT = (attributeValue: xmlAttribute) =>
@@ -276,13 +276,21 @@ export function interpolateMsg(
  * @returns {BlockList} An array of the top-level blocks.
  */
 export function getCodeBlocks(): BlockList {
-  const codeBlocks = Blockly.mainBlockSpace.getTopBlocks(true) as BlockList;
+  let codeBlocks: BlockList = [];
+  let hiddenBlocks: BlockList = [];
+  const mainBlocks = Blockly.mainBlockSpace.getTopBlocks(true) as BlockList;
+
   // The hidden workspace is only present in Google Blockly labs where the modal
   // function editor is enabled.
   if (Blockly.getHiddenDefinitionWorkspace()) {
-    const hiddenBlocks =
-      Blockly.getHiddenDefinitionWorkspace().getTopBlocks(true);
-    codeBlocks.push(...hiddenBlocks);
+    hiddenBlocks = Blockly.getHiddenDefinitionWorkspace().getTopBlocks(
+      true
+    ) as BlockList;
   }
+
+  // Hidden blocks need to be listed first in case they would set the
+  // value of global variables.
+  codeBlocks = [...hiddenBlocks, ...mainBlocks];
+
   return codeBlocks;
 }

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -313,11 +313,10 @@ module.exports = class Maze {
     let code = '';
     if (studioApp().isUsingBlockly()) {
       let codeBlocks = getCodeBlocks();
-      if (studioApp().initializationBlocks) {
-        codeBlocks = studioApp().initializationBlocks.concat(codeBlocks);
+      if (studioApp().initializationCode) {
+        code = studioApp().initializationCode;
       }
-
-      code = Blockly.Generator.blocksToCode('JavaScript', codeBlocks);
+      code += Blockly.Generator.blocksToCode('JavaScript', codeBlocks);
     } else {
       code = generateCodeAliases(dropletConfig, 'Maze');
       code += studioApp().editor.getValue();


### PR DESCRIPTION
Some levels, such as `/s/course4/lessons/16/levels/3`, include "invisible" blocks. We've seen this before, including for "orphaned" variable blocks which simply aim to help pre-populate the dropdown menu of a student's variable block. In this level, they are used to initialize two variables (which students are then expected to access in their programs):
<img width="527" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/c5429ba3-9647-4346-936f-5a736bf86a09">

We handle these blocks by moving them to our hidden workspace. When we generate code, we do so for the main workspace and then the hidden workspace. This works fine for function definitions, but not when we are initializing a variable as part of the main program flow. We need to flip the order of workspaces so that the hidden workspace's generated code is listed first. (This actually would be parity with CDO Blockly.) Swapping the order makes the executed code for level 3 correct:

```
var left, right, direction;

function get_3_nectar(direction) {
    executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}
  if (direction == left) {
    Maze.turnLeft('block_id_}Z?JkkA!YDq_H:m{:=/~');
  } else {
    Maze.turnRight('block_id_Lmi2[i/xkd!WbPQ3H8]:');
  }
  Maze.moveForward('block_id_km*|+O*$Pdk[!vZDGF9m');
  Maze.moveForward('block_id_e#0xG-N/(q9=t,.mKc#(');
  for (var count = 0; count < 3; count++) {
      executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}
    Maze.getNectar('block_id_n(ZC9YU#S|qGO1L[=)Ke');
  }
  Maze.moveBackward('block_id_@KfZ_,f4$~u`G~rpRzW(');
  Maze.moveBackward('block_id_N,4mRm{Pzmqy9}EaRF;y');
  if (direction == left) {
    Maze.turnRight('block_id_8(Px6x/@MXMcy;GK$3#G');
  } else {
    Maze.turnLeft('block_id_@pnq`e}~vMZ!T|l(rrk%');
  }
}

left = 0;
right = 1;

Maze.moveForward('block_id_2z{9*kUT{C0Aen^Z~#=s');
Maze.moveForward('block_id_.c5^~Qr9n0OW2kn{oG]c');
get_3_nectar(right);
Maze.moveForward('block_id_eYW-JXX{T-wJEImNK4gV');
Maze.moveForward('block_id_s?N%^_]jiV0WuL;!^(d8');
get_3_nectar(left);
Maze.moveForward('block_id_Q[X_T:aF0(Urg-^RB`ns');
Maze.moveForward('block_id_jO0Q7eN2k,l+8O^Y]JE)');
get_3_nectar(right);
```

To make it more confusing, some levels, such as `/s/course4/lessons/16/levels/4`, define these blocks as "initialization blocks", which means they are on a totally separate workspace. These blocks are not present on the student's main workspace but are still part of the generated code for the level. 
<img width="429" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/252f8e3a-4e26-4f0a-9ec5-acbae3408e24">

When Maze calls `execute_` it concats these initialization blocks with all student blocks and then generates code. Unfortunately, this doesn't quite work with Google Blockly. Because the intialization blocks are on a totally separate workspace (without any event mirroring for variables), the variable ids are out of sync. This means we can't generate code for the full list of blocks in one go. Instead, I've reworked this so that Studio App will actually write the generated code for the read-only initialization blocks. When pressing Run, we can retrieve this code string, reinitialize the JS generator, and then generate code for the student blocks. The result is that the execute code will begin with the initialization blocks, then the hidden workspace blocks, then the main workspace block. This works fine in both CDO and Google Blockly.

Now, we can get correct code to execute with Google Blockly in level 4:

```
var left, right;

left = 0;
right = 1;
var direction, left, right;

function get_3_nectar(direction) {
    executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}
  if (direction == left) {
    Maze.turnLeft('block_id_|W(UEsmA:Zg-Z#O,|D0;');
  } else {
    Maze.turnRight('block_id_txnF=P5aJ{wTWKd;].vN');
  }
  Maze.moveForward('block_id_Zg5h6D2oQ+Ekh*e(H/BR');
  Maze.moveForward('block_id_~#3G:~ZUrc_/fYh}r)(-');
  for (var count = 0; count < 3; count++) {
      executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}
    Maze.getNectar('block_id_^o!Ey)}`3{]/_Y,8VC{i');
  }
  Maze.moveBackward('block_id_r)O=}oH97,2:[p?v}`X.');
  Maze.moveBackward('block_id_b$L%!v:1]?Y~y`pARe;L');
  if (direction == left) {
    Maze.turnRight('block_id_dB:#ILHT`;js7NBj?9H_');
  } else {
    Maze.turnLeft('block_id_}Vp9=czrjc9;]%}qanU{');
  }
}

for (var count2 = 0; count2 < 2; count2++) {
    executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}
  Maze.moveForward('block_id_6LGc`jRmi;P,n,Rd{hAO');
  get_3_nectar(left);
  Maze.moveForward('block_id_q@v_|D][GkNXJU)*^0NC');
  get_3_nectar(right);
}
```

While here, I also simplified the work done when we call `xmlToBlocks`. Previously, we created an embedded workspace, like we might do for putting a block in instructions or hints. The div containing this rendered workspace isn't actually put anywhere, because we don't really need it. Instead we can just create a headless workspace for this operation which saves us from having to traverse a ton of custom logic. There is no need to actually create SVGs of blocks just to generate code, so there wasn't an advantage to the old way; I believe we just copied the approach from what was done in CDO Blockly. https://github.com/code-dot-org/code-dot-org/pull/55302 https://github.com/code-dot-org/blockly/blob/v4.1.0/core/code_generation/generator.js#L124




## Links

https://codedotorg.atlassian.net/browse/CT-625

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
