### PR TITLE
Rotate Unison Logfiles

### DIFF
--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -38,7 +38,10 @@ FOLDERS = {
 INTERVAL_SECONDS = 5
 TOTAL_SECONDS = 55 - INTERVAL_SECONDS
 
-logger = HighFrequencyReporter.new(Slack, 'sync-dropbox-staging', '/home/ubuntu/dropbox_sync_error_log.csv')
+LOG_DIR = '/home/ubuntu/staging/log'.freeze
+FileUtils.mkdir_p(LOG_DIR) # This directory should always exist, but just in case
+
+logger = HighFrequencyReporter.new(Slack, 'sync-dropbox-staging', File.join(LOG_DIR, 'dropbox_sync_error_log.csv'))
 logger.load # load errors from most recent sync
 
 while (Time.now - SCRIPT_START) < TOTAL_SECONDS
@@ -46,8 +49,13 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
   logger.reset_new_events # reset new events such that they represent one run through all FOLDERS
   FOLDERS.each do |key, value|
     # 'unison' will sync the two folders. It will return true on success and false on failure.
-    # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
-    command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod -log -logfile /home/ubuntu/unison.log"
+    # For full details, see unison's man page. Docs are also here:
+    # https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
+    command = [
+      "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value}",
+      '-silent -ignore "Name .dropbox" -auto -perms 0 -dontchmod',
+      "-log -logfile #{File.join(LOG_DIR, 'unison.log')}"
+    ].join(' ')
     stdout, stderr, _ = Open3.capture3(command)
     next unless stdout == "" && stderr == ""
     error_message = <<~ERROR_MSG

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -130,6 +130,8 @@ end
 # which causes this error: https://github.com/tzinfo/tzinfo/wiki/Resolving-TZInfo::DataSourceNotFound-Errors
 apt_package 'tzdata'
 
+include_recipe 'cdo-apps::logrotate'
+
 include_recipe 'cdo-apps::dashboard'
 include_recipe 'cdo-apps::pegasus'
 include_recipe node['cdo-apps']['nginx_enabled'] ?

--- a/cookbooks/cdo-apps/recipes/logrotate.rb
+++ b/cookbooks/cdo-apps/recipes/logrotate.rb
@@ -1,0 +1,10 @@
+# Set up log rotation for the generic logs directory at the root of the repo.
+# Log rotation for the dashboard and pegasus directories is established by CdoApps.setup_app
+
+template '/etc/logrotate.d/code-dot-org' do
+  source 'logrotate.erb'
+  user 'root'
+  group 'root'
+  mode '0644'
+  variables log_dir: "#{node[:home]}/#{node.chef_environment}/log"
+end


### PR DESCRIPTION
The file `/home/ubuntu/unison.log` on our staging server has grown to ~84 gigabytes, very little if any of which we actually need. To reduce this unnecessary usage of our staging server's storage space, this PR proposes that we start managing that file with [`logrotate`](https://linux.die.net/man/8/logrotate)

Specifically, we move the log files generated by Unison from the home directory to [our existing generic log
directory](https://github.com/code-dot-org/code-dot-org/blob/71fb40f1d9f0f53e817d7cb4a7e0599e1015e419/.gitignore#L32) at the root of the repository. Then configure [our existing `logrotate` functionality](https://github.com/code-dot-org/code-dot-org/blob/71fb40f1d9f0f53e817d7cb4a7e0599e1015e419/cookbooks/cdo-apps/libraries/cdo_apps.rb#L99-L106) to apply to that directory as well. Current configuration is set up to rotate files every day, and to retain the previous 15 days worth of logs.

Note that **this will have a side effect of also rotating `chat_messages.log` on all our persistent managed servers**. (It would also rotate any other `*.log` files in that directory if we had any, but none of our existing servers appear to.) This is probably desirable, but not quite as necessary as rotating the unison log; the test server has by far the longest chat message log, and it's still just under 40 megabytes. I don't know of any reason why we might want to preserve these longs for longer than 15 days, but I wanted to call out this side effect just in case anyone else can think of one.

It wouldn't be difficult to scope this change to only affect `unison.log` or to only affect the staging server, but rotating the entire `log` directory on all our persistent servers seems like a good idea to me. What do y'all think? I'm open to narrowing this change if anyone would prefer.

## Links

- [Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1720468091032489)
- [`logrotate` template](https://github.com/code-dot-org/code-dot-org/blob/staging/cookbooks/cdo-apps/templates/default/logrotate.erb)

## Testing story

Tested on an adhoc that `/etc/logrotate.d/code-dot-org` is configured as expected. Manually generated a `unison.log` file in `/home/ubuntu/adhoc/log` and verified that it is rotated as expected:

```bash
ubuntu@adhoc-rotate-unison-log:~$ ll adhoc/log
total 36
drwxr-xr-x  2 ubuntu ubuntu  4096 Jul  9 01:54 ./
drwxr-xr-x 22 ubuntu ubuntu  4096 Jul  9 01:32 ../
-rw-r--r--  1 ubuntu ubuntu  9676 Jul  9 01:31 chat_messages.log
-rw-rw-r--  1 ubuntu ubuntu    17 Jul  9 01:29 dropbox_sync_error_log.csv
-rw-------  1 ubuntu ubuntu 10762 Jul  9 01:33 unison.log
ubuntu@adhoc-rotate-unison-log:~$ sudo logrotate --force /etc/logrotate.d/code-dot-org
ubuntu@adhoc-rotate-unison-log:~$ ll adhoc/log/
total 20
drwxr-xr-x  2 ubuntu ubuntu 4096 Jul 10 00:15 ./
drwxr-xr-x 22 ubuntu ubuntu 4096 Jul  9 01:32 ../
-rw-r--r--  1 ubuntu ubuntu    0 Jul 10 00:15 chat_messages.log
-rw-r--r--  1 ubuntu ubuntu 1794 Jul  9 01:31 chat_messages.log-20240710.gz
-rw-rw-r--  1 ubuntu ubuntu   17 Jul  9 01:29 dropbox_sync_error_log.csv
-rw-------  1 ubuntu ubuntu    0 Jul 10 00:15 unison.log
-rw-------  1 ubuntu ubuntu 1101 Jul  9 01:33 unison.log-20240710.gz

```

Note that `dropbox_sync_error_log.csv` does not get rotated, because the existing template is scoped to just `*.log` files. This seems reasonable to me, but it is a little odd. Worth mentioning, I think probably not worth doing anything about.

## Follow-up work

We'll want to decide what to do with the existing information in the `unison.log` file. We could preserve that information for a while by moving the file into the new destination directory and allowing it to get rotated out after 15 days, or we could simply delete or truncate the file.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
