### PR TITLE
Submittable python lab levels: part 1

### DIFF
--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -411,7 +411,7 @@ export const sendSubmitReport = createAsyncThunk<
   const extraPayload = {
     submitted: payload.submitted,
   };
-  sendReportHelper(
+  await sendReportHelper(
     payload.appType,
     TestResults.CONTAINED_LEVEL_RESULT,
     thunkAPI.dispatch,

--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -95,7 +95,7 @@ export interface MilestoneReport extends OptionalMilestoneData {
 
 interface OptionalMilestoneData {
   program?: string;
-  submitted?: boolean;
+  submitted?: string;
 }
 
 const initialState: ProgressState = {
@@ -409,7 +409,7 @@ export const sendSubmitReport = createAsyncThunk<
   }
 >('progress/sendSubmitReport', async (payload, thunkAPI) => {
   const extraPayload = {
-    submitted: payload.submitted,
+    submitted: payload.submitted.toString(),
   };
   await sendReportHelper(
     payload.appType,

--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -411,12 +411,20 @@ export const sendSubmitReport = createAsyncThunk<
   const extraPayload = {
     submitted: payload.submitted.toString(),
   };
+  const result = payload.submitted
+    ? TestResults.SUBMITTED_RESULT
+    : TestResults.UNSUBMITTED_ATTEMPT;
   await sendReportHelper(
     payload.appType,
-    TestResults.CONTAINED_LEVEL_RESULT,
+    result,
     thunkAPI.dispatch,
     thunkAPI.getState,
     extraPayload
+  );
+  // Submit status isn't properly updated by just saving the status code, so re-query
+  // user progress to force the bubble to update.
+  thunkAPI.dispatch(
+    queryUserProgress(thunkAPI.getState().currentUser.userId.toString())
   );
 });
 

--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -95,6 +95,7 @@ export interface MilestoneReport extends OptionalMilestoneData {
 
 interface OptionalMilestoneData {
   program?: string;
+  // Submitted is a boolean, which the server expects as a string.
   submitted?: string;
 }
 

--- a/apps/src/codebridge/ControlButtons/index.tsx
+++ b/apps/src/codebridge/ControlButtons/index.tsx
@@ -6,12 +6,16 @@ import {
   navigateToNextLevel,
   sendSubmitReport,
 } from '@cdo/apps/code-studio/progressRedux';
-import {nextLevelId} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {
+  getCurrentLevel,
+  nextLevelId,
+} from '@cdo/apps/code-studio/progressReduxSelectors';
 import Button from '@cdo/apps/componentLibrary/button';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {useFetch} from '@cdo/apps/util/useFetch';
+import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import moduleStyles from './control-buttons.module.scss';
 
@@ -40,7 +44,9 @@ const ControlButtons: React.FunctionComponent = () => {
     state => state.lab.levelProperties?.submittable
   );
   const appType = useAppSelector(state => state.lab.levelProperties?.appName);
-  const hasSubmitted = useAppSelector(state => state.lab.submitted);
+  const hasSubmitted = useAppSelector(
+    state => getCurrentLevel(state)?.status === LevelStatus.submitted
+  );
   const disableRunAndTest = loading || (isPredictLevel && !hasPredictResponse);
 
   const onContinue = () => dispatch(navigateToNextLevel());

--- a/apps/src/codebridge/ControlButtons/index.tsx
+++ b/apps/src/codebridge/ControlButtons/index.tsx
@@ -33,6 +33,9 @@ const ControlButtons: React.FunctionComponent = () => {
   const isPredictLevel = useAppSelector(
     state => state.lab.levelProperties?.predictSettings?.isPredictLevel
   );
+  // const isSubmittable = useAppSelector(
+  //   state => state.lab.levelProperties?.submittable
+  // );
   const disableRunAndTest = loading || (isPredictLevel && !hasPredictResponse);
 
   const navigationButtonText = hasNextLevel

--- a/apps/src/codebridge/ControlButtons/index.tsx
+++ b/apps/src/codebridge/ControlButtons/index.tsx
@@ -69,25 +69,25 @@ const ControlButtons: React.FunctionComponent = () => {
     }
   };
 
-  const handleNavigation = () => {
+  const getNavigationButtonProps = () => {
     if (isSubmittable) {
-      onSubmit();
+      return {
+        navigationText: hasSubmitted
+          ? commonI18n.unsubmit()
+          : commonI18n.submit(),
+        handleNavigation: onSubmit,
+      };
     } else if (hasNextLevel) {
-      onContinue();
+      return {
+        navigationText: commonI18n.continue(),
+        handleNavigation: onContinue,
+      };
     } else {
-      onFinish();
+      return {navigationText: commonI18n.finish(), handleNavigation: onFinish};
     }
   };
 
-  const getNavigationButtonText = () => {
-    if (isSubmittable) {
-      return hasSubmitted ? commonI18n.unsubmit() : commonI18n.submit();
-    } else if (hasNextLevel) {
-      return commonI18n.continue();
-    } else {
-      return commonI18n.finish();
-    }
-  };
+  const {navigationText, handleNavigation} = getNavigationButtonProps();
 
   return (
     <div className={moduleStyles.controlButtonsContainer}>
@@ -109,7 +109,7 @@ const ControlButtons: React.FunctionComponent = () => {
         size={'s'}
       />
       <Button
-        text={getNavigationButtonText()}
+        text={navigationText}
         onClick={handleNavigation}
         disabled={loading}
         color={'purple'}

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -121,7 +121,6 @@ export const setUpWithLevel = createAsyncThunk(
       const levelProperties = await loadLevelProperties(
         payload.levelPropertiesPath
       );
-      console.log({levelProperties});
 
       Lab2Registry.getInstance()
         .getMetricsReporter()
@@ -168,7 +167,7 @@ export const setUpWithLevel = createAsyncThunk(
 
       if (levelProperties.submittable && payload.scriptId) {
         const userLevel = await getUserLevel(payload.levelId, payload.scriptId);
-        console.log({userLevel});
+        thunkAPI.dispatch(setSubmitted(userLevel?.submitted || false));
       }
 
       // Create a new project manager. If we have a channel id,
@@ -523,10 +522,9 @@ export const {
   clearPageError,
   setValidationState,
   setIsShareView,
-  setSubmitted,
 } = labSlice.actions;
 
 // These should not be set outside of the lab slice.
-const {setChannel, onLevelChange} = labSlice.actions;
+const {setChannel, onLevelChange, setSubmitted} = labSlice.actions;
 
 export default labSlice.reducer;

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -70,9 +70,6 @@ export interface LabState {
   levelProperties: LevelProperties | undefined;
   // If this lab should presented in a "share" or "play-only" view, which may hide certain UI elements.
   isShareView: boolean | undefined;
-  // If this is a submittable level, boolean indicating if the user has submitted their response.
-  // A submitted level should be read-only.
-  submitted: boolean | undefined;
 }
 
 const initialState: LabState = {
@@ -84,7 +81,6 @@ const initialState: LabState = {
   validationState: getInitialValidationState(),
   levelProperties: undefined,
   isShareView: undefined,
-  submitted: undefined,
 };
 
 // Thunks

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -40,6 +40,7 @@ import {
 } from '@cdo/apps/lab2/projects/utils';
 import {START_SOURCES} from './constants';
 import {getPredictResponse, getUserLevel} from './projects/userLevelsApi';
+import {sendSubmitReport} from '../code-studio/progressRedux';
 
 interface PageError {
   errorMessage: string;
@@ -397,6 +398,9 @@ const labSlice = createSlice({
     });
     builder.addCase(setUpWithoutLevel.pending, state => {
       state.isLoadingProjectOrLevel = true;
+    });
+    builder.addCase(sendSubmitReport.fulfilled, (state, action) => {
+      state.submitted = action.meta.arg.submitted;
     });
   },
 });

--- a/apps/src/lab2/projects/userLevelsApi.ts
+++ b/apps/src/lab2/projects/userLevelsApi.ts
@@ -1,7 +1,28 @@
 import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
 
 const rootUrl = (levelId: number, scriptId: number) =>
-  `/user_levels/level_source/${scriptId}/${levelId}`;
+  `/user_levels/${scriptId}/${levelId}`;
+
+interface UserLevelResponse {
+  user_level: UserLevel;
+}
+
+export interface UserLevel {
+  id: number;
+  level_id: number;
+  script_id: number;
+  user_id: number;
+  attempts: number;
+  submitted: boolean;
+  created_at: string;
+  updated_at: string;
+  best_result: number;
+  level_source_id: number;
+  readonly_answers: boolean | null;
+  time_spent: number;
+  unlocked_at: string | null;
+  deleted_at: string | null;
+}
 
 export async function getPredictResponse(
   levelId: number,
@@ -9,11 +30,33 @@ export async function getPredictResponse(
 ): Promise<string | null> {
   try {
     const response = await HttpClient.fetchJson<{data: string}>(
-      rootUrl(levelId, scriptId),
+      `${rootUrl(levelId, scriptId)}/level_source`,
       {}
     );
     // The program is the predict response.
     return response.value?.data;
+  } catch (e) {
+    if (e instanceof NetworkError) {
+      // If we hit a network error, it could mean there is no logged-in user
+      // or we had some other issue.
+      // In this case, just return null rather than crashing the page.
+      return null;
+    }
+    throw e;
+  }
+}
+
+export async function getUserLevel(
+  levelId: number,
+  scriptId: number
+): Promise<UserLevel | null> {
+  try {
+    const response = await HttpClient.fetchJson<UserLevelResponse>(
+      rootUrl(levelId, scriptId),
+      {}
+    );
+    // The program is the predict response.
+    return response.value?.user_level;
   } catch (e) {
     if (e instanceof NetworkError) {
       // If we hit a network error, it could mean there is no logged-in user

--- a/apps/src/lab2/projects/userLevelsApi.ts
+++ b/apps/src/lab2/projects/userLevelsApi.ts
@@ -1,28 +1,7 @@
 import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
 
 const rootUrl = (levelId: number, scriptId: number) =>
-  `/user_levels/${scriptId}/${levelId}`;
-
-interface UserLevelResponse {
-  user_level: UserLevel;
-}
-
-export interface UserLevel {
-  id: number;
-  level_id: number;
-  script_id: number;
-  user_id: number;
-  attempts: number;
-  submitted: boolean;
-  created_at: string;
-  updated_at: string;
-  best_result: number;
-  level_source_id: number;
-  readonly_answers: boolean | null;
-  time_spent: number;
-  unlocked_at: string | null;
-  deleted_at: string | null;
-}
+  `/user_levels/level_source/${scriptId}/${levelId}`;
 
 export async function getPredictResponse(
   levelId: number,
@@ -30,32 +9,11 @@ export async function getPredictResponse(
 ): Promise<string | null> {
   try {
     const response = await HttpClient.fetchJson<{data: string}>(
-      `${rootUrl(levelId, scriptId)}/level_source`,
+      rootUrl(levelId, scriptId),
       {}
     );
     // The program is the predict response.
     return response.value?.data;
-  } catch (e) {
-    if (e instanceof NetworkError) {
-      // If we hit a network error, it could mean there is no logged-in user
-      // or we had some other issue.
-      // In this case, just return null rather than crashing the page.
-      return null;
-    }
-    throw e;
-  }
-}
-
-export async function getUserLevel(
-  levelId: number,
-  scriptId: number
-): Promise<UserLevel | null> {
-  try {
-    const response = await HttpClient.fetchJson<UserLevelResponse>(
-      rootUrl(levelId, scriptId),
-      {}
-    );
-    return response.value?.user_level;
   } catch (e) {
     if (e instanceof NetworkError) {
       // If we hit a network error, it could mean there is no logged-in user

--- a/apps/src/lab2/projects/userLevelsApi.ts
+++ b/apps/src/lab2/projects/userLevelsApi.ts
@@ -55,7 +55,6 @@ export async function getUserLevel(
       rootUrl(levelId, scriptId),
       {}
     );
-    // The program is the predict response.
     return response.value?.user_level;
   } catch (e) {
     if (e instanceof NetworkError) {

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -160,6 +160,7 @@ export interface LevelProperties {
   // For Teachers Only value
   teacherMarkdown?: string;
   predictSettings?: LevelPredictSettings;
+  submittable?: boolean;
 }
 
 // Level configuration data used by project-backed labs that don't require

--- a/dashboard/app/controllers/user_levels_controller.rb
+++ b/dashboard/app/controllers/user_levels_controller.rb
@@ -40,13 +40,22 @@ class UserLevelsController < ApplicationController
     return head :ok
   end
 
-  # GET /user_levels/level_source/:script_id/:level_id
+  # GET /user_levels/:script_id/:level_id/level_source
   # Get the level source data for the current user's most recent attempt at the given level in the given script.
   # If there is no attempt, return null.
   def get_level_source
     user_levels = UserLevel.where(user_id: current_user.id, level_id: params[:level_id], script_id: params[:script_id])
     most_recent_user_level = user_levels.order(updated_at: :desc).first
     return render json: {data: most_recent_user_level&.level_source&.data}, status: :ok
+  end
+
+  # GET /user_levels/:script_id/:level_id
+  # Get the user level for the current user's most recent attempt at the given level in the given script.
+  # If there is no attempt, return null.
+  def get
+    user_levels = UserLevel.where(user_id: current_user.id, level_id: params[:level_id], script_id: params[:script_id])
+    most_recent_user_level = user_levels.order(updated_at: :desc).first
+    return render json: {user_level: most_recent_user_level}, status: :ok
   end
 
   private def set_user_level

--- a/dashboard/app/controllers/user_levels_controller.rb
+++ b/dashboard/app/controllers/user_levels_controller.rb
@@ -1,5 +1,5 @@
 class UserLevelsController < ApplicationController
-  before_action :authenticate_user!, except: [:get_level_source, :get]
+  before_action :authenticate_user!, except: [:get_level_source]
   check_authorization
   load_and_authorize_resource
   protect_from_forgery except: [:update] # referer is the script level page which is publically cacheable

--- a/dashboard/app/controllers/user_levels_controller.rb
+++ b/dashboard/app/controllers/user_levels_controller.rb
@@ -1,5 +1,5 @@
 class UserLevelsController < ApplicationController
-  before_action :authenticate_user!, except: [:get_level_source]
+  before_action :authenticate_user!, except: [:get_level_source, :get]
   check_authorization
   load_and_authorize_resource
   protect_from_forgery except: [:update] # referer is the script level page which is publically cacheable
@@ -40,22 +40,13 @@ class UserLevelsController < ApplicationController
     return head :ok
   end
 
-  # GET /user_levels/:script_id/:level_id/level_source
+  # GET /user_levels/level_source/:script_id/:level_id
   # Get the level source data for the current user's most recent attempt at the given level in the given script.
   # If there is no attempt, return null.
   def get_level_source
     user_levels = UserLevel.where(user_id: current_user.id, level_id: params[:level_id], script_id: params[:script_id])
     most_recent_user_level = user_levels.order(updated_at: :desc).first
     return render json: {data: most_recent_user_level&.level_source&.data}, status: :ok
-  end
-
-  # GET /user_levels/:script_id/:level_id
-  # Get the user level for the current user's most recent attempt at the given level in the given script.
-  # If there is no attempt, return null.
-  def get
-    user_levels = UserLevel.where(user_id: current_user.id, level_id: params[:level_id], script_id: params[:script_id])
-    most_recent_user_level = user_levels.order(updated_at: :desc).first
-    return render json: {user_level: most_recent_user_level}, status: :ok
   end
 
   private def set_user_level

--- a/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
@@ -6,7 +6,7 @@
 
 #special-levels.in.collapse
   -# Dance and Spritelab are special types of Gamelab levels
-  - if @level.is_a?(Gamelab) || @level.is_a?(Applab) || @level.is_a?(Weblab) || @level.is_a?(FreeResponse) || @level.is_a?(Javalab)
+  - if @level.is_a?(Gamelab) || @level.is_a?(Applab) || @level.is_a?(Weblab) || @level.is_a?(FreeResponse) || @level.is_a?(Javalab) || @level.is_a?(Pythonlab)
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :submittable, description: "Submittable"}
     %p
       If checked, students with teachers can "submit" a solution for

--- a/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 7.level
+++ b/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 7.level
@@ -1,0 +1,41 @@
+<Pythonlab>
+  <config><![CDATA[{
+  "published": true,
+  "game_id": 72,
+  "created_at": "2024-07-10T04:07:00.000Z",
+  "level_num": "custom",
+  "user_id": 6959,
+  "properties": {
+    "encrypted": "false",
+    "source": {
+      "files": {
+        "0": {
+          "id": "0",
+          "name": "main.py",
+          "language": "py",
+          "contents": "print('Hello start!')",
+          "folderId": "1",
+          "active": true,
+          "open": true
+        }
+      },
+      "folders": {
+        "1": {
+          "id": "1",
+          "name": "src",
+          "parentId": "0",
+          "open": true
+        }
+      }
+    },
+    "long_instructions": "## Submittable Level\r\nHere's a sample submittable level!",
+    "hide_share_and_remix": "true",
+    "teacher_markdown": "Teachers should see this extra info.",
+    "submittable": "true",
+    "predict_settings": {
+      "isPredictLevel": false
+    }
+  },
+  "audit_log": "[{\"changed_at\":\"2024-07-09T14:07:00.198-07:00\",\"changed\":[\"cloned from \\\"Allthethings Python Lab 1\\\"\"],\"cloned_from\":\"Allthethings Python Lab 1\"},{\"changed_at\":\"2024-07-09 14:07:34 -0700\",\"changed\":[\"long_instructions\",\"reference_links\",\"map_reference\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]"
+}]]></config>
+</Pythonlab>

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -26,8 +26,7 @@ Dashboard::Application.routes.draw do
     resources :user_levels, only: [:update, :destroy]
     post '/delete_predict_level_progress', to: 'user_levels#delete_predict_level_progress'
     get '/user_levels/get_token', to: 'user_levels#get_token'
-    get '/user_levels/:script_id/:level_id/level_source', to: 'user_levels#get_level_source'
-    get '/user_levels/:script_id/:level_id', to: 'user_levels#get'
+    get '/user_levels/level_source/:script_id/:level_id', to: 'user_levels#get_level_source'
 
     patch '/api/v1/user_scripts/:script_id', to: 'api/v1/user_scripts#update'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -26,7 +26,8 @@ Dashboard::Application.routes.draw do
     resources :user_levels, only: [:update, :destroy]
     post '/delete_predict_level_progress', to: 'user_levels#delete_predict_level_progress'
     get '/user_levels/get_token', to: 'user_levels#get_token'
-    get '/user_levels/level_source/:script_id/:level_id', to: 'user_levels#get_level_source'
+    get '/user_levels/:script_id/:level_id/level_source', to: 'user_levels#get_level_source'
+    get '/user_levels/:script_id/:level_id', to: 'user_levels#get'
 
     patch '/api/v1/user_scripts/:script_id', to: 'api/v1/user_scripts#update'
 

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2024-06-26 17:56:17 UTC",
+    "serialized_at": "2024-07-09 21:08:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -6521,6 +6521,9 @@
       "activity_section_position": 5,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Allthethings Python Lab 5"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6542,6 +6545,9 @@
       "activity_section_position": 6,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Allthethings Python Lab 6"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6559,6 +6565,27 @@
     },
     {
       "chapter": 183,
+      "position": 7,
+      "activity_section_position": 7,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Allthethings Python Lab 7"
+        ],
+        "lesson.key": "lesson-53",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "465bc905-13b5-487c-8fd6-8043676ee607"
+      },
+      "level_keys": [
+        "Allthethings Python Lab 7"
+      ]
+    },
+    {
+      "chapter": 184,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6582,7 +6609,7 @@
       ]
     },
     {
-      "chapter": 184,
+      "chapter": 185,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6606,7 +6633,7 @@
       ]
     },
     {
-      "chapter": 185,
+      "chapter": 186,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6630,7 +6657,7 @@
       ]
     },
     {
-      "chapter": 186,
+      "chapter": 187,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6654,7 +6681,7 @@
       ]
     },
     {
-      "chapter": 187,
+      "chapter": 188,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6678,7 +6705,7 @@
       ]
     },
     {
-      "chapter": 188,
+      "chapter": 189,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6702,7 +6729,7 @@
       ]
     },
     {
-      "chapter": 189,
+      "chapter": 190,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6726,7 +6753,7 @@
       ]
     },
     {
-      "chapter": 190,
+      "chapter": 191,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6750,7 +6777,7 @@
       ]
     },
     {
-      "chapter": 191,
+      "chapter": 192,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -6774,7 +6801,7 @@
       ]
     },
     {
-      "chapter": 192,
+      "chapter": 193,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -9102,6 +9129,18 @@
         "level.key": "Allthethings Python Lab 6",
         "script_level.level_keys": [
           "Allthethings Python Lab 6"
+        ],
+        "lesson.key": "lesson-53",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "465bc905-13b5-487c-8fd6-8043676ee607"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Allthethings Python Lab 7",
+        "script_level.level_keys": [
+          "Allthethings Python Lab 7"
         ],
         "lesson.key": "lesson-53",
         "lesson_group.key": "",


### PR DESCRIPTION
Part 1 of making submittable python levels. Submittable levels work as follows:
 1. The level is designated as submittable in the level configuration
 2. The continue/finish button says "submit" instead of continue/finish.
 3. The user must run their code at least once for the submit button to be enabled.
 4. When the user clicks submit, their code is marked as submitted and is locked for edits. The user can "unsubmit" their code (the submit button becomes an unsubmit button in this case) in order to edit again.
 5. The progress bubble turns purple when their code is submitted.

This PR covers most of the work for this. The work not included is the logic to ensure the user has run their code before submitting, and adding a confirmation modal on submit/unsubmit. These will be covered in a follow-up PR.

## Links

- jira ticket: [CT-621](https://codedotorg.atlassian.net/browse/CT-621)

## Testing story
Tested that you can submit and unsubmit a submittable python lab level, and other levels are unchanged.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
