### PR TITLE
Script to remove section association to prepare for unit deletion.

### DIFF
--- a/bin/curriculum/delete_section_association.rb
+++ b/bin/curriculum/delete_section_association.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'optparse'
+
+# Given a unit name, the script will iterate over all the sections that
+# have the unit assigned and remove that association by setting assigned
+# unit for those sections to null.
+
+def parse_options
+  OpenStruct.new.tap do |options|
+    options.unit_names = nil
+    options.dry_run = false
+
+    opt_parser = OptionParser.new do |opts|
+      opts.banner = "Usage: #{$0} [options]"
+
+      opts.separator ""
+
+      opts.on('-u', '--unit_names UnitName1,UnitName2', Array, 'Unit names to remove all section associations') do |unit_names|
+        options.unit_names = unit_names.map(&:strip)
+      end
+
+      opts.on('-n', '--dry-run', 'List out the count sections that would be impacted.') do
+        options.dry_run = true
+      end
+
+      opts.on_tail("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+    end
+
+    opt_parser.parse!(ARGV)
+  end
+end
+
+options = parse_options
+raise "unit name is required. Use -h for options." if options.unit_names.nil?
+
+require_relative '../../dashboard/config/environment'
+options.unit_names.each do |unit_nm|
+  unit_to_remove_sec_association = Unit.find_by(name: unit_nm)
+  raise "Unit with name #{unit_nm} not found" if unit_to_remove_sec_association.nil?
+
+  assigned_sections = Section.where(script_id: unit_to_remove_sec_association.id)
+  puts "Number of sections that have unit #{unit_nm} associated: #{assigned_sections.count}."
+
+  if options.dry_run
+    puts "Skipping section update due to dry run mode."
+  elsif assigned_sections.count > 0
+    puts "Removing all section assignments."
+    assigned_sections.each do |section|
+      section.script_id = nil
+      section.save!
+    end
+  end
+end

--- a/bin/curriculum/delete_section_association.rb
+++ b/bin/curriculum/delete_section_association.rb
@@ -50,9 +50,6 @@ options.unit_names.each do |unit_nm|
     puts "Skipping section update due to dry run mode."
   elsif assigned_sections.count > 0
     puts "Removing all section assignments."
-    assigned_sections.each do |section|
-      section.script_id = nil
-      section.save!
-    end
+    assigned_sections.update_all(script_id: nil)
   end
 end


### PR DESCRIPTION
The script is to automate parts of the workflow to delete a unit. If a section has deleted units assigned to them, it breaks loading the teacher dashboard page. Hence, as part of the unit deletion process, we additionally remove any section associations for the unit.

This PR includes a script to remove the section association for a give set of unit(s).

## Links

https://codedotorg.atlassian.net/browse/TEACH-1161

## Testing story

Validating running the script locally for units with no sections and units with a section associated. The units were marked in_development before running the script, hence from end user perspective, they were already not showing up in the section dashboard. Upon running this script, there was same end user experience.

## Deployment strategy

Regular DTP

## Follow-up work

Follow up work is captured https://codedotorg.atlassian.net/browse/TEACH-1161

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
