### PR TITLE
Use translated welcome emails

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -125,9 +125,9 @@ class RegistrationsController < Devise::RegistrationsController
 
     if current_user && current_user.errors.blank?
       if current_user.teacher?
-        if MailJet.enabled? && request.locale != 'es-MX'
+        if MailJet.enabled?
           begin
-            MailJet.create_contact_and_send_welcome_email(current_user)
+            MailJet.create_contact_and_send_welcome_email(current_user, request.locale)
           rescue => exception
             # If the welcome email fails to send, we don't want to disrupt
             # sign up, but we do want to know about it.

--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -36,7 +36,7 @@ module MailJet
     end
   end
 
-  def self.create_contact_and_send_welcome_email(user)
+  def self.create_contact_and_send_welcome_email(user, locale = 'en-US')
     return unless enabled?
 
     return unless user&.id.present?
@@ -46,7 +46,8 @@ module MailJet
     update_contact_field(contact, 'sign_up_date', user.created_at.to_datetime.rfc3339)
     send_template_email(
       contact,
-      EMAILS[:welcome]
+      EMAILS[:welcome],
+      locale
     )
   end
 
@@ -107,7 +108,7 @@ module MailJet
     end
   end
 
-  def self.send_template_email(contact, email_config)
+  def self.send_template_email(contact, email_config, locale = 'en-US')
     return unless enabled?
     return unless contact&.email.present?
 
@@ -119,7 +120,8 @@ module MailJet
 
     from_address = email_config[:from_address]
     from_name = email_config[:from_name]
-    template_id = email_config[:template_id][subaccount.to_sym]
+    template_config = email_config[:template_id][subaccount.to_sym]
+    template_id = template_config[locale.to_sym] || template_config[:default]
 
     Mailjet::Send.create(messages:
       [{

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -5,7 +5,7 @@ module MailJetConstants
         production: {
           default: 5_831_384,
           'es-MX': 5_973_069,
-          'ex-ES': 5_973_070
+          'es-ES': 5_973_070
         },
         staging: {
           default: 5_917_989

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -4,15 +4,15 @@ module MailJetConstants
       template_id: {
         production: {
           default: 5_831_384,
-          'es-MX': 5_973_069,
-          'es-ES': 5_973_070
+          'es-MX': 6_135_180,
+          'es-ES': 6_135_179
         },
         staging: {
           default: 5_917_989
         },
         development: {
           default: 5_917_988,
-          'es-MX': 6_104_709,
+          'es-MX': 6_142_048,
         }
       },
       from_address: 'hadi_partovi@code.org',

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -2,9 +2,18 @@ module MailJetConstants
   EMAILS = {
     welcome: {
       template_id: {
-        production: 5_831_384,
-        staging: 5_917_989,
-        development: 5_917_988
+        production: {
+          default: 5_831_384,
+          'es-MX': 5_973_069,
+          'ex-ES': 5_973_070
+        },
+        staging: {
+          default: 5_917_989
+        },
+        development: {
+          default: 5_917_988,
+          'es-MX': 6_104_709,
+        }
       },
       from_address: 'hadi_partovi@code.org',
       from_name: 'Hadi Partovi',

--- a/lib/test/cdo/test_mailjet.rb
+++ b/lib/test/cdo/test_mailjet.rb
@@ -57,7 +57,7 @@ class MailJetTest < Minitest::Test
     MailJet.update_contact_field(mock_contact, 'field_name', 'field_value')
   end
 
-  def test_send_template_email
+  def test_send_template_email_default_locale
     to_email = 'fake.email@test.xx'
     to_name = 'Fake Name'
     from_address = 'test@code.org'
@@ -74,7 +74,9 @@ class MailJetTest < Minitest::Test
       from_address: from_address,
       from_name: from_name,
       template_id: {
-        unit_test: template_id
+        unit_test: {
+          default: template_id
+        }
       }
     }
 
@@ -89,7 +91,46 @@ class MailJetTest < Minitest::Test
         messages[0][:TemplateID] == template_id
     end
 
-    MailJet.send_template_email(mock_contact, email_config)
+    MailJet.send_template_email(mock_contact, email_config, 'en-US')
+  end
+
+  def test_send_template_email_locoalized
+    to_email = 'fake.email@test.xx'
+    to_name = 'Fake Name'
+    from_address = 'test@code.org'
+    from_name = 'Test Name'
+    default_template_id = 123
+    localized_template_id = 456
+
+    MailJet.stubs(:subaccount).returns('unit_test')
+
+    mock_contact = mock('Mailjet::Contact')
+    mock_contact.stubs(:email).returns(to_email)
+    mock_contact.stubs(:name).returns(to_name)
+
+    email_config = {
+      from_address: from_address,
+      from_name: from_name,
+      template_id: {
+        unit_test: {
+          default: default_template_id,
+          'es-MX': localized_template_id
+        }
+      }
+    }
+
+    Mailjet::Send.expects(:create).with do |params|
+      messages = params[:messages]
+      messages.length == 1 &&
+        messages[0][:From][:Email] == from_address &&
+        messages[0][:From][:Name] == from_name &&
+        messages[0][:To].length == 1 &&
+        messages[0][:To][0][:Email] == to_email &&
+        messages[0][:To][0][:Name] == to_name &&
+        messages[0][:TemplateID] == localized_template_id
+    end
+
+    MailJet.send_template_email(mock_contact, email_config, 'es-MX')
   end
 
   def test_create_contact_and_send_welcome_email
@@ -108,7 +149,7 @@ class MailJetTest < Minitest::Test
 
     MailJet.expects(:update_contact_field).with(mock_contactdata, 'sign_up_date', sign_up_time.rfc3339)
 
-    MailJet.expects(:send_template_email).with(mock_contactdata, MailJet::EMAILS[:welcome])
+    MailJet.expects(:send_template_email).with(mock_contactdata, MailJet::EMAILS[:welcome], 'en-US')
 
     MailJet.create_contact_and_send_welcome_email(user)
   end

--- a/lib/test/cdo/test_mailjet.rb
+++ b/lib/test/cdo/test_mailjet.rb
@@ -94,7 +94,7 @@ class MailJetTest < Minitest::Test
     MailJet.send_template_email(mock_contact, email_config, 'en-US')
   end
 
-  def test_send_template_email_locoalized
+  def test_send_template_email_localized
     to_email = 'fake.email@test.xx'
     to_name = 'Fake Name'
     from_address = 'test@code.org'


### PR DESCRIPTION
Uses the translated welcome emails! 🥳 

<img width="1061" alt="Screenshot 2024-07-16 at 12 02 49 PM" src="https://github.com/user-attachments/assets/cd7cf419-59cb-47df-877c-a2bf6be9e098">


I've created [a task](https://codedotorg.atlassian.net/browse/ACQ-2071) to clean up more of the code in a follow-up.