### PR TITLE
AI Tutor: use constants for generic prompt suggestions 

### DIFF
--- a/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
+++ b/apps/src/aiTutor/views/AITutorSuggestedPrompts.tsx
@@ -9,11 +9,12 @@ import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {genericCompilation, genericValidation} from '../constants';
 import {askAITutor} from '../redux/aiTutorRedux';
 
 const QuickActions = {
-  [ActionType.COMPILATION]: "Why doesn't my code compile?",
-  [ActionType.VALIDATION]: "Why aren't my tests passing?",
+  [ActionType.COMPILATION]: genericCompilation,
+  [ActionType.VALIDATION]: genericValidation,
 };
 
 const AITutorSuggestedPrompts: React.FunctionComponent = () => {


### PR DESCRIPTION
Small clean up to use constants we already have rather than hardcoding strings for suggested prompts. 