### PR TITLE
Piping self paced pl course offerings into build your own workshop topics dropdown

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -65,14 +65,7 @@ const placeholderSession = {
   endTime: '5:00pm',
 };
 
-// TODO pipe in PL topics via ACQ-2020
-const ALL_PL_TOPICS = [
-  'Test Self Paced PL Topic',
-  'Another Test Self Paced PL Topic',
-  'A Third Test Self Paced PL Topic',
-  'And a Final Very Long Test Self Paced PL Topic That Takes Up a Line',
-];
-
+let ALL_PL_TOPICS = {};
 const INPUT_HEIGHT = 34;
 
 // When selecting whether a workshop is virtual through the UI,
@@ -185,6 +178,7 @@ export class WorkshopForm extends React.Component {
       this.loadAvailableFacilitators(props.workshop.course);
     }
 
+    this.loadPlCourseOfferings();
     this.loadRegionalPartners();
 
     return initialState;
@@ -197,9 +191,11 @@ export class WorkshopForm extends React.Component {
     if (this.loadWorkshopRequest) {
       this.loadWorkshopRequest.abort();
     }
-
     if (this.loadRegionalPartnersRequest) {
       this.loadRegionalPartnersRequest.abort();
+    }
+    if (this.loadPlCoursesRequest) {
+      this.loadPlCoursesRequest.abort();
     }
   }
 
@@ -228,6 +224,16 @@ export class WorkshopForm extends React.Component {
       this.setState({
         regionalPartners: data,
       });
+    });
+  }
+
+  loadPlCourseOfferings() {
+    this.loadPlCoursesRequest = $.ajax({
+      method: 'GET',
+      url: `/course_offerings/self_paced_pl_course_offerings`,
+      dataType: 'json',
+    }).done(data => {
+      ALL_PL_TOPICS = data;
     });
   }
 
@@ -738,17 +744,17 @@ export class WorkshopForm extends React.Component {
   };
 
   // Selects the given value in the topic dropdown
