### PR TITLE
Checks that :root has changed instead of body.

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -83,12 +83,12 @@ end
 def navigate_to(url)
   Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, sleep: 10, tries: 3) do
     with_read_timeout(DEFAULT_WAIT_TIMEOUT + 5.seconds) do
-      page_body = @browser.find_element(:css, 'body')
+      root = @browser.find_element(css: ':root')
       @browser.navigate.to url
       # Wait until the document has actually changed
-      if page_body
+      if root
         wait_until do
-          page_body != @browser.find_element(:css, 'body')
+          root != @browser.find_element(css: ':root')
         end
       end
       # Then, wait until the document is done loading


### PR DESCRIPTION
This makes the page load check a little less strict about the document having a body.

One UI test was failing on the test server (gets past this step locally though) because it relies on loading the browser error page and checking for text on that page. Apparently, not all browsers render a body on their error page!

This checks for `:root` instead which is part of the shadow DOM that all pages have as their root element.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
