### PR TITLE
Lab2: minor container style cleanup

### DIFF
--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -3,8 +3,8 @@
 
 .labContainer {
   position: fixed;
-  top: 52px;
-  bottom: 2px;
+  top: $top-spacing;
+  bottom: 0;
   left: 0;
   right: 0;
   font-size: 13px;

--- a/apps/src/lab2/views/common.scss
+++ b/apps/src/lab2/views/common.scss
@@ -14,3 +14,5 @@
   left: 0;
   z-index: 80;
 }
+
+$top-spacing: 50px;

--- a/apps/src/lab2/views/loading.module.scss
+++ b/apps/src/lab2/views/loading.module.scss
@@ -1,4 +1,5 @@
 @import 'color.scss';
+@import './common.scss';
 
 // We actually fade out the block to reveal the lab underneath.
 // We will do it over 1s, and then leave it invisible.
@@ -45,7 +46,7 @@
   width: 100%;
   height: 100%;
   position: fixed;
-  top: 52px;
+  top: $top-spacing;
   left: 0;
   right: 0;
   bottom: 0;
@@ -70,8 +71,6 @@
   &.fadeLoaded {
     animation: fade-out-block 0.5s;
   }
-
-
 
   .slowLoadContainer {
     display: flex;

--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -10,7 +10,7 @@ $default-spacing: 2px;
   background-color: $dark_black;
   width: 100%;
   height: 100%;
-  padding: 0;
+  padding: 2px 0;
   box-sizing: border-box;
   border-radius: $default-border-radius;
   overflow: hidden;

--- a/apps/src/pythonlab/pythonlab-view.module.scss
+++ b/apps/src/pythonlab/pythonlab-view.module.scss
@@ -7,7 +7,7 @@ $default-spacing: 2px;
   background-color: $dark_black;
   width: 100%;
   height: 100%;
-  padding: 0;
+  padding: 2px 0;
   box-sizing: border-box;
   border-radius: 0s;
   overflow: hidden;
@@ -16,4 +16,3 @@ $default-spacing: 2px;
   flex-direction: column;
   gap: $default-spacing;
 }
-

--- a/dashboard/app/views/levels/_lab2.html.haml
+++ b/dashboard/app/views/levels/_lab2.html.haml
@@ -1,5 +1,4 @@
-#codeApp{style: "position: absolute; top: 60px; bottom: 10px; left: 10px; right: 10px"}
-  #lab2-container{style: "height: 100%"}
+#lab2-container
 
 - content_for(:head) do
   %script{src: webpack_asset_path("js/#{js_locale}/music_locale.js")}


### PR DESCRIPTION
Two small style cleanups on the lab2 container and some individual containers to fix some cross-lab style quirks. None of this is user facing and only manifests when there are multiple different lab types in the same progression (e.g. in the lab2 showcase allthethings lesson), but should keep things tidy as we add new labs and update styles.
- Removed the `#codeApp` wrapper since it functionally wasn't doing anything (the lab2 container uses `position: fixed` so it ignores all of `#codeApp`'s positioning)
- Change the top spacing from 52px to 50px - the height of the header is 50px, and I believe we chose 52px to give a small 2px gap between the header and the lab content. However, this means that individual labs don't have control over the background color that appears in that small spacing, which is especially apparent when moving from a dark mode lab to a light mode lab, and vice versa. For example, when starting the lab2 all the things progression on level 1 (Music Lab), and then going to level 2 (AI Chat) you'll see a small black bar above the lab in the 2px space:
  - <img width="1512" alt="Screenshot 2024-07-08 at 3 41 43 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/cf0fe0af-7e01-4e37-96fb-d3c60f094364">
  - And vice versa:
  - <img width="1512" alt="Screenshot 2024-07-08 at 3 42 03 PM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/c2147f5e-e8cf-476b-b2b3-37d80d4c5b82">
  - By changing it to 50px, we can instead move the 2px spacing inside the lab, where the lab's own background color will fill the space according to its desired theme.

## Testing story

Tested on allthethings Lab2 showcase progression