### PR TITLE
Fix lti_section_owner_changed metric

### DIFF
--- a/dashboard/app/controllers/lti/v1/sections_controller.rb
+++ b/dashboard/app/controllers/lti/v1/sections_controller.rb
@@ -20,6 +20,7 @@ module Lti
               section_id: section.id,
               previous_owner_id: section.user_id,
               new_owner_id: owner_id,
+              lms_name: section&.lti_course&.lti_integration&.platform_name,
             }
             section.update!(user_id: owner_id)
             Metrics::Events.log_event(


### PR DESCRIPTION
The original ticket for this was to add the missing `lms_name` property to the event metadata. However, I also noticed that events were being published even when the section owner did not change. This was happening because the IDs were strings. Rails automatically casts the strings to ints, so the function was working, but when we compared the new and old owner IDs to determine whether or not to publish the `lti_section_owner_changed`, they never matched, because the real ID is never a string.

This PR:
- Adds the missing `lms_name` property
- Casts the two offending IDs into ints for consistency and to fix the comparison

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1012)

## Testing story

Tested locally. Example output pre-change. Note the first event, where the `previous_owner_id` is `203` and the `new_owner_id` is `"203"`:
```
Logging Event: {"user_id":203,"custom_ids":{"user_type":"teacher"},"event_name":"lti_section_owner_changed","event_value":"lti_section_owner_changed","metadata":{"section_id":78,"previous_owner_id":203,"new_owner_id":"203","lms_name":"canvas_cloud"}}
Logging Event: {"user_id":203,"custom_ids":{"user_type":"teacher"},"event_name":"lti_section_owner_changed","event_value":"lti_section_owner_changed","metadata":{"section_id":79,"previous_owner_id":203,"new_owner_id":"209","lms_name":"canvas_cloud"}}
```



Example post-change. No event is published for the section that didn't have an actual change in ownership, and the event for the changed section does have numbers in all the number fields.
```
Logging Event: {"user_id":203,"custom_ids":{"user_type":"teacher"},"event_name":"lti_section_owner_changed","event_value":"lti_section_owner_changed","metadata":{"section_id":81,"previous_owner_id":203,"new_owner_id":209,"lms_name":"canvas_cloud"}}
```

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
