### PR TITLE
Students in cpa lockout flow cannot change age or us state

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/edit.js
+++ b/apps/src/sites/studio/pages/devise/registrations/edit.js
@@ -21,7 +21,6 @@ import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 // Values loaded from scriptData are always initial values, not the latest
 // (possibly unsaved) user-edited values on the form.
 const scriptData = getScriptData('edit');
-console.log(scriptData);
 const {
   userAge,
   userState,

--- a/apps/src/sites/studio/pages/devise/registrations/edit.js
+++ b/apps/src/sites/studio/pages/devise/registrations/edit.js
@@ -23,7 +23,6 @@ import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 const scriptData = getScriptData('edit');
 const {
   userAge,
-  userState,
   userType,
   isAdmin,
   isPasswordRequired,
@@ -34,7 +33,6 @@ const {
   dependentStudentsCount,
   personalAccountLinkingEnabled,
   lmsName,
-  studentInLockoutFlow,
 } = scriptData;
 
 $(document).ready(() => {
@@ -160,13 +158,6 @@ $(document).ready(() => {
       />,
       deleteAccountMountPoint
     );
-  }
-
-  if (userAge && userState && studentInLockoutFlow) {
-    const usStateDropdown = document.getElementById('user_us_state');
-    const ageDropdown = document.getElementById('user_age');
-    usStateDropdown.disabled = true;
-    ageDropdown.disabled = true;
   }
 
   analyticsReporter.sendEvent(

--- a/apps/src/sites/studio/pages/devise/registrations/edit.js
+++ b/apps/src/sites/studio/pages/devise/registrations/edit.js
@@ -21,8 +21,10 @@ import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 // Values loaded from scriptData are always initial values, not the latest
 // (possibly unsaved) user-edited values on the form.
 const scriptData = getScriptData('edit');
+console.log(scriptData);
 const {
   userAge,
+  userState,
   userType,
   isAdmin,
   isPasswordRequired,
@@ -33,6 +35,7 @@ const {
   dependentStudentsCount,
   personalAccountLinkingEnabled,
   lmsName,
+  studentInLockoutFlow,
 } = scriptData;
 
 $(document).ready(() => {
@@ -158,6 +161,13 @@ $(document).ready(() => {
       />,
       deleteAccountMountPoint
     );
+  }
+
+  if (userAge && userState && studentInLockoutFlow) {
+    const usStateDropdown = document.getElementById('us_state_dropdown');
+    const ageDropdown = document.getElementById('user_age');
+    usStateDropdown.disabled = true;
+    ageDropdown.disabled = true;
   }
 
   analyticsReporter.sendEvent(

--- a/apps/src/sites/studio/pages/devise/registrations/edit.js
+++ b/apps/src/sites/studio/pages/devise/registrations/edit.js
@@ -163,7 +163,7 @@ $(document).ready(() => {
   }
 
   if (userAge && userState && studentInLockoutFlow) {
-    const usStateDropdown = document.getElementById('us_state_dropdown');
+    const usStateDropdown = document.getElementById('user_us_state');
     const ageDropdown = document.getElementById('user_age');
     usStateDropdown.disabled = true;
     ageDropdown.disabled = true;

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -389,10 +389,32 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def edit
     @permission_status = current_user.child_account_compliance_state
-    @personal_account_linking_enabled = Policies::ChildAccount.can_link_new_personal_account?(current_user)
+
+    # Get the request location
+    location = Geocoder.search(request.ip).try(:first)
+    country_code = location&.country_code.to_s.upcase
+    @is_usa = ['US', 'RD'].include?(country_code)
+
+    # We determine if the student is potentially locked by looking at their age
+    # If they are older (or there is no policy for them) they are unlocked
+    # This ignores them being explicitly unlocked by parental permission so we
+    # can show the 'Granted' status of that permission later.
+    @potentially_locked = Policies::ChildAccount.underage?(current_user)
+
+    # The student is in a 'lockout' flow if they are potentially locked out and not unlocked
+    @student_in_lockout_flow = @potentially_locked && !Policies::ChildAccount::ComplianceState.permission_granted?(current_user)
+    # We need to also account for the case when the US State is not specified
+    # All students are locked out of account settings features until they specify these
+    @locked = @student_in_lockout_flow || current_user.country_code.nil? || current_user.us_state.nil?
+    # Only for US-based requests
+    @locked &&= @is_usa
+    # Put this behind an experiment flag for now
+    @locked &&= !!experiment_value('cpa-partial-lockout', request)
+
+    @personal_account_linking_enabled = !@locked
 
     # Handle users who aren't locked out, but still need parent permission to link personal accounts.
-    if Policies::ChildAccount.user_predates_policy?(current_user)
+    if @potentially_locked
       permission_request = current_user.latest_parental_permission_request
       @pending_email = permission_request&.parent_email
       @request_date = permission_request&.updated_at || Date.new

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -406,6 +406,8 @@ class RegistrationsController < Devise::RegistrationsController
     # We need to also account for the case when the US State is not specified
     # All students are locked out of account settings features until they specify these
     @locked = @student_in_lockout_flow || current_user.country_code.nil? || current_user.us_state.nil?
+    # Only for students
+    @locked &&= current_user.student?
     # Only for US-based requests
     @locked &&= @is_usa
     # Put this behind an experiment flag for now

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -392,8 +392,8 @@ class RegistrationsController < Devise::RegistrationsController
 
     # Get the request location
     location = Geocoder.search(request.ip).try(:first)
-    country_code = location&.country_code.to_s.upcase
-    @is_usa = ['US', 'RD'].include?(country_code)
+    @country_code = location&.country_code.to_s.upcase
+    @is_usa = ['US', 'RD'].include?(@country_code)
 
     # We determine if the student is potentially locked by looking at their age
     # If they are older (or there is no policy for them) they are unlocked

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -394,7 +394,12 @@ class TestController < ApplicationController
       :data_transfer_agreement_source,
       :data_transfer_agreement_at,
     )
-    user = User.create!(**user_opts)
+    if params[:sso]
+      user = User.new(**user_opts)
+      User.initialize_new_oauth_user(user, OmniAuth::AuthHash.new({provider: params[:sso], uid: params[:uid], info: {name: params[:name]}}))
+    else
+      user = User.create!(**user_opts)
+    end
     sign_in user
     head :ok
   end

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -5,7 +5,7 @@
 - require 'queries/user'
 - @page_title = t('activerecord.attributes.user.edit_header')
 - no_email = current_user.no_personal_email? || params[:noEmail] == 'true'
-- studentInLockoutFlow = Policies::ChildAccount.underage?(current_user) && !Policies::ChildAccount::ComplianceState.permission_granted?(current_user)
+- studentInLockoutFlow = !!Policies::ChildAccount.lockout_date(user)
 
 = render_parental_permission_banner(current_user, request)
 

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -74,7 +74,7 @@
       - if studentInLockoutFlow
         %em= t('user.update_field_parent_permission_required')
         %br/
-      = f.select :age, User::AGE_DROPDOWN_OPTIONS
+      = f.select :age, User::AGE_DROPDOWN_OPTIONS, {}, disabled: studentInLockoutFlow
     - if experiment_value('gender', request)
       .field
         = f.label :gender_student_input, t('signup_form.gender'), class: "label-bold"
@@ -86,7 +86,7 @@
       - if studentInLockoutFlow
         %em= t('user.update_field_parent_permission_required')
         %br/
-      = f.select :us_state, us_state_options, {include_blank: t('school_info.select_state')}, required: true
+      = f.select :us_state, us_state_options, {include_blank: t('school_info.select_state')}, disabled: studentInLockoutFlow, required: true
       = f.hidden_field :country_code, value: country_code
   - if resource.teacher?
     .field
@@ -311,7 +311,6 @@
       dependentStudentsCount: Queries::User.dependent_students_count(current_user.id),
       personalAccountLinkingEnabled: @personal_account_linking_enabled,
       lmsName: Queries::Lti.get_lms_name_from_user(current_user),
-      studentInLockoutFlow: studentInLockoutFlow,
     }.to_json
   }
 %script{src: webpack_asset_path('js/devise/registrations/edit.js'), data: script_data}

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -5,7 +5,7 @@
 - require 'queries/user'
 - @page_title = t('activerecord.attributes.user.edit_header')
 - no_email = current_user.no_personal_email? || params[:noEmail] == 'true'
-- studentInLockoutFlow = !!Policies::ChildAccount.lockout_date(user)
+- studentInLockoutFlow = !!Policies::ChildAccount.lockout_date(current_user)
 
 = render_parental_permission_banner(current_user, request)
 

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -300,7 +300,6 @@
   script_data = {
     edit: {
       userAge: current_user.age,
-      userState: current_user.us_state,
       userType: current_user.user_type,
       isAdmin: current_user.admin,
       isOauth: current_user.oauth?,
@@ -310,7 +309,7 @@
       isCleverStudent: current_user.clever_student?,
       dependentStudentsCount: Queries::User.dependent_students_count(current_user.id),
       personalAccountLinkingEnabled: @personal_account_linking_enabled,
-      lmsName: Queries::Lti.get_lms_name_from_user(current_user),
+      lmsName: Queries::Lti.get_lms_name_from_user(current_user)
     }.to_json
   }
 %script{src: webpack_asset_path('js/devise/registrations/edit.js'), data: script_data}

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -5,6 +5,7 @@
 - require 'queries/user'
 - @page_title = t('activerecord.attributes.user.edit_header')
 - no_email = current_user.no_personal_email? || params[:noEmail] == 'true'
+- studentInLockoutFlow = Policies::ChildAccount.underage?(current_user) && !Policies::ChildAccount::ComplianceState.permission_granted?(current_user)
 
 = render_parental_permission_banner(current_user, request)
 
@@ -70,6 +71,9 @@
   - if !resource.teacher?
     .field
       = f.label t('signup_form.age'), class: "label-bold"
+      - if studentInLockoutFlow
+        %em= t('user.update_field_parent_permission_required')
+        %br/
       = f.select :age, User::AGE_DROPDOWN_OPTIONS
     - if experiment_value('gender', request)
       .field
@@ -79,7 +83,10 @@
       - location = Geocoder.search(request.ip).try(:first)
       - country_code = location&.country_code.to_s.upcase
       = f.label :us_state, t('activerecord.attributes.user.us_state'), class: 'label-bold'
-      = f.select :us_state, us_state_options, {include_blank: t('school_info.select_state')}, required: true
+      - if studentInLockoutFlow
+        %em= t('user.update_field_parent_permission_required')
+        %br/
+      = f.select :us_state, us_state_options, {include_blank: t('school_info.select_state')}, required: true, id: 'us_state_dropdown'
       = f.hidden_field :country_code, value: country_code
   - if resource.teacher?
     .field
@@ -293,6 +300,7 @@
   script_data = {
     edit: {
       userAge: current_user.age,
+      userState: current_user.us_state,
       userType: current_user.user_type,
       isAdmin: current_user.admin,
       isOauth: current_user.oauth?,
@@ -302,7 +310,8 @@
       isCleverStudent: current_user.clever_student?,
       dependentStudentsCount: Queries::User.dependent_students_count(current_user.id),
       personalAccountLinkingEnabled: @personal_account_linking_enabled,
-      lmsName: Queries::Lti.get_lms_name_from_user(current_user)
+      lmsName: Queries::Lti.get_lms_name_from_user(current_user),
+      studentInLockoutFlow: studentInLockoutFlow,
     }.to_json
   }
 %script{src: webpack_asset_path('js/devise/registrations/edit.js'), data: script_data}

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -85,7 +85,7 @@
           %em= t('user.update_field_parent_permission_required')
           %br/
         = f.select :us_state, us_state_options, {include_blank: t('school_info.select_state')}, disabled: @student_in_lockout_flow, required: true
-        = f.hidden_field :country_code, value: country_code
+        = f.hidden_field :country_code, value: @country_code
   - if resource.teacher?
     .field
       = f.label :school, class: "label-bold"

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -5,7 +5,19 @@
 - require 'queries/user'
 - @page_title = t('activerecord.attributes.user.edit_header')
 - no_email = current_user.no_personal_email? || params[:noEmail] == 'true'
-- studentInLockoutFlow = !!Policies::ChildAccount.lockout_date(current_user)
+
+-# We determine if the student is potentially locked by looking at their age
+-# If they are older (or there is no policy for them) they are unlocked
+-# This ignores them being explicitly unlocked by parental permission so we
+-# can show the 'Granted' status of that permission later.
+- potentially_locked = Policies::ChildAccount.underage?(current_user)
+-# The student is in a 'lockout' flow if they are potentially locked out and not unlocked
+- studentInLockoutFlow = potentially_locked && !Policies::ChildAccount::ComplianceState.permission_granted?(current_user)
+-# We need to also account for the case when the US State is not specified
+-# All students are locked out of account settings features until they specify these
+- locked = studentInLockoutFlow || current_user.country_code.nil? || current_user.us_state.nil?
+-# Put this behind an experiment flag for now
+- locked &&= !!experiment_value('cpa-partial-lockout', request)
 
 = render_parental_permission_banner(current_user, request)
 
@@ -143,12 +155,7 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put, id: 'lti-sync-settings-form'}) do |f|
     = f.hidden_field :lti_roster_sync_enabled
 
--# The CPA checks for whether or not the account is a personal login... so we check everything except that
-- potentially_locked = experiment_value('cpa-partial-lockout', request) && Policies::ChildAccount.underage?(current_user)
--# We need to also account for the case when the US State is not specified
-- locked = (potentially_locked && !Policies::ChildAccount::ComplianceState.permission_granted?(current_user)) || current_user.country_code.nil? || current_user.us_state.nil?
-
-- if potentially_locked
+- if potentially_locked && experiment_value('cpa-partial-lockout', request)
   %div#lockout-linked-accounts{
     data: {
       request_date: @request_date&.iso8601,

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -86,7 +86,7 @@
       - if studentInLockoutFlow
         %em= t('user.update_field_parent_permission_required')
         %br/
-      = f.select :us_state, us_state_options, {include_blank: t('school_info.select_state')}, required: true, id: 'us_state_dropdown'
+      = f.select :us_state, us_state_options, {include_blank: t('school_info.select_state')}, required: true
       = f.hidden_field :country_code, value: country_code
   - if resource.teacher?
     .field

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -6,19 +6,6 @@
 - @page_title = t('activerecord.attributes.user.edit_header')
 - no_email = current_user.no_personal_email? || params[:noEmail] == 'true'
 
--# We determine if the student is potentially locked by looking at their age
--# If they are older (or there is no policy for them) they are unlocked
--# This ignores them being explicitly unlocked by parental permission so we
--# can show the 'Granted' status of that permission later.
-- potentially_locked = Policies::ChildAccount.underage?(current_user)
--# The student is in a 'lockout' flow if they are potentially locked out and not unlocked
-- studentInLockoutFlow = potentially_locked && !Policies::ChildAccount::ComplianceState.permission_granted?(current_user)
--# We need to also account for the case when the US State is not specified
--# All students are locked out of account settings features until they specify these
-- locked = studentInLockoutFlow || current_user.country_code.nil? || current_user.us_state.nil?
--# Put this behind an experiment flag for now
-- locked &&= !!experiment_value('cpa-partial-lockout', request)
-
 = render_parental_permission_banner(current_user, request)
 
 = link_to :back do
@@ -83,23 +70,22 @@
   - if !resource.teacher?
     .field
       = f.label t('signup_form.age'), class: "label-bold"
-      - if studentInLockoutFlow
+      - if @student_in_lockout_flow
         %em= t('user.update_field_parent_permission_required')
         %br/
-      = f.select :age, User::AGE_DROPDOWN_OPTIONS, {}, disabled: studentInLockoutFlow
+      = f.select :age, User::AGE_DROPDOWN_OPTIONS, {}, disabled: @student_in_lockout_flow
     - if experiment_value('gender', request)
       .field
         = f.label :gender_student_input, t('signup_form.gender'), class: "label-bold"
         = f.text_field :gender_student_input, maxlength: 50
-    .field
-      - location = Geocoder.search(request.ip).try(:first)
-      - country_code = location&.country_code.to_s.upcase
-      = f.label :us_state, t('activerecord.attributes.user.us_state'), class: 'label-bold'
-      - if studentInLockoutFlow
-        %em= t('user.update_field_parent_permission_required')
-        %br/
-      = f.select :us_state, us_state_options, {include_blank: t('school_info.select_state')}, disabled: studentInLockoutFlow, required: true
-      = f.hidden_field :country_code, value: country_code
+    - if @is_usa
+      .field
+        = f.label :us_state, t('activerecord.attributes.user.us_state'), class: 'label-bold'
+        - if @student_in_lockout_flow
+          %em= t('user.update_field_parent_permission_required')
+          %br/
+        = f.select :us_state, us_state_options, {include_blank: t('school_info.select_state')}, disabled: @student_in_lockout_flow, required: true
+        = f.hidden_field :country_code, value: country_code
   - if resource.teacher?
     .field
       = f.label :school, class: "label-bold"
@@ -155,7 +141,7 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put, id: 'lti-sync-settings-form'}) do |f|
     = f.hidden_field :lti_roster_sync_enabled
 
-- if potentially_locked && experiment_value('cpa-partial-lockout', request)
+- if @potentially_locked && experiment_value('cpa-partial-lockout', request)
   %div#lockout-linked-accounts{
     data: {
       request_date: @request_date&.iso8601,
@@ -191,7 +177,7 @@
   %h2= t('user.create_personal_login')
 
   %p#edit_user_create_personal_account_description
-    - if locked
+    - if @locked
       - if current_user.us_state.nil?
         = t('user.create_personal_login_state_required')
       - else
@@ -200,14 +186,14 @@
       = no_email ? t('user.create_personal_login_under_13_info') : t('user.create_personal_login_info')
       = t('user.create_personal_login_link_account') if current_user.migrated?
   .div{style: 'position: relative'}
-    = form_for(current_user, url: '/users/upgrade', html: {id: 'edit_user_create_personal_account', style: (locked ? 'opacity: 0.25;' : '')}, namespace: 'create_personal') do |form|
+    = form_for(current_user, url: '/users/upgrade', html: {id: 'edit_user_create_personal_account', style: (@locked ? 'opacity: 0.25;' : '')}, namespace: 'create_personal') do |form|
       = form.hidden_field :hashed_email
       %h3= t('user.enter_new_login_info')
       - if no_email
         = hidden_field_tag :noEmail, true
         .field
           = form.label t('user.create_personal_login_under_13_username'), class: "label-bold"
-          = form.text_field :username, maxlength: 255, disabled: locked
+          = form.text_field :username, maxlength: 255, disabled: @locked
       - else
         .field
           = form.label :personal_email, class: "label-bold" do
@@ -216,26 +202,26 @@
           = form.email_field :email, placeholder: '', autocomplete: 'off', maxlength: 255
       .field
         = form.label :password, maxlength: 255, class: "label-bold"
-        = form.password_field :password, autocomplete: 'off', maxlength: 255, disabled: locked
+        = form.password_field :password, autocomplete: 'off', maxlength: 255, disabled: @locked
       .field
         = form.label :password_confirmation, class: "label-bold"
         = form.password_field :password_confirmation, autocomplete: 'off', maxlength: 255
-      - if !locked
+      - if !@locked
         - if current_user.secret_word_account?
           %h3= t('user.confirm_secret_words')
           .field
             = form.label :secret_words, class: "label-bold"
-            = form.text_field :secret_words, autocomplete: 'off', value: '', maxlength: 255, disabled: locked
+            = form.text_field :secret_words, autocomplete: 'off', value: '', maxlength: 255, disabled: @locked
         - if no_email
           %h3= t('user.enter_parent_email')
           .field
             = form.label t('user.create_personal_login_under_13_parent_email'), class: "label-bold"
-            = form.text_field :parent_email, maxlength: 255, disabled: locked
+            = form.text_field :parent_email, maxlength: 255, disabled: @locked
         = t('user.create_personal_login_terms_markdown', terms_of_service_url: CDO.code_org_url('/tos'), markdown: true).html_safe
         - unless no_email
           = t('user.create_personal_login_email_note_markdown', privacy_policy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
         %div= form.submit t('crud.submit'), id: 'create-personal-login', class: 'btn btn-warning'
-    - if locked
+    - if @locked
       %div{style: 'position: absolute; left: 0; right: 0; top: 0; bottom: 0; display: flex; flex-direction: row; align-items: center; justify-content: center; pointer-events: none'}
         %img{src: asset_path('auth/lock.svg'), style: 'width: 3rem; height: 3rem'}
 

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -555,6 +555,7 @@ en:
     parent_email_hint: "(this can be used for password recovery)"
     enter_parent_email: "Enter your parent or guardian's email address (for password recovery)"
     update: "Update Account"
+    update_field_parent_permission_required: '(You must obtain parental permission before updating this field)'
     account_successfully_updated: "Account successfully updated."
     auth_option_saved: "You have successfully linked your %{provider} account with email %{email}."
     auth_option_saved_no_email: "You have successfully linked your %{provider} account."

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -365,3 +365,23 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is disabled
     Then element "#user_age" is disabled
   
+   Scenario: Student account under-13 not in Colorado created after CPA exception using clever cannot change their age and state
+    Given I create a young student using clever named "Tandy" after CPA exception
+
+    Given I am on "http://studio.code.org/users/edit"
+
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is enabled
+    Then element "#user_age" is enabled
+  
+  Scenario: Student account under-13 not in Colorado created before CPA exception using clever cannot change their age and state
+    Given I create a young student using clever named "Tandy" before CPA exception
+
+    Given I am on "http://studio.code.org/users/edit"
+
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is enabled
+    Then element "#user_age" is enabled
+  

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -264,27 +264,104 @@ Feature: Policy Compliance and Parental Permission
 
     # And it should tell me that the request was granted
     And element "#permission-status" contains text "Granted"
-  
-  Scenario: Student in the CPA flow cannot change their age or state
-    Given I create an authorized teacher-associated under-13 student in Colorado named "Tandy" after CPA exception
 
-    # Find the disabled region to provide a personal login
+  Scenario: Student account Under-13 in Colorado created before CPA exception cannot change age and state
+    Given I create a young student in Colorado named "Tandy" before CPA exception
+
     Given I am on "http://studio.code.org/users/edit"
 
-    # Navigate the lockout process via the Account Settings page
     Then I wait to see "#user_age"
     Then I wait to see "#user_us_state"
     Then element "#user_us_state" is disabled
     Then element "#user_age" is disabled
   
-  Scenario: Student not in the CPA flow can change their age or state
-    Given I create an authorized teacher-associated under-13 student named "Tandy" after CPA exception
+  Scenario: Student account Under-13 in Colorado created after CPA exception cannot change age and state
+    Given I create a young student in Colorado named "Tandy" after CPA exception
 
-    # Find the disabled region to provide a personal login
     Given I am on "http://studio.code.org/users/edit"
 
-    # Navigate the lockout process via the Account Settings page
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is disabled
+    Then element "#user_age" is disabled
+
+  Scenario: Student account Under-13 not in Colorado created after CPA exception can change their age and state
+    Given I create a young student named "Tandy" after CPA exception
+
+    Given I am on "http://studio.code.org/users/edit"
+
     Then I wait to see "#user_age"
     Then I wait to see "#user_us_state"
     Then element "#user_us_state" is enabled
     Then element "#user_age" is enabled
+  
+  Scenario: Student account Under-13 not in Colorado created before CPA exception can change their age and state
+    Given I create a young student named "Tandy" before CPA exception
+
+    Given I am on "http://studio.code.org/users/edit"
+
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is enabled
+    Then element "#user_age" is enabled
+
+  Scenario: Student account Over-13 and in Colorado created after CPA exception can change their age and state
+    Given I create a student in Colorado named "Tandy" after CPA exception
+
+    Given I am on "http://studio.code.org/users/edit"
+
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is enabled
+    Then element "#user_age" is enabled
+
+  Scenario: Student account Over-13 and in Colorado created before CPA exception can change their age and state
+    Given I create a student in Colorado named "Tandy" before CPA exception
+
+    Given I am on "http://studio.code.org/users/edit"
+
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is enabled
+    Then element "#user_age" is enabled
+
+  Scenario: Student account under-13 and in Colorado created after CPA exception using only clever cannot change their age and state
+    Given I create a young student using clever in Colorado named "Tandy" after CPA exception
+
+    Given I am on "http://studio.code.org/users/edit"
+
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is disabled
+    Then element "#user_age" is disabled
+
+   Scenario: Student account under-13 and in Colorado created before CPA exception using only clever cannot change their age and state
+    Given I create a young student using clever in Colorado named "Tandy" before CPA exception
+
+    Given I am on "http://studio.code.org/users/edit"
+
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is disabled
+    Then element "#user_age" is disabled
+
+  Scenario: Student account under-13 and in Colorado created before CPA exception using google cannot change their age and state
+    Given I create a young student using google in Colorado named "Tandy" before CPA exception
+
+    Given I am on "http://studio.code.org/users/edit"
+
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is disabled
+    Then element "#user_age" is disabled
+
+  Scenario: Student account under-13 and in Colorado created after CPA exception using google cannot change their age and state
+    Given I create a young student using google in Colorado named "Tandy" after CPA exception
+
+    Given I am on "http://studio.code.org/users/edit"
+
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is disabled
+    Then element "#user_age" is disabled
+  

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -272,6 +272,7 @@ Feature: Policy Compliance and Parental Permission
     Given I am on "http://studio.code.org/users/edit?cpa-partial-lockout=1"
 
     # Navigate the lockout process via the Account Settings page
-    Then I wait to see "#us_state_dropdown"
-    Then element "#us_state_dropdown" is disabled
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is disabled
     Then element "#user_age" is disabled

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -264,3 +264,14 @@ Feature: Policy Compliance and Parental Permission
 
     # And it should tell me that the request was granted
     And element "#permission-status" contains text "Granted"
+  
+  Scenario: Users in the CPA flow cannot change their age or state
+    Given I create an authorized teacher-associated under-13 student in Colorado named "Tandy" after CPA exception
+
+    # Find the disabled region to provide a personal login
+    Given I am on "http://studio.code.org/users/edit?cpa-partial-lockout=1"
+
+    # Navigate the lockout process via the Account Settings page
+    Then I wait to see "#us_state_dropdown"
+    Then element "#us_state_dropdown" is disabled
+    Then element "#user_age" is disabled

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -265,14 +265,26 @@ Feature: Policy Compliance and Parental Permission
     # And it should tell me that the request was granted
     And element "#permission-status" contains text "Granted"
   
-  Scenario: Users in the CPA flow cannot change their age or state
+  Scenario: Student in the CPA flow cannot change their age or state
     Given I create an authorized teacher-associated under-13 student in Colorado named "Tandy" after CPA exception
 
     # Find the disabled region to provide a personal login
-    Given I am on "http://studio.code.org/users/edit?cpa-partial-lockout=1"
+    Given I am on "http://studio.code.org/users/edit"
 
     # Navigate the lockout process via the Account Settings page
     Then I wait to see "#user_age"
     Then I wait to see "#user_us_state"
     Then element "#user_us_state" is disabled
     Then element "#user_age" is disabled
+  
+  Scenario: Student not in the CPA flow can change their age or state
+    Given I create an authorized teacher-associated under-13 student named "Tandy" after CPA exception
+
+    # Find the disabled region to provide a personal login
+    Given I am on "http://studio.code.org/users/edit"
+
+    # Navigate the lockout process via the Account Settings page
+    Then I wait to see "#user_age"
+    Then I wait to see "#user_us_state"
+    Then element "#user_us_state" is enabled
+    Then element "#user_age" is enabled


### PR DESCRIPTION
Students in cpa lockout flow cannot change age or us state.

Also adds ability to create a clever/google oauth account within a UI test.

<img width="1792" alt="Screenshot 2024-06-27 at 10 35 34 AM" src="https://github.com/code-dot-org/code-dot-org/assets/137838584/7c6bbf6d-63f5-4a58-a4c6-13473ad58624">

## Links
- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/P20/boards/69?assignee=712020%3Af0e2716f-09f9-4686-8490-9f1f9a08bb06&selectedIssue=P20-952)

## Testing story
UI Tests within `dashboard/test/ui/features/platform/policy_compliance.feature`

## Follow up Work
Implementing backend so students in CPA flow cannot force update to us_state and age
