### PR TITLE
AI Chat: disable update/save/publish buttons until changes have been made

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -544,6 +544,12 @@ export const selectAllMessages = (state: {aichat: AichatState}) => {
   return messages;
 };
 
+export const selectHavePropertiesChanged = (state: RootState) =>
+  findChangedProperties(
+    state.aichat.savedAiCustomizations,
+    state.aichat.currentAiCustomizations
+  ).length > 0;
+
 // Actions not to be used outside of this file
 const {
   addChatMessage,

--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -7,6 +7,7 @@ import {
   saveModelCard,
   publishModel,
   selectHasFilledOutModelCard,
+  selectHavePropertiesChanged,
 } from '@cdo/apps/aichat/redux/aichatRedux';
 import Button from '@cdo/apps/componentLibrary/button/Button';
 import {FontAwesomeV6IconProps} from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';
@@ -38,6 +39,7 @@ const PublishNotes: React.FunctionComponent = () => {
   const isReadOnly = useSelector(isReadOnlyWorkspace) || isDisabled(visibility);
   const saveInProgress = useAppSelector(state => state.aichat.saveInProgress);
   const currentSaveType = useAppSelector(state => state.aichat.currentSaveType);
+  const havePropertiesChanged = useAppSelector(selectHavePropertiesChanged);
 
   const onSave = useCallback(() => {
     dispatch(saveModelCard());
@@ -109,7 +111,7 @@ const PublishNotes: React.FunctionComponent = () => {
           }
           type="secondary"
           color="black"
-          disabled={isReadOnly || saveInProgress}
+          disabled={isReadOnly || saveInProgress || !havePropertiesChanged}
           onClick={onSave}
           className={modelCustomizationStyles.updateButton}
         />
@@ -120,7 +122,12 @@ const PublishNotes: React.FunctionComponent = () => {
               ? spinnerIconProps
               : {iconName: 'upload'}
           }
-          disabled={isReadOnly || !hasFilledOutModelCard || saveInProgress}
+          disabled={
+            isReadOnly ||
+            !hasFilledOutModelCard ||
+            saveInProgress ||
+            !havePropertiesChanged
+          }
           onClick={onPublish}
           className={modelCustomizationStyles.updateButton}
         />

--- a/apps/src/aichat/views/modelCustomization/UpdateButton.tsx
+++ b/apps/src/aichat/views/modelCustomization/UpdateButton.tsx
@@ -3,7 +3,10 @@ import React, {useCallback} from 'react';
 import {Button} from '@cdo/apps/componentLibrary/button';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {updateAiCustomization} from '../../redux/aichatRedux';
+import {
+  selectHavePropertiesChanged,
+  updateAiCustomization,
+} from '../../redux/aichatRedux';
 
 import styles from '../model-customization-workspace.module.scss';
 
@@ -21,11 +24,12 @@ const UpdateButton: React.FunctionComponent<UpdateButtonProps> = ({
   );
   const saveInProgress = useAppSelector(state => state.aichat.saveInProgress);
   const currentSaveType = useAppSelector(state => state.aichat.currentSaveType);
+  const havePropertiesChanged = useAppSelector(selectHavePropertiesChanged);
 
   return (
     <Button
       text="Update"
-      disabled={isDisabledDefault || saveInProgress}
+      disabled={isDisabledDefault || saveInProgress || !havePropertiesChanged}
       iconLeft={
         saveInProgress && currentSaveType === 'updateChatbot'
           ? {iconName: 'spinner', animationType: 'spin'}


### PR DESCRIPTION
This just checks if the existing `findChangedProperties` method returns any items, and if so, enables the update buttons.

https://github.com/code-dot-org/code-dot-org/assets/85528507/99773b4e-1569-4f73-b436-1928ee173285

## Links

https://codedotorg.atlassian.net/browse/LABS-744

## Testing story

Tested locally on a Gen AI pilot level and allthethings.