### PR TITLE
wait for page load after confirm in pairing UI test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/pairing.feature
+++ b/dashboard/test/ui/features/teacher_tools/pairing.feature
@@ -17,11 +17,9 @@ Feature: Student pairing
     And I click selector "#submitButton"
     Then I wait to see ".modal"
     And I wait until element "#confirm-button" is visible
-    And I click selector "#confirm-button"
-    # safari sometimes doesn't wait for the page load to initiate before checking if it's finished
-    And I wait for 5 seconds
-    And I wait until I am on "http://studio.code.org/s/allthethings/lessons/18/levels/8"
+    And I click selector "#confirm-button" to load a new page
     And I wait for the page to fully load
+    And check that the URL contains "/s/allthethings/lessons/18/levels/8"
     And I verify progress in the header of the current page is "perfect_assessment" for level 7
     And I sign out
     # verify the level is completed for the other student


### PR DESCRIPTION
speculative fix for flaky teacher_tools/pairing test (see [cucumber logs](https://cucumber-logs.s3.amazonaws.com/test/test/Safari_teacher_tools_pairing_output.html?versionId=Frv4EWAVgOVGm6EySq8XvXbP4zcUWsPa)). clicking a button to navigate to a new page without using the "...to load a new page" step is a known source of flakiness, and the [saucelabs video](https://app.saucelabs.com/tests/d31880ca421e426e827e1a7311bc6794) shows that Safari is passing the `I wait until I am on "http://studio.code.org/s/allthethings/lessons/18/levels/8"` step at the instant that the new page starts loading, which is messing up the steps that come after.

## Testing story

new test is passing locally in Safari. since the test is already blocking the pipeline and this doesn't risk breaking anything else, I'm proposing we merge without waiting for drone.