### PR TITLE
Use `template` EnforcedStyle for `Style/FormatStringToken`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,6 +91,9 @@ Style/EmptyElse:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
+Style/FormatStringToken:
+  EnforcedStyle: template
+
 Style/NumericLiterals:
   MinDigits: 7
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -201,13 +201,6 @@ Style/ExpandPathArguments:
 Style/FetchEnvVar:
   Enabled: false
 
-# Offense count: 99
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, MaxUnannotatedPlaceholdersAllowed, AllowedMethods, AllowedPatterns.
-# SupportedStyles: annotated, template, unannotated
-Style/FormatStringToken:
-  Enabled: false
-
 # Offense count: 3539
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle.


### PR DESCRIPTION
The default style for this cop is `annotated`, which looks like:

```
format('%<greeting>s', greeting: 'Hello')
```

Currently in our codebase, we consistently use the `template` style, which looks like:

```
format('%{greeting}', greeting: 'Hello')
```

Similar to the style used by classic string interpolation. I'm not sure whether this was intentional or if we simply defaulted to this style since most of us are likely more familiar with string interpolation than with the format method, but given how consistent we are (and how many violations there are with the default style), I think it makes sense to codify this behavior.

## Links

See https://github.com/code-dot-org/code-dot-org/pull/59224 for an example of what adopting the default style would look like.

- https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/FormatStringToken
- https://docs.rubocop.org/rubocop/cops_style.html#styleformatstringtoken

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
