### PR TITLE
P20-1013: Restore English Apps TTS sync-out

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -19,7 +19,6 @@ class I18nScriptUtils
   PROGRESS_BAR_FORMAT = '%t: |%B| %p% %a'.freeze
   PARALLEL_PROCESSES = Parallel.processor_count.freeze
   SOURCE_LOCALE = I18n.default_locale.to_s.freeze
-  TTS_LOCALES = (::TextToSpeech::VOICES.keys - %I[#{SOURCE_LOCALE}]).freeze
   TESTING_BY_DEFAULT = false
 
   # @return [Hash] the Crowdin credentials.

--- a/bin/i18n/resources/apps/text_to_speech/sync_out.rb
+++ b/bin/i18n/resources/apps/text_to_speech/sync_out.rb
@@ -14,6 +14,7 @@ module I18n
       module TextToSpeech
         class SyncOut < I18n::Utils::SyncOutBase
           METRIC_CONTEXT = 'update_i18n_static_messages'.freeze
+          TTS_LOCALES = ::TextToSpeech::VOICES.keys.freeze
 
           # TODO: (elijah) formalize a process for flagging these strings somewhere in apps code,
           # rather than maintaining this ugly manual Hash
@@ -99,8 +100,8 @@ module I18n
           def perform
             progress_bar.start
 
-            progress_bar.total = I18nScriptUtils::TTS_LOCALES.size * LABS_FEEDBACK_MESSAGE_KEYS.size
-            I18nScriptUtils.process_in_threads(I18nScriptUtils::TTS_LOCALES) do |locale|
+            progress_bar.total = TTS_LOCALES.size * LABS_FEEDBACK_MESSAGE_KEYS.size
+            I18nScriptUtils.process_in_threads(TTS_LOCALES) do |locale|
               js_locale = I18nScriptUtils.to_js_locale(locale)
 
               LABS_FEEDBACK_MESSAGE_KEYS.each do |lab, message_keys|

--- a/bin/i18n/resources/dashboard/text_to_speech/sync_out.rb
+++ b/bin/i18n/resources/dashboard/text_to_speech/sync_out.rb
@@ -14,6 +14,7 @@ module I18n
       module TextToSpeech
         class SyncOut < I18n::Utils::SyncOutBase
           METRIC_CONTEXT = 'update_level_i18n'.freeze
+          TTS_LOCALES = ::TextToSpeech::VOICES.keys - %i[en-US]
 
           def perform
             progress_bar.start
@@ -23,7 +24,7 @@ module I18n
               next unless unit.text_to_speech_enabled?
 
               unit.levels.merge(Blockly.all).find_each do |level|
-                I18nScriptUtils.process_in_threads(I18nScriptUtils::TTS_LOCALES) do |locale|
+                I18nScriptUtils.process_in_threads(TTS_LOCALES) do |locale|
                   upload_tts_short_instructions_l10n(level, locale)
                   upload_tts_long_instructions_l10n(level, locale) unless unit.csf_international? || unit.twenty_hour?
                   upload_tts_authored_hints_l10n(level, locale)

--- a/bin/test/i18n/resources/apps/text_to_speech/test_sync_out.rb
+++ b/bin/test/i18n/resources/apps/text_to_speech/test_sync_out.rb
@@ -17,6 +17,12 @@ describe I18n::Resources::Apps::TextToSpeech::SyncOut do
     assert_equal I18n::Utils::SyncOutBase, described_class.superclass
   end
 
+  describe 'TTS_LOCALES' do
+    it 'returns TextToSpeech VOICES keys' do
+      _(described_class::TTS_LOCALES).must_equal %i[en-US es-ES es-MX it-IT pt-BR]
+    end
+  end
+
   describe '#perform' do
     let(:perform_sync_out) {described_instance.perform}
 
@@ -33,7 +39,7 @@ describe I18n::Resources::Apps::TextToSpeech::SyncOut do
     let(:labs_feedback_message_keys) {{lab => [lab_message_key]}}
 
     around do |test|
-      I18nScriptUtils.stub_const(:TTS_LOCALES, [locale]) do
+      described_class.stub_const(:TTS_LOCALES, [locale]) do
         described_class.stub_const(:LABS_FEEDBACK_MESSAGE_KEYS, labs_feedback_message_keys) {test.call}
       end
     end

--- a/bin/test/i18n/resources/dashboard/text_to_speech/test_sync_out.rb
+++ b/bin/test/i18n/resources/dashboard/text_to_speech/test_sync_out.rb
@@ -21,6 +21,12 @@ describe I18n::Resources::Dashboard::TextToSpeech::SyncOut do
     assert_equal I18n::Utils::SyncOutBase, described_class.superclass
   end
 
+  describe 'TTS_LOCALES' do
+    it 'returns TextToSpeech VOICES keys excluding :en-US' do
+      _(described_class::TTS_LOCALES).must_equal %i[es-ES es-MX it-IT pt-BR]
+    end
+  end
+
   describe '#perform' do
     let(:perform_sync_out) {described_instance.perform}
 
@@ -41,7 +47,7 @@ describe I18n::Resources::Dashboard::TextToSpeech::SyncOut do
     end
 
     around do |test|
-      I18nScriptUtils.stub_const(:TTS_LOCALES, [locale]) {test.call}
+      described_class.stub_const(:TTS_LOCALES, [locale]) {test.call}
     end
 
     before do


### PR DESCRIPTION
## Summary
Restored the sync-out of the English Apps TTS, which was lost during the script refactoring:
https://github.com/code-dot-org/code-dot-org/blob/6e9095d6b8f6d5f30c64c9b6e2baaaab75d1e1b5/dashboard/scripts/update_tts_i18n_static_messages.rb#L90-L97

## Links
- JIRA ticket: [P20-1013](https://codedotorg.atlassian.net/browse/P20-1013)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/54519
- Related commit: https://github.com/code-dot-org/code-dot-org/commit/ef0b1eff509eaccd31ec0dd3544da8ed5a8558b3#diff-ab4ef6f102b825436b26b9724f7805e781c3589372f2579759ada67f7415a90dR23-R24