### PR TITLE
Cleaning up old school association in finish sign up

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -104,8 +104,7 @@ $(document).ready(() => {
   });
 
   function cleanSchoolInfo() {
-    // Clear school_id if the searched school is not found.
-    // New school search flow
+    // Clear school_id and zip if the searched school is not found.
     const newSchoolIdEl = $(
       'select[name="user[school_info_attributes][school_id]"]'
     );
@@ -115,7 +114,6 @@ $(document).ready(() => {
       )
     ) {
       newSchoolIdEl.val('');
-      // Clear out zip before saving as well
       $('input[name="user[school_info_attributes][school_zip]"]').val('');
     }
   }

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -1,11 +1,9 @@
 import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import SchoolInfoInputs from '@cdo/apps/templates/SchoolInfoInputs';
 import SchoolDataInputs from '@cdo/apps/templates/SchoolDataInputs';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-import statsigReporter from '@cdo/apps/lib/util/StatsigReporter';
 import experiments from '@cdo/apps/util/experiments';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
@@ -40,15 +38,6 @@ const {usIp, signUpUID} = scriptData;
 const teacherButton = document.getElementById('select-user-type-teacher');
 const studentButton = document.getElementById('select-user-type-student');
 
-// Auto-fill country and countryCode if we detect a US IP address.
-let schoolData = {
-  country: usIp ? 'United States' : '',
-  countryCode: usIp ? 'US' : '',
-};
-
-// Keep track of whether the current user is in the U.S. or not (for regional partner email sharing)
-let isInUnitedStates = schoolData.countryCode === 'US';
-
 let userInRegionalPartnerVariant = experiments.isEnabled(
   experiments.OPT_IN_EMAIL_REG_PARTNER
 );
