### PR TITLE
Fix translated code-block's format in long_instructions

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -1008,6 +1008,7 @@ class Blockly < Level
   # @param text [String] the text to unescape.
   # @return [String] the text with unescaped backticks.
   private def unescape_codeblocks(text)
+    return text unless text
     text.gsub('\\`', '`')
   end
 end

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -465,7 +465,7 @@ class Blockly < Level
     localized_blockly_in_text(unescaped_codeblocks)
   end
 
-  # Processes and localizes the TRANSALTIONTEXT from i18n start libraries content.
+  # Processes and localizes the TRANSLATIONTEXT from i18n start libraries content.
   # @param start_libraries [String] JSON-encoded string representing an array of library objects.
   # Each library object should contain a name and source field.
   # @return [String] JSON-encoded string representing the localized start libraries.

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -457,11 +457,18 @@ class Blockly < Level
     get_localized_property('failure_message_override')
   end
 
+  # Retrieve the localized property for "long_instructions",
+  # @return [String] the localized long_instructions property
   def localized_long_instructions
     localized_long_instructions = get_localized_property("long_instructions")
-    localized_blockly_in_text(localized_long_instructions)
+    unescaped_codeblocks = unescape_codeblocks(localized_long_instructions)
+    localized_blockly_in_text(unescaped_codeblocks)
   end
 
+  # Processes and localizes the TRANSALTIONTEXT from i18n start libraries content.
+  # @param start_libraries [String] JSON-encoded string representing an array of library objects.
+  # Each library object should contain a name and source field.
+  # @return [String] JSON-encoded string representing the localized start libraries.
   def localized_start_libraries(start_libraries)
     return unless start_libraries
     level_libraries = JSON.parse(start_libraries)
@@ -995,5 +1002,12 @@ class Blockly < Level
         skin: skin
       }
     )
+  end
+
+  # Unescapes the backticks used to format codeblocks in the given text.
+  # @param text [String] the text to unescape.
+  # @return [String] the text with unescaped backticks.
+  private def unescape_codeblocks(text)
+    text.gsub('\\`', '`')
   end
 end

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -1006,9 +1006,9 @@ class Blockly < Level
 
   # Unescapes the backticks used to format codeblocks in the given text.
   # @param text [String] the text to unescape.
-  # @return [String] the text with unescaped backticks.
+  # @return [String] the text with unescaped backticks. If the text is nil or empty, it will be returned as is.
   private def unescape_codeblocks(text)
-    return text unless text
+    return text if text.blank?
     text.gsub('\\`', '`')
   end
 end

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -1262,15 +1262,27 @@ class BlocklyTest < ActiveSupport::TestCase
     assert_equal 'translated long instructions', level.localized_long_instructions
   end
 
-  test 'returns empty strings when long_instruction is an empty string' do
+  test 'localizes long_instruction and removes escaped backticks when present' do
+    test_locale = 'te-ST'
+    level_name = 'test localize long_instruction'
     level = create(
       :level,
       :blockly,
-      name: 'test localize long_instruction',
-      long_instructions: ''
+      name: level_name,
+      long_instructions: 'original long instructions with [`block`](#bloc)'
     )
 
-    assert_equal '', level.localized_long_instructions
+    custom_i18n = {
+      'data' => {
+        'long_instructions' => {
+          level_name => 'translated long instructions with [\`block\`](#bloc)'
+        }
+      }
+    }
+    I18n.locale = test_locale
+    I18n.backend.store_translations test_locale, custom_i18n
+
+    assert_equal 'translated long instructions with [`block`](#bloc)', level.localized_long_instructions
   end
 
   test 'localizes start_libraries when i18n_library is present' do

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -1239,6 +1239,40 @@ class BlocklyTest < ActiveSupport::TestCase
     assert_equal parsed_xml.at_xpath('//block[@type="studio_ask"]/*[@name="VAR"]').content, localized_variable_str
   end
 
+  test 'localizes long_instruction when present' do
+    test_locale = 'te-ST'
+    level_name = 'test localize long_instruction'
+    level = create(
+      :level,
+      :blockly,
+      name: level_name,
+      long_instructions: 'original long instructions'
+    )
+
+    custom_i18n = {
+      'data' => {
+        'long_instructions' => {
+          level_name => 'translated long instructions'
+        }
+      }
+    }
+    I18n.locale = test_locale
+    I18n.backend.store_translations test_locale, custom_i18n
+
+    assert_equal 'translated long instructions', level.localized_long_instructions
+  end
+
+  test 'returns empty strings when long_instruction is an empty string' do
+    level = create(
+      :level,
+      :blockly,
+      name: 'test localize long_instruction',
+      long_instructions: ''
+    )
+
+    assert_equal '', level.localized_long_instructions
+  end
+
   test 'localizes start_libraries when i18n_library is present' do
     test_locale = 'te-ST'
     level_name = 'test localize start_libraries'

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -1239,9 +1239,9 @@ class BlocklyTest < ActiveSupport::TestCase
     assert_equal parsed_xml.at_xpath('//block[@type="studio_ask"]/*[@name="VAR"]').content, localized_variable_str
   end
 
-  test 'localizes long_instruction when present' do
+  test 'localizes long_instructions when present' do
     test_locale = 'te-ST'
-    level_name = 'test localize long_instruction'
+    level_name = 'test localize long_instructions'
     level = create(
       :level,
       :blockly,
@@ -1262,9 +1262,9 @@ class BlocklyTest < ActiveSupport::TestCase
     assert_equal 'translated long instructions', level.localized_long_instructions
   end
 
-  test 'localizes long_instruction and removes escaped backticks when present' do
+  test 'localizes long_instructions and removes escaped backticks when present' do
     test_locale = 'te-ST'
-    level_name = 'test localize long_instruction'
+    level_name = 'test localize long_instructions'
     level = create(
       :level,
       :blockly,


### PR DESCRIPTION
### The issue: 
Blocks in instructions do not render properly. It doesn’t completely break the experience because students can still access the appropriate documentation page, but it doesn’t look as neat as the instruction in English.

### The reason:

The translated content has the code backticks escaped: [\`if-statement\`(#64B5F6)] vs [\\\`if-statement\\\`(#64B5F6)]

**Why are backticks escaped?** Backtics are naturally escaped in strings, however, the back 
slash escaping backticks, also get escaped when downloading translations from crowdin, resulting in a double scped backtick (\\\\`).
We do not redact code blocks in course_content (we can redact code blocs and we do so in other strings). A process that would prevent this format issue during the download process.
We could start redacting these code blocks, however, translations already exist and we would have to re-translate all strings containing code blocks (very time-consuming).

I opted for a less elegant solution reformating existing translations.

This PR:
- Adds a private method (`unescape_codeblocks`) that unescapes backticks. 
- Uses the `unescape_codeblocks` in the `localized_long_instructions` method.
- Additionally add some documentation in undocumented methods.

## Links

- jira ticket: [P20-853](https://codedotorg.atlassian.net/browse/P20-853)

## Testing story

![Screenshot 2024-06-27 at 12 36 01](https://github.com/code-dot-org/code-dot-org/assets/66776217/8a2182ae-6b92-4a68-8f01-431271a61cf6)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
