### PR TITLE
Enable datablock storage for Game Lab

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -31,7 +31,11 @@ var p5GroupWrapper = require('./P5GroupWrapper');
 var gamelabCommands = require('./gamelab/commands');
 import {initializeSubmitHelper, onSubmitComplete} from '@cdo/apps/submitHelper';
 var dom = require('@cdo/apps/dom');
-import {initStorage, FIREBASE_STORAGE} from '../storage/storage';
+import {
+  initStorage,
+  FIREBASE_STORAGE,
+  DATABLOCK_STORAGE,
+} from '../storage/storage';
 import {getStore} from '@cdo/apps/redux';
 import {
   allAnimationsSingleFrameSelector,
@@ -254,14 +258,22 @@ export default class P5Lab {
     config.usesAssets = true;
 
     this.studioApp_.labUserId = config.labUserId;
-    // TODO: unfirebase, convert to datablock storage: #56995
-    this.studioApp_.storage = initStorage(FIREBASE_STORAGE, {
-      channelId: config.channel,
-      firebaseName: config.firebaseName,
-      firebaseAuthToken: config.firebaseAuthToken,
-      firebaseChannelIdSuffix: config.firebaseChannelIdSuffix || '',
-      showRateLimitAlert: this.studioApp_.showRateLimitAlert,
-    });
+
+    // TODO: post-firebase-cleanup, remove this conditional when we're removing firebase: #56994
+    if (!!config.useDatablockStorage) {
+      this.studioApp_.storage = initStorage(DATABLOCK_STORAGE, {
+        channelId: config.channel,
+      });
+    } else {
+      this.studioApp_.storage = initStorage(FIREBASE_STORAGE, {
+        channelId: config.channel,
+        firebaseName: config.firebaseName,
+        firebaseAuthToken: config.firebaseAuthToken,
+        firebaseSharedAuthToken: config.firebaseSharedAuthToken,
+        firebaseChannelIdSuffix: config.firebaseChannelIdSuffix || '',
+        showRateLimitAlert: this.studioApp_.showRateLimitAlert,
+      });
+    }
 
     this.p5Wrapper.init({
       gameLab: this,

--- a/apps/src/p5lab/gamelab/commands.js
+++ b/apps/src/p5lab/gamelab/commands.js
@@ -2,6 +2,9 @@
 import {singleton as studioApp} from '@cdo/apps/StudioApp';
 import {commands as audioCommands} from '@cdo/apps/lib/util/audioApi';
 import {commands as timeoutCommands} from '@cdo/apps/lib/util/timeoutApi';
+import {rateLimit} from '@cdo/apps/storage/rateLimit';
+
+import {outputError} from '../../lib/util/javascriptMode';
 
 /*
   The 'commands' file assembles a set of calls that student code can make
@@ -25,7 +28,12 @@ gamelabCommands.getUserId = function () {
 gamelabCommands.getKeyValue = function (opts) {
   var onSuccess = gamelabCommands.handleReadValue.bind(this, opts);
   var onError = opts.onError;
-  studioApp().storage.getKeyValue(opts.key, onSuccess, onError);
+  try {
+    rateLimit();
+    studioApp().storage.getKeyValue(opts.key, onSuccess, onError);
+  } catch (e) {
+    outputError(e.message);
+  }
 };
 
 gamelabCommands.handleReadValue = function (opts, value) {
@@ -37,7 +45,12 @@ gamelabCommands.handleReadValue = function (opts, value) {
 gamelabCommands.setKeyValue = function (opts) {
   var onSuccess = gamelabCommands.handleSetKeyValue.bind(this, opts);
   var onError = opts.onError;
-  studioApp().storage.setKeyValue(opts.key, opts.value, onSuccess, onError);
+  try {
+    rateLimit();
+    studioApp().storage.setKeyValue(opts.key, opts.value, onSuccess, onError);
+  } catch (e) {
+    outputError(e.message);
+  }
 };
 
 gamelabCommands.handleSetKeyValue = function (opts) {

--- a/apps/src/p5lab/gamelab/commands.js
+++ b/apps/src/p5lab/gamelab/commands.js
@@ -4,7 +4,10 @@ import {commands as audioCommands} from '@cdo/apps/lib/util/audioApi';
 import {commands as timeoutCommands} from '@cdo/apps/lib/util/timeoutApi';
 import {rateLimit} from '@cdo/apps/storage/rateLimit';
 
-import {outputError} from '../../lib/util/javascriptMode';
+import {
+  getAsyncOutputWarning,
+  outputError,
+} from '../../lib/util/javascriptMode';
 
 /*
   The 'commands' file assembles a set of calls that student code can make
@@ -27,7 +30,7 @@ gamelabCommands.getUserId = function () {
 
 gamelabCommands.getKeyValue = function (opts) {
   var onSuccess = gamelabCommands.handleReadValue.bind(this, opts);
-  var onError = opts.onError;
+  var onError = opts.onError || getAsyncOutputWarning();
   try {
     rateLimit();
     studioApp().storage.getKeyValue(opts.key, onSuccess, onError);
@@ -44,7 +47,7 @@ gamelabCommands.handleReadValue = function (opts, value) {
 
 gamelabCommands.setKeyValue = function (opts) {
   var onSuccess = gamelabCommands.handleSetKeyValue.bind(this, opts);
-  var onError = opts.onError;
+  var onError = opts.onError || getAsyncOutputWarning();
   try {
     rateLimit();
     studioApp().storage.setKeyValue(opts.key, opts.value, onSuccess, onError);

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -452,8 +452,7 @@ class Projects
 
   # TODO: post-firebase-cleanup, remove this once we switch 100% to datablock storage
   private def set_use_datablock_storage(project_id, project_type)
-    # TODO: unfirebase, include 'gamelab' in this list, see #56995
-    if ['applab'].include? project_type
+    if ['applab', 'gamelab'].include? project_type
       # While we transition, a fraction of new projects will be set at creation
       # to use datablock storage. As we gain confidence, we can increase this
       # DCDO flag to 1.0. At that point, we're ready to migrate all the old projects.


### PR DESCRIPTION
Game Lab has undocumented setKeyValue and getKeyValue data blocks. This shifts them to using datablock storage instead of Firebase.

Fixes #56995 