### PR TITLE
Schoology Account Linking Bug

### DIFF
--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -18,7 +18,7 @@ module Lti
         # clear the session, so we need to store cache key first, sign them out,
         # then set it again in their now empty session.
         if current_user
-          partial_registration_cache_key = PartialRegistration.cache_key(current_user)
+          partial_registration_cache_key = session[PartialRegistration::SESSION_KEY]
           sign_out current_user
           session[PartialRegistration::SESSION_KEY] = partial_registration_cache_key
         end

--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -19,7 +19,7 @@ module Lti
         # then set it again in their now empty session.
         if current_user
           partial_registration_cache_key = PartialRegistration.cache_key(current_user)
-          sign_out
+          sign_out current_user
           session[PartialRegistration::SESSION_KEY] = partial_registration_cache_key
         end
 


### PR DESCRIPTION
 This PR addresses a bug where users LTI launching from Schoology aren't taken into the expected account linking flow.

https://docs.google.com/document/d/1122s4C6M3HW_cj2DF3QqDTCA9BFLAEwRemsy8SMZD4Q/edit#heading=h.e9dpt2pc7d0

- Update `sign_out` to specify the `current_user` resource (see [devise docs](https://www.rubydoc.info/github/plataformatec/devise/main/Devise%2FControllers%2FSignInOut:sign_out))
- Change the cache key to the key stored in the session


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
