### PR TITLE
Set up relationship between Course Offerings and Workshops for join table

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -34,6 +34,8 @@ class CourseOffering < ApplicationRecord
   has_many :course_versions, -> {where(content_root_type: ['UnitGroup', 'Unit'])}
   belongs_to :self_paced_pl_course_offering, class_name: 'CourseOffering', optional: true
 
+  has_and_belongs_to_many :pd_workshops, class_name: 'Pd::Workshop', join_table: :course_offerings_pd_workshops, association_foreign_key: 'pd_workshop_id'
+
   validates :curriculum_type, acceptance: {accept: Curriculum::SharedCourseConstants::COURSE_OFFERING_CURRICULUM_TYPES.to_h.values, message: "must be one of the course offering curriculum types. Expected one of: #{Curriculum::SharedCourseConstants::COURSE_OFFERING_CURRICULUM_TYPES.to_h.values}. Got: \"%{value}\"."}, allow_nil: true
   validates :marketing_initiative, acceptance: {accept: Curriculum::SharedCourseConstants::COURSE_OFFERING_MARKETING_INITIATIVES.to_h.values, message: "must be one of the course offering marketing initiatives. Expected one of: #{Curriculum::SharedCourseConstants::COURSE_OFFERING_MARKETING_INITIATIVES.to_h.values}. Got: \"%{value}\"."}, allow_nil: true
   validate :grade_levels_format

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -49,7 +49,7 @@ class Pd::Workshop < ApplicationRecord
 
   has_many :regional_partner_program_managers, source: :program_managers, through: :regional_partner
 
-  has_and_belongs_to_many :course_offerings, join_table: :course_offerings_pd_workshops, foreign_key: 'pd_workshop_id', association_foreign_key: 'course_offering_id'
+  has_and_belongs_to_many :course_offerings, join_table: :course_offerings_pd_workshops, foreign_key: 'pd_workshop_id'
 
   serialized_attrs [
     'fee',

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -49,6 +49,8 @@ class Pd::Workshop < ApplicationRecord
 
   has_many :regional_partner_program_managers, source: :program_managers, through: :regional_partner
 
+  has_and_belongs_to_many :course_offerings, join_table: :course_offerings_pd_workshops
+
   serialized_attrs [
     'fee',
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -49,7 +49,7 @@ class Pd::Workshop < ApplicationRecord
 
   has_many :regional_partner_program_managers, source: :program_managers, through: :regional_partner
 
-  has_and_belongs_to_many :course_offerings, join_table: :course_offerings_pd_workshops
+  has_and_belongs_to_many :course_offerings, join_table: :course_offerings_pd_workshops, foreign_key: 'pd_workshop_id', association_foreign_key: 'course_offering_id'
 
   serialized_attrs [
     'fee',


### PR DESCRIPTION
Following [this PR](https://github.com/code-dot-org/code-dot-org/pull/59485) which added the join table between `course_offerings` and `pd_workshops`, this adds the many-to-many relationship definitions for course offerings and workshops. I used [the user.rb](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/user.rb#L230) join table relation line and [the workshop.rb](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/pd/workshop.rb#L42) join table relation line as reference since they represent a many-to-many relation with a join table that includes `pd_workshop`.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2048)
