### PR TITLE
chore(deps): bump jshint to latest to mitigate lodash critical

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -253,7 +253,7 @@
     "jquery": "1.12.1",
     "jquery-ui": "^1.12.1",
     "js-cookie": "^2.1.2",
-    "jshint": "^2.9.5",
+    "jshint": "^2.13.6",
     "jsonic": "^0.3.0",
     "jszip": "3.10.1",
     "lazysizes": "^4.0.0-rc1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8796,7 +8796,7 @@ __metadata:
     jquery: 1.12.1
     jquery-ui: ^1.12.1
     js-cookie: ^2.1.2
-    jshint: ^2.9.5
+    jshint: ^2.13.6
     json-parse-better-errors: ^1.0.1
     jsonic: ^0.3.0
     jszip: 3.10.1
@@ -17864,21 +17864,20 @@ es6-shim@latest:
   languageName: node
   linkType: hard
 
-"jshint@npm:^2.9.5":
-  version: 2.9.5
-  resolution: "jshint@npm:2.9.5"
+"jshint@npm:^2.13.6":
+  version: 2.13.6
+  resolution: "jshint@npm:2.13.6"
   dependencies:
     cli: ~1.0.0
     console-browserify: 1.1.x
     exit: 0.1.x
     htmlparser2: 3.8.x
-    lodash: 3.7.x
+    lodash: ~4.17.21
     minimatch: ~3.0.2
-    shelljs: 0.3.x
     strip-json-comments: 1.0.x
   bin:
-    jshint: ./bin/jshint
-  checksum: e04da959ad69fc49852cfa052f7e8541c77158a942d71ddd5511f5f6edeb222779eb56cca1d5527040e93ca851186406e474ca12e9cdf85537aaca3134cb8d7e
+    jshint: bin/jshint
+  checksum: ec7f67feef215445a338f4d1594396428db42a47cb2e157e543331b41a7d590d83fa6441302af4d19a1700e1f9132328747913090d5590d2730798de4c9826d2
   languageName: node
   linkType: hard
 
@@ -18586,13 +18585,6 @@ es6-shim@latest:
   version: 4.4.2
   resolution: "lodash.truncate@npm:4.4.2"
   checksum: b463d8a382cfb5f0e71c504dcb6f807a7bd379ff1ea216669aa42c52fc28c54e404bfbd96791aa09e6df0de2c1d7b8f1b7f4b1a61f324d38fe98bc535aeee4f5
-  languageName: node
-  linkType: hard
-
-"lodash@npm:3.7.x":
-  version: 3.7.0
-  resolution: "lodash@npm:3.7.0"
-  checksum: 78b7ab0eeb1e6999a22ff855bed8e2d0d1ee58392956ed8c5f46ad4c3b449ea76c01767225713ec1836e77841319ae1d3a7f1f8972bb51e57adea9a15f50eb96
   languageName: node
   linkType: hard
 
@@ -24819,15 +24811,6 @@ es6-shim@latest:
   version: 1.8.1
   resolution: "shell-quote@npm:1.8.1"
   checksum: 5f01201f4ef504d4c6a9d0d283fa17075f6770bfbe4c5850b074974c68062f37929ca61700d95ad2ac8822e14e8c4b990ca0e6e9272e64befd74ce5e19f0736b
-  languageName: node
-  linkType: hard
-
-"shelljs@npm:0.3.x":
-  version: 0.3.0
-  resolution: "shelljs@npm:0.3.0"
-  bin:
-    shjs: ./bin/shjs
-  checksum: 6e57d6bff3bb101525f251fd80358b983fb9c8175dc31593496bfcdf66701b78dba33b9319e38026ac31b2c80875794fc71bd2fdd9cdb86fbeb81fcbfce28d7b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Our version of jshint brings in an outdated version of lodash. Updating jshint to bring up lodash and the latest changes from the jshint package.

```
├─ jshint@npm:2.9.5
│  └─ lodash@npm:3.7.0 (via npm:3.7.x)
```

## Links

- [jshint changelog](https://jshint.com/blog/)

## Testing story

jshint is used in code mirror, was able to confirm jshint appears on level builder:

![image](https://github.com/code-dot-org/code-dot-org/assets/538214/d4f35363-c42c-4142-8655-de6e38a69021)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
