### PR TITLE
Remove "Coming soon" for LMS banner

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/lms-integrations-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/lms-integrations-banner.scss
@@ -1,24 +1,4 @@
 .logos {
-  margin-block: 3rem 1rem;
+  margin-block: 2rem;
   gap: 4rem;
-
-  .coming-soon {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.75rem;
-
-    p {
-      background: var(--brand_primary_light);
-      color: var(--neutral_dark90);
-      border-radius: 1rem;
-      margin: 0 0 0 0.875rem;
-      padding: 7px 12px 6px;
-      font-size: 0.65rem;
-      font-weight: var(--semi-bold-font-weight);
-      text-transform: uppercase;
-      letter-spacing: 0.03rem;
-      line-height: 1;
-    }
-  }
 }

--- a/pegasus/sites.v3/code.org/public/teach.haml
+++ b/pegasus/sites.v3/code.org/public/teach.haml
@@ -124,8 +124,7 @@ theme: responsive_full_width
         %strong
           Are you a district leader or administrator? <a href="/administrators">Find out how to bring Code.org to your district</a>.
 
-- if !!DCDO.get('show-updated-lms-content', false)
-  = view :"lms/lms_integrations_banner"
+= view :"lms/lms_integrations_banner"
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/views/lms/lms_integrations_banner.haml
+++ b/pegasus/sites.v3/code.org/views/lms/lms_integrations_banner.haml
@@ -8,12 +8,7 @@
     .logos.flex-container.justify-center.align-items-start.wrap
       %img{src: "/images/avatars/lms-logo-clever.png", alt: "Clever", style: "width: 115px"}
       %img{src: "/images/avatars/lms-logo-google-classroom.png", alt: "Google Classroom", style: "width: 185px"}
-      .coming-soon
-        %img{src: "/images/avatars/lms-logo-canvas.png", alt: "Canvas", style: "width: 150px"}
-        %p=hoc_s(:module_label_coming_soon)
-      .coming-soon
-        %img{src: "/images/avatars/lms-logo-schoology.png", alt: "Schoology", style: "width: 185px"}
-        %p=hoc_s(:module_label_coming_soon)
-    - if !!DCDO.get('show-updated-lms-content', false)
-      %a.link-button{href: "/lms", target: "_blank", rel: "noopener noreferrer"}
-        =hoc_s(:admins_page_lms_call_to_action)
+      %img{src: "/images/avatars/lms-logo-canvas.png", alt: "Canvas", style: "width: 150px"}
+      %img{src: "/images/avatars/lms-logo-schoology.png", alt: "Schoology", style: "width: 185px"}
+    %a.link-button{href: "/lms", target: "_blank", rel: "noopener noreferrer"}
+      =hoc_s(:admins_page_lms_call_to_action)


### PR DESCRIPTION
Following this thread, this PR:
- Removes the "Coming soon" tags for Canvas and Schoology
- Separates the integration banner from the `show-updated-lms-content` DCDO flag

![No_Coming_Soon](https://github.com/code-dot-org/code-dot-org/assets/56283563/278dd562-8f5b-461a-9270-206e26e693a6)

## Links
Slack thread: [here](https://codedotorg.slack.com/archives/C0453TUMLE7/p1719420405236829?thread_ts=1719420094.811089&cid=C0453TUMLE7)

## Testing story
Local testing.
