### PR TITLE
hide pop up when user toggles back to V1

### DIFF
--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -31,17 +31,13 @@ function SectionProgressSelector({
   const [hasJustSwitchedToV1, setHasJustSwitchedToV1] = React.useState(false);
 
   const onShowProgressTableV2Change = useCallback(() => {
-    console.log('showProgressTableV2: ', showProgressTableV2);
     if (showProgressTableV2) {
       setHasJustSwitchedToV1(true);
-      console.log('should indicate a user switched to V1 from V2');
-      // do not show pop-up
     }
     const shouldShowV2 = !showProgressTableV2;
     new UserPreferences().setShowProgressTableV2(shouldShowV2);
     setShowProgressTableV2(shouldShowV2);
     setHasJustSwitchedToV2(true);
-    console.log('should indicate a user switched to V2 from V1.... maybe');
 
     if (shouldShowV2) {
       analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW_NEW_PROGRESS, {

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -109,11 +109,10 @@ function SectionProgressSelector({
 
   const includeModalIfAvailable = () => {
     const disableModal = DCDO.get('disable-try-new-progress-view-modal', false);
-    console.log(hasJustSwitchedToV1);
-    if (
-      !disableModal ||
-      (!hasJustSwitchedToV1 && !hasSeenProgressTableInvite)
-    ) {
+    if (disableModal || hasJustSwitchedToV1) {
+      return;
+    }
+    if (!hasSeenProgressTableInvite) {
       return (
         <InviteToV2ProgressModal
           sectionId={sectionId}

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -112,7 +112,7 @@ function SectionProgressSelector({
     console.log(hasJustSwitchedToV1);
     if (
       !disableModal ||
-      (!hasJustSwitchedToV1 && !hasSeenProgressTableInvite && !disableModal)
+      (!hasJustSwitchedToV1 && !hasSeenProgressTableInvite)
     ) {
       return (
         <InviteToV2ProgressModal

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -27,17 +27,13 @@ function SectionProgressSelector({
   sectionId,
   hasSeenProgressTableInvite,
 }) {
-  const [hasJustSwitchedToV2, setHasJustSwitchedToV2] = React.useState(false);
-  const [hasJustSwitchedToV1, setHasJustSwitchedToV1] = React.useState(false);
+  const [hasJustToggledViews, setHasJustToggledViews] = React.useState(false);
 
   const onShowProgressTableV2Change = useCallback(() => {
-    if (showProgressTableV2) {
-      setHasJustSwitchedToV1(true);
-    }
     const shouldShowV2 = !showProgressTableV2;
     new UserPreferences().setShowProgressTableV2(shouldShowV2);
     setShowProgressTableV2(shouldShowV2);
-    setHasJustSwitchedToV2(true);
+    setHasJustToggledViews(true);
 
     if (shouldShowV2) {
       analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW_NEW_PROGRESS, {
@@ -105,14 +101,14 @@ function SectionProgressSelector({
 
   const includeModalIfAvailable = () => {
     const disableModal = DCDO.get('disable-try-new-progress-view-modal', false);
-    if (disableModal || hasJustSwitchedToV1) {
+    if (disableModal || hasJustToggledViews) {
       return;
     }
     if (!hasSeenProgressTableInvite) {
       return (
         <InviteToV2ProgressModal
           sectionId={sectionId}
-          setHasJustSwitchedToV2={setHasJustSwitchedToV2}
+          setHasJustSwitchedToV2={setHasJustToggledViews}
         />
       );
     }
@@ -121,7 +117,7 @@ function SectionProgressSelector({
   return (
     <div className={styles.pageContent}>
       {displayV2 && (
-        <ProgressBanners hasJustSwitchedToV2={hasJustSwitchedToV2} />
+        <ProgressBanners hasJustSwitchedToV2={hasJustToggledViews} />
       )}
       {toggleV1OrV2Link()}
 

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -25,14 +25,23 @@ function SectionProgressSelector({
   setShowProgressTableV2,
   progressTableV2ClosedBeta,
   sectionId,
+  hasSeenProgressTableInvite,
 }) {
   const [hasJustSwitchedToV2, setHasJustSwitchedToV2] = React.useState(false);
+  const [hasJustSwitchedToV1, setHasJustSwitchedToV1] = React.useState(false);
 
   const onShowProgressTableV2Change = useCallback(() => {
+    console.log('showProgressTableV2: ', showProgressTableV2);
+    if (showProgressTableV2) {
+      setHasJustSwitchedToV1(true);
+      console.log('should indicate a user switched to V1 from V2');
+      // do not show pop-up
+    }
     const shouldShowV2 = !showProgressTableV2;
     new UserPreferences().setShowProgressTableV2(shouldShowV2);
     setShowProgressTableV2(shouldShowV2);
     setHasJustSwitchedToV2(true);
+    console.log('should indicate a user switched to V2 from V1.... maybe');
 
     if (shouldShowV2) {
       analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW_NEW_PROGRESS, {
@@ -100,7 +109,11 @@ function SectionProgressSelector({
 
   const includeModalIfAvailable = () => {
     const disableModal = DCDO.get('disable-try-new-progress-view-modal', false);
-    if (!disableModal) {
+    console.log(hasJustSwitchedToV1);
+    if (
+      !disableModal ||
+      (!hasJustSwitchedToV1 && !hasSeenProgressTableInvite && !disableModal)
+    ) {
       return (
         <InviteToV2ProgressModal
           sectionId={sectionId}
@@ -134,6 +147,7 @@ SectionProgressSelector.propTypes = {
   progressTableV2ClosedBeta: PropTypes.bool,
   setShowProgressTableV2: PropTypes.func.isRequired,
   sectionId: PropTypes.number,
+  hasSeenProgressTableInvite: PropTypes.bool,
 };
 
 export const UnconnectedSectionProgressSelector = SectionProgressSelector;
@@ -143,6 +157,7 @@ export default connect(
     showProgressTableV2: state.currentUser.showProgressTableV2,
     progressTableV2ClosedBeta: state.currentUser.progressTableV2ClosedBeta,
     sectionId: state.teacherSections.selectedSectionId,
+    hasSeenProgressTableInvite: state.currentUser.hasSeenProgressTableInvite,
   }),
   dispatch => ({
     setShowProgressTableV2: showProgressTableV2 =>

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
@@ -191,7 +191,7 @@ describe('SectionProgressSelector', () => {
     expect(screen.queryByTestId(V2_TEST_ID)).to.not.exist;
   });
 
-  it('shows modal if modal is available', () => {
+  it('shows modal if modal is enabled and the user has not seen the invite before', () => {
     DCDO.set('progress-table-v2-enabled', true);
     DCDO.set('progress-table-v2-closed-beta-enabled', true);
     DCDO.set('disable-try-new-progress-view-modal', false);
@@ -204,7 +204,7 @@ describe('SectionProgressSelector', () => {
     screen.getByText(i18n.progressTrackingAnnouncement());
   });
 
-  it('does not show modal if modal is not available', () => {
+  it('does not show modal if modal is disabled', () => {
     DCDO.set('progress-table-v2-enabled', true);
     DCDO.set('progress-table-v2-closed-beta-enabled', true);
     DCDO.set('disable-try-new-progress-view-modal', true);
@@ -214,6 +214,29 @@ describe('SectionProgressSelector', () => {
 
     renderDefault();
 
+    screen.getByText(V1_PAGE_LINK_TEXT);
+    screen.getByTestId(V1_TEST_ID);
+
+    expect(screen.queryByText(i18n.progressTrackingAnnouncement())).to.not
+      .exist;
+  });
+
+  it('does not show modal if the user has just switched from V1', () => {
+    DCDO.set('progress-table-v2-enabled', true);
+    DCDO.set('progress-table-v2-closed-beta-enabled', true);
+    DCDO.set('disable-try-new-progress-view-modal', false);
+
+    store.dispatch(setDateProgressTableInvitationDelayed(''));
+    store.dispatch(setHasSeenProgressTableInvite(false));
+
+    renderDefault();
+    store.dispatch(setShowProgressTableV2(true));
+
+    // Click the link to switch to V1
+    const link = screen.getByText(V2_PAGE_LINK_TEXT);
+    fireEvent.click(link);
+
+    // Check that the modal is not shown.
     screen.getByText(V1_PAGE_LINK_TEXT);
     screen.getByTestId(V1_TEST_ID);
 


### PR DESCRIPTION
Prevents the pop-up from popping up IMMEDIATELY after a user switches back to V1.  The pop-up will show up when the user re-loads the page while on V1 view.

The video below describes the behavior - sound on for my narration :) 

https://github.com/code-dot-org/code-dot-org/assets/24883357/10fe64c6-abf8-44a7-9b0f-9ef6cc6ba64b

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1089)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

