### PR TITLE
update step mode and simpledrag tests

### DIFF
--- a/apps/src/maze/startBlocks.xml.ejs
+++ b/apps/src/maze/startBlocks.xml.ejs
@@ -7,7 +7,7 @@ var page = locals.page;
 %>
 <% if (page === 2) { -%>
   <% if (level < 4) { -%>
-    <block type="maze_moveForward" x="70" y="70"></block>
+    <block type="maze_moveForward" x="70" y="70" id="startBlock">></block>
   <% } else if (level === 8) { -%>
     <block type="controls_repeat" x="70" y="70" editable="false"
       deletable="false" id="undeletableRepeat">

--- a/apps/src/maze/startBlocks.xml.ejs
+++ b/apps/src/maze/startBlocks.xml.ejs
@@ -7,7 +7,7 @@ var page = locals.page;
 %>
 <% if (page === 2) { -%>
   <% if (level < 4) { -%>
-    <block type="maze_moveForward" x="70" y="70" id="startBlock">></block>
+    <block type="maze_moveForward" x="70" y="70" id="startBlock"></block>
   <% } else if (level === 8) { -%>
     <block type="controls_repeat" x="70" y="70" editable="false"
       deletable="false" id="undeletableRepeat">

--- a/apps/src/maze/toolboxes/maze.xml.ejs
+++ b/apps/src/maze/toolboxes/maze.xml.ejs
@@ -7,8 +7,8 @@ var page = locals.page;
 %>
 <xml id="toolbox" style="display: none;">
   <block type="maze_moveForward" id="moveForward"></block>
-  <block type="maze_turn"><title name="DIR">turnLeft</title></block>
-  <block type="maze_turn"><title name="DIR">turnRight</title></block>
+  <block type="maze_turn" id="turnLeft"><title name="DIR">turnLeft</title></block>
+  <block type="maze_turn" id="turnRight"><title name="DIR">turnRight</title></block>
   <% if (page === 1) { -%>
     <% if (level > 2) { -%>
       <block type="maze_forever"></block>

--- a/dashboard/test/ui/features/star_labs/simpledrag.feature
+++ b/dashboard/test/ui/features/star_labs/simpledrag.feature
@@ -1,11 +1,11 @@
 Feature: Blocks can be dragged
 
 Scenario: Connect two blocks from toolbox
-  Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/5?noautoplay=true"
+  Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/5?noautoplay=true&blocklyVersion=google"
   When I wait for the page to fully load
   And I dismiss the login reminder
   And I wait to see ".blocklySvg"
-  And I drag block "1" to offset "160, 100"
-  And I drag block "1" to offset "160, 130"
+  And I drag block "turnLeft" to offset "160, 100"
+  And I drag block "turnRight" to offset "160, 75"
   And I wait for 1 seconds
-  Then block "6" is child of block "5"
+  Then block "turnRight" is child of block "turnLeft"

--- a/dashboard/test/ui/features/star_labs/step_mode.feature
+++ b/dashboard/test/ui/features/star_labs/step_mode.feature
@@ -2,31 +2,31 @@
 Feature: Step Mode
 
 Scenario: Step Only - Failure
-  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1"
+  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1?blocklyVersion=google"
     And I wait for the page to fully load
   Then element "#runButton" is hidden
     And element "#resetButton" is hidden
     And element "#stepButton" is visible
     And element "#stepButton" is not disabled
 
-  When I drag block "1" to block "5"
+  When I drag block "moveForward" to block "startBlock"
     And I press "stepButton"
     And I wait for 1 second
     And I wait until "#stepButton" is not disabled
   Then element "#runButton" is hidden
     And element "#resetButton" is visible
     And element "#stepButton" is not disabled
-    And block "5" has class "blocklySelected"
-    And block "6" doesn't have class "blocklySelected"
+    And block "startBlock" has class "blocklySelected"
+    And block "moveForward" doesn't have class "blocklySelected"
 
   # After second press, second block is highlighted and step button goes away
   When I press "stepButton"
-    And I wait until block "6" has class "blocklySelected"
+    And I wait until block "moveForward" has class "blocklySelected"
   Then element "#runButton" is hidden
     And element "#resetButton" is visible
     And element "#stepButton" is disabled
-    And block "5" doesn't have class "blocklySelected"
-    And block "6" has class "blocklySelected"
+    And block "startBlock" doesn't have class "blocklySelected"
+    And block "moveForward" has class "blocklySelected"
 
   When I press "resetButton"
   Then element "#runButton" is not displayed
@@ -35,15 +35,15 @@ Scenario: Step Only - Failure
     And element "#stepButton" is not disabled
 
 Scenario: Step Only - Success
-  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1"
+  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1?blocklyVersion=google"
     And I wait for the page to fully load
   Then element "#runButton" is hidden
     And element "#resetButton" is hidden
     And element "#stepButton" is visible
     And element "#stepButton" is not disabled
 
-  When I drag block "1" to block "4"
-    And I drag block "1" to block "5"
+  When I drag block "moveForward" to block "startBlock"
+    And I drag block "moveForward" to block "moveForward"
     And I press "stepButton"
       And I wait for 1 second
       And I wait until "#stepButton" is not disabled
@@ -55,14 +55,14 @@ Scenario: Step Only - Success
   Then element ".congrats" has text "Congratulations! You completed Puzzle 1."
 
 Scenario: Step Only - Reset while stepping
-  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1"
+  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1?blocklyVersion=google"
     And I wait for the page to fully load
   Then element "#runButton" is hidden
     And element "#resetButton" is hidden
     And element "#stepButton" is visible
     And element "#stepButton" is not disabled
 
-  When I drag block "1" to block "5"
+  When I drag block "moveForward" to block "startBlock"
     And I press "stepButton"
     And I wait for 1 second
     And I wait until "#stepButton" is not disabled
@@ -78,19 +78,19 @@ Scenario: Step Only - Reset while stepping
     And element "#stepButton" is not disabled
 
 Scenario: Step and Run - Stepping
-  Given I am on "http://studio.code.org/s/step/lessons/1/levels/2"
+  Given I am on "http://studio.code.org/s/step/lessons/1/levels/2?blocklyVersion=google"
     And I wait for the page to fully load
   Then element "#runButton" is visible
     And element "#resetButton" is hidden
     And element "#stepButton" is visible
     And element "#stepButton" is not disabled
 
-  When I drag block "1" to block "5"
+  When I drag block "moveForward" to block "startBlock"
     And I press "stepButton"
     And I wait for 1 second
     And I wait until "#stepButton" is not disabled
-  Then block "5" has class "blocklySelected"
-    And block "6" doesn't have class "blocklySelected"
+  Then block "startBlock" has class "blocklySelected"
+    And block "moveForward" doesn't have class "blocklySelected"
     And element "#runButton" is hidden
     And element "#resetButton" is visible
     And element "#stepButton" is visible
@@ -103,13 +103,13 @@ Scenario: Step and Run - Stepping
     And element "#stepButton" is not disabled
 
 Scenario: Step and Run - Running
-  Given I am on "http://studio.code.org/s/step/lessons/1/levels/2"
+  Given I am on "http://studio.code.org/s/step/lessons/1/levels/2?blocklyVersion=google"
     And I wait for the page to fully load
   Then element "#runButton" is visible
     And element "#resetButton" is hidden
     And element "#stepButton" is visible
     And element "#stepButton" is not disabled
-  When I drag block "1" to block "5"
+  When I drag block "moveForward" to block "startBlock"
     And I press "runButton"
   Then element "#stepButton" is disabled
     And element "#runButton" is hidden


### PR DESCRIPTION
This adds hard-coded block ids to a few level blocks and updates associated UI tests to use those ids explicitly so that the test can run on Google Blockly.

The Step Mode test works exactly as it used to. The Simple Drag test works the same way but now connects to different blocks rather than two copies of the same block. This is because a second block of the same type would have a randomly generated ID which would make it impossible to track within the workspace.

## Links
https://codedotorg.atlassian.net/browse/CT-675

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
