### PR TITLE
Curriculum Launch 2024 - Homepage hero banner

### DIFF
--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -37,6 +37,15 @@
       "buttonText": "Learn more",
       "buttonUrl": "https://code.org/lms",
       "buttonId": "lms-launch"
+    },
+    "curriculum-launch-2024": {
+      "dcdo": "curriculum-launch-2024",
+      "image": "",
+      "title": "Discover new and updated curriculum!",
+      "body": "Explore our latest units and professional learning resources to inspire future tech innovators.",
+      "buttonText": "See what's new",
+      "buttonUrl": "",
+      "buttonId": "curriculum-launch-2024"
     }
   }
 }

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -31,6 +31,7 @@ class DCDOBase < DynamicConfigBase
       'frontend-i18n-tracking': DCDO.get('frontend-i18n-tracking', false),
       'pl-teacher-application-off-season': DCDO.get('pl_teacher_application', false),
       'pl-launch-hero-banner': DCDO.get('pl-launch-hero-banner', false),
+      'curriculum-launch-2024': DCDO.get('curriculum-launch-2024', false),
       'csta-form-extension': DCDO.get('csta-form-extension', false),
       cpa_experience: DCDO.get('cpa_experience', false),
       gender: DCDO.get('gender', false),

--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -4,7 +4,8 @@
       "hoc2023-soon-hoc",
       "hoc2023-actual-hoc",
       "pl-launch-superhero",
-      "music-lab-launch-2024"
+      "music-lab-launch-2024",
+      "curriculum-launch-2024"
     ]
   },
 
@@ -122,6 +123,23 @@
           "text_desc_02": "music_lab.in_partnership_with",
           "logo_list_01": "/images/avatars/amazon_future_engineer_light.png",
           "logo_list_01_alt": "music_lab.amazon_future_engineer"
+        }
+      ]
+    },
+    "curriculum-launch-2024": {
+      "dcdo": "curriculum-launch-2024",
+      "class": "curriculum-banner-hero homepage",
+      "desktopImage": "/images/banners/banner-bg-school-supplies-dark-black.png",
+      "actions": [
+        {
+          "type": "flex-container",
+          "text_h1": "curriculum_launch_2024.banner.heading",
+          "text_desc": "curriculum_launch_2024.banner.desc",
+          "external_link": true,
+          "button_color_white": true,
+          "button_link": "#",
+          "button_text": "curriculum_launch_2024.banner.button_learn_more_here",
+          "img_src": "/images/banners/banner-curriculum-catalog-illustration-black.png"
         }
       ]
     }

--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -4,8 +4,8 @@
       "hoc2023-soon-hoc",
       "hoc2023-actual-hoc",
       "pl-launch-superhero",
-      "music-lab-launch-2024",
-      "curriculum-launch-2024"
+      "curriculum-launch-2024",
+      "music-lab-launch-2024"
     ]
   },
 

--- a/pegasus/sites.v3/code.org/public/css/banners-curriculum-launch.scss
+++ b/pegasus/sites.v3/code.org/public/css/banners-curriculum-launch.scss
@@ -1,0 +1,71 @@
+@import 'breakpoints';
+
+// Overrides the text align so this
+// works with LTR and RTL languages
+#homepage #hero #actions {
+  .curriculum-banner-hero {
+    text-align: initial;
+  }
+}
+
+.curriculum-banner-hero.homepage {
+  max-width: 960px;
+  margin: 0 auto;
+  position: relative;
+
+  .flex-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-flow: row wrap;
+    gap: 1rem;
+
+    .text-wrapper {
+      width: 60%;
+
+      @media (max-width: $width-sm) {
+        width: 100%;
+        text-align: center;
+      }
+
+      h1, p {
+        color: var(--neutral_white);
+      }
+
+      h1 {
+        margin: 0;
+
+        @media (max-width: $width-md) {
+          font-size: 2.875em;
+        }
+      }
+
+      p {
+        font-size: 1.4em;
+        line-height: 1.5;
+        margin: 1em 0;
+        text-wrap: balance;
+
+        @media (max-width: $width-md) {
+          font-size: 1.2em;
+        }
+      }
+    }
+
+    figure {
+      margin: 0;
+      display: flex;
+      justify-content: center;
+      flex: 1;
+
+      img {
+        width: 100%;
+        margin-inline-start: -1rem;
+
+        @media (max-width: $width-sm) {
+          max-width: 250px;
+        }
+      }
+    }
+  }
+}

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -19,8 +19,12 @@ style_min: true
 -# Apply this stylesheet when 'pl-launch-hero-banner' is set to 'true'
 - if !!DCDO.get('pl-launch-hero-banner', false)
   =inline_css '/generated/pl-hero-banner.css'
