### PR TITLE
P20 fix account settings lock for teachers

### DIFF
--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -185,7 +185,7 @@ class ManageLinkedAccounts extends React.Component {
       this.shouldDisableConnectButton
     );
     return (
-      <div>
+      <div style={styles.container}>
         <hr />
         <h2 style={styles.header}>{i18n.manageLinkedAccounts()}</h2>
         <table style={styles.table}>
@@ -367,6 +367,9 @@ const BUTTON_WIDTH = 105;
 const BUTTON_PADDING = 8;
 const CELL_WIDTH = tableLayoutStyles.table.width / 3;
 const styles = {
+  container: {
+    clear: 'both',
+  },
   header: {
     fontSize: 22,
   },

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -367,9 +367,6 @@ const BUTTON_WIDTH = 105;
 const BUTTON_PADDING = 8;
 const CELL_WIDTH = tableLayoutStyles.table.width / 3;
 const styles = {
-  container: {
-    clear: 'both',
-  },
   header: {
     fontSize: 22,
   },

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -389,7 +389,7 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def edit
     @permission_status = current_user.child_account_compliance_state
-    @personal_account_linking_enabled = Policies::ChildAccount.can_link_new_personal_account?(current_user) && (!current_user.student? || !(current_user.country_code.nil? && current_user.us_state.nil?))
+    @personal_account_linking_enabled = Policies::ChildAccount.can_link_new_personal_account?(current_user)
 
     # Handle users who aren't locked out, but still need parent permission to link personal accounts.
     if Policies::ChildAccount.user_predates_policy?(current_user)

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -389,7 +389,7 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def edit
     @permission_status = current_user.child_account_compliance_state
-    @personal_account_linking_enabled = Policies::ChildAccount.can_link_new_personal_account?(current_user) && !(current_user.country_code.nil? && current_user.us_state.nil?)
+    @personal_account_linking_enabled = Policies::ChildAccount.can_link_new_personal_account?(current_user) && (!current_user.student? || !(current_user.country_code.nil? && current_user.us_state.nil?))
 
     # Handle users who aren't locked out, but still need parent permission to link personal accounts.
     if Policies::ChildAccount.user_predates_policy?(current_user)

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -393,7 +393,7 @@ class RegistrationsController < Devise::RegistrationsController
 
     # Handle users who aren't locked out, but still need parent permission to link personal accounts.
     if Policies::ChildAccount.user_predates_policy?(current_user)
-      permission_request = current_user.latest_permission_request
+      permission_request = current_user.latest_parental_permission_request
       @pending_email = permission_request&.parent_email
       @request_date = permission_request&.updated_at || Date.new
 

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -152,7 +152,7 @@
       ),
       permission_status: @permission_status,
       user_email: current_user.hashed_email,
-    }
+    },
   }
 
 -# Skip this section as ai-rubrics experiment needs to be unit aware

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -170,6 +170,7 @@ class Policies::ChildAccount
 
   # Checks if the user will not be old enough by the lockout date
   def self.underage?(user)
+    return false unless user.student?
     return false unless user.birthday
 
     policy = state_policy(user)
@@ -197,6 +198,7 @@ class Policies::ChildAccount
   # Whether or not the user can create/link new personal logins
   def self.can_link_new_personal_account?(user)
     return true unless user.student?
+    return false unless user.us_state && user.country_code
     return true unless user.birthday
     return true unless underage?(user)
 

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -272,6 +272,14 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       Policies::ChildAccount.stubs(:state_policy).with(user).returns(user_state_policy)
     end
 
+    context 'the user is a teacher' do
+      let(:user) {build_stubbed(:teacher)}
+
+      it 'returns false' do
+        _(underage?).must_equal false
+      end
+    end
+
     context 'there is no state policy for the user' do
       let(:user_state_policy) {nil}
 
@@ -423,7 +431,7 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
     let(:can_link_new_personal_account?) {Policies::ChildAccount.can_link_new_personal_account?(user)}
 
     let(:user_birthday) {DateTime.now}
-    let(:user) {build_stubbed(:student, birthday: user_birthday)}
+    let(:user) {build_stubbed(:student, birthday: user_birthday, us_state: 'CO', country_code: 'US')}
     let(:underage?) {true}
     let(:permission_granted?) {true}
 
