### PR TITLE
Tidy Projects: remove unused canShare prop from PersonalProjectsTable + tendrils

### DIFF
--- a/apps/src/sites/studio/pages/projects/index.js
+++ b/apps/src/sites/studio/pages/projects/index.js
@@ -51,7 +51,6 @@ $(document).ready(() => {
         <div className={'main container'}>
           <ProjectsGallery
             limitedGallery={projectsData.limitedGallery}
-            canShare={!!projectsData.canShare}
           />
         </div>
       </div>

--- a/apps/src/sites/studio/pages/projects/index.js
+++ b/apps/src/sites/studio/pages/projects/index.js
@@ -49,9 +49,7 @@ $(document).ready(() => {
           projectCount={projectsData.projectCount}
         />
         <div className={'main container'}>
-          <ProjectsGallery
-            limitedGallery={projectsData.limitedGallery}
-          />
+          <ProjectsGallery limitedGallery={projectsData.limitedGallery} />
         </div>
       </div>
     </Provider>,

--- a/apps/src/templates/projects/PersonalProjectsTable.jsx
+++ b/apps/src/templates/projects/PersonalProjectsTable.jsx
@@ -36,8 +36,6 @@ export const COLUMNS = {
 
 class PersonalProjectsTable extends React.Component {
   static propTypes = {
-    canShare: PropTypes.bool.isRequired,
-
     // Provided by Redux
     personalProjectsList: PropTypes.arrayOf(personalProjectDataPropType),
     isLoadingPersonalProjectsList: PropTypes.bool.isRequired,

--- a/apps/src/templates/projects/PersonalProjectsTable.story.jsx
+++ b/apps/src/templates/projects/PersonalProjectsTable.story.jsx
@@ -25,7 +25,6 @@ WithProjects.args = {
   personalProjectsList: stubFakePersonalProjectData,
   isLoadingPersonalProjectsList: false,
   isUserSignedIn: true,
-  canShare: true,
 };
 
 export const WithoutProjects = Template.bind({});
@@ -33,5 +32,4 @@ WithoutProjects.args = {
   personalProjectsList: [],
   isLoadingPersonalProjectsList: false,
   isUserSignedIn: true,
-  canShare: true,
 };

--- a/apps/src/templates/projects/ProjectsGallery.jsx
+++ b/apps/src/templates/projects/ProjectsGallery.jsx
@@ -35,7 +35,6 @@ const galleryTabs = [
 class ProjectsGallery extends Component {
   static propTypes = {
     limitedGallery: PropTypes.bool,
-    canShare: PropTypes.bool.isRequired,
 
     // Provided by Redux
     selectedGallery: PropTypes.string.isRequired,
@@ -65,7 +64,7 @@ class ProjectsGallery extends Component {
           ))}
         </div>
         {this.props.selectedGallery === Galleries.PRIVATE && (
-          <PersonalProjectsTable canShare={this.props.canShare} />
+          <PersonalProjectsTable />
         )}
         {this.props.selectedGallery === Galleries.LIBRARIES && <LibraryTable />}
         {this.props.selectedGallery === Galleries.PUBLIC && (

--- a/apps/test/unit/templates/projects/PersonalProjectsTableTest.js
+++ b/apps/test/unit/templates/projects/PersonalProjectsTableTest.js
@@ -39,7 +39,6 @@ describe('PersonalProjectsTable', () => {
             personalProjectsList={stubFakePersonalProjectData}
             isLoadingPersonalProjectsList={false}
             isUserSignedIn={true}
-            canShare={true}
           />
         </Provider>
       );
@@ -80,7 +79,6 @@ describe('PersonalProjectsTable', () => {
             personalProjectsList={[]}
             isLoadingPersonalProjectsList={false}
             isUserSignedIn={true}
-            canShare={true}
           />
         </Provider>
       );
@@ -94,7 +92,6 @@ describe('PersonalProjectsTable', () => {
             personalProjectsList={[]}
             isLoadingPersonalProjectsList={false}
             isUserSignedIn={false}
-            canShare={true}
           />
         </Provider>
       );
@@ -114,7 +111,6 @@ describe('PersonalProjectsTable', () => {
             personalProjectsList={[]}
             isLoadingPersonalProjectsList={true}
             isUserSignedIn={true}
-            canShare={true}
           />
         </Provider>
       );

--- a/dashboard/app/views/projects/index.html.haml
+++ b/dashboard/app/views/projects/index.html.haml
@@ -7,7 +7,6 @@
 
   if current_user
     projects_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)
-    projects_data[:canShare] = !current_user&.sharing_disabled?
   end
 
   projects_data[:specialAnnouncement] = Announcements.get_announcement_for_page("/projects")


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

There was a big effort (https://github.com/code-dot-org/code-dot-org/pull/57473) to remove the ability for students to publish projects to a public gallery for safety and customer support time management (see [spec](https://docs.google.com/document/d/1vU68tzXG72Z80MvM6xYEDwF5hLDf7V097P-0dDfpouc/edit)). When that work was done there was a lingering prop `canShare` in the `PersonalProjectsTable` that was no longer being used.  I removed the `canShare` prop from the component, the parent component, the js + haml entrypoint to the gallery, and the corresponding test and storybook entries. 

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

There is additional clean up work to continue removing references to "publishing" e.g. https://codedotorg.atlassian.net/browse/LABS-574. This felt like a small, contained start to cleaning up that space that I could take on in the time I had without needing to consult with other engineers or Product. 😁 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
