### PR TITLE
Datablock Storage: fix migration edge cases

### DIFF
--- a/bin/migrate_firebase_projects
+++ b/bin/migrate_firebase_projects
@@ -21,7 +21,7 @@
 # TODO: post-firebase-cleanup, remove this script #56994
 
 # If DRY_RUN: run SQL in a transaction but rollback before committing
-DRY_RUN = true
+DRY_RUN = false
 
 # De-duplicate tables: see if the records exactly match an existing shared
 # table and link it to that using is_shared_table instead of copying the records
@@ -64,11 +64,11 @@ def set_active_record_connection_pool_size(pool_size)
   )
 end
 
-set_active_record_connection_pool_size(10)
+# set_active_record_connection_pool_size(10)
 
 # Don't use more workers than we have connections in our SQL connection pool.
-NUM_PARALLEL_WORKERS = 1
-# NUM_PARALLEL_WORKERS = ActiveRecord::Base.connection_pool.size - 1
+# NUM_PARALLEL_WORKERS = 1
+NUM_PARALLEL_WORKERS = ActiveRecord::Base.connection_pool.size - 1
 
 def get_project_id(channel_id)
   storage_decrypt_channel_id(channel_id)[1]
@@ -203,7 +203,11 @@ def fetch_datablock_tables(channel, project_id)
 
   current_tables = channel["current_tables"]
   current_tables = {} unless current_tables.is_a? Hash
