### PR TITLE
Datablock Storage: Don't double json-encode kvps

### DIFF
--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -69,7 +69,8 @@ class DatablockStorageController < ApplicationController
 
   def get_key_value
     kvp = DatablockStorageKvp.find_by(project_id: @project_id, key: params[:key])
-    render json: kvp ? JSON.parse(kvp.value).to_json : nil
+    # render json: assumes a string is already json encoded, so to_json is necessary.
+    render json: kvp&.value.to_json
   end
 
   def delete_key_value

--- a/dashboard/app/models/datablock_storage_kvp.rb
+++ b/dashboard/app/models/datablock_storage_kvp.rb
@@ -29,12 +29,12 @@ class DatablockStorageKvp < ApplicationRecord
   def self.get_kvps(project_id)
     where(project_id: project_id).
       select(:key, :value).
-      to_h {|kvp| [kvp.key, JSON.parse(kvp.value)]}
+      to_h {|kvp| [kvp.key, kvp.value]}
   end
 
   def self.set_kvps(project_id, key_value_hashmap, upsert: true)
     kvps = key_value_hashmap.map do |key, value|
-      kvp_attr = {project_id: project_id, key: key, value: value.to_json}
+      kvp_attr = {project_id: project_id, key: key, value: value}
       DatablockStorageKvp.new(kvp_attr).valid?
       kvp_attr
     end

--- a/dashboard/db/migrate/20240702214406_remove_json_encoding_from_datablock_storage_kvps.rb
+++ b/dashboard/db/migrate/20240702214406_remove_json_encoding_from_datablock_storage_kvps.rb
@@ -4,10 +4,10 @@ class RemoveJSONEncodingFromDatablockStorageKvps < ActiveRecord::Migration[6.1]
       kvp.update!(value: JSON.parse(kvp.value))
     rescue => exception
       message = <<~LOG
-        Failed to do the thingy: #{exception.message}
-
-        Traceback:
-        #{exception.backtrace.join("\n")}
+        Failed to migrate KVP (project_id=#{kvp.project_id}, key=#{kvp.key.inspect})
+          Exception: #{exception.message}
+          Traceback:
+        #{exception.backtrace.join("\n\t\t")}
       LOG
       Rails.logger.warn message
       puts message

--- a/dashboard/db/migrate/20240702214406_remove_json_encoding_from_datablock_storage_kvps.rb
+++ b/dashboard/db/migrate/20240702214406_remove_json_encoding_from_datablock_storage_kvps.rb
@@ -1,0 +1,22 @@
+class RemoveJSONEncodingFromDatablockStorageKvps < ActiveRecord::Migration[6.1]
+  def up
+    DatablockStorageKvp.all.each do |kvp|
+      kvp.update!(value: JSON.parse(kvp.value))
+    rescue => exception
+      message = <<~LOG
+        Failed to do the thingy: #{exception.message}
+
+        Traceback:
+        #{exception.backtrace.join("\n")}
+      LOG
+      Rails.logger.warn message
+      puts message
+    end
+  end
+
+  def down
+    DatablockStorageKvp.all.each do |kvp|
+      kvp.update!(value: kvp.value.to_json)
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_01_205906) do
+ActiveRecord::Schema.define(version: 2024_07_02_214406) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -428,7 +428,7 @@ ActiveRecord::Schema.define(version: 2024_07_01_205906) do
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 
-  create_table "course_offerings_pd_workshops", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "course_offerings_pd_workshops", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "pd_workshop_id", null: false
     t.bigint "course_offering_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/dashboard/test/controllers/datablock_storage_controller_test.rb
+++ b/dashboard/test/controllers/datablock_storage_controller_test.rb
@@ -499,6 +499,15 @@ class DatablockStorageControllerTest < ActionDispatch::IntegrationTest
     assert_equal ({"click_count" => 5}), JSON.parse(@response.body)
   end
 
+  test "populate_key_values_with_string_value" do
+    put _url(:populate_key_values), params: {key_values_json: '{"click_count": "backends"}'}
+    assert_response :success
+
+    get _url(:get_key_values)
+    assert_response :success
+    assert_equal ({"click_count" => "backends"}), JSON.parse(@response.body)
+  end
+
   test "populate_key_values does not overwrite existing data" do
     post _url(:set_key_value), params: {key: 'click_count', value: 1.to_json}
     assert_response :success


### PR DESCRIPTION
In the original implementation of kvps in datablock storage, we accidentally double json-encoded kvp values in the DB. This PR includes:

- A migration that json-decodes one level on the datablock_storage_kvps value column.
- Fixes datablock_storage_controller and datablock_storage_kvp to do the correct json encodings when getting and setting these values.

While migrations applied to prod can timeout after only 30s, this migration only updates 1500 rows and we expect it to finish in time.