### PR TITLE
Clean up existing ProjectUseDatablockStorage rows before creating a new one

### DIFF
--- a/bin/migrate_firebase_projects
+++ b/bin/migrate_firebase_projects
@@ -276,6 +276,7 @@ def migrate(channel_id)
     insert_datablock_kvps(kvps)
 
     # Now that its migrated, switch the project over to using DatablockStorage
+    ProjectUseDatablockStorage.where(project_id: project_id).delete_all
     ProjectUseDatablockStorage.create!(project_id: project_id, use_datablock_storage: true)
 
     # Do not allow transaction to complete if DRY_RUN==true


### PR DESCRIPTION
We allow multiple ProjectUseDatablockStorage rows with the same project_id (oops), so we need to clean up old ones before creating a new one.