### PR TITLE
Prevent new account creation during account linking flow

### DIFF
--- a/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
+++ b/dashboard/app/assets/stylesheets/lti/login_lti_account_linking.scss
@@ -25,6 +25,13 @@
   color: $white;
 }
 
+#flash-messages {
+  text-align: center;
+  width: fit-content;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .call-to-action-container {
   display: flex;
   justify-content: space-between;

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -25,8 +25,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     return connect_provider if should_connect_provider?
 
     user = find_user_by_credential
+    return link_accounts user if should_link_accounts?
     if user
-      return link_accounts user if should_link_accounts?
       sign_in_clever user
     else
       sign_up_clever
@@ -38,7 +38,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     user = find_user_by_credential
     user&.update_oauth_credential_tokens auth_hash
 
-    return link_accounts user if user && should_link_accounts?
+    return link_accounts user if should_link_accounts?
     return connect_provider if should_connect_provider?
     login
   end
@@ -48,7 +48,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     user = find_user_by_credential
     user&.update_oauth_credential_tokens auth_hash
 
-    return link_accounts user if user && should_link_accounts?
+    return link_accounts user if should_link_accounts?
 
     # Redirect to open roster dialog on home page if user just authorized access
     # to Google Classroom courses and rosters

--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -2,6 +2,7 @@
 
 %h2#linking-page-header= t('lti.account_linking.linking_page_header', provider: params[:lms_name])
 %p#linking-page-description= t('lti.account_linking.linking_page_description')
+%div#flash-messages= show_flashes.html_safe
 
 %div#link-account
   .flex-container
@@ -20,7 +21,6 @@
     #email-side
       %h3= t('lti.account_linking.connect_with_email')
       = form_with(url: :lti_v1_account_linking_link_email, method: :post) do |f|
-        = show_flashes.html_safe
 
         / Email
         .field

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1424,6 +1424,7 @@ en:
     your_friends: "Your Friends at Code.org"
   lti:
     account_linking:
+      account_not_found: "Account not found"
       connect_button: "Connect with %{provider}"
       connect_with: "Connect with..."
       connect_with_email: "Connect with personal login"

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1768,7 +1768,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     OmniauthCallbacksController.expects(:sign_in_google_oauth2).never
     OmniauthCallbacksController.expects(:sign_up_google_oauth2).never
     assert_response :redirect
-    assert_nil User.last
+    assert_nil User.find_by_credential type: AuthenticationOption::GOOGLE, id: auth.uid
   end
 
   # Try to link a credential to the provided user

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1758,6 +1758,19 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_includes existing_user.authentication_options, ao
   end
 
+  test 'Account linking flow doesn\'t sign up new users' do
+    DCDO.stubs(:get).with('lti_account_linking_enabled', false).returns(true)
+    OmniauthCallbacksController.stubs(:should_link_accounts?).returns(true)
+    auth = generate_auth_user_hash provider: AuthenticationOption::GOOGLE, uid: 'some-uid'
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+    get :google_oauth2
+    OmniauthCallbacksController.expects(:sign_in_google_oauth2).never
+    OmniauthCallbacksController.expects(:sign_up_google_oauth2).never
+    assert_response :redirect
+    assert_nil User.last
+  end
+
   # Try to link a credential to the provided user
   # @return [OmniAuth::AuthHash] the auth hash, useful for validating
   #   linked credentials with assert_auth_option


### PR DESCRIPTION
If a user attempts to link an oauth account and succeeds in the oauth login even though they don't have an existing Code.org account, the current code will create a new account for them. However, the linking won't happen, which is a confusing UX.

This PR changes the linking flow so that if you successfully log in but we can't find an existing account, it kicks you back to the login screen with an error instead of creating a new account.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-994)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
