### PR TITLE
Teach 1119/Fixes flakiness inherent to 'navigate_to' in UI tests.

### DIFF
--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -228,6 +228,12 @@ end
 
 Then /^the section table row at index (\d+) has (primary|secondary) assignment path "([^"]+)"$/ do |row_index, assignment_type, expected_path|
   link_index = (assignment_type == 'primary') ? 0 : 1
+  # Wait until the link loads in the table
+  wait_until do
+    @browser.execute_script("return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(3) a:eq(#{link_index})').attr('href') !== null;")
+  end
+
+  # Then grab it
   href = @browser.execute_script(
     "return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(3) a:eq(#{link_index})').attr('href');"
   )

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -96,7 +96,13 @@ end
 
 Given /^I am on "([^"]*)"$/ do |url|
   check_window_for_js_errors('before navigation')
-  navigate_to replace_hostname(url)
+  begin
+    navigate_to replace_hostname(url)
+  rescue Selenium::WebDriver::Error::TimeoutError => exception
+    puts "Timeout: I am not on #{url} like I want."
+    puts "         I am on #{@browser.current_url} instead."
+    raise exception
+  end
 end
 
 And /^I take note of the current loaded page$/ do

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -84,6 +84,7 @@ def navigate_to(url)
   Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, sleep: 10, tries: 3) do
     with_read_timeout(DEFAULT_WAIT_TIMEOUT + 5.seconds) do
       @browser.navigate.to url
+      wait_until {@browser.current_url == url}
       wait_until do
         @browser.execute_script('return document.readyState;') == 'complete'
       end

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -83,8 +83,15 @@ end
 def navigate_to(url)
   Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, sleep: 10, tries: 3) do
     with_read_timeout(DEFAULT_WAIT_TIMEOUT + 5.seconds) do
+      page_body = @browser.find_element(:css, 'body')
       @browser.navigate.to url
-      wait_until {@browser.current_url == url}
+      # Wait until the document has actually changed
+      if page_body
+        wait_until do
+          page_body != @browser.find_element(:css, 'body')
+        end
+      end
+      # Then, wait until the document is done loading
       wait_until do
         @browser.execute_script('return document.readyState;') == 'complete'
       end


### PR DESCRIPTION
The original flaky test (`teacher_tools/fun_o_meter.feature`) was an issue where the page load raced the next action. In this particular case the following steps were meant to run:

```
  And I press "runButton"
  And I wait to see ".congrats"

  ...

  Given I am on "http://studio.code.org/s/allthethings/lessons/4/levels/4?noautoplay=true"
  And I wait for the page to fully load

  When I press "runButton"
  And I wait to see ".congrats"
```

In the original `navigate_to`, it sets the new `url` and then waits until `readyState` is `complete`. However, if it checks too quickly, it gets the `readyState` of the original page... which is obviously already `complete`. And then it is the next step that determines if the test will pass... if _it_ waits, it _might_ be ok, but if it is something that is true for the current page (such as the `wait for the page to fully load`) or an action that is true for that page (`press "runButton"`) then it will do that for the current page and then get interrupted by the actual page load from before!!

This test fails if it races pressing the `runButton` on the original page or the new page. The `iPad` set of tests are slow enough that it consistently fails this race.

The new `navigate_to` keeps a reference to the page body. This reference changes if the `body` is actively different... so it is a good way to ensure that the page has navigated away. Then the original check for `readyState` takes over and waits until that newly navigated page completes its static loading.

This also seems to reduce the total time dramatically due to not having to rerun flaky UI tests or from waiting less for steps to complete somehow:

Before

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/b460d887-b9fd-4981-9de3-d35ffe830f38)

After

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/4ae2b2d4-3d07-4cc9-b073-d4bc810ebc5e)

After (Restarted to get another datapoint):

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/783f95bf-ff3c-4802-b6d7-7f0101d1ef8e)

It doesn't always mean faster tests... this one had a few flaky tests in other areas.

## Links

- jira ticket: [TEACH-1119](https://codedotorg.atlassian.net/browse/TEACH-1119)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
