### PR TITLE
Music: update notes style

### DIFF
--- a/apps/src/music/views/SoundStyle.module.scss
+++ b/apps/src/music/views/SoundStyle.module.scss
@@ -16,5 +16,5 @@
   @include sound-type-style(Fx, #E3CB0C, #E3CB0C, #928308, #E3CB0C);
   @include sound-type-style(Vocal, #ff8c00, #ff8c00, #a35a02, #ff8c00);
   @include sound-type-style(Pattern, black, black, black, $neutral_light);
-  @include sound-type-style(Chord, $light_cyan, $light_cyan, $light_cyan, $neutral_dark80);
+  @include sound-type-style(Chord, $light_cyan, $light_cyan, $light_cyan, #4289a3);
 }


### PR DESCRIPTION
This makes a small change to the style of the `play notes` entries in the timeline to avoid the smallest version of the block being grey, due only the border being visible at that size.

### Before

<img width="1512" alt="Screenshot 2024-06-12 at 9 36 02 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/1236194e-0e78-43c9-a7bd-2b3d3dce9441">

<img width="1512" alt="Screenshot 2024-06-12 at 9 40 26 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/7b1ad298-c317-43d7-ba4c-060b31b92dc0">

### After

<img width="1512" alt="Screenshot 2024-06-12 at 9 35 20 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/5cb445f2-462d-45e9-b81c-0588e90f216d">

<img width="1512" alt="Screenshot 2024-06-12 at 9 35 28 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/b0acf5db-aaf4-49fa-abe7-939d3826d1e1">


