### PR TITLE
Adds new unit test for build your own workshop

### DIFF
--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -536,6 +536,29 @@ describe('WorkshopForm test', () => {
     assert(wrapper.find('#suppress_email').first().props().disabled);
   });
 
+  it('selecting Build Your Own Workshop does not show subject or paid fields', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <WorkshopForm
+            permission={new Permission([WorkshopAdmin])}
+            facilitatorCourses={[]}
+            today={getFakeToday(false)}
+            readOnly={false}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const courseField = wrapper.find('#course').first();
+    courseField.simulate('change', {
+      target: {name: 'course', value: 'Build Your Own Workshop'},
+    });
+
+    expect(wrapper.find('#subject')).to.have.lengthOf(0);
+    expect(wrapper.find('#funded')).to.have.lengthOf(0);
+  });
+
   it('editing form as non-admin does not show organizer field', () => {
     const wrapper = mount(
       <Provider store={store}>


### PR DESCRIPTION
This adds test coverage for the new workshop added in https://github.com/code-dot-org/code-dot-org/pull/59457. This verifies that when a user selects 'Build Your Own Workshop' from the dropdown, two of the common fields don't appear.

## Links

- spec: https://docs.google.com/document/d/16IsvtmDFDIDzjn3vv1bIskRkET9ivC_l9LyUXpN0Fno/edit
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2024

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
