### PR TITLE
Don't lint apps/storybook-deploy

### DIFF
--- a/apps/.eslintignore
+++ b/apps/.eslintignore
@@ -4,6 +4,7 @@
 
 /lib
 /build
+/storybook-deploy
 node_modules
 
 !.storybook


### PR DESCRIPTION
The `apps/storybook-deploy` directory is auto-generated by `yarn storybook:deploy` and shouldn't be linted.

At one point this directory caused `yarn lint:js` to hang forever, and blocked build on staging.