### PR TITLE
mutation must be immediate child of block

### DIFF
--- a/apps/src/blockly/addons/cdoXml.ts
+++ b/apps/src/blockly/addons/cdoXml.ts
@@ -149,7 +149,8 @@ export function removeIdsFromBlocks(
  */
 export function addMutationToMiniToolboxBlocks(blockElement: Element) {
   const miniflyoutAttribute = blockElement.getAttribute('miniflyout');
-  const existingMutationElement = blockElement.querySelector('mutation');
+  const existingMutationElement =
+    blockElement.querySelector(':scope > mutation');
   if (!miniflyoutAttribute || existingMutationElement) {
     // The block is the wrong type or has somehow already been processed.
     return;
@@ -202,7 +203,7 @@ export function addMutationToBehaviorBlocks(blockElement: Element) {
     return;
   }
   const mutationElement =
-    blockElement.querySelector('mutation') ||
+    blockElement.querySelector(':scope > mutation') ||
     blockElement.ownerDocument.createElement('mutation');
   // Place mutator before fields, values, and other nested blocks.
   blockElement.insertBefore(mutationElement, blockElement.firstChild);
@@ -244,7 +245,7 @@ export function addMutationToProcedureDefBlocks(blockElement: Element) {
     return;
   }
   const mutationElement =
-    blockElement.querySelector('mutation') ||
+    blockElement.querySelector(':scope > mutation') ||
     blockElement.ownerDocument.createElement('mutation');
   // Place mutator before fields, values, and other nested blocks.
   blockElement.insertBefore(mutationElement, blockElement.firstChild);
@@ -282,7 +283,7 @@ export function addMutationToInvisibleBlocks(blockElement: Element) {
     return;
   }
   const mutationElement =
-    blockElement.querySelector('mutation') ||
+    blockElement.querySelector(':scope > mutation') ||
     blockElement.ownerDocument.createElement('mutation');
   // Place mutator before fields, values, and other nested blocks.
   blockElement.insertBefore(mutationElement, blockElement.firstChild);
@@ -321,7 +322,7 @@ export function addNameToBlockFunctionCallBlock(blockElement: Element) {
     return;
   }
   const mutationElement =
-    blockElement.querySelector('mutation') ||
+    blockElement.querySelector(':scope > mutation') ||
     blockElement.ownerDocument.createElement('mutation');
   // Place mutator before fields, values, and other nested blocks.
   blockElement.insertBefore(mutationElement, blockElement.firstChild);
@@ -379,7 +380,7 @@ export function addMutationToTextJoinBlock(blockElement: Element) {
     return;
   }
   const mutationElement =
-    blockElement.querySelector('mutation') ||
+    blockElement.querySelector(':scope > mutation') ||
     blockElement.ownerDocument.createElement('mutation');
   // Place mutator before fields, values, and other nested blocks.
   blockElement.insertBefore(mutationElement, blockElement.firstChild);


### PR DESCRIPTION
While working on migrating parameters, I noticed that instances of a `if/else` block were losing their `else` branch on page reload if the block was inside a function:
<img width="45%" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/43782a9c-6151-4679-a653-be5037ee4392"> <img width="45%" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/6691d5ee-97ef-4bf9-8d2f-2c06d41f7975">

This was happening due to a bug while deserializing student XML.  To make our XML compatible with Google Blockly, we've had to move some extra state into mutations. We would first attempt to see if the `<block/>` already contained a `<mutation/>`. If not, we'd create one, and then append it to the appropriate place as the block's first child (ahead of fields or next blocks). However, there was a bug in the query selector. Due to the nested XML structure of next blocks, we would look for the first mutation we could find in that block _or its children_, and then modify/move it. This meant that we could find the mutation for the `if/else` block and move it onto the definition block. If the `if/else` block no longer has its mutation, it would use the default single-branch state.

We perform a similar mutation operation for procedure definitions, invisible blocks, function call blocks, and text join blocks. Unfortunately, each place had the same bug. To fix each, I added the `:scope` pseudoclass to the selector, which matches the element element on which it is called. https://developer.mozilla.org/en-US/docs/Web/CSS/:scope

For the case above, this results in no mutation being found for the procedure definition (as expected). In turn, the `if/else` block's mutation is left alone so the block is rendered correctly.

## Links

https://codedotorg.atlassian.net/browse/CT-625

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