@@ -437,6 +445,30 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
 
       it 'returns true' do
         _(can_link_new_personal_account?).must_equal true
+      end
+    end
+
+    context 'when the user does not have a state' do
+      let(:user) {build_stubbed(:student, birthday: user_birthday, us_state: nil)}
+
+      it 'returns false' do
+        _(can_link_new_personal_account?).must_equal false
+      end
+    end
+
+    context 'when the user does not have a country' do
+      let(:user) {build_stubbed(:student, birthday: user_birthday, country_code: nil)}
+
+      it 'returns false' do
+        _(can_link_new_personal_account?).must_equal false
+      end
+    end
+
+    context 'when the user does not have a state nor country' do
+      let(:user) {build_stubbed(:student, birthday: user_birthday, us_state: nil, country_code: nil)}
+
+      it 'returns false' do
+        _(can_link_new_personal_account?).must_equal false
       end
     end
 

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -161,7 +161,7 @@ Feature: Policy Compliance and Parental Permission
     # Find the unlocked buttons to connect an account
     Given I am on "http://studio.code.org/users/edit?cpa-partial-lockout=1"
     Then I wait to see "#manage-linked-accounts"
-    Then I wait until "form[action=\'/users/auth/google_oauth2?action=connect\'] button" is enabled
+    Then I wait until "form[action=\'/users/auth/google_oauth2?action=connect\'] button" is not disabled
 
   Scenario: Student should not be able to connect a third-party account until their account is unlocked
     Given I create a young student in Colorado who has never signed in named "Coco Student" after CPA exception and go home

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -155,6 +155,14 @@ Feature: Policy Compliance and Parental Permission
     Given I create a young student in Colorado who has never signed in named "Sally Student" before CPA exception and go home
     Given I am on "http://studio.code.org/home"
 
+  Scenario: Teacher should be able to connect a third-party account even without a state specified
+    Given I create a teacher who has never signed in named "Amstrad Teacher" after CPA exception and go home
+
+    # Find the unlocked buttons to connect an account
+    Given I am on "http://studio.code.org/users/edit?cpa-partial-lockout=1"
+    Then I wait to see "#manage-linked-accounts"
+    Then I wait until "form[action=\'/users/auth/google_oauth2?action=connect\'] button" is enabled
+
   Scenario: Student should not be able to connect a third-party account until their account is unlocked
     Given I create a young student in Colorado who has never signed in named "Coco Student" after CPA exception and go home
 

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -196,10 +196,28 @@ And(/^I create a student in the eu named "([^"]*)"$/) do |name|
   )
 end
 
-And(/^I create a teacher( who has never signed in)? named "([^"]*)"( and go home)?$/) do |new_account, name, home|
+And(/^I create a teacher( who has never signed in)? named "([^"]*)"( after CPA exception)?( before CPA exception)?( and go home)?$/) do |new_account, name, after_cpa_exception, before_cpa_exception, home|
   sign_in_count = new_account ? 0 : 2
 
-  create_user(name, age: '21+', user_type: 'teacher', email_preference_opt_in: 'yes', sign_in_count: sign_in_count)
+  user_opts = {
+    user_type: 'teacher',
+    age: '21+',
+    email_preference_opt_in: 'yes',
+    sign_in_count: sign_in_count,
+  }
+
+  # See Cpa::CREATED_AT_EXCEPTION_DATE
+  cpa_exception_date = DateTime.parse('2024-05-26T00:00:00MDT')
+
+  if after_cpa_exception
+    user_opts[:created_at] = cpa_exception_date
+  end
+
+  if before_cpa_exception
+    user_opts[:created_at] = cpa_exception_date - 1.second
+  end
+
+  create_user(name, **user_opts)
   navigate_to replace_hostname('http://studio.code.org') if home
 end
 


### PR DESCRIPTION
Quickly fixes the missed logic that inadvertently would have led to teachers being locked out when the `cpa-partial-lockout` experiment is turned on.

## Testing story

Manually reproduced a locked out teacher easily.

Fixed problem.

Manually saw that teacher was no longer locked.

Manually re-tested a sponsored student the entire way through the flow: setting state, sending parent request, accepting request, and finally looking at the page. The buttons for connecting accounts / creating personal login were still locked.

Wrote UI test to capture this regression.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
