### PR TITLE
Re-enable applab versions test on iPad

### DIFF
--- a/dashboard/test/ui/features/star_labs/applab/versions.feature
+++ b/dashboard/test/ui/features/star_labs/applab/versions.feature
@@ -1,9 +1,7 @@
-# This test has been very flaky recently. Temporarily disabling on mobile while we investigate in LABS-867
-@no_mobile
+@no_phone
 @as_student
 Feature: App Lab Versions
 
-@no_phone
 Scenario: Script Level Versions
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1?noautoplay=true"
   And I wait for the page to fully load


### PR DESCRIPTION
We disabled our Applab versions UI tests on iPad and iPhone [about a month ago](https://github.com/code-dot-org/code-dot-org/pull/59032).

Using my local env, I can't repro failures in SauceLabs currently, either in current staging or if I revert back to the point in git history where we disabled this test. I'm a little stumped and a little unsure what to do at this point other than to turn it back on and see what happens. Some more discussion in [this thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1720027967484039).

I've left these tests disabled for phones, since we don't support Applab on phones. There are also a couple of tests in this file that have been disabled on "mobile" (for years), which would continue to be disabled for iPads.

Relatedly, I think there's probably an argument to be made to disable all Applab tests on phones and enable all of them on iPads, since we don't support them (except maybe tests that exercise our sharing feature?). Looking in the `applab` dir in our UI testing folder, I see a mix of tests disabled/enabled for these platforms. I added [a follow-up to look into this.](https://codedotorg.atlassian.net/browse/LABS-910)

I think our IT guidance has changed for iPad/Applab over the years per [this thread on the teacher forum](https://forum.code.org/t/using-app-lab-on-ipads/32449/5) -- it looks like we currently support it for iPads if you use an external keyboard / mouse (which we did not in the past).

## Links

- jira ticket: [LABS-867](https://codedotorg.atlassian.net/browse/LABS-867)

## Testing story

I ran this test ~10x successfully in a row on iPad locally last week. I also ran in Drone successfully twice. To be totally transparent, I was able to get some failures in one of the test scenarios ("Script Level Versions"), but the failure I was seeing didn't match what we've seen in test builds, so I'm still inclined to merge this :).