### PR TITLE
put expand all rows dropdown behind DCDO flag

### DIFF
--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -48,6 +48,11 @@ function SectionProgressV2({
     getLocalStorage(scriptId, sectionId)
   );
 
+  const expandedMetadataEnabled = React.useMemo(
+    () => DCDO.get('progress-v2-metadata-enabled', false),
+    []
+  );
+
   React.useEffect(() => {
     setExpandedLessonIds(getLocalStorage(scriptId, sectionId));
     analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW, {
@@ -103,9 +108,7 @@ function SectionProgressV2({
           {i18n.lessonsIn()}
 
           <UnitSelectorV2 className={styles.titleUnitSelectorDropdown} />
-          {DCDO.get('progress-table-v2-metadata-enabled', false) && (
-            <MoreOptionsDropdown />
-          )}
+          {expandedMetadataEnabled && <MoreOptionsDropdown />}
         </Heading6>
       </div>
       <ProgressTableV2

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -108,6 +108,7 @@ function SectionProgressV2({
           {i18n.lessonsIn()}
 
           <UnitSelectorV2 className={styles.titleUnitSelectorDropdown} />
+          {console.log(expandedMetadataEnabled)}
           {expandedMetadataEnabled && <MoreOptionsDropdown />}
         </Heading6>
       </div>

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 import {Heading1, Heading6} from '@cdo/apps/componentLibrary/typography';
+import DCDO from '@cdo/apps/dcdo';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
@@ -102,7 +103,9 @@ function SectionProgressV2({
           {i18n.lessonsIn()}
 
           <UnitSelectorV2 className={styles.titleUnitSelectorDropdown} />
-          <MoreOptionsDropdown />
+          {DCDO.get('progress-table-v2-metadata-enabled', false) && (
+            <MoreOptionsDropdown />
+          )}
         </Heading6>
       </div>
       <ProgressTableV2

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -108,7 +108,6 @@ function SectionProgressV2({
           {i18n.lessonsIn()}
 
           <UnitSelectorV2 className={styles.titleUnitSelectorDropdown} />
-          {console.log(expandedMetadataEnabled)}
           {expandedMetadataEnabled && <MoreOptionsDropdown />}
         </Heading6>
       </div>

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressV2Test.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressV2Test.jsx
@@ -38,6 +38,7 @@ describe('SectionProgressV2', () => {
     store = createStore(5, 5);
     store.dispatch(setScriptId(1));
     store.dispatch(finishLoadingProgress());
+    DCDO.set('progress-v2-metadata-enabled', false);
   });
 
   afterEach(() => {

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressV2Test.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressV2Test.jsx
@@ -2,6 +2,7 @@ import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {Provider} from 'react-redux';
 
+import DCDO from '@cdo/apps/dcdo';
 import {registerReducers, restoreRedux, stubRedux} from '@cdo/apps/redux';
 import unitSelection, {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
 import currentUser from '@cdo/apps/templates/currentUserRedux';
@@ -52,6 +53,7 @@ describe('SectionProgressV2', () => {
   }
 
   it('shows expand and collapse dropdown', () => {
+    DCDO.set('progress-v2-metadata-enabled', true);
     renderDefault();
 
     store.dispatch(setStudentsForCurrentSection(1, STUDENTS));


### PR DESCRIPTION
Puts button to expand and contract all rows of metadata behind a DCDO flag. 

![image](https://github.com/code-dot-org/code-dot-org/assets/24883357/c966d2ab-8242-4c61-8f80-d97db9e33030)


Updated tests as needed. 