### PR TITLE
P20-893: Fix duplication of CAP user events

### DIFF
--- a/dashboard/app/models/cap/user_event.rb
+++ b/dashboard/app/models/cap/user_event.rb
@@ -28,6 +28,7 @@ module CAP
       GRACE_PERIOD_START = 'grace_period_start'.freeze,
       ACCOUNT_LOCKING = 'account_locking'.freeze,
       ACCOUNT_PURGING = 'account_purging'.freeze,
+      COMPLIANCE_REMOVING = 'compliance_removing'.freeze,
     ].freeze
 
     enum policy: POLICIES.index_by(&:underscore), _suffix: true
@@ -37,12 +38,5 @@ module CAP
 
     validates :name, presence: true
     validates :policy, presence: true
-
-    before_save :ensure_state_is_set
-
-    private def ensure_state_is_set
-      self.state_before ||= user.child_account_compliance_state
-      self.state_after ||= user.child_account_compliance_state
-    end
   end
 end

--- a/dashboard/lib/services/child_account/event_logger.rb
+++ b/dashboard/lib/services/child_account/event_logger.rb
@@ -7,6 +7,7 @@ module Services
       # def self.log_grace_period_start(user)
       # def self.log_account_locking(user)
       # def self.log_account_purging(user)
+      # def self.log_compliance_removing(user)
       CAP::UserEvent.names.each_key do |event_name|
         define_singleton_method("log_#{event_name}") do |user|
           call(user: user, event_name: event_name)

--- a/dashboard/test/lib/services/child_account/event_logger_test.rb
+++ b/dashboard/test/lib/services/child_account/event_logger_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Services::ChildAccount::EventLoggerTest < ActiveSupport::TestCase
   setup do
-    @user = create(:non_compliant_child, child_account_compliance_state: 'l')
+    @user = create(:locked_out_child)
   end
 
   test 'call - creates CAP user event' do
@@ -68,5 +68,11 @@ class Services::ChildAccount::EventLoggerTest < ActiveSupport::TestCase
     event_name = CAP::UserEvent::ACCOUNT_PURGING
     Services::ChildAccount::EventLogger.expects(:call).with(user: @user, event_name: event_name).returns(event_name)
     assert_equal event_name, Services::ChildAccount::EventLogger.log_account_purging(@user)
+  end
+
+  test 'log_compliance_removing' do
+    event_name = CAP::UserEvent::COMPLIANCE_REMOVING
+    Services::ChildAccount::EventLogger.expects(:call).with(user: @user, event_name: event_name).returns(event_name)
+    assert_equal event_name, Services::ChildAccount::EventLogger.log_compliance_removing(@user)
   end
 end

--- a/dashboard/test/lib/services/child_account_test.rb
+++ b/dashboard/test/lib/services/child_account_test.rb
@@ -33,6 +33,15 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
   end
 
   class GrantPermissionRequest < ActionDispatch::IntegrationTest
