### PR TITLE
Tidy Projects: delete unused projects UI step definitions

### DIFF
--- a/dashboard/test/ui/features/step_definitions/applab.rb
+++ b/dashboard/test/ui/features/step_definitions/applab.rb
@@ -101,7 +101,7 @@ end
 
 When /^I navigate to the embedded version of my project$/ do
   steps <<-GHERKIN
-    When I open the share dialog
+    When I open the project share dialog
     And I click selector "#project-share a:contains('Show advanced options')"
     And I click selector "#project-share li:contains('Embed')"
     And I copy the embed code into a new document
@@ -110,7 +110,7 @@ end
 
 When /^I navigate to the embedded version of my project with source hidden$/ do
   steps <<-GHERKIN
-    When I open the share dialog
+    When I open the project share dialog
     And I click selector "#project-share a:contains('Show advanced options')"
     And I click selector "#project-share li:contains('Embed')"
     And I click selector "#project-share label:contains('Hide ability to view code')"

--- a/dashboard/test/ui/features/step_definitions/droplet_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/droplet_steps.rb
@@ -137,7 +137,7 @@ end
 
 Then /^I open the library publish dialog/ do
   steps <<-STEPS
-    When I open the share dialog
+    When I open the project share dialog
     And I click selector "#project-share a:contains('Show advanced options')" if it exists
     And I click selector "#project-share li:contains('Share as library')"
     And I click selector "button:contains('Share as library')"

--- a/dashboard/test/ui/features/step_definitions/project_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/project_steps.rb
@@ -72,43 +72,10 @@ Then(/^I report abuse on the project$/) do
   GHERKIN
 end
 
-Then(/^I publish the project$/) do
-  steps <<~GHERKIN
-    Given I open the project share dialog
-    And the project is unpublished
-    When I publish the project from the share dialog
-  GHERKIN
-end
-
 Then /^I open the project share dialog$/ do
   steps <<-GHERKIN
     Then I click selector ".project_share"
     And I wait to see a dialog titled "Share your project"
-  GHERKIN
-end
-
-Then /^I publish the project from the share dialog$/ do
-  steps <<-GHERKIN
-    And I click selector "#share-dialog-publish-button"
-    Then I publish the project from the publish to gallery dialog
-  GHERKIN
-end
-
-Then /^I publish the project from the personal projects table publish button$/ do
-  steps <<-GHERKIN
-    And I wait until element ".ui-personal-projects-publish-button" is visible
-    Then I click selector ".ui-personal-projects-publish-button"
-    Then I publish the project from the publish to gallery dialog
-    And I wait until element ".ui-personal-projects-unpublish-button" is visible
-  GHERKIN
-end
-
-Then /^I publish the project from the publish to gallery dialog$/ do
-  steps <<-GHERKIN
-    And I wait to see a publish dialog with title containing "Publish to Public Gallery"
-    And element "#publish-dialog-publish-button" is visible
-    And I click selector "#publish-dialog-publish-button"
-    And I wait for the dialog to close
   GHERKIN
 end
 
@@ -128,35 +95,6 @@ Then /^I navigate to the personal gallery via the gallery switcher$/ do
     And I wait until element "#uitest-personal-projects" is visible
     And element "#uitest-public-projects" is not visible
   GHERKIN
-end
-
-Then /^I wait to see a publish dialog with title containing "((?:[^"\\]|\\.)*)"$/ do |expected_text|
-  steps <<-GHERKIN
-    Then I wait to see ".publish-dialog-title"
-    And element ".publish-dialog-title" contains text "#{expected_text}"
-  GHERKIN
-end
-
-Then /^I unpublish the project from the share dialog$/ do
-  steps <<-GHERKIN
-    Then I click selector "#share-dialog-unpublish-button"
-    And I wait for the dialog to close
-  GHERKIN
-end
-
-Then /^the project is (un)?published/ do |negation|
-  published = negation.nil?
-  expect(element_visible?("#share-dialog-publish-button")).to eq(!published)
-  expect(element_visible?("#share-dialog-unpublish-button")).to eq(published)
-end
-
-Then /^the project cannot be published$/ do
-  expect(element_visible?("#share-dialog-publish-button")).to eq(false)
-  expect(element_visible?("#share-dialog-unpublish-button")).to eq(false)
-end
-
-Then /^the project can be published$/ do
-  expect(element_visible?("#share-dialog-publish-button")).to eq(true)
 end
 
 Then /^I reload the project page/ do

--- a/dashboard/test/ui/features/step_definitions/project_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/project_steps.rb
@@ -72,13 +72,6 @@ Then(/^I report abuse on the project$/) do
   GHERKIN
 end
 
-Then /^I open the project share dialog$/ do
-  steps <<-GHERKIN
-    Then I click selector ".project_share"
-    And I wait to see a dialog titled "Share your project"
-  GHERKIN
-end
-
 Then /^I navigate to the public gallery via the gallery switcher$/ do
   steps <<-GHERKIN
     Then I click selector "#uitest-gallery-switcher div:contains(Featured Projects)"
@@ -138,7 +131,7 @@ Then /^I save the share URL$/ do
   last_shared_url = @browser.execute_script("return document.getElementById('sharing-dialog-copy-button').value")
 end
 
-When /^I open the share dialog$/ do
+When /^I open the project share dialog$/ do
   Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, sleep: 10, tries: 3) do
     steps <<-GHERKIN
       When I click selector ".project_share"
@@ -149,7 +142,7 @@ end
 
 When /^I navigate to the shared version of my project$/ do
   steps <<-GHERKIN
-    When I open the share dialog
+    When I open the project share dialog
     And I navigate to the share URL
   GHERKIN
 end

--- a/dashboard/test/ui/features/teacher_tools/projects/artist_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/artist_project.feature
@@ -11,7 +11,6 @@ Scenario: Save Artist Project
 
   When I am not signed in
   And I open the project share dialog
-  Then the project cannot be published
 
   And I navigate to the share URL
   And I wait until element "#visualization" is visible


### PR DESCRIPTION
We removed ability for students to publish projects to a public gallery for safety and customer support time management (see [spec](https://docs.google.com/document/d/1vU68tzXG72Z80MvM6xYEDwF5hLDf7V097P-0dDfpouc/edit)). When that work was done (https://github.com/code-dot-org/code-dot-org/pull/57473) a handful of UI tests related to the (un)publishing projects were updated. However, there were lingering unused step definitions. This PR removes the unused code. 🗑️ 

With the clutter gone, I noticed there were two very similar step definitions "I open the share dialog" and "I open the project share dialog". I consolidated them keeping the step definition that included a retry to avoid flakiness and the more descriptive name. Then I updated references to that step.  

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
