### PR TITLE
Fix lti_section_owner_changed metric

### DIFF
--- a/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/lib/ui/lti/sync/LtiSectionSyncDialog.tsx
@@ -149,7 +149,7 @@ export default function LtiSectionSyncDialog({
       url: '/lti/v1/sections/bulk_update_owners',
       type: 'PATCH',
       data: {
-        section_owners: sectionOwners,
+        section_owners: JSON.stringify(sectionOwners),
       },
       success: () => {
         handleClose();

--- a/dashboard/app/controllers/lti/v1/sections_controller.rb
+++ b/dashboard/app/controllers/lti/v1/sections_controller.rb
@@ -6,7 +6,7 @@ module Lti
       before_action :authenticate_user!
 
       def bulk_update_owners
-        section_owners = params.require(:section_owners)
+        section_owners = JSON.parse(params.require(:section_owners))
         ActiveRecord::Base.transaction do
           section_owners.each do |lti_section_id, owner_id|
             section = LtiSection.find_by(id: lti_section_id)&.section

--- a/dashboard/app/controllers/lti/v1/sections_controller.rb
+++ b/dashboard/app/controllers/lti/v1/sections_controller.rb
@@ -20,6 +20,7 @@ module Lti
               section_id: section.id,
               previous_owner_id: section.user_id,
               new_owner_id: owner_id,
+              lms_name: section&.lti_course&.lti_integration&.platform_name,
             }
             section.update!(user_id: owner_id)
             Metrics::Events.log_event(

--- a/dashboard/test/controllers/lti/v1/lti_sections_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/lti_sections_controller_test.rb
@@ -14,7 +14,7 @@ class Lti::V1::SectionsControllerTest < ActionController::TestCase
     create :section_instructor, section: section_one, instructor: new_owner
     create :section_instructor, section: section_two, instructor: new_owner
 
-    patch :bulk_update_owners, params: {section_owners: {lti_section_one.id => new_owner.id, lti_section_two.id => new_owner.id}}, format: :json
+    patch :bulk_update_owners, params: {section_owners: {lti_section_one.id => new_owner.id, lti_section_two.id => new_owner.id}.to_json}, format: :json
     assert_response :ok
     assert_equal new_owner.id, section_one.reload.user_id
     assert_equal new_owner.id, section_two.reload.user_id
@@ -24,7 +24,7 @@ class Lti::V1::SectionsControllerTest < ActionController::TestCase
     other_teacher = create :teacher
     section = create :section, user: other_teacher
     lti_section = create :lti_section, section: section
-    patch :bulk_update_owners, params: {section_owners: {lti_section.id => @user.id}}, format: :json
+    patch :bulk_update_owners, params: {section_owners: {lti_section.id => @user.id}.to_json}, format: :json
     assert_response :forbidden
     assert_equal other_teacher.id, section.reload.user_id
   end
@@ -35,14 +35,14 @@ class Lti::V1::SectionsControllerTest < ActionController::TestCase
     lti_section = create :lti_section, section: section
     create :section_instructor, section: section, instructor: new_owner
 
-    patch :bulk_update_owners, params: {section_owners: {lti_section.id => new_owner.id}}, format: :json
+    patch :bulk_update_owners, params: {section_owners: {lti_section.id => new_owner.id}.to_json}, format: :json
     assert_response :ok
     refute section.reload.user_id == @user.id
     assert section.instructors.include? @user
   end
 
   test 'returns a 404 if a section is not found' do
-    patch :bulk_update_owners, params: {section_owners: {'foo' => @user.id}}, format: :json
+    patch :bulk_update_owners, params: {section_owners: {'foo' => @user.id}.to_json}, format: :json
     assert_response :not_found
   end
 end

--- a/dashboard/test/controllers/lti/v1/lti_sections_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/lti_sections_controller_test.rb
@@ -42,6 +42,7 @@ class Lti::V1::SectionsControllerTest < ActionController::TestCase
   end
 
   test 'returns a 404 if a section is not found' do
+    Metrics::Events.expects(:log_event).never
     patch :bulk_update_owners, params: {section_owners: {'foo' => @user.id}.to_json}, format: :json
     assert_response :not_found
   end

--- a/dashboard/test/controllers/lti/v1/lti_sections_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/lti_sections_controller_test.rb
@@ -14,6 +14,30 @@ class Lti::V1::SectionsControllerTest < ActionController::TestCase
     create :section_instructor, section: section_one, instructor: new_owner
     create :section_instructor, section: section_two, instructor: new_owner
 
+    Metrics::Events.expects(:log_event).with(
+      has_entries(
+        user: @user,
+        event_name: 'lti_section_owner_changed',
+        metadata: {
+          section_id: section_one.id,
+          previous_owner_id: @user.id,
+          new_owner_id: new_owner.id,
+          lms_name: lti_section_one.lti_course.lti_integration.platform_name,
+        },
+      )
+    )
+    Metrics::Events.expects(:log_event).with(
+      has_entries(
+        user: @user,
+        event_name: 'lti_section_owner_changed',
+        metadata: {
+          section_id: section_two.id,
+          previous_owner_id: @user.id,
+          new_owner_id: new_owner.id,
+          lms_name: lti_section_two.lti_course.lti_integration.platform_name,
+        },
+      )
+    )
     patch :bulk_update_owners, params: {section_owners: {lti_section_one.id => new_owner.id, lti_section_two.id => new_owner.id}.to_json}, format: :json
     assert_response :ok
     assert_equal new_owner.id, section_one.reload.user_id
@@ -24,6 +48,7 @@ class Lti::V1::SectionsControllerTest < ActionController::TestCase
     other_teacher = create :teacher
     section = create :section, user: other_teacher
     lti_section = create :lti_section, section: section
+    Metrics::Events.expects(:log_event).never
     patch :bulk_update_owners, params: {section_owners: {lti_section.id => @user.id}.to_json}, format: :json
     assert_response :forbidden
     assert_equal other_teacher.id, section.reload.user_id
@@ -35,6 +60,18 @@ class Lti::V1::SectionsControllerTest < ActionController::TestCase
     lti_section = create :lti_section, section: section
     create :section_instructor, section: section, instructor: new_owner
 
+    Metrics::Events.expects(:log_event).with(
+      has_entries(
+        user: @user,
+        event_name: 'lti_section_owner_changed',
+        metadata: {
+          section_id: section.id,
+          previous_owner_id: @user.id,
+          new_owner_id: new_owner.id,
+          lms_name: lti_section.lti_course.lti_integration.platform_name,
+        },
+      )
+    )
     patch :bulk_update_owners, params: {section_owners: {lti_section.id => new_owner.id}.to_json}, format: :json
     assert_response :ok
     refute section.reload.user_id == @user.id


### PR DESCRIPTION
The original ticket for this was to add the missing `lms_name` property to the event metadata. While testing this change, I also noticed that events were being published even when the section owner did not change. This was happening because the IDs were strings when pulled from the params. Rails automatically casts the strings to ints, so the controller was working, but when we compared the new and old owner IDs to determine whether or not to publish the `lti_section_owner_changed`, they never matched, because the real ID is never a string.

This PR:
- Adds the missing `lms_name` property
- Stringifies the JSON on the client side, and parses it in the controller, preserving the original data types

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1012)

## Testing story

Tested locally. Example output pre-change. Note the first event, where the `previous_owner_id` is `203` and the `new_owner_id` is `"203"`:
```
Logging Event: {"user_id":203,"custom_ids":{"user_type":"teacher"},"event_name":"lti_section_owner_changed","event_value":"lti_section_owner_changed","metadata":{"section_id":78,"previous_owner_id":203,"new_owner_id":"203","lms_name":"canvas_cloud"}}
Logging Event: {"user_id":203,"custom_ids":{"user_type":"teacher"},"event_name":"lti_section_owner_changed","event_value":"lti_section_owner_changed","metadata":{"section_id":79,"previous_owner_id":203,"new_owner_id":"209","lms_name":"canvas_cloud"}}
```



Example post-change. No event is published for the section that didn't have an actual change in ownership, and the event for the changed section does have numbers in all the number fields.
```
Logging Event: {"user_id":203,"custom_ids":{"user_type":"teacher"},"event_name":"lti_section_owner_changed","event_value":"lti_section_owner_changed","metadata":{"section_id":81,"previous_owner_id":203,"new_owner_id":209,"lms_name":"canvas_cloud"}}
```
<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
