### PR TITLE
P20-992: Fix CPA time zones

### DIFF
--- a/dashboard/lib/cpa.rb
+++ b/dashboard/lib/cpa.rb
@@ -6,8 +6,8 @@ module Cpa
   ALL_USER_LOCKOUT_WARNING = 'cpa_all_user_lockout_warning'
   ALL_USER_LOCKOUT = 'cpa_all_user_lockout'
 
-  NEW_USER_LOCKOUT_DATE = DateTime.parse('2023-07-01T00:00:00MST').freeze
-  ALL_USER_LOCKOUT_DATE = DateTime.parse('2024-07-01T00:00:00MST').freeze
+  NEW_USER_LOCKOUT_DATE = DateTime.parse('2023-07-01T00:00:00MDT').freeze
+  ALL_USER_LOCKOUT_DATE = DateTime.parse('2024-07-01T00:00:00MDT').freeze
 
   # There are four phases for the Colorado Privacy Act:
   # 1. Nothing - nil
@@ -27,8 +27,8 @@ module Cpa
     # schedule [Map] A map of the CPA phases to dates. Example:
     # {
     #   “cpa_new_user_lockout”:         “2023-07-05T23:15:00+00:00”,
-    #   “cpa_all_user_lockout_warning”: “2024-05-01T00:00:00MST”,
-    #   “cpa_all_user_lockout”:         “2024-07-01T00:00:00MST”
+    #   “cpa_all_user_lockout_warning”: “2024-05-01T00:00:00MDT”,
+    #   “cpa_all_user_lockout”:         “2024-07-01T00:00:00MDT”
     # }
     schedule = experiment_value('cpa_schedule', current_request)
     # Ensure the schedule is a Hash

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -27,7 +27,7 @@ class Policies::ChildAccount
   # P20-937 - We had a regression which we have chosen to mitigate by allowing
   # accounts created before the below date to have their lock-out delayed until
   # the CAP policy is set to lockout all users.
-  CPA_CREATED_AT_EXCEPTION_DATE = DateTime.parse('2024-05-26T00:00:00MST')
+  CPA_CREATED_AT_EXCEPTION_DATE = DateTime.parse('2024-05-26T00:00:00MDT')
 
   # The delay is intended to provide notice to a parent
   # when a student may no longer be monitoring the "parent's email."

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -78,14 +78,14 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       [[:student], false],
       [[:student, :U13], false],
       [[:student, :U13, :unknown_us_region], false],
-      [[:non_compliant_child, {created_at: '2023-06-29T23:59:59MST'}], true],
-      [[:non_compliant_child, {created_at: '2024-06-29T23:59:59MST'}], false],
-      [[:non_compliant_child, {created_at: '2024-07-01T00:00:00MST'}], false],
-      [[:non_compliant_child, :migrated_imported_from_clever, {created_at: '2023-06-29T23:59:59MST'}], false],
-      [[:non_compliant_child, :migrated_imported_from_clever, {created_at: '2024-06-29T23:59:59MST'}], false],
-      [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2023-06-29T23:59:59MST'}], true],
-      [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2024-06-29T23:59:59MST'}], true],
-      [[:non_compliant_child, :with_google_authentication_option, {created_at: '2024-06-29T23:59:59MST'}], true],
+      [[:non_compliant_child, {created_at: '2023-06-29T23:59:59MDT'}], true],
+      [[:non_compliant_child, {created_at: '2024-06-29T23:59:59MDT'}], false],
+      [[:non_compliant_child, {created_at: '2024-07-01T00:00:00MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_clever, {created_at: '2023-06-29T23:59:59MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_clever, {created_at: '2024-06-29T23:59:59MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2023-06-29T23:59:59MDT'}], true],
+      [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2024-06-29T23:59:59MDT'}], true],
+      [[:non_compliant_child, :with_google_authentication_option, {created_at: '2024-06-29T23:59:59MDT'}], true],
       # The following test cases address P20-937
       [[:non_compliant_child, :before_p20_937_exception_date], true],
       [[:non_compliant_child, :microsoft_v2_sso_provider, :before_p20_937_exception_date], true],
@@ -118,8 +118,8 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
 
     describe 'for Colorado' do
       let(:co_state_policy) {state_policies['CO']}
-      let(:default_start_date) {DateTime.parse('2023-07-01T00:00:00MST')}
-      let(:default_lockout_date) {DateTime.parse('2024-07-01T00:00:00MST')}
+      let(:default_start_date) {DateTime.parse('2023-07-01T00:00:00MDT')}
+      let(:default_lockout_date) {DateTime.parse('2024-07-01T00:00:00MDT')}
 
       it 'contains expected max age' do
         _(co_state_policy[:max_age]).must_equal 12

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -146,7 +146,7 @@ And(/^I create( as a parent)? a (young )?student( in Colorado)?( who has never s
   end
 
   # See Policies::ChildAccount::CPA_CREATED_AT_EXCEPTION_DATE
-  cpa_exception_date = DateTime.parse('2024-05-26T00:00:00MST')
+  cpa_exception_date = DateTime.parse('2024-05-26T00:00:00MDT')
 
   if after_cpa_exception
     user_opts[:created_at] = cpa_exception_date


### PR DESCRIPTION
## Summary
On `2023-07-01` and `2024-07-01`, Colorado observes Mountain Daylight Time (MDT) rather than Mountain Standard Time (MST), so we needed to adjust the time zones accordingly.

## Links
- JIRA ticket: [P20-992](https://codedotorg.atlassian.net/browse/P20-992)