### PR TITLE
Support co-teacher swap in LTI account linking flow

### DIFF
--- a/dashboard/lib/services/lti/account_linker.rb
+++ b/dashboard/lib/services/lti/account_linker.rb
@@ -41,10 +41,23 @@ module Services
       # via a roster sync. In this case, we need to swap the pre-existing user
       # into these sections to avoid the roster being in a bad state.
       private def handle_sections(user_to_remove, user_to_add)
+        handle_student_sections(user_to_remove, user_to_add) if user_to_remove.student?
+        handle_coteacher_sections(user_to_remove, user_to_add) if user_to_remove.teacher?
+      end
+
+      private def handle_student_sections(user_to_remove, user_to_add)
         return if user_to_remove.sections_as_student.empty?
         user_to_remove.sections_as_student.each do |section|
           section.students << user_to_add
-          section.students.destroy(user_to_remove)
+          section.students.destroy(user_to_remove&.id)
+        end
+      end
+
+      private def handle_coteacher_sections(user_to_remove, user_to_add)
+        return if user_to_remove.sections_instructed.empty?
+        user_to_remove.sections_instructed.each do |section|
+          section.add_instructor(user_to_add)
+          section.remove_instructor(user_to_remove)
         end
       end
 

--- a/dashboard/lib/services/lti/account_linker.rb
+++ b/dashboard/lib/services/lti/account_linker.rb
@@ -57,6 +57,7 @@ module Services
         return if user_to_remove.sections_instructed.empty?
         user_to_remove.sections_instructed.each do |section|
           section.add_instructor(user_to_add)
+          section.update(user_id: user_to_add.id) if section.user_id == user_to_remove.id
           section.remove_instructor(user_to_remove)
         end
       end

--- a/dashboard/test/lib/services/lti/account_linker_test.rb
+++ b/dashboard/test/lib/services/lti/account_linker_test.rb
@@ -68,4 +68,29 @@ class Services::Lti::AccountLinkerTest < ActiveSupport::TestCase
     assert lti_section.section.active_section_instructors.find_by(instructor_id: existing_teacher.id)
     assert new_teacher.reload.deleted?
   end
+
+  test 'Swaps the existing user in as a section owner' do
+    new_teacher = create :teacher
+    existing_teacher = create :teacher
+    lti_course = create :lti_course, lti_integration: @lti_integration
+    lti_section = create :lti_section, lti_course: lti_course
+    lti_section.section.add_instructor(new_teacher)
+    lti_section.section.update(user_id: new_teacher.id)
+
+    ao = create :lti_authentication_option
+    fake_id_token = {iss: @lti_integration.issuer, aud: @lti_integration.client_id, sub: 'foo'}
+    auth_id = Services::Lti::AuthIdGenerator.new(fake_id_token).call
+    ao.update(authentication_id: auth_id)
+    new_teacher.authentication_options = [ao]
+    PartialRegistration.persist_attributes @session, new_teacher
+    assert_equal 1, existing_teacher.authentication_options.count
+    refute Policies::Lti.lti?(existing_teacher)
+
+    Services::Lti::AccountLinker.call(user: existing_teacher, session: @session)
+    assert_equal 2, existing_teacher.reload.authentication_options.count
+    assert Policies::Lti.lti?(existing_teacher)
+    assert lti_section.section.reload.active_section_instructors.find_by(instructor_id: existing_teacher.id)
+    assert lti_section.section.user_id == existing_teacher.id
+    assert new_teacher.reload.deleted?
+  end
 end

--- a/dashboard/test/lib/services/lti/account_linker_test.rb
+++ b/dashboard/test/lib/services/lti/account_linker_test.rb
@@ -24,7 +24,6 @@ class Services::Lti::AccountLinkerTest < ActiveSupport::TestCase
   end
 
   test 'Swaps the existing user into the defunct user\'s sections' do
-    skip 'test is flaky'
     new_student = create :student
     existing_student = create :student
     lti_course = create :lti_course, lti_integration: @lti_integration
@@ -45,5 +44,28 @@ class Services::Lti::AccountLinkerTest < ActiveSupport::TestCase
     assert Policies::Lti.lti?(existing_student)
     assert lti_section.section.students.include?(existing_student)
     assert new_student.reload.deleted?
+  end
+
+  test 'Swaps the existing user in as a co-teacher' do
+    new_teacher = create :teacher
+    existing_teacher = create :teacher
+    lti_course = create :lti_course, lti_integration: @lti_integration
+    lti_section = create :lti_section, lti_course: lti_course
+    lti_section.section.add_instructor(new_teacher)
+
+    ao = create :lti_authentication_option
+    fake_id_token = {iss: @lti_integration.issuer, aud: @lti_integration.client_id, sub: 'foo'}
+    auth_id = Services::Lti::AuthIdGenerator.new(fake_id_token).call
+    ao.update(authentication_id: auth_id)
+    new_teacher.authentication_options = [ao]
+    PartialRegistration.persist_attributes @session, new_teacher
+    assert_equal 1, existing_teacher.authentication_options.count
+    refute Policies::Lti.lti?(existing_teacher)
+
+    Services::Lti::AccountLinker.call(user: existing_teacher, session: @session)
+    assert_equal 2, existing_teacher.reload.authentication_options.count
+    assert Policies::Lti.lti?(existing_teacher)
+    assert lti_section.section.active_section_instructors.find_by(instructor_id: existing_teacher.id)
+    assert new_teacher.reload.deleted?
   end
 end


### PR DESCRIPTION
Previously, only students would be swapped into the proper sections after linking their accounts. This adds support for swapping pre-synced co-teachers into the correct sections as instructors after they link their accounts. Also swaps section owners if the synced user was already the owner of a section.

Also re-enables the flaky test for swapping students. I think that changing the account linking function to pass the user's ID into `destroy` instead of passing the full user object should make the test pass. Rails does technically pull the ID out and use it if you pass the whole object in, but that is deprecated functionality that the Drone environment doesn't like. For reference, the error was:

```
ArgumentError: You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.
``` 

## Links

[JIRA for coteacher swap](https://codedotorg.atlassian.net/browse/P20-1010)
[JIRA for test bug](https://codedotorg.atlassian.net/browse/P20-1002)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
