### PR TITLE
Add "Donate" string to the header translations

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -418,6 +418,7 @@ en:
       learn: "Learn"
       stats: "Stats"
       help_us: "Help Us"
+      donate: "Donate"
       teach: "Teach"
       about: "About"
       incubator: "Incubator"


### PR DESCRIPTION
Adds a `Donate` string for future use in the header navigation. I also added this to the [i18n gsheet](https://docs.google.com/spreadsheets/d/1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU/edit?gid=0#gid=0&range=1526:1526). 

## Links
Jira ticket: [ACQ-2050](https://codedotorg.atlassian.net/browse/ACQ-2050)