### PR TITLE
Open privacy link from state modal in new tab

### DIFF
--- a/dashboard/app/views/layouts/_student_information_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_student_information_interstitial.html.haml
@@ -8,7 +8,8 @@
       %p{style: 'font-size: 13px; line-height: 18px; color: #333'}
         = t('parent_mailer.parent_email_added_subject')
         = t('activerecord.attributes.user.finish_sign_up_header_account_information')
-        = t('age_interstitial.disclaimer', url: SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL, markdown: :inline).html_safe
+        %a{href: SharedConstants::EMAIL_LINKS.PRIVACY_POLICY_URL, target: '_blank'}
+          = t('age_interstitial.disclaimer', markdown: :inline).html_safe
       = form_for(student, url: users_set_student_information_url, remote: true, html: {id: 'edit_user'}) do |f|
         - if student.age.nil?
           .form-group

--- a/dashboard/config/locales/ar-SA.yml
+++ b/dashboard/config/locales/ar-SA.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:543bccd75df1e477f05dbcff5ff9d99cc4d1c977a3139b33a8ffa59703c9a431
-size 105717
+oid sha256:e746d79ec8d9d1edcff4aab77c75467777fce52daa21daaa90bcaf0a27a0f53b
+size 105706

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -952,7 +952,7 @@ en:
     age: Your age
     header: Account Information Update
     warning: "We're in the process of updating our experience to provide you with even stronger privacy protections. To do this, we need existing users to enter their age here."
-    disclaimer: 'Code.org [will never rent, sell or share this information with any third parties](%{url}).'
+    disclaimer: 'Code.org will never rent, sell or share this information with any third parties.'
     sign_out_markdown: 'If you do not wish to provide your age you may [sign out](%{url}).'
   terms_interstitial:
     title: "Updated Terms of Service and Privacy Policy"

--- a/dashboard/config/locales/fr-FR.yml
+++ b/dashboard/config/locales/fr-FR.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af375306137dc8be880d12a75514cd0dd3b7638a124e7e5644200e5eee53a105
-size 89144
+oid sha256:e6e3340faa55a92a918eb3c4794cb51f4f389fac828bd935d25d77580d054f2a
+size 89134

--- a/dashboard/config/locales/it-IT.yml
+++ b/dashboard/config/locales/it-IT.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd925564a3485f5214b70ab62383a2b1284ba279244c3796cfdf5ae3e8fc0597
-size 85492
+oid sha256:4fa2add8460266d86e31b96f6aee2a7b3d66525e9e959caa5117927b127eca4f
+size 85476

--- a/dashboard/config/locales/pl-PL.yml
+++ b/dashboard/config/locales/pl-PL.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc109e2e91ac6eabb9c3f43b4473ece325273ce339d4abb89a182b11509f5641
-size 87421
+oid sha256:1e69a1c811a9beac2b2833ea915133669341a34dce7ffde67f3b2667372939cd
+size 87404

--- a/dashboard/config/locales/sk-SK.yml
+++ b/dashboard/config/locales/sk-SK.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1cd80b8fd712b8f1308ee3ddb7b3db876ed73eb9c2f7e0341dbdbc3222c9261e
-size 81494
+oid sha256:b05894a08fc7ee6aabac0e6351c3baf540adb55694dfbbd0cb35ea57419cdf46
+size 81484

--- a/dashboard/config/locales/sq-AL.yml
+++ b/dashboard/config/locales/sq-AL.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:678dce8f653659f920bf375f9a1f67df1a10d2966421a48cdc3c816b959681be
-size 95152
+oid sha256:1959e0125dc5f7d544cce7591ac8f6473f75056a5335ba468ab7962a6b615fa8
+size 95135

--- a/dashboard/config/locales/tr-TR.yml
+++ b/dashboard/config/locales/tr-TR.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8b822b9249a56ca1830ca6f2a5e84bd7eebd8c330bcc72aba8d5ddfa568800e
-size 91065
+oid sha256:08a9b7b5bc34f9bf4fca10b236436b9a44adcd27fa3af8d7000d74721d92051c
+size 91056


### PR DESCRIPTION
This PR updates the behavior of the state modal link to open in a new tab instead of the same tab.
The changes remove a link from the markdown content `[link](link)` and add a link to the Haml file `= %a`. This allows the insertion of a `target=_blank` attribute to the link.

In addition to this PR translations will need to be updated in [crowdin](https://crowdin.com/editor/codeorg/40/enus-ar?view=comfortable&filter=basic&value=0#q=age_interstitial) for the following languages:
`ar-SA`, `fr-FR`, `it-IT`, `pl-PL`, `sk-SK`, `sq-AL`, and `tr-TR`

## Links

- jira ticket: [P20-951](https://codedotorg.atlassian.net/browse/P20-951)

## Testing story

https://github.com/code-dot-org/code-dot-org/assets/66776217/a158dfc2-ed83-46c7-bcbb-fdef58a5ef1c

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
