### PR TITLE
[Google Blockly] Prevent variable duplication when using parameter blocks

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.ts
@@ -170,7 +170,7 @@ export const blocks = {
                   fields: {
                     VAR: {
                       name: parameter.getName(),
-                      type: parameter.getTypes(),
+                      type: '',
                     },
                   },
                 });


### PR DESCRIPTION
During the Maze migration bug bash today, @molly-moen noticed a bug where multiple variables with the same name were created when dragging out a new parameter block from a definition block's flyout.

> When you add a parameter named direction to your new function, there’s now 2 “direction” options in the variable dropdown. This happens after you pull the “direction” parameter block out of the parameter mini toolbox. It will add another duplicate parameter to the list again if you pull the block out again, but it stops after 3 duplicates.
> This behavior doesn’t happen in cdo. 
> ![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/eaf77bd8-8fff-4dc5-a7b3-70b31b30b9b0)

For context, Blockly supports typed variables (e.g. number, string) which are specified as strings. We don't use this feature and instead indicate a null type with an empty string. (This just means students can attempt to use a variable wherever they want, like JavaScript, and it might or might not work, like JavaScript.)

When Blockly checks to see if a variable already exists, it checks both the name and its type. The existing variables have the expected type `''` but the new variable has the type `[]`.  This is because I assumed we could use the parameter's type for the variable too, but apparently not.

It's worth noting that types have not been implemented in the shareable procedures block plugin at this time. Parameter variables are also created by the plugin with an empty string.
Exhibit A: https://github.com/google/blockly-samples/blob/master/plugins/block-shareable-procedures/src/observable_parameter_model.ts#L51
Exhibit B: https://github.com/google/blockly-samples/blob/master/plugins/block-shareable-procedures/src/observable_parameter_model.ts#L79

However, and perhaps unintentionally (?),  the type of a parameter is always returned as an empty array:
https://github.com/google/blockly-samples/blob/master/plugins/block-shareable-procedures/src/observable_parameter_model.ts#L109-L111

To make things behave consistently, we should follow the logic of the first two examples and always create the variable with an empty string type. By doing so, duplicate variables are avoided because Blockly is able to find an existing model with the matching name and type:

![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/3c26a778-d25c-4bee-b29a-172a322b88c2)


## Links

Bug bash notes: https://docs.google.com/document/d/14_fjbaK7hbsvmw7O5uJwSJbC7tW9TSxQCbXxk12IO0U/edit


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
