### PR TITLE
Stephen/new account dupe

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1654,6 +1654,7 @@
   "ltiLinkAccountNewAccountCardHeaderLabel": "I am new to Code.org",
   "ltiLinkAccountNewAccountCardContent": "You'll need to finish creating an account on Code.org to connect with {providerName}",
   "ltiLinkAccountNewAccountCardActionLabel": "Finish creating my account",
+  "ltiLinkAccountContinueAccountCardContent": "Continue to Code.org without linking to another existing Code.org account.",
   "ltiLinkAccountWelcomeBannerHeaderLabel": "Welcome to Code.org!",
   "ltiLinkAccountWelcomeBannerContent": "Looks like this is your first time logging in from {providerName}, select one of the options below to continue.",
   "ltiSectionSyncButtonDisabledAltText": "Roster sync is disabled. To re-enable, go to your account settings.",

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ContinueCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ContinueCard/index.tsx
@@ -1,0 +1,61 @@
+import {
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+} from '@cdo/apps/componentLibrary/card';
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';
+import classNames from 'classnames';
+import styles from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/link-account.module.scss';
+import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
+import React, {useContext} from 'react';
+import i18n from '@cdo/locale';
+import {LtiProviderContext} from '../../context';
+import {navigateToHref} from '@cdo/apps/utils';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+
+const ContinueAccountCard = () => {
+  const {ltiProviderName, continueAccountUrl} = useContext(LtiProviderContext)!;
+
+  const handleSubmit = () => {
+    const eventPayload = {
+      lms_name: ltiProviderName,
+    };
+    analyticsReporter.sendEvent(
+      'lti_continue_account_click',
+      eventPayload,
+      PLATFORMS.STATSIG
+    );
+
+    navigateToHref(continueAccountUrl);
+  };
+
+  return (
+    <Card data-testid={'continue-account-card'}>
+      <CardHeader
+        title={i18n.ltiLinkAccountNewAccountCardHeaderLabel()}
+        icon={
+          <FontAwesomeV6Icon
+            className={classNames(styles.icon, 'fa-3x')}
+            iconName={'user-plus'}
+          />
+        }
+      />
+      <CardContent>
+        {i18n.ltiLinkAccountContinueAccountCardContent()}
+      </CardContent>
+      <CardActions>
+        <Button
+          className={classNames(styles.button, styles.cardSecondaryButton)}
+          color={buttonColors.white}
+          size="l"
+          text={i18n.ltiIframeCallToAction()}
+          onClick={handleSubmit}
+        />
+      </CardActions>
+    </Card>
+  );
+};
+
+export default ContinueAccountCard;

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/context.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/context.tsx
@@ -5,8 +5,10 @@ export interface LtiProviderContextProps {
   ltiProvider: LtiProvider;
   ltiProviderName: string;
   newAccountUrl: string;
+  continueAccountUrl: string;
   existingAccountUrl: URL;
   emailAddress: string;
+  newCtaType: 'continue' | 'new';
 }
 
 export const LtiProviderContext = createContext<

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/index.tsx
@@ -1,23 +1,28 @@
 import styles from './link-account.module.scss';
-import React from 'react';
+import React, {useContext} from 'react';
 
 import NewAccountCard from './cards/NewAccountCard';
 import ExistingAccountCard from './cards/ExistingAccountCard';
+import ContinueCard from './cards/ContinueCard';
 import WelcomeBanner from './WelcomeBanner';
 import i18n from '@cdo/locale';
 import {navigateToHref} from '@cdo/apps/utils';
 import Link from '@cdo/apps/componentLibrary/link';
