### PR TITLE
wait for Run AI Assessment buttons to become enabled

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -95,7 +95,7 @@ Feature: Evaluate student code against rubrics using AI
     # Teacher views AI evaluation status in settings tab
     When I click selector "#ui-floatingActionButton"
     And I wait until element "#uitest-rubric-content" is visible
-    And element ".uitest-run-ai-assessment" is enabled
+    And I wait until element ".uitest-run-ai-assessment" is enabled
 
     # Teacher runs AI evaluation
     When I click selector ".uitest-run-ai-assessment"
@@ -140,20 +140,20 @@ Feature: Evaluate student code against rubrics using AI
     And I wait for the page to fully load
     And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
     And I click selector ".introjs-skipbutton" if it exists
-    And I wait until element ".congrats" is gone 
+    And I wait until element ".congrats" is gone
     #Then I verify progress in the header of the current page is "attempted_assessment" for level 2
     And element "#ui-floatingActionButton" is visible
 
     # Teacher views AI evaluation status in settings tab
     When I click selector "#ui-floatingActionButton"
     And I wait until element "#uitest-rubric-content" is visible
-    And element ".uitest-run-ai-assessment" is enabled
+    And I wait until element ".uitest-run-ai-assessment" is enabled
 
     # Teacher switches to Class Management tab
     When I click selector "button:contains('Class Data')"
     And I wait until element ".uitest-run-ai-assessment-all" is visible
-    And I wait until element "#ui-teacherFeedback" is enabled 
-    And element ".uitest-run-ai-assessment-all" is enabled
+    And I wait until element "#ui-teacherFeedback" is enabled
+    And I wait until element ".uitest-run-ai-assessment-all" is enabled
 
     # Teacher runs AI evaluation
     When I click selector ".uitest-run-ai-assessment-all"


### PR DESCRIPTION
I am point person today and happened to see some ongoing flakiness in ai_evaluate_student_code UI tests after https://github.com/code-dot-org/code-dot-org/pull/59132 was merged:
![Screenshot 2024-06-24 at 3 33 02 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/0d83f108-88bb-40b5-9636-68e1582f7570)

When I try this scenario manually on my local machine, it takes a few seconds for the button to become enabled while we wait for the network request to fetch the evaluation status. This PR tries to work around that by waiting until the button is enabled.
