### PR TITLE
Curriculum launch 2024 - Update Coding with AI page

### DIFF
--- a/pegasus/sites.v3/code.org/public/curriculum/coding-with-ai.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/coding-with-ai.haml
@@ -50,6 +50,16 @@ theme: responsive_full_width
     = view :"coding_with_ai/coding_with_ai_lessons"
 
 %section.bg-neutral-light
+  .wrapper
+    %h2=hoc_s("coding_with_ai_page.teach.heading")
+    = view :"coding_with_ai/coding_with_ai_teach"
+
+%section
+  .wrapper
+    %h2=hoc_s("coding_with_ai_page.faq.heading")
+    = view :"coding_with_ai/coding_with_ai_faq"
+
+%section.bg-neutral-light
   .wrapper.centered
     %h2=hoc_s("coding_with_ai_page.learn_more.heading")
     = view :"coding_with_ai/coding_with_ai_learn_more"
@@ -58,14 +68,3 @@ theme: responsive_full_width
     %p=hoc_s("coding_with_ai_page.learn_more.desc")
     %a.link-button.secondary{href: "/ai"}
       =hoc_s("coding_with_ai_page.learn_more.button")
-
-%section.no-padding-bottom
-  .wrapper
-    %h2=hoc_s("coding_with_ai_page.faq.heading")
-    = view :"coding_with_ai/coding_with_ai_faq"
-
-%section
-  .wrapper
-    %h2=hoc_s("coding_with_ai_page.resources.heading")
-    %p=hoc_s("coding_with_ai_page.resources.desc")
-    = view :"ai_pages_shared/ai_pages_resources", white_bg: false

--- a/pegasus/sites.v3/code.org/public/curriculum/coding-with-ai.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/coding-with-ai.haml
@@ -49,10 +49,14 @@ theme: responsive_full_width
     %p=hoc_s("coding_with_ai_page.lessons.desc")
     = view :"coding_with_ai/coding_with_ai_lessons"
 
-%section.bg-neutral-light
-  .wrapper
-    %h2=hoc_s("coding_with_ai_page.teach.heading")
-    = view :"coding_with_ai/coding_with_ai_teach"
+-# TODO remove DCDO logic after the 2024 curriculum launch
+- if !!DCDO.get('curriculum-launch-2024', false)
+  %section.bg-neutral-light
+    .wrapper
+      %h2=hoc_s("coding_with_ai_page.teach.heading")
+      = view :"coding_with_ai/coding_with_ai_teach"
+- else
+  = view :section_divider_line
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/images/action-blocks/action-block-coding-with-ai.png
+++ b/pegasus/sites.v3/code.org/public/images/action-blocks/action-block-coding-with-ai.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59bd9f137cd85b35050d7e5092cdfa427305d8ca2689bc04d9ed401ebea58b84
-size 9075
+oid sha256:1228fc100478a915b4f9389851efdc402356dc7b56c8e0516d6e9910c1a513cd
+size 13941

--- a/pegasus/sites.v3/code.org/views/coding_with_ai/coding_with_ai_teach.haml
+++ b/pegasus/sites.v3/code.org/views/coding_with_ai/coding_with_ai_teach.haml
@@ -1,0 +1,13 @@
+.action-block.action-block--two-col.white
+  .media-wrapper.col-50
+    %img{src: "/images/action-blocks/action-block-coding-with-ai.png", alt: ""}
+  .text-wrapper.col-50
+    %p.overline
+      =hoc_s("coding_with_ai_page.teach.tile.overline")
+    %h3
+      =hoc_s("coding_with_ai_page.teach.tile.title")
+    %p
+      =hoc_s("coding_with_ai_page.teach.tile.desc")
+    %a.link-button{href: CDO.studio_url("/courses/self-paced-pl-coding-with-ai-2024")}
+      =hoc_s("coding_with_ai_page.teach.tile.button")
+  .clear

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10959,6 +10959,13 @@
         title: "Get Support"
         desc: "Our customer support team is ready to answer your questions. Email us at [support@code.org](%{email_url}) or check out our support center, which offers useful guides and answers!"
         button: "Visit our support center"
+    teach:
+      heading: "Preparing to teach Coding with AI"
+      tile:
+        overline: "6-12 Teachers"
+        title: "Teaching Coding with AI"
+        desc: "This professional learning module prepares teachers to guide 6-12 students through Code.org's Coding with AI unit, where students leverage Large Language Models to write more powerful code while exploring ethical considerations and responsible AI use."
+        button: "Start professional learning"
 
   coding_with_ai_tile:
     title: "Coding with AI"


### PR DESCRIPTION
Updates https://code.org/curriculum/coding-with-ai for the 2024 curriculum launch.
- Adds a new “Preparing to teach Coding with AI” section when the `curriculum-launch-2024` DCDO flag is `true`
- Removes the "Additional resources" section currently at the bottom of the page
- Moves the "Additional AI resources" section to the bottom of the page

## Links
Jira ticket: [ACQ-1983](https://codedotorg.atlassian.net/browse/ACQ-1983)
Figma mock: [here](https://www.figma.com/design/HwXIyBGQ0b2ZI213sWb3cK/2024-Curriculum-Launch?node-id=2727-15994&t=jGl5q48qwtNY5vra-1)

## Testing story
Tested locally to make sure the DCDO logic works.

----

## DCDO is set to true and sections are removed/rearranged (shows new PL section)
![localhost code org_3000_curriculum_coding-with-ai](https://github.com/code-dot-org/code-dot-org/assets/9256643/1b8f56a0-315c-48ac-b908-bf7996804825)

## DCDO is set to false 
<img width="1161" alt="False" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/a3089c41-63db-4b1e-b06d-2621dc5f7379">
