### PR TITLE
fix(jest): mock out imageUtils to prevent a race condition

### DIFF
--- a/apps/test/setupJest.js
+++ b/apps/test/setupJest.js
@@ -88,5 +88,6 @@ jest.mock('@cdo/apps/lib/util/firehose', () => ({
 jest.mock('@cdo/apps/imageUtils', () => ({
   ...jest.requireActual('@cdo/apps/imageUtils'),
   toImage: jest.fn(),
+  dataURIToSourceSize: jest.fn(),
 }));
 fetch.mockIf('/api/v1/users/current', JSON.stringify(''));

--- a/apps/test/setupJest.js
+++ b/apps/test/setupJest.js
@@ -83,4 +83,10 @@ global.PISKEL_DEVELOPMENT_MODE = 'false';
 jest.mock('@cdo/apps/lib/util/firehose', () => ({
   putRecord: jest.fn(),
 }));
+// Mock out toImage as it produces a live image relying on browser callbacks to properly instantiate
+// imageUtils is tested in the integration test suite instead of jest.
+jest.mock('@cdo/apps/imageUtils', () => ({
+  ...jest.requireActual('@cdo/apps/imageUtils'),
+  toImage: jest.fn(),
+}));
 fetch.mockIf('/api/v1/users/current', JSON.stringify(''));

--- a/apps/test/unit/code-studio/initApp/loadAppTest.js
+++ b/apps/test/unit/code-studio/initApp/loadAppTest.js
@@ -16,6 +16,8 @@ const SERVER_LEVEL_ID = 5;
 const SERVER_PROJECT_LEVEL_ID = 10;
 const OLD_CODE = '<some><blocks with="stuff">in<them/></blocks></some>';
 
+jest.unmock('@cdo/apps/imageUtils');
+
 describe('loadApp.js', () => {
   let oldAppOptions, appOptions, writtenLevelId, readLevelId;
 

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -1028,7 +1028,11 @@ describe('RubricContainer', () => {
       </Provider>
     );
 
-    const skipButton = await findByRole('button', {name: '×'});
+    const skipButton = await findByRole(
+      'button',
+      {name: '×'},
+      {timeout: 10_000} // wait for introjs to load
+    );
 
     fireEvent.click(skipButton);
 


### PR DESCRIPTION
The animation reducer uses the file uploader callback which throws due to our implementation of Image. The image api uses live browser callbacks to render out which causes random tests to fail when the callback is fired. Instead, mock out the imageUtil library as images are tested in the integration test library.

This wasn't captured in the development of jest as the staging server runs slower than my machine giving a higher chance of this happening due to timing.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Ran fix on the staging server, passed 5/5 times after fix.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
