### PR TITLE
P20-993: Update "pre-policy" created users check

### DIFF
--- a/dashboard/app/views/sessions/lockout.html.haml
+++ b/dashboard/app/views/sessions/lockout.html.haml
@@ -8,7 +8,7 @@
       controller: :policy_compliance
     ),
     disallowed_email: @disallowed_email,
-    is_pre_lockout_user: Policies::ChildAccount.pre_lockout_user?(current_user).to_json,
+    is_pre_lockout_user: Policies::ChildAccount.user_predates_policy?(current_user).to_json,
   }
 }
 

--- a/dashboard/lib/cpa.rb
+++ b/dashboard/lib/cpa.rb
@@ -2,12 +2,19 @@ require_relative '../../shared/middleware/helpers/experiments'
 require 'date'
 # Support for the Colorado Privacy Act (CPA) compliance.
 module Cpa
+  NAME = 'CPA'.freeze
+
   NEW_USER_LOCKOUT = 'cpa_new_user_lockout'
   ALL_USER_LOCKOUT_WARNING = 'cpa_all_user_lockout_warning'
   ALL_USER_LOCKOUT = 'cpa_all_user_lockout'
 
   NEW_USER_LOCKOUT_DATE = DateTime.parse('2023-07-01T00:00:00MDT').freeze
   ALL_USER_LOCKOUT_DATE = DateTime.parse('2024-07-01T00:00:00MDT').freeze
+
+  # P20-937 - We had a regression which we have chosen to mitigate by allowing
+  # accounts created before the below date to have their lock-out delayed until
+  # the CAP policy is set to lockout all users.
+  CREATED_AT_EXCEPTION_DATE = DateTime.parse('2024-05-26T00:00:00MDT')
 
   # There are four phases for the Colorado Privacy Act:
   # 1. Nothing - nil

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -24,11 +24,6 @@ class Policies::ChildAccount
     end
   end
 
-  # P20-937 - We had a regression which we have chosen to mitigate by allowing
-  # accounts created before the below date to have their lock-out delayed until
-  # the CAP policy is set to lockout all users.
-  CPA_CREATED_AT_EXCEPTION_DATE = DateTime.parse('2024-05-26T00:00:00MDT')
-
   # The delay is intended to provide notice to a parent
   # when a student may no longer be monitoring the "parent's email."
   PERMISSION_GRANTED_MAIL_DELAY = 24.hours
@@ -68,21 +63,23 @@ class Policies::ChildAccount
   # policy going into effect.
   def self.user_predates_policy?(user)
     return false unless parent_permission_required?(user)
-    return false unless state_policy(user)
-    policy_start_date = state_policy(user)[:start_date]
 
-    user.created_at < policy_start_date ||
-      user.created_at < CPA_CREATED_AT_EXCEPTION_DATE ||
-      user.authentication_options.any?(&:google?)
-  end
+    user_state_policy = state_policy(user)
+    return false unless user_state_policy
 
-  # Checks if a user affected by a state policy was created before the lockout date.
-  def self.pre_lockout_user?(user)
-    lockout_date = state_policy(user).try(:[], :lockout_date)
-    return false unless lockout_date
-    return user_predates_policy?(user) if DateTime.now < lockout_date
+    if user_state_policy[:name] == Cpa::NAME
+      # Accounts created before 5/26/2024 should have been locked upon creation,
+      # but they weren't because their state wasn't collected.
+      # To avoid immediate lockout after the state banner rollout,
+      # their lockout was postponed to the start of the "all-user lockout" phase.
+      return true if user.created_at < Cpa::CREATED_AT_EXCEPTION_DATE
 
-    user.created_at < lockout_date
+      # Due to a leaky bucket issue, roster-synced Google accounts weren't being locked out as intended.
+      # Therefore, it was decided to move their locking out to the "all-user lockout" phase.
+      return true if user.created_at < user_state_policy[:lockout_date] && user.authentication_options.any?(&:google?)
+    end
+
+    user.created_at < user_state_policy[:start_date]
   end
 
   # The date on which the student's account will be locked if the account is not compliant.
