### PR TITLE
Add strings for July 2024 Teach AI launch

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -11247,6 +11247,12 @@
     call_to_action: "Start here!"
     call_to_action_aria_label: "Start self-paced professional learning"
 
+  teach_ai_banner_july_2024:
+    headline: "Guidance on the Future of CS Education in an Age of AI"
+    subtitle: "New"
+    description: "Why is it still important for students to learn to program? How are teachers in CS classrooms already incorporating AI? Explore the guidance and engage in the future of CS education in an age of AI."
+    button_text: "Explore the guidance"
+
   language_code:
     ar: "Arabic"
     az: "Azerbaijani"


### PR DESCRIPTION
Adds the strings for the Teach AI July launch. I used the date in the string key here as I didn't have any better ideas, but I'm open to alternate suggestions!

