### PR TITLE
Prevent students in CPA flow from changing state and age backend

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2774,8 +2774,7 @@ class User < ApplicationRecord
 
   private def enforce_age_or_state_update
     # Create copy of user to mock the user's state before an update.
-    user_before_update = User.new(attributes.deep_merge(changed_attributes))
-
+    user_before_update = User.new(attributes.merge(changed_attributes))
     potentially_locked = Policies::ChildAccount.underage?(user_before_update)
     # The student is in a 'lockout' flow if they are potentially locked out and not unlocked
     if potentially_locked && !Policies::ChildAccount::ComplianceState.permission_granted?(user_before_update)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2781,7 +2781,8 @@ class User < ApplicationRecord
     potentially_locked = Policies::ChildAccount.underage?(user_before_update)
     # The student is in a 'lockout' flow if they are potentially locked out and not unlocked
     if potentially_locked && !Policies::ChildAccount::ComplianceState.permission_granted?(user_before_update)
-      errors.add(:us_state, :invalid)
+      errors.add(:us_state,  I18n.t('activerecord.errors.models.user.attributes.lockout_flow')) if us_state_changed?
+      errors.add(:age,  I18n.t('activerecord.errors.models.user.attributes.lockout_flow')) if birthday_changed?
     end
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2766,7 +2766,7 @@ class User < ApplicationRecord
     new_record? || us_state_changed?
   end
 
-  def should_check_age_or_state_update?
+  private def should_check_age_or_state_update?
     return false unless student?
     return false unless %w[US RD].include? country_code
     birthday_changed? || us_state_changed?

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2767,7 +2767,8 @@ class User < ApplicationRecord
   end
 
   def student_in_lockout_flow?
-    return unless should_validate_us_state?
+    return unless user_type == TYPE_STUDENT
+    return unless %w[US RD].include? country_code
     return unless birthday_changed? || us_state_changed?
 
     # Create copy of user to mock the user's state before an update.

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2781,7 +2781,7 @@ class User < ApplicationRecord
     potentially_locked = Policies::ChildAccount.underage?(user_before_update)
     # The student is in a 'lockout' flow if they are potentially locked out and not unlocked
     if potentially_locked && !Policies::ChildAccount::ComplianceState.permission_granted?(user_before_update)
-      errors.add(:us_state, "LOCKOUT FLOW")
+      errors.add(:us_state, :invalid)
     end
   end
 

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
               invalid: "is invalid. Note that each link can only be used once to reset your password, and only the most recently sent link will work."
             unlock_token:
               invalid: "is invalid or expired, possibly because your account has already been unlocked."
-            lockout_flow: "cannot be updated when in lockout flow."
+            lockout_flow: "cannot be updated because you need parent or guardian permission first."
       messages:
         blank: "is required"
         blank_plural: "are required"

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
               invalid: "is invalid. Note that each link can only be used once to reset your password, and only the most recently sent link will work."
             unlock_token:
               invalid: "is invalid or expired, possibly because your account has already been unlocked."
+            lockout_flow: "cannot be updated when in lockout flow."
       messages:
         blank: "is required"
         blank_plural: "are required"

--- a/dashboard/test/integration/cap/cpa/lockout_test.rb
+++ b/dashboard/test/integration/cap/cpa/lockout_test.rb
@@ -136,7 +136,7 @@ module CAP
 
             before do
               Timecop.travel(grace_period_duration.from_now)
-              student.update!(age: 13)
+              student.update_attribute(:age, 13) # bypass validation
             end
 
             it 'student should not be locked out' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -5453,7 +5453,7 @@ class UserTest < ActiveSupport::TestCase
 
     student = create :student, :U13, :in_colorado, :with_parent_permission
     student.update!(us_state: 'WA')
-    studet.reload
+    student.reload
     assert_equal student.us_state, 'WA'
 
     student = create :student, :U13

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -5439,7 +5439,7 @@ class UserTest < ActiveSupport::TestCase
     assert student.us_state_changed?
   end
 
-  test "student in lockout flow cannot change us_state or age" do
+  test "student in cpa lockout flow cannot change us_state or age" do
     student = create :student, :U13, :in_colorado, :without_parent_permission
     assert_raises(ActiveRecord::RecordInvalid) do
       student.update!(us_state: 'CA')
@@ -5453,14 +5453,17 @@ class UserTest < ActiveSupport::TestCase
 
     student = create :student, :U13, :in_colorado, :with_parent_permission
     student.update!(us_state: 'WA')
+    studet.reload
     assert_equal student.us_state, 'WA'
 
     student = create :student, :U13
     student.update!(us_state: 'WA')
+    student.reload
     assert_equal student.us_state, 'WA'
 
     student = create :student, :in_colorado
     student.update!(us_state: 'WA')
+    student.reload
     assert_equal student.us_state, 'WA'
   end
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -5439,7 +5439,7 @@ class UserTest < ActiveSupport::TestCase
     assert student.us_state_changed?
   end
 
-  test "lockout flow" do
+  test "student in lockout flow cannot change us_state or age" do
     student = create :student, :U13, :in_colorado, :without_parent_permission
     assert_raises(ActiveRecord::RecordInvalid) do
       student.update!(us_state: 'CA')

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -5439,6 +5439,31 @@ class UserTest < ActiveSupport::TestCase
     assert student.us_state_changed?
   end
 
+  test "lockout flow" do
+    student = create :student, :U13, :in_colorado, :without_parent_permission
+    assert_raises(ActiveRecord::RecordInvalid) do
+      student.update!(us_state: 'CA')
+    end
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      student.update!(age: 16)
+    end
+    student.reload
+    refute_equal student.age, 16
+
+    student = create :student, :U13, :in_colorado, :with_parent_permission
+    student.update!(us_state: 'WA')
+    assert_equal student.us_state, 'WA'
+
+    student = create :student, :U13
+    student.update!(us_state: 'WA')
+    assert_equal student.us_state, 'WA'
+
+    student = create :student, :in_colorado
+    student.update!(us_state: 'WA')
+    assert_equal student.us_state, 'WA'
+  end
+
   describe '#latest_parental_permission_request' do
     let(:latest_parental_permission_request) {user.latest_parental_permission_request}
 


### PR DESCRIPTION
Follow up to this [PR](https://github.com/code-dot-org/code-dot-org/pull/59437). Prevents students who are in CPA flow from changing their `us_state` and/or `age` in the backend.

## Links

- jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/P20/boards/69?assignee=712020%3Af0e2716f-09f9-4686-8490-9f1f9a08bb06&selectedIssue=P20-1021)


## Testing story
New test within `user_test.rb`
