### PR TITLE
`dashboard-console`: fix wonky scrollback / nav behavior

### DIFF
--- a/dashboard/.irbrc
+++ b/dashboard/.irbrc
@@ -1,22 +1,21 @@
 require 'irb'
 
 app = Rails.application.class.name.split('::').first.downcase
-env = Rails.env
-
 colors = {
-  development: :green,
-  production: :red,
-  levelbuilder: :cyan,
-  staging: :cyan,
+  development: [:GREEN],
+  production: [:RED, :BOLD],
+  levelbuilder: [:CYAN],
+  staging: [:CYAN],
 }
-color = colors[env.to_sym] || :white
+
+color = colors.fetch(Rails.env.to_sym, [])
+env = IRB::Color.colorize(Rails.env, color)
 
 IRB.conf[:PROMPT] ||= {}
 IRB.conf[:PROMPT][:RAILS_APP] = {
-  PROMPT_I: "[#{env.to_s.colorize(color)}] #{app} > ",
-  PROMPT_N: nil,
-  PROMPT_S: nil,
-  PROMPT_C: nil,
+  PROMPT_I: "[#{env}] #{app} > ",
+  PROMPT_S: "[#{env}] #{app} %l ",
+  PROMPT_C: "[#{env}] #{app} * ",
   RETURN: "=> %s\n",
 }
 


### PR DESCRIPTION
We had hacked color into `bin/dashboard-console` using a method that resulted in broken arrow navigation due to not closing color codes. Additionally, it did not keep a consistent indent in history navigation, making it confusing and hard to follow.

This uses IRB's builtin colorize methods to properly terminate color codes, and uses more normal IRB indent "codes".

Based on the technique used for the new default rails console formatting (merged jan 19): https://github.com/rails/rails/pull/50796/files, but adds our app name in as well.

Before, broken arrow-to-navigate in `bin/dashboard-console` results in wild cursor positions:

https://github.com/code-dot-org/code-dot-org/assets/223277/4a1848a5-62bc-4533-968f-2d07e0058e21

After, arrow-to-navigate is rock solid:

https://github.com/code-dot-org/code-dot-org/assets/223277/0781a3d1-739d-43e1-9213-5cb9606a0ce8


Before (inconsistent indenting, weird history behavior):
<img width="397" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/709fab03-07db-47a2-97e5-bde4a47aaddd">

After (consistent indenting of history):
<img width="459" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/223277/5e0ffb65-16cb-4e3e-aab0-1409d4b0f328">