### PR TITLE
Unit deletion script updates to be more flexible

### DIFF
--- a/bin/curriculum/delete_unit.rb
+++ b/bin/curriculum/delete_unit.rb
@@ -42,7 +42,7 @@ require_relative '../../dashboard/config/environment'
 options.unit_names.each do |unit_nm|
   unit_to_del = Unit.find_by(name: unit_nm)
   raise "Unit with name #{unit_nm} not found" if unit_to_del.nil?
-  raise "Only units in_development can be deleted as they wouldn't have usage and hence any DB references." unless unit_to_del.published_state == "in_development"
+  raise "Published units (state set as 'Stable') cannot be deleted as they could have active sections and progress." unless unit_to_del.published_state != "stable"
 
   assigned_section_count = Section.where(script_id: unit_to_del.id).count
   raise "Unit is currently assigned to some sections, deleting will break loading dashboard for those teachers." unless assigned_section_count == 0

--- a/bin/curriculum/delete_unit.rb
+++ b/bin/curriculum/delete_unit.rb
@@ -46,6 +46,7 @@ options.unit_names.each do |unit_nm|
   raise "Unit with name #{unit_nm} not found" if unit_to_del.nil?
   raise "Published units (state set as 'Stable') cannot be deleted as they could have active sections and progress." unless unit_to_del.get_published_state != "stable"
 
+  # Include additional warning if the script is not in one of the safe states where its not available for use externally.
   if unit_to_del.get_published_state != "in_development"
     print "Published state for Unit [#{unit_nm}] is not in_development, script might have usage. " \
       "Please confirm with curriculum team and ensure comms has been sent before deletion. Continue? (Y/N)"

--- a/bin/curriculum/delete_unit.rb
+++ b/bin/curriculum/delete_unit.rb
@@ -40,6 +40,8 @@ raise "unit name is required. Use -h for options." if options.unit_names.nil?
 
 require_relative '../../dashboard/config/environment'
 options.unit_names.each do |unit_nm|
+  puts "Processing unit [#{unit_nm}]..."
+
   unit_to_del = Unit.find_by(name: unit_nm)
   raise "Unit with name #{unit_nm} not found" if unit_to_del.nil?
   raise "Published units (state set as 'Stable') cannot be deleted as they could have active sections and progress." unless unit_to_del.published_state != "stable"
@@ -48,9 +50,12 @@ options.unit_names.each do |unit_nm|
   raise "Unit is currently assigned to some sections, deleting will break loading dashboard for those teachers." unless assigned_section_count == 0
 
   user_progress_count = UserScript.where(script_id: unit_to_del.id).count
-  raise "Some users have existing progress in this unit" unless user_progress_count == 0
+  if user_progress_count > 0
+    print "Some users have existing progress in unit [#{unit_nm}]. Continue with deletion? (Y/N)"
+    next unless gets.chomp.casecmp('y').zero?
+  end
 
-  puts "No references to Unit found from sections or user progress."
+  puts "No references to Unit [#{unit_nm}] found from sections."
   if options.dry_run
     puts "Skipping deletion due to dry run mode."
   else

--- a/bin/curriculum/delete_unit.rb
+++ b/bin/curriculum/delete_unit.rb
@@ -44,7 +44,13 @@ options.unit_names.each do |unit_nm|
 
   unit_to_del = Unit.find_by(name: unit_nm)
   raise "Unit with name #{unit_nm} not found" if unit_to_del.nil?
-  raise "Published units (state set as 'Stable') cannot be deleted as they could have active sections and progress." unless unit_to_del.published_state != "stable"
+  raise "Published units (state set as 'Stable') cannot be deleted as they could have active sections and progress." unless unit_to_del.get_published_state != "stable"
+
+  if unit_to_del.get_published_state != "in_development"
+    print "Published state for Unit [#{unit_nm}] is not in_development, script might have usage. " \
+      "Please confirm with curriculum team and ensure comms has been sent before deletion. Continue? (Y/N)"
+    next unless gets.chomp.casecmp('y').zero?
+  end
 
   assigned_section_count = Section.where(script_id: unit_to_del.id).count
   raise "Unit is currently assigned to some sections, deleting will break loading dashboard for those teachers." unless assigned_section_count == 0

--- a/bin/curriculum/delete_unit.rb
+++ b/bin/curriculum/delete_unit.rb
@@ -44,6 +44,9 @@ options.unit_names.each do |unit_nm|
 
   unit_to_del = Unit.find_by(name: unit_nm)
   raise "Unit with name #{unit_nm} not found" if unit_to_del.nil?
+
+  # Ensure the unit getting deleted is not marked stable. Using the get_published_state method to address units that are part of unit groups
+  # This would return the state for the unit if not null else fall back to return state of unit group
   raise "Published units (state set as 'Stable') cannot be deleted as they could have active sections and progress." unless unit_to_del.get_published_state != "stable"
 
   # Include additional warning if the script is not in one of the safe states where its not available for use externally.

--- a/bin/curriculum/delete_unit.rb
+++ b/bin/curriculum/delete_unit.rb
@@ -51,11 +51,11 @@ options.unit_names.each do |unit_nm|
 
   user_progress_count = UserScript.where(script_id: unit_to_del.id).count
   if user_progress_count > 0
-    print "Some users have existing progress in unit [#{unit_nm}]. Continue with deletion? (Y/N)"
+    print "Some users have existing progress in unit [#{unit_nm}]. Continue? (Y/N)"
     next unless gets.chomp.casecmp('y').zero?
   end
 
-  puts "No references to Unit [#{unit_nm}] found from sections."
+  puts "No references to Unit [#{unit_nm}] found from sections. All validations for deletion passed."
   if options.dry_run
     puts "Skipping deletion due to dry run mode."
   else


### PR DESCRIPTION
Unit deletion script does not allow for deletion when the unit is not in `in_development` or when there is any references to the unit from the section or progress table.

As we are looking at deleting units in CSD-2024 for task https://codedotorg.atlassian.net/browse/TEACH-1161, these limitations are too strict and can be made more flexible without significant user impact.

The changes in this PR include

1. Updating the condition to check for unit state to only block deletion of units in `stable` state
2. Instead of blocking the deletion when user progress is present, change the flow to confirm with the user. 


## Links

https://codedotorg.atlassian.net/browse/TEACH-1161

## Testing story

Manually validated the following through dry run mode

1. A script in `preview` state to ensure it will allow deletion
2. A script that has progress to ensure it will allow deletion (validated both 'yes' and 'no' flows on confirmation)
3. A script in stable state is blocked
4. A script assigned to sections (even if not in stable state) is blocked.

## Deployment strategy

DTP

## Follow-up work

Tracked by https://codedotorg.atlassian.net/browse/TEACH-1161

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
