### PR TITLE
P20 fix lockout path redirection

### DIFF
--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -61,7 +61,7 @@ class SessionsController < Devise::SessionsController
     return redirect_to new_user_session_path unless current_user
 
     # If the user is npt locked out with the Child Account Policy, redirect them to /home
-    redirect_to home_path unless Policies::ChildAccount::ComplianceState.locked_out?(current_user)
+    return redirect_to home_path unless Policies::ChildAccount::ComplianceState.locked_out?(current_user)
 
     # Basic defaults. If the @pending_email is empty, the request was never sent
     @pending_email = ''


### PR DESCRIPTION
There was a missing `return` that led the controller action for rendering the `/lockout` not redirecting home properly for grace period students. Instead it errors dealing with lockout logic using data that does not exist for them.

## Testing story

Wrote the integration tests first to see red status:

```
...
ERROR["test_0002_student should be redirected away from the lockout page", "CAP::Cpa::LockoutTest::locking out::all user lockout phase::when student was created before policy took effect::when student provider is Clever", 18.903787778999
686]
 test_0002_student should be redirected away from the lockout page#CAP::Cpa::LockoutTest::locking out::all user lockout phase::when student was created before policy took effect::when student provider is Clever (18.91s)
Minitest::UnexpectedError:         RuntimeError: not a redirect! 500 Internal Server Error
            test/integration/cap/cpa/lockout_test.rb:270:in `assert_student_is_redirected_away_from_lockout'
            test/integration/cap/cpa/lockout_test.rb:151:in `block (5 levels) in <class:LockoutTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'

ERROR["test_0002_student should be redirected away from the lockout page", "CAP::Cpa::LockoutTest::locking out::new user lockout phase::when student is CAP compliant", 19.744084800000564]
 test_0002_student should be redirected away from the lockout page#CAP::Cpa::LockoutTest::locking out::new user lockout phase::when student is CAP compliant (19.75s)
Minitest::UnexpectedError:         RuntimeError: not a redirect! 500 Internal Server Error
            test/integration/cap/cpa/lockout_test.rb:270:in `assert_student_is_redirected_away_from_lockout'
            test/integration/cap/cpa/lockout_test.rb:96:in `block (4 levels) in <class:LockoutTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'

  25/25: [==============================================================================================================================================================================================] 100% Time: 00:00:19, Time: 00:00:19

Finished in 19.75277s
25 tests, 147 assertions, 0 failures, 11 errors, 0 skips
```

Then added the single `return` haha and now:

```
Running via Spring preloader in process 389
Started with run options --seed 56679

  25/25: [==============================================================================================================================================================================================] 100% Time: 00:00:21, Time: 00:00:21

Finished in 21.11891s
25 tests, 169 assertions, 0 failures, 0 errors, 0 skips
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
