### PR TITLE
One off script to update name_suffix for all CSD microbit levels to nil 

### DIFF
--- a/bin/oneoff/data_fix/remove_level_name_suffix_CSD_microbit_2024.rb
+++ b/bin/oneoff/data_fix/remove_level_name_suffix_CSD_microbit_2024.rb
@@ -24,8 +24,7 @@ def remove_level_name_suffix
     if level.name_suffix == "_mb_2024"
       puts "Processing level [#{level.name}] with name_suffix [#{level.name_suffix}]"
 
-      level.update(name_suffix: nil)
-      level.save!
+      level.update!(name_suffix: nil)
     else
       puts "Ignoring level [#{level.name}] with name_suffix [#{level.name_suffix}] not matching _mb_2024"
     end

--- a/bin/oneoff/data_fix/remove_level_name_suffix_CSD_microbit_2024.rb
+++ b/bin/oneoff/data_fix/remove_level_name_suffix_CSD_microbit_2024.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+# https://codedotorg.atlassian.net/browse/TEACH-1161
+# When cloning CSD for SY 24-25, we hit an issue were all microbit levels were overwritten
+# by circuit playground ones. The underlying root cause was that both these levels in 2023
+# version of the curriculum had the same prefix, and only differed by the suffix., ie.,
+# circuit playground levels had _2023 suffix, while microbit had _mb2022 suffix.
+
+# During cloning, both these suffixes were replaced with _2024 initially, leading to the
+# circuit playground levels getting overwritten. To fix the issues, the microbit units were
+# deleted and recloned with _mb_2024 suffix. But, this issue could potentially happen when
+# cloning for SY 25-26 if both units are cloned with 2025 as suffix. The below script is to
+# avoid that issue. It does that by setting name_suffix property of the micro bit levels to
+# nil. If its nil, during cloning, only the _2024 part of the microbit suffix would get
+# replaced, hence preserving the unique name between circuit playground and microbit.
+
+require_relative '../../../dashboard/config/environment'
+
+def remove_level_name_suffix
+  raise unless Rails.application.config.levelbuilder_mode
+
+  unit = Unit.find_by_name("csd6b-2024")
+  unit.levels.each do |level|
+    next unless level.name_suffix == "mb_2024"
+
+    puts "Updating name suffix for level [#{level.name}]"
+    level.update(name_suffix: nil)
+    level.save!
+  end
+end
+
+remove_level_name_suffix

--- a/bin/oneoff/data_fix/remove_level_name_suffix_CSD_microbit_2024.rb
+++ b/bin/oneoff/data_fix/remove_level_name_suffix_CSD_microbit_2024.rb
@@ -21,7 +21,7 @@ def remove_level_name_suffix
 
   unit = Unit.find_by_name("csd6b-2024")
   unit.levels.each do |level|
-    next unless level.name_suffix == "mb_2024"
+    next unless level.name_suffix == "_mb_2024"
 
     puts "Updating name suffix for level [#{level.name}]"
     level.update(name_suffix: nil)

--- a/bin/oneoff/data_fix/remove_level_name_suffix_CSD_microbit_2024.rb
+++ b/bin/oneoff/data_fix/remove_level_name_suffix_CSD_microbit_2024.rb
@@ -19,13 +19,16 @@ require_relative '../../../dashboard/config/environment'
 def remove_level_name_suffix
   raise unless Rails.application.config.levelbuilder_mode
 
-  unit = Unit.find_by_name("csd6b-2024")
-  unit.levels.each do |level|
-    next unless level.name_suffix == "_mb_2024"
+  levels_to_update = Level.where("name LIKE ?", "%\\_mb\\_2024")
+  levels_to_update.each do |level|
+    if level.name_suffix == "_mb_2024"
+      puts "Processing level [#{level.name}] with name_suffix [#{level.name_suffix}]"
 
-    puts "Updating name suffix for level [#{level.name}]"
-    level.update(name_suffix: nil)
-    level.save!
+      level.update(name_suffix: nil)
+      level.save!
+    else
+      puts "Ignoring level [#{level.name}] with name_suffix [#{level.name_suffix}] not matching _mb_2024"
+    end
   end
 end
 


### PR DESCRIPTION
Context: When cloning CSD for SY 24-25, we hit an issue were all microbit levels were overwritten by circuit playground ones. The underlying root cause was that both these levels in 2023 version of the curriculum had the same prefix, and only differed by the suffix., ie., circuit playground levels had _2023 suffix, while microbit had _mb2022 suffix.

During cloning, both these suffixes were replaced with _2024 initially, leading to the circuit playground levels getting overwritten. To fix the issues, the microbit units were deleted and recloned with _mb_2024 suffix. 

Issue: The level conflict issue could potentially happen again when cloning for SY 25-26 if both units are cloned with 2025 as suffix (which is very likely). 

Fix: The oneoff script in this PR is to avoid the issue when cloning for SY25-26 by setting name_suffix property of the micro bit levels to nil. [If the name_suffix is nil, during cloning, only the _2024 part of the microbit suffix would get replaced](https://github.com/code-dot-org/code-dot-org/blob/9b807edfc2d632baf01bcf4f25b473a5150c94b0/dashboard/app/models/levels/level.rb#L885C15-L885C24), hence preserving the unique name between circuit playground and microbit for all future clones.

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1161

## Testing story

Local environment validation

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Manual execution only on levelbuilder environment, this would update level files which would seed in other environments

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
