### PR TITLE
Add Open Graph title to certificates show page

### DIFF
--- a/dashboard/app/controllers/certificates_controller.rb
+++ b/dashboard/app/controllers/certificates_controller.rb
@@ -24,6 +24,8 @@ class CertificatesController < ApplicationController
     image_alt = data['name'] ?
       I18n.t('certificates.alt_text_with_name', course_name: course_name, student_name: data['name']) :
       I18n.t('certificates.alt_text_no_name', course_name: course_name)
+    # The alt text string is a good page title, so re-using it here.
+    @page_title = I18n.t('certificates.alt_text_no_name', course_name: course_name)
 
     @certificate_data = {
       imageUrl: @image_url,

--- a/dashboard/app/views/certificates/show.html.haml
+++ b/dashboard/app/views/certificates/show.html.haml
@@ -1,5 +1,6 @@
 - content_for :og do
   = tag 'meta', property: 'og:image', content: @image_url
+  = tag 'meta', property: 'og:title', content: @page_title
 
 %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
 %script{src: webpack_asset_path('js/certificates/show.js'), data: {certificate: @certificate_data.to_json}}


### PR DESCRIPTION
Tentatively resolves https://codedotorg.atlassian.net/browse/ACQ-2002. The LinkedIn share doesn't work with localhost so I couldn't actually test that bit, but I did confirm the `og:title` tag is set correctly.

![Screenshot 2024-06-25 at 8 38 36 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/41ba035d-251c-475f-bd9c-7a494ce69fcc)

I'll test the LinkedIn share when this hits staging or production. I just didn't want to spin up an adhoc for such a small change. 😅 

