### PR TITLE
Add strings for updated Computer Vision page

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10967,6 +10967,77 @@
     aria_label: "Explore the Coding with AI lessons"
     button_label: "Explore lessons"
 
+  computer_vision_page:
+    heading: "Computer vision"
+    top:
+      dec: "Explore how artificial intelligence interprets visual data through our computer vision units. Equip students with essential skills in image processing, object recognition, and ethical AI considerations, preparing them for future opportunities in technology."
+      button: "Explore curriculum"
+    why:
+      heading: "Why teach computer vision?"
+      desc: "Empower students to solve real-world challenges, foster innovation, and explore AI's ethical implications in visual data."
+      real_world:
+        heading: "Real-world applications"
+        desc: "Empower students to solve real-world problems by understanding how AI interprets visual data, from healthcare diagnostics to autonomous vehicles."
+      innovative:
+        heading: "Innovative thinking"
+        desc: "Foster innovative thinking by engaging students with cutting-edge technology, encouraging them to develop creative solutions and explore new possibilities."
+      ethical:
+        heading: "Ethical awareness"
+        desc: "Teach students to critically assess the ethical implications of AI, promoting responsible and thoughtful application of computer vision technologies."
+      button:
+        explore_curriculum: "Explore curriculum"
+        see_professional_learning: "See professional learning"
+    resources:
+      heading: "Resources to support you every step of the way"
+      desc: "Get access to materials that will help you teach computer science with confidence — even without prior CS teaching experience — when you create a **free** Code.org account."
+      button: "Create a free account"
+    get_started:
+      heading: "Get started with computer vision"
+      computer_vision:
+        overline: "Grades 9-12"
+        title: "Computer Vision"
+        desc: "This comprehensive module introduces high school students to the principles of computer vision through hands-on projects and real-world applications. Students will learn essential skills in image processing, feature detection, and object recognition, fostering both technical proficiency and ethical awareness in AI."
+        duration: "3 Weeks"
+        button: "Explore module"
+        aria_label: "Explore the Computer Vision module"
+      csa:
+        overline: "Grades 9-12"
+        title: "AP® CSA Computer Vision"
+        desc: "This two-chapter post-AP® CSA module offers high school students hands-on experience with professional software development tools, including GitHub and GitHub Copilot, and imparts them with the real-world skills to develop a computer vision program."
+        duration: "2 Weeks"
+        button: "Explore module"
+        aria_label: "Explore the AP CSA Computer Vision module"
+    teach:
+      heading: "Preparing to teach about computer vision"
+      desc: "Boost your teaching skills with our self-paced professional learning for computer vision."
+      overline: "9-12 Teachers"
+      title: "Teaching Computer Vision"
+      desc: "This professional learning module equips educators to teach Code.org's Computer Vision unit, where students (grades 6-12) explore image and video analysis through engaging activities and discussions on ethics and real-world applications."
+      button: "Start professional learning"
+    learn_more:
+      heading: "Learn more about Artificial Intelligence"
+      dance:
+        overline: "Grades 3-12"
+        title: "Dance Party: AI Edition"
+        desc: "Learn about artificial intelligence (AI) concepts to create your own virtual dance party showcasing today's top artists."
+        button: "Explore Dance Party AI"
+      how_ai_works:
+        overline: "Grades 6-12"
+        title: "How AI Works"
+        desc: "This series of short videos and accompanying lessons will introduce you and your students to how artificial intelligence works and why it matters."
+        button: "View lessons"
+        aria_label: "View How AI Works lessons"
+      ai_101:
+        overline: "PProfessional Learning"
+        title: "AI 101 for Teachers"
+        desc: "Discover the groundbreaking world of AI and its transformative potential in education with our foundational online learning series for teachers."
+        button: "Watch videos"
+        aria_label: "Watch AI 101 for Teachers videos"
+      discover:
+        heading: "Discover our extensive AI resources"
+        desc: "We're rapidly expanding our AI offerings, including robust AI-focused curriculum, professional learning, educational videos, and more! Explore everything we have to offer and find what's right for you."
+        button: "Explore AI resources"
+
   ai_ta_page:
     heading: "AI Teaching Assistant"
     desc: "Introducing our AI Teaching Assistant: Designed for CS educators, it offers instant, insightful project assessments, enabling teachers to concentrate on inspiring and connecting with their students."

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10970,7 +10970,7 @@
   computer_vision_page:
     heading: "Computer vision"
     top:
-      dec: "Explore how artificial intelligence interprets visual data through our computer vision units. Equip students with essential skills in image processing, object recognition, and ethical AI considerations, preparing them for future opportunities in technology."
+      desc: "Explore how artificial intelligence interprets visual data through our computer vision units. Equip students with essential skills in image processing, object recognition, and ethical AI considerations, preparing them for future opportunities in technology."
       button: "Explore curriculum"
     why:
       heading: "Why teach computer vision?"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10980,7 +10980,7 @@
         desc: "Empower students to solve real-world problems by understanding how AI interprets visual data, from healthcare diagnostics to autonomous vehicles."
       innovative:
         heading: "Innovative thinking"
-        desc: "Foster innovative thinking by engaging students with cutting-edge technology, encouraging them to develop creative solutions and explore new possibilities."
+        desc: "Foster innovative thinking by engaging students with cutting-edge technology, encouraging them to develop creative solutions, and explore new possibilities."
       ethical:
         heading: "Ethical awareness"
         desc: "Teach students to critically assess the ethical implications of AI, promoting responsible and thoughtful application of computer vision technologies."
@@ -11010,10 +11010,11 @@
     teach:
       heading: "Preparing to teach about computer vision"
       desc: "Boost your teaching skills with our self-paced professional learning for computer vision."
-      overline: "9-12 Teachers"
-      title: "Teaching Computer Vision"
-      desc: "This professional learning module equips educators to teach Code.org's Computer Vision unit, where students (grades 6-12) explore image and video analysis through engaging activities and discussions on ethics and real-world applications."
-      button: "Start professional learning"
+      tile:
+        overline: "9-12 Teachers"
+        title: "Teaching Computer Vision"
+        desc: "This professional learning module equips educators to teach Code.org's Computer Vision unit, where students (grades 6-12) explore image and video analysis through engaging activities and discussions on ethics and real-world applications."
+        button: "Start professional learning"
     learn_more:
       heading: "Learn more about Artificial Intelligence"
       dance:
@@ -11028,7 +11029,7 @@
         button: "View lessons"
         aria_label: "View How AI Works lessons"
       ai_101:
-        overline: "PProfessional Learning"
+        overline: "Professional Learning"
         title: "AI 101 for Teachers"
         desc: "Discover the groundbreaking world of AI and its transformative potential in education with our foundational online learning series for teachers."
         button: "Watch videos"


### PR DESCRIPTION
Adds strings for the updated https://code.org/curriculum/computer-vision page.

## Links
Jira ticket: [ACQ-2007](https://codedotorg.atlassian.net/browse/ACQ-2007)
Figma mock: [here](https://www.figma.com/design/HwXIyBGQ0b2ZI213sWb3cK/2024-Curriculum-Launch?node-id=2424-20914&t=517sv9Osf9RSfJkH-1)
Followup ticket where strings will be used: [ACQ-1961](https://codedotorg.atlassian.net/browse/ACQ-1961)
