### PR TITLE
Move Music Lab Launch banner on /teach

### DIFF
--- a/pegasus/sites.v3/code.org/public/teach.haml
+++ b/pegasus/sites.v3/code.org/public/teach.haml
@@ -21,9 +21,6 @@ theme: responsive_full_width
 
 = view :"lms/lms_skinny_banner"
 
-// TODO - Remove this once the Music Lab launch is over
-= view :"music/music_lab_skinny_banner"
-
 %section.why-teach-cs.bg-neutral-light
   .wrapper
     %h2.centered
@@ -112,6 +109,9 @@ theme: responsive_full_width
 %section.resources.bg-neutral-light
   .wrapper
     = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
+
+// TODO - Remove this once the Music Lab launch is over
+= view :"music/music_lab_skinny_banner"
 
 %section.pl-offerings.centered
   .wrapper


### PR DESCRIPTION
Moves the Music Lab Launch banner lower down on the [/teach](https://code.org/teach) page. This will give space at the top for when the LMS Launch banner goes live on Friday.

### When LMS Launch DCDO flag is off
![LMS off](https://github.com/code-dot-org/code-dot-org/assets/56283563/93e072e4-3eb6-4b57-96a6-27e1d0cc6b43)

### When LMS Launch DCDO flag is on
![LMS on](https://github.com/code-dot-org/code-dot-org/assets/56283563/c02f5bd0-b405-4ed1-ba4d-0ad47e2c886b)

## Testing story
Local testing.
