### PR TITLE
Add aria labels to carousel buttons on Hour of Code /beyond page

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -682,6 +682,7 @@
   module_label_self_paced: "Self-paced module"
   module_label_event_or_lessons: "Event or lessons"
   module_label_or: "Or"
+  module_label_visit_site: "Visit %{site_name}"
 
   module_ages_5_10: "5-10"
   module_ages_11_18: "11-18"

--- a/pegasus/sites.v3/hourofcode.com/views/course_carousel.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/course_carousel.haml
@@ -29,7 +29,7 @@
                   = tutorial[:platformtext]
                 %p.slide-longdescription= tutorial[:longdescription]
               .content-footer
-                %a.link-button{href: url, target: "_blank", aria: {label: tutorial[:buttonarialabel]}}
+                %a.link-button{href: url, target: "_blank", aria: {label: hoc_s(:module_label_visit_site, markdown: :inline, locals: {site_name: tutorial[:name]})}}
                   =I18n.t(:go)
 
     %button.swiper-nav-prev{class: id}

--- a/pegasus/sites.v3/hourofcode.com/views/course_carousel.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/course_carousel.haml
@@ -29,7 +29,7 @@
                   = tutorial[:platformtext]
                 %p.slide-longdescription= tutorial[:longdescription]
               .content-footer
-                %a.link-button{href: url, target: "_blank"}
+                %a.link-button{href: url, target: "_blank", aria: {label: tutorial[:buttonarialabel]}}
                   =I18n.t(:go)
 
     %button.swiper-nav-prev{class: id}


### PR DESCRIPTION
Adds aria labels to "Go" buttons in carousels on [hourofcode.com/beyond](https://hourofcode.com/us/beyond). Currently, each card in the carousels just has an external link button that says "Go" without additional info, so this PR provides that extra context.

![ex_aria](https://github.com/code-dot-org/code-dot-org/assets/56283563/8d66fa38-5ea6-4605-880f-c4834cec25a3)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1893)
Spreadsheet with aria labels: [here](https://docs.google.com/spreadsheets/d/1RZ6iutiOV8LTol1uooJ3m1GiHHPbpmssNSWkT87oTNI/edit?gid=822908068#gid=822908068)

## Testing story
Local testing.
