### PR TITLE
P20-1014: Allow current user data retrieving during CAP lockout

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -346,6 +346,8 @@ class ApplicationController < ActionController::Base
 
     # URLs we should not redirect.
     return if Set[
+      # Allow retrieval of current user data for event reporting
+      api_v1_users_current_path,
       # Don't block any user from signing out
       destroy_user_session_path,
       # Don't block any user from changing the language

--- a/dashboard/test/controllers/application_controller_test.rb
+++ b/dashboard/test/controllers/application_controller_test.rb
@@ -32,6 +32,11 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
       assert_redirected_to lockout_path
     end
 
+    it 'allows current user data retrieving' do
+      get api_v1_users_current_path
+      refute_redirect_to lockout_path
+    end
+
     it 'allows sign out' do
       get destroy_user_session_path
       refute_redirect_to lockout_path


### PR DESCRIPTION
## Summary
Due to the error `SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON`, the `currentUser` data is not set in the Redux store and is absent from the Amplitude events.

### Error
<img  src="https://github.com/code-dot-org/code-dot-org/assets/11708250/b4c3c43d-bc94-4f43-b26a-84e39126b652">

<img width="686" alt="Screenshot 2024-06-30 at 20 29 51" src="https://github.com/code-dot-org/code-dot-org/assets/11708250/32260efc-ed8a-4a69-a7c1-b2cf463948c4">

### Invalid Event
<img src="https://github.com/code-dot-org/code-dot-org/assets/11708250/c4c487a4-8051-402a-9031-5e1a3b9941f9">

<img src="https://github.com/code-dot-org/code-dot-org/assets/11708250/d63cb51c-d897-44bf-bfd2-f4d28fcc7e7d">

## Fix
<img src="https://github.com/code-dot-org/code-dot-org/assets/11708250/1afb3ac1-67ae-46ed-8015-7e315e32f77a">

<img src="https://github.com/code-dot-org/code-dot-org/assets/11708250/075c06b6-fec8-4cc1-8837-20f8f5806836">

## Links
- JIRA ticket: [P20-1014](https://codedotorg.atlassian.net/browse/P20-1014)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/59438#discussion_r1660216339

