### PR TITLE
 fix(lms): only lock out users if session is populated with context

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -372,7 +372,7 @@ class ApplicationController < ActionController::Base
 
   # Check that the user has completed the LMS onboarding flow
   protected def assert_lms_landing_policy
-    return unless Policies::Lti.lti?(current_user) && !current_user.lms_landing_opted_out
+    return unless Policies::Lti.account_linking?(session, current_user)
 
     # URLs we should not redirect.
     return if Set[

--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -18,8 +18,8 @@ module Lti
         # clear the session, so we need to store cache key first, sign them out,
         # then set it again in their now empty session.
         if current_user
-          partial_registration_cache_key = PartialRegistration.cache_key(current_user)
-          sign_out
+          partial_registration_cache_key = session[PartialRegistration::SESSION_KEY]
+          sign_out current_user
           session[PartialRegistration::SESSION_KEY] = partial_registration_cache_key
         end
 

--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -45,15 +45,14 @@ module Lti
       # POST /lti/v1/account_linking/new_account
       def new_account
         if current_user
+          return render status: :bad_request, json: {} if current_user.nil?
 
           current_user.lms_landing_opted_out = true
           current_user.save!
-        elsif PartialRegistration.in_progress?(session)
+        else
           partial_user = User.new_with_session(ActionController::Parameters.new, session)
           partial_user.lms_landing_opted_out = true
           PartialRegistration.persist_attributes(session, partial_user)
-        else
-          render status: :bad_request, json: {}
         end
       end
 

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -141,6 +141,10 @@ class Policies::Lti
     !user.authentication_options.empty? && user.authentication_options.any?(&:lti?)
   end
 
+  def self.only_lti_auth?(user)
+    user.authentication_options&.length == 1 && user.authentication_options.first.lti?
+  end
+
   def self.issuer(user)
     auth_options = user.authentication_options.find(&:lti?)
     if auth_options
@@ -218,5 +222,9 @@ class Policies::Lti
   # Check if a partial registration is in progress for an LTI user.
   def self.lti_registration_in_progress?(session)
     PartialRegistration.in_progress?(session) && PartialRegistration.get_provider(session) == AuthenticationOption::LTI_V1
+  end
+
+  def self.account_linking?(session, user)
+    session[:lms_landing].present? && Policies::Lti.only_lti_auth?(user) && !user.lms_landing_opted_out
   end
 end

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -225,6 +225,6 @@ class Policies::Lti
   end
 
   def self.account_linking?(session, user)
-    session[:lms_landing].present? && Policies::Lti.only_lti_auth?(user) && !user.lms_landing_opted_out
+    session[:lms_landing].present? && only_lti_auth?(user) && !user.lms_landing_opted_out
   end
 end

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -713,7 +713,7 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
       create :teacher_feedback, script: script, level: weblab_level, student: student, teacher: @teacher
     end
 
-    assert_queries 16 do
+    assert_queries 14 do
       get :section_feedback, params: {section_id: @section.id, script_id: script.id}
     end
 

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -147,7 +147,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: score}]}
 
-    assert_queries 10 do
+    assert_queries 8 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
 
@@ -159,7 +159,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal section.students.count, 11
 
-    assert_queries 10 do
+    assert_queries 8 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
   end

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1110,7 +1110,7 @@ class ApiControllerTest < ActionController::TestCase
   test "should get progress for section with section script" do
     Unit.stubs(:should_cache?).returns true
 
-    assert_queries 10 do
+    assert_queries 8 do
       get :section_progress, params: {section_id: @flappy_section.id}
     end
     assert_response :success

--- a/dashboard/test/controllers/application_controller_test.rb
+++ b/dashboard/test/controllers/application_controller_test.rb
@@ -150,32 +150,22 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
       sign_in user
     end
 
-    it 'should redirect to landing path' do
-      get root_path
+    describe 'with session initialized' do
+      before do
+        Policies::Lti.stubs(:account_linking?).returns(true)
+      end
 
-      assert_redirected_to lti_v1_account_linking_landing_path
-    end
+      it 'should redirect to landing path' do
+        get root_path
 
-    it 'should NOT redirect if opted out' do
-      user.lms_landing_opted_out = true
-      user.save
+        assert_redirected_to lti_v1_account_linking_landing_path
+      end
 
-      get root_path
-      assert_redirected_to home_path
-    end
+      it 'should NOT redirect to landing path for allow listed paths' do
+        get destroy_user_session_path
 
-    it 'should NOT redirect to landing path for allow listed paths' do
-      get destroy_user_session_path
-
-      assert_redirected_to '//test.code.org'
-    end
-
-    it 'should NOT redirect if not a lti user' do
-      regular_user = create(:student)
-      sign_in regular_user
-      get root_path
-
-      assert_redirected_to home_path
+        assert_redirected_to '//test.code.org'
+      end
     end
   end
 

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -52,9 +52,9 @@ class CoursesControllerTest < ActionController::TestCase
       @unit_group_regular = create :unit_group, name: 'non-plc-course', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
     end
 
-    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 12
+    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 10
 
-    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 6
+    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 4
   end
 
   class CachedQueryCounts < ActionController::TestCase

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -55,7 +55,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level.id
     )
 
-    assert_cached_queries(6) do
+    assert_cached_queries(4) do
       get user_app_options_path,
         headers: {HTTP_USER_AGENT: 'test'}
       assert_response :success
@@ -70,7 +70,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
-    assert_cached_queries(13) do
+    assert_cached_queries(11) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -87,7 +87,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
-    assert_cached_queries(11) do
+    assert_cached_queries(9) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -103,7 +103,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     sl = create(:script, :with_levels, levels_count: 3).script_levels[2]
     params = {program: 'fake program', testResult: 0, result: 'false'}
 
-    assert_cached_queries(11) do
+    assert_cached_queries(9) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -131,7 +131,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(script)
     sign_in student
 
-    assert_cached_queries(8) do
+    assert_cached_queries(7) do
       get "/s/#{script.name}"
       assert_response :success
     end
@@ -139,12 +139,12 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     # Simulate all the ajax requests which the unit overview page sends to the
     # server on page load.
 
-    assert_cached_queries(8) do
+    assert_cached_queries(6) do
       get "/api/user_progress/#{script.name}"
       assert_response :success
     end
 
-    assert_cached_queries(6) do
+    assert_cached_queries(4) do
       get "/api/v1/teacher_feedbacks/count?student_id=#{student.id}"
       assert_response :success
     end
@@ -182,12 +182,12 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     # Simulate all the ajax requests which the level page sends to the
     # server on page load.
 
-    assert_cached_queries(4) do
+    assert_cached_queries(2) do
       get "/api/user_app_options/#{unit.name}/1/1/#{level.id}"
       assert_response :success
     end
 
-    assert_cached_queries(6) do
+    assert_cached_queries(4) do
       get "/levels/#{level.id}/get_rubric"
       assert_response :success
     end


### PR DESCRIPTION
This PR updates the lock out criteria to ensure we only lock out if the session is instantiated with the appropriate context. It also improves the specificity by only locking out new LTI users.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-1015)

## Testing story

[Tested by Carl
](https://codedotorg.slack.com/archives/C061VNB3YE9/p1719425018081999?thread_ts=1719413948.321039&cid=C061VNB3YE9)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
