### PR TITLE
[Google Blockly] Allow spaces when naming variables and parameters

### DIFF
--- a/apps/src/blockly/addons/cdoFieldParameter.ts
+++ b/apps/src/blockly/addons/cdoFieldParameter.ts
@@ -20,6 +20,13 @@ import {ExtendedWorkspaceSvg, ProcedureBlock} from '../types';
 const RENAME_PARAMETER_ID = 'RENAME_VARIABLE_ID';
 const DELETE_PARAMETER_ID = 'DELETE_VARIABLE_ID';
 
+interface ParameterPromptOptions {
+  promptText: string; // Description text for window prompt
+  confirmButtonLabel: string; // Label of confirm button, e.g., "Rename"
+  callback: (newName: string) => void; // Callback with text of new parameter name
+  isDeleteDialog: boolean; // True for delete dialog; False for rename dialog
+  defaultText?: string; // Default input text for window prompt
+}
 export default class CdoFieldParameter extends GoogleBlockly.FieldVariable {
   /**
    * Handle the selection of an item in the parameter dropdown menu.
@@ -41,7 +48,7 @@ export default class CdoFieldParameter extends GoogleBlockly.FieldVariable {
             }),
             confirmButtonLabel: commonI18n.rename(),
             callback: this.renameSelectedParameter.bind(this),
-            prompt: true,
+            isDeleteDialog: false,
             defaultText: oldVar,
           });
           break;
@@ -53,7 +60,7 @@ export default class CdoFieldParameter extends GoogleBlockly.FieldVariable {
             }),
             confirmButtonLabel: commonI18n.delete(),
             callback: this.deleteSelectedParameter.bind(this),
-            prompt: false,
+            isDeleteDialog: true,
           });
           break;
         default:
@@ -242,30 +249,19 @@ export default class CdoFieldParameter extends GoogleBlockly.FieldVariable {
 
   /**
    * Prompt the user to name or delete a parameter.
-   * @param {object} options The options object.
-   * @param {string} options.promptText Description text for window prompt.
-   * @param {string} options.confirmButtonLabel Label of confirm button, e.g., "Rename".
-   * @param {function} options.callback Callback with parameter (text) of new name.
-   * @param {boolean} options.prompt Whether to prompt for a string value.
-   * @param {string} [options.defaultText] Default input text for window prompt.
+   * @param {ParameterPromptOptions} options The options object.
    */
-  static parameterPrompt = function (options: {
-    promptText: string;
-    confirmButtonLabel: string;
-    callback: (newName: string) => void;
-    prompt: boolean;
-    defaultText?: string;
-  }) {
+  static parameterPrompt = function (options: ParameterPromptOptions) {
     Blockly.customSimpleDialog({
       bodyText: options.promptText,
-      prompt: options.prompt,
+      prompt: !options.isDeleteDialog,
       promptPrefill: options.defaultText,
       cancelText: options.confirmButtonLabel,
-      isDangerCancel: !options.prompt,
+      isDangerCancel: !!options.isDeleteDialog,
       confirmText: commonI18n.cancel(),
       onConfirm: null,
       onCancel: options.callback,
-      disableSpaceClose: !!prompt,
+      disableSpaceClose: !options.isDeleteDialog,
     });
   };
 }
@@ -287,7 +283,7 @@ export const getAddParameterButtonWithCallback = (
         const newIndex = procedure.getParameters().length;
         procedure.insertParameter(newParameter, newIndex);
       },
-      prompt: true,
+      isDeleteDialog: false,
     });
   });
 