-  current_tables = current_tables.keys
+  current_tables = Set.new(current_tables.keys)
+
+  datablock_tables.filter! do |table|
+    !current_tables.include?(table[:table][:table_name])
+  end
 
   datablock_tables += current_tables.map do |table_name|
     {

--- a/bin/migrate_firebase_projects
+++ b/bin/migrate_firebase_projects
@@ -197,9 +197,15 @@ def fetch_datablock_tables(channel, project_id)
     datablock_tables << {table: datablock_table, records: datablock_records}
   end
 
+  # Sort shared_tables to the end so if we have to truncate to make the max table count (10)
+  # we truncate shared_tables first.
+  datablock_tables.sort_by! {|table| table[:table][:is_shared_table].nil? ? 0 : 1}
+
   current_tables = channel["current_tables"]
   current_tables = {} unless current_tables.is_a? Hash
-  datablock_tables += current_tables.map do |table_name, _value|
+  current_tables = current_tables.keys
+
+  datablock_tables += current_tables.map do |table_name|
     {
       table: {
         project_id: project_id,
@@ -212,7 +218,7 @@ def fetch_datablock_tables(channel, project_id)
     }
   end
 
-  datablock_tables
+  datablock_tables[0...10]
 end
 
 def fetch_datablock_kvps(channel, project_id)

--- a/bin/migrate_firebase_projects
+++ b/bin/migrate_firebase_projects
@@ -34,7 +34,7 @@ FIND_SHARED_TABLES = true
 # Probably want `SKIP_MISSING_PROJECT_IDS = true` for the real production run,
 # but when running locally, you'll probably want it set to false (since you don't
 # have a real Projects table locally).
-SKIP_MISSING_PROJECT_IDS = true
+SKIP_MISSING_PROJECT_IDS = false
 
 # DEBUG FLAGS:
 DEBUG_SHARED_TABLES = false
@@ -67,8 +67,8 @@ end
 set_active_record_connection_pool_size(10)
 
 # Don't use more workers than we have connections in our SQL connection pool.
-# NUM_PARALLEL_WORKERS = 1
-NUM_PARALLEL_WORKERS = ActiveRecord::Base.connection_pool.size - 1
+NUM_PARALLEL_WORKERS = 1
+# NUM_PARALLEL_WORKERS = ActiveRecord::Base.connection_pool.size - 1
 
 def get_project_id(channel_id)
   storage_decrypt_channel_id(channel_id)[1]
@@ -259,6 +259,67 @@ end
 class SkippedMissingProject < StandardError
 end
 
+def do_migration_transaction(project_id, tables, kvps)
+  ActiveRecord::Base.transaction do
+    insert_datablock_tables(tables)
+    insert_datablock_kvps(kvps)
+
+    # Now that its migrated, switch the project over to using DatablockStorage
+    ProjectUseDatablockStorage.where(project_id: project_id).delete_all
+    ProjectUseDatablockStorage.create!(project_id: project_id, use_datablock_storage: true)
+
+    # Do not allow transaction to complete if DRY_RUN==true
+    raise ActiveRecord::Rollback if DRY_RUN
+  end
+end
+
+def replace_trailing_spaces_with_underscore(str)
+  trailing_spaces_count = str.length - str.rstrip.length
+  str.rstrip + ("_" * trailing_spaces_count)
+end
+
+def do_migration_patchup_trailing_spaces(project_id, kvps, tables)
+  # Datablock Storage can't tell the difference between 'key ' and 'key' due
+  # to quirks in how MySQL indexes work. If we get a failed transaction,
+  # we first replace trailing spaces with underscores, and then try again
+
+  message = ""
+  message += "Failed to do transaction:\n"
+  kvps.each do |kvp|
+    key = kvp[:key]
+    if key.start_with?("takenusername", "userTaken")
+      return nil
+    end
+    return nil if key.start_with?("takenusername", "userTaken")
+    newkey = replace_trailing_spaces_with_underscore(key)
+    message += "\tRenaming key: #{kvp[:key].inspect} -> #{newkey.inspect}\n" if key != newkey
+    kvp[:key] = newkey
+  end
+  tables.each do |table|
+    table_name = table[:table][:table_name]
+    newtablename = replace_trailing_spaces_with_underscore(table_name)
+    message += "\tRenaming table: #{table[:table][:table_name]} -> #{newtablename}\n" if table_name != newtablename
+    table[:table][:table_name] = newtablename
+  end
+  begin
+    do_migration_transaction(project_id, tables, kvps)
+  rescue ActiveRecord::RecordNotUnique
+    message += "\n"
+    message += "\tSECOND FAILURE\n"
+    message += "\tkvps:\n"
+    kvps.each do |kvp|
+      message += "\t\t#{kvp[:key]}\n"
+    end
+    message += "\ttables:\n"
+    tables.each do |table|
+      message += "\t\t#{table[:table][:table_name]}\n"
+    end
+    message += "\tEND SECOND FAILURE\n"
+    puts message
+    raise
+  end
+end
+
 def migrate(channel_id)
   channel = firebase_get_channel(channel_id)
   project_id = get_project_id(channel_id)
@@ -271,16 +332,11 @@ def migrate(channel_id)
 
   tables = fetch_datablock_tables(channel, project_id)
   kvps = fetch_datablock_kvps(channel, project_id)
-  ActiveRecord::Base.transaction do
-    insert_datablock_tables(tables)
-    insert_datablock_kvps(kvps)
 
-    # Now that its migrated, switch the project over to using DatablockStorage
-    ProjectUseDatablockStorage.where(project_id: project_id).delete_all
-    ProjectUseDatablockStorage.create!(project_id: project_id, use_datablock_storage: true)
-
-    # Do not allow transaction to complete if DRY_RUN==true
-    raise ActiveRecord::Rollback if DRY_RUN
+  begin
+    do_migration_transaction(project_id, tables, kvps)
+  rescue ActiveRecord::RecordNotUnique
+    do_migration_patchup_trailing_spaces(project_id, kvps, tables)
   end
 end
 

--- a/bin/migrate_firebase_projects
+++ b/bin/migrate_firebase_projects
@@ -34,7 +34,7 @@ FIND_SHARED_TABLES = true
 # Probably want `SKIP_MISSING_PROJECT_IDS = true` for the real production run,
 # but when running locally, you'll probably want it set to false (since you don't
 # have a real Projects table locally).
-SKIP_MISSING_PROJECT_IDS = false
+SKIP_MISSING_PROJECT_IDS = true
 
 # DEBUG FLAGS:
 DEBUG_SHARED_TABLES = false

--- a/bin/migrate_firebase_projects
+++ b/bin/migrate_firebase_projects
@@ -21,7 +21,7 @@
 # TODO: post-firebase-cleanup, remove this script #56994
 
 # If DRY_RUN: run SQL in a transaction but rollback before committing
-DRY_RUN = false
+DRY_RUN = true
 
 # De-duplicate tables: see if the records exactly match an existing shared
 # table and link it to that using is_shared_table instead of copying the records
@@ -278,7 +278,7 @@ def replace_trailing_spaces_with_underscore(str)
   str.rstrip + ("_" * trailing_spaces_count)
 end
 
-def do_migration_patchup_trailing_spaces(project_id, kvps, tables)
+def do_migration_patchup_trailing_spaces(channel_id, project_id, kvps, tables)
   # Datablock Storage can't tell the difference between 'key ' and 'key' due
   # to quirks in how MySQL indexes work. If we get a failed transaction,
   # we first replace trailing spaces with underscores, and then try again
@@ -287,10 +287,10 @@ def do_migration_patchup_trailing_spaces(project_id, kvps, tables)
   message += "Failed to do transaction:\n"
   kvps.each do |kvp|
     key = kvp[:key]
+    # These are all variations of a chat app
     if key.start_with?("takenusername", "userTaken")
       return nil
     end
-    return nil if key.start_with?("takenusername", "userTaken")
     newkey = replace_trailing_spaces_with_underscore(key)
     message += "\tRenaming key: #{kvp[:key].inspect} -> #{newkey.inspect}\n" if key != newkey
     kvp[:key] = newkey
@@ -298,24 +298,33 @@ def do_migration_patchup_trailing_spaces(project_id, kvps, tables)
   tables.each do |table|
     table_name = table[:table][:table_name]
     newtablename = replace_trailing_spaces_with_underscore(table_name)
-    message += "\tRenaming table: #{table[:table][:table_name]} -> #{newtablename}\n" if table_name != newtablename
+    message += "\tRenaming table: #{table[:table][:table_name].inspect} -> #{newtablename.inspect}\n" if table_name != newtablename
+    table[:records].each do |record|
+      record[:table_name] = newtablename
+    end
     table[:table][:table_name] = newtablename
   end
   begin
     do_migration_transaction(project_id, tables, kvps)
-  rescue ActiveRecord::RecordNotUnique
+  rescue ActiveRecord::RecordNotUnique => exception
     message += "\n"
-    message += "\tSECOND FAILURE\n"
+    message += "\tSECOND FAILURE on #{channel_id}\n"
+    message += "\ttable defs:\n"
+    tables.each do |table|
+      message += "\t#{table[:table].inspect}\n"
+    end
     message += "\tkvps:\n"
     kvps.each do |kvp|
-      message += "\t\t#{kvp[:key]}\n"
+      message += "\t\t#{kvp[:key].inspect}\n"
     end
     message += "\ttables:\n"
     tables.each do |table|
-      message += "\t\t#{table[:table][:table_name]}\n"
+      message += "\t\t#{table[:table][:table_name].inspect}\n"
     end
     message += "\tEND SECOND FAILURE\n"
     puts message
+    puts
+    puts exception.message
     raise
   end
 end
@@ -336,7 +345,7 @@ def migrate(channel_id)
   begin
     do_migration_transaction(project_id, tables, kvps)
   rescue ActiveRecord::RecordNotUnique
-    do_migration_patchup_trailing_spaces(project_id, kvps, tables)
+    do_migration_patchup_trailing_spaces(channel_id, project_id, kvps, tables)
   end
 end
 


### PR DESCRIPTION
- If we see key conflicts due to MySQL making 'key ' == 'key', replace keys and table names with trailing spaces with trailing _s.
- If we detect a known chatapp pattern (keys starting with takenusername and userTaken) do not import them
- Truncate tables to max of 10 (datablock storage limit), prioritizing keeping non-shared/current tables
- When current_table name conflicts with a local table, drop the local table (they are usually empty)