### PR TITLE
Fixes pixelation widget.

### DIFF
--- a/apps/src/sites/studio/pages/levels/_pixelation.js
+++ b/apps/src/sites/studio/pages/levels/_pixelation.js
@@ -47,6 +47,8 @@ function setMinTextValues() {
   bitsPerPixelText.value = getPositiveValue(bitsPerPixelText);
 }
 
+window.setMinTextValues = setMinTextValues;
+
 function isHexSelected() {
   return 'hex' === document.querySelector('input[name="binHex"]:checked').value;
 }
@@ -724,6 +726,25 @@ function changeVal(elementID) {
 }
 
 window.changeVal = changeVal;
+
+/**
+ * Updates the sliders when they are updated via the text inputs or key input
+ * on the Pixelation widget.
+ */
+function setSliders() {
+  // Make sure slider value is at least 1
+  heightRange.value = getPositiveValue(heightText);
+  widthRange.value = getPositiveValue(widthText);
+  bitsPerPixelRange.value = getPositiveValue(bitsPerPixelText);
+
+  if (options.version !== '1') {
+    updateBinaryDataToMatchSliders();
+    formatBitDisplay();
+  }
+  drawGraph();
+}
+
+window.setSliders = setSliders;
 
 /**
  * Creates a PNG the given canvas and opens it in a new window.  Image can be copy/pasted, saved, etc. from there.

--- a/dashboard/test/ui/features/star_labs/pixelation.feature
+++ b/dashboard/test/ui/features/star_labs/pixelation.feature
@@ -33,6 +33,29 @@ Feature: Pixelation levels
     Then pixelation data has text "0000 0100 0000 0010 0000 0011 000 111 100 010 001 110 111 000 111 000 01"
 
   @as_student
+  Scenario: Pixelation sliders are accessible via keyboard keys
+    Given I am on the 2nd pixelation test level
+    And pixelation data has text "0000 0100 0000 0010 0000 0011 000 111 100 010 001 110"
+
+    When I press keys ":arrow_up" for element "#width"
+    And pixelation data has text "0000 0101 0000 0010 0000 0011 000 111 100 010 001 110"
+
+    When I press keys ":arrow_down" for element "#width"
+    And pixelation data has text "0000 0100 0000 0010 0000 0011 000 111 100 010 001 110"
+
+    When I press keys ":arrow_up" for element "#height"
+    And pixelation data has text "0000 0100 0000 0011 0000 0011 000 111 100 010 001 110"
+
+    When I press keys ":arrow_down" for element "#height"
+    And pixelation data has text "0000 0100 0000 0010 0000 0011 000 111 100 010 001 110"
+
+    When I press keys "7" for element "#height"
+    And pixelation data has text "0000 0100 0000 0111 0000 0011 000 111 100 010 001 110"
+
+    When I press keys "7" for element "#width"
+    And pixelation data has text "0000 0111 0000 0111 0000 0011 000 111 100 010 001 110"
+
+  @as_student
   Scenario: Pixelation version 3 in color with sliders starting in hex mode
     Given I am on the 3rd pixelation test level
     And pixelation data has text "04 04 18 FF0000 00AAAA"

--- a/dashboard/test/ui/features/star_labs/pixelation.feature
+++ b/dashboard/test/ui/features/star_labs/pixelation.feature
@@ -49,9 +49,11 @@ Feature: Pixelation levels
     When I press keys ":arrow_down" for element "#height"
     And pixelation data has text "0000 0100 0000 0010 0000 0011 000 111 100 010 001 110"
 
+    When I press keys ":backspace" for element "#height"
     When I press keys "7" for element "#height"
     And pixelation data has text "0000 0100 0000 0111 0000 0011 000 111 100 010 001 110"
 
+    When I press keys ":backspace" for element "#width"
     When I press keys "7" for element "#width"
     And pixelation data has text "0000 0111 0000 0111 0000 0011 000 111 100 010 001 110"
 

--- a/dashboard/test/ui/features/star_labs/pixelation.feature
+++ b/dashboard/test/ui/features/star_labs/pixelation.feature
@@ -33,7 +33,7 @@ Feature: Pixelation levels
     Then pixelation data has text "0000 0100 0000 0010 0000 0011 000 111 100 010 001 110 111 000 111 000 01"
 
   @as_student
-  Scenario: Pixelation sliders are accessible via keyboard keys
+  Scenario: Pixelation slider input fields are accessible via keyboard keys
     Given I am on the 2nd pixelation test level
     And pixelation data has text "0000 0100 0000 0010 0000 0011 000 111 100 010 001 110"
 


### PR DESCRIPTION
This file is a bit of a kludge from older days. I put it in the asset pipeline when I added localization way back when. Eventually, [we put up some stricter linting and the function got deleted](https://github.com/code-dot-org/code-dot-org/pull/51598/files#r1180616080) since it wasn't referenced the normal way.

I have restored it.

## Links

- [Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/499206)
- [Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1719348763588029)

## Testing story

Reproduced it locally first, wrote UI tests to also get a red test run, then reintroduced the missing code.

UI tests now are green. The new tests will type in the boxes and press 'up' and 'down' in the inputs to see that they are wired up and working accessibly. It's pretty tricky to test the up/down buttons but the keyboard keys are a great facsimile... they should go hand-in-hand, so I'm confident.

Here is the red UI test (locally):

```
[star_labs/pixelation] @no_mobile
[star_labs/pixelation] Feature: Pixelation levels
[star_labs/pixelation]
[star_labs/pixelation]   @as_student
[star_labs/pixelation]   Scenario: Pixelation sliders are accessible via keyboard keys                          # features/star_labs/pixelation.feature:4
[star_labs/pixelation]     Given I am on the 2nd pixelation test level                                          # features/step_definitions/pixelation.rb:1
[star_labs/pixelation]     And pixelation data has text "0000 0100 0000 0010 0000 0011 000 111 100 010 001 110" # features/step_definitions/pixelation.rb:40
[star_labs/pixelation]     When I press keys ":arrow_up" for element "#width"                                   # features/step_definitions/steps.rb:1244
[star_labs/pixelation]     And pixelation data has text "0000 0101 0000 0010 0000 0011 000 111 100 010 001 110" # features/step_definitions/pixelation.rb:40
[star_labs/pixelation]
[star_labs/pixelation]       expected: "000001010000001000000011000111100010001110"
[star_labs/pixelation]            got: "000001000000001000000011000111100010001110"
```

The green UI test (locally):

```
./runner.rb --verbose --pegasus=localhost.code.org:3000 --dashboard=localhost-studio.code.org:3000 --local --headed --feature=/app/src/dashboard/test/ui/features/star_labs/pixelation.feature
Finished test:ui (1 minute)
```

Here it is working, visually, via manual testing (`http://localhost-studio.code.org:3000/s/pixelation/lessons/4/levels/2`):

![image](https://github.com/code-dot-org/code-dot-org/assets/31674/910caf9d-c24a-4e49-b008-76d5cc9d35cc)

No errors in the JS console.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