+import {LtiProviderContext} from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/context';
 
 const LtiLinkAccountPage = () => {
   const handleCancel = () => {
     navigateToHref(`/users/cancel`);
   };
 
+const LtiLinkAccountPage = () => {
+  const {newCtaType} = useContext(LtiProviderContext)!;
+
   return (
     <main className={styles.mainContainer}>
       <WelcomeBanner />
       <div className={styles.cardContainer}>
-        <NewAccountCard />
+        {newCtaType === 'new' ? <NewAccountCard /> : <ContinueCard />}
         <ExistingAccountCard />
       </div>
       <div className={styles.cancelButtonContainer}>

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/index.tsx
@@ -11,12 +11,10 @@ import Link from '@cdo/apps/componentLibrary/link';
 import {LtiProviderContext} from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/context';
 
 const LtiLinkAccountPage = () => {
+  const {newCtaType} = useContext(LtiProviderContext)!;
   const handleCancel = () => {
     navigateToHref(`/users/cancel`);
   };
-
-const LtiLinkAccountPage = () => {
-  const {newCtaType} = useContext(LtiProviderContext)!;
 
   return (
     <main className={styles.mainContainer}>

--- a/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
+++ b/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
@@ -18,6 +18,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const newAccountUrl = scriptData['new_account_url'];
   const existingAccountUrl = new URL(scriptData['existing_account_url']);
   const emailAddress = scriptData['email'];
+  const newCtaType = scriptData['new_cta_type'];
+  const continueAccountUrl = scriptData['continue_account_url'];
 
   const ltiProviderContext = {
     ltiProvider,
@@ -25,6 +27,8 @@ document.addEventListener('DOMContentLoaded', () => {
     newAccountUrl,
     existingAccountUrl,
     emailAddress,
+    newCtaType,
+    continueAccountUrl,
   };
 
   ReactDOM.render(

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -17,6 +17,8 @@ const DEFAULT_CONTEXT: LtiProviderContextProps = {
   newAccountUrl: '/new-account',
   existingAccountUrl: new URL('https://example.com/existing-account'),
   emailAddress: 'test@code.org',
+  newCtaType: 'new',
+  continueAccountUrl: '/continue',
 };
 
 describe('LTI Link Account Page Tests', () => {

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/WelcomeBanner/WelcomeBannerTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/WelcomeBanner/WelcomeBannerTest.tsx
@@ -1,17 +1,22 @@
 import {render, screen} from '@testing-library/react';
 import WelcomeBanner from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/WelcomeBanner';
-import {LtiProviderContext} from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/context';
+import {
+  LtiProviderContext,
+  LtiProviderContextProps,
+} from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/context';
 import {LtiProvider} from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/types';
 import React from 'react';
 import i18n from '@cdo/locale';
 
-const getContext = (ltiProvider: LtiProvider) => {
+const getContext = (ltiProvider: LtiProvider): LtiProviderContextProps => {
   return {
     ltiProvider,
     ltiProviderName: 'LMS',
     newAccountUrl: '/new-account',
     existingAccountUrl: new URL('https://test.com/existing-account'),
     emailAddress: 'test@code.org',
+    newCtaType: 'new',
+    continueAccountUrl: '/continue',
   };
 };
 

--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -12,6 +12,20 @@ module Lti
         @user = User.new_with_session(ActionController::Parameters.new, session)
       end
 
+      # GET /lti/v1/account_linking/finish_link
+      def finish_link
+        # If the user is logged in, we need to log them out. Signing them out will
+        # clear the session, so we need to store cache key first, sign them out,
+        # then set it again in their now empty session.
+        if current_user
+          partial_registration_cache_key = PartialRegistration.cache_key(current_user)
+          sign_out
+          session[PartialRegistration::SESSION_KEY] = partial_registration_cache_key
+        end
+
+        redirect_to user_session_path
+      end
+
       # POST /lti/v1/account_linking/link_email
       def link_email
         head :bad_request unless PartialRegistration.in_progress?(session)

--- a/dashboard/app/views/lti/v1/account_linking/landing.haml
+++ b/dashboard/app/views/lti/v1/account_linking/landing.haml
@@ -3,12 +3,15 @@
     script_data = {}
     lti_provider ||= params[:lti_provider]
     email ||= params[:email]
+    new_cta_type ||= params[:new_cta_type]
     new_account_url = DCDO.get('student-email-post-enabled', false) ? users_finish_sign_up_path : new_user_registration_url
     script_data[:lti_provider] = lti_provider
     script_data[:lti_provider_name] = Policies::Lti::LMS_PLATFORMS[lti_provider.to_sym][:name]
     script_data[:new_account_url] = new_account_url
-    script_data[:existing_account_url] = CDO.studio_url(user_session_path, CDO.default_scheme)
+    script_data[:existing_account_url] = CDO.studio_url(lti_v1_account_linking_finish_link_path, CDO.default_scheme)
+    script_data[:continue_account_url] = session[:user_return_to] || home_path
     script_data[:email] = email
+    script_data[:new_cta_type] = new_cta_type
 
   %script{src: webpack_asset_path('js/lti/v1/account_linking/landing.js'), data: {json: script_data.to_json}}}
 %body

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -631,6 +631,7 @@ Dashboard::Application.routes.draw do
         namespace :account_linking do
           get :landing
           get :existing_account
+          get :finish_link
           post :link_email
         end
       end


### PR DESCRIPTION
Fixes the bug that was causing roster synced users to be unable to create a new account from the linking flow.

- Updates the landing page to provide two different cards on the left side: an option to "finish creating" your account if you're launching for the first time via SSO, and and option to "continue" into your account if you're launching for the first time into an account that has been pre-created via roster sync.
- Signs in users earlier in the LTI login route. This ensures that roster synced users can continue directly into their already logged-in account.
- Automatically signs out users who choose to link their account. This ensures that the login buttons will work properly, and prevents any possible scenarios where users experience issues linking because they already had an active session in their browser.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1003)

## Testing story

I've run through some, but not all of the provider scenarios from the bug bash, including:

- Making sure the "continue" vs. "finish" buttons are showing up properly for SSO vs synced users
- Continuing with a synced user
- Finishing registration with a purely SSO user
- Linking Clever, Microsoft, and email accounts for roster-synced users
- Linking a Google account for an SSO'd user
- Made sure that the roster synced account gets deleted once the auth option is linked to the pre-existing account

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
