### PR TITLE
Use session[:user_return_to] in account linking flow

### DIFF
--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -20,7 +20,8 @@ module Lti
         if existing_user&.valid_password?(params[:password])
           Services::Lti::AccountLinker.call(user: existing_user, session: session)
           sign_in existing_user
-          redirect_to home_path
+          target_url = session[:user_return_to] || home_path
+          redirect_to target_url
         else
           head :unauthorized
         end

--- a/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
@@ -17,12 +17,14 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
       credential_type: AuthenticationOption::LTI_V1,
       email: @user.email,
     )
+    target_url = "some/test/path"
+    session[:user_return_to] = target_url
     partial_lti_teacher.authentication_options = [ao]
     PartialRegistration.persist_attributes session, partial_lti_teacher
     User.any_instance.stubs(:valid_password?).returns(true)
 
     post :link_email, params: {email: @user.email, password: 'password'}
-    assert_redirected_to home_path
+    assert_redirected_to target_url
     assert Policies::Lti.lti?(@user)
   end
 


### PR DESCRIPTION
After account linking completes, parse session key `session[:user_return_to]` and redirect to that url, or home_path if empty. This is handled by devise automatically for devise handled controller actions and routes, however we need to do this manually since the account linking flow doesn't call devise.
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[Jira](https://codedotorg.atlassian.net/browse/P20-996)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
