### PR TITLE
Turn off all email sends for workshop if 'Build Your Own' selected

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -490,28 +490,30 @@ export class WorkshopForm extends React.Component {
               <HelpBlock>{validation.help.virtual}</HelpBlock>
             </FormGroup>
           </Col>
-          <Col sm={5}>
-            <FormGroup validationState={validation.style.suppress_email}>
-              <ControlLabel>
-                Enable workshop reminders?
-                <HelpTip>
-                  <p>
-                    Choose if you'd like automated 10-day and 3-day pre-workshop
-                    reminders to be sent to your participants.
-                  </p>
-                </HelpTip>
-              </ControlLabel>
-              <SelectSuppressEmail
-                onChange={this.handleSuppressEmailChange}
-                value={this.state.suppress_email || false}
-                readOnly={
-                  this.props.readOnly ||
-                  MustSuppressEmailSubjects.includes(this.state.subject)
-                }
-              />
-              <HelpBlock>{validation.help.suppress_email}</HelpBlock>
-            </FormGroup>
-          </Col>
+          {!isBuildYourOwnWorkshop && (
+            <Col sm={5}>
+              <FormGroup validationState={validation.style.suppress_email}>
+                <ControlLabel>
+                  Enable workshop reminders?
+                  <HelpTip>
+                    <p>
+                      Choose if you'd like automated 10-day and 3-day
+                      pre-workshop reminders to be sent to your participants.
+                    </p>
+                  </HelpTip>
+                </ControlLabel>
+                <SelectSuppressEmail
+                  onChange={this.handleSuppressEmailChange}
+                  value={this.state.suppress_email || false}
+                  readOnly={
+                    this.props.readOnly ||
+                    MustSuppressEmailSubjects.includes(this.state.subject)
+                  }
+                />
+                <HelpBlock>{validation.help.suppress_email}</HelpBlock>
+              </FormGroup>
+            </Col>
+          )}
         </Row>
       </FormGroup>
     );
@@ -794,7 +796,7 @@ export class WorkshopForm extends React.Component {
     });
     this.loadAvailableFacilitators(course);
     if (course === 'Build Your Own Workshop') {
-      this.setState({funded: false});
+      this.setState({funded: false, suppress_email: true});
     }
   };
 

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -536,7 +536,7 @@ describe('WorkshopForm test', () => {
     assert(wrapper.find('#suppress_email').first().props().disabled);
   });
 
-  it('selecting Build Your Own Workshop does not show subject or paid fields', () => {
+  it('selecting Build Your Own Workshop does not show subject, paid, or email fields', () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>
@@ -557,6 +557,7 @@ describe('WorkshopForm test', () => {
 
     expect(wrapper.find('#subject')).to.have.lengthOf(0);
     expect(wrapper.find('#funded')).to.have.lengthOf(0);
+    expect(wrapper.find('#suppress_email')).to.have.lengthOf(0);
   });
 
   it('editing form as non-admin does not show organizer field', () => {

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -43,8 +43,6 @@ class Pd::WorkshopMailer < ApplicationMailer
     @online_url = ONLINE_URL
     @is_enrollment_receipt = true
 
-    return if @workshop.course == 'Build Your Own Workshop'
-
     # Facilitator training workshops use different email addresses
     if @enrollment.workshop.course == Pd::Workshop::COURSE_FACILITATOR
       from = from_facilitators
@@ -65,8 +63,6 @@ class Pd::WorkshopMailer < ApplicationMailer
     @enrollment = enrollment
     @workshop = enrollment.workshop
 
-    return if @workshop.course == 'Build Your Own Workshop'
-
     mail content_type: 'text/html',
       from: from_no_reply,
       subject: 'Code.org workshop registration',
@@ -76,8 +72,6 @@ class Pd::WorkshopMailer < ApplicationMailer
   def teacher_cancel_receipt(enrollment)
     @enrollment = enrollment
     @workshop = enrollment.workshop
-
-    return if @workshop.course == 'Build Your Own Workshop'
 
     mail content_type: 'text/html',
       from: from_teacher,
@@ -90,8 +84,6 @@ class Pd::WorkshopMailer < ApplicationMailer
     @enrollment = enrollment
     @workshop = enrollment.workshop
 
-    return if @workshop.course == 'Build Your Own Workshop'
-
     mail content_type: 'text/html',
       from: from_no_reply,
       subject: 'Code.org workshop cancellation',
@@ -100,8 +92,6 @@ class Pd::WorkshopMailer < ApplicationMailer
 
   def organizer_should_close_reminder(workshop)
     @workshop = workshop
-
-    return if @workshop.course == 'Build Your Own Workshop'
 
     mail content_type: 'text/html',
       from: from_no_reply,
@@ -128,7 +118,7 @@ class Pd::WorkshopMailer < ApplicationMailer
       reply_to = email_address(@workshop.organizer.name, @workshop.organizer.email)
     end
 
-    return if @workshop.suppress_reminders? || @workshop.suppress_email? || @workshop.course == 'Build Your Own Workshop'
+    return if @workshop.suppress_reminders? || @workshop.suppress_email?
 
     mail content_type: 'text/html',
       from: from,
@@ -155,7 +145,7 @@ class Pd::WorkshopMailer < ApplicationMailer
     @cancel_url = '#'
     @is_reminder = true
 
-    return if @workshop.suppress_reminders? || @workshop.suppress_email? || @workshop.course == 'Build Your Own Workshop'
+    return if @workshop.suppress_reminders? || @workshop.suppress_email?
 
     mail content_type: 'text/html',
          from: from_teacher,
@@ -167,8 +157,6 @@ class Pd::WorkshopMailer < ApplicationMailer
   def facilitator_pre_workshop(user, workshop)
     @user = user
     @workshop = workshop
-
-    return if @workshop.course == 'Build Your Own Workshop'
 
     mail content_type: 'text/html',
          from: from_facilitators,
@@ -182,8 +170,6 @@ class Pd::WorkshopMailer < ApplicationMailer
     @workshop = workshop
     survey_params = "workshop_id=#{workshop.id}"
     @survey_url = CDO.studio_url "pd/workshop_survey/facilitator_post_foorm?#{survey_params}", CDO.default_scheme
-
-    return if @workshop.course == 'Build Your Own Workshop'
 
     @regional_partner_name = @workshop.regional_partner&.name
     @deadline = (Time.now + 10.days).strftime('%B %-d, %Y').strip
@@ -203,7 +189,7 @@ class Pd::WorkshopMailer < ApplicationMailer
     @cancel_url = '#'
     @is_reminder = true
 
-    return if @workshop.suppress_reminders? || @workshop.suppress_email? || @workshop.course == 'Build Your Own Workshop'
+    return if @workshop.suppress_reminders? || @workshop.suppress_email?
 
     mail content_type: 'text/html',
          from: from_teacher,
@@ -217,8 +203,6 @@ class Pd::WorkshopMailer < ApplicationMailer
     @workshop = enrollment.workshop
     @cancel_url = url_for controller: 'pd/workshop_enrollment', action: :cancel, code: enrollment.code
 
-    return if @workshop.course == 'Build Your Own Workshop'
-
     mail content_type: 'text/html',
       from: from_teacher,
       subject: detail_change_notification_subject(@workshop),
@@ -231,8 +215,6 @@ class Pd::WorkshopMailer < ApplicationMailer
     @workshop = workshop
     @cancel_url = '#'
 
-    return if @workshop.course == 'Build Your Own Workshop'
-
     mail content_type: 'text/html',
       from: from_teacher,
       subject: detail_change_notification_subject(@workshop),
@@ -244,8 +226,6 @@ class Pd::WorkshopMailer < ApplicationMailer
     @workshop = workshop
     @cancel_url = '#'
 
-    return if @workshop.course == 'Build Your Own Workshop'
-
     mail content_type: 'text/html',
          from: from_teacher,
          subject: detail_change_notification_subject(@workshop),
@@ -256,8 +236,6 @@ class Pd::WorkshopMailer < ApplicationMailer
   def teacher_survey_reminder(enrollment)
     @enrollment = enrollment
     @workshop = enrollment.workshop
-
-    return if @workshop.course == 'Build Your Own Workshop'
 
     # Pre-workshop survey reminder
     mail content_type: 'text/html',
@@ -274,8 +252,6 @@ class Pd::WorkshopMailer < ApplicationMailer
     @teacher = enrollment.user
     @enrollment = enrollment
     @survey_url = enrollment.exit_survey_url
-
-    return if @workshop.course == 'Build Your Own Workshop'
 
     content_type = 'text/html'
     if @workshop.course == Pd::Workshop::COURSE_CSF

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -43,6 +43,8 @@ class Pd::WorkshopMailer < ApplicationMailer
     @online_url = ONLINE_URL
     @is_enrollment_receipt = true
 
+    return if @workshop.course == 'Build Your Own Workshop'
+
     # Facilitator training workshops use different email addresses
     if @enrollment.workshop.course == Pd::Workshop::COURSE_FACILITATOR
       from = from_facilitators
@@ -63,6 +65,8 @@ class Pd::WorkshopMailer < ApplicationMailer
     @enrollment = enrollment
     @workshop = enrollment.workshop
 
+    return if @workshop.course == 'Build Your Own Workshop'
+
     mail content_type: 'text/html',
       from: from_no_reply,
       subject: 'Code.org workshop registration',
@@ -72,6 +76,8 @@ class Pd::WorkshopMailer < ApplicationMailer
   def teacher_cancel_receipt(enrollment)
     @enrollment = enrollment
     @workshop = enrollment.workshop
+
+    return if @workshop.course == 'Build Your Own Workshop'
 
     mail content_type: 'text/html',
       from: from_teacher,
@@ -84,6 +90,8 @@ class Pd::WorkshopMailer < ApplicationMailer
     @enrollment = enrollment
     @workshop = enrollment.workshop
 
+    return if @workshop.course == 'Build Your Own Workshop'
+
     mail content_type: 'text/html',
       from: from_no_reply,
       subject: 'Code.org workshop cancellation',
@@ -92,6 +100,8 @@ class Pd::WorkshopMailer < ApplicationMailer
 
   def organizer_should_close_reminder(workshop)
     @workshop = workshop
+
+    return if @workshop.course == 'Build Your Own Workshop'
 
     mail content_type: 'text/html',
       from: from_no_reply,
@@ -118,7 +128,7 @@ class Pd::WorkshopMailer < ApplicationMailer
       reply_to = email_address(@workshop.organizer.name, @workshop.organizer.email)
     end
 
-    return if @workshop.suppress_reminders? || @workshop.suppress_email?
+    return if @workshop.suppress_reminders? || @workshop.suppress_email? || @workshop.course == 'Build Your Own Workshop'
 
     mail content_type: 'text/html',
       from: from,
@@ -145,7 +155,7 @@ class Pd::WorkshopMailer < ApplicationMailer
     @cancel_url = '#'
     @is_reminder = true
 
-    return if @workshop.suppress_reminders? || @workshop.suppress_email?
+    return if @workshop.suppress_reminders? || @workshop.suppress_email? || @workshop.course == 'Build Your Own Workshop'
 
     mail content_type: 'text/html',
          from: from_teacher,
@@ -157,6 +167,8 @@ class Pd::WorkshopMailer < ApplicationMailer
   def facilitator_pre_workshop(user, workshop)
     @user = user
     @workshop = workshop
+
+    return if @workshop.course == 'Build Your Own Workshop'
 
     mail content_type: 'text/html',
          from: from_facilitators,
@@ -170,6 +182,8 @@ class Pd::WorkshopMailer < ApplicationMailer
     @workshop = workshop
     survey_params = "workshop_id=#{workshop.id}"
     @survey_url = CDO.studio_url "pd/workshop_survey/facilitator_post_foorm?#{survey_params}", CDO.default_scheme
+
+    return if @workshop.course == 'Build Your Own Workshop'
 
     @regional_partner_name = @workshop.regional_partner&.name
     @deadline = (Time.now + 10.days).strftime('%B %-d, %Y').strip
@@ -189,7 +203,7 @@ class Pd::WorkshopMailer < ApplicationMailer
     @cancel_url = '#'
     @is_reminder = true
 
-    return if @workshop.suppress_reminders? || @workshop.suppress_email?
+    return if @workshop.suppress_reminders? || @workshop.suppress_email? || @workshop.course == 'Build Your Own Workshop'
 
     mail content_type: 'text/html',
          from: from_teacher,
@@ -203,6 +217,8 @@ class Pd::WorkshopMailer < ApplicationMailer
     @workshop = enrollment.workshop
     @cancel_url = url_for controller: 'pd/workshop_enrollment', action: :cancel, code: enrollment.code
 
+    return if @workshop.course == 'Build Your Own Workshop'
+
     mail content_type: 'text/html',
       from: from_teacher,
       subject: detail_change_notification_subject(@workshop),
@@ -215,6 +231,8 @@ class Pd::WorkshopMailer < ApplicationMailer
     @workshop = workshop
     @cancel_url = '#'
 
+    return if @workshop.course == 'Build Your Own Workshop'
+
     mail content_type: 'text/html',
       from: from_teacher,
       subject: detail_change_notification_subject(@workshop),
@@ -226,6 +244,8 @@ class Pd::WorkshopMailer < ApplicationMailer
     @workshop = workshop
     @cancel_url = '#'
 
+    return if @workshop.course == 'Build Your Own Workshop'
+
     mail content_type: 'text/html',
          from: from_teacher,
          subject: detail_change_notification_subject(@workshop),
@@ -236,6 +256,8 @@ class Pd::WorkshopMailer < ApplicationMailer
   def teacher_survey_reminder(enrollment)
     @enrollment = enrollment
     @workshop = enrollment.workshop
+
+    return if @workshop.course == 'Build Your Own Workshop'
 
     # Pre-workshop survey reminder
     mail content_type: 'text/html',
@@ -252,6 +274,8 @@ class Pd::WorkshopMailer < ApplicationMailer
     @teacher = enrollment.user
     @enrollment = enrollment
     @survey_url = enrollment.exit_survey_url
+
+    return if @workshop.course == 'Build Your Own Workshop'
 
     content_type = 'text/html'
     if @workshop.course == Pd::Workshop::COURSE_CSF

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -256,28 +256,4 @@ class WorkshopMailerTest < ActionMailer::TestCase
 
     assert_equal MailerConstants::PLC_EMAIL_LOG, mail.bcc.first
   end
-
-  test 'emails are skipped for Build Your Own workshops' do
-    facilitator = create :facilitator
-    workshop = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, facilitators: [facilitator]
-    enrollment = create :pd_enrollment, workshop: workshop
-
-    assert_emails 0 do
-      Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now
-      Pd::WorkshopMailer.organizer_enrollment_receipt(enrollment).deliver_now
-      Pd::WorkshopMailer.teacher_cancel_receipt(enrollment).deliver_now
-      Pd::WorkshopMailer.organizer_cancel_receipt(enrollment).deliver_now
-      Pd::WorkshopMailer.organizer_should_close_reminder(workshop).deliver_now
-      Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, options: {days_before: 10}).deliver_now
-      Pd::WorkshopMailer.facilitator_enrollment_reminder(facilitator, workshop).deliver_now
-      Pd::WorkshopMailer.facilitator_pre_workshop(facilitator, workshop).deliver_now
-      Pd::WorkshopMailer.facilitator_post_workshop(facilitator, workshop).deliver_now
-      Pd::WorkshopMailer.organizer_enrollment_reminder(workshop).deliver_now
-      Pd::WorkshopMailer.detail_change_notification(enrollment).deliver_now
-      Pd::WorkshopMailer.facilitator_detail_change_notification(facilitator, workshop).deliver_now
-      Pd::WorkshopMailer.organizer_detail_change_notification(workshop).deliver_now
-      Pd::WorkshopMailer.teacher_survey_reminder(enrollment).deliver_now
-      Pd::WorkshopMailer.exit_survey(enrollment).deliver_now
-    end
-  end
 end

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -256,4 +256,28 @@ class WorkshopMailerTest < ActionMailer::TestCase
 
     assert_equal MailerConstants::PLC_EMAIL_LOG, mail.bcc.first
   end
+
+  test 'emails are skipped for Build Your Own workshops' do
+    facilitator = create :facilitator
+    workshop = create :workshop, course: Pd::Workshop::COURSE_BUILD_YOUR_OWN, facilitators: [facilitator]
+    enrollment = create :pd_enrollment, workshop: workshop
+
+    assert_emails 0 do
+      Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now
+      Pd::WorkshopMailer.organizer_enrollment_receipt(enrollment).deliver_now
+      Pd::WorkshopMailer.teacher_cancel_receipt(enrollment).deliver_now
+      Pd::WorkshopMailer.organizer_cancel_receipt(enrollment).deliver_now
+      Pd::WorkshopMailer.organizer_should_close_reminder(workshop).deliver_now
+      Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, options: {days_before: 10}).deliver_now
+      Pd::WorkshopMailer.facilitator_enrollment_reminder(facilitator, workshop).deliver_now
+      Pd::WorkshopMailer.facilitator_pre_workshop(facilitator, workshop).deliver_now
+      Pd::WorkshopMailer.facilitator_post_workshop(facilitator, workshop).deliver_now
+      Pd::WorkshopMailer.organizer_enrollment_reminder(workshop).deliver_now
+      Pd::WorkshopMailer.detail_change_notification(enrollment).deliver_now
+      Pd::WorkshopMailer.facilitator_detail_change_notification(facilitator, workshop).deliver_now
+      Pd::WorkshopMailer.organizer_detail_change_notification(workshop).deliver_now
+      Pd::WorkshopMailer.teacher_survey_reminder(enrollment).deliver_now
+      Pd::WorkshopMailer.exit_survey(enrollment).deliver_now
+    end
+  end
 end


### PR DESCRIPTION
This PR suppresses emails sent for 'Build Your Own' workshops. I originally followed the pattern used for emails that can be suppressed where the mailer function returns before actually sending the email if the given condition is met ([example](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/mailers/pd/workshop_mailer.rb#L121)). Since the spec says, "turn off all email sends", I thought it was calling for no emails to be sent relating to 'Build Your Own' workshops. However, the phrase "(but the field can stay on the create page)" and [this discussion with Hannah](https://docs.google.com/document/d/16IsvtmDFDIDzjn3vv1bIskRkET9ivC_l9LyUXpN0Fno/edit?disco=AAABQUJsroU) makes me think we want to just suppress reminder emails the same way they would be if the facilitator set that email field to `suppress_email = true`.

Assuming this is the case, I thought it would make more sense to have a solution similar to [Hannah's PR](https://github.com/code-dot-org/code-dot-org/pull/59457/files) that ensured the `funded` workshop form field doesn't show up when 'Build Your Own' workshop is selected. This way, `suppress_email` is set to `true` and the field for it doesn't show up at all if the user selects 'Build Your Own'.

If we actually do want to suppress all emails related to 'Build Your Own' workshops, I can do a follow-up PR (while still keeping this functionality so that the form doesn't show the email question for 'Build Your Own' workshops).

### 'Build Your Own' doesn't show the suppress emails question
![no email](https://github.com/code-dot-org/code-dot-org/assets/56283563/5087d80b-a73c-42c0-94dc-933fa6158a39)

### Other courses still show the suppress emails question
![shows_emails](https://github.com/code-dot-org/code-dot-org/assets/56283563/03298351-5938-48e3-82ef-e37967acabe7)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2025)
Spec: [item 6](https://docs.google.com/document/d/16IsvtmDFDIDzjn3vv1bIskRkET9ivC_l9LyUXpN0Fno/edit#heading=h.4schd43y1qoc)
PR that adds 'Build Your Own' workshops: [here](https://github.com/code-dot-org/code-dot-org/pull/59457)

## Testing story
Local testing and updating a unit test.