@@ -56,7 +45,6 @@ let userInRegionalPartnerVariant = experiments.isEnabled(
 $(document).ready(() => {
   const schoolInfoMountPoint = document.getElementById('school-info-inputs');
   let user_type = $('#user_user_type').val();
-  let isInSchoolAssociationExperiment = false;
   init();
 
   function init() {
@@ -91,11 +79,8 @@ $(document).ready(() => {
     if (user_type === 'teacher') {
       cleanSchoolInfo();
       $('#user_age').val('21+');
-      // If the new or old school association flow has a school, update to true
-      if (
-        $('select[name="user[school_info_attributes][school_id]"]')?.val() ||
-        $('input[name="user[school_info_attributes][school_id]"]')?.val()
-      ) {
+      // If the school association flow has a school, update to true
+      if ($('select[name="user[school_info_attributes][school_id]"]')?.val()) {
         has_school = true;
       }
       // Check if either of the marketing opt in/out radio buttons are selected
@@ -119,13 +104,6 @@ $(document).ready(() => {
   });
 
   function cleanSchoolInfo() {
-    // The country set in our form is the long-form string name of the country.
-    // We want it to be the 2-letter country code, so we change the value on form submission.
-    const countryInputEl = $(
-      'input[name="user[school_info_attributes][country]"]'
-    );
-    countryInputEl.val(schoolData.countryCode);
-
     // Clear school_id if the searched school is not found.
     // New school search flow
     const newSchoolIdEl = $(
@@ -139,13 +117,6 @@ $(document).ready(() => {
       newSchoolIdEl.val('');
       // Clear out zip before saving as well
       $('input[name="user[school_info_attributes][school_zip]"]').val('');
-    }
-    // Old school search flow
-    if (schoolData.ncesSchoolId === '-1') {
-      const schoolIdEl = $(
-        'input[name="user[school_info_attributes][school_id]"]'
-      );
-      schoolIdEl.val('');
     }
   }
 
@@ -214,12 +185,7 @@ $(document).ready(() => {
   function switchToTeacher() {
     fadeInFields(TEACHER_ONLY_FIELDS);
     hideFields(STUDENT_ONLY_FIELDS);
-    toggleVisShareEmailRegPartner(isInUnitedStates);
-    isInSchoolAssociationExperiment = statsigReporter.getIsInExperiment(
-      'school_association_update_2024_v3',
-      'showNewFlow',
-      false
-    );
+    toggleVisShareEmailRegPartner(usIp);
     renderSchoolInfo();
   }
 
@@ -265,81 +231,12 @@ $(document).ready(() => {
 
   function renderSchoolInfo() {
     if (schoolInfoMountPoint) {
-      if (isInSchoolAssociationExperiment) {
-        ReactDOM.render(
-          <div style={{padding: 10}}>
-            <SchoolDataInputs usIp={usIp} />
-          </div>,
-          schoolInfoMountPoint
-        );
-      } else {
-        ReactDOM.render(
-          <div style={{padding: 10}}>
-            <SchoolInfoInputs
-              schoolType={schoolData.schoolType}
-              country={schoolData.country}
-              ncesSchoolId={schoolData.ncesSchoolId}
-              schoolName={schoolData.schoolName}
-              schoolCity={schoolData.schoolCity}
-              schoolState={schoolData.schoolState}
-              schoolZip={schoolData.schoolZip}
-              schoolLocation={schoolData.schoolLocation}
-              useLocationSearch={schoolData.useLocationSearch}
-              onCountryChange={onCountryChange}
-              onSchoolTypeChange={onSchoolTypeChange}
-              onSchoolChange={onSchoolChange}
-              onSchoolNotFoundChange={onSchoolNotFoundChange}
-              showRequiredIndicator={false}
-              styles={{width: 580}}
-            />
-          </div>,
-          schoolInfoMountPoint
-        );
-      }
-    }
-  }
-
-  function onCountryChange(_, event) {
-    if (event) {
-      schoolData.country = event.value;
-      schoolData.countryCode = event.label;
-      analyticsReporter.sendEvent(
-        EVENTS.COUNTRY_SELECTED,
-        {country: schoolData.country, countryCode: schoolData.countryCode},
-        PLATFORMS.BOTH
+      ReactDOM.render(
+        <div style={{padding: 10}}>
+          <SchoolDataInputs usIp={usIp} />
+        </div>,
+        schoolInfoMountPoint
       );
     }
-    isInUnitedStates = schoolData.countryCode === 'US';
-    toggleVisShareEmailRegPartner(isInUnitedStates);
-    renderSchoolInfo();
-  }
-
-  function onSchoolTypeChange(event) {
-    schoolData.schoolType = event ? event.target.value : '';
-    renderSchoolInfo();
-  }
-
-  function onSchoolChange(_, event) {
-    schoolData.ncesSchoolId = event ? event.value : '';
-    // ID is set to -1 and '' respectively as user toggles 'I cannot find my
-    // school above': exlude these from school selection events
-    if (!['-1', ''].includes(schoolData.ncesSchoolId)) {
-      analyticsReporter.sendEvent(
-        EVENTS.SCHOOL_SELECTED_FROM_LIST,
-        {ncesId: schoolData.ncesSchoolId},
-        PLATFORMS.BOTH
-      );
-    }
-    renderSchoolInfo();
-  }
-
-  function onSchoolNotFoundChange(field, event) {
-    if (event) {
-      schoolData = {
-        ...schoolData,
-        [field]: event.target.value,
-      };
-    }
-    renderSchoolInfo();
   }
 });

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -58,8 +58,6 @@ experiments.SPRITE_LAB_DOCS = 'sl_docs';
 experiments.KEYBOARD_NAVIGATION = 'blockly_keyboard';
 // Adds the ability to toggle between v1 and v2 of the section progress page of the teacher dashboard
 experiments.SECTION_PROGRESS_V2 = 'section_progress_v2';
-// Enables a user to utilize the new school association flow
-experiments.SCHOOL_ASSOCIATION_V2 = 'school_association_v2';
 // Allows the playspace to be dragged to take up a larger portion of the screen
 experiments.BIG_PLAYSPACE = 'bigPlayspace';
 // Shows the new sign-up flow

--- a/dashboard/test/ui/features/acquisition_products/sign_up.feature
+++ b/dashboard/test/ui/features/acquisition_products/sign_up.feature
@@ -8,8 +8,7 @@ Scenario: Teacher can create an account with the new school association flow
   And I press keys "password" for element "#user_password"
   And I press keys "password" for element "#user_password_confirmation"
   And I press "#signup_form_submit" using jQuery
-  And I wait for 2 seconds
-  And I press "select-user-type-teacher"
+  And I click selector "#select-user-type-teacher" once I see it
   And I press keys "myDisplayName" for element "#user_name"
   And I select the "United States" option in dropdown "uitest-country-dropdown"
   And I press keys "31513" for element "#uitest-school-zip"

--- a/dashboard/test/ui/features/acquisition_products/sign_up.feature
+++ b/dashboard/test/ui/features/acquisition_products/sign_up.feature
@@ -8,7 +8,8 @@ Scenario: Teacher can create an account with the new school association flow
   And I press keys "password" for element "#user_password"
   And I press keys "password" for element "#user_password_confirmation"
   And I press "#signup_form_submit" using jQuery
-  And I press "select-user-type-teacher" once I see it
+  And I wait for 2 seconds
+  And I press "select-user-type-teacher"
   And I press keys "myDisplayName" for element "#user_name"
   And I select the "United States" option in dropdown "uitest-country-dropdown"
   And I press keys "31513" for element "#uitest-school-zip"

--- a/dashboard/test/ui/features/acquisition_products/sign_up.feature
+++ b/dashboard/test/ui/features/acquisition_products/sign_up.feature
@@ -1,4 +1,3 @@
-@skip
 @eyes
 Feature: Teacher can create a new account
 
@@ -9,9 +8,7 @@ Scenario: Teacher can create an account with the new school association flow
   And I press keys "password" for element "#user_password"
   And I press keys "password" for element "#user_password_confirmation"
   And I press "#signup_form_submit" using jQuery
-  # Add the experiment flag
-  And I am on "http://studio.code.org/users/sign_up?enableExperiments=school_association_v2"
-  And I press "select-user-type-teacher"
+  And I press "select-user-type-teacher" once I see it
   And I press keys "myDisplayName" for element "#user_name"
   And I select the "United States" option in dropdown "uitest-country-dropdown"
   And I press keys "31513" for element "#uitest-school-zip"


### PR DESCRIPTION
This PR follows the launch of the updated school association section in the sign up flow. Because we haven't replaced the other instances of the older school association flow, this PR doesn't include deletion of those components. 

This PR does remove the experiment flag and reenables the sign up UI test.

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-1977

## Testing story

I reenabled the UI test and updated it to not require the experiment flag. 

Locally, I tested that I could still create a student account, and teacher accounts both with (internationally and in US) and without schools associated.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
