### PR TITLE
Update LMS top_desc string typo

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1811,7 +1811,7 @@
 
   lms_page:
     heading: "Integrate Code.org with your LMS platform"
-    top_desc: "Connect existing LMS classrooms in your school to Code.org with one-click roster syncing, single sign-on (SSO), and integrated access curriculum."
+    top_desc: "Connect existing LMS classrooms in your school to Code.org with one-click roster syncing, single sign-on (SSO), and integrated curriculum access."
     top_module:
       heading: "Code.org supports major learning management systems"
       desc: "Code.org has seamless, secure, one-click integrations for most major LMS & SSO providers."


### PR DESCRIPTION
Updates a typo in the top section on the https://code.org/lms page.

## Before
<img width="1038" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/17428e06-d41e-4244-bef1-ba22ee1401bc">

## After
<img width="1038" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/837dd5d1-f9e3-4782-bf2b-97bb1df451e8">