### PR TITLE
[Google Blockly] clear procedure maps on start over

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -827,14 +827,23 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
 
   // Google Blockly labs also need to clear separate workspaces for the function editor.
   blocklyWrapper.clearAllStudentWorkspaces = function () {
-    Blockly.getMainWorkspace().clear();
-    const functionEditorWorkspace = Blockly.getFunctionEditorWorkspace();
-    if (functionEditorWorkspace) {
-      functionEditorWorkspace.clear();
-    }
-    if (Blockly.getHiddenDefinitionWorkspace()) {
-      Blockly.getHiddenDefinitionWorkspace().clear();
-    }
+    // Disable Blockly events to prevent unnecessary event mirroring
+    Blockly.Events.disable();
+
+    const studentWorkspaces = [
+      Blockly.getMainWorkspace(),
+      Blockly.getFunctionEditorWorkspace(),
+      Blockly.getHiddenDefinitionWorkspace(),
+    ];
+
+    studentWorkspaces.forEach(workspace => {
+      if (workspace) {
+        workspace.clear();
+        workspace.getProcedureMap().clear();
+      }
+    });
+
+    Blockly.Events.enable();
   };
 
   blocklyWrapper.customBlocks = customBlocks;


### PR DESCRIPTION
Following the Maze migration bug bash, @molly-moen reported an issue where the procedure map wasn't being reset when a user clicks "Start Over". 

1. create a "do something" function
2. Click start over
3. Go to create another function, the default name is now "do something2", implying that the function names didn't get wiped on start over
4. Close the editor, pull out "do something2" and the in-workspace editor pops up!

This problem wasn't noticeable with Sprite Lab because the Version History "Start Over" triggers a full page reload. It's also not easily reproducible in Dance or Minecraft as those labs don't use the modal function editor.

Fortunately, there's a straight-forward fix. When we clear each of the three student workspaces, we can manually clear each of their procedure maps. Following this step, we'll reload the start blocks as normal which will re-populate any expected procedures defined by the start blocks. Now, previously-used procedure names are available again:

https://github.com/code-dot-org/code-dot-org/assets/43474485/b570a258-99c7-4c03-ac3e-cbc47cab28ad


## Links

Slack thread:
- https://codedotorg.slack.com/archives/C05HZFH7BED/p1719508995108649
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
