### PR TITLE
AI Chat: fix start over error

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -424,9 +424,12 @@ const aichatSlice = createSlice({
       }
 
       // Make sure model ID is valid
-      reconciledAiCustomizations.selectedModelId = validateModelId(
-        reconciledAiCustomizations.selectedModelId
-      );
+      reconciledAiCustomizations = {
+        ...reconciledAiCustomizations,
+        selectedModelId: validateModelId(
+          reconciledAiCustomizations.selectedModelId
+        ),
+      };
 
       state.savedAiCustomizations = reconciledAiCustomizations;
       state.currentAiCustomizations = reconciledAiCustomizations;
@@ -439,13 +442,16 @@ const aichatSlice = createSlice({
     ) => {
       const levelAichatSettings = action.payload;
 
-      const defaultAiCustomizations: AiCustomizations =
+      let defaultAiCustomizations: AiCustomizations =
         levelAichatSettings?.initialCustomizations || EMPTY_AI_CUSTOMIZATIONS;
 
       // Make sure model ID is valid
-      defaultAiCustomizations.selectedModelId = validateModelId(
-        defaultAiCustomizations.selectedModelId
-      );
+      defaultAiCustomizations = {
+        ...defaultAiCustomizations,
+        selectedModelId: validateModelId(
+          defaultAiCustomizations.selectedModelId
+        ),
+      };
 
       state.savedAiCustomizations = defaultAiCustomizations;
       state.currentAiCustomizations = defaultAiCustomizations;


### PR DESCRIPTION
Fix an issue with Start Over in AI Chat that was caused by trying to write to a readonly property (`selectedModelId`). For some reason, this wasn't happening/reproducing locally, potentially due to differences in how redux/redux-toolkit runs in dev mode. However I was able to repro with a local production build and verify this fix.

## Links

https://codedotorg.atlassian.net/browse/LABS-894

## Testing story

Tested locally in the Gen AI pilot. Used a local production build to verify the repro and fix.