### PR TITLE
Lab2: Use project template source if it exists

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -844,6 +844,10 @@ class Level < ApplicationRecord
     properties_camelized[:appName] = game&.app
     properties_camelized[:useRestrictedSongs] = game.use_restricted_songs?
     properties_camelized[:usesProjects] = try(:is_project_level) || channel_backed?
+    if try(:project_template_level).try(:source) || try(:source)
+      # Override start sources with project template level sources if they exist
+      properties_camelized['source'] = try(:project_template_level).try(:source) || try(:source)
+    end
     # Localized properties
     properties_camelized["validations"] = localized_validations if properties_camelized["validations"]
     properties_camelized["panels"] = localized_panels if properties_camelized["panels"]

--- a/dashboard/app/models/levels/pythonlab.rb
+++ b/dashboard/app/models/levels/pythonlab.rb
@@ -25,7 +25,7 @@
 #
 class Pythonlab < Level
   serialized_attrs %w(
-    start_sources
+    source
     encrypted_exemplar_sources
     encrypted_validation
     hide_share_and_remix

--- a/dashboard/app/models/levels/weblab2.rb
+++ b/dashboard/app/models/levels/weblab2.rb
@@ -25,7 +25,7 @@
 #
 class Weblab2 < Level
   serialized_attrs %w(
-    start_sources
+    source
     hide_share_and_remix
     is_project_level
     encrypted_exemplar_sources


### PR DESCRIPTION
Project template backed levels should use the start source from the project template level if it exists, otherwise fall back to their own start source. I realized I missed adding this logic when I added support for project template levels in Python Lab.

## Testing story
Tested locally that Python Lab project template levels now get their sources from the template level, non-template levels are unchanged, and other lab2 labs are unchanged.

## Follow-up work
While working on this I realized when we added start sources to web lab 2 and python lab we started using `source` rather than `start_sources` in the level configuration. Java Lab uses `start_sources`. In order to make things simpler to eventually migrate Java Lab levels to the same system, I filed a [follow-up task](https://codedotorg.atlassian.net/browse/CT-644) to update python lab and web lab 2 to use `start_sources` rather than `source`. Since there's few levels right now and they are all test levels it's easier to do this sooner rather than later.

This change also makes start sources buggy on template-backed levels. We load the source from the template level rather than the original level now. I filed a [follow up task](https://codedotorg.atlassian.net/browse/CT-645) to clean this up as well.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
