### PR TITLE
Fixing issue where locked out CPA students could not login

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -11,7 +11,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # TODO: figure out how to avoid skipping CSRF verification for Powerschool
   skip_before_action :verify_authenticity_token, only: :powerschool
 
-  before_action :check_account_linking_lock, on: %i[connect_provider link_accounts]
+  before_action :check_account_linking_lock, only: %i[connect_provider link_accounts]
 
   # Note: We can probably remove these once we've broken out all providers
   BROKEN_OUT_TYPES = [


### PR DESCRIPTION
Bug: Users who have account linking locked could not sign back in.
Cause: The `check_account_linking_lock` was being called for all OAuth actions (such as signing in), not just the account linking actions.
Fix: Correct a misspelling so `check_account_linking_lock` is only called for account linking actions.

## Testing story
* Create a CPA student through Google or Microsoft. Sign out. Sign in.

## Screenshot
Here is a picture of what the user would see when trying to login for a 2nd time:
![image](https://github.com/code-dot-org/code-dot-org/assets/1372238/e694ed3d-2840-4410-952a-58404682706f)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
