### PR TITLE
[Google Blockly] only toggle definition block state on main workspace

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
@@ -159,9 +159,11 @@ export const procedureDefMutator = {
 
     setBlockDescription(this, state['description']);
     this.doProcedureUpdate();
-    this.setDeletable(state['initialDeleteConfig'] === false ? false : true);
-    this.setEditable(state['initialEditConfig'] === false ? false : true);
-    this.setMovable(state['initialMoveConfig'] === false ? false : true);
+    if (!Blockly.useModalFunctionEditor) {
+      this.setDeletable(state['initialDeleteConfig'] === false ? false : true);
+      this.setEditable(state['initialEditConfig'] === false ? false : true);
+      this.setMovable(state['initialMoveConfig'] === false ? false : true);
+    }
     this.setStatements_(state['hasStatements'] === false ? false : true);
     this.userCreated = state['userCreated'];
   },

--- a/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor.feature
+++ b/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor.feature
@@ -31,7 +31,7 @@ Scenario: Can edit a function
   # Open Sprites flyout
   And I press "blockly-d"
   # Drag new sprite block to top of function
-  And I drag block number 3 to offset "40, 100"
+  And I drag block number 2 to offset "40, 100"
   # Close function
   And I press "closeModalFunctionEditor"
   And element "#modalFunctionEditor" is not visible


### PR DESCRIPTION
While working on adding support for functions with parameters, I discovered that function definition blocks are unexpectedly movable from within the modal editor.  This was happening due to some custom logic we had implemented during the block's `loadExtraState` hook which was intended to correctly set the deletable/editable/movable state based on its initial configuration. However, this hook executes _after_ the function editor's `showForFunction`, effectively undoing the work to make it always immovable. Similarly, I was observing that function blocks didn't have the right editable state either. We also shouldn't need to toggle the block's deletability since this is handled by the modal editor's Delete button (when the function is user-created).

A solution is to only toggle these block state values if we're not using the modal function editor.
In addition to fixing this issue, I also tested that it still works as needed in non-editor contacts. Music Lab functions can still be made immovable on the main workspace. https://github.com/code-dot-org/code-dot-org/pull/55648#discussion_r1458134249 Minecraft functions can still be uneditable on the main workspace. https://github.com/code-dot-org/code-dot-org/pull/55993#uneditable-functions

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
