### PR TITLE
Add an indicator that a lesson includes a level

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialog.jsx
@@ -45,7 +45,12 @@ export default class AddLevelDialog extends Component {
           style={styles.dialogContent}
           className="uitest-level-dialog-content"
         >
-          <AddLevelDialogTop addLevel={this.props.addLevel} />
+          <AddLevelDialogTop
+            addLevel={this.props.addLevel}
+            currentLevelIds={this.props.activitySection.scriptLevels.map(
+              scriptLevel => scriptLevel.activeId
+            )}
+          />
           <div style={styles.bottomArea}>
             <h4>Levels in Progression</h4>
             <div style={styles.levelsBox}>

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialogTop.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialogTop.jsx
@@ -121,7 +121,7 @@ function AddLevelDialogTop(props) {
 
 AddLevelDialogTop.propTypes = {
   addLevel: PropTypes.func.isRequired,
-  currentLevelIds: PropTypes.array.isRequired,
+  currentLevelIds: PropTypes.array,
 
   // from redux
   searchOptions: PropTypes.object.isRequired,

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialogTop.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialogTop.jsx
@@ -101,6 +101,7 @@ function AddLevelDialogTop(props) {
                 currentPage={currentPage}
                 addLevel={props.addLevel}
                 levels={levels}
+                currentLevelIds={props.currentLevelIds}
                 numPages={numPages}
               />
             </div>
@@ -120,6 +121,7 @@ function AddLevelDialogTop(props) {
 
 AddLevelDialogTop.propTypes = {
   addLevel: PropTypes.func.isRequired,
+  currentLevelIds: PropTypes.array.isRequired,
 
   // from redux
   searchOptions: PropTypes.object.isRequired,

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
@@ -11,6 +11,7 @@ export default class AddLevelTable extends Component {
     currentPage: PropTypes.number.isRequired,
     setCurrentPage: PropTypes.func.isRequired,
     numPages: PropTypes.number.isRequired,
+    currentLevelIds: PropTypes.array.isRequired,
   };
 
   render() {
@@ -31,6 +32,7 @@ export default class AddLevelTable extends Component {
               <AddLevelTableRow
                 key={level.id}
                 addLevel={this.props.addLevel}
+                isInLesson={this.props.currentLevelIds.includes(level.id)}
                 level={level}
               />
             ))}

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
@@ -11,7 +11,7 @@ export default class AddLevelTable extends Component {
     currentPage: PropTypes.number.isRequired,
     setCurrentPage: PropTypes.func.isRequired,
     numPages: PropTypes.number.isRequired,
-    currentLevelIds: PropTypes.array.isRequired,
+    currentLevelIds: PropTypes.array,
   };
 
   render() {
@@ -32,7 +32,10 @@ export default class AddLevelTable extends Component {
               <AddLevelTableRow
                 key={level.id}
                 addLevel={this.props.addLevel}
-                isInLesson={this.props.currentLevelIds.includes(level.id)}
+                isInLesson={
+                  this.props.currentLevelIds &&
+                  this.props.currentLevelIds.includes(level.id)
+                }
                 level={level}
               />
             ))}

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
@@ -33,7 +33,7 @@ export default class AddLevelTable extends Component {
                 key={level.id}
                 addLevel={this.props.addLevel}
                 isInLesson={
-                  this.props.currentLevelIds &&
+                  !!this.props.currentLevelIds &&
                   this.props.currentLevelIds.includes(level.id)
                 }
                 level={level}

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelTableRow.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelTableRow.jsx
@@ -8,6 +8,7 @@ export default class AddLevelTableRow extends Component {
   static propTypes = {
     addLevel: PropTypes.func.isRequired,
     level: PropTypes.object.isRequired,
+    isInLesson: PropTypes.bool.isRequired,
   };
 
   constructor(props) {
@@ -61,10 +62,12 @@ export default class AddLevelTableRow extends Component {
   };
 
   render() {
-    const {level} = this.props;
-
+    const {level, isInLesson} = this.props;
     return (
-      <tr key={level.id}>
+      <tr
+        key={level.id}
+        style={isInLesson ? {border: '2px solid', borderColor: color.teal} : {}}
+      >
         <td>
           <button onClick={this.handleAddLevel.bind(this, level)} type="button">
             <FontAwesome icon="plus" />

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelTableRow.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelTableRow.jsx
@@ -66,7 +66,9 @@ export default class AddLevelTableRow extends Component {
     return (
       <tr
         key={level.id}
-        style={isInLesson ? {border: '2px solid', borderColor: color.teal} : {}}
+        style={
+          isInLesson ? {color: color.white, backgroundColor: color.teal} : {}
+        }
       >
         <td>
           <button onClick={this.handleAddLevel.bind(this, level)} type="button">

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelDialogTopTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelDialogTopTest.jsx
@@ -12,7 +12,6 @@ describe('AddLevelDialogTop', () => {
     defaultProps = {
       addLevel,
       searchOptions: searchOptions,
-      currentLevelIds: [],
     };
   });
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelDialogTopTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelDialogTopTest.jsx
@@ -12,6 +12,7 @@ describe('AddLevelDialogTop', () => {
     defaultProps = {
       addLevel,
       searchOptions: searchOptions,
+      currentLevelIds: [],
     };
   });
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelTableRowTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelTableRowTest.jsx
@@ -10,6 +10,7 @@ describe('AddLevelTableRow', () => {
     addLevel = sinon.spy();
     defaultProps = {
       addLevel,
+      isInLesson: false,
       level: {
         id: 1,
         name: 'Level 1',

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelTableTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelTableTest.jsx
@@ -14,7 +14,6 @@ describe('AddLevelTable', () => {
       currentPage: 1,
       setCurrentPage,
       numPages: 7,
-      isInLesson: false,
       levels: [
         {
           id: 1,

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelTableTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelTableTest.jsx
@@ -14,6 +14,7 @@ describe('AddLevelTable', () => {
       currentPage: 1,
       setCurrentPage,
       numPages: 7,
+      isInLesson: false,
       levels: [
         {
           id: 1,


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adds a selection indicator for levels that are already in the lesson or recently selected. This should make it clearer that a level has been added and what levels are included in the lesson when editing.

https://github.com/code-dot-org/code-dot-org/assets/25193259/931d51e6-2cd2-4103-b022-dc0f98fd4b44

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
