### PR TITLE
Curriculum launch 2024 - Misc fixes

### DIFF
--- a/pegasus/sites.v3/code.org/public/maker/index.haml
+++ b/pegasus/sites.v3/code.org/public/maker/index.haml
@@ -51,14 +51,14 @@ theme: responsive_full_width
   .wrapper
     %h2=hoc_s("maker_page.get_started.heading")
     %p=hoc_s("maker_page.get_started.desc")
-    = view :maker_devices, curriculum_link_cp: "#curriculum_link_cp", curriculum_link_microbit: "#curriculum_link_microbit",  button_label: hoc_s("maker_page.get_started.button.see_curriculum.label"), aria_label_cp: hoc_s("maker_page.get_started.button.see_curriculum.aria_label", markdown: :inline, locals:{device: "BBC micro:bit"}), aria_label_microbit: hoc_s("maker_page.get_started.button.see_curriculum.aria_label", markdown: :inline, locals:{device: "Circuit Playground"})
+    = view :maker_devices, curriculum_link_cp: "#curriculum-link-cp", curriculum_link_microbit: "#curriculum-link-microbit",  button_label: hoc_s("maker_page.get_started.button.see_curriculum.label"), aria_label_cp: hoc_s("maker_page.get_started.button.see_curriculum.aria_label", markdown: :inline, locals:{device: "BBC micro:bit"}), aria_label_microbit: hoc_s("maker_page.get_started.button.see_curriculum.aria_label", markdown: :inline, locals:{device: "Circuit Playground"})
 
 %section.bg-neutral-light
   .wrapper.centered
     %h2=hoc_s("maker_page.why.heading")
     = view :maker_why_list
 
-%section#curriculum_link_microbit
+%section#curriculum-link-microbit
   .wrapper
     %h2=hoc_s("maker_page.curricula_microbit.heading")
     %p=hoc_s("maker_page.curricula_microbit.desc")
@@ -71,7 +71,7 @@ theme: responsive_full_width
 
 = view :section_divider_line
 
-%section#curriculum_link_cp
+%section#curriculum-link-cp
   .wrapper
     %h2=hoc_s("maker_page.curricula_circuit_playground.heading")
     = view :maker_curriculum_circuit_playground, explore_unit_link: CDO.studio_url("/s/devices?viewAs=Instructor"), teach_unit_link: CDO.studio_url("/courses/self-paced-pl-physical-computing")

--- a/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_pl.haml
+++ b/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_pl.haml
@@ -17,7 +17,7 @@
       img: "/images/action-blocks/action-block-ai-decisions.png",
       desc: hoc_s("ai_page.pl.tile.decisions.desc"),
       duration: hoc_s("ai_page.pl.tile.decisions.duration"),
-      url: CDO.studio_url("#"),
+      url: CDO.studio_url("/courses/elementaryai-2024"),
       aria_label: hoc_s("ai_page.pl.tile.decisions.aria_label"),
       button_label: hoc_s("ai_page.pl.tile.decisions.button"),
       new: true,

--- a/pegasus/sites.v3/code.org/views/curriculum_pages_additional_resources.haml
+++ b/pegasus/sites.v3/code.org/views/curriculum_pages_additional_resources.haml
@@ -11,7 +11,7 @@
       title: hoc_s('curricula_pages.additional_resources.self_paced.title'),
       image: "/images/professional-learning/self-paced-pl-discover.png",
       desc: hoc_s('curricula_pages.additional_resources.self_paced.desc'),
-      url: "/online-pl",
+      url: "/professional-learning/self-paced",
       button_label: hoc_s('curricula_pages.additional_resources.self_paced.button')
     },
     {

--- a/pegasus/sites.v3/code.org/views/game_design/game_design_curriculum_elementary.haml
+++ b/pegasus/sites.v3/code.org/views/game_design/game_design_curriculum_elementary.haml
@@ -6,7 +6,7 @@
       img: "/images/action-blocks/action-block-game-design.png",
       desc: hoc_s("game_design_page.elementary_curricula.game_design.desc"),
       duration: hoc_s("game_design_page.elementary_curricula.game_design.duration"),
-      url: CDO.studio_url("/s/pilot-k5-game-design"),
+      url: CDO.studio_url("/s/elem-game-design-2024"),
       aria_label: hoc_s("game_design_page.elementary_curricula.game_design.aria_label"),
       button_label: hoc_s("game_design_page.elementary_curricula.game_design.button"),
       new: true,

--- a/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_elementary.haml
+++ b/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_elementary.haml
@@ -12,7 +12,19 @@
       aria_label_primary: hoc_s(:aria_label_call_to_action_ai_101),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_ai_101),
       new: true
