### PR TITLE
Remove parent email section for LTI users

### DIFF
--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -80,35 +80,36 @@
         -# Sign-up user type original
         .span5{:id => 'select-user-type-original'}
           = f.select :user_type, user_type_options, {include_blank: true}, {disabled: @user.should_disable_user_type?}
-    .row#parent-email-container
-      .span8#parent-email-section
-        .padded-container
-          .row.parent-email-section-header
-            .span7.parent-email-field-input
-              .checkbox
-                = f.label :parent_email_preference_opt_in_required do
-                  = f.check_box :parent_email_preference_opt_in_required
-                  %span= t('signup_form.parent_account_checkbox')
-          .row.parent-email-field
-            .span3.signup-field-label
-              = f.label :parent_email do
-                %span.required= t('signup_form.parent_account_email_label')
-              - if @user.errors[:parent_email_preference_email].present?
-                %p.error= @user.errors[:parent_email_preference_email]&.first
-            .span4.parent-email-field-input
-              = f.email_field :parent_email_preference_email, maxlength: 255, value: @user.parent_email_preference_email
-          .row.parent-email-field
-            .span6.signup-field-label
-              .required= t('signup_form.parent_account_email_progress_permission', privacy_policy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
-              - if @user.errors[:parent_email_preference_opt_in].present?
-                %p.error= t('signup_form.email_preference_required')
-            .span1.parent-email-field-input{style:"display:block"}
-              .radio
-                = f.radio_button :parent_email_preference_opt_in, 'yes'
-                = f.label :parent_email_preference_opt_in, t('signup_form.email_preference_yes'), value: 'yes'
-              .radio
-                = f.radio_button :parent_email_preference_opt_in, 'no'
-                = f.label :parent_email_preference_opt_in, t('signup_form.email_preference_no'), value: 'no'
+    - unless is_lti
+      .row#parent-email-container
+        .span8#parent-email-section
+          .padded-container
+            .row.parent-email-section-header
+              .span7.parent-email-field-input
+                .checkbox
+                  = f.label :parent_email_preference_opt_in_required do
+                    = f.check_box :parent_email_preference_opt_in_required
+                    %span= t('signup_form.parent_account_checkbox')
+            .row.parent-email-field
+              .span3.signup-field-label
+                = f.label :parent_email do
+                  %span.required= t('signup_form.parent_account_email_label')
+                - if @user.errors[:parent_email_preference_email].present?
+                  %p.error= @user.errors[:parent_email_preference_email]&.first
+              .span4.parent-email-field-input
+                = f.email_field :parent_email_preference_email, maxlength: 255, value: @user.parent_email_preference_email || @user.email
+            .row.parent-email-field
+              .span6.signup-field-label
+                .required= t('signup_form.parent_account_email_progress_permission', privacy_policy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
+                - if @user.errors[:parent_email_preference_opt_in].present?
+                  %p.error= t('signup_form.email_preference_required')
+              .span1.parent-email-field-input{style:"display:block"}
+                .radio
+                  = f.radio_button :parent_email_preference_opt_in, 'yes'
+                  = f.label :parent_email_preference_opt_in, t('signup_form.email_preference_yes'), value: 'yes'
+                .radio
+                  = f.radio_button :parent_email_preference_opt_in, 'no'
+                  = f.label :parent_email_preference_opt_in, t('signup_form.email_preference_no'), value: 'no'
 
     - if Policies::Lti.show_email_input? @user
       = f.fields_for :authentication_options do |ao_form|

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -96,7 +96,7 @@
               - if @user.errors[:parent_email_preference_email].present?
                 %p.error= @user.errors[:parent_email_preference_email]&.first
             .span4.parent-email-field-input
-              = f.email_field :parent_email_preference_email, maxlength: 255, value: @user.parent_email_preference_email || @user.email
+              = f.email_field :parent_email_preference_email, maxlength: 255, value: @user.parent_email_preference_email
           .row.parent-email-field
             .span6.signup-field-label
               .required= t('signup_form.parent_account_email_progress_permission', privacy_policy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -612,4 +612,12 @@ class RegistrationsControllerTest < ActionController::TestCase
     assert_equal "male", student.gender_student_input
     assert_equal "m", student.gender
   end
+
+  test 'does not render the parent email section for LTI users' do
+    user = create :student, :with_lti_auth
+    PartialRegistration.persist_attributes session, user
+    get :new
+    assert_template partial: '_finish_sign_up'
+    assert_select '#parent_email-container', 0
+  end
 end


### PR DESCRIPTION
Removes the parent email section from the finish signup page for LTI users:

<img width="812" alt="Screenshot 2024-06-20 at 3 12 56 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/3632056d-b23f-4b0f-afdf-0cfd0bdb4cad">



## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1000)

## Testing story

Tested locally to make sure no student email shows up

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
