### PR TITLE
mark computer-vision and csd2-2024 as ready to be translated

### DIFF
--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -269,7 +269,9 @@ module ScriptConstants
     K5_ONLINEPD_2019 = 'k5-onlinepd-2019'.freeze,
     K5_ONLINEPD = 'K5-OnlinePD'.freeze,
     KODEA_PD_2021 = 'kodea-pd-2021'.freeze,
-    ALLTHETHINGS = 'allthethings'.freeze
+    ALLTHETHINGS = 'allthethings'.freeze,
+    COMPUTER_VISION = 'computer-vision'.freeze,
+    CSD2_2024 = 'csd2-2024'.freeze,
   ]
 
   DEFAULT_VERSION_YEAR = '2017'


### PR DESCRIPTION
per [slack discussion](https://codedotorg.slack.com/archives/C045UAX4WKH/p1719438916277409?thread_ts=1719357431.904909&cid=C045UAX4WKH), we're not marking most 2024 courses as ready to translate any time soon. only these two are ready to translate.

## Testing story

existing test coverage, just to make sure nothing is broken

## Follow-up work

See the same slack thread above for ideas about moving this into a levelbuilder setting, especially since the curriculum team is generally managing the curriculum launch process now.