### PR TITLE
Gen AI: handle new message key on CSV export

### DIFF
--- a/bin/oneoff/aichat_logs_to_csv
+++ b/bin/oneoff/aichat_logs_to_csv
@@ -76,7 +76,7 @@ def main
           *base_row,
           message["status"],
           message["role"],
-          message["content"]
+          message["content"] || message["chatMessageText"]
         ]
         csv << row
       end


### PR DESCRIPTION
Quick follow-up to https://github.com/code-dot-org/code-dot-org/pull/58668, see relevant comment [here](https://github.com/code-dot-org/code-dot-org/pull/58668#issuecomment-2168705151)) -- handles CSV export of chat messages now that we have a different key storing the content (`chatMessageText` rather than `content`) of chat messages.