### PR TITLE
Prevent nil method error in email account linking

### DIFF
--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -31,7 +31,7 @@ module Lti
         head :bad_request unless PartialRegistration.in_progress?(session)
         params.require([:email, :password])
         existing_user = User.find_by_email_or_hashed_email(params[:email])
-        if existing_user.admin?
+        if existing_user&.admin?
           flash[:alert] = I18n.t('lti.account_linking.admin_not_allowed')
           redirect_to user_session_path(lti_provider: params[:lti_provider], lms_name: params[:lms_name]) and return
         end


### PR DESCRIPTION
The email account linking controller checks the existing_user to make sure it isn't an admin account. If existing_user is nil, it will throw. This adds the safe method operator to ensure we don't blow up if no existing_user is found.

## Links

[Honeybadger](https://app.honeybadger.io/projects/3240/faults/108881746)
[JIRA](https://codedotorg.atlassian.net/browse/P20-1020)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
