### PR TITLE
Update Maze UI tests to use Google Blockly

### DIFF
--- a/dashboard/config/levels/custom/maze/2-3 Maze 1.level
+++ b/dashboard/config/levels/custom/maze/2-3 Maze 1.level
@@ -1,7 +1,8 @@
 <Maze>
   <config><![CDATA[{
+  "published": true,
   "game_id": 25,
-  "created_at": "2014-05-07T19:06:41.000Z",
+  "created_at": "2022-02-16T19:37:58.000Z",
   "level_num": "custom",
   "user_id": 19,
   "properties": {
@@ -30,19 +31,30 @@
     "authored_hints": "[\r\n {\r\n  \"hint_class\": \"pointer\",\r\n  \"hint_markdown\": \"To use a `move forward` block, drag it from the toolbar area out into the workspace and connect it to the `when run` block.\",\r\n  \"hint_id\": \"2-3_Maze_1_a\",\r\n  \"hint_type\": \"general\"\r\n }\r\n]",
     "long_instructions": "Can you help me catch the naughty pig? \r\n\r\nStack a couple of `move forward` blocks below the `when run` block and press \"Run\". ",
     "instructions_important": "true",
-    "hint_prompt_attempts_threshold": 3,
-    "contained_level_names": null
+    "hint_prompt_attempts_threshold": "3",
+    "encrypted": "false",
+    "hide_share_and_remix": "false",
+    "disable_if_else_editing": "false",
+    "show_type_hints": "false",
+    "maze_data": null,
+    "shape_shift": "false",
+    "preload_asset_list": null
   },
-  "published": true,
   "notes": "",
+  "audit_log": "[{\"changed_at\":\"2024-07-08 15:13:58 -0400\",\"changed\":[\"toolbox_blocks\",\"recommended_blocks\",\"solution_blocks\",\"hint_prompt_attempts_threshold\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"mike@code.org\"}]",
   "level_concept_difficulty": {
     "sequencing": 2
   }
 }]]></config>
   <blocks>
+    <start_blocks>
+      <xml>
+        <block type="when_run" id="whenRun"/>
+      </xml>
+    </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="maze_moveForward"/>
+        <block type="maze_moveForward" id="moveForward"/>
         <block type="maze_turn">
           <title name="DIR">turnLeft</title>
         </block>

--- a/dashboard/config/levels/custom/maze/k-1 maze 1.level
+++ b/dashboard/config/levels/custom/maze/k-1 maze 1.level
@@ -1,7 +1,8 @@
 <Maze>
   <config><![CDATA[{
+  "published": true,
   "game_id": 25,
-  "created_at": "2014-05-07T17:04:10.000Z",
+  "created_at": "2022-02-16T19:37:58.000Z",
   "level_num": "custom",
   "user_id": 19,
   "properties": {
@@ -28,22 +29,33 @@
     "examples_required": "false",
     "disable_examples": "false",
     "instructions_important": "true",
-    "hint_prompt_attempts_threshold": 3,
-    "contained_level_names": null
+    "hint_prompt_attempts_threshold": "3",
+    "encrypted": "false",
+    "hide_share_and_remix": "false",
+    "disable_if_else_editing": "false",
+    "show_type_hints": "false",
+    "maze_data": null,
+    "shape_shift": "false",
+    "preload_asset_list": null
   },
-  "published": true,
   "notes": "",
+  "audit_log": "[{\"changed_at\":\"2024-07-08 09:13:39 -0400\",\"changed\":[\"toolbox_blocks\",\"recommended_blocks\",\"solution_blocks\",\"hint_prompt_attempts_threshold\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"mike@code.org\"}]",
   "level_concept_difficulty": {
     "sequencing": 2
   }
 }]]></config>
   <blocks>
+    <start_blocks>
+      <xml>
+        <block type="when_run" id="whenRun"/>
+      </xml>
+    </start_blocks>
     <toolbox_blocks>
       <xml>
         <block type="maze_moveNorth"/>
         <block type="maze_moveSouth"/>
         <block type="maze_moveEast"/>
-        <block type="maze_moveWest"/>
+        <block type="maze_moveWest" id="moveWest"/>
       </xml>
     </toolbox_blocks>
     <recommended_blocks>

--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -3,6 +3,11 @@ PUZZLE_SOLUTIONS = {
     And I drag block "4" to block "5"
     And I drag block "4" to block "6" plus offset 0, 50
   },
