### PR TITLE
AI Chat: design tweaks

### DIFF
--- a/apps/src/aichat/views/aichatView.module.scss
+++ b/apps/src/aichat/views/aichatView.module.scss
@@ -20,6 +20,7 @@ $column-min-width: 200px;
   display: flex;
   flex-direction: column;
   margin: 2px;
+  background: $light_gray_50;
 
   .instructionsArea {
     width: 30%;
@@ -48,11 +49,10 @@ $column-min-width: 200px;
 .labCoreContainer {
   display: flex;
   flex: 1;
-  gap: 2px;
+  gap: 16px;
   overflow: auto;
 }
 
 .aichatViewButton {
   margin-right: 5px;
 }
-

--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -10,6 +10,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  background: $light_white;
 
   textarea {
     @extend %full-width;

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -36,7 +36,7 @@
 
 .instructions-light {
   @extend %instructions;
-  background-color: $neutral_dark10;
+  background-color: $light_white;
 }
 
 .item {
@@ -120,7 +120,7 @@
 
 .text-light {
   @extend %text;
-  background-color: $neutral_white;
+  background-color: $light_white;
   color: $neutral_dark;
 }
 
@@ -140,9 +140,9 @@
 
 .message-light {
   @extend %message;
-  background-color: $neutral_white;
+  background-color: $light_gray_50;
   color: $neutral_dark;
-  border: dashed $neutral_white 2px;
+  border: dashed $light_gray_100 2px;
 }
 
 .buttonInstruction {


### PR DESCRIPTION
A few minor design tweaks
- larger gap between panels
- light grey background for the lab (instead of white)
- white background for instructions and light grey background for callouts / validation (currently this is just the continue button).

Before:
<img width="1513" alt="Screenshot 2024-06-27 at 11 37 59 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/33ad76f6-8e82-4eb6-bed4-9d190e6a891e">

After:
<img width="1513" alt="Screenshot 2024-06-27 at 11 37 51 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/3350e942-a73f-48bf-b626-8ecaeb26e11d">

## Links

[Figma](https://www.figma.com/design/tjkMqlAXi2iTqpUHSljB3A/Gen-AI-Unit?node-id=2653-6892&m=dev)

## Testing story

Tested locally with a few Gen AI pilot levels with a variety of instructions sizes.