+-# Apply this stylesheet when 'curriculum-launch-2024' is set to 'true'
+- if !!DCDO.get('curriculum-launch-2024', false)
+  =inline_css '/generated/banners-curriculum-launch.css'
 -# TODO: Remove this after the Music Lab launch is over
-=inline_css '/generated/music-lab-hero-banner.css'
+- if !!DCDO.get('music-lab-launch-2024', false)
+  =inline_css '/generated/music-lab-hero-banner.css'
 
 - cookie_key = environment_specific_cookie_name '_user_type'
 - user_type = request.cookies[cookie_key]

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -65,12 +65,8 @@
               = I18n.t(entry[:text_h1])
             %p
               = I18n.t(entry[:text_desc])
-            - if entry[:studio_button_link]
-              %a.link-button{href: CDO.studio_url(entry[:studio_button_link])}
-                = I18n.t(entry[:button_text])
-            - else
-              %a.link-button{href: entry[:button_link], class: [(entry[:external_link] ? "has-external-link" : nil), (entry[:button_color_white] ? "white" : nil)].compact.join(' ')}
-                = I18n.t(entry[:button_text])
+            %a.link-button{href: entry[:studio_button_link] ? CDO.studio_url(entry[:studio_button_link]) : entry[:button_link], class: [(entry[:external_link] ? "has-external-link" : nil), (entry[:button_color_white] ? "white" : nil)].compact.join(' '), target: (entry[:external_link] ? "_blank" : nil), rel: (entry[:external_link] ? "noopener noreferrer" : nil)}
+              = I18n.t(entry[:button_text])
           %figure
             %img{src: entry[:img_src], alt: ""}
       - elsif entry[:type] == "music-lab-launch-2024"

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -69,7 +69,7 @@
               %a.link-button{href: CDO.studio_url(entry[:studio_button_link])}
                 = I18n.t(entry[:button_text])
             - else
-              %a.link-button{href: entry[:button_link]}
+              %a.link-button{href: entry[:button_link], class: [(entry[:external_link] ? "has-external-link" : nil), (entry[:button_color_white] ? "white" : nil)].compact.join(' ')}
                 = I18n.t(entry[:button_text])
           %figure
             %img{src: entry[:img_src], alt: ""}

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -137,6 +137,13 @@
   curriculum_launch_2023_title: "Introducing incredible updates to our curriculum"
   curriculum_launch_2023_desc: "Updates to CSC, CSP, CSD, and more — plus a new Curriculum Catalog and redesigned Teach page to help you find it all!"
 
+  curriculum_launch_2024:
+    banner:
+      heading: "Discover new and updated curriculum!"
+      desc: "Explore our latest units and professional learning resources to inspire future tech innovators."
+      button_learn_more_here: "Learn more here!"
+      button_learn_more: "Learn more"
+
   in_partnership_with: "In partnership with"
 
   shop_code_dot_org_heading: "Shop Code.org"
@@ -1722,7 +1729,7 @@
     skinny_banner:
       heading: "Discover our new LMS integrations!"
       desc: "We've added new LMS integrations for %{canvas} and %{schoology}! Learn how to get started!"
-  
+
   lms_partner_page:
     heading: "Integrate Code.org with %{website}"
     desc: "Sync your rosters and sign in to code.org with one-click. Plus, Code.org content is now available directly on %{website}."

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -251,6 +251,8 @@ class Homepage
           text_desc: action["text_desc"],
           text_desc_02: action["text_desc_02"],
           text_overline: action["text_overline"],
+          external_link: action["external_link"],
+          button_color_white: action["button_color_white"],
           button_link: action["button_link"],
           studio_button_link: action["studio_button_link"],
           button_label_primary: action["button_label_primary"],


### PR DESCRIPTION
Adds the code.org homepage hero banner for the 2024 Curriculum Launch:
- Works with the `curriculum-launch-2024` DCDO flag
- Fully responsive and works w/ LTR and RTL languages

**Note:** I added the other banner strings here for the skinny banners ([ACQ-1969](https://codedotorg.atlassian.net/browse/ACQ-1969)) and teacher homepage banner ([ACQ-1968](https://codedotorg.atlassian.net/browse/ACQ-1968)) so they can get in the pipeline sooner.

## Links
Jira ticket: [ACQ-1967](https://codedotorg.atlassian.net/browse/ACQ-1967)
Figma mock: [here](https://www.figma.com/design/HwXIyBGQ0b2ZI213sWb3cK/2024-Curriculum-Launch?node-id=2436-4603&t=dFI9Qgia70mMmEsS-1)

## Testing story
Tested locally

## Followup
Add the blog post URL if we don't get it before this gets merged.

----


https://github.com/code-dot-org/code-dot-org/assets/9256643/8f7cd75c-c630-44ba-a6e4-f975c23bdb3a

