### PR TITLE
chore(jest): move test report to test report directory in `build`

### DIFF
--- a/apps/jest.config.js
+++ b/apps/jest.config.js
@@ -142,6 +142,7 @@ const config = {
         includeStackTrace: true,
         includeSuiteFailure: true,
         pageTitle: 'Test Report',
+        outputPath: '<rootDir>/build/test-report/index.html',
       },
     ],
   ],


### PR DESCRIPTION
Previously, the test report for jest is put in `apps` which is not git ignored. Since this is a build artifact, put the test report in `apps/build/test-report/index.html` instead.

## Links

[Slack thread ](https://codedotorg.slack.com/archives/C046G4TRLEN/p1720453139180129)

## Testing story

```
npx jest
```

Confirmed report was moved to the artifacts directory

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