-    }
+    },
+    {
+      overline: hoc_s(:module_grade_k_5_teachers),
+      title: hoc_s(:module_label_teaching_k5_basics),
+      image: "/images/CSFimages/students_with_tablets.png",
+      curriculum: hoc_s(:curriculum_name_all_k5),
+      duration: hoc_s(:module_duration_2_hrs),
+      prerequisites: hoc_s(:module_prerequisites_none),
+      url_primary: CDO.studio_url("/courses/self-paced-pl-k5-2024"),
+      url_secondary: "/educate/curriculum/elementary-school",
+      aria_label_primary: hoc_s(:aria_label_call_to_action_explore_k5_self_paced_pl),
+      aria_label_secondary: hoc_s(:aria_label_call_to_action_explore_k_5_curriculum),
+    },
   ]
   if !!DCDO.get('curriculum-launch-2024', false)
     block_items +=[
@@ -21,7 +33,7 @@
         title: hoc_s(:module_label_teaching_how_ai_makes_decisions),
         image: '/images/self-paced-pl-tile-how-ai-makes-decisions.jpg',
         curriculum: hoc_s(:curriculum_name_how_ai_makes_decisions),
-        duration: hoc_s(:module_duration_1_hr),  
+        duration: hoc_s(:module_duration_1_hr),
         prerequisites: hoc_s(:module_prerequisites_none),
         url_primary: CDO.studio_url("/courses/elementaryai-2024"),
         url_secondary: CDO.studio_url('/s/k5-ai-data-2024'),
@@ -50,7 +62,7 @@
         duration: hoc_s(:module_duration_1_hr_30_minutes),
         prerequisites: hoc_s(:module_prerequisites_none),
         url_primary: CDO.studio_url("/courses/microbitmakermodule-2024"),
-        url_secondary: "/maker",
+        url_secondary: "/maker#curriculum-link-microbit",
         aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_microbit_maker_module),
         aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_microbit_maker_module),
         new: true
@@ -81,19 +93,7 @@
       url_secondary: "/educate/csc",
       aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_csc),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_csc),
-    },
-    {
-      overline: hoc_s(:module_grade_k_5_teachers),
-      title: hoc_s(:module_label_teaching_k5_basics),
-      image: "/images/CSFimages/students_with_tablets.png",
-      curriculum: hoc_s(:curriculum_name_all_k5),
-      duration: hoc_s(:module_duration_2_hrs),
-      prerequisites: hoc_s(:module_prerequisites_none),
-      url_primary: CDO.studio_url("/courses/self-paced-pl-k5-2024"),
-      url_secondary: "/educate/curriculum/elementary-school",
-      aria_label_primary: hoc_s(:aria_label_call_to_action_explore_k5_self_paced_pl),
-      aria_label_secondary: hoc_s(:aria_label_call_to_action_explore_k_5_curriculum),
-    },
+    }
   ]
 
 .carousel-wrapper

--- a/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_elementary.haml
+++ b/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_elementary.haml
@@ -12,19 +12,7 @@
       aria_label_primary: hoc_s(:aria_label_call_to_action_ai_101),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_ai_101),
       new: true