-  handleTopicSelect = event => {
+  handleTopicSelect = (id, event) => {
     const value = Object.keys(event)[0];
     const isChecked = event[value];
 
     let updatedTopics;
     if (isChecked) {
       // Add checked item into applied filters
-      updatedTopics = [...this.state.plTopics, value];
+      updatedTopics = [...this.state.plTopics, id];
     } else {
       // Remove unchecked item from applied filters
-      updatedTopics = this.state.plTopics.filter(item => item !== value);
+      updatedTopics = this.state.plTopics.filter(item => item !== id);
     }
     this.setState({plTopics: updatedTopics});
   };
@@ -1193,18 +1199,18 @@ export class WorkshopForm extends React.Component {
                       aria-labelledby="dropdownMenuButton"
                     >
                       <ul style={styles.listItems}>
-                        {ALL_PL_TOPICS.map(label => (
+                        {Object.values(ALL_PL_TOPICS).map(object => (
                           <li
                             className="dropdown-item"
                             style={styles.singleItem}
-                            key={label}
+                            key={object.id}
                           >
                             <SingleCheckbox
                               style={styles.check}
-                              name={label}
-                              label={label}
-                              onChange={e => this.handleTopicSelect(e)}
-                              value={this.state.plTopics.includes(label)}
+                              name={object.display_name}
+                              label={object.display_name}
+                              onChange={e => this.handleTopicSelect(object.id, e)}
+                              value={this.state.plTopics.includes(object.id)}
                             />
                           </li>
                         ))}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -1209,7 +1209,9 @@ export class WorkshopForm extends React.Component {
                               style={styles.check}
                               name={object.display_name}
                               label={object.display_name}
-                              onChange={e => this.handleTopicSelect(object.id, e)}
+                              onChange={e =>
+                                this.handleTopicSelect(object.id, e)
+                              }
                               value={this.state.plTopics.includes(object.id)}
                             />
                           </li>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -1199,20 +1199,20 @@ export class WorkshopForm extends React.Component {
                       aria-labelledby="dropdownMenuButton"
                     >
                       <ul style={styles.listItems}>
-                        {Object.values(ALL_PL_TOPICS).map(object => (
+                        {Object.values(ALL_PL_TOPICS).map(topic => (
                           <li
                             className="dropdown-item"
                             style={styles.singleItem}
-                            key={object.id}
+                            key={topic.id}
                           >
                             <SingleCheckbox
                               style={styles.check}
-                              name={object.display_name}
-                              label={object.display_name}
+                              name={topic.display_name}
+                              label={topic.display_name}
                               onChange={e =>
-                                this.handleTopicSelect(object.id, e)
+                                this.handleTopicSelect(topic.id, e)
                               }
-                              value={this.state.plTopics.includes(object.id)}
+                              value={this.state.plTopics.includes(topic.id)}
                             />
                           </li>
                         ))}

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -560,6 +560,46 @@ describe('WorkshopForm test', () => {
     expect(wrapper.find('#suppress_email')).to.have.lengthOf(0);
   });
 
+  it('selecting Build Your Own Workshop shows pl topics', () => {
+    const server = sinon.fakeServer.create();
+    server.respondWith(
+      'GET',
+      '/course_offerings/self_paced_pl_course_offerings',
+      [
+        200,
+        {'Content-Type': 'application/json'},
+        JSON.stringify([
+          {id: '123', display_name: 'myPlTestTopic'},
+          {id: '234', display_name: 'mySecondTopic'},
+        ]),
+      ]
+    );
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <WorkshopForm
+            permission={new Permission([WorkshopAdmin])}
+            facilitatorCourses={[]}
+            today={getFakeToday(false)}
+            readOnly={false}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    server.respond();
+    // Verify the topics dropdown doesn't show up until Build Your Own is selected
+    expect(wrapper.find('#topics')).to.have.lengthOf(0);
+    const courseField = wrapper.find('#course').first();
+    courseField.simulate('change', {
+      target: {name: 'course', value: 'Build Your Own Workshop'},
+    });
+    expect(wrapper.find('#topics')).to.have.lengthOf(1);
+    wrapper.find('#dropdownMenuButton').first().simulate('click');
+    // A user can select either the label or checkbox, so we expect 2 for each here
+    expect(wrapper.find('#myPlTestTopic')).to.have.lengthOf(2);
+    expect(wrapper.find('#mySecondTopic')).to.have.lengthOf(2);
+  });  
+
   it('editing form as non-admin does not show organizer field', () => {
     const wrapper = mount(
       <Provider store={store}>

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -598,7 +598,7 @@ describe('WorkshopForm test', () => {
     // A user can select either the label or checkbox, so we expect 2 for each here
     expect(wrapper.find('#myPlTestTopic')).to.have.lengthOf(2);
     expect(wrapper.find('#mySecondTopic')).to.have.lengthOf(2);
-  });  
+  });
 
   it('editing form as non-admin does not show organizer field', () => {
     const wrapper = mount(

--- a/dashboard/app/controllers/course_offerings_controller.rb
+++ b/dashboard/app/controllers/course_offerings_controller.rb
@@ -38,7 +38,7 @@ class CourseOfferingsController < ApplicationController
   def self_paced_pl_course_offerings
     return head :bad_request unless current_user
     offerings = CourseOffering.assignable_course_offerings(current_user).select {|co| co.get_participant_audience == 'teacher' && co.instruction_type == 'self_paced'}
-    render :ok, json: offerings.map(&:summarize_self_paced_pl).to_json
+    render :ok, json: offerings&.map(&:summarize_self_paced_pl).to_json
   end
 
   private def course_offering_params

--- a/dashboard/app/controllers/course_offerings_controller.rb
+++ b/dashboard/app/controllers/course_offerings_controller.rb
@@ -1,7 +1,7 @@
 class CourseOfferingsController < ApplicationController
-  load_and_authorize_resource except: [:quick_assign_course_offerings]
+  load_and_authorize_resource except: [:quick_assign_course_offerings, :self_paced_pl_course_offerings]
 
-  before_action :require_levelbuilder_mode, except: [:quick_assign_course_offerings]
+  before_action :require_levelbuilder_mode, except: [:quick_assign_course_offerings, :self_paced_pl_course_offerings]
   before_action :authenticate_user!
 
   def edit
@@ -33,6 +33,12 @@ class CourseOfferingsController < ApplicationController
 
     offerings = QuickAssignHelper.course_offerings(current_user, request.locale, participant_type)
     render :ok, json: offerings.to_json
+  end
+
+  def self_paced_pl_course_offerings
+    return head :bad_request unless current_user
+    offerings = CourseOffering.assignable_course_offerings(current_user).select {|co| co.get_participant_audience == 'teacher' && co.instruction_type == 'self_paced'}
+    render :ok, json: offerings.map(&:summarize_self_paced_pl).to_json
   end
 
   private def course_offering_params

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -271,6 +271,13 @@ class CourseOffering < ApplicationRecord
     }
   end
 
+  def summarize_self_paced_pl
+    {
+      id: id,
+      display_name: display_name_with_latest_year
+    }
+  end
+
   def localized_display_name
     localized_name = I18n.t(
       key,

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -350,6 +350,7 @@ Dashboard::Application.routes.draw do
       end
     end
 
+    get 'course_offerings/self_paced_pl_course_offerings', to: 'course_offerings#self_paced_pl_course_offerings'
     get '/course/:course_name', to: redirect('/courses/%{course_name}')
     get '/courses/:course_name/vocab/edit', to: 'vocabularies#edit'
     # these routes use course_course_name to match generated routes below that are nested within courses


### PR DESCRIPTION
This PR populates the topics list for the 'Build Your Own Workshop' option. It sets up the backend controller action to bring in only the data we needed (this seemed preferable to reusing the curriculum quick assign options but having to filter out the long list of other course types). 

I added a test (and mocked the server response) to cover this new functionality, and also verified it works with our actual PL course list (see pic below).

<img width="707" alt="Screenshot 2024-07-03 at 4 55 19 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/f3abfe0d-03e4-428f-937e-3dc2895ca535">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2020

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
