### PR TITLE
Fix bug with dynamic registration platform name

### DIFF
--- a/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
+++ b/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
@@ -56,6 +56,7 @@ module Lti
         return unauthorized_status if registration_data.nil?
 
         platform = Policies::Lti.find_platform_by_issuer(registration_data[:issuer])
+        platform_name = Policies::Lti.find_platform_name_by_issuer(registration_data[:issuer])
         if platform.nil?
           message = "Unsupported issuer: #{registration_data[:issuer]}"
           Honeybadger.notify(
@@ -82,7 +83,7 @@ module Lti
             name: registration_data[:lms_account_name],
             client_id: registration_response[:client_id],
             issuer: platform[:issuer],
-            platform_name: platform[:name],
+            platform_name: platform_name,
             auth_redirect_url: platform[:auth_redirect_url],
             jwks_url: platform[:jwks_url],
             access_token_url: platform[:access_token_url],

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -162,6 +162,11 @@ class Policies::Lti
     LMS_PLATFORMS.values.find {|platform| platform[:issuer] == issuer}
   end
 
+  def self.find_platform_name_by_issuer(issuer)
+    platform_name, _ = LMS_PLATFORMS.find {|_, platform| platform[:issuer] == issuer}
+    platform_name.to_s
+  end
+
   # Returns the email provided by the LMS when creating the User through LTI
   # provisioning.
   def self.lti_provided_email(user)

--- a/dashboard/test/lib/policies/lti_test.rb
+++ b/dashboard/test/lib/policies/lti_test.rb
@@ -58,6 +58,13 @@ class Policies::LtiTest < ActiveSupport::TestCase
     assert_nil Policies::Lti.find_platform_by_issuer(invalid_issuer)
   end
 
+  test 'find_platform_name_by_issuer should return the platform name (string) or empty string if it does not exist' do
+    valid_issuer = 'https://canvas.instructure.com'
+    invalid_issuer = 'https://fake.com'
+    assert Policies::Lti.find_platform_name_by_issuer(valid_issuer)
+    assert_empty Policies::Lti.find_platform_name_by_issuer(invalid_issuer)
+  end
+
   test 'lti_provided_email should return the :email stored in the LTI option given LTI user' do
     user = create :teacher, :with_lti_auth
     assert_equal user.email, Policies::Lti.lti_provided_email(user)


### PR DESCRIPTION
  - Add new method to return top level platform name by issuer
  - Add unit test
  - Update registration data to ref new platform name

LTI Integration now has correct platform_name via dynamic registration
<img width="1049" alt="Screenshot 2024-06-17 at 1 05 41 PM" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/bb69634d-d0c2-422e-a5bd-e06719604e41">



<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