--- a/apps/src/blockly/addons/cdoFieldParameter.ts
+++ b/apps/src/blockly/addons/cdoFieldParameter.ts
@@ -35,24 +35,26 @@ export default class CdoFieldParameter extends GoogleBlockly.FieldVariable {
       switch (id) {
         case RENAME_PARAMETER_ID:
           // Rename all instances of this variable.
-          CdoFieldParameter.modalDialogName(
-            commonI18n.renameParameterPromptTitle({parameterName: oldVar}),
-            commonI18n.rename(),
-            this.renameSelectedParameter.bind(this),
-            true,
-            false,
-            oldVar
-          );
+          CdoFieldParameter.parameterPrompt({
+            promptText: commonI18n.renameParameterPromptTitle({
+              parameterName: oldVar,
+            }),
+            confirmButtonLabel: commonI18n.rename(),
+            callback: this.renameSelectedParameter.bind(this),
+            prompt: true,
+            defaultText: oldVar,
+          });
           break;
         case DELETE_PARAMETER_ID:
           // Delete this parameter and any of its parameter blocks.
-          CdoFieldParameter.modalDialogName(
-            commonI18n.deleteParameterTitle({parameterName: oldVar}),
-            commonI18n.delete(),
-            this.deleteSelectedParameter.bind(this),
-            false,
-            true
-          );
+          CdoFieldParameter.parameterPrompt({
+            promptText: commonI18n.deleteParameterTitle({
+              parameterName: oldVar,
+            }),
+            confirmButtonLabel: commonI18n.delete(),
+            callback: this.deleteSelectedParameter.bind(this),
+            prompt: false,
+          });
           break;
         default:
           // If we have somehow have another option (we shouldn't), and
@@ -239,31 +241,31 @@ export default class CdoFieldParameter extends GoogleBlockly.FieldVariable {
   };
 
   /**
-   * Prompt the user for a variable name or delete a variable.
-   * @param promptText description text for window prompt
-   * @param confirmButtonLabel Label of confirm button, e.g. "Rename"
-   * @param callback with parameter (text) of new name
-   * @param prompt Whether to prompt for a string value
-   * @param isDangerCancel Should cancel button has a danger type
-   * @param defaultText default input text for window prompt
+   * Prompt the user to name or delete a parameter.
+   * @param {object} options The options object.
+   * @param {string} options.promptText Description text for window prompt.
+   * @param {string} options.confirmButtonLabel Label of confirm button, e.g., "Rename".
+   * @param {function} options.callback Callback with parameter (text) of new name.
+   * @param {boolean} options.prompt Whether to prompt for a string value.
+   * @param {string} [options.defaultText] Default input text for window prompt.
    */
-  static modalDialogName = function (
-    promptText: string,
-    confirmButtonLabel: string,
-    callback: (newName: string) => void,
-    prompt: boolean,
-    isDangerCancel: boolean,
-    defaultText?: string
-  ) {
+  static parameterPrompt = function (options: {
+    promptText: string;
+    confirmButtonLabel: string;
+    callback: (newName: string) => void;
+    prompt: boolean;
+    defaultText?: string;
+  }) {
     Blockly.customSimpleDialog({
-      bodyText: promptText,
-      prompt,
-      promptPrefill: defaultText,
-      cancelText: confirmButtonLabel,
-      isDangerCancel,
+      bodyText: options.promptText,
+      prompt: options.prompt,
+      promptPrefill: options.defaultText,
+      cancelText: options.confirmButtonLabel,
+      isDangerCancel: !options.prompt,
       confirmText: commonI18n.cancel(),
       onConfirm: null,
-      onCancel: callback,
+      onCancel: options.callback,
+      disableSpaceClose: !!prompt,
     });
   };
 }
@@ -274,10 +276,10 @@ export const getAddParameterButtonWithCallback = (
 ) => {
   const addParameterCallbackKey = 'addParameterCallback';
   workspace.registerButtonCallback(addParameterCallbackKey, () => {
-    CdoFieldParameter.modalDialogName(
-      commonI18n.newParameterTitle(),
-      commonI18n.create(),
-      parameterName => {
+    CdoFieldParameter.parameterPrompt({
+      promptText: commonI18n.newParameterTitle(),
+      confirmButtonLabel: commonI18n.create(),
+      callback: parameterName => {
         const newParameter = new ObservableParameterModel(
           workspace,
           parameterName
@@ -285,9 +287,8 @@ export const getAddParameterButtonWithCallback = (
         const newIndex = procedure.getParameters().length;
         procedure.insertParameter(newParameter, newIndex);
       },
-      true,
-      false
-    );
+      prompt: true,
+    });
   });
 
   return {

--- a/apps/src/blockly/addons/cdoFieldVariable.ts
+++ b/apps/src/blockly/addons/cdoFieldVariable.ts
@@ -28,32 +28,32 @@ export default class CdoFieldVariable extends GoogleBlockly.FieldVariable {
       switch (id) {
         case RENAME_ALL_ID:
           // Rename all instances of this variable.
-          CdoFieldVariable.modalPromptName(
-            commonI18n.renameAllPromptTitle({variableName: oldVar}),
-            commonI18n.rename(),
-            oldVar,
-            newName =>
+          CdoFieldVariable.variableNamePrompt({
+            promptText: commonI18n.renameAllPromptTitle({variableName: oldVar}),
+            confirmButtonLabel: commonI18n.rename(),
+            defaultText: oldVar,
+            callback: newName =>
               this.sourceBlock_?.workspace.renameVariableById(
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 ((this as any).variable as VariableModel).getId(),
                 newName
-              )
-          );
+              ),
+          });
           break;
         case RENAME_THIS_ID:
           // Rename just this variable.
-          CdoFieldVariable.modalPromptName(
-            commonI18n.renameThisPromptTitle(),
-            commonI18n.create(),
-            '',
-            newName => {
+          CdoFieldVariable.variableNamePrompt({
+            promptText: commonI18n.renameThisPromptTitle(),
+            confirmButtonLabel: commonI18n.create(),
+            defaultText: '',
+            callback: newName => {
               const newVar =
                 this.sourceBlock_?.workspace.createVariable(newName);
               if (newVar) {
                 this.setValue(newVar.getId());
               }
-            }
-          );
+            },
+          });
           break;
         default:
           this.setValue(id);
@@ -116,28 +116,29 @@ export default class CdoFieldVariable extends GoogleBlockly.FieldVariable {
     return options;
   };
 
-  // Fix built-in block
   /**
    * Prompt the user for a variable name and perform some whitespace cleanup
-   * @param promptText description text for window prompt
-   * @param confirmButtonLabel Label of confirm button, e.g. "Rename"
-   * @param defaultText default input text for window prompt
-   * @param callback with parameter (text) of new name
+   * @param {object} options The options object.
+   * @param {string} options.promptText Description text for window prompt.
+   * @param {string} options.confirmButtonLabel Label of confirm button, e.g., "Rename".
+   * @param {string} options.defaultText Default input text for window prompt.
+   * @param {function} options.callback Callback with parameter (text) of new name.
    */
-  static modalPromptName = function (
-    promptText: string,
-    confirmButtonLabel: string,
-    defaultText: string,
-    callback: (newName: string) => void
-  ) {
+  static variableNamePrompt = function (options: {
+    promptText: string;
+    confirmButtonLabel: string;
+    defaultText: string;
+    callback: (newName: string) => void;
+  }) {
     Blockly.customSimpleDialog({
-      bodyText: promptText,
+      bodyText: options.promptText,
       prompt: true,
-      promptPrefill: defaultText,
-      cancelText: confirmButtonLabel,
+      promptPrefill: options.defaultText,
+      cancelText: options.confirmButtonLabel,
       confirmText: commonI18n.cancel(),
       onConfirm: null,
-      onCancel: callback,
+      onCancel: options.callback,
+      disableSpaceClose: true,
     });
   };
 }

--- a/apps/src/blockly/addons/cdoFieldVariable.ts
+++ b/apps/src/blockly/addons/cdoFieldVariable.ts
@@ -12,6 +12,12 @@ import {commonI18n} from '@cdo/apps/types/locale';
 const RENAME_THIS_ID = 'RENAME_THIS_ID';
 const RENAME_ALL_ID = 'RENAME_ALL_ID';
 
+interface VariableNamePromptOptions {
+  promptText: string; // Description text for window prompt
+  confirmButtonLabel: string; // Label of confirm button, e.g., "Rename"
+  defaultText: string; // Default input text for window prompt
+  callback: (newName: string) => void; // Callback with text of new variable name
+}
 export default class CdoFieldVariable extends GoogleBlockly.FieldVariable {
   /**
    * Handle the selection of an item in the variable dropdown menu.
@@ -118,18 +124,9 @@ export default class CdoFieldVariable extends GoogleBlockly.FieldVariable {
 
   /**
    * Prompt the user for a variable name and perform some whitespace cleanup
-   * @param {object} options The options object.
-   * @param {string} options.promptText Description text for window prompt.
-   * @param {string} options.confirmButtonLabel Label of confirm button, e.g., "Rename".
-   * @param {string} options.defaultText Default input text for window prompt.
-   * @param {function} options.callback Callback with parameter (text) of new name.
+   * @param {VariableNamePromptOptions} options The options object.
    */
-  static variableNamePrompt = function (options: {
-    promptText: string;
-    confirmButtonLabel: string;
-    defaultText: string;
-    callback: (newName: string) => void;
-  }) {
+  static variableNamePrompt = function (options: VariableNamePromptOptions) {
     Blockly.customSimpleDialog({
       bodyText: options.promptText,
       prompt: true,

--- a/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.ts
@@ -55,14 +55,14 @@ export function flyoutCategory(workspace: WorkspaceSvg) {
 const getNewVariableButtonWithCallback = (workspace: WorkspaceSvg) => {
   const callbackKey = 'newVariableCallback';
   workspace.registerButtonCallback(callbackKey, () => {
-    Blockly.FieldVariable.modalPromptName(
-      commonI18n.renameThisPromptTitle(),
-      commonI18n.create(),
-      '',
-      newName => {
+    Blockly.FieldVariable.variableNamePrompt({
+      promptText: commonI18n.renameThisPromptTitle(),
+      confirmButtonLabel: commonI18n.create(),
+      defaultText: '',
+      callback: newName => {
         workspace.createVariable(newName);
-      }
-    );
+      },
+    });
   });
 
   return {

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -1290,6 +1290,7 @@ FeedbackUtils.prototype.showClearPuzzleConfirmation = function (
  * @param {string} options.isDangerCancel Should cancel button has a danger type
  * @param {string} options.confirmText Text for confirm button
  * @param {boolean} [options.hideIcon=false] Whether to hide the icon
+ * @param {boolean} [options.disableSpaceClose=false] Whether to disable closing the dialog with the spacebar
  * @param {onConfirmCallback} [options.onConfirm] Function to be called after clicking confirm
  * @param {onCancelCallback} [options.onCancel] Function to be called after clicking cancel
  */
@@ -1324,6 +1325,7 @@ FeedbackUtils.prototype.showSimpleDialog = function (options) {
     contentDiv: contentDiv,
     icon: options.hideIcon ? null : this.studioApp_.icon,
     defaultBtnSelector: '#again-button',
+    disableSpaceClose: !!options.disableSpaceClose,
   });
 
   var cancelButton = contentDiv.querySelector('#again-button');
@@ -1777,6 +1779,7 @@ function simulateClick(element) {
  * @param {string} options.id
  * @param {HTMLElement} options.header
  * @param {boolean} options.showXButton
+ * @param {boolean} [options.disableSpaceClose]
  */
 FeedbackUtils.prototype.createModalDialog = function (options) {
   var modalBody = document.createElement('div');
@@ -1799,7 +1802,12 @@ FeedbackUtils.prototype.createModalDialog = function (options) {
 
   var btn = options.contentDiv.querySelector(options.defaultBtnSelector);
   var keydownHandler = function (e) {
-    if (e.keyCode === KeyCodes.ENTER || e.keyCode === KeyCodes.SPACE) {
+    if (
+      e.keyCode === KeyCodes.ENTER ||
+      // This dialog is also used for renaming variables in Blockly labs.
+      // We disable this check for these instances so that spaces can be entered.
+      (!options.disableSpaceClose && e.keyCode === KeyCodes.SPACE)
+    ) {
       simulateClick(btn);
 
       e.stopPropagation();


### PR DESCRIPTION
Yesterday, during the Maze migration bug bash, @molly-moen made the following observation regarding https://studio.code.org/s/course4/lessons/16/levels/6:

> The level instructions say to add a parameter called “nectar units” but we don’t seem to allow spaces in parameter names. If you try to add a space it closes the modal.
> If you start in cdo with a parameter with spaces it does transfer over correctly, so it might be a problem with the modal.

This branch introduces changes that make it possible to add spaces for both variables and parameters on Google Blockly:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/b483713c-1abc-4b86-9e9b-3a08852042bc)
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/c85f5972-bea8-472c-954a-82545ce9d8eb)
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/3053512f-d7b0-49d2-80a5-5d2d559a0a73)


While investigating this, I learned:

- Both versions of Blockly support spaces in function names and variable names. This is another good reason that we should probably allow spaces. (The fact that level instructions say you can is the first good reason.)
- Spaces can already be added to function names with either version of Blockly. In CDO, you use a text field on the modal, and in Google, you use the name field on the block itself. Spaces are fine in both places.
- For parameters, CDO Blockly supports spaces because it uses another text field on the modal. However, the new Google Blockly implementation uses a modal dialog. If you press “space” while the dialog is open, it is closed immediately. :bangbang:
- Currently, spaces cannot practically be used in variables in either version of Blockly (although they are technically supported). This is because both versions of Blockly use the same prompt described above, which closes immediately upon pressing space.

It's important to understand that `Blockly.customSimpleDialog` is actually just `FeedbackUtils.showSimpleDialog` with some custom mapping of options. This dialog was designed for other purposes, such as to display the “Clear Puzzle” confirmation dialog between levels. The modal dialog it creates includes a key down handler that dismisses the modal when enter or space are pressed. In a Blockly context, this prevents spaces from being added to variable/parameter names. We want to maintain the experience for non-Blockly contexts.

As a team, we considered several options:
1. Redesigning the new parameter authoring experience to not use `Blockly.customSimpleDialog`.
2. Creating a new component that is specifically tailored for the options we need in Blockly contexts and stop using the feedback dialog.
3. **Updating the feedback dialog to support an option to ignore spacebar presses.**
4. Revising the level instructions to remove the reference to a multi-word parameter name.

We opted to start with option 3 above with the possibility of pursuing option 2 later. This is the path of least resistance that doesn't negatively impact the curriculum or student experience.

After weaving the option through, I also decided to refactor and rename the two main helpers that call `Blockly.customSimpleDialog`. Instead of having a growing list of parameters, each now uses a keyed set of properties in an options object. 

Here's a breakdown of how variables/parameters/functions are renamed or deleted. This branch only changes two scenarios, marked with *.

|Task|CDO Blockly|Google Blockly|
|-|-|-|
|Rename variable|Dialog|**Dialog***|
|Remame parameter|Modal Editor UI|**Dialog***|
|Rename function|Modal Editor UI|Block field|
|Delete variable|n\a|n\a|
|Delete parameter|Dialog|Dialog|
|Delete function|Dialog|Dialog|

In terms of spaces in names, the following illustrates where it will be supported:
||CDO Blockly|Google Blockly|
|-|-|-|
|Variable|No|**Yes***|
|Parameter|Yes|Yes|
|Function|Yes|Yes|

In order to make it so that CDO Blockly variables can use spaces, we would need to update the fork, so that is unlikely to happen.

As an added bonus to this work, Sprite Lab variable watchers have increased potential as player-facing game elements. Because a student can create a variable with spaces, they can also create a watcher with a multi-word label - without resorting to camel case:
![image](https://github.com/code-dot-org/code-dot-org/assets/43474485/8d6456e4-ca64-4334-b8da-532add3410be)


## Links

Slack thread: https://codedotorg.slack.com/archives/C05HZFH7BED/p1719522385377469
Bug bash doc: https://docs.google.com/document/d/14_fjbaK7hbsvmw7O5uJwSJbC7tW9TSxQCbXxk12IO0U/edit

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Follow-up work

Decouple `Blockly.customSimpleDialog` from `FeedbackUtils.showSimpleDialog`: https://codedotorg.atlassian.net/browse/CT-665
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
