### PR TITLE
Add Curriculum Launch 2024 skinny banner

### DIFF
--- a/pegasus/sites.v3/code.org/public/administrators.haml
+++ b/pegasus/sites.v3/code.org/public/administrators.haml
@@ -21,7 +21,10 @@ theme: responsive_full_width
     .clear
 
 - if !DCDO.get('show-updated-lms-content', false)
-  = view :section_divider_line
+  - if !!DCDO.get('curriculum-launch-2024', false)
+    = view :curriculum_launch_skinny_banner
+  - else
+    = view :section_divider_line
 
 = view :"lms/lms_skinny_banner"
 

--- a/pegasus/sites.v3/code.org/public/css/curriculum-launch-skinny-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/curriculum-launch-skinny-banner.scss
@@ -1,0 +1,46 @@
+$width-sm: 640px;
+
+.curriculum-banner-skinny {
+  background: url('/images/banners/banner-lms-pattern.png') center center;
+  background-color: #292F36;
+  background-size: cover;
+  padding: 1rem 2rem;
+
+  .wrapper {
+    max-width: 960px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 5rem;
+
+    @media (max-width: 900px) {
+      gap: 2rem;
+    }
+
+    @media (max-width: $width-sm) {
+      padding-block: 2rem;
+      flex-direction: column;
+      justify-content: center;
+      gap: 1rem;
+    }
+  }
+
+  .text-wrapper {
+    flex: 2;
+    align-items: center;
+
+    @media (max-width: $width-sm) {
+      text-align: center;
+    }
+  }
+
+  img {
+    max-width: 10rem;
+    
+    @media (max-width: $width-sm) {
+      align-self: center;
+    }
+  }
+}

