### PR TITLE
Add join table for workshops and course offerings

### DIFF
--- a/dashboard/db/migrate/20240628202031_create_join_table_workshop_course_offering.rb
+++ b/dashboard/db/migrate/20240628202031_create_join_table_workshop_course_offering.rb
@@ -1,0 +1,9 @@
+class CreateJoinTableWorkshopCourseOffering < ActiveRecord::Migration[6.1]
+  def change
+    create_join_table :pd_workshops, :course_offerings, table_name: :pl_workshop_topics do |t|
+      t.index :pd_workshop_id
+      t.index :course_offering_id
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/migrate/20240628202031_create_join_table_workshop_course_offering.rb
+++ b/dashboard/db/migrate/20240628202031_create_join_table_workshop_course_offering.rb
@@ -1,9 +1,0 @@
-class CreateJoinTableWorkshopCourseOffering < ActiveRecord::Migration[6.1]
-  def change
-    create_join_table :pd_workshops, :course_offerings, table_name: :pl_workshop_topics do |t|
-      t.index :pd_workshop_id
-      t.index :course_offering_id
-      t.timestamps
-    end
-  end
-end

--- a/dashboard/db/migrate/20240701205906_create_join_table_pd_workshop_course_offering.rb
+++ b/dashboard/db/migrate/20240701205906_create_join_table_pd_workshop_course_offering.rb
@@ -1,0 +1,9 @@
+class CreateJoinTablePdWorkshopCourseOffering < ActiveRecord::Migration[6.1]
+  def change
+    create_join_table :pd_workshops, :course_offerings do |t|
+      t.index :pd_workshop_id
+      t.index :course_offering_id
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1516,15 +1516,6 @@ ActiveRecord::Schema.define(version: 2024_07_01_205906) do
     t.index ["name"], name: "index_pilots_on_name", unique: true
   end
 
-  create_table "pl_workshop_topics", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "pd_workshop_id", null: false
-    t.bigint "course_offering_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["course_offering_id"], name: "index_pl_workshop_topics_on_course_offering_id"
-    t.index ["pd_workshop_id"], name: "index_pl_workshop_topics_on_pd_workshop_id"
-  end
-
   create_table "plc_course_units", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "plc_course_id"
     t.string "unit_name"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_06_24_164604) do
+ActiveRecord::Schema.define(version: 2024_06_28_202031) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1505,6 +1505,15 @@ ActiveRecord::Schema.define(version: 2024_06_24_164604) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_pilots_on_name", unique: true
+  end
+
+  create_table "pl_workshop_topics", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "pd_workshop_id", null: false
+    t.bigint "course_offering_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["course_offering_id"], name: "index_pl_workshop_topics_on_course_offering_id"
+    t.index ["pd_workshop_id"], name: "index_pl_workshop_topics_on_pd_workshop_id"
   end
 
   create_table "plc_course_units", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_06_28_202031) do
+ActiveRecord::Schema.define(version: 2024_07_01_205906) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -426,6 +426,15 @@ ActiveRecord::Schema.define(version: 2024_06_28_202031) do
     t.datetime "published_date"
     t.integer "self_paced_pl_course_offering_id"
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
+  end
+
+  create_table "course_offerings_pd_workshops", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "pd_workshop_id", null: false
+    t.bigint "course_offering_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["course_offering_id"], name: "index_course_offerings_pd_workshops_on_course_offering_id"
+    t.index ["pd_workshop_id"], name: "index_course_offerings_pd_workshops_on_pd_workshop_id"
   end
 
   create_table "course_scripts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Creates a join table between `pd_workshops` and `course_offerings` to represent the PL workshop topics for "Build your own workshops" (where `course_offerings` will be the representation of a given topic for the PL workshop). This relation will be many-to-many because multiple PL workshops can have the same topic and a given PL workshop can have multiple topics. To be clearer about the table's use,

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2021)
Spec: [Step 2C in the doc](https://docs.google.com/document/d/16IsvtmDFDIDzjn3vv1bIskRkET9ivC_l9LyUXpN0Fno/edit#heading=h.4schd43y1qoc)

## Testing story
Successfully migrated locally:
![success creates](https://github.com/code-dot-org/code-dot-org/assets/56283563/d3b2801e-22e2-4c39-95e0-72606f3da92e)

After migration, table shows up in dashboard db:
![shows in db](https://github.com/code-dot-org/code-dot-org/assets/56283563/04539d04-eb66-4111-b09c-1f351480063a)
