### PR TITLE
Remove deprecated 'purple secondary' buttons

### DIFF
--- a/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
@@ -75,6 +75,7 @@ const RetrievalCustomization: React.FunctionComponent = () => {
           <Button
             text="Add"
             type="secondary"
+            color="gray"
             size="s"
             onClick={onAdd}
             iconLeft={{iconName: 'plus'}}

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -102,6 +102,7 @@ const SetupCustomization: React.FunctionComponent = () => {
             text="Compare Models"
             onClick={() => setIsShowingModelDialog(true)}
             type="secondary"
+            color="gray"
             className={classNames(
               styles.updateButton,
               styles.compareModelsButton

--- a/apps/src/templates/MultiItemInput.tsx
+++ b/apps/src/templates/MultiItemInput.tsx
@@ -56,6 +56,7 @@ export const MultiItemInput: React.FunctionComponent<{
               isIconOnly
               size="s"
               type="secondary"
+              color="gray"
               icon={{iconName: 'plus'}}
             />
           )}
@@ -65,6 +66,7 @@ export const MultiItemInput: React.FunctionComponent<{
             isIconOnly
             size="s"
             type="secondary"
+            color="gray"
             icon={{iconName: 'minus'}}
           />
         </div>


### PR DESCRIPTION
Remove the deprecated "purple secondary" buttons, changing them to secondary / gray. This matches the designs in figma as well.

Compare Models button:
![Screenshot 2024-07-02 at 11 40 31 AM](https://github.com/code-dot-org/code-dot-org/assets/85528507/1fec6c86-76ec-411c-bb73-a94a89ac2b15)

Retrieval Add button:
![Screenshot 2024-07-02 at 11 40 40 AM](https://github.com/code-dot-org/code-dot-org/assets/85528507/4499ccd0-e54a-4654-b898-00b0c1b49cbd)

Multi-item input plus/minus buttons:
![Screenshot 2024-07-02 at 11 40 48 AM](https://github.com/code-dot-org/code-dot-org/assets/85528507/def96c7e-6ab4-4daf-b326-d92b62ff15c5)

## Links

[Figma](https://www.figma.com/design/tjkMqlAXi2iTqpUHSljB3A/Gen-AI-Unit?node-id=2574-23860&m=dev)
[JIRA](https://codedotorg.atlassian.net/browse/LABS-849)

## Testing story

Tested on allthethings AI Chat and a few pilot levels.