### PR TITLE
Added link to Helpful Links for levelbuilders

### DIFF
--- a/dashboard/app/views/home/_levelbuilder.html.haml
+++ b/dashboard/app/views/home/_levelbuilder.html.haml
@@ -1,6 +1,7 @@
 - if current_user && current_user.permission?(UserPermission::LEVELBUILDER)
   = render layout: 'shared/extra_links' do
     %li= link_to 'Videos', videos_path
+    %li= link_to 'Images', '/images/new'
     %li
       = link_to 'Scripts', scripts_path
       = link_to '(Update all)', scripts_path(rake: '1'), data: { confirm: 'Are you sure want to re-seed script data?'}


### PR DESCRIPTION
Added link to new images page on "Helpful links" box.

<img width="359" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/02f0dfc2-7daa-4437-8bfb-e9dbd40675a2">

This redirects to the stand-alone page for uploading images: studio.code.org/images/new