### PR TITLE
Disallow admins from linking LTI accounts

### DIFF
--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -31,6 +31,10 @@ module Lti
         head :bad_request unless PartialRegistration.in_progress?(session)
         params.require([:email, :password])
         existing_user = User.find_by_email_or_hashed_email(params[:email])
+        if existing_user.admin?
+          flash[:alert] = "Admins cannot link LTI accounts"
+          redirect_to user_session_path(lti_provider: params[:lti_provider], lms_name: params[:lms_name]) and return
+        end
         if existing_user&.valid_password?(params[:password])
           Services::Lti::AccountLinker.call(user: existing_user, session: session)
           sign_in existing_user

--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -32,7 +32,7 @@ module Lti
         params.require([:email, :password])
         existing_user = User.find_by_email_or_hashed_email(params[:email])
         if existing_user.admin?
-          flash[:alert] = "Admins cannot link LTI accounts"
+          flash[:alert] = I18n.t('lti.account_linking.admin_not_allowed')
           redirect_to user_session_path(lti_provider: params[:lti_provider], lms_name: params[:lms_name]) and return
         end
         if existing_user&.valid_password?(params[:password])

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -551,7 +551,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if user
       if user.admin?
         flash[:alert] = I18n.t('lti.account_linking.admin_not_allowed')
-        redirect_to user_session_path(lti_provider: params[:lti_provider], lms_name: params[:lms_name]) and return
+        redirect_to user_session_path and return
       end
       begin
         Services::Lti::AccountLinker.call(user: user, session: session)

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -549,7 +549,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # For linking new LTI auth options to existing accounts
   private def link_accounts(user)
     if user
-      if user.admin
+      if user.admin?
         flash[:alert] = I18n.t('lti.account_linking.admin_not_allowed')
         redirect_to user_session_path(lti_provider: params[:lti_provider], lms_name: params[:lms_name]) and return
       end

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -549,6 +549,10 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # For linking new LTI auth options to existing accounts
   private def link_accounts(user)
     if user
+      if user.admin
+        flash[:alert] = "Admins cannot link LTI accounts"
+        redirect_to user_session_path(lti_provider: params[:lti_provider], lms_name: params[:lms_name]) and return
+      end
       begin
         Services::Lti::AccountLinker.call(user: user, session: session)
       rescue => exception

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -550,7 +550,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private def link_accounts(user)
     if user
       if user.admin
-        flash[:alert] = "Admins cannot link LTI accounts"
+        flash[:alert] = I18n.t('lti.account_linking.admin_not_allowed')
         redirect_to user_session_path(lti_provider: params[:lti_provider], lms_name: params[:lms_name]) and return
       end
       begin

--- a/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
+++ b/dashboard/app/views/devise/sessions/_login_lti_account_linking.haml
@@ -33,6 +33,7 @@
           = f.label :password
           = f.password_field :password, autofocus: email != '', required: true
 
+        / Additional values to be used in redirects on the link_email controller action
         = f.hidden_field :lti_provider, value: params[:lti_provider]
         = f.hidden_field :lms_name, value: params[:lms_name]
 

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1428,6 +1428,7 @@ en:
   lti:
     account_linking:
       account_not_found: "Account not found"
+      admin_not_allowed: "Admins cannot link LTI accounts"
       connect_button: "Connect with %{provider}"
       connect_with: "Connect with..."
       connect_with_email: "Connect with personal login"

--- a/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
   setup do
     @user = create(:teacher, email: 'test@lti.com')
-    @admin = create :admin, email: 'admin@lti.com'
+    @admin = create :admin
     @lti_integration = create :lti_integration
     DCDO.stubs(:get)
     DCDO.stubs(:get).with('lti_account_linking_enabled', false).returns(true)
@@ -29,7 +29,6 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
     assert Policies::Lti.lti?(@user)
   end
 
-  # TODO: This is failing
   test 'disallow account linking for admin users' do
     partial_lti_teacher = create :teacher
     fake_id_token = {iss: @lti_integration.issuer, aud: @lti_integration.client_id, sub: 'bar'}


### PR DESCRIPTION
Adds logic to disallow linking for admins, and returns an error message to them. This alert is displayed after they attempt to link the account, as that's the point where the existing user account is looked up and determined to be an admin.

Since this error message will only be for internal Code.org users, a simple flash alert was used.

**Alert**
<img width="1080" alt="Screenshot 2024-06-26 at 9 00 24 AM" src="https://github.com/code-dot-org/code-dot-org/assets/8847422/c6cc8e3e-655b-40c4-8981-e5ab82703e56">



<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
