### PR TITLE
Update game design curriculum link on Self-Paced PL page

### DIFF
--- a/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_elementary.haml
+++ b/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_elementary.haml
@@ -37,7 +37,7 @@
         duration: hoc_s(:module_duration_1_hr_30_minutes),
         prerequisites: hoc_s(:module_prerequisites_none),
         url_primary: CDO.studio_url("/courses/3-5gamedesign-2024"),
-        url_secondary: CDO.studio_url('/courses/3-5gamedesign-2024'),
+        url_secondary: CDO.studio_url('/s/elem-game-design-2024'),
         aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_elementary_game_design),
         aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_elementary_game_design),
         new: true


### PR DESCRIPTION
Updates the curriculum link on the self-paced PL page. See [Slack thread](https://codedotorg.slack.com/archives/C060J3A3BBK/p1719263223505979).

