### PR TITLE
AI Chat: always enable publish button if model card is complete

### DIFF
--- a/apps/i18n/aichat/en_us.json
+++ b/apps/i18n/aichat/en_us.json
@@ -1,5 +1,6 @@
 {
   "aichatWorkspaceHeader": "AI Chat",
+  "startOverAichatModelCustomizations": "This will reset this level to its start state and remove any model customizations or model card information you’ve added or changed.",
   "continue": "Continue",
   "inappropriateUserMessage": "This message has been flagged as inappropriate.",
   "tooPersonalUserMessage": "This message has been flagged as too personal.",

--- a/apps/i18n/aichat/en_us.json
+++ b/apps/i18n/aichat/en_us.json
@@ -1,8 +1,8 @@
 {
   "aichatWorkspaceHeader": "AI Chat",
-  "startOverAichatModelCustomizations": "This will reset this level to its start state and remove any model customizations or model card information you’ve added or changed.",
   "continue": "Continue",
   "inappropriateUserMessage": "This message has been flagged as inappropriate.",
+  "startOverAichatModelCustomizations": "This will reset this level to its start state and remove any model customizations or model card information you’ve added or changed.",
   "tooPersonalUserMessage": "This message has been flagged as too personal.",
   "waitingForChatResponse": "Waiting for a response...",
   "whatIsPersonalInformation": "What is considered personal information?"

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2686,7 +2686,6 @@
   "startOver": "Start Over",
   "startOverTitle": "Are you sure you want to start over?",
   "startOverBody": "This will reset the puzzle to its start state and reset all the data you've added or changed.",
-  "startOverAichatModelCustomizations": "This will reset this level to its start state and remove any model customizations or model card information you’ve added or changed.",
   "startOverWorkspace": "This will reset the workspace to its start state and remove all the blocks you've added or changed.",
   "startOverWorkspaceText": "This will reset the workspace to its start state and remove all the code you've added or changed.",
   "startWithUnit": "Start with unit:",

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -236,6 +236,17 @@ export const onSaveComplete =
     }
   };
 
+// Thunk called when a save no-ops (there are no changes to save)
+export const onSaveNoop =
+  () => (dispatch: AppDispatch, getState: () => RootState) => {
+    // Even if no changes were saved, go to the presentation page if the user tried to publish
+    // a model card.
+    if (getState().aichat.currentSaveType === 'publishModelCard') {
+      dispatch(setViewMode(ViewMode.PRESENTATION));
+    }
+    dispatch(endSave());
+  };
+
 // Thunk called when a save has failed.
 export const onSaveFail = () => (dispatch: AppDispatch) => {
   dispatch(

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -25,13 +25,14 @@ import aichatI18n from '../locale';
 import {
   addNotification,
   clearChatMessages,
-  endSave,
   onSaveComplete,
   onSaveFail,
+  onSaveNoop,
   resetToDefaultAiCustomizations,
   selectAllFieldsHidden,
   setStartingAiCustomizations,
   setViewMode,
+  updateAiCustomization,
 } from '../redux/aichatRedux';
 import {getNewMessageId} from '../redux/utils';
 import {AichatLevelProperties, Notification, ViewMode} from '../types';
@@ -89,7 +90,7 @@ const AichatView: React.FunctionComponent = () => {
     }
     // No save occurred
     projectManager.addSaveNoopListener(() => {
-      dispatch(endSave());
+      dispatch(onSaveNoop());
     });
 
     projectManager.addSaveSuccessListener(() => {
@@ -163,6 +164,8 @@ const AichatView: React.FunctionComponent = () => {
 
   const resetProject = useCallback(() => {
     dispatch(resetToDefaultAiCustomizations(levelAichatSettings));
+    // Save the customizations to the user's project.
+    dispatch(updateAiCustomization());
     dispatch(clearChatMessages());
     dispatch(addNotification(getResetModelNotification()));
   }, [dispatch, levelAichatSettings]);

--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -122,12 +122,7 @@ const PublishNotes: React.FunctionComponent = () => {
               ? spinnerIconProps
               : {iconName: 'upload'}
           }
-          disabled={
-            isReadOnly ||
-            !hasFilledOutModelCard ||
-            saveInProgress ||
-            !havePropertiesChanged
-          }
+          disabled={isReadOnly || !hasFilledOutModelCard || saveInProgress}
           onClick={onPublish}
           className={modelCustomizationStyles.updateButton}
         />

--- a/apps/src/lab2/views/dialogs/StartOverDialog.tsx
+++ b/apps/src/lab2/views/dialogs/StartOverDialog.tsx
@@ -5,10 +5,12 @@ import moduleStyles from './confirm-dialog.module.scss';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {TEXT_BASED_LABS} from '../../constants';
 import {commonI18n} from '@cdo/apps/types/locale';
+import aichatI18n from '@cdo/apps/aichat/locale';
+import {AppName} from '../../types';
 
 // Lab-specific messages for starting over.
-const LAB_SPECIFIC_MESSAGES: {[key: string]: string} = {
-  aichat: commonI18n.startOverAichatModelCustomizations(),
+const LAB_SPECIFIC_MESSAGES: {[appName in AppName]?: string} = {
+  aichat: aichatI18n.startOverAichatModelCustomizations(),
 };
 
 /**
@@ -18,14 +20,15 @@ const StartOverDialog: React.FunctionComponent<BaseDialogProps> = ({
   handleConfirm,
   handleCancel,
 }) => {
-  const currentAppName =
-    useAppSelector(state => state.lab.levelProperties?.appName) || '';
+  const currentAppName = useAppSelector(
+    state => state.lab.levelProperties?.appName
+  );
 
   const isTextWorkspace =
     currentAppName && TEXT_BASED_LABS.includes(currentAppName);
 
   const dialogMessage =
-    LAB_SPECIFIC_MESSAGES[currentAppName] ||
+    (currentAppName && LAB_SPECIFIC_MESSAGES[currentAppName]) ||
     (isTextWorkspace
       ? commonI18n.startOverWorkspaceText()
       : commonI18n.startOverWorkspace());


### PR DESCRIPTION
Fast follow to https://github.com/code-dot-org/code-dot-org/pull/59403 (thanks @fisher-alice for catching this edge case). Always enable the publish button (as long as model card is complete) even if there haven't been any changes made. I felt that this was the simplest solution since, even if there aren't any changes to save, the Publish button still functions as a way to transition the user to the Presentation View, and we can still show the "Ready to Publish" banner without it being too confusing.

https://github.com/code-dot-org/code-dot-org/assets/85528507/67cd06f8-a0aa-4f87-9844-5a42e4682d5b

## Testing story

Tested on Gen AI pilot model card level.