### PR TITLE
Commenting out priority deadline

### DIFF
--- a/pegasus/sites.v3/code.org/public/youngwomen.haml
+++ b/pegasus/sites.v3/code.org/public/youngwomen.haml
@@ -45,8 +45,8 @@ theme: responsive_full_width
         %h2
           =hoc_s((!applications_closed ? :call_to_action_applications_open_exclamation : :cs_ambassador_application_closed_title))
         - if !applications_closed
-          %p.heading-xs
-            =hoc_s(:cs_ambassador_priority_deadline)
+          -# %p.heading-xs
+            -# =hoc_s(:cs_ambassador_priority_deadline)
           %p.heading-xs.no-margin-bottom
             =hoc_s(:cs_ambassador_application_subhead)
         %p.body-three


### PR DESCRIPTION
Commenting out priority deadline. Because the applications are being extended, I didn't flip the 'applciations_closed' variable (which would've updated several places on the page). Additionally, I chose not to delete the line because we will likely keep/reuse a priority deadline in the future.

Before:
![Screenshot 2024-07-03 at 2 35 39 PM](https://github.com/code-dot-org/code-dot-org/assets/37230822/9e2d7093-9073-41b3-b0ea-9dbf4cf074c8)

After:
![Screenshot 2024-07-03 at 12 39 58 PM](https://github.com/code-dot-org/code-dot-org/assets/37230822/55308491-1dc5-4955-8b58-c57864770202)

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2046

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
