### PR TITLE
warn when using "wait until I am on" steps in Safari

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -335,6 +335,9 @@ And /^check that the URL matches "([^"]*)"$/ do |regex_text|
 end
 
 Then /^I wait until I am on "([^"]*)"$/ do |url|
+  if @browser.capabilities.browser_name == 'Safari'
+    puts "WARNING: 'I wait until I am on' is not reliable in Safari. Consider 'to load a new page' steps instead."
+  end
   url = replace_hostname(url)
   begin
     wait_until {@browser.current_url == url}


### PR DESCRIPTION
discussion of https://github.com/code-dot-org/code-dot-org/pull/59358 revealed a problem with "wait until I am on" steps in Safari, that could be having widespread effect on flaky UI tests. I didn't investigate the root cause, but instead I'm adding a breadcrumb for anyone who runs into this while investigating flaky UI tests.

## screenshots

warning is visible in cucumber log output in Safari:
![Screenshot 2024-06-25 at 12 38 42 PM](https://github.com/code-dot-org/code-dot-org/assets/8001765/a4c40d63-121c-4934-8542-1ac7e6ef0dbc)

