### PR TITLE
AI Tutor: remove isProjectBacked boolean for AI Tutor levels

### DIFF
--- a/apps/src/aiTutor/redux/aiTutorRedux.ts
+++ b/apps/src/aiTutor/redux/aiTutorRedux.ts
@@ -67,7 +67,6 @@ export const askAITutor = createAsyncThunk(
     const instructionsState = state as {instructions: InstructionsState};
     const levelContext = {
       levelId: aiTutorState.aiTutor.level?.id,
-      isProjectBacked: aiTutorState.aiTutor.level?.isProjectBacked,
       scriptId: aiTutorState.aiTutor.scriptId,
     };
 

--- a/apps/src/aiTutor/types.ts
+++ b/apps/src/aiTutor/types.ts
@@ -22,7 +22,6 @@ export interface AITutorInteraction {
   levelId?: number;
   scriptId?: number;
   type: AITutorTypesValue | undefined;
-  isProjectBacked?: boolean;
   prompt: string;
   status: AITutorInteractionStatusValue;
   aiResponse?: string;
@@ -60,7 +59,6 @@ export interface Level {
   id: number;
   type: string;
   hasValidation: boolean;
-  isProjectBacked: boolean;
   aiTutorAvailable: boolean;
   isAssessment: boolean;
 }

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -63,19 +63,12 @@ function initPage() {
 
   if (hasScriptData('script[data-aitutordata]')) {
     const aiTutorData = getScriptData('aitutordata');
-    const {
-      levelId,
-      type,
-      hasValidation,
-      isProjectBacked,
-      aiTutorAvailable,
-      isAssessment,
-    } = aiTutorData;
+    const {levelId, type, hasValidation, aiTutorAvailable, isAssessment} =
+      aiTutorData;
     const level = {
       id: levelId,
       type,
       hasValidation,
-      isProjectBacked,
       aiTutorAvailable,
       isAssessment,
     };

--- a/dashboard/app/controllers/ai_tutor_interactions_controller.rb
+++ b/dashboard/app/controllers/ai_tutor_interactions_controller.rb
@@ -27,8 +27,8 @@ class AiTutorInteractionsController < ApplicationController
     ai_tutor_interaction_params[:user_id] = current_user.id
     ai_tutor_interaction_params[:ai_model_version] = SharedConstants::AI_TUTOR_CHAT_MODEL_VERISON
 
-    # TODO: There might be a way to restrict this to only do this lookup for levels that use the projects system, but isProjectBacked
-    # isn't it. For now, since all the levels this is enabled for use projects/are JavaLab levels, we can just do this for all of them.
+    # TODO: There might be a way to restrict this to only do this lookup for levels that use the projects system.
+    # For now, since all the levels this is enabled for use projects/are JavaLab levels, we can just do this for all of them.
     project_data = find_project_and_version_id(ai_tutor_interaction_params[:level_id], ai_tutor_interaction_params[:script_id])
     ai_tutor_interaction_params[:project_id] = project_data[:project_id]
     ai_tutor_interaction_params[:project_version_id] = project_data[:version_id]

--- a/dashboard/app/controllers/ai_tutor_interactions_controller.rb
+++ b/dashboard/app/controllers/ai_tutor_interactions_controller.rb
@@ -27,7 +27,7 @@ class AiTutorInteractionsController < ApplicationController
     ai_tutor_interaction_params[:user_id] = current_user.id
     ai_tutor_interaction_params[:ai_model_version] = SharedConstants::AI_TUTOR_CHAT_MODEL_VERISON
 
-    # TODO: There might be a way to restrict this to only do this lookup for levels that use the projects system.
+    # TODO: We may want to only do this lookup for levels that use the projects system (e.g. level.channel_backed?)
     # For now, since all the levels this is enabled for use projects/are JavaLab levels, we can just do this for all of them.
     project_data = find_project_and_version_id(ai_tutor_interaction_params[:level_id], ai_tutor_interaction_params[:script_id])
     ai_tutor_interaction_params[:project_id] = project_data[:project_id]

--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -16,7 +16,7 @@
 
 - if @script_level
   - level_data = { redirect_script_url: @redirect_unit_url, script_name: @script_level.script&.name, course_name: @script_level.script&.unit_group&.name, level_name: @level.name, tts_autoplay_enabled: @tts_autoplay_enabled, code_review_enabled: @code_review_enabled_for_level, show_unversioned_redirect_warning: @show_unversioned_redirect_warning}
-  - ai_tutor_data = {levelId: @level&.id, scriptId: @script_level.script&.id, type: @level&.type, hasValidation: !!@level&.properties["encrypted_validation"], isProjectBacked: !!@level&.properties["project_template_level_name"], aiTutorAvailable: @level&.ai_tutor_available?, isAssessment: @script_level&.assessment}
+  - ai_tutor_data = {levelId: @level&.id, scriptId: @script_level.script&.id, type: @level&.type, hasValidation: !!@level&.properties["encrypted_validation"], aiTutorAvailable: @level&.ai_tutor_available?, isAssessment: @script_level&.assessment}
   %link{href: asset_path('css/levels.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/levels/show.js'), data: { aiTutorData: ai_tutor_data.to_json, level: level_data.to_json, rubricData: @rubric_data&.to_json }}
   -# Mount point for RedirectDialog React component.


### PR DESCRIPTION
[CT-604](https://codedotorg.atlassian.net/browse/CT-604)
Follow up to https://github.com/code-dot-org/code-dot-org/pull/58867

`isProjectBacked` is meaningless, but it was still hanging around.  Deleted all of the references and updated the follow up [ticket](https://codedotorg.atlassian.net/browse/CT-607) to use a different check if AI Tutor is used more broadly. 