### PR TITLE
Change log event method

### DIFF
--- a/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
+++ b/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
@@ -92,7 +92,8 @@ module Lti
           metadata = {
             lms_name: platform[:name],
           }
-          Metrics::Events.log_event(
+          Metrics::Events.log_event_with_session(
+            session: session,
             event_name: 'lti_dynamic_registration_completed',
             metadata: metadata,
           )

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -421,7 +421,8 @@ class LtiV1Controller < ApplicationController
       metadata = {
         lms_name: platform_name,
       }
-      Metrics::Events.log_event(
+      Metrics::Events.log_event_with_session(
+        session: session,
         event_name: 'lti_portal_registration_completed',
         metadata: metadata,
       )

--- a/dashboard/test/controllers/lti/v1/dynamic_registration_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/dynamic_registration_controller_test.rb
@@ -39,6 +39,16 @@ class Lti::V1::DynamicRegistrationControllerTest < ActionController::TestCase
     response = {client_id: client_id}
     LtiDynamicRegistrationClient.any_instance.stubs(:make_registration_request).returns(response)
 
+    Metrics::Events.expects(:log_event_with_session).with(
+      has_entries(
+        session: session,
+        event_name: 'lti_dynamic_registration_completed',
+        metadata: {
+          lms_name: Policies::Lti::LMS_PLATFORMS[:canvas_cloud][:name],
+        },
+      )
+    )
+
     post :create_registration, params: {email: email, registration_id: registration_id}
     assert_response :created
     integration = Queries::Lti.get_lti_integration(registration_data[:issuer], client_id)

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -5,7 +5,6 @@ require 'policies/lti'
 require "services/lti"
 require "clients/lti_advantage_client"
 require 'clients/lti_dynamic_registration_client'
-require 'metrics/events'
 
 class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -856,32 +856,12 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     email = "fake@email.com"
 
     post '/lti/v1/integrations', params: {name: name, client_id: client_id, lms: lms, email: email}
-    # Something is different with this test suite. Getting a 500 server error
-    Metrics::Events.expects(:log_event_with_session).with(
-      has_entries(
-        session: session,
-        event_name: 'lti_portal_registration_completed',
-        metadata: {
-          lms_name: Policies::Lti::LMS_PLATFORMS[:canvas_cloud][:name],
-        },
-      )
-    )
     assert_response :ok
 
     client_id = "5678schoology"
     lms = "schoology"
 
     post '/lti/v1/integrations', params: {name: name, client_id: client_id, lms: lms, email: email}
-
-    Metrics::Events.expects(:log_event_with_session).with(
-      has_entries(
-        session: session,
-        event_name: 'lti_portal_registration_completed',
-        metadata: {
-          lms_name: Policies::Lti::LMS_PLATFORMS[:schoology][:name],
-        },
-      )
-    )
     assert_response :ok
   end
 


### PR DESCRIPTION
The Metrics::Events.log_event Statsig wrapper was refactored to set the user to nil if empty in the method parameters. However, it was discovered this causes issues in the Statsig dashboard. The wrapper was refactored to include a [Metrics::Events.log_event_with_session](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/metrics/events.rb#L49) for this case. 

Changes:
* Use `log_event_with_session` instead of `log_event`, and pass in session as argument

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[Jira](https://codedotorg.atlassian.net/browse/P20-1018)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
