### PR TITLE
fix(link account): add cancel button to link account flow

### DIFF
--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/index.tsx
@@ -4,9 +4,9 @@ import React from 'react';
 import NewAccountCard from './cards/NewAccountCard';
 import ExistingAccountCard from './cards/ExistingAccountCard';
 import WelcomeBanner from './WelcomeBanner';
-import {buttonColors, Button} from '@cdo/apps/componentLibrary/button';
 import i18n from '@cdo/locale';
 import {navigateToHref} from '@cdo/apps/utils';
+import Link from '@cdo/apps/componentLibrary/link';
 
 const LtiLinkAccountPage = () => {
   const handleCancel = () => {
@@ -15,19 +15,13 @@ const LtiLinkAccountPage = () => {
 
   return (
     <main className={styles.mainContainer}>
-      <div className={styles.cancelButtonContainer}>
-        <Button
-          className={styles.cardSecondaryButton}
-          color={buttonColors.white}
-          size="l"
-          text={i18n.cancel()}
-          onClick={handleCancel}
-        />
-      </div>
       <WelcomeBanner />
       <div className={styles.cardContainer}>
         <NewAccountCard />
         <ExistingAccountCard />
+      </div>
+      <div className={styles.cancelButtonContainer}>
+        <Link text={i18n.cancel()} href={`#`} onClick={handleCancel} />
       </div>
     </main>
   );

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/index.tsx
@@ -4,10 +4,26 @@ import React from 'react';
 import NewAccountCard from './cards/NewAccountCard';
 import ExistingAccountCard from './cards/ExistingAccountCard';
 import WelcomeBanner from './WelcomeBanner';
+import {buttonColors, Button} from '@cdo/apps/componentLibrary/button';
+import i18n from '@cdo/locale';
+import {navigateToHref} from '@cdo/apps/utils';
 
 const LtiLinkAccountPage = () => {
+  const handleCancel = () => {
+    navigateToHref(`/users/cancel`);
+  };
+
   return (
     <main className={styles.mainContainer}>
+      <div className={styles.cancelButtonContainer}>
+        <Button
+          className={styles.cardSecondaryButton}
+          color={buttonColors.white}
+          size="l"
+          text={i18n.cancel()}
+          onClick={handleCancel}
+        />
+      </div>
       <WelcomeBanner />
       <div className={styles.cardContainer}>
         <NewAccountCard />

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/link-account.module.scss
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/link-account.module.scss
@@ -14,6 +14,7 @@
 }
 
 .cancelButtonContainer {
+  padding-top: 30px;
   display: flex;
   justify-content: flex-end;
 }

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/link-account.module.scss
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/link-account.module.scss
@@ -13,6 +13,11 @@
   width: 100%;
 }
 
+.cancelButtonContainer {
+  display: flex;
+  justify-content: flex-end;
+}
+
 // Increase specificity to override base button
 .cardSecondaryButton.cardSecondaryButton {
   border: 1px solid #292F36

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -124,4 +124,20 @@ describe('LTI Link Account Page Tests', () => {
       );
     });
   });
+
+  describe('cancel button', () => {
+    it('should link to the cancel controller', () => {
+      render(
+        <LtiProviderContext.Provider value={DEFAULT_CONTEXT}>
+          <LtiLinkAccountPage />
+        </LtiProviderContext.Provider>
+      );
+
+      const cancelButton = screen.getByText(i18n.cancel());
+
+      fireEvent.click(cancelButton);
+
+      expect(utils.navigateToHref).to.have.been.calledWith(`/users/cancel`);
+    });
+  });
 });

--- a/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
+++ b/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
@@ -25,9 +25,13 @@
   color: $white;
 }
 
+.call-to-action-container {
+  display: flex;
+  justify-content: space-between;
+}
+
 .go-back-link {
   display: block;
-  margin-top: 60px;
 }
 
 .oauth-sign-in {

--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -1,5 +1,9 @@
 %link{href: "/shared/css/phase1-design-system.css", rel: "stylesheet"}
 
+%div.buttons-right-aligned{style: "margin-bottom: 0"}
+  %a{href: users_cancel_path}
+    %button#link-account-cancel-button= t('cancel')
+
 %h2#linking-page-header= t('lti.account_linking.linking_page_header', provider: params[:lms_name])
 %p#linking-page-description= t('lti.account_linking.linking_page_description')
 
@@ -10,9 +14,10 @@
       = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
         = image_tag("oauth/#{provider}.svg")
         = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))
