### PR TITLE
Teach 1144/fix teacher homepage flakiness

### DIFF
--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -228,6 +228,12 @@ end
 
 Then /^the section table row at index (\d+) has (primary|secondary) assignment path "([^"]+)"$/ do |row_index, assignment_type, expected_path|
   link_index = (assignment_type == 'primary') ? 0 : 1
+  # Wait until the link loads in the table
+  wait_until do
+    @browser.execute_script("return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(3) a:eq(#{link_index})').attr('href') !== null;")
+  end
+
+  # Then grab it
   href = @browser.execute_script(
     "return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(3) a:eq(#{link_index})').attr('href');"
   )


### PR DESCRIPTION
The `teacher_homepage.feature` tests would sometimes flake out because they were assessing the content of the section table, yet that table is dynamically loaded.

Here is an example of that test failing in sauce labs:

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/a9ec716b-3d44-4b62-8c6b-5c91fd3d3a51)

In this case, it returned `null` when it was pulling out the row data. You can see this on sauce labs itself:

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/650857ad-3a26-4a09-8a95-155ba82c9fad)

The video shows the link grayed out as it was querying for it and returning `null`. We just need to wait until it is not `null`.

## Links

- jira ticket: [TEACH-1144](https://codedotorg.atlassian.net/browse/TEACH-1144)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
