### PR TITLE
AI Chat: fix auto-scroll behavior

### DIFF
--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -23,6 +23,7 @@ const ChatWorkspace: React.FunctionComponent = () => {
   );
 
   const messages = useSelector(selectAllMessages);
+
   const isWaitingForChatResponse = useSelector(
     (state: {aichat: AichatState}) => state.aichat.isWaitingForChatResponse
   );

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -23,11 +23,13 @@ const ChatWorkspace: React.FunctionComponent = () => {
   );
 
   const messages = useSelector(selectAllMessages);
-
   const isWaitingForChatResponse = useSelector(
     (state: {aichat: AichatState}) => state.aichat.isWaitingForChatResponse
   );
 
+  // Compare the messages as a string since the object reference will change on every update.
+  // This way we will only scroll when the contents of the messages have changed.
+  const messagesString = JSON.stringify(messages);
   const conversationContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -37,7 +39,7 @@ const ChatWorkspace: React.FunctionComponent = () => {
         behavior: 'smooth',
       });
     }
-  }, [conversationContainerRef, messages, isWaitingForChatResponse]);
+  }, [messagesString, isWaitingForChatResponse]);
 
   const dispatch = useAppDispatch();
 


### PR DESCRIPTION
Fix a bug where the chat would auto-scroll on any update in the customization window (opening dropdown, typing text, changing slider, etc) instead of only when new messages or notifications appear.

**Before**

https://github.com/code-dot-org/code-dot-org/assets/85528507/da581a93-4ede-46e1-87e7-61a6e652c881

**After**

https://github.com/code-dot-org/code-dot-org/assets/85528507/20964704-afb3-41db-859b-82127c2f2541

## Testing story

Tested on pilot levels.