### PR TITLE
Add user_type to link account button events

### DIFF
--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ContinueCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ContinueCard/index.tsx
@@ -17,12 +17,14 @@ import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 
 const ContinueAccountCard = () => {
-  const {ltiProviderName, continueAccountUrl} = useContext(LtiProviderContext)!;
+  const {ltiProviderName, continueAccountUrl, userType} =
+    useContext(LtiProviderContext)!;
   const [isSaving, setIsSaving] = useState(false);
 
   const handleNewAccountSaved = () => {
     const eventPayload = {
       lms_name: ltiProviderName,
+      user_type: userType,
     };
     analyticsReporter.sendEvent(
       'lti_continue_account_click',

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ExistingAccountCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/ExistingAccountCard/index.tsx
@@ -17,8 +17,13 @@ import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {navigateToHref} from '@cdo/apps/utils';
 
 const ExistingAccountCard = () => {
-  const {ltiProvider, ltiProviderName, existingAccountUrl, emailAddress} =
-    useContext(LtiProviderContext)!;
+  const {
+    ltiProvider,
+    ltiProviderName,
+    existingAccountUrl,
+    emailAddress,
+    userType,
+  } = useContext(LtiProviderContext)!;
   const urlParams = new URLSearchParams({
     lms_name: ltiProviderName,
     lti_provider: ltiProvider,
@@ -29,6 +34,7 @@ const ExistingAccountCard = () => {
   const handleExistingAccountSubmit = () => {
     const eventPayload = {
       lms_name: ltiProvider,
+      user_type: userType,
     };
     analyticsReporter.sendEvent(
       'lti_existing_account_click',

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/NewAccountCard/index.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/cards/NewAccountCard/index.tsx
@@ -19,7 +19,7 @@ import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 
 const NewAccountCard = () => {
-  const {ltiProviderName, newAccountUrl, emailAddress} =
+  const {ltiProviderName, newAccountUrl, emailAddress, userType} =
     useContext(LtiProviderContext)!;
   const finishSignupFormRef = useRef<HTMLFormElement>(null);
   const isStudentEmailPostEnabled = DCDO.get(
@@ -31,6 +31,7 @@ const NewAccountCard = () => {
   const handleNewAccountSaved = () => {
     const eventPayload = {
       lms_name: ltiProviderName,
+      user_type: userType,
     };
     analyticsReporter.sendEvent(
       'lti_new_account_click',

--- a/apps/src/lib/ui/lti/link/LtiLinkAccountPage/context.tsx
+++ b/apps/src/lib/ui/lti/link/LtiLinkAccountPage/context.tsx
@@ -9,6 +9,7 @@ export interface LtiProviderContextProps {
   existingAccountUrl: URL;
   emailAddress: string;
   newCtaType: 'continue' | 'new';
+  userType?: string;
 }
 
 export const LtiProviderContext = createContext<

--- a/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
+++ b/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
@@ -20,6 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const emailAddress = scriptData['email'];
   const newCtaType = scriptData['new_cta_type'];
   const continueAccountUrl = scriptData['continue_account_url'];
+  const userType = scriptData['user_type'];
 
   const ltiProviderContext = {
     ltiProvider,
@@ -29,6 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
     emailAddress,
     newCtaType,
     continueAccountUrl,
+    userType,
   };
 
   ReactDOM.render(

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -175,7 +175,7 @@ class LtiV1Controller < ApplicationController
 
         # If this is the user's first login, send them into the account linking flow
         if DCDO.get('lti_account_linking_enabled', false) && !user.lms_landing_opted_out
-          Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'continue')
+          Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'continue', user.user_type)
           PartialRegistration.persist_attributes(session, user)
           publish_linking_page_visit(user, integration[:platform_name])
           render 'lti/v1/account_linking/landing', locals: {email: Services::Lti.get_claim(decoded_jwt, :email)} and return
@@ -208,7 +208,7 @@ class LtiV1Controller < ApplicationController
         email_address = Services::Lti.get_claim(decoded_jwt, :email)
         PartialRegistration.persist_attributes(session, user)
         if DCDO.get('lti_account_linking_enabled', false)
-          Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'new')
+          Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'new', user.user_type)
           publish_linking_page_visit(user, integration[:platform_name])
           render 'lti/v1/account_linking/landing', locals: {email: email_address} and return
         end

--- a/dashboard/app/views/lti/v1/account_linking/landing.haml
+++ b/dashboard/app/views/lti/v1/account_linking/landing.haml
@@ -20,6 +20,7 @@
     script_data[:continue_account_url] = session[:user_return_to] || home_path
     script_data[:email] = email
     script_data[:new_cta_type] = new_cta_type
+    script_data[:user_type] = landing_session[:user_type] || current_user&.user_type
 
   %script{src: webpack_asset_path('js/lti/v1/account_linking/landing.js'), data: {json: script_data.to_json}}}
 %body

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -300,10 +300,11 @@ module Services
       course_sync_result
     end
 
-    def self.initialize_lms_landing_session(session, lti_provider_name, new_cta_type)
+    def self.initialize_lms_landing_session(session, lti_provider_name, new_cta_type, user_type)
       session[:lms_landing] = {
         lti_provider_name: lti_provider_name,
-        new_cta_type: new_cta_type
+        new_cta_type: new_cta_type,
+        user_type: user_type,
       }
     end
   end

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -607,7 +607,8 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
 
     expected = {
       lti_provider_name: "platform_name",
-      new_cta_type: "new"
+      new_cta_type: "new",
+      user_type: "student",
     }
 
     assert_equal expected, session[:lms_landing]

--- a/dashboard/test/lib/policies/lti_test.rb
+++ b/dashboard/test/lib/policies/lti_test.rb
@@ -99,7 +99,7 @@ class Policies::LtiTest < ActiveSupport::TestCase
     user = create_opted_out_user
 
     session = {}
-    Services::Lti.initialize_lms_landing_session(session, 'canvas_cloud', 'new')
+    Services::Lti.initialize_lms_landing_session(session, 'canvas_cloud', 'new', user.user_type)
 
     assert_equal true, Policies::Lti.account_linking?(session, user)
   end
@@ -119,7 +119,7 @@ class Policies::LtiTest < ActiveSupport::TestCase
     user.save
 
     session = {}
-    Services::Lti.initialize_lms_landing_session(session, 'canvas_cloud', 'new')
+    Services::Lti.initialize_lms_landing_session(session, 'canvas_cloud', 'new', user.user_type)
 
     assert_equal false, Policies::Lti.account_linking?(session, user)
   end
@@ -130,7 +130,7 @@ class Policies::LtiTest < ActiveSupport::TestCase
     user.save
 
     session = {}
-    Services::Lti.initialize_lms_landing_session(session, 'canvas_cloud', 'new')
+    Services::Lti.initialize_lms_landing_session(session, 'canvas_cloud', 'new', user.user_type)
 
     assert_equal false, Policies::Lti.account_linking?(session, user)
   end


### PR DESCRIPTION
The events for clicking continue/new or link existing account did not have user_type in the payload. This adds `user_type` to the `lms_landing_session` to make it available during the account linking flow.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1004)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally for both roster synced and brand new users.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