-    %a.go-back-link{href: lti_v1_account_linking_landing_path(lti_provider: params[:lti_provider], email: params[:email])}
-      %i.fa.fa-arrow-left
-      = t('lti.account_linking.go_back')
+    - if params[:lti_provider].present? && params[:email].present?
+      %a.go-back-link{href: lti_v1_account_linking_landing_path(lti_provider: params[:lti_provider], email: params[:email])}
+        %i.fa.fa-arrow-left
+        = t('lti.account_linking.go_back')
   %div.vertical-or
     %hr
     = t("or").upcase

--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -1,46 +1,51 @@
 %link{href: "/shared/css/phase1-design-system.css", rel: "stylesheet"}
 
-%div.buttons-right-aligned{style: "margin-bottom: 0"}
-  %a{href: users_cancel_path}
-    %button#link-account-cancel-button= t('cancel')
-
 %h2#linking-page-header= t('lti.account_linking.linking_page_header', provider: params[:lms_name])
 %p#linking-page-description= t('lti.account_linking.linking_page_description')
 
-.flex-container
-  #oauth-side.devise-links
-    %h3= t('lti.account_linking.connect_with')
-    - [:google_oauth2, :microsoft_v2_auth, :facebook, :clever].each do |provider|
-      = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
-        = image_tag("oauth/#{provider}.svg")
-        = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))
-    - if params[:lti_provider].present? && params[:email].present?
-      %a.go-back-link{href: lti_v1_account_linking_landing_path(lti_provider: params[:lti_provider], email: params[:email])}
-        %i.fa.fa-arrow-left
-        = t('lti.account_linking.go_back')
-  %div.vertical-or
-    %hr
-    = t("or").upcase
-    %hr
+%div#link-account
+  .flex-container
+    #oauth-side.devise-links
+      %h3= t('lti.account_linking.connect_with')
+      - [:google_oauth2, :microsoft_v2_auth, :facebook, :clever].each do |provider|
+        = button_to omniauth_authorize_path(resource_name, provider), id: "#{provider}-sign-in", class: "oauth-sign-in with-#{provider}" do
+          = image_tag("oauth/#{provider}.svg")
+          = t('lti.account_linking.connect_button', provider: t("auth.#{provider}"))
 
-  #email-side
-    %h3= t('lti.account_linking.connect_with_email')
-    = form_with(url: :lti_v1_account_linking_link_email, method: :post) do |f|
-      = show_flashes.html_safe
+    %div.vertical-or
+      %hr
+      = t("or").upcase
+      %hr
 
-      / Email
-      .field
-        = f.label :email
-        - email = params[:email] || ''
-        = f.text_field :email, value: email, autofocus: email == '', required: true
+    #email-side
+      %h3= t('lti.account_linking.connect_with_email')
+      = form_with(url: :lti_v1_account_linking_link_email, method: :post) do |f|
+        = show_flashes.html_safe
 
-      / Password
-      .field#password_field
-        = f.label :password
-        = f.password_field :password, autofocus: email != '', required: true
+        / Email
+        .field
+          = f.label :email
+          - email = params[:email] || ''
+          = f.text_field :email, value: email, autofocus: email == '', required: true
 
-      / Sign in button
-      %button#signin-connect-button= t('lti.account_linking.sign_in_and_connect')
+        / Password
+        .field#password_field
+          = f.label :password
+          = f.password_field :password, autofocus: email != '', required: true
+
+        / Sign in button
+        %button#signin-connect-button= t('lti.account_linking.sign_in_and_connect')
+
+  %div.call-to-action-container
+    %div
+      - if params[:lti_provider].present? && params[:email].present?
+        %a.go-back-link{href: lti_v1_account_linking_landing_path(lti_provider: params[:lti_provider], email: params[:email])}
+          %i.fa.fa-arrow-left
+          = t('lti.account_linking.go_back')
+
+    = link_to t('cancel'), users_cancel_path
+
+
 
 %br/
 %br/


### PR DESCRIPTION
Currently, users who enter the link account flow gets "locked" into that state. If a user wishes to navigate out of the link account flow or cancel the flow (because they realize this is the wrong account), the user is unable to with no options to log out or cancel. This change adds a cancel button to allow the user to escape from the flow.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-998)
- [jira ticket](https://codedotorg.atlassian.net/browse/P20-997)

## Testing story

![Screenshot from 2024-06-18 10-49-54](https://github.com/code-dot-org/code-dot-org/assets/538214/2a756220-381d-4591-8380-6c5856bdae18)
![Screenshot from 2024-06-18 10-49-48](https://github.com/code-dot-org/code-dot-org/assets/538214/99f89c79-f780-496d-aed3-5ae08553a2aa)



<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
