### PR TITLE
Support Default ParameterGroups in `clone_cluster`

### DIFF
--- a/lib/cdo/aws/rds.rb
+++ b/lib/cdo/aws/rds.rb
@@ -51,18 +51,17 @@ module Cdo
           db_instances.
           first
 
-        copy_source_writer_instance_parameter_group = rds_client.copy_db_parameter_group(
-          source_db_parameter_group_identifier: source_writer_instance[:db_parameter_groups][0][:db_parameter_group_name],
-          target_db_parameter_group_description: clone_instance_parameter_group,
-          target_db_parameter_group_identifier: clone_instance_parameter_group,
-        ).db_parameter_group
+        copy_source_writer_instance_parameter_group_name = copy_or_default_parameter_group(
+          source_writer_instance[:db_parameter_groups][0][:db_parameter_group_name],
+          clone_instance_parameter_group
+        )
 
         rds_client.create_db_instance(
           db_instance_identifier: clone_instance_id,
           db_instance_class: instance_type,
           engine: source_cluster.engine,
           db_cluster_identifier: clone_cluster_id,
-          db_parameter_group_name: copy_source_writer_instance_parameter_group.db_parameter_group_name
+          db_parameter_group_name: copy_source_writer_instance_parameter_group_name
         )
         # The RDS SDK doesn't provide a waiter for cluster operations.  Once the db instance is provisioned, the
         # cluster is ready.
@@ -146,6 +145,28 @@ module Cdo
         "#{db_cluster_id} deletion to complete.  Current cluster status - #{cluster_state}"
         )
       end
+    end
+
+    # You can't copy a default parameter group, so we provide a simple helper
+    # method which if the specified parameter group is a default will simply
+    # return the name of that same default to be reused, and will otherwise
+    # create a copy and return the name of that copy.
+    #
+    # See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithDBClusterParamGroups.html#USER_WorkingWithParamGroups.CopyingCluster
+    private_class_method def self.copy_or_default_parameter_group(source_name, target_name, target_description = nil)
+      # It really seems like there should be a more reliable
+      # way to determine whether a given parameter group is
+      # default or custom than inspecting the name, but I
+      # haven't been able to find one.
+      return source_name if source_name.start_with?('default.')
+
+      copied_parameter_group = rds_client.copy_db_parameter_group(
+        source_db_parameter_group_identifier: source_name,
+        target_db_parameter_group_identifier: target_name,
+        # reuse identifier for description if none specified
+        target_db_parameter_group_description: target_description || target_name,
+      ).db_parameter_group
+      return copied_parameter_group.db_parameter_group_name
     end
   end
 end

--- a/lib/cdo/aws/rds.rb
+++ b/lib/cdo/aws/rds.rb
@@ -51,7 +51,7 @@ module Cdo
           db_instances.
           first
 
-        copy_source_writer_instance_parameter_group_name = copy_or_default_parameter_group(
+        copy_source_writer_instance_parameter_group_name = copy_parameter_group_unless_default(
           source_writer_instance[:db_parameter_groups][0][:db_parameter_group_name],
           clone_instance_parameter_group
         )
@@ -147,17 +147,16 @@ module Cdo
       end
     end
 
-    # You can't copy a default parameter group, so we provide a simple helper
-    # method which if the specified parameter group is a default will simply
-    # return the name of that same default to be reused, and will otherwise
-    # create a copy and return the name of that copy.
+    # You can't copy a default parameter group, so we provide a helper method
+    # which if the specified parameter group is a default will return the name
+    # of that same default to be reused, and will otherwise create a copy and
+    # return the name of that copy.
     #
     # See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithDBClusterParamGroups.html#USER_WorkingWithParamGroups.CopyingCluster
-    private_class_method def self.copy_or_default_parameter_group(source_name, target_name, target_description = nil)
-      # It really seems like there should be a more reliable
-      # way to determine whether a given parameter group is
-      # default or custom than inspecting the name, but I
-      # haven't been able to find one.
+    private_class_method def self.copy_parameter_group_unless_default(source_name, target_name, target_description = nil)
+      # It really seems like there should be a more reliable way to determine
+      # whether a given parameter group is default or custom than inspecting
+      # the name, but I haven't been able to find one.
       return source_name if source_name.start_with?('default.')
 
       copied_parameter_group = rds_client.copy_db_parameter_group(

--- a/lib/cdo/aws/rds.rb
+++ b/lib/cdo/aws/rds.rb
@@ -159,6 +159,7 @@ module Cdo
       # the name, but I haven't been able to find one.
       return source_name if source_name.start_with?('default.')
 
+      rds_client = Aws::RDS::Client.new
       copied_parameter_group = rds_client.copy_db_parameter_group(
         source_db_parameter_group_identifier: source_name,
         target_db_parameter_group_identifier: target_name,


### PR DESCRIPTION
Currently, attempting to clone an RDS cluster with our custom `rds:clone_cluster` rake task fails with the extremely misleading error message:

    Aws::RDS::Errors::InvalidParameterValue: The parameter DBParameterGroupName is not a valid identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.
    /home/elijah/projects/work/code-dot-org/lib/cdo/aws/rds.rb:54:in `clone_cluster'
    /home/elijah/projects/work/code-dot-org/lib/rake/rds.rake:19:in `block (2 levels) in <top (required)>'
    /home/elijah/projects/work/code-dot-org/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `block in execute'
    /home/elijah/projects/work/code-dot-org/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `execute'
    /home/elijah/.rbenv/versions/3.0.5/bin/bundle:23:in `load'
    /home/elijah/.rbenv/versions/3.0.5/bin/bundle:23:in `<main>'
    Tasks: TOP => rds:clone_cluster
    (See full trace by running task with --trace)

I'm not entirely sure why this is what the error manifests as, but the underlying problem is that we started using default parameter groups rather than custom parameter groups for our provisioned clusters, and default parameter groups [cannot be cloned](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithDBClusterParamGroups.html#USER_WorkingWithParamGroups.CopyingCluster)

To resolve, we simply check if the parameter group on the source database is a default parameter group before attempting to clone, and reuse it rather than cloning it if it is. I was unfortunately unable to come up with a better way to check for default vs custom parameter group than just inspecting the name; please let me know if you have a better idea!

Note that the corresponding `delete_cluster` method [already has logic to only delete the parameter group if it's
custom](https://github.com/code-dot-org/code-dot-org/blob/f19b11d47a17456fd99e692167fd5ce29c461979/lib/cdo/aws/rds.rb#L100-L101), and so does not need to be correspondingly updated.

## Follow-up work

We also need to update the default instance type we're targeting for this operation, since [`db.r4.large` is deprecated](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html):
- https://github.com/code-dot-org/code-dot-org/pull/59493

## Testing story

Tested locally with `bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=adhoc-bugcrowd-cluster CLONE_CLUSTER_ID=bugcrowd-clone-to-test-clone-task-tweaks` (with the changes in https://github.com/code-dot-org/code-dot-org/pull/59493 also applied locally)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
