### PR TITLE
feat(lms): add a state for LMS account linking to enforce the requirement of making a decision for linking

### DIFF
--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ContinueCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ContinueCard/index.tsx
@@ -8,17 +8,19 @@ import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';
 import classNames from 'classnames';
 import styles from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/link-account.module.scss';
 import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
-import React, {useContext} from 'react';
+import React, {useContext, useState} from 'react';
 import i18n from '@cdo/locale';
 import {LtiProviderContext} from '../../context';
 import {navigateToHref} from '@cdo/apps/utils';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 
 const ContinueAccountCard = () => {
   const {ltiProviderName, continueAccountUrl} = useContext(LtiProviderContext)!;
+  const [isSaving, setIsSaving] = useState(false);
 
-  const handleSubmit = () => {
+  const handleNewAccountSaved = () => {
     const eventPayload = {
       lms_name: ltiProviderName,
     };
@@ -29,6 +31,21 @@ const ContinueAccountCard = () => {
     );
 
     navigateToHref(continueAccountUrl);
+  };
+  const handleSubmit = async () => {
+    setIsSaving(true);
+
+    fetch('/lti/v1/account_linking/new_account', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': await getAuthenticityToken(),
+      },
+    }).then(response => {
+      if (response.ok) {
+        handleNewAccountSaved();
+      }
+    });
   };
 
   return (
@@ -50,6 +67,8 @@ const ContinueAccountCard = () => {
           className={classNames(styles.button, styles.cardSecondaryButton)}
           color={buttonColors.white}
           size="l"
+          isPending={isSaving}
+          disabled={isSaving}
           text={i18n.ltiIframeCallToAction()}
           onClick={handleSubmit}
         />

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ContinueCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ContinueCard/index.tsx
@@ -43,6 +43,7 @@ const ContinueAccountCard = () => {
       },
     }).then(response => {
       if (response.ok) {
+        setIsSaving(false);
         handleNewAccountSaved();
       }
     });

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/NewAccountCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/NewAccountCard/index.tsx
@@ -8,7 +8,7 @@ import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';
 import classNames from 'classnames';
 import styles from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/link-account.module.scss';
 import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
-import React, {useContext, useRef} from 'react';
+import React, {useContext, useRef, useState} from 'react';
 import i18n from '@cdo/locale';
 import {LtiProviderContext} from '../../context';
 import DCDO from '@cdo/apps/dcdo';
