### PR TITLE
Fix LTI account linking new account link

### DIFF
--- a/dashboard/app/views/lti/v1/account_linking/landing.haml
+++ b/dashboard/app/views/lti/v1/account_linking/landing.haml
@@ -3,9 +3,10 @@
     script_data = {}
     lti_provider ||= params[:lti_provider]
     email ||= params[:email]
+    new_account_url = DCDO.get('student-email-post-enabled', false) ? users_finish_sign_up_path : new_user_registration_url
     script_data[:lti_provider] = lti_provider
     script_data[:lti_provider_name] = Policies::Lti::LMS_PLATFORMS[lti_provider.to_sym][:name]
-    script_data[:new_account_url] = new_user_registration_url
+    script_data[:new_account_url] = new_account_url
     script_data[:existing_account_url] = CDO.studio_url(user_session_path, CDO.default_scheme)
     script_data[:email] = email
 


### PR DESCRIPTION
When the email post remediation is enabled, the form needs to post to the finish registration URL. Otherwise, it needs to redirect to the new_user_registration_url.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-989)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
