### PR TITLE
AI Component Library: add key for suggested prompts

### DIFF
--- a/apps/src/aiComponentLibrary/suggestedPrompt/SuggestedPrompts.tsx
+++ b/apps/src/aiComponentLibrary/suggestedPrompt/SuggestedPrompts.tsx
@@ -18,6 +18,7 @@ const SuggestedPrompts: React.FC<SuggestedPromptsProps> = ({
   <div className={moduleStyles.prompts}>
     {suggestedPrompts.map(prompt => (
       <SuggestedPrompt
+        key={prompt.label}
         onClick={prompt.onClick}
         label={prompt.label}
         show={prompt.show}


### PR DESCRIPTION
Tiny follow up to https://github.com/code-dot-org/code-dot-org/pull/59238

Added a key to the `SuggestedPrompt` components rendered by `SuggestedPrompts` to resolve this error
![Screenshot 2024-06-24 at 3 35 00 PM](https://github.com/code-dot-org/code-dot-org/assets/12300669/259579ac-9619-4dbe-b8e9-ed5bb5e4aa3d)
