### PR TITLE
UnitGroupUnit table entries must be deleted when unit is deleted

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -63,8 +63,8 @@ class Unit < ApplicationRecord
   has_one :plc_course_unit, class_name: 'Plc::CourseUnit', foreign_key: 'script_id', inverse_of: :script, dependent: :destroy
   belongs_to :wrapup_video, class_name: 'Video', optional: true
   belongs_to :user, optional: true
-  has_many :unit_group_units, foreign_key: 'script_id'
-  has_many :unit_groups, through: :unit_group_units, dependent: :destroy
+  has_many :unit_group_units, foreign_key: 'script_id', dependent: :destroy
+  has_many :unit_groups, through: :unit_group_units
   has_one :course_version, as: :content_root, dependent: :destroy
 
   scope :with_associated_models, -> do

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -64,7 +64,7 @@ class Unit < ApplicationRecord
   belongs_to :wrapup_video, class_name: 'Video', optional: true
   belongs_to :user, optional: true
   has_many :unit_group_units, foreign_key: 'script_id'
-  has_many :unit_groups, through: :unit_group_units
+  has_many :unit_groups, through: :unit_group_units, dependent: :destroy
   has_one :course_version, as: :content_root, dependent: :destroy
 
   scope :with_associated_models, -> do

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -2481,6 +2481,7 @@ class UnitTest < ActiveSupport::TestCase
     unit_in_course.destroy
 
     assert Unit.find_by(id: unit_id).nil?
+    assert UnitGroup.find_by(id: unit_group.id)
 
     # Course version is associated to unit group and shouldn't be deleted
     assert CourseVersion.find_by(id: course_version.id)


### PR DESCRIPTION
Issue: When a unit that belongs to a unit group is deleted, the corresponding entries in UnitGroupUnit table are not deleted. As a result, loading the unit group through course overview page fails with the invalid reference.

Fix: Include a dependency to delete corresponding UnitGroupUnit entry during Unit deletion.

## Links

JIRA https://codedotorg.atlassian.net/browse/TEACH-1161

## Testing story

Unit test, drone 
Validated the change locally in level builder mode.
 - Deleted the unit
 - Confirmed corresponding entry from UnitGroupUnit table was deleted
 - Loading the course overview page was successful.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

DTP

## Follow-up work

Captured in same JIRA task

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
