### PR TITLE
Add a banner to toolbox block editing

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1383,6 +1383,7 @@
   "inProgress": "In progress",
   "inProgressAndUpcomingWorkshops": "In Progress and Upcoming Workshops",
   "inStartBlocksMode": "You are editing start blocks.",
+  "inToolboxBlocksMode": "You are editing toolbox blocks.",
   "inspireStudents": "Inspire students",
   "instructionalLesson": "Instructional Lesson",
   "instructionalMinutesPerWeek": "Instructional minutes per week",

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3440,6 +3440,7 @@ StudioApp.prototype.setPageConstants = function (config, appSpecificConstants) {
       locale: config.locale,
       assetUrl: this.assetUrl,
       inStartBlocksMode: level.edit_blocks === START_BLOCKS,
+      inToolboxBlocksMode: level.edit_blocks === TOOLBOX_EDIT_MODE,
       isReadOnlyWorkspace: !!config.readonlyWorkspace,
       isDroplet: !!level.editCode,
       isBlockly: this.isUsingBlockly(),

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -16,6 +16,7 @@ var ALLOWED_KEYS = new Set([
   'hasDataMode',
   'hasDesignMode',
   'inStartBlocksMode',
+  'inToolboxBlocksMode',
   'isChallengeLevel',
   'isEmbedView',
   'isResponsive',

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -29,6 +29,7 @@ class CodeWorkspace extends React.Component {
     displayNotStartedBanner: PropTypes.bool,
     displayOldVersionBanner: PropTypes.bool,
     inStartBlocksMode: PropTypes.bool,
+    inToolboxBlocksMode: PropTypes.bool,
     isRtl: PropTypes.bool.isRequired,
     editCode: PropTypes.bool.isRequired,
     readonlyWorkspace: PropTypes.bool.isRequired,
@@ -123,6 +124,8 @@ class CodeWorkspace extends React.Component {
         {...{isRunning, runModeIndicators, showMakerToggle, autogenerateML}}
       />
     );
+
+    console.log('lfm', this.props.inToolboxBlocksMode);
 
     return [
       <PaneSection
@@ -262,7 +265,9 @@ class CodeWorkspace extends React.Component {
             id="codeTextbox"
             className={classNames(
               this.props.pinWorkspaceToBottom ? 'pin_bottom' : '',
-              this.props.inStartBlocksMode ? 'has_banner' : ''
+              this.props.inStartBlocksMode || this.props.inToolboxBlocksMode
+                ? 'has_banner'
+                : ''
             )}
             canUpdate={true}
           >
@@ -294,6 +299,16 @@ class CodeWorkspace extends React.Component {
               {this.props.isProjectTemplateLevel
                 ? i18n.startBlocksTemplateWarning()
                 : i18n.inStartBlocksMode()}
+            </div>
+          </>
+        )}
+        {this.props.inToolboxBlocksMode && (
+          <>
+            <div
+              id="toolboxBlocksBanner"
+              style={{...styles.topBanner, ...styles.toolboxBlocksBanner}}
+            >
+              {i18n.inToolboxBlocksMode()}
             </div>
           </>
         )}
@@ -347,6 +362,9 @@ const styles = {
   startBlocksBanner: {
     backgroundColor: color.lighter_yellow,
   },
+  toolboxBlocksBanner: {
+    backgroundColor: color.lighter_teal,
+  },
   topBanner: {
     zIndex: 99,
     padding: 5,
@@ -385,6 +403,7 @@ export default connect(
     displayOldVersionBanner: state.pageConstants.displayOldVersionBanner,
     editCode: state.pageConstants.isDroplet,
     inStartBlocksMode: state.pageConstants.inStartBlocksMode,
+    inToolboxBlocksMode: state.pageConstants.inToolboxBlocksMode,
     isRtl: state.isRtl,
     readonlyWorkspace: state.pageConstants.isReadOnlyWorkspace,
     isRunning: !!state.runState.isRunning,

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -125,8 +125,6 @@ class CodeWorkspace extends React.Component {
       />
     );
 
-    console.log('lfm', this.props.inToolboxBlocksMode);
-
     return [
       <PaneSection
         id="toolbox-header"


### PR DESCRIPTION
For start block editing, we have a helpful banner that shows you are editing start blocks: 
<img width="1231" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/25193259/9368123a-d0d8-456e-9918-6401974e65b4">

This PR adds a similar helpful banner that shows if you are editing toolbox blocks:
![image](https://github.com/code-dot-org/code-dot-org/assets/25193259/e3795bbd-cf35-4c98-a0ca-7b9cf6dab13a)

Currently, there is no easy way to determine from a glance what you are editing if you are editing toolbox blocks. This should be a small QOL fix.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
