### PR TITLE
fix(lms): refactor roster sync button to use flex box

### DIFF
--- a/apps/src/lib/ui/accounts/LtiRosterSyncSettings.jsx
+++ b/apps/src/lib/ui/accounts/LtiRosterSyncSettings.jsx
@@ -47,23 +47,26 @@ export default function LtiRosterSyncSettings(props) {
         size={'s'}
         name={'lti_roster_sync_enabled'}
       />
-      <button
-        type={'button'}
-        className={'btn'}
-        style={styles.button}
-        onClick={handleSubmit}
-        tabIndex={'0'}
-        disabled={!changed}
-      >
-        {i18n.ltiSectionSyncSettingsButtonText()}
-      </button>
+      <div style={styles.buttonContainer}>
+        <button
+          type={'button'}
+          className={'btn'}
+          onClick={handleSubmit}
+          tabIndex={'0'}
+          disabled={!changed}
+        >
+          {i18n.ltiSectionSyncSettingsButtonText()}
+        </button>
+      </div>
     </div>
   );
 }
 
 const styles = {
-  button: {
-    float: 'right',
+  buttonContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
   },
 };
 


### PR DESCRIPTION
The prior roster sync save button used floats which caused issues when the below div shifted up leading to some overlaps. Instead, refactor to use flex box which also improves the accessibility and RTL support for this page.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

![image](https://github.com/code-dot-org/code-dot-org/assets/538214/2f126a76-8500-411f-943d-2a52a53951da)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
