### PR TITLE
Closing case where passwords were leaked to build log files

### DIFF
--- a/pegasus/rake/db.rake
+++ b/pegasus/rake/db.rake
@@ -53,7 +53,6 @@ namespace :db do
 
   desc 'Perform migration up to latest migration available'
   timed_task_with_logging :migrate do
-    p DB
     Sequel::Migrator.run(DB, migrations_dir)
     Rake::Task['db:version'].execute
   end


### PR DESCRIPTION
This PR addresses a critical issue where database passwords were being leaked into build logs. The affected code, introduced nine years ago, contained a debug statement `p DB` in the migrate rake task, which outputted the database object. This object included the main connection string, revealing the username and password for the production database (db-production.code.org). As a result, these sensitive credentials were inadvertently stored in S3 build logs. 

This change removes the problematic debug line to ensure that database connection information is no longer printed in logs.

Once this is released, the compromised passwords will be rotated.

## Links
- jira ticket: [INF-1321](https://codedotorg.atlassian.net/browse/INF-1321)

## Deployment strategy
[ ] After deploy examine that the logs no longer have this debug output in them

## Follow-up work
1. After this we rotate the passwords affected (all envs with a database cluster)
