### PR TITLE
AI Chat: move clear chat button under message editor

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useCallback, useMemo} from 'react';
 
 import Button from '@cdo/apps/componentLibrary/button/Button';
-import i18n from '@cdo/locale';
+import {commonI18n} from '@cdo/apps/types/locale';
 
 import moduleStyles from './user-message-editor.module.scss';
 
@@ -12,11 +12,13 @@ import moduleStyles from './user-message-editor.module.scss';
 export interface UserMessageEditorProps {
   onSubmit: (userMessage: string) => void;
   disabled: boolean;
+  showSubmitLabel?: boolean;
 }
 
 const UserMessageEditor: React.FunctionComponent<UserMessageEditorProps> = ({
   onSubmit,
   disabled,
+  showSubmitLabel = false,
 }) => {
   const [userMessage, setUserMessage] = useState<string>('');
 
@@ -38,11 +40,12 @@ const UserMessageEditor: React.FunctionComponent<UserMessageEditorProps> = ({
     [onSubmit]
   );
 
+  const icon = {iconName: 'paper-plane'};
   return (
     <div className={moduleStyles.editorContainer}>
       <textarea
         className={moduleStyles.textArea}
-        placeholder={i18n.aiUserMessagePlaceholder()}
+        placeholder={commonI18n.aiUserMessagePlaceholder()}
         onChange={e => setUserMessage(e.target.value)}
         value={userMessage}
         disabled={disabled}
@@ -51,10 +54,11 @@ const UserMessageEditor: React.FunctionComponent<UserMessageEditorProps> = ({
 
       <div className={moduleStyles.centerSingleItemContainer}>
         <Button
-          isIconOnly
-          icon={{iconName: 'paper-plane'}}
+          isIconOnly={!showSubmitLabel}
           onClick={() => handleSubmit(userMessage)}
           disabled={disabled || !userMessage || userMessageIsEmpty}
+          text={showSubmitLabel ? commonI18n.submit() : undefined}
+          {...{[showSubmitLabel ? 'iconLeft' : 'icon']: icon}}
         />
       </div>
     </div>

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -178,6 +178,17 @@ const AichatView: React.FunctionComponent = () => {
     }
   }, [dialogControl, resetProject]);
 
+  const onClear = useCallback(() => {
+    dispatch(clearChatMessages());
+    analyticsReporter.sendEvent(
+      EVENTS.CHAT_ACTION,
+      {
+        action: 'Clear chat history',
+      },
+      PLATFORMS.BOTH
+    );
+  }, [dispatch]);
+
   return (
     <div id="aichat-lab" className={moduleStyles.aichatLab}>
       {showPresentationToggle() && (
@@ -256,7 +267,7 @@ const AichatView: React.FunctionComponent = () => {
               );
             })}
           >
-            <ChatWorkspace />
+            <ChatWorkspace onClear={onClear} />
           </PanelContainer>
         </div>
       </div>
@@ -267,15 +278,6 @@ const AichatView: React.FunctionComponent = () => {
 const renderChatWorkspaceHeaderRight = (onClear: () => void) => {
   return (
     <div className={moduleStyles.chatHeaderRight}>
-      <Button
-        onClick={onClear}
-        text="Clear"
-        iconLeft={{iconName: 'paintbrush'}}
-        size="xs"
-        color="white"
-        type="secondary"
-        className={moduleStyles.aichatViewButton}
-      />
       <CopyButton />
     </div>
   );

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -256,29 +256,16 @@ const AichatView: React.FunctionComponent = () => {
             headerContent={chatWorkspaceHeader}
             className={moduleStyles.panelContainer}
             headerClassName={moduleStyles.panelHeader}
-            rightHeaderContent={renderChatWorkspaceHeaderRight(() => {
-              dispatch(clearChatMessages());
-              analyticsReporter.sendEvent(
-                EVENTS.CHAT_ACTION,
-                {
-                  action: 'Clear chat history',
-                },
-                PLATFORMS.BOTH
-              );
-            })}
+            rightHeaderContent={
+              <div className={moduleStyles.chatHeaderRight}>
+                <CopyButton />
+              </div>
+            }
           >
             <ChatWorkspace onClear={onClear} />
           </PanelContainer>
         </div>
       </div>
-    </div>
-  );
-};
-
-const renderChatWorkspaceHeaderRight = (onClear: () => void) => {
-  return (
-    <div className={moduleStyles.chatHeaderRight}>
-      <CopyButton />
     </div>
   );
 };

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -7,6 +7,7 @@ import {
   setShowWarningModal,
 } from '@cdo/apps/aichat/redux/aichatRedux';
 import ChatWarningModal from '@cdo/apps/aiComponentLibrary/warningModal/ChatWarningModal';
+import {Button} from '@cdo/apps/componentLibrary/button';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import ChatItemView from './ChatItemView';
@@ -14,10 +15,16 @@ import UserChatMessageEditor from './UserChatMessageEditor';
 
 import moduleStyles from './chatWorkspace.module.scss';
 
+interface ChatWorkspaceProps {
+  onClear: () => void;
+}
+
 /**
  * Renders the AI Chat Lab main chat workspace component.
  */
-const ChatWorkspace: React.FunctionComponent = () => {
+const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
+  onClear,
+}) => {
   const showWarningModal = useSelector(
     (state: {aichat: AichatState}) => state.aichat.showWarningModal
   );
@@ -75,6 +82,16 @@ const ChatWorkspace: React.FunctionComponent = () => {
         {showWaitingAnimation()}
       </div>
       <UserChatMessageEditor />
+      <div className={moduleStyles.buttonRow}>
+        <Button
+          text="Clear chat"
+          iconLeft={{iconName: 'eraser'}}
+          size="s"
+          type="secondary"
+          color="gray"
+          onClick={onClear}
+        />
+      </div>
     </div>
   );
 };

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -28,7 +28,13 @@ const UserChatMessageEditor: React.FunctionComponent = () => {
 
   const disabled = isWaitingForChatResponse || saveInProgress;
 
-  return <UserMessageEditor onSubmit={handleSubmit} disabled={disabled} />;
+  return (
+    <UserMessageEditor
+      onSubmit={handleSubmit}
+      disabled={disabled}
+      showSubmitLabel
+    />
+  );
 };
 
 export default UserChatMessageEditor;

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -26,3 +26,8 @@ $default-spacing: 16px;
 .waitingForResponse {
   width: 50px;
 }
+
+.buttonRow {
+  display: flex;
+  padding: 0 10px 10px 10px;
+}


### PR DESCRIPTION
Move the clear chat button under the message editor as per product/design guidance.

Note: I'm waiting from product confirmation on if the "Submit" text should be shown in the message editor. Regardless though, we'll need some way to show the label if necessary as per design, so I'll plan to keep the logic and just change the prop value if needed.

No impact to AI Tutor.

With Submit label:
![Screenshot 2024-07-09 at 3 46 42 PM](https://github.com/code-dot-org/code-dot-org/assets/85528507/818c7440-4dd6-4cc6-9b16-d99741d4becc)

Without Submit label:
![Screenshot 2024-07-09 at 3 46 10 PM](https://github.com/code-dot-org/code-dot-org/assets/85528507/80ae041e-c3e5-43b7-acb0-0f4f19d92d6b)

## Links

https://codedotorg.atlassian.net/browse/LABS-907

## Testing story

Tested on Gen AI levels and AI Tutor (to confirm no impact).