### PR TITLE
[Google Blockly] Fix block counts for modal function editor and child blocks

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -523,6 +523,14 @@ StudioApp.prototype.init = function (config) {
       }, this)
     );
 
+    if (Blockly.getHiddenDefinitionWorkspace()) {
+      this.hiddenWorkspaceChangeListener =
+        Blockly.getHiddenDefinitionWorkspace().addChangeListener(
+          _.bind(function () {
+            this.updateBlockCount();
+          }, this)
+        );
+    }
     if (config.level.openFunctionDefinition) {
       this.openFunctionDefinition_(config);
     }
@@ -3575,6 +3583,9 @@ if (IN_UNIT_TEST) {
     instance.libraries = {};
     if (instance.changeListener) {
       Blockly.removeChangeListener(instance.changeListener);
+    }
+    if (instance.hiddenWorkspaceChangeListener) {
+      Blockly.removeChangeListener(instance.hiddenWorkspaceChangeListener);
     }
     instance = __oldInstance;
     __oldInstance = null;

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -827,14 +827,23 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
 
   // Google Blockly labs also need to clear separate workspaces for the function editor.
   blocklyWrapper.clearAllStudentWorkspaces = function () {
-    Blockly.getMainWorkspace().clear();
-    const functionEditorWorkspace = Blockly.getFunctionEditorWorkspace();
-    if (functionEditorWorkspace) {
-      functionEditorWorkspace.clear();
-    }
-    if (Blockly.getHiddenDefinitionWorkspace()) {
-      Blockly.getHiddenDefinitionWorkspace().clear();
-    }
+    // Disable Blockly events to prevent unnecessary event mirroring
+    Blockly.Events.disable();
+
+    const studentWorkspaces = [
+      Blockly.getMainWorkspace(),
+      Blockly.getFunctionEditorWorkspace(),
+      Blockly.getHiddenDefinitionWorkspace(),
+    ];
+
+    studentWorkspaces.forEach(workspace => {
+      if (workspace) {
+        workspace.clear();
+        workspace.getProcedureMap().clear();
+      }
+    });
+
+    Blockly.Events.enable();
   };
 
   blocklyWrapper.customBlocks = customBlocks;

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -490,7 +490,9 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   extendedWorkspaceSvg.addUnusedBlocksHelpListener = function () {};
 
   extendedWorkspaceSvg.getAllUsedBlocks = function () {
-    return this.getAllBlocks().filter(block => block.isEnabled());
+    return this.getAllBlocks().filter(
+      block => block.isEnabled() && block.getRootBlock().isEnabled()
+    );
   };
 
   extendedWorkspaceSvg.isReadOnly = function () {


### PR DESCRIPTION
Following today's Maze migration bug bashk, @molly-moen noticed two similar bugs where the used block count was inaccurate:

> minimal repro of the counting issue (did this on https://studio.code.org/s/course4/lessons/16/levels/5):
> 1. Create a new function, add a parameter to it, block count for "empty" workspace is 2 (I think this is expected because when run + function definition)
> 2. pull that function into the workspace, block count is now 3
> 3. add a variable to the parameter slot on the function, block count is now 4
> 4. Pull function off of when run, block count is 3 (should be 2)
> 5. Trash function, now block count is correctly 2

https://github.com/code-dot-org/code-dot-org/assets/43474485/72f3dac4-6835-4b01-88dc-97fadaae38c5


For step 1, the count should be 2 before you add the parameter. It’s still 1 until you add the parameter. This is because we call `updateBlockCount` as soon as the modal is opened but before the event can be mirrored to the hidden workspace. The count is off by one because at the moment we check, the block isn't on the hidden workspace yet. (We use main+hidden as our source of truth for block counts.)
When the parameter block is added, it’s just a sufficient change to trigger another count. (Flyout blocks are never counted, and we were never counting the parameter block in this scenario.)

We can see in StudioApp that we only update the block count with changes to the main workspace, but this doesn't cover changes elsewhere. By adding a change listener to the hidden workspace, we can ensure that the block count is accurate whenever changes are made in the function editor. (When using the modal editor, we mirror any changes over to the hidden workspace, but not to the main workspace.)


The issue in step 4 is that the variable block isn’t technically disabled, while the function call block is disabled. 
We can fix this by checking both the block and its root block to be sure both are enabled when counting all “used blocks”.

This video demonstrates that both bugs have been fixed and the block count updates as expected:

https://github.com/code-dot-org/code-dot-org/assets/43474485/2990e04a-6eee-4b83-8597-bcacedc16018


## Links

Slack thread: https://codedotorg.slack.com/archives/C05HZFH7BED/p1719508736520979
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
