### PR TITLE
Swap teacher homepage banner to curriculum launch banner

### DIFF
--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -40,7 +40,7 @@
     },
     "curriculum-launch-2024": {
       "dcdo": "curriculum-launch-2024",
-      "image": "",
+      "image": "/shared/images/banners/banner-curriculum-launch-2024.png",
       "title": "Discover new and updated curriculum!",
       "body": "Explore our latest units and professional learning resources to inspire future tech innovators.",
       "buttonText": "See what's new",

--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -1,6 +1,6 @@
 {
   "pages": {
-    "/home": "lms-launch",
+    "/home": "curriculum-launch-2024",
     "/student-home": "music-lab-launch"
   },
   "banners": {

--- a/shared/images/banners/banner-curriculum-launch-2024.png
+++ b/shared/images/banners/banner-curriculum-launch-2024.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87c7d5496cfd47ab58b7fe56d732b029b521354c041581d22405e133a1abd2bd
-size 293443
+oid sha256:64d38e40dd8602aa0c74bd01168b2efd14b9a0e3d9dc71cae0f86d62ef66dc5f
+size 205420

--- a/shared/images/banners/banner-curriculum-launch-2024.png
+++ b/shared/images/banners/banner-curriculum-launch-2024.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87c7d5496cfd47ab58b7fe56d732b029b521354c041581d22405e133a1abd2bd
+size 293443


### PR DESCRIPTION
This updates the teacher homepage to show the curriculum launch banner once the DCDO flag is flipped. Unfortunately, it will take down the LMS banner once it hits production.

I'll merge this PR sometime on Thursday July 11, which will get it deployed either on Thursday or Friday.

