### PR TITLE
[ProgressV2M] Add loading state for added metadata progress cells

### DIFF
--- a/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
@@ -1,13 +1,18 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {connect} from 'react-redux';
 
 import LessonProgressColumnHeader from './LessonProgressColumnHeader';
 
 import styles from './progress-table-v2.module.scss';
 import skeletonizeContent from '@cdo/apps/componentLibrary/skeletonize-content.module.scss';
 
-export default function SkeletonProgressDataColumn({lesson, sortedStudents}) {
+function SkeletonProgressDataColumn({
+  lesson,
+  sortedStudents,
+  expandedMetadataStudentIds,
+}) {
   return (
     <div className={styles.lessonColumn}>
       <LessonProgressColumnHeader
@@ -25,6 +30,7 @@ export default function SkeletonProgressDataColumn({lesson, sortedStudents}) {
                 styles.lessonSkeletonCell,
                 skeletonizeContent.skeletonizeContent
               )}
+              data-testid={`lesson-skeleton-cell-${student.id}`}
             />
           </div>
         ))}
@@ -36,4 +42,11 @@ export default function SkeletonProgressDataColumn({lesson, sortedStudents}) {
 SkeletonProgressDataColumn.propTypes = {
   sortedStudents: PropTypes.array,
   lesson: PropTypes.object.isRequired,
+  expandedMetadataStudentIds: PropTypes.array,
 };
+
+export const UnconnectedSkeletonProgressDataColumn = SkeletonProgressDataColumn;
+
+export default connect(state => ({
+  expandedMetadataStudentIds: state.sectionProgress.expandedMetadataStudentIds,
+}))(SkeletonProgressDataColumn);

--- a/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
@@ -10,18 +10,22 @@ import skeletonizeContent from '@cdo/apps/componentLibrary/skeletonize-content.m
 
 const getId = (student, lesson) => student.id + '.' + lesson.id;
 
-const getSkeletonCell = id => (
+const skeletonContent = (
+  <div
+    className={classNames(
+      styles.lessonSkeletonCell,
+      skeletonizeContent.skeletonizeContent
+    )}
+  />
+);
+
+const getSkeletonCell = (id, key = undefined) => (
   <div
     className={classNames(styles.gridBox, styles.gridBoxLesson)}
-    key={id}
+    key={key}
     data-testid={'lesson-skeleton-cell-' + id}
   >
-    <div
-      className={classNames(
-        styles.lessonSkeletonCell,
-        skeletonizeContent.skeletonizeContent
-      )}
-    />
+    {skeletonContent}
   </div>
 );
 
@@ -32,23 +36,13 @@ const getMetadataExpandedSkeletonCell = id => (
       className={classNames(styles.gridBox, styles.gridBoxMetadata)}
       data-testid={'lesson-skeleton-cell-' + id + '-time-spent'}
     >
-      <div
-        className={classNames(
-          styles.lessonSkeletonCell,
-          skeletonizeContent.skeletonizeContent
-        )}
-      />
+      {skeletonContent}
     </div>
     <div
       className={classNames(styles.gridBox, styles.gridBoxMetadata)}
       data-testid={'lesson-skeleton-cell-' + id + '-last-updated'}
     >
-      <div
-        className={classNames(
-          styles.lessonSkeletonCell,
-          skeletonizeContent.skeletonizeContent
-        )}
-      />
+      {skeletonContent}
     </div>
   </div>
 );
@@ -68,7 +62,7 @@ function SkeletonProgressDataColumn({
         {sortedStudents.map(student =>
           expandedMetadataStudentIds.includes(student.id)
             ? getMetadataExpandedSkeletonCell(getId(student, lesson))
-            : getSkeletonCell(getId(student, lesson))
+            : getSkeletonCell(getId(student, lesson), getId(student, lesson))
         )}
       </div>
     </div>

--- a/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
@@ -8,6 +8,51 @@ import LessonProgressColumnHeader from './LessonProgressColumnHeader';
 import styles from './progress-table-v2.module.scss';
 import skeletonizeContent from '@cdo/apps/componentLibrary/skeletonize-content.module.scss';
 
+const getId = (student, lesson) => student.id + '.' + lesson.id;
+
+const getSkeletonCell = id => (
+  <div
+    className={classNames(styles.gridBox, styles.gridBoxLesson)}
+    key={id}
+    data-testid={'lesson-skeleton-cell-' + id}
+  >
+    <div
+      className={classNames(
+        styles.lessonSkeletonCell,
+        skeletonizeContent.skeletonizeContent
+      )}
+    />
+  </div>
+);
+
+const getMetadataExpandedSkeletonCell = id => (
+  <div className={styles.lessonDataCellExpanded} key={id}>
+    {getSkeletonCell(id)}
+    <div
+      className={classNames(styles.gridBox, styles.gridBoxMetadata)}
+      data-testid={'lesson-skeleton-cell-' + id + '-time-spent'}
+    >
+      <div
+        className={classNames(
+          styles.lessonSkeletonCell,
+          skeletonizeContent.skeletonizeContent
+        )}
+      />
+    </div>
+    <div
+      className={classNames(styles.gridBox, styles.gridBoxMetadata)}
+      data-testid={'lesson-skeleton-cell-' + id + '-last-updated'}
+    >
+      <div
+        className={classNames(
+          styles.lessonSkeletonCell,
+          skeletonizeContent.skeletonizeContent
+        )}
+      />
+    </div>
+  </div>
+);
+
 function SkeletonProgressDataColumn({
   lesson,
   sortedStudents,
@@ -20,20 +65,11 @@ function SkeletonProgressDataColumn({
         addExpandedLesson={() => {}}
       />
       <div className={styles.lessonDataColumn}>
-        {sortedStudents.map(student => (
-          <div
-            className={classNames(styles.gridBox, styles.gridBoxLesson)}
-            key={student.id + '.' + lesson.id}
-          >
-            <div
-              className={classNames(
-                styles.lessonSkeletonCell,
-                skeletonizeContent.skeletonizeContent
-              )}
-              data-testid={`lesson-skeleton-cell-${student.id}`}
-            />
-          </div>
-        ))}
+        {sortedStudents.map(student =>
+          expandedMetadataStudentIds.includes(student.id)
+            ? getMetadataExpandedSkeletonCell(getId(student, lesson))
+            : getSkeletonCell(getId(student, lesson))
+        )}
       </div>
     </div>
   );
@@ -42,7 +78,7 @@ function SkeletonProgressDataColumn({
 SkeletonProgressDataColumn.propTypes = {
   sortedStudents: PropTypes.array,
   lesson: PropTypes.object.isRequired,
-  expandedMetadataStudentIds: PropTypes.array,
+  expandedMetadataStudentIds: PropTypes.array.isRequired,
 };
 
 export const UnconnectedSkeletonProgressDataColumn = SkeletonProgressDataColumn;

--- a/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
@@ -1,12 +1,10 @@
-import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {render, screen} from '@testing-library/react';
 import React from 'react';
 
 import {fakeLessonWithLevels} from '@cdo/apps/templates/progress/progressTestHelpers';
-import SkeletonProgressDataColumn from '@cdo/apps/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx';
+import {UnconnectedSkeletonProgressDataColumn} from '@cdo/apps/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx';
 
 import {expect} from '../../../util/reconfiguredChai';
-
-import skeletonizeContent from '@cdo/apps/componentLibrary/skeletonize-content.module.scss';
 
 const STUDENT_1 = {id: 1, name: 'Student 1', familyName: 'FamNameB'};
 const STUDENT_2 = {id: 2, name: 'Student 2', familyName: 'FamNameA'};
@@ -18,25 +16,39 @@ const DEFAULT_PROPS = {
   sortedStudents: STUDENTS,
 };
 
-const setUp = overrideProps => {
-  const props = {...DEFAULT_PROPS, ...overrideProps};
-  return mount(<SkeletonProgressDataColumn {...props} />);
-};
+function renderDefault(overrideProps = {}) {
+  render(
+    <UnconnectedSkeletonProgressDataColumn
+      {...DEFAULT_PROPS}
+      {...overrideProps}
+    />
+  );
+}
 
 describe('SkeletonProgressDataColumn', () => {
   it('Shows skeleton if fake lesson', () => {
-    const wrapper = setUp({lesson: {id: 1, isFake: true}});
+    renderDefault({lesson: {id: 1, isFake: true}});
 
-    expect(
-      wrapper.find(`.${skeletonizeContent.skeletonizeContent}`)
-    ).to.have.length(STUDENTS.length + 1);
+    screen.getByTestId('lesson-skeleton-cell-1');
+    screen.getByTestId('lesson-skeleton-cell-2');
+    screen.getByLabelText('Loading lesson');
+    expect(screen.getAllByTestId(/lesson-skeleton-cell-.*/)).to.have.length(2);
   });
 
   it('Shows real header', () => {
-    const wrapper = setUp();
+    renderDefault();
 
-    expect(
-      wrapper.find(`.${skeletonizeContent.skeletonizeContent}`)
-    ).to.have.length(STUDENTS.length);
+    screen.getByTestId('lesson-skeleton-cell-1');
+    screen.getByTestId('lesson-skeleton-cell-2');
+    expect(screen.queryByLabelText('Loading lesson')).to.not.exist;
+    expect(screen.getAllByTestId(/lesson-skeleton-cell-.*/)).to.have.length(2);
+  });
+
+  it('Shows expanded metadata rows', () => {
+    renderDefault({expandedMetadataStudentIds: [1]});
+
+    screen.getByTestId('lesson-skeleton-cell-1');
+    screen.getByTestId('lesson-skeleton-cell-2');
+    expect(screen.getAllByTestId(/lesson-skeleton-cell-.*/)).to.have.length(4);
   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
@@ -33,8 +33,8 @@ describe('SkeletonProgressDataColumn', () => {
   it('Shows skeleton if fake lesson', () => {
     renderDefault({lesson: {id: 1, isFake: true}});
 
-    screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id));
-    screen.getByTestId(getTestId(LESSON.id, STUDENT_2.id));
+    screen.getByTestId(getTestId(1, STUDENT_1.id));
+    screen.getByTestId(getTestId(1, STUDENT_2.id));
     screen.getByLabelText('Loading lesson');
     expect(
       screen.getAllByTestId('lesson-skeleton-cell', {exact: false})

--- a/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
@@ -14,7 +14,11 @@ const LESSON = fakeLessonWithLevels({}, 1);
 const DEFAULT_PROPS = {
   lesson: LESSON,
   sortedStudents: STUDENTS,
+  expandedMetadataStudentIds: [],
 };
+
+const getTestId = (lessonId, studentId, suffix = '') =>
+  `lesson-skeleton-cell-${studentId}.${lessonId}${suffix}`;
 
 function renderDefault(overrideProps = {}) {
   render(
@@ -29,26 +33,34 @@ describe('SkeletonProgressDataColumn', () => {
   it('Shows skeleton if fake lesson', () => {
     renderDefault({lesson: {id: 1, isFake: true}});
 
-    screen.getByTestId('lesson-skeleton-cell-1');
-    screen.getByTestId('lesson-skeleton-cell-2');
+    screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id));
+    screen.getByTestId(getTestId(LESSON.id, STUDENT_2.id));
     screen.getByLabelText('Loading lesson');
-    expect(screen.getAllByTestId(/lesson-skeleton-cell-.*/)).to.have.length(2);
+    expect(
+      screen.getAllByTestId('lesson-skeleton-cell', {exact: false})
+    ).to.have.length(2);
   });
 
   it('Shows real header', () => {
     renderDefault();
 
-    screen.getByTestId('lesson-skeleton-cell-1');
-    screen.getByTestId('lesson-skeleton-cell-2');
+    screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id));
+    screen.getByTestId(getTestId(LESSON.id, STUDENT_2.id));
     expect(screen.queryByLabelText('Loading lesson')).to.not.exist;
-    expect(screen.getAllByTestId(/lesson-skeleton-cell-.*/)).to.have.length(2);
+    expect(
+      screen.getAllByTestId('lesson-skeleton-cell', {exact: false})
+    ).to.have.length(2);
   });
 
   it('Shows expanded metadata rows', () => {
     renderDefault({expandedMetadataStudentIds: [1]});
 
-    screen.getByTestId('lesson-skeleton-cell-1');
-    screen.getByTestId('lesson-skeleton-cell-2');
-    expect(screen.getAllByTestId(/lesson-skeleton-cell-.*/)).to.have.length(4);
+    screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id));
+    screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id, '-last-updated'));
+    screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id, '-time-spent'));
+    screen.getByTestId(getTestId(LESSON.id, STUDENT_2.id));
+    expect(
+      screen.getAllByTestId('lesson-skeleton-cell', {exact: false})
+    ).to.have.length(4);
   });
 });


### PR DESCRIPTION
Adds skeleton loaders for time spent and last updated cells in the progress v2 page:

![image](https://github.com/code-dot-org/code-dot-org/assets/25193259/34117262-6423-436c-8316-8639ee09684e)

Also converts the relevant test to React Testing Library

## Links
[TEACH-1132](https://codedotorg.atlassian.net/browse/TEACH-1132)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