-    },
-    {
-      overline: hoc_s(:module_grade_k_5_teachers),
-      title: hoc_s(:module_label_teaching_k5_basics),
-      image: "/images/CSFimages/students_with_tablets.png",
-      curriculum: hoc_s(:curriculum_name_all_k5),
-      duration: hoc_s(:module_duration_2_hrs),
-      prerequisites: hoc_s(:module_prerequisites_none),
-      url_primary: CDO.studio_url("/courses/self-paced-pl-k5-2024"),
-      url_secondary: "/educate/curriculum/elementary-school",
-      aria_label_primary: hoc_s(:aria_label_call_to_action_explore_k5_self_paced_pl),
-      aria_label_secondary: hoc_s(:aria_label_call_to_action_explore_k_5_curriculum),
-    },
+    }
   ]
   if !!DCDO.get('curriculum-launch-2024', false)
     block_items +=[
@@ -70,6 +58,18 @@
     ]
   end
   block_items += [
+    {
+      overline: hoc_s(:module_grade_k_5_teachers),
+      title: hoc_s(:module_label_teaching_k5_basics),
+      image: "/images/CSFimages/students_with_tablets.png",
+      curriculum: hoc_s(:curriculum_name_all_k5),
+      duration: hoc_s(:module_duration_2_hrs),
+      prerequisites: hoc_s(:module_prerequisites_none),
+      url_primary: CDO.studio_url("/courses/self-paced-pl-k5-2024"),
+      url_secondary: "/educate/curriculum/elementary-school",
+      aria_label_primary: hoc_s(:aria_label_call_to_action_explore_k5_self_paced_pl),
+      aria_label_secondary: hoc_s(:aria_label_call_to_action_explore_k_5_curriculum),
+    },
     {
       overline: hoc_s(:module_grade_k_5_teachers),
       title: hoc_s(:module_label_teaching_csf),

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -228,7 +228,7 @@
       self_paced:
         title: "Self-Paced Learning"
         desc: "These modules allow you to engage at your own pace and on your own time while focusing on areas most important to your needs and teaching context."
-        button: "Discover the district program"
+        button: "Explore professional learning"
       workshops:
         title_k_5: "K-5 Workshops"
         title_6_12: "6-12 Workshops"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -233,7 +233,7 @@
         title_k_5: "K-5 Workshops"
         title_6_12: "6-12 Workshops"
         desc: "With our Regional Partners as hosts and our Code.org facilitators as guides, our workshops around the country focus on reflection, discussion, and growth-oriented learning."
-        button: "Explore professional learning"
+        button: "Explore workshops"
 
   facilitator_led_pl_heading: "Facilitator-Led Professional Learning Workshops"
   facilitator_led_pl_desc: "Learn about our professional learning workshops for elementary, middle, and high school teachers."


### PR DESCRIPTION
Updates misc fixes for pages for the 2024 curriculum launch. This PR contains fixes for the following Jira tickets:

----

## On self paced PL page make code.org/maker microbit curriculum link jump to microbit curriculum section, and rearrange tile order
- Jira ticket: [ACQ-2036](https://codedotorg.atlassian.net/browse/ACQ-2036)

| Update Maker link | Rearrange tile order |
| ---- | ---- |
| <img width="839" alt="Self Paced PL Maker Link" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/9dd350a8-0547-4c3b-8a7d-204e9c132b8d"> | <img width="1142" alt="Self Paced PL Order" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/b1209981-e85f-453b-87d4-92cc7ba75843"> |

## Make sure on code.org/ai that Teaching How AI Makes Decisions has right link
- Jira ticket: [ACQ-2034](https://codedotorg.atlassian.net/browse/ACQ-2034)

| Updates link |
| ---- |
| <img width="600" alt="AI Decisions" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/4272136e-6b6a-4c0c-b356-583668270933"> |

## Update K5 game design link on new game design page
- Jira ticket: [ACQ-2038](https://codedotorg.atlassian.net/browse/ACQ-2038)

| Updates link |
| ---- |
| <img width="450" alt="Game Design K5" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/c6eae650-d7ae-42e6-a969-522c67b7ee68"> |

## On Elementary, Middle and High pages make sure additional resources self-paced button has correct text
- Jira ticket: [ACQ-2035](https://codedotorg.atlassian.net/browse/ACQ-2035)

| Updates button label |
| ---- |
| <img width="1045" alt="Screenshot 2024-06-28 at 9 18 55 AM" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/01b0d105-b46a-44a0-9f42-fe65d95593be"> |

----

## Testing story
Tested locally