### PR TITLE
Enable Aurora MySQL Enhanced Binary Logging

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -174,6 +174,13 @@
         gtid-mode: 'ON'
         enforce_gtid_consistency: 'ON'
 
+        # Enable Enhanced Binary Logging to support Zero-ETL Integration with Redshift
+        aurora_enhanced_binlog: 1
+        binlog_backup: 0
+        binlog_replication_globaldb: 0
+        binlog_row_image: full # This is actually a dynamic setting, but let's keep all these settings together.
+        binlog_row_metadata: full # Also dynamic.
+
         innodb_autoinc_lock_mode: 2
         #END: Static configuration settings.
 


### PR DESCRIPTION
Support enabling Redshift / Aurora Zero ETL integration
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/zero-etl.setting-up.html

This change has a secondary benefit of improving CPU utilization and write performance when binary logging is enabled:
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Replication.MySQL.html#AuroraMySQL.Enhanced.binlog

Note the limitations:
<img width="1282" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/2157034/5a50e85d-fedf-4b19-b59e-8d39a2fb6911">


## Testing story

This adhoc provisioned successfully:

`bundle exec rake adhoc:start RAILS_ENV=edhoc DATABASE=yesAuroraPlease`

## Deployment strategy

This change will trigger a restart of all database instances in non-production database clusters, and will require a manual restart of production database instances (incurring ~60 seconds of downtime). I will deploy this in a small, contained, evening release.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
