### PR TITLE
Creates experiment flag for New Sign-Up Flow

### DIFF
--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -62,6 +62,8 @@ experiments.SECTION_PROGRESS_V2 = 'section_progress_v2';
 experiments.SCHOOL_ASSOCIATION_V2 = 'school_association_v2';
 // Allows the playspace to be dragged to take up a larger portion of the screen
 experiments.BIG_PLAYSPACE = 'bigPlayspace';
+// Shows the new sign-up flow
+experiments.NEW_SIGN_UP_FLOW = 'new_sign_up_flow';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
Creates a new experiment flag for the new sign-up flow. All of the new changes will remain behind this flag so that we can easily set up the A/B experiment later like in [this PR](https://github.com/code-dot-org/code-dot-org/pull/58470/files).

## Links
Spec: [Step 1 here](https://docs.google.com/document/d/1-Bxt7orcLUsc6sHR8dKYj3XmfMNs3pG7AK8j0xeVIG8/edit)
