### PR TITLE
remove category column from course_offerings table

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -7,7 +7,6 @@
 #  display_name                     :string(255)      not null
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
-#  category                         :string(255)      default("other"), not null
 #  is_featured                      :boolean          default(FALSE), not null
 #  assignable                       :boolean          default(TRUE), not null
 #  curriculum_type                  :string(255)

--- a/dashboard/db/migrate/20240701162711_remove_category_from_course_offerings.rb
+++ b/dashboard/db/migrate/20240701162711_remove_category_from_course_offerings.rb
@@ -1,0 +1,8 @@
+class RemoveCategoryFromCourseOfferings < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :course_offerings, :category
+  end
+
+  def down
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -409,7 +409,6 @@ ActiveRecord::Schema.define(version: 2024_07_01_205906) do
     t.string "display_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "category", default: "other", null: false
     t.boolean "is_featured", default: false, null: false
     t.boolean "assignable", default: true, null: false
     t.string "curriculum_type"

--- a/dashboard/test/fixtures/course_offerings.yml
+++ b/dashboard/test/fixtures/course_offerings.yml
@@ -11,7 +11,6 @@ hour-of-code:
     utc: 2022-04-13 23:51:28.000000000 Z
     zone: *1
     time: 2022-04-13 23:51:28.000000000 Z
-  category: other
   is_featured: false
   assignable: true
   curriculum_type:
@@ -39,7 +38,6 @@ events:
     utc: 2022-04-13 23:51:27.000000000 Z
     zone: *1
     time: 2022-04-13 23:51:27.000000000 Z
-  category: other
   is_featured: false
   assignable: true
   curriculum_type:
@@ -67,7 +65,6 @@ jigsaw:
     utc: 2024-04-22 22:49:31.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:31.000000000 Z
-  category: other
   is_featured: false
   assignable: true
   curriculum_type:
@@ -99,7 +96,6 @@ hourofcode:
     utc: 2024-04-22 22:49:31.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:31.000000000 Z
-  category: hoc
   is_featured: false
   assignable: true
   curriculum_type:
@@ -131,7 +127,6 @@ starwars:
     utc: 2024-04-22 22:49:31.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:31.000000000 Z
-  category: hoc
   is_featured: false
   assignable: true
   curriculum_type:
@@ -163,7 +158,6 @@ frozen:
     utc: 2024-04-22 22:49:31.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:31.000000000 Z
-  category: hoc
   is_featured: false
   assignable: true
   curriculum_type:
@@ -195,7 +189,6 @@ playlab:
     utc: 2024-04-22 22:49:31.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:31.000000000 Z
-  category: hoc
   is_featured: false
   assignable: true
   curriculum_type:
@@ -227,7 +220,6 @@ artist:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: hoc
   is_featured: false
   assignable: true
   curriculum_type:
@@ -259,7 +251,6 @@ algebra:
     utc: 2023-07-28 03:13:45.000000000 Z
     zone: *1
     time: 2023-07-28 03:13:45.000000000 Z
-  category: math
   is_featured: false
   assignable: false
   curriculum_type:
@@ -287,7 +278,6 @@ flappy:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: hoc
   is_featured: false
   assignable: true
   curriculum_type:
@@ -319,7 +309,6 @@ flappy:
     utc: 2024-04-22 22:49:29.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:29.000000000 Z
-  category: twenty_hour
   is_featured: false
   assignable: true
   curriculum_type: Course
@@ -351,7 +340,6 @@ course1:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: csf_international
   is_featured: false
   assignable: true
   curriculum_type:
@@ -383,7 +371,6 @@ course2:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: csf_international
   is_featured: false
   assignable: true
   curriculum_type:
@@ -415,7 +402,6 @@ course3:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: csf_international
   is_featured: false
   assignable: true
   curriculum_type:
@@ -447,7 +433,6 @@ course4:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: csf_international
   is_featured: false
   assignable: true
   curriculum_type:
@@ -479,7 +464,6 @@ cspunit1:
     utc: 2022-04-13 23:51:28.000000000 Z
     zone: *1
     time: 2022-04-13 23:51:28.000000000 Z
-  category: other
   is_featured: false
   assignable: true
   curriculum_type:
@@ -507,7 +491,6 @@ cspunit2:
     utc: 2022-04-13 23:51:28.000000000 Z
     zone: *1
     time: 2022-04-13 23:51:28.000000000 Z
-  category: other
   is_featured: false
   assignable: true
   curriculum_type:
@@ -535,7 +518,6 @@ cspunit3:
     utc: 2022-04-13 23:51:28.000000000 Z
     zone: *1
     time: 2022-04-13 23:51:28.000000000 Z
-  category: other
   is_featured: false
   assignable: true
   curriculum_type:
@@ -563,7 +545,6 @@ cspunit4:
     utc: 2022-04-13 23:51:29.000000000 Z
     zone: *1
     time: 2022-04-13 23:51:29.000000000 Z
-  category: other
   is_featured: false
   assignable: true
   curriculum_type:
@@ -591,7 +572,6 @@ cspunit5:
     utc: 2022-04-13 23:51:29.000000000 Z
     zone: *1
     time: 2022-04-13 23:51:29.000000000 Z
-  category: other
   is_featured: false
   assignable: true
   curriculum_type:
@@ -619,7 +599,6 @@ cspunit6:
     utc: 2022-04-13 23:51:27.000000000 Z
     zone: *1
     time: 2022-04-13 23:51:27.000000000 Z
-  category: other
   is_featured: false
   assignable: true
   curriculum_type:
@@ -647,7 +626,6 @@ allthethingscourse:
     utc: 2022-04-13 23:51:28.000000000 Z
     zone: *1
     time: 2022-04-13 23:51:28.000000000 Z
-  category: other
   is_featured: false
   assignable: true
   curriculum_type:
@@ -675,7 +653,6 @@ coursea:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: csf
   is_featured: false
   assignable: true
   curriculum_type: Course
@@ -707,7 +684,6 @@ courseb:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: csf
   is_featured: false
   assignable: true
   curriculum_type: Course
@@ -740,7 +716,6 @@ coursec:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: csf
   is_featured: false
   assignable: true
   curriculum_type: Course
@@ -773,7 +748,6 @@ coursed:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: csf
   is_featured: false
   assignable: true
   curriculum_type: Course
@@ -805,7 +779,6 @@ coursee:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: csf
   is_featured: false
   assignable: true
   curriculum_type: Course
@@ -837,7 +810,6 @@ coursef:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: csf
   is_featured: false
   assignable: true
   curriculum_type: Course
@@ -869,7 +841,6 @@ express:
     utc: 2024-04-22 22:49:30.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:30.000000000 Z
-  category: csf
   is_featured: false
   assignable: true
   curriculum_type: Course
@@ -902,7 +873,6 @@ pre-express:
     utc: 2024-04-22 22:49:31.000000000 Z
     zone: *1
     time: 2024-04-22 22:49:31.000000000 Z
-  category: csf
   is_featured: false
   assignable: true
   curriculum_type: Course

--- a/dashboard/test/ui/config/course_offerings/ui-test-course.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-course.json
@@ -1,7 +1,6 @@
 {
   "key": "ui-test-course",
   "display_name": "ui-test-course",
-  "category": "other",
   "is_featured": false,
   "assignable": false
 }

--- a/dashboard/test/ui/config/course_offerings/ui-test-csa-family-script.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-csa-family-script.json
@@ -1,7 +1,6 @@
 {
   "key": "ui-test-csa-family-script",
   "display_name": "ui-test-csa-family-script",
-  "category": "other",
   "is_featured": false,
   "assignable": false
 }

--- a/dashboard/test/ui/config/course_offerings/ui-test-facilitator-pl-course.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-facilitator-pl-course.json
@@ -1,7 +1,6 @@
 {
   "key": "ui-test-facilitator-pl-course",
   "display_name": "Facilitator PL Course",
-  "category": "pl_other",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/test/ui/config/course_offerings/ui-test-teacher-pl-course.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-teacher-pl-course.json
@@ -1,7 +1,6 @@
 {
   "key": "ui-test-teacher-pl-course",
   "display_name": "Teacher PL Course",
-  "category": "pl_other",
   "is_featured": false,
   "assignable": true,
   "curriculum_type": "Professional Learning",


### PR DESCRIPTION
This is the final PR to remove the category column from the course offerings table. Here is the sequence leading up to it. See these PRs for background:

* https://github.com/code-dot-org/code-dot-org/pull/58922
* https://github.com/code-dot-org/code-dot-org/pull/58949
* ac3edac5585c2455d58ff3cdba56d40805f421a8 removes category from dashboard/config/course_offerings/*.json via levelbuilder content scoop
* this PR

I've confirmed with the RED team that this column is no longer being used for data analysis (see [slack](https://codedotorg.slack.com/archives/C0SUN2W3D/p1719605917431759?thread_ts=1718726696.904969&cid=C0SUN2W3D))

## Testing story

* existing test coverage in drone
* `rake seed:all` is passing locally