### PR TITLE
[Deisgn2-123] DSCO - Add support of onFocus,OnBlur, onMouseEnter, onMouseLeave, etc. native html props pt.1

### DIFF
--- a/apps/src/componentLibrary/button/CHANGELOG.md
+++ b/apps/src/componentLibrary/button/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.1]()
+## [0.4.1](https://github.com/code-dot-org/code-dot-org/pull/59610)
 
 * updated BaseButton props to support native HTML element attributes
 

--- a/apps/src/componentLibrary/button/CHANGELOG.md
+++ b/apps/src/componentLibrary/button/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.0]()
+## [0.4.1]()
+
+* updated BaseButton props to support native HTML element attributes
+
+## [0.4.0](https://github.com/code-dot-org/code-dot-org/pull/58636)
 
 * added background fill color to secondary black and white buttons
 * added ```gray``` secondary button

--- a/apps/src/componentLibrary/button/_baseButton/_BaseButton.tsx
+++ b/apps/src/componentLibrary/button/_baseButton/_BaseButton.tsx
@@ -1,8 +1,7 @@
 import classNames from 'classnames';
-import React, {memo, useMemo, AriaAttributes} from 'react';
+import React, {memo, useMemo, HTMLAttributes} from 'react';
 
 import {ButtonType, ButtonColor} from '@cdo/apps/componentLibrary/button';
-import {getAriaPropsFromProps} from '@cdo/apps/componentLibrary/common/helpers';
 import {ComponentSizeXSToL} from '@cdo/apps/componentLibrary/common/types';
 import FontAwesomeV6Icon, {
   FontAwesomeV6IconProps,
@@ -29,7 +28,7 @@ export interface IconOnlyButtonSpecificProps {
 export interface CoreButtonProps
   extends TextButtonSpecificProps,
     IconOnlyButtonSpecificProps,
-    AriaAttributes {
+    HTMLAttributes<HTMLButtonElement | HTMLAnchorElement> {
   /** Button Component type */
   type?: ButtonType;
   /** Custom class name */
@@ -44,6 +43,12 @@ export interface CoreButtonProps
   isPending?: boolean;
   /** Button aria-label */
   ariaLabel?: string;
+  /** OnClick handler for the button */
+  onClick?: (
+    event:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.MouseEvent<HTMLAnchorElement>
+  ) => void;
   /** Size of button */
   size?: ComponentSizeXSToL;
 }
@@ -206,7 +211,6 @@ const BaseButton: React.FunctionComponent<_BaseButtonProps> = ({
 }) => {
   const ButtonTag = useAsLink ? 'a' : 'button';
 
-  const ariaProps = getAriaPropsFromProps(rest);
   const tagSpecificProps =
     ButtonTag === 'a'
       ? {
@@ -269,9 +273,9 @@ const BaseButton: React.FunctionComponent<_BaseButtonProps> = ({
       )}
       id={id}
       disabled={disabled}
-      {...ariaProps}
-      aria-disabled={disabled || ariaProps['aria-disabled']}
-      aria-label={ariaLabel || ariaProps['aria-label']}
+      {...rest}
+      aria-disabled={disabled || rest['aria-disabled']}
+      aria-label={ariaLabel || rest['aria-label']}
       {...tagSpecificProps}
     >
       {isPending && spinnerPosition === 'left' && (

--- a/apps/src/componentLibrary/tooltip/CHANGELOG.md
+++ b/apps/src/componentLibrary/tooltip/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1] ()
+
+* used DSCO Button component for stories with Multiple Tooltips
+
 ## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/59106)
 
 * Reworked `WithTooltip` to use React Portal for rendering tooltip content outside the DOM hierarchy of the parent
   component. This allows the tooltip to be rendered outside the parent component's overflow boundaries.
-* `WithTooltip` is now a recomended way to use `Tooltip` and `TooltipOverlay` components. 
+* `WithTooltip` is now a recomended way to use `Tooltip` and `TooltipOverlay` components.
 
 ## [0.1.0](https://github.com/code-dot-org/code-dot-org/pull/58273)
 

--- a/apps/src/componentLibrary/tooltip/CHANGELOG.md
+++ b/apps/src/componentLibrary/tooltip/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.1] ()
+## [0.2.1] (https://github.com/code-dot-org/code-dot-org/pull/59610)
 
 * used DSCO Button component for stories with Multiple Tooltips
 

--- a/apps/src/componentLibrary/tooltip/CHANGELOG.md
+++ b/apps/src/componentLibrary/tooltip/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.1] (https://github.com/code-dot-org/code-dot-org/pull/59610)
 
-* used DSCO Button component for stories with Multiple Tooltips
+* used DSCO Button component for `Tooltip` stories
 
 ## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/59106)
 

--- a/apps/src/componentLibrary/tooltip/WithTooltip.story.tsx
+++ b/apps/src/componentLibrary/tooltip/WithTooltip.story.tsx
@@ -1,6 +1,8 @@
 import {Meta, StoryFn} from '@storybook/react';
 import React from 'react';
 
+import {Button} from '@cdo/apps/componentLibrary/button';
+
 import Tooltip, {TooltipProps, WithTooltip} from './index';
 
 export default {
@@ -35,9 +37,7 @@ const MultipleTemplate: StoryFn<{components: TooltipProps[]}> = args => (
     <div style={{display: 'flex', gap: '20px', flexWrap: 'wrap'}}>
       {args.components?.map(componentArg => (
         <WithTooltip key={componentArg.tooltipId} tooltipProps={componentArg}>
-          <button style={{margin: 0}} type="button">
-            Hover Me
-          </button>
+          <Button onClick={() => null} text={'Hover me'} />
         </WithTooltip>
       ))}
     </div>

--- a/apps/src/componentLibrary/tooltip/WithTooltip.story.tsx
+++ b/apps/src/componentLibrary/tooltip/WithTooltip.story.tsx
@@ -21,9 +21,7 @@ export default {
 //
 const SingleTemplate: StoryFn<TooltipProps> = args => (
   <WithTooltip tooltipProps={{...args}}>
-    <button style={{margin: 0}} type="button">
-      Hover me
-    </button>
+    <Button onClick={() => null} text="Hover me" />
   </WithTooltip>
 );
 
@@ -37,7 +35,7 @@ const MultipleTemplate: StoryFn<{components: TooltipProps[]}> = args => (
     <div style={{display: 'flex', gap: '20px', flexWrap: 'wrap'}}>
       {args.components?.map(componentArg => (
         <WithTooltip key={componentArg.tooltipId} tooltipProps={componentArg}>
-          <Button onClick={() => null} text={'Hover me'} />
+          <Button onClick={() => null} text="Hover me" />
         </WithTooltip>
       ))}
     </div>


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [Deisgn2-123] DSCO - Add support of onFocus,OnBlur, onMouseEnter, onMouseLeave, etc. native html props pt.1

* updated BaseButton props to support native HTML element attributes
* used DSCO Button component for stories with Multiple Tooltips

## Links
- jira ticket: [Deisgn2-123](https://codedotorg.atlassian.net/browse/DESIGN2-123)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