@@ -16,6 +16,7 @@ import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
 import {navigateToHref} from '@cdo/apps/utils';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 
 const NewAccountCard = () => {
   const {ltiProviderName, newAccountUrl, emailAddress} =
@@ -25,8 +26,9 @@ const NewAccountCard = () => {
     'student-email-post-enabled',
     false
   );
+  const [isSaving, setIsSaving] = useState(false);
 
-  const handleNewAccountSubmit = () => {
+  const handleNewAccountSaved = () => {
     const eventPayload = {
       lms_name: ltiProviderName,
     };
@@ -40,6 +42,22 @@ const NewAccountCard = () => {
     } else {
       navigateToHref(newAccountUrl);
     }
+  };
+
+  const handleNewAccountSubmit = async () => {
+    setIsSaving(true);
+
+    fetch('/lti/v1/account_linking/new_account', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': await getAuthenticityToken(),
+      },
+    }).then(response => {
+      if (response.ok) {
+        handleNewAccountSaved();
+      }
+    });
   };
 
   return (
@@ -75,6 +93,8 @@ const NewAccountCard = () => {
           color={buttonColors.white}
           size="l"
           text={i18n.ltiLinkAccountNewAccountCardActionLabel()}
+          isPending={isSaving}
+          disabled={isSaving}
           onClick={handleNewAccountSubmit}
         />
       </CardActions>

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/index.tsx
@@ -13,7 +13,9 @@ import {LtiProviderContext} from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/c
 const LtiLinkAccountPage = () => {
   const {newCtaType} = useContext(LtiProviderContext)!;
   const handleCancel = () => {
-    navigateToHref(`/users/cancel`);
+    newCtaType === 'new'
+      ? navigateToHref(`/users/cancel`)
+      : navigateToHref(`/users/sign_out`);
   };
 
   return (

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -5,18 +5,20 @@ import {
   waitFor,
   within,
 } from '@testing-library/react';
+import React from 'react';
+import sinon from 'sinon';
+
+import DCDO from '@cdo/apps/dcdo';
+import LtiLinkAccountPage from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage';
 import {
   LtiProviderContext,
   LtiProviderContextProps,
 } from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/context';
-import React from 'react';
-import i18n from '@cdo/locale';
-import {expect} from '../../../../../../util/reconfiguredChai';
-import LtiLinkAccountPage from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage';
-import sinon from 'sinon';
-import * as utils from '@cdo/apps/utils';
-import DCDO from '@cdo/apps/dcdo';
 import * as authenticityTokenStore from '@cdo/apps/util/AuthenticityTokenStore';
+import * as utils from '@cdo/apps/utils';
+import i18n from '@cdo/locale';
+
+import {expect} from '../../../../../../util/reconfiguredChai';
 
 const DEFAULT_CONTEXT: LtiProviderContextProps = {
   ltiProvider: 'canvas_cloud',

--- a/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/lib/ui/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -1,17 +1,22 @@
-import {fireEvent, render, screen, within} from '@testing-library/react';
-import React from 'react';
-import sinon from 'sinon';
-
-import DCDO from '@cdo/apps/dcdo';
-import LtiLinkAccountPage from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import {
   LtiProviderContext,
   LtiProviderContextProps,
 } from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage/context';
-import * as utils from '@cdo/apps/utils';
+import React from 'react';
 import i18n from '@cdo/locale';
-
 import {expect} from '../../../../../../util/reconfiguredChai';
+import LtiLinkAccountPage from '@cdo/apps/lib/ui/lti/link/LtiLinkAccountPage';
+import sinon from 'sinon';
+import * as utils from '@cdo/apps/utils';
+import DCDO from '@cdo/apps/dcdo';
+import * as authenticityTokenStore from '@cdo/apps/util/AuthenticityTokenStore';
 
 const DEFAULT_CONTEXT: LtiProviderContextProps = {
   ltiProvider: 'canvas_cloud',
@@ -70,7 +75,18 @@ describe('LTI Link Account Page Tests', () => {
   });
 
   describe('LTI Link Account New Account Card Tests', () => {
-    it('should render a new account card', () => {
+    it('should render a new account card', async () => {
+      const authenticityTokenStoreStub = sinon.stub(
+        authenticityTokenStore,
+        'getAuthenticityToken'
+      );
+      authenticityTokenStoreStub.returns(Promise.resolve('123'));
+
+      const fetchStub = sinon.stub(window, 'fetch');
+      fetchStub
+        .withArgs('/lti/v1/account_linking/new_account')
+        .returns(Promise.resolve({ok: true} as never));
+
       render(
         <LtiProviderContext.Provider value={DEFAULT_CONTEXT}>
           <LtiLinkAccountPage />
@@ -95,7 +111,11 @@ describe('LTI Link Account Page Tests', () => {
 
       fireEvent.click(newAccountButton);
 
-      expect(utils.navigateToHref).to.have.been.calledWith('/new-account');
+      await waitFor(
+        () =>
+          expect(utils.navigateToHref).to.have.been.calledWith('/new-account'),
+        {timeout: 999999}
+      );
     });
 
     it('should render a new account card - student email post enabled', () => {
@@ -142,6 +162,22 @@ describe('LTI Link Account Page Tests', () => {
       fireEvent.click(cancelButton);
 
       expect(utils.navigateToHref).to.have.been.calledWith(`/users/cancel`);
+    });
+
+    it('should link to the sign out controller', () => {
+      render(
+        <LtiProviderContext.Provider
+          value={{...DEFAULT_CONTEXT, newCtaType: 'continue'}}
+        >
+          <LtiLinkAccountPage />
+        </LtiProviderContext.Provider>
+      );
+
+      const cancelButton = screen.getByText(i18n.cancel());
+
+      fireEvent.click(cancelButton);
+
+      expect(utils.navigateToHref).to.have.been.calledWith(`/users/sign_out`);
     });
   });
 });

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -372,7 +372,7 @@ class ApplicationController < ActionController::Base
 
   # Check that the user has completed the LMS onboarding flow
   protected def assert_lms_landing_policy
-    return unless current_user.authentication_options.first&.lti? && !current_user.lms_landing_opted_out
+    return unless Policies::Lti.lti?(current_user) && !current_user.lms_landing_opted_out
 
     # URLs we should not redirect.
     return if Set[

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_action :handle_cap_lockout, if: :current_user
+  before_action :handle_cap_lockout, :assert_lms_landing_policy, if: :current_user
 
   # this is needed to avoid devise breaking on email param
   before_action :configure_permitted_parameters, if: :devise_controller?
@@ -368,6 +368,29 @@ class ApplicationController < ActionController::Base
         request_path: request.path,
       }
     )
+  end
+
+  # Check that the user has completed the LMS onboarding flow
+  protected def assert_lms_landing_policy
+    return unless current_user.authentication_options.first&.lti? && !current_user.lms_landing_opted_out
+
+    # URLs we should not redirect.
+    return if Set[
+      # Don't block any user from signing out
+      destroy_user_session_path,
+      # Don't block any user from changing the language
+      locale_path,
+      # Avoid an infinite redirect loop to the lockout page
+      lti_v1_account_linking_landing_path,
+      # Allow the 'finish link' path
+      lti_v1_account_linking_finish_link_path,
+      # Allow API call to set lockout state
+      lti_v1_account_linking_new_account_path,
+      # Allow cancelling the link
+      users_cancel_path
+    ].include?(request.path)
+
+    redirect_to lti_v1_account_linking_landing_path
   end
 
   # Creates a stable statsig id for use of session tracking (whether the user is logged in or not)

--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -42,6 +42,19 @@ module Lti
         end
       end
 
+      # POST /lti/v1/account_linking/new_account
+      def new_account
+        if PartialRegistration.in_progress?(session)
+          partial_user = User.new_with_session(ActionController::Parameters.new, session)
+          partial_user.lms_landing_opted_out = true
+          PartialRegistration.persist_attributes(session, partial_user)
+        else
+          head :bad_request unless current_user
+          current_user.lms_landing_opted_out = true
+          current_user.save!
+        end
+      end
+
       private def lti_account_linking_enabled?
         head :not_found unless DCDO.get('lti_account_linking_enabled', false)
       end

--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -44,14 +44,15 @@ module Lti
 
       # POST /lti/v1/account_linking/new_account
       def new_account
-        if PartialRegistration.in_progress?(session)
+        if current_user
+          return render status: :bad_request, json: {} if current_user.nil?
+
+          current_user.lms_landing_opted_out = true
+          current_user.save!
+        else
           partial_user = User.new_with_session(ActionController::Parameters.new, session)
           partial_user.lms_landing_opted_out = true
           PartialRegistration.persist_attributes(session, partial_user)
-        else
-          head :bad_request unless current_user
-          current_user.lms_landing_opted_out = true
-          current_user.save!
         end
       end
 

--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -45,14 +45,15 @@ module Lti
       # POST /lti/v1/account_linking/new_account
       def new_account
         if current_user
-          return render status: :bad_request, json: {} if current_user.nil?
 
           current_user.lms_landing_opted_out = true
           current_user.save!
-        else
+        elsif PartialRegistration.in_progress?(session)
           partial_user = User.new_with_session(ActionController::Parameters.new, session)
           partial_user.lms_landing_opted_out = true
           PartialRegistration.persist_attributes(session, partial_user)
+        else
+          render status: :bad_request, json: {}
         end
       end
 

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -171,14 +171,14 @@ class LtiV1Controller < ApplicationController
       session[:user_return_to] = destination_url
 
       if user
-        original_sign_in_count = user.sign_in_count
         sign_in user
 
         # If this is the user's first login, send them into the account linking flow
-        if original_sign_in_count < 1 && DCDO.get('lti_account_linking_enabled', false)
+        if DCDO.get('lti_account_linking_enabled', false) && !user.lms_landing_opted_out
+          Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'continue')
           PartialRegistration.persist_attributes(session, user)
           publish_linking_page_visit(user, integration[:platform_name])
-          render 'lti/v1/account_linking/landing', locals: {lti_provider: integration[:platform_name], email: Services::Lti.get_claim(decoded_jwt, :email), new_cta_type: 'continue'} and return
+          render 'lti/v1/account_linking/landing', locals: {email: Services::Lti.get_claim(decoded_jwt, :email)} and return
         end
 
         metadata = {
@@ -208,8 +208,9 @@ class LtiV1Controller < ApplicationController
         email_address = Services::Lti.get_claim(decoded_jwt, :email)
         PartialRegistration.persist_attributes(session, user)
         if DCDO.get('lti_account_linking_enabled', false)
+          Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'new')
           publish_linking_page_visit(user, integration[:platform_name])
-          render 'lti/v1/account_linking/landing', locals: {lti_provider: integration[:platform_name], email: email_address, new_cta_type: 'new'} and return
+          render 'lti/v1/account_linking/landing', locals: {email: email_address} and return
         end
 
         if DCDO.get('student-email-post-enabled', false)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -160,6 +160,7 @@ class User < ApplicationRecord
     has_seen_progress_table_v2_invitation
     date_progress_table_invitation_last_delayed
     user_provided_us_state
+    lms_landing_opted_out
   )
 
   attr_accessor(

--- a/dashboard/app/views/lti/v1/account_linking/landing.haml
+++ b/dashboard/app/views/lti/v1/account_linking/landing.haml
@@ -1,9 +1,17 @@
 - content_for(:head) do
   :ruby
     script_data = {}
-    lti_provider ||= params[:lti_provider]
+    landing_session = session[:lms_landing]
+
+    if landing_session.present?
+      lti_provider = landing_session[:lti_provider_name]
+      new_cta_type = landing_session[:new_cta_type]
+    else
+      lti_provider ||= params[:lti_provider]
+      new_cta_type ||= params[:new_cta_type]
+    end
+
     email ||= params[:email]
-    new_cta_type ||= params[:new_cta_type]
     new_account_url = DCDO.get('student-email-post-enabled', false) ? users_finish_sign_up_path : new_user_registration_url
     script_data[:lti_provider] = lti_provider
     script_data[:lti_provider_name] = Policies::Lti::LMS_PLATFORMS[lti_provider.to_sym][:name]

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -633,6 +633,7 @@ Dashboard::Application.routes.draw do
           get :existing_account
           get :finish_link
           post :link_email
+          post :new_account
         end
       end
     end

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -299,5 +299,12 @@ module Services
       end
       course_sync_result
     end
+
+    def self.initialize_lms_landing_session(session, lti_provider_name, new_cta_type)
+      session[:lms_landing] = {
+        lti_provider_name: lti_provider_name,
+        new_cta_type: new_cta_type
+      }
+    end
   end
 end

--- a/dashboard/lib/services/lti/account_linker.rb
+++ b/dashboard/lib/services/lti/account_linker.rb
@@ -16,6 +16,7 @@ module Services
           Services::Lti.create_lti_user_identity(user)
           handle_sections(rehydrated_user, user)
           user.lti_roster_sync_enabled = true if user.teacher?
+          user.lms_landing_opted_out = true
           PartialRegistration.delete(session)
           rehydrated_user.destroy if rehydrated_user.id
         end

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -713,7 +713,7 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
       create :teacher_feedback, script: script, level: weblab_level, student: student, teacher: @teacher
     end
 
-    assert_queries 14 do
+    assert_queries 16 do
       get :section_feedback, params: {section_id: @section.id, script_id: script.id}
     end
 

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -147,7 +147,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: score}]}
 
-    assert_queries 8 do
+    assert_queries 10 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
 
@@ -159,7 +159,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal section.students.count, 11
 
-    assert_queries 8 do
+    assert_queries 10 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
   end

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1110,7 +1110,7 @@ class ApiControllerTest < ActionController::TestCase
   test "should get progress for section with section script" do
     Unit.stubs(:should_cache?).returns true
 
-    assert_queries 8 do
+    assert_queries 10 do
       get :section_progress, params: {section_id: @flappy_section.id}
     end
     assert_response :success

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -52,9 +52,9 @@ class CoursesControllerTest < ActionController::TestCase
       @unit_group_regular = create :unit_group, name: 'non-plc-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
     end
 
-    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 10
+    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 12
 
-    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 4
+    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 6
   end
 
   class CachedQueryCounts < ActionController::TestCase

--- a/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
@@ -49,4 +49,32 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
     get :existing_account
     assert_response :ok
   end
+
+  test 'returns bad request if not logged in' do
+    post :new_account
+
+    assert_response :bad_request
+  end
+
+  test 'opts out of lms landing for a signed in user' do
+    lti_user = create :student
+    sign_in lti_user
+
+    post :new_account
+
+    lti_user.reload
+
+    assert_equal true, lti_user.lms_landing_opted_out
+  end
+
+  test 'opts out of lms landing for a partial registration user' do
+    lti_user = create :student
+    PartialRegistration.persist_attributes(session, lti_user)
+
+    post :new_account
+
+    partial_user = User.new_with_session(ActionController::Parameters.new, session)
+
+    assert_equal true, partial_user.lms_landing_opted_out
+  end
 end

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -591,6 +591,29 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     assert_template 'omniauth/redirect'
   end
 
+  test 'auth - should render the landing page and store session state' do
+    DCDO.stubs(:get)
+    Cpa.stubs(:cpa_experience).with(any_parameters).returns(false)
+    SignUpTracking.stubs(:begin_sign_up_tracking).returns(false)
+    DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
+    DCDO.stubs(:get).with('lti_account_linking_enabled', false).returns(true)
+    DCDO.stubs(:get).with('student-email-post-enabled', false).returns(true)
+    payload = {**get_valid_payload, Policies::Lti::LTI_ROLES_KEY => [Policies::Lti::CONTEXT_LEARNER_ROLE]}
+    jwt = create_jwt_and_stub(payload)
+
+    deployment = LtiDeployment.create(deployment_id: @deployment_id, lti_integration_id: @integration.id)
+    assert deployment
+    post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
+
+    expected = {
+      lti_provider_name: "platform_name",
+      new_cta_type: "new"
+    }
+
+    assert_equal expected, session[:lms_landing]
+    assert_template 'lti/v1/account_linking/landing'
+  end
+
   test 'sync - should redirect students to homepage without syncing' do
     user = create :student
     sign_in user

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -477,6 +477,7 @@ FactoryBot.define do
 
     trait :with_lti_auth do
       after(:create) do |user|
+        user.lms_landing_opted_out = true
         user.authentication_options.destroy_all
         lti_auth = create(:lti_authentication_option, user: user)
         user.authentication_options << lti_auth

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -55,7 +55,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level.id
     )
 
-    assert_cached_queries(4) do
+    assert_cached_queries(6) do
       get user_app_options_path,
         headers: {HTTP_USER_AGENT: 'test'}
       assert_response :success
@@ -70,7 +70,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
-    assert_cached_queries(11) do
+    assert_cached_queries(13) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -87,7 +87,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
-    assert_cached_queries(9) do
+    assert_cached_queries(11) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -103,7 +103,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     sl = create(:script, :with_levels, levels_count: 3).script_levels[2]
     params = {program: 'fake program', testResult: 0, result: 'false'}
 
-    assert_cached_queries(9) do
+    assert_cached_queries(11) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -131,7 +131,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(script)
     sign_in student
 
-    assert_cached_queries(7) do
+    assert_cached_queries(8) do
       get "/s/#{script.name}"
       assert_response :success
     end
@@ -139,12 +139,12 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     # Simulate all the ajax requests which the unit overview page sends to the
     # server on page load.
 
-    assert_cached_queries(6) do
+    assert_cached_queries(8) do
       get "/api/user_progress/#{script.name}"
       assert_response :success
     end
 
-    assert_cached_queries(4) do
+    assert_cached_queries(6) do
       get "/api/v1/teacher_feedbacks/count?student_id=#{student.id}"
       assert_response :success
     end
@@ -182,12 +182,12 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     # Simulate all the ajax requests which the level page sends to the
     # server on page load.
 
-    assert_cached_queries(2) do
+    assert_cached_queries(4) do
       get "/api/user_app_options/#{unit.name}/1/1/#{level.id}"
       assert_response :success
     end
 
-    assert_cached_queries(4) do
+    assert_cached_queries(6) do
       get "/levels/#{level.id}/get_rubric"
       assert_response :success
     end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This PR adds a new state to the user property bag which determines whether a LTI user has made a decision regarding account linking. Unless a user specifically opts out of account linking, the user will be sent to the account linking page to make a decision.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
- [jira ticket](https://codedotorg.atlassian.net/browse/P20-1009)

## Testing story

Tested on [adhoc](https://adhoc-stephen-lms-lockout-studio.cdn-code.org/users/sign_in)

### Scenario 1: Landing Page
#### Scenario 1a: Click on “Continue to Code.org”

Expected: Opt-out of account linking

#### Scenario 1b: Click on “sign in with my account”

Expected: Remains opted-in to account linking (via opt-in to account linking by default)

#### Scenario 1c: Click on any of the links in the header or footer

Expected: Remains opted-in to account linking (via opt-in to account linking by default)

#### Scenario 1d: Close the browser window or tab

Expected: Remains opted-in to account linking (via opt-in to account linking by default)

### Scenario 2: On the Account Linking Page
#### Scenario 2a: Successfully login to account

Expected: Opt-out of account linking

#### Scenario 2b: Unsuccessfully login to account

Expected: Remains opted-in to account linking (via opt-in to account linking by default)

#### Scenario 2c: Click “go back”

Expected: Remains opted-in to account linking (via opt-in to account linking by default)

#### Scenario 2d: Click on any of the links in the header or footer

Expected: Remains opted-in to account linking (via opt-in to account linking by default)

#### Scenario 2e: Close the browser window or tab
Expected: Remains opted-in to account linking (via opt-in to account linking by default)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
