### PR TITLE
fix(lms): do not style the teacher and student button for lti

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -171,6 +171,11 @@ $(document).ready(() => {
 
   // Style selected user type button to show it has been clicked
   function styleSelectedUserTypeButton(value) {
+    // For LTI, the user type is implied from the LMS so the buttons will not appear
+    if (!teacherButton || !studentButton) {
+      return;
+    }
+
     if (value === 'teacher') {
       teacherButton.classList.add('select-user-type-button-selected');
       studentButton.classList.remove('select-user-type-button-selected');


### PR DESCRIPTION
When SSOing from LTI, the user type is implied through the roster and therefore, the user does not need to select the user type. As such, we removed the student and teacher buttons but the finish signup script attempts to style these buttons. This causes a JS error which causes the submit event listener to not be attached. Adding a safety check to prevent styling if the buttons do not exist.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [slack thread](https://codedotorg.slack.com/archives/CFTFD6BPV/p1719949268433889)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. Create new teacher on Canvas
2. SSO Login first time (not roster synced)
3. Attempt to create account with school info
4. Select the no school option

Expected: Fields blank

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
