### PR TITLE
Curriculum launch 2024 - Update CSF page

### DIFF
--- a/pegasus/sites.v3/code.org/public/curriculum/csf.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/csf.haml
@@ -30,6 +30,8 @@ theme: responsive_full_width
         %li=hoc_s(:csf_page_intro_list_02)
         %li=hoc_s(:csf_page_intro_list_03)
         %li=hoc_s(:csf_page_intro_list_04)
+        -# The list item below is using the new namespace pattern for strings
+        %li=hoc_s("csf_page.intro_list_05")
       %a.link-button{href: "#pick-a-course"}
         =hoc_s(:call_to_action_explore_courses)
     .clear

--- a/pegasus/sites.v3/code.org/public/curriculum/csf.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/csf.haml
@@ -117,4 +117,11 @@ theme: responsive_full_width
   .wrapper
     = view :subscribe_form, subscribe_form_section_title: hoc_s(:subscribe_form_section_title), subscribe_form_section_desc: hoc_s(:subscribe_form_section_desc_csf), form_height: "375px", form_src: "http://go.pardot.com/l/153401/2018-10-02/lzp5jd"
 
+%section.bg-neutral-light
+  .wrapper
+    -# The section is using the new namespace pattern for strings
+    %h2=hoc_s("csf_page.additional_resources.heading")
+    %p=hoc_s("csf_page.additional_resources.desc")
+    = view :csf_additional_resources
+
 = view :analytics_event_log_helper, event_name: AnalyticsConstants::CSF_CURRICULUM_PAGE_VISITED_EVENT

--- a/pegasus/sites.v3/code.org/views/csf_additional_resources.haml
+++ b/pegasus/sites.v3/code.org/views/csf_additional_resources.haml
@@ -1,0 +1,37 @@
+:ruby
+  resource_item = [
+    {
+      title: hoc_s("csf_page.additional_resources.catalog.title"),
+      image: "/images/action-blocks/action-block-catalog.png",
+      desc: hoc_s("csf_page.additional_resources.catalog.desc"),
+      url: CDO.studio_url("/catalog"),
+      button_label: hoc_s("csf_page.additional_resources.catalog.button")
+    },
+    {
+      title: hoc_s("csf_page.additional_resources.videos.title"),
+      image: "/images/action-blocks/action-block-videos.png",
+      desc: hoc_s("csf_page.additional_resources.videos.desc"),
+      url: "/videos",
+      button_label: hoc_s("csf_page.additional_resources.videos.button")
+    },
+    {
+      title: hoc_s("csf_page.additional_resources.support.title"),
+      image: "/images/action-blocks/action-block-support.png",
+      desc: hoc_s("csf_page.additional_resources.support.desc", markdown: :inline, locals: {email_url: "mailto:support@code.org"}),
+      url: "https://support.code.org",
+      button_label: hoc_s("csf_page.additional_resources.support.button")
+    },
+  ]
+
+.action-block__wrapper.action-block__wrapper--three-col
+  - resource_item.each do |resource_item|
+    .action-block.action-block--one-col.flex-space-between.white
+      .content-wrapper
+        %h3
+          = resource_item[:title]
+        %img{src: resource_item[:image], alt: ""}
+        %p
+          = resource_item[:desc]
+      .content-footer
+        %a.link-button{href: resource_item[:url]}
+          = resource_item[:button_label]


### PR DESCRIPTION
Updates https://code.org/csf for the 2024 curriculum launch:
- Adds a new list item: "Aligned to K-5 CSTA curriculum standards" in the top video section
- Adds an Additional Resources section to the bottom of the page

_Note:_ Prepping this now, but will merge when the launch gets closer.

## Links
Jira ticket: [ACQ-1966](https://codedotorg.atlassian.net/browse/ACQ-1966)
Figma mock: [here](https://www.figma.com/design/HwXIyBGQ0b2ZI213sWb3cK/2024-Curriculum-Launch?node-id=2435-2736&t=9DXJmZrox9gPwDQA-1)

## Testing story
Tested locally

----

## New list item
<img width="1063" alt="Screenshot 2024-06-24 at 8 28 39 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/8c09aa14-c2e2-4a5a-b1fa-17fed77b9549">

## Additional Resources
<img width="1079" alt="Screenshot 2024-06-24 at 8 39 31 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/3c8a1e7f-0748-4cf5-aa9d-852d1334a932">
