### PR TITLE
Update MySQL to 8.0.37

### DIFF
--- a/cookbooks/cdo-mysql/recipes/client.rb
+++ b/cookbooks/cdo-mysql/recipes/client.rb
@@ -6,13 +6,13 @@ mysql_client_packages = ['mysql-client']
 mysql_client_versions = ['5.7.42-1ubuntu18.04']
 
 # It's not entirely clear why this needs to be explicitly installed; for some
-# reason, `sudo apt install mysql-client=8.0.36-0ubuntu0.20.04.1` fails with
+# reason, `sudo apt install mysql-client=8.0.37-0ubuntu0.20.04.3` fails with
 # `mysql-client : Depends: mysql-client-8.0 but it is not going to be
 # installed`, even though I would expect it to be able to install that
 # dependency automatically.
 if node['cdo-mysql']['target_version'] == '8.0'
   mysql_client_packages << 'mysql-client-8.0'
-  mysql_client_versions = ['8.0.36-0ubuntu0.20.04.1', '8.0.36-0ubuntu0.20.04.1']
+  mysql_client_versions = ['8.0.37-0ubuntu0.20.04.3', '8.0.37-0ubuntu0.20.04.3']
 end
 
 apt_package mysql_client_packages do

--- a/cookbooks/cdo-mysql/recipes/server.rb
+++ b/cookbooks/cdo-mysql/recipes/server.rb
@@ -6,7 +6,7 @@ apt_package 'mysql-server' do
   if node['cdo-mysql']['target_version'] == '5.7'
     version '5.7.42-1ubuntu18.04'
   elsif node['cdo-mysql']['target_version'] == '8.0'
-    version '8.0.36-0ubuntu0.20.04.1'
+    version '8.0.37-0ubuntu0.20.04.3'
   end
 
   notifies :create, 'template[cdo.cnf]', :immediately

--- a/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
+++ b/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
@@ -39,7 +39,7 @@ mysql_variables=
 
   # The server version with which the proxy will respond to the clients.
   # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-server_version
-  server_version="<%=node['cdo-mysql']['target_version'] == '5.7' ? '5.7.12-proxysql' : '8.0.36-proxysql'%>"
+  server_version="<%=node['cdo-mysql']['target_version'] == '5.7' ? '5.7.12-proxysql' : '8.0.37-proxysql'%>"
 
   # The user needs only USAGE privileges to connect, ping and check read_only.
   # The user needs also REPLICATION CLIENT if it needs to monitor replication lag.


### PR DESCRIPTION
We are currently attempting to install version 8.0.36, which was the latest version available at the time we assembled the change. Unfortunately, that attempt is currently failing with the error:

```
no candidate version available for mysql-client, mysql-client-8.0
```

It appears that version 8.0.36 is no longer provided by the MySQL apt repositories we're using, and they are now only providing version 8.0.37, which represents a minor security update:

```bash
ubuntu@test:~$ apt-cache madison mysql-client
mysql-client | 8.0.37-1ubuntu20.04 | http://repo.mysql.com/apt/ubuntu focal/mysql-8.0 amd64 Packages
mysql-client | 8.0.37-0ubuntu0.20.04.3 | http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages
mysql-client | 8.0.37-0ubuntu0.20.04.3 | http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages
mysql-client | 8.0.19-0ubuntu5 | http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal/main amd64 Packages
ubuntu@test:~$ apt-cache madison mysql-client-8.0
mysql-client-8.0 | 8.0.37-0ubuntu0.20.04.3 | http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages
mysql-client-8.0 | 8.0.37-0ubuntu0.20.04.3 | http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages
mysql-client-8.0 | 8.0.19-0ubuntu5 | http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal/main amd64 Packages
```

Presumably 8.0.36 was pulled because of the security vulnerabilities fixed by 8.0.37, although I so far have been unable to find an official announcement to that effect.

Regardless, picking up this security patch seems like a good idea which will also unblock the pipeline.

## Testing story

Tested on [an adhoc](https://adhoc-mysql-8-0-37.cdn-code.org) to verify that with this change in place we are again able to successfully install mysql from apt.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
