### PR TITLE
added korean certificates to panel translation

### DIFF
--- a/dashboard/config/locales/panels.ko-KR.json
+++ b/dashboard/config/locales/panels.ko-KR.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34290e90bcecac2a423b395536b42c8f3e1c7010ad982494fad831409593b97f
-size 5765
+oid sha256:642dc941f6e2c2e0ae9b188a4dae909e696064f5310e8ca15b67d9a3f0ea4939
+size 5933


### PR DESCRIPTION
Our Korean partners would like us to show a custom certificate for Korean students. 
This PR adds a link to a certificate provided by our partner to the Korean translation of the Music Lab Intro last panel (`musiclab_intro_panels_end_2`) 
The links will be removed once their HoC promotion is over.
What's different from the last request: We added Music Lab as a new activity.

## Links
- Jira task: [P20-948](https://codedotorg.atlassian.net/browse/P20-948)
- Certificate added: [online coding party 2024](code.org/files/online-coding-party-2024-1-music.png
)
- Related PR: [#59094](https://github.com/code-dot-org/code-dot-org/pull/59094)

## Testing story
<img width="1728" alt="Screenshot 2024-06-13 at 14 50 01" src="https://github.com/code-dot-org/code-dot-org/assets/66776217/de4c61fc-2049-4dab-a094-af40dee53909">

https://github.com/code-dot-org/code-dot-org/assets/66776217/4c8f772e-228b-4267-ad5b-f4018c653d8b


## PR Checklist:

<!--



  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
