### PR TITLE
Add `unlock_token` to Users

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -147,6 +147,7 @@ cron-user-hierarchy:
     - invitation_by_id
     - invitations_count
     - parent_email
+    - unlock_token
 - dashboard.user_geos:
     remove_column:
     - ip_address

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -49,6 +49,7 @@
 #  urm                      :boolean
 #  races                    :string(255)
 #  primary_contact_info_id  :integer
+#  unlock_token             :string(255)
 #
 # Indexes
 #
@@ -66,6 +67,7 @@
 #  index_users_on_reset_password_token_and_deleted_at  (reset_password_token,deleted_at) UNIQUE
 #  index_users_on_school_info_id                       (school_info_id)
 #  index_users_on_studio_person_id                     (studio_person_id)
+#  index_users_on_unlock_token                         (unlock_token) UNIQUE
 #  index_users_on_username_and_deleted_at              (username,deleted_at) UNIQUE
 #
 

--- a/dashboard/app/serializers/user_serializer.rb
+++ b/dashboard/app/serializers/user_serializer.rb
@@ -49,6 +49,7 @@
 #  urm                      :boolean
 #  races                    :string(255)
 #  primary_contact_info_id  :integer
+#  unlock_token             :string(255)
 #
 # Indexes
 #
@@ -66,6 +67,7 @@
 #  index_users_on_reset_password_token_and_deleted_at  (reset_password_token,deleted_at) UNIQUE
 #  index_users_on_school_info_id                       (school_info_id)
 #  index_users_on_studio_person_id                     (studio_person_id)
+#  index_users_on_unlock_token                         (unlock_token) UNIQUE
 #  index_users_on_username_and_deleted_at              (username,deleted_at) UNIQUE
 #
 

--- a/dashboard/db/migrate/20240321204728_add_devise_lockable_to_users.rb
+++ b/dashboard/db/migrate/20240321204728_add_devise_lockable_to_users.rb
@@ -29,7 +29,7 @@ class AddDeviseLockableToUsers < ActiveRecord::Migration[6.1]
   end
 
   def self.down
-    remove_column :users, :unlock_token
     remove_index :users, :unlock_token
+    remove_column :users, :unlock_token
   end
 end

--- a/dashboard/db/migrate/20240321204728_add_devise_lockable_to_users.rb
+++ b/dashboard/db/migrate/20240321204728_add_devise_lockable_to_users.rb
@@ -11,17 +11,20 @@ class AddDeviseLockableToUsers < ActiveRecord::Migration[6.1]
     # column; we therefore implement both in the properties blob.
     add_column :users, :unlock_token, :string
 
-    # On MySQL 8.0, adding an index does not lock the table but it does still
-    # take quite a while to apply successfully; see
-    # https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-column-syntax-notes
+    # Attempting to create this index via a migration will fail on a table as
+    # large as the one we have in production. To avoid that, we plan to execute
+    # the index creation query manually after the rest of this migration has
+    # completed.
     #
+    # Specifically: on MySQL 8.0, adding an index does not lock the table but
+    # it does still take quite a while to apply successfully (see
+    # https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-column-syntax-notes).
     # When tested against a clone of our production database, this operation
     # took approximately 35 minutes, much longer than the 30 seconds migrations
-    # will wait before erroring out. To avoid this migration failing in
-    # production, we plan to execute the index creation query manually after
-    # the rest of this migration has completed.
+    # will wait before erroring out. To create the index without the time limit
+    # enforced by migrations, we should run this command from a bash shell on
+    # production-console:
     #
-    # Specifically, we should from a bash shell on production-console run:
     #     nohup mysql-client-dashboard-writer "CREATE UNIQUE INDEX index_users_on_unlock_token ON users (unlock_token)" &
     unless Rails.env.production?
       add_index :users, :unlock_token, unique: true

--- a/dashboard/db/migrate/20240321204728_add_devise_lockable_to_users.rb
+++ b/dashboard/db/migrate/20240321204728_add_devise_lockable_to_users.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Adds all fields required for enabling Devise's Lockable functionality to the
+# User model, in preparation for enabling the feature.
+#
+# See https://github.com/heartcombo/devise/wiki/How-To:-Add-:lockable-to-Users
+class AddDeviseLockableToUsers < ActiveRecord::Migration[6.1]
+  def self.up
+    # Note that we do not add `failed_attempts` or `locked_at` here.
+    # Because neither field is used for querying, neither needs to be an actual
+    # column; we therefore implement both in the properties blob.
+    add_column :users, :unlock_token, :string
+
+    # On MySQL 8.0, adding an index does not lock the table but it does still
+    # take quite a while to apply successfully; see
+    # https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-column-syntax-notes
+    #
+    # When tested against a clone of our production database, this operation
+    # took approximately 35 minutes, much longer than the 30 seconds migrations
+    # will wait before erroring out. To avoid this migration failing in
+    # production, we plan to execute the index creation query manually after
+    # the rest of this migration has completed.
+    #
+    # Specifically, we should from a bash shell on production-console run:
+    #     nohup mysql-client-dashboard-writer "CREATE UNIQUE INDEX index_users_on_unlock_token ON users (unlock_token)" &
+    unless Rails.env.production?
+      add_index :users, :unlock_token, unique: true
+    end
+  end
+
+  def self.down
+    remove_column :users, :unlock_token
+    remove_index :users, :unlock_token
+  end
+end


### PR DESCRIPTION
In preparation for eventually adding the ability to lock out user accounts on repeated failed authentication attempts, we first add a column with an index on the Users table which will allow users to unlock their accounts by clicking a link in an email we'll send them.

Because we are on MySQL 8, [adding a column is now an instant operation](https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-column-operations-table), even on a table as large as our Users table. Unfortunately, [adding an index is not](https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-index-operations-table).

## Testing story

 I did some manual testing on a clone of the production database using an adhoc, and was able to confirm that adding the new column takes less than a second and adding the index for that column takes about 35 minutes. During that time, the table is still available for reads and writes; only schema changes are locked.

This means we can safely apply the change in production without needing to use `gh-ost`, but we will need to execute the query to add the index outside of the context of our Rails migrations, which have a 30-second limit.

## Follow-up work

Once the change has been fully deployed, all servers should have a new column and all servers except production should have an index on that column. To bring production in line with the rest of our pipeline, we will after deployment kick off a `CREATE UNIQUE INDEX` query from `production-console`:

```bash
nohup mysql-client-dashboard-writer "CREATE UNIQUE INDEX index_users_on_unlock_token ON users (unlock_token)" &
```

## Links

Work-in-progress PR to fully enable the feature:
- https://github.com/code-dot-org/code-dot-org/pull/57515

Devise documentation:
- https://github.com/heartcombo/devise/wiki/How-To:-Add-:lockable-to-Users

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
