### PR TITLE
Add missing LTI signin metrics

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -173,14 +173,6 @@ class LtiV1Controller < ApplicationController
       if user
         sign_in user
 
-        # If this is the user's first login, send them into the account linking flow
-        if DCDO.get('lti_account_linking_enabled', false) && !user.lms_landing_opted_out
-          Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'continue', user.user_type)
-          PartialRegistration.persist_attributes(session, user)
-          publish_linking_page_visit(user, integration[:platform_name])
-          render 'lti/v1/account_linking/landing', locals: {email: Services::Lti.get_claim(decoded_jwt, :email)} and return
-        end
-
         metadata = {
           'user_type' => user.user_type,
           'lms_name' => integration[:platform_name],
@@ -190,6 +182,14 @@ class LtiV1Controller < ApplicationController
           event_name: 'lti_user_signin',
           metadata: metadata,
         )
+
+        # If this is the user's first login, send them into the account linking flow
+        if DCDO.get('lti_account_linking_enabled', false) && !user.lms_landing_opted_out
+          Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'continue', user.user_type)
+          PartialRegistration.persist_attributes(session, user)
+          publish_linking_page_visit(user, integration[:platform_name])
+          render 'lti/v1/account_linking/landing', locals: {email: Services::Lti.get_claim(decoded_jwt, :email)} and return
+        end
 
         # If on code.org, the user is a student and the LTI has the same user as a teacher, upgrade the student to a teacher.
         if lti_account_type == User::TYPE_TEACHER && user.user_type == User::TYPE_STUDENT

--- a/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
@@ -24,6 +24,18 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
     PartialRegistration.persist_attributes session, partial_lti_teacher
     User.any_instance.stubs(:valid_password?).returns(true)
 
+    Metrics::Events.expects(:log_event).with(
+      has_entries(
+        user: @user,
+        event_name: 'lti_account_linked'
+      )
+    )
+    Metrics::Events.expects(:log_event).with(
+      has_entries(
+        user: @user,
+        event_name: 'lti_user_signin'
+      )
+    )
     post :link_email, params: {email: @user.email, password: 'password'}
     assert_redirected_to target_url
     assert Policies::Lti.lti?(@user)

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1781,6 +1781,18 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         end
 
         it 'links an LTI auth option to an existing account' do
+          Metrics::Events.expects(:log_event).with(
+            has_entries(
+              user: user,
+              event_name: 'lti_user_signin'
+            )
+          )
+          Metrics::Events.expects(:log_event).with(
+            has_entries(
+              user: user,
+              event_name: 'lti_account_linked'
+            )
+          )
           get provider
           # The user factory automatically creates an email auth option,
           # so this includes 1 email, 1 SSO, and 1 LTI auth option


### PR DESCRIPTION
This fixes a couple spots where we weren't publishing `lti_user_signin` events. Specifically:
- When we moved the sign_in call earlier in the LTI auth method, we left the sign in event where it was, meaning that we aren't currently publishing sign-in events when roster synced users are signed in on the landing page.
- We didn't have sign-in events when a user links their account, even though they are signed in at the end of the process.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1025)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
