### PR TITLE
Calculate CPA delete date from lockout date instead of created_at

### DIFF
--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -74,7 +74,7 @@ class SessionsController < Devise::SessionsController
     end
 
     # Determine the deletion date as the lockout date of the account + 7 days
-    @delete_date = Date.parse(current_user.child_account_compliance_lock_out_date).since(7.days)
+    @delete_date = DateTime.parse(current_user.child_account_compliance_lock_out_date).since(7.days)
 
     # Find any existing permission request for this user
     # Students might have issued a few requests. We render the latest one.

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -73,8 +73,8 @@ class SessionsController < Devise::SessionsController
       @disallowed_email = current_user.hashed_email
     end
 
-    # Determine the deletion date as the creation time of the account + 7 days
-    @delete_date = current_user.created_at.since(7.days)
+    # Determine the deletion date as the lockout date of the account + 7 days
+    @delete_date = Date.parse(current_user.child_account_compliance_lock_out_date).since(7.days)
 
     # Find any existing permission request for this user
     # Students might have issued a few requests. We render the latest one.

--- a/dashboard/test/controllers/sessions_controller_test.rb
+++ b/dashboard/test/controllers/sessions_controller_test.rb
@@ -333,6 +333,7 @@ class SessionsControllerTest < ActionController::TestCase
 
     before do
       Policies::ChildAccount::ComplianceState.stubs(:locked_out?).with(user).returns(user_is_locked_out)
+      user.update(child_account_compliance_lock_out_date: DateTime.now)
 
       sign_in user
     end
@@ -347,9 +348,9 @@ class SessionsControllerTest < ActionController::TestCase
       _(assigns[:disallowed_email]).must_equal ''
     end
 
-    it 'assigns @delete_date with 7 day after user creation' do
+    it 'assigns @delete_date with 7 day after user lockout date' do
       get :lockout
-      _(assigns[:delete_date]).must_equal user.created_at.since(7.days)
+      _(assigns[:delete_date]).must_equal DateTime.parse(user.child_account_compliance_lock_out_date).since(7.days)
     end
 
     it 'renders lockout page' do


### PR DESCRIPTION
The delete date on the lockout page was being calculated based on created_at + 7 days, because during phase 1 the rules only applied to newly created accounts. This changes the controller to calculate the date from the lockout date instead.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1023)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally. Example user has:
- `created_at: "2024-06-27 01:50:10.000000000 +0000"`
- `"child_account_compliance_lock_out_date"=>"2024-07-01T11:49:22.800-07:00"`

<img width="708" alt="Screenshot 2024-07-01 at 12 01 21 PM" src="https://github.com/code-dot-org/code-dot-org/assets/131809324/b9eb79ed-d2d6-4a56-9e35-2fc63add04c3">


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
