### PR TITLE
wait for learning goal title to change

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -164,7 +164,6 @@ Feature: Evaluate student code against rubrics using AI
     When I click selector "button:contains('Assess a Student')"
     And I wait until element "#uitest-next-goal" is visible
     And I click selector "#uitest-next-goal"
-    And I wait until element ".uitest-learning-goal-title" is visible
-    Then element ".uitest-learning-goal-title" contains text "Sprites"
+    Then I wait until element ".uitest-learning-goal-title" contains text "Sprites"
     And I wait until element ".uitest-ai-assessment" is visible
     Then element ".uitest-ai-assessment" contains text "Aiden has achieved Extensive or Convincing Evidence"


### PR DESCRIPTION
more flakiness in the latest DTT after https://github.com/code-dot-org/code-dot-org/pull/59374 and https://github.com/code-dot-org/code-dot-org/pull/59132:
https://cucumber-logs.s3.amazonaws.com/test/test/Safari_teacher_tools_rubrics_ai_evaluate_student_code_output.html?versionId=IX00Jip9DJDK8gbHdYwaGYEdj7gbnZKB
![Screenshot 2024-06-24 at 7 59 44 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/60b84ba6-d044-43cd-bcb8-6fe35e998c7b)

The problem appears to be that we're trying to wait for the learning goal title to become visible, but it already is visible, with the old title. The fix is to wait for it to contain the new text. 