### PR TITLE
[Google Blockly] update challenge level test

### DIFF
--- a/dashboard/config/levels/custom/maze/courseC_maze_programming3.level
+++ b/dashboard/config/levels/custom/maze/courseC_maze_programming3.level
@@ -1,7 +1,8 @@
 <Maze>
   <config><![CDATA[{
+  "published": true,
   "game_id": 25,
-  "created_at": "2016-07-14T20:50:32.000Z",
+  "created_at": "2022-02-16T19:37:58.000Z",
   "level_num": "custom",
   "user_id": 19,
   "properties": {
@@ -34,12 +35,14 @@
     "disable_if_else_editing": "false",
     "shape_shift": "false",
     "disable_procedure_autopopulate": "false",
-    "hint_prompt_attempts_threshold": 5,
-    "contained_level_names": null
+    "hint_prompt_attempts_threshold": "5",
+    "encrypted": "false",
+    "show_type_hints": "false",
+    "maze_data": null,
+    "preload_asset_list": null
   },
-  "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2017-07-06 03:34:41 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"contained_level_names\"],\"changed_by_id\":302,\"changed_by_email\":\"mara.downing@code.org\"},{\"changed_at\":\"2017-07-21 17:47:43 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"contained_level_names\"],\"changed_by_id\":302,\"changed_by_email\":\"mara.downing@code.org\"},{\"changed_at\":\"2017-07-28 22:12:49 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"never_autoplay_video\",\"contained_level_names\"],\"changed_by_id\":684,\"changed_by_email\":\"audrey.clark@code.org\"},{\"changed_at\":\"2017-08-23 15:22:09 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"contained_level_names\"],\"changed_by_id\":684,\"changed_by_email\":\"audrey.clark@code.org\"},{\"changed_at\":\"2017-09-28 00:09:29 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"markdown_instructions\",\"contained_level_names\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 18:45:40 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 18:57:31 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\",\"maze_data\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 18:58:29 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\",\"maze_data\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 19:16:35 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\",\"maze_data\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 19:18:12 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\",\"maze_data\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 19:25:29 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\",\"maze_data\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"}]",
+  "audit_log": "[{\"changed_at\":\"2017-07-06 03:34:41 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"contained_level_names\"],\"changed_by_id\":302,\"changed_by_email\":\"mara.downing@code.org\"},{\"changed_at\":\"2017-07-21 17:47:43 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"contained_level_names\"],\"changed_by_id\":302,\"changed_by_email\":\"mara.downing@code.org\"},{\"changed_at\":\"2017-07-28 22:12:49 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"never_autoplay_video\",\"contained_level_names\"],\"changed_by_id\":684,\"changed_by_email\":\"audrey.clark@code.org\"},{\"changed_at\":\"2017-08-23 15:22:09 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"authored_hints\",\"contained_level_names\"],\"changed_by_id\":684,\"changed_by_email\":\"audrey.clark@code.org\"},{\"changed_at\":\"2017-09-28 00:09:29 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"markdown_instructions\",\"contained_level_names\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 18:45:40 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 18:57:31 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\",\"maze_data\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 18:58:29 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\",\"maze_data\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 19:16:35 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\",\"maze_data\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 19:18:12 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\",\"maze_data\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2017-10-18 19:25:29 +0000\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"callout_json\",\"contained_level_names\",\"maze_data\"],\"changed_by_id\":63,\"changed_by_email\":\"kiki@code.org\"},{\"changed_at\":\"2024-07-09 07:55:55 -0400\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"hint_prompt_attempts_threshold\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"mike@code.org\"},{\"changed_at\":\"2024-07-09 08:04:23 -0400\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"maze_data\"],\"changed_by_id\":1,\"changed_by_email\":\"mike@code.org\"}]",
   "level_concept_difficulty": {
     "sequencing": 1,
     "debugging": 1
@@ -50,11 +53,11 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="maze_moveForward" deletable="false">
+            <block type="maze_moveForward" deletable="false" id="stoneMoveTop">
               <next>
                 <block type="maze_moveForward" id="extraBlock">
                   <next>
-                    <block type="maze_turn" deletable="false" editable="false">
+                    <block type="maze_turn" deletable="false" editable="false" id="stoneTurn">
                       <title name="DIR">turnLeft</title>
                       <next>
                         <block type="maze_moveForward" deletable="false">

--- a/dashboard/test/ui/features/step_definitions/blockly.rb
+++ b/dashboard/test/ui/features/step_definitions/blockly.rb
@@ -45,6 +45,16 @@ When /^I drag block "([^"]*)" to block "([^"]*)"$/ do |from, to|
   @browser.execute_script code
 end
 
+When /^I connect block "([^"]*)" to block "([^"]*)"$/ do |from, to|
+  code = connect_block(from, to)
+  @browser.execute_script code
+end
+
+When /^I delete block "([^"]*)"$/ do |id|
+  code = delete_block(id)
+  @browser.execute_script code
+end
+
 When /^I drag block matching selector "([^"]*)" to block matching selector "([^"]*)"$/ do |from, to|
   code = generate_selector_drag_code(from, to, 0, 30)
   @browser.execute_script code

--- a/dashboard/test/ui/features/support/blockly_helpers.rb
+++ b/dashboard/test/ui/features/support/blockly_helpers.rb
@@ -109,4 +109,17 @@ def get_id_selector
   google_blockly? ? 'data-id' : 'block-id'
 end
 
+def connect_block(from, to)
+  "var workspace = Blockly.getMainWorkspace();" \
+  "var blockToMove = workspace.getBlockById('#{from}');" \
+  "var targetBlock = workspace.getBlockById('#{to}');" \
+  "targetBlock.nextConnection.connect(blockToMove.previousConnection);"
+end
+
+def delete_block(id)
+  "var workspace = Blockly.getMainWorkspace();" \
+  "var blockToDelete = workspace.getBlockById('#{id}');" \
+  "blockToDelete.dispose();"
+end
+
 World(BlocklyHelpers)

--- a/dashboard/test/ui/features/teacher_tools/challenge_level.feature
+++ b/dashboard/test/ui/features/teacher_tools/challenge_level.feature
@@ -2,21 +2,21 @@ Feature: Challenge level shows different dialogs
 
 Background:
   Given I am on "http://studio.code.org/reset_session"
-  Given I am on "http://studio.code.org/s/allthethings/lessons/2/levels/6?noautoplay=true"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/2/levels/6?noautoplay=true&blocklyVersion=google"
   And I wait for the page to fully load
 
 Scenario: Submit passing and perfect solutions
   Given I wait until element "#uitest-challenge-title" is visible
   Then element "#uitest-challenge-title" has text "Challenge Puzzle!"
   Given I press "challengePrimaryButton"
-  And I drag block "7" to block "5"
+  And I connect block "stoneTurn" to block "stoneMoveTop"
   When I press "runButton"
   And I wait until element "#uitest-challenge-title" is visible
   Then element "#uitest-challenge-title" has text "You did it!"
   Given I press "challengeCancelButton"
   And I wait until element ".modal-body" is not visible
   And I press "resetButton"
-  And I drag block "6" to block "2"
+  And I delete block "extraBlock"
   When I press "runButton"
   And I wait until element "#uitest-challenge-title" is visible
   Then element "#uitest-challenge-title" has text "Challenge Complete!"


### PR DESCRIPTION
This updates an existing UI test which relies on dragging blocks to complete a level in two different ways.

|State|Blocks|Modal|
|-|-|-|
|Initial|<img width="137" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/18f44bf5-dc96-4385-92c4-2e51b1eda59b">|<img width="595" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/253bd13d-f2df-4c58-9121-326688373d0c">|
|Imperfect Solution (extra block)|<img width="137" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/5811ed19-606a-4ca2-a8da-d7cafbc23ed4">|<img width="481" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/a1e4b6b3-1f27-4a52-8179-17a1ebd8b4d7">|
|Perfect solution|<img width="135" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/56555805-86ab-497f-adcf-1bc9d8b3aabe">|<img width="408" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/43474485/37311abe-5980-4d3b-aa43-3f4e3b1db72f">|

Like our other block-dragging tests, this one has been relying on `jquery-simulate` to perform a calcuated drag operation. This works fine in either version of Blockly when we are dragging a block from the flyout to the main workspace. However, for a reason I can't determine, the simulate drag is _not_ working on blocks already in the workspace. This could be a bug with Blockly. I used my browser console on the Blockly Playground site to load jQuery and the simulate plugin and also wasn't able to drag a block there. To do this, I asked ChatGPT for help writing a quick script to do this. I was able to get jQuery to return a jQuery object, but the simulate code didn't work. For reference (in case we want to submit a ticket to Blockly), here is the script I used:

```
function loadSimulatePlugin() {
    var script = document.createElement('script');
    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/jquery-simulate/1.0.1/jquery.simulate.min.js';
    script.onload = function() {
        console.log('jquery-simulate plugin loaded');
        // Now you can use the simulate method
        // Example usage:
        $('[data-id="val"]').simulate('click');
    };
    document.head.appendChild(script);
}

// Step 1: Load jQuery
var script = document.createElement('script');
script.src = 'https://code.jquery.com/jquery-3.6.0.min.js';
script.onload = function() {
    console.log('jQuery loaded');
    // Step 2: Load jquery-simulate plugin
    var simulateScript = document.createElement('script');
    simulateScript.src = 'https://cdnjs.cloudflare.com/ajax/libs/jquery-simulate/1.0.1/jquery.simulate.min.js';
    simulateScript.onload = function() {
        console.log('jquery-simulate plugin loaded');
    };
    document.head.appendChild(simulateScript);
};
document.head.appendChild(script);
```

While looking for a workaround, I came across what I believe is actually a simpler and more reliable way manipulating blocks during tests - the actual Blockly APIs. Below is a comparison of the generated code we'd run for a step where one block is moved to another block on the same workspace. (Illustrated in the table above as the change in blocks between rows 1 and 2)

**Old jQuery Code** (comments added to PR for clarity)
```
// Calculate the horizontal drag distance
var drag_dx = $("[data-id='5']").filter(function (index) {
    return $(this).parents(':hidden').length === 0;
}).offset().left - $("[data-id='7']:last").filter(function (index) {
    return $(this).parents(':hidden').length === 0;
}).offset().left;

// Calculate the vertical drag distance
var drag_dy = $("[data-id='5']").filter(function (index) {
    return $(this).parents(':hidden').length === 0;
}).offset().top - $("[data-id='7']:last").filter(function (index) {
    return $(this).parents(':hidden').length === 0;
}).offset().top;

// Simulate a drag using the calculated distances (plus an extra 50px vertically to account for the height of the block)
$("[data-id='7']:last").simulate('drag', {handle: 'corner', dx: drag_dx + 0, dy: drag_dy + 50, moves: 5});
```

**New Blockly API Code**
```
var workspace = Blockly.getMainWorkspace();
var blockToMove = workspace.getBlockById('stoneTurn');
var targetBlock = workspace.getBlockById('stoneMoveTop');
targetBlock.nextConnection.connect(blockToMove.previousConnection);
```

The new code is simpler and easier to read.

## Links

https://codedotorg.atlassian.net/browse/CT-675

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
