### PR TITLE
Cloudwatch metrics update for failing test runs.

### DIFF
--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -330,7 +330,7 @@ def log_browser_error(msg)
   puts msg if $options.verbose
 end
 
-def run_tests(env, feature, arguments, log_prefix)
+def run_tests(env, feature, target_platform, arguments, log_prefix)
   start_time = Time.now
   cmd = "cucumber #{feature} #{arguments}"
   puts "#{log_prefix}#{cmd}"
@@ -342,7 +342,8 @@ def run_tests(env, feature, arguments, log_prefix)
     eyes_succeeded = count_eyes_errors(stdout) == 0
     duration = Time.now - start_time
     extra_dimensions = {test_type: test_type,
-                        feature_name: feature}
+                        feature_name: feature.split(".feature")[0],
+                        target_browser: target_platform}
     # Metrics for individual feature runs. They will be flushed once all of them run
     Infrastructure::Logger.put("runner_feature_success", cucumber_succeeded ? 1 : 0, extra_dimensions)
     Infrastructure::Logger.put("runner_feature_failure", cucumber_succeeded ? 0 : 1, extra_dimensions)
@@ -762,7 +763,7 @@ def run_feature(browser, feature, options)
   reruns = 0
   arguments = cucumber_arguments_for_browser(browser, options)
   arguments += cucumber_arguments_for_feature(options, test_run_string, max_reruns)
-  cucumber_succeeded, eyes_succeeded, output_stdout, output_stderr, test_duration = run_tests(run_environment, feature, arguments, log_prefix)
+  cucumber_succeeded, eyes_succeeded, output_stdout, output_stderr, test_duration = run_tests(run_environment, feature, browser_name_or_unknown(browser), arguments, log_prefix)
   feature_succeeded = cucumber_succeeded && eyes_succeeded
   log_link = upload_log_and_get_public_link(
     html_log,
@@ -793,7 +794,7 @@ def run_feature(browser, feature, options)
 
     rerun_feature = File.exist?(rerun_file) ? File.read(rerun_file).split.join(' ') : feature
 
-    cucumber_succeeded, eyes_succeeded, output_stdout, output_stderr, test_duration = run_tests(run_environment, rerun_feature, arguments, log_prefix)
+    cucumber_succeeded, eyes_succeeded, output_stdout, output_stderr, test_duration = run_tests(run_environment, rerun_feature, browser_name_or_unknown(browser), arguments, log_prefix)
     feature_succeeded = cucumber_succeeded && eyes_succeeded
     log_link = upload_log_and_get_public_link(
       html_log,

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -342,7 +342,7 @@ def run_tests(env, feature, target_platform, arguments, log_prefix)
     eyes_succeeded = count_eyes_errors(stdout) == 0
     duration = Time.now - start_time
     extra_dimensions = {test_type: test_type,
-                        feature_name: feature.split(".feature")[0],
+                        feature_name: feature.include?(".feature") ? feature.split(".feature")[0] : feature,
                         target_browser: target_platform}
     # Metrics for individual feature runs. They will be flushed once all of them run
     Infrastructure::Logger.put("runner_feature_success", cucumber_succeeded ? 1 : 0, extra_dimensions)


### PR DESCRIPTION
We are currently tracking the set of failing tests through a spreadsheet which would give us data around which test fixes need to be prioritized. Given this involves manual updates to the spreadsheet, the process is time consuming, especially during busy DoTD days. 

This change is to leverage an existing could watch metric that is being emitted for every test run through runner.rb to include more information to help prioritize which tests to fix. There are two changes in this PR

1. When UI tests are re-run the test name is emitted as the sub secenario which is failing, which leads to metrics getting split for the same test. 
![image](https://github.com/code-dot-org/code-dot-org/assets/124813947/cfa179e0-49db-48d9-b59d-699a22839798)

3. The metrics today does not include the browser platform dimension, including that as part of this change.

Here is the dashboard which would be updated once these changes are rolled out https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/DoTD_Health?start=PT672H&end=null

## Links

None

## Testing story

Validated by running tests locally and checking if the test name doesn't contain anything after ".feature" and the new dimension.

[Link to time series](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(view~'timeSeries~stacked~false~start~'-PT672H~end~'P0D~region~'us-east-1~metrics~(~(~'Infrastructure~'runner_feature_execution_time~'environment~'development~'feature_name~'features*2fteacher_tools*2fteacher_dashboard*2fteacher_dashboard_assessments2.feature~'test_type~'UI~'is_continuous_integration_run~'false)~(~'.~'runner_feature_success~'.~'.~'.~'.~'.~'.~'.~'.)~(~'.~'runner_feature_failure~'.~'.~'.~'.~'.~'.~'.~'.)~(~'.~'runner_feature_success~'.~'test~'.~'features*2fteacher_tools*2fteacher_dashboard*2fteacher_dashboard_progress_v2.feature*3a110~'.~'Eyes~'.~'.)~(~'.~'runner_feature_execution_time~'.~'.~'.~'.~'.~'.~'.~'.)~(~'.~'runner_feature_failure~'.~'.~'.~'.~'.~'.~'.~'.)))&query=~'*7bInfrastructure*2cenvironment*2cfeature_name*2cis_continuous_integration_run*2ctarget_browser*2ctest_type*7d)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Regular DTP

## Follow-up work

The environment dimension currently published is either development or test, which doesn't differentiate between drone runs vs the managed test environment. This needs to be updated in a different PR

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