+  "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google" => %{
+    And I drag block "moveWest" to block "whenRun"
+    And I drag block "moveWest" to block "moveWest"
+    And I wait for 2 seconds
+  },
   "http://studio.code.org/s/allthethings/lessons/29/levels/1?level_name=2-3 Maze 1" => %{
     And I drag block "1" to block "4"
     And I drag block "1" to block "5"

--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -1,16 +1,11 @@
 PUZZLE_SOLUTIONS = {
-  "http://studio.code.org/s/allthethings/lessons/2/levels/1" => %{
-    And I drag block "4" to block "5"
-    And I drag block "4" to block "6" plus offset 0, 50
-  },
   "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google" => %{
     And I drag block "moveWest" to block "whenRun"
     And I drag block "moveWest" to block "moveWest"
-    And I wait for 2 seconds
   },
-  "http://studio.code.org/s/allthethings/lessons/29/levels/1?level_name=2-3 Maze 1" => %{
-    And I drag block "1" to block "4"
-    And I drag block "1" to block "5"
+  "http://studio.code.org/s/allthethings/lessons/29/levels/1?blocklyVersion=google&level_name=2-3 Maze 1" => %{
+    And I drag block "moveForward" to block "whenRun"
+    And I drag block "moveForward" to block "moveForward"
   },
   "http://studio.code.org/s/allthethings/lessons/29/levels/4?level_name=2-3 Artist 1 new" => %{
     And I drag block "1" to block "25"

--- a/dashboard/test/ui/features/support/blockly_helpers.rb
+++ b/dashboard/test/ui/features/support/blockly_helpers.rb
@@ -8,7 +8,7 @@ module BlocklyHelpers
 
   def generate_drag_code(from, to, target_dx, target_dy)
     id_selector = get_id_selector
-    generate_selector_drag_code "[#{id_selector}='#{from}']", "[#{id_selector}='#{to}']", target_dx, target_dy
+    generate_selector_drag_code "[#{id_selector}='#{from}']:last", "[#{id_selector}='#{to}']", target_dx, target_dy
   end
 
   def generate_selector_drag_code(from, to, target_dx, target_dy)

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_swap.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_swap.feature
@@ -19,7 +19,7 @@ Feature: Swapped levels
   @as_student
   @no_mobile
   Scenario: Student with progress sees old version
-    Given I complete the level on "http://studio.code.org/s/allthethings/lessons/29/levels/1?level_name=2-3 Maze 1"
+    Given I complete the level on "http://studio.code.org/s/allthethings/lessons/29/levels/1?blocklyVersion=google&level_name=2-3 Maze 1"
     And I complete the level on "http://studio.code.org/s/allthethings/lessons/29/levels/4?level_name=2-3 Artist 1 new"
     And I am on "http://studio.code.org/s/allthethings/lessons/29/levels/5?level_name=ramp_video_loopsArtist&noautoplay=true"
     And I wait until element ".submitButton" is visible

--- a/dashboard/test/ui/features/teacher_tools/progress.feature
+++ b/dashboard/test/ui/features/teacher_tools/progress.feature
@@ -3,7 +3,7 @@ Feature: Level Progress
   Scenario: Progress is saved for signed-in student
     Given I am a student
 
-    When I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    When I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
     Then I verify progress in the header of the current page is "perfect" for level 1
     And I verify progress in the header of the current page is "not_tried" for level 2
 
@@ -20,7 +20,7 @@ Feature: Level Progress
   Scenario: Progress is saved for signed-out student
     Given I am not signed in
 
-    When I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    When I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
     Then I verify progress in the header of the current page is "perfect" for level 1
     And I verify progress in the header of the current page is "not_tried" for level 2
 

--- a/dashboard/test/ui/features/teacher_tools/script_overview.feature
+++ b/dashboard/test/ui/features/teacher_tools/script_overview.feature
@@ -8,7 +8,7 @@ Feature: Unit overview page
     Given I create an authorized teacher-associated student named "Sally"
 
     # Make progress as student
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
 
     # Verify progress as student on script overview page
     And I am on "http://studio.code.org/s/allthethings"

--- a/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
@@ -4,7 +4,7 @@ Feature: Using the SectionActionDropdown
   # * Check that we get redirected to the right page
   Scenario: Viewing progress from SectionActionDropdown
     Given I create a teacher-associated student named "Sally"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
     And I complete the free response on "http://studio.code.org/s/allthethings/lessons/27/levels/1"
     And I submit the assessment on "http://studio.code.org/s/allthethings/lessons/33/levels/1"
     And I sign out

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/progress_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/progress_tab_views_eyes.feature
@@ -10,7 +10,7 @@ Feature: Using the progress tab of the teacher dashboard
     Given I am assigned to unit "coursea-2019"
     Given I am assigned to unit "allthethings"
 
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
     And I complete the free response on "http://studio.code.org/s/allthethings/lessons/27/levels/1"
     And I submit the assessment on "http://studio.code.org/s/allthethings/lessons/33/levels/1"
 

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
@@ -3,7 +3,7 @@ Feature: Using the teacher dashboard
 
   Scenario: Visiting student name URLs in teacher dashboard
     Given I create an authorized teacher-associated student named "Sally"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
 
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
@@ -21,7 +21,7 @@ Feature: Using the teacher dashboard
   Scenario: Viewing a student
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
     And I complete the free response on "http://studio.code.org/s/allthethings/lessons/27/levels/1"
     And I submit the assessment on "http://studio.code.org/s/allthethings/lessons/33/levels/1"
 
@@ -107,7 +107,7 @@ Feature: Using the teacher dashboard
 
   Scenario: Toggling student progress
     Given I create an authorized teacher-associated student named "Sally"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
     And I complete the free response on "http://studio.code.org/s/allthethings/lessons/27/levels/1"
     And I submit the assessment on "http://studio.code.org/s/allthethings/lessons/33/levels/1"
 
@@ -239,7 +239,7 @@ Feature: Using the teacher dashboard
   Scenario: Decline invitation to new progress view
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
 
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
@@ -254,7 +254,7 @@ Feature: Using the teacher dashboard
   Scenario: Accept invitation to new progress view and see new view immediately. 
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
 
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
@@ -269,7 +269,7 @@ Feature: Using the teacher dashboard
   Scenario: Delay responding to invitation to new progress view and see old view immediately. 
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
 
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
@@ -4,7 +4,7 @@ Feature: Using the V2 teacher dashboard
 Scenario: Teacher can open and close Icon Key and details
   Given I create an authorized teacher-associated student named "Sally"
   Given I am assigned to unit "allthethings"
-  And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+  And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
 
   When I sign in as "Teacher_Sally" and go home
   And I get levelbuilder access
@@ -86,7 +86,7 @@ Scenario: Teacher can view lesson progress for when students have completed a le
   Given I create an authorized teacher-associated student named "Sally"
   Given I am assigned to unit "allthethings"
   # Student completes one of many levels in lesson 2
-  And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+  And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
 
   # Student completes all the levels in lesson 10 (there is only one level)
   Given I am on "http://studio.code.org/s/allthethings/lessons/10/levels/1?noautoplay=true"


### PR DESCRIPTION
We have a bunch of UI tests that check various site functionality which assume that we can pass a simple Maze level. Because of differences in how each version of Blockly handles block ids, we need to update these tests and their associated levels before we can migration Maze to Google Blockly.

Google Blockly uses a different method to assign ids and uses a different attribute on the svg element. It also can potentially re-use an id of a toolbox block when it is dragged to the workspace.

**Review of key differences**
||CDO Blockly|Google Blockly|
|-|-|-|
|ID attribute|`block-id`|`data-id`|
|ID values| assigned sequentially (1, 2, 3,...), unless hard-coded|string of random characters, unless hard-coded|
|ID reuse for new blocks from flyout|New block ids are assigned sequentially, which makes them predicatable|New block ids will match the flyout block's id unless it's already in use. Subsequent copies of the same block will still have unique/random ids.|

For example a block might have `block-id="4"` in CDO Blockly, but `data-id="[{UiJ(GM._~}=@l[Iog!"` in Google Blockly. By adding an `id=` attribute to the block XML, we can override the ID that is used. For test readability, I opted to use descriptive ids like "moveWest" instead of the seemingly arbitrary integers that CDO Blockly would generate. (This contrasts with how our callouts script modifies XML automatically, since it's not smart enough to come up with descriptive ids.)

In most cases, the changes described above were sufficient to get the test steps working. However, in cases where a user needs to drag two of the same block out, it gets a little tricky. For example, several tests use a level where you are expected to connect to "move west" blocks. After dragging the first "move west" block to the "when run" block, you end up with two "move west" blocks that both have the same `"moveWest"` id (one in the toolbox, one on the workspace):
<img width="824" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/a7724b6c-4168-4d0e-8373-254fc6799cf3">

When we would generate drag code for the second "move west" block, the id selector was finding the workspace block and re-dragging it, rather than finding the toolbox block as expected. This is because Google Blockly's workspace blocks show up in the DOM earlier than the flyout blocks. Essentially, `$("[data-id='moveWest']")` finds the wrong block. As a fix for this, we can append `:last` to the selector for the block to be dragged. This shouldn't affect any tests still running CDO Blockly because there should only be one block in the list. 



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

This PR will immediately cause UI tests to use Google Blockly - ahead of the migration. There should be no impact to users, but we can expect to need to update baselines for the eyes tests.

Once Maze has been migrated (and we are confident a revert will not be needed), we can remove the `?blocklyVersion=google` param from each URL.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