+    let(:grant_permission_request!) {Services::ChildAccount.grant_permission_request!(parental_permission_request)}
+
+    let(:user) {create(:non_compliant_child)}
+    let(:parental_permission_request) {create(:parental_permission_request, user: user)}
+
+    let(:expect_permission_granting_cap_event_logging) do
+      Services::ChildAccount::EventLogger.expects(:log_permission_granting).with(user)
+    end
+
     def assert_enqueued_parent_permission_confirm_mail(permission, &block)
       assert_enqueued_with(
         job: ParentMailer.delivery_job,
@@ -52,8 +61,8 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
     end
 
     test 'given permission request it should update user and send email' do
-      permission = create :parental_permission_request
-      user = permission.user
+      permission = parental_permission_request
+      expect_permission_granting_cap_event_logging.once
       assert_enqueued_parent_permission_confirm_mail(permission) do
         Services::ChildAccount.grant_permission_request! permission
       end
@@ -63,8 +72,8 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
     end
 
     test 'granting permission twice only makes changes once' do
-      permission = create :parental_permission_request
-      user = permission.user
+      permission = parental_permission_request
+      expect_permission_granting_cap_event_logging.once
       assert_enqueued_parent_permission_confirm_mail(permission) do
         Services::ChildAccount.grant_permission_request! permission
       end
@@ -81,6 +90,19 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
       user.reload
       # The date shouldn't be updated
       assert_equal last_updated, user.child_account_compliance_state_last_updated
+    end
+
+    context 'when something goes wrong during user saving' do
+      let(:error) {'expected_error'}
+
+      before do
+        user.stubs(:save!).raises(error)
+      end
+
+      it 'does not log "permission_granting" CAP user event' do
+        expect_permission_granting_cap_event_logging.never
+        assert_raises(error) {grant_permission_request!}
+      end
     end
   end
 
@@ -100,8 +122,39 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
 
       assert_attributes user, {
         child_account_compliance_state: 'p',
+        child_account_compliance_lock_out_date: nil,
         child_account_compliance_state_last_updated: DateTime.now.iso8601(3),
       }
+    end
+
+    it 'logs "grace_period_start" CAP user event' do
+      assert_difference 'CAP::UserEvent.count' do
+        start_grace_period
+      end
+
+      cap_user_event = CAP::UserEvent.find_by(user: user)
+
+      refute_nil cap_user_event
+      assert_attributes cap_user_event, {
+        name: 'grace_period_start',
+        policy: 'cpa',
+        state_before: nil,
+        state_after: 'p',
+      }
+    end
+
+    context 'when something goes wrong during user saving' do
+      let(:error) {'expected_error'}
+
+      before do
+        user.stubs(:save!).raises(error)
+      end
+
+      it 'does not log "grace_period_start" CAP user event' do
+        assert_no_difference 'CAP::UserEvent.count' do
+          assert_raises(error) {start_grace_period}
+        end
+      end
     end
   end
 
@@ -119,11 +172,41 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
         lock_out
       end
 
-      assert_attributes user, {
+      assert_attributes user.reload, {
         child_account_compliance_state: 'l',
         child_account_compliance_lock_out_date: DateTime.now.iso8601(3),
         child_account_compliance_state_last_updated: DateTime.now.iso8601(3),
       }
+    end
+
+    it 'logs "account_locking" CAP user event' do
+      assert_difference 'CAP::UserEvent.count' do
+        lock_out
+      end
+
+      cap_user_event = CAP::UserEvent.find_by(user: user)
+
+      refute_nil cap_user_event
+      assert_attributes cap_user_event, {
+        name: 'account_locking',
+        policy: 'cpa',
+        state_before: nil,
+        state_after: 'l',
+      }
+    end
+
+    context 'when something goes wrong during user saving' do
+      let(:error) {'expected_error'}
+
+      before do
+        user.stubs(:save!).raises(error)
+      end
+
+      it 'does not log "account_locking" CAP user event' do
+        assert_no_difference 'CAP::UserEvent.count' do
+          assert_raises(error) {lock_out}
+        end
+      end
     end
   end
 
@@ -151,6 +234,36 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
     it 'updates user CAP compliance state last updated date' do
       assert_changes -> {user.reload.child_account_compliance_state_last_updated}, from: user_cap_compliance_updated_at.iso8601(3), to: DateTime.now.iso8601(3) do
         remove_user_cap_compliance_state
+      end
+    end
+
+    it 'logs "compliance_removing" CAP user event' do
+      assert_difference 'CAP::UserEvent.count' do
+        remove_user_cap_compliance_state
+      end
+
+      cap_user_event = CAP::UserEvent.find_by(user: user)
+
+      refute_nil cap_user_event
+      assert_attributes cap_user_event, {
+        name: 'compliance_removing',
+        policy: 'cpa',
+        state_before: 'p',
+        state_after: nil,
+      }
+    end
+
+    context 'when something goes wrong during user saving' do
+      let(:error) {'expected_error'}
+
+      before do
+        user.stubs(:save!).raises(error)
+      end
+
+      it 'does not log "compliance_removing" CAP user event' do
+        assert_no_difference 'CAP::UserEvent.count' do
+          assert_raises(error) {remove_user_cap_compliance_state}
+        end
       end
     end
   end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -84,45 +84,6 @@ class UserTest < ActiveSupport::TestCase
     @levelbuilder = create :levelbuilder
   end
 
-  class CAPEventLogging < ActiveSupport::TestCase
-    setup do
-      @student = create(:non_compliant_child)
-    end
-
-    test 'logs CAP event "account_locking" after student compliance state changed to "p"' do
-      Services::ChildAccount.update_compliance(@student, Policies::ChildAccount::ComplianceState::GRACE_PERIOD)
-
-      Services::ChildAccount::EventLogger.expects(:log_grace_period_start).with(@student).once
-
-      @student.save!
-    end
-
-    test 'logs CAP event "account_locking" after student compliance state changed to "l"' do
-      Services::ChildAccount.update_compliance(@student, Policies::ChildAccount::ComplianceState::LOCKED_OUT)
-
-      Services::ChildAccount::EventLogger.expects(:log_account_locking).with(@student).once
-
-      @student.save!
-    end
-
-    test 'logs CAP event "permission_granting" after student compliance state changed to "g"' do
-      Services::ChildAccount.update_compliance(@student, Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED)
-
-      Services::ChildAccount::EventLogger.expects(:log_permission_granting).with(@student).once
-
-      @student.save!
-    end
-
-    test 'does not log any CAP events if compliance state was not changed' do
-      Services::ChildAccount.update_compliance(@student, Policies::ChildAccount::ComplianceState::LOCKED_OUT)
-      @student.save!
-
-      Services::ChildAccount::EventLogger.expects(:new).with(user: @student, event_name: anything).never
-
-      @student.save!
-    end
-  end
-
   test 'from_identifier finds user by id' do
     student = create :student
     assert_equal student, User.from_identifier(student.id.to_s)


### PR DESCRIPTION
## Summary
- Fixed duplication of CAP user events
- Fixed the `state_before` to set it to nil when it is not present

## Scripts
### Duplicates Removal
```ruby
%w[grace_period_start account_locking permission_granting].each do |event_name|
  events = CAP::UserEvent.where(policy: 'cpa', name: event_name)
  original_event_ids = events.group(:user_id).pluck('min(id)')
  events.where.not(id: original_event_ids).in_batches.delete_all
end
```

### Events correction
```ruby
%w[grace_period_start account_locking].each do |event_name|
  CAP::UserEvent.where(policy: 'cpa', name: event_name).in_batches.update_all(state_before: nil)
end
```

## Links
- JIRA ticket: [P20-893](https://codedotorg.atlassian.net/browse/P20-893)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/58568