### PR TITLE
[Code Bridge] Move continue button out of Instructions Panel

### DIFF
--- a/apps/src/codebridge/ControlButtons/control-buttons.module.scss
+++ b/apps/src/codebridge/ControlButtons/control-buttons.module.scss
@@ -2,15 +2,20 @@
 
 .controlButtonsContainer {
   grid-area: control-buttons;
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr repeat(2, auto) 1fr;
   padding: 8px 0;
   justify-content: center;
   align-items: center;
-  flex-shrink: 0;
   background-color: $neutral_dark80;
+  column-gap: 8px;
 }
 
-.controlButton {
-  margin-left: 8px;
+.firstControlButton {
+  grid-column-start: 2;
+}
+
+.navigationButton {
+  margin-left: auto;
   margin-right: 8px;
 }

--- a/apps/src/codebridge/ControlButtons/control-buttons.module.scss
+++ b/apps/src/codebridge/ControlButtons/control-buttons.module.scss
@@ -5,8 +5,6 @@
   display: grid;
   grid-template-columns: 1fr repeat(2, auto) 1fr;
   padding: 8px 0;
-  justify-content: center;
-  align-items: center;
   background-color: $neutral_dark80;
   column-gap: 8px;
 }

--- a/apps/src/codebridge/ControlButtons/index.tsx
+++ b/apps/src/codebridge/ControlButtons/index.tsx
@@ -20,7 +20,6 @@ const ControlButtons: React.FunctionComponent = () => {
   const {onRun} = useCodebridgeContext();
   const {loading, data} = useFetch('/api/v1/users/current/permissions');
   const dispatch = useAppDispatch();
-  const [isFinished, setIsFinished] = React.useState(false);
 
   const source = useAppSelector(
     state => state.lab2Project.projectSource?.source
@@ -34,7 +33,9 @@ const ControlButtons: React.FunctionComponent = () => {
     : commonI18n.finish();
 
   const onContinue = () => dispatch(navigateToNextLevel());
-  const onFinish = () => setIsFinished(true);
+  // No-op for now. TODO: figure out what the finish button should do.
+  // https://codedotorg.atlassian.net/browse/CT-664
+  const onFinish = () => {};
 
   const handleRun = (runTests: boolean) => {
     if (onRun) {
@@ -56,6 +57,7 @@ const ControlButtons: React.FunctionComponent = () => {
         iconLeft={{iconStyle: 'solid', iconName: 'play'}}
         className={moduleStyles.firstControlButton}
         size={'s'}
+        color={'white'}
       />
       <Button
         text="Test"
@@ -68,10 +70,15 @@ const ControlButtons: React.FunctionComponent = () => {
       <Button
         text={navigationButtonText}
         onClick={hasNextLevel ? onContinue : onFinish}
-        disabled={loading || isFinished}
+        disabled={loading}
         color={'purple'}
         className={moduleStyles.navigationButton}
         size={'s'}
+        iconLeft={
+          hasNextLevel
+            ? {iconStyle: 'solid', iconName: 'arrow-right'}
+            : undefined
+        }
       />
     </div>
   );

--- a/apps/src/codebridge/ControlButtons/index.tsx
+++ b/apps/src/codebridge/ControlButtons/index.tsx
@@ -1,11 +1,13 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {appendSystemMessage} from '@codebridge/redux/consoleRedux';
 import React from 'react';
-import {useDispatch} from 'react-redux';
 
+import {navigateToNextLevel} from '@cdo/apps/code-studio/progressRedux';
+import {nextLevelId} from '@cdo/apps/code-studio/progressReduxSelectors';
 import Button from '@cdo/apps/componentLibrary/button';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {commonI18n} from '@cdo/apps/types/locale';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {useFetch} from '@cdo/apps/util/useFetch';
 
 import moduleStyles from './control-buttons.module.scss';
@@ -17,11 +19,22 @@ interface PermissionResponse {
 const ControlButtons: React.FunctionComponent = () => {
   const {onRun} = useCodebridgeContext();
   const {loading, data} = useFetch('/api/v1/users/current/permissions');
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
+  const [isFinished, setIsFinished] = React.useState(false);
 
   const source = useAppSelector(
     state => state.lab2Project.projectSource?.source
   ) as MultiFileSource | undefined;
+  const hasNextLevel = useAppSelector(
+    state => nextLevelId(state) !== undefined
+  );
+
+  const navigationButtonText = hasNextLevel
+    ? commonI18n.continue()
+    : commonI18n.finish();
+
+  const onContinue = () => dispatch(navigateToNextLevel());
+  const onFinish = () => setIsFinished(true);
 
   const handleRun = (runTests: boolean) => {
     if (onRun) {
@@ -50,6 +63,14 @@ const ControlButtons: React.FunctionComponent = () => {
         disabled={loading}
         iconLeft={{iconStyle: 'solid', iconName: 'flask'}}
         color={'black'}
+        className={moduleStyles.controlButton}
+        size={'s'}
+      />
+      <Button
+        text={navigationButtonText}
+        onClick={hasNextLevel ? onContinue : onFinish}
+        disabled={loading || isFinished}
+        color={'purple'}
         className={moduleStyles.controlButton}
         size={'s'}
       />

--- a/apps/src/codebridge/ControlButtons/index.tsx
+++ b/apps/src/codebridge/ControlButtons/index.tsx
@@ -54,7 +54,7 @@ const ControlButtons: React.FunctionComponent = () => {
         onClick={() => handleRun(false)}
         disabled={loading}
         iconLeft={{iconStyle: 'solid', iconName: 'play'}}
-        className={moduleStyles.controlButton}
+        className={moduleStyles.firstControlButton}
         size={'s'}
       />
       <Button
@@ -63,7 +63,6 @@ const ControlButtons: React.FunctionComponent = () => {
         disabled={loading}
         iconLeft={{iconStyle: 'solid', iconName: 'flask'}}
         color={'black'}
-        className={moduleStyles.controlButton}
         size={'s'}
       />
       <Button
@@ -71,7 +70,7 @@ const ControlButtons: React.FunctionComponent = () => {
         onClick={hasNextLevel ? onContinue : onFinish}
         disabled={loading || isFinished}
         color={'purple'}
-        className={moduleStyles.controlButton}
+        className={moduleStyles.navigationButton}
         size={'s'}
       />
     </div>

--- a/apps/src/codebridge/InfoPanel/index.tsx
+++ b/apps/src/codebridge/InfoPanel/index.tsx
@@ -22,6 +22,12 @@ const panelMap = {
   [Panels.ForTeachersOnly]: ForTeachersOnly,
 };
 
+const panelProps = {
+  [Panels.Instructions]: {manageNavigation: false},
+  [Panels.HelpAndTips]: {},
+  [Panels.ForTeachersOnly]: {},
+};
+
 export const InfoPanel = React.memo(() => {
   const mapReference = useAppSelector(
     state => state.lab.levelProperties?.mapReference
@@ -112,7 +118,7 @@ export const InfoPanel = React.memo(() => {
           </ul>
         </form>
       )}
-      <CurrentPanelView />
+      <CurrentPanelView {...panelProps[currentPanel]} />
     </PanelContainer>
   );
 });

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -30,6 +30,7 @@ interface InstructionsProps {
    * A callback when the user clicks on clickable text.
    */
   handleInstructionsTextClick?: (id: string) => void;
+  manageNavigation?: boolean;
 }
 
 /**
@@ -46,6 +47,7 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   layout,
   imagePopOutDirection,
   handleInstructionsTextClick,
+  manageNavigation = true,
 }) => {
   const instructionsText = useSelector(
     (state: {lab: LabState}) => state.lab.levelProperties?.longInstructions
@@ -57,12 +59,14 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
 
   // If there are no validation conditions, we can show the continue button so long as
   // there is another level. If validation is present, also check that conditions are satisfied.
-  const showContinueButton = (!hasConditions || satisfied) && hasNextLevel;
+  const showContinueButton =
+    manageNavigation && (!hasConditions || satisfied) && hasNextLevel;
 
   // If there are no validation conditions, we can show the finish button so long as
   // this is the last level in the progression. If validation is present, also
   // check that conditions are satisfied.
-  const showFinishButton = (!hasConditions || satisfied) && !hasNextLevel;
+  const showFinishButton =
+    manageNavigation && (!hasConditions || satisfied) && !hasNextLevel;
 
   const dispatch = useAppDispatch();
 

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -58,13 +58,14 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
   );
 
   // If there are no validation conditions, we can show the continue button so long as
-  // there is another level. If validation is present, also check that conditions are satisfied.
+  // there is another level and manageNavigation is true.
+  // If validation is present, also check that conditions are satisfied.
   const showContinueButton =
     manageNavigation && (!hasConditions || satisfied) && hasNextLevel;
 
   // If there are no validation conditions, we can show the finish button so long as
-  // this is the last level in the progression. If validation is present, also
-  // check that conditions are satisfied.
+  // this is the last level in the progression and the instructions panel is managing navigation.
+  // If validation is present, also check that conditions are satisfied.
   const showFinishButton =
     manageNavigation && (!hasConditions || satisfied) && !hasNextLevel;
 


### PR DESCRIPTION
For Code bridge only, move the continue/finish button out of the instructions panel. I added a prop to the lab2 instructions panel, `manageNavigation`, which if true includes the button. The prop is true by default so the existing labs such as Music still have a continue/finish button in the instructions panel.

For Python Lab, the button is now in the bottom right. Web Lab 2 doesn't have a spot decided yet, so it no longer has a finish button. This felt reasonable to me for now since we don't have specific mocks for Web Lab 2.

For now clicking continue takes you to the next level but does not turn the bubble green, and finish doesn't do anything. There are follow-up tasks to cover turning the bubble green and to figure out what to do on finish.

I also changed the run button to white rather than purple, which matches the [figma](https://www.figma.com/design/vcNGOFsIks0HhRk6GEOfZf/Upper-Lab?node-id=3186-22172&m=dev)

### Screenshots
<img width="1706" alt="Screenshot 2024-06-27 at 4 03 39 PM" src="https://github.com/code-dot-org/code-dot-org/assets/33666587/7baec06e-fa96-47bd-aa3b-6f2f4a215c0b">

<img width="1706" alt="Screenshot 2024-06-27 at 4 03 50 PM" src="https://github.com/code-dot-org/code-dot-org/assets/33666587/b98ba446-1c45-4155-b4f8-ac6897bf85c1">

## Links
- [figma](https://www.figma.com/design/vcNGOFsIks0HhRk6GEOfZf/Upper-Lab?node-id=3186-22172&m=dev)
- jira ticket: [CT-633](https://codedotorg.atlassian.net/browse/CT-633)

## Testing story
Tested locally that Python Lab has the moved continue button and other non-Code Bridge labs are unaffected.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
