### PR TITLE
[test all browsers] Reenabling fun o meter after PR 59255 with potential fix

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/fun_o_meter.feature
+++ b/dashboard/test/ui/features/teacher_tools/fun_o_meter.feature
@@ -1,4 +1,4 @@
-@as_student @no_phone
+@as_student
 Feature: Fun-O-Meter
 
 Scenario: Rate a Puzzle


### PR DESCRIPTION
The PR https://github.com/code-dot-org/code-dot-org/pull/59255 has a potential fix that can re-enable the fun_o_meter UI test for phones. This change is to re-enable the test for phones.

## Links

None

## Testing story

Ran drone 5 times and confirmed the fun_o_meter test passed successfully on all platforms during all iterations.

## Deployment strategy

DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