--- a/pegasus/sites.v3/code.org/public/css/curriculum-launch-skinny-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/curriculum-launch-skinny-banner.scss
@@ -1,7 +1,7 @@
 $width-sm: 640px;
 
 .curriculum-banner-skinny {
-  background: url('/images/banners/banner-lms-pattern.png') center center;
+  background: url('/images/banners/banner-bg-school-supplies-dark-black.png') center center;
   background-color: #292F36;
   background-size: cover;
   padding: 1rem 2rem;

--- a/pegasus/sites.v3/code.org/public/teach.haml
+++ b/pegasus/sites.v3/code.org/public/teach.haml
@@ -20,6 +20,8 @@ theme: responsive_full_width
     .clear
 
 = view :"lms/lms_skinny_banner"
+- if !DCDO.get('show-updated-lms-content', false)
+  = view :curriculum_launch_skinny_banner
 
 %section.why-teach-cs.bg-neutral-light
   .wrapper

--- a/pegasus/sites.v3/code.org/views/curriculum_launch_skinny_banner.haml
+++ b/pegasus/sites.v3/code.org/views/curriculum_launch_skinny_banner.haml
@@ -1,14 +1,15 @@
 - if !!DCDO.get('curriculum-launch-2024', false)
+  - button_url = "https://codeorg.medium.com/ai-game-design-and-more-in-code-orgs-2024-25-curriculum-updates-caff691935ad"
   %link{href: "/css/generated/curriculum-launch-skinny-banner.css", rel: "stylesheet"}
 
   .curriculum-banner-skinny
     .wrapper.flex-container.justify-space-between.align-items-center.wrap
       .text-wrapper
-        %h5.white
+        %h2.heading-sm.white
           =hoc_s('curriculum_launch_2024.banner.heading')
         %p.white.no-margin-bottom
           =hoc_s('curriculum_launch_2024.banner.desc')
       %img{src: "/images/banners/banner-curriculum-catalog-illustration-black.png", alt: ""}
-      %a.link-button.has-external-link.white{href: CDO.studio_url("/catalog"), target: "_blank", rel: "noopener noreferrer"}
+      %a.link-button.has-external-link.white{href: button_url, target: "_blank", rel: "noopener noreferrer"}
         =hoc_s('curriculum_launch_2024.banner.button_learn_more')
   .clear

--- a/pegasus/sites.v3/code.org/views/curriculum_launch_skinny_banner.haml
+++ b/pegasus/sites.v3/code.org/views/curriculum_launch_skinny_banner.haml
@@ -1,0 +1,14 @@
+- if !!DCDO.get('curriculum-launch-2024', false)
+  %link{href: "/css/generated/curriculum-launch-skinny-banner.css", rel: "stylesheet"}
+
+  .curriculum-banner-skinny
+    .wrapper.flex-container.justify-space-between.align-items-center.wrap
+      .text-wrapper
+        %h5.white
+          =hoc_s('curriculum_launch_2024.banner.heading')
+        %p.white.no-margin-bottom
+          =hoc_s('curriculum_launch_2024.banner.desc')
+      %img{src: "/images/banners/banner-curriculum-catalog-illustration-black.png", alt: ""}
+      %a.link-button.has-external-link.white{href: CDO.studio_url("/catalog"), target: "_blank", rel: "noopener noreferrer"}
+        =hoc_s('curriculum_launch_2024.banner.button_learn_more')
+  .clear


### PR DESCRIPTION
This PR adds in the Curriculum Launch skinny banner for 2024. There was one for 2023 created in [this PR](https://github.com/code-dot-org/code-dot-org/pull/52918) but it was deleted in [this PR](https://github.com/code-dot-org/code-dot-org/pull/55604). I would've salvaged more from it but it wasn't quite in the same format we've made our more recent skinny banners, so I based it on [the LMS one](https://github.com/code-dot-org/code-dot-org/pull/59035) since it was a similar structure.

Since the banner will be going where LMS banners are currently, they'll only show once the `show-updated-lms-content` DCDO flag is flipped off and `curriculum-launch-2024` is flipped on so that both aren't showing in the same spot. For the [/teach](https://code.org/teach) and [/administrators](https://code.org/administrators) pages, the LMS banner will just be gone once `show-updated-lms-content` is off since these pages already have the "Seamless LMS integration for simplified management" section.

Note: The banner looks a bit different than in the Figma. The background design is darker rather than a light gray. In [this thread](https://codedotorg.slack.com/archives/C04540KNGDQ/p1719434151141999), we thought it would be best to just use the existing pattern image since it was the same one just darker.

## Demos
### /teach page
Shows when `show-updated-lms-content` flag is off and `curriculum-launch-2024` is on:
![teach](https://github.com/code-dot-org/code-dot-org/assets/56283563/c11403df-9755-44db-9491-71cb14c44ac7)

Does not show when `show-updated-lms-content` is on or `curriculum-launch-2024` is off:
![teach_both_on](https://github.com/code-dot-org/code-dot-org/assets/56283563/110c9861-e20a-419f-aaaa-547a63e6bce2)

### /administrators page
Shows when `show-updated-lms-content` flag is off and `curriculum-launch-2024` is on:
![admin](https://github.com/code-dot-org/code-dot-org/assets/56283563/a5cc11d1-411a-4082-ad7b-30a66f769737)

Does not show when `show-updated-lms-content` is on or `curriculum-launch-2024` is off:
![admin_both_on](https://github.com/code-dot-org/code-dot-org/assets/56283563/5e9cc536-caaa-4c03-99d1-716fe1e0e2a9)

Shows divider line if both are off:
![show_divider](https://github.com/code-dot-org/code-dot-org/assets/56283563/3ebb7ddd-c030-4420-b929-43f535cefb3e)

### RTL
![rtl](https://github.com/code-dot-org/code-dot-org/assets/56283563/d4f7b695-ca8a-405f-924e-9618c99c5002)

### Responsive

https://github.com/code-dot-org/code-dot-org/assets/56283563/eb35903a-6bbf-47fc-b47a-f5bdf10de39a

## Links
Jira ticket to add to /teach: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1969)
Jira ticket to add to /administrators: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1970)
Figma: [here](https://www.figma.com/design/HwXIyBGQ0b2ZI213sWb3cK/2024-Curriculum-Launch?node-id=2727-11696&t=JQnQYZpI6ghryzZ6-0)

## Testing story
Local testing.
