### PR TITLE
Validate account linking permission only when trying to link an account

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -11,7 +11,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # TODO: figure out how to avoid skipping CSRF verification for Powerschool
   skip_before_action :verify_authenticity_token, only: :powerschool
 
-  before_action :check_account_linking_lock, on: %i[connect_provider link_accounts]
+  before_action :check_account_linking_lock
 
   # Note: We can probably remove these once we've broken out all providers
   BROKEN_OUT_TYPES = [
@@ -519,8 +519,14 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     return !!lookup_user
   end
 
+  # Are we trying to connect a new OAuth provider?
+  private def connecting_new_provider?
+    current_user && auth_params.fetch("action", nil) == "connect"
+  end
+
+  # Should we try to add a new OAuth provider?
   private def should_connect_provider?
-    return current_user && auth_params.fetch("action", nil) == "connect"
+    connecting_new_provider? && !account_linking_locked?
   end
 
   private def get_connect_provider_errors(auth_option)
@@ -530,20 +536,34 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     I18n.t('auth.unable_to_connect_provider', provider: I18n.t("auth.#{auth_option.credential_type}"))
   end
 
-  private def check_account_linking_lock
+  # Is this user able to link new providers?
+  private def account_linking_locked?
     user = current_user || find_user_by_credential
     return unless user
 
-    lock_reason = account_linking_lock_reason(user)
-    return unless lock_reason
+    account_linking_lock_reason(user)
+  end
 
+  # If we are trying to connect a new provider to an existing account and the
+  # user does not have permission to add new providers, then stop the linking
+  # and report an error.
+  private def check_account_linking_lock
+    # Only check for account link locking when trying to link a new provider.
+    return unless connecting_new_provider? || lti_registration?
+    lock_reason = account_linking_locked?
+    return unless lock_reason
     redirect_back fallback_location: new_user_session_path, alert: lock_reason
+  end
+
+  # Are we trying to link a new provider while registering an LTI account?
+  private def lti_registration?
+    DCDO.get('lti_account_linking_enabled', false) && Policies::Lti.lti_registration_in_progress?(session)
   end
 
   # Determine whether to link a new LTI auth option to an existing account
   # Not to be confused with the connect_provider flow
   private def should_link_accounts?
-    DCDO.get('lti_account_linking_enabled', false) && Policies::Lti.lti_registration_in_progress?(session)
+    lti_registration? && !account_linking_locked?
   end
 
   # For linking new LTI auth options to existing accounts


### PR DESCRIPTION
Bug: Users who have account linking locked could not sign back in.
Cause: The check_account_linking_lock was being called for all OAuth controller actions (such as signing in), not just the account linking actions.
Fix: Limit the account linking lock redirect to only when the user is attempting to link an account.

## Links
* [Original "fix"](https://github.com/code-dot-org/code-dot-org/pull/59463)  which was reverted.

## Testing story
* Added unit test which reproduces the bug if "fix" in this PR is missing.
* Manually tested on localhost (see before and after).

## Videos
### Before
https://github.com/code-dot-org/code-dot-org/assets/1372238/2ecd2f75-dcaf-4ca2-b875-bbbd5dcbce38

### After
https://github.com/code-dot-org/code-dot-org/assets/1372238/2ccf0743-ad92-4c08-9b5a-369c65367cc4

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
