### PR TITLE
P20-987: Use `Rack::CookieDCDO` in Pegasus

### DIFF
--- a/pegasus/config.ru
+++ b/pegasus/config.ru
@@ -50,6 +50,12 @@ if CDO.image_optim
   use Rack::Optimize
 end
 
+if CDO.use_cookie_dcdo
+  # Enables the setting of DCDO via cookies for testing purposes.
+  require 'cdo/rack/cookie_dcdo'
+  use Rack::CookieDCDO
+end
+
 # Disable Sinatra auto-initialization.
 # Add Honeybadger::Rack::ErrorNotifier to Rack middleware directly.
 use Honeybadger::Rack::ErrorNotifier


### PR DESCRIPTION
We need to include the `Rack::CookieDCDO` middleware in Pegasus, as it runs on a different process than the dashboard
## Links
- JIRA task: [P20-987](https://codedotorg.atlassian.net/browse/P20-987)
- Related task: https://github.com/code-dot-org/code-dot-org/pull/59442