@@ -138,7 +135,7 @@ class Policies::ChildAccount
     # start_date: the date on which this policy first went into effect.
     {
       'CO' => {
-        name: 'CPA', # Colorado Privacy Act
+        name: Cpa::NAME,
         max_age: 12,
         lockout_date: DateTime.parse(DCDO.get('cpa_schedule', {})[Cpa::ALL_USER_LOCKOUT] || Cpa::ALL_USER_LOCKOUT_DATE.iso8601),
         start_date: DateTime.parse(DCDO.get('cpa_schedule', {})[Cpa::NEW_USER_LOCKOUT] || Cpa::NEW_USER_LOCKOUT_DATE.iso8601),

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -437,11 +437,11 @@ FactoryBot.define do
       end
 
       trait :before_p20_937_exception_date do
-        created_at {Policies::ChildAccount::CPA_CREATED_AT_EXCEPTION_DATE - 1.second}
+        created_at {Cpa::CREATED_AT_EXCEPTION_DATE.ago(1.second)}
       end
 
       trait :p20_937_exception_date do
-        created_at {Policies::ChildAccount::CPA_CREATED_AT_EXCEPTION_DATE}
+        created_at {Cpa::CREATED_AT_EXCEPTION_DATE}
       end
 
       factory :non_compliant_child, traits: [:U13, :in_colorado, :p20_937_exception_date] do

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -85,7 +85,9 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       [[:non_compliant_child, :migrated_imported_from_clever, {created_at: '2024-06-29T23:59:59MDT'}], false],
       [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2023-06-29T23:59:59MDT'}], true],
       [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2024-06-29T23:59:59MDT'}], true],
+      [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2024-07-01T00:00:00MDT'}], false],
       [[:non_compliant_child, :with_google_authentication_option, {created_at: '2024-06-29T23:59:59MDT'}], true],
+      [[:non_compliant_child, :with_google_authentication_option, {created_at: '2024-07-01T00:00:00MDT'}], false],
       # The following test cases address P20-937
       [[:non_compliant_child, :before_p20_937_exception_date], true],
       [[:non_compliant_child, :microsoft_v2_sso_provider, :before_p20_937_exception_date], true],
@@ -161,63 +163,6 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
         it 'contains DCDO configured lockout_date' do
           _(co_state_policy[:lockout_date]).must_equal cpa_all_user_lockout
         end
-      end
-    end
-  end
-
-  describe '.pre_lockout_user?' do
-    let(:pre_lockout_user?) {Policies::ChildAccount.pre_lockout_user?(user)}
-
-    let(:user) {build_stubbed(:student, created_at: user_lockout_date.ago(1.second))}
-
-    let(:user_lockout_date) {DateTime.now}
-    let(:user_state_policy) {{lockout_date: user_lockout_date}}
-    let(:user_predates_policy?) {false}
-
-    around do |test|
-      Timecop.freeze {test.call}
-    end
-
-    before do
-      Policies::ChildAccount.stubs(:state_policy).with(user).returns(user_state_policy)
-      Policies::ChildAccount.stubs(:user_predates_policy?).with(user).returns(user_predates_policy?)
-    end
-
-    it 'returns true' do
-      _(pre_lockout_user?).must_equal true
-    end
-
-    context 'when user was created during lockout phase' do
-      before do
-        user.created_at = user_lockout_date.since(1.second)
-      end
-
-      it 'returns false' do
-        _(pre_lockout_user?).must_equal false
-      end
-    end
-
-    context 'when currently is pre lockout phase' do
-      let(:user_lockout_date) {1.second.since}
-
-      it 'returns false' do
-        _(pre_lockout_user?).must_equal false
-      end
-
-      context 'if user predates policy' do
-        let(:user_predates_policy?) {true}
-
-        it 'returns true' do
-          _(pre_lockout_user?).must_equal true
-        end
-      end
-    end
-
-    context 'when user is not affected by a state policy' do
-      let(:user_state_policy) {nil}
-
-      it 'returns false' do
-        _(pre_lockout_user?).must_equal false
       end
     end
   end

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -145,7 +145,7 @@ And(/^I create( as a parent)? a (young )?student( in Colorado)?( who has never s
     user_opts[:user_provided_us_state] = true
   end
 
-  # See Policies::ChildAccount::CPA_CREATED_AT_EXCEPTION_DATE
+  # See Cpa::CREATED_AT_EXCEPTION_DATE
   cpa_exception_date = DateTime.parse('2024-05-26T00:00:00MDT')
 
   if after_cpa_exception


### PR DESCRIPTION
## Summary
1. Accounts created before 5/26/2024 should have been locked upon creation, but they weren't because their state wasn't collected. To avoid immediate lockout after the state banner rollout, their lockout was postponed to the start of the "all-user lockout" phase.
2. Due to a leaky bucket issue, roster-synced Google accounts weren't being locked out as intended. Therefore, it was decided to move their locking out to the "all-user lockout" phase.
3. Replaced incorrect `pre_lockout_user?` check with `user_predates_policy?`.

## Links
- JIRA ticket: [P20-993](https://codedotorg.atlassian.net/browse/P20-993)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/58712