### PR TITLE
Revert "Delete all datablock storage tables and kvps for user on account deletion"

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -50,6 +50,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     end
 
     # Skip real Firebase operations
+    # TODO: unfirebase, write a version of this for Datablock Storage: #57004
     # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
     FirebaseHelper.stubs(:delete_channel)
     FirebaseHelper.stubs(:delete_channels)
@@ -1909,55 +1910,6 @@ class DeleteAccountsHelperTest < ActionView::TestCase
           with(storage_encrypt_channel_id(storage_id, project_id_b))
 
         purge_user student
-      end
-    end
-  end
-
-  #
-  # Project tables and kvps i.e. datablock storage
-  #
-
-  # Table: dashboard.datablock_storage_tables, dashboard.datablock_storage_records
-  test "Datablock Storage: hard-deletes all of user's project tables" do
-    student = create :student
-    with_channel_for student do |project_id_a, _|
-      with_channel_for student do |project_id_b, _|
-        timestamp = DateTime.now
-        DASHBOARD_DB[:datablock_storage_tables].insert(project_id: project_id_a, table_name: "table_a", columns: '["id", "name"]', created_at: timestamp, updated_at: timestamp)
-        DASHBOARD_DB[:datablock_storage_records].insert(project_id: project_id_a, table_name: "table_a", record_id: 1, record_json: '{"id": 1, "name": "Bob"}')
-        DASHBOARD_DB[:datablock_storage_tables].insert(project_id: project_id_b, table_name: "table_b", columns: '["id", "name"]', created_at: timestamp, updated_at: timestamp)
-        DASHBOARD_DB[:datablock_storage_records].insert(project_id: project_id_b, table_name: "table_b", record_id: 1, record_json: '{"id": 1, "name": "Alice"}')
-
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_tables].where(project_id: project_id_a).count
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_tables].where(project_id: project_id_b).count
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_records].where(project_id: project_id_a).count
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_records].where(project_id: project_id_b).count
-
-        purge_user student
-        assert_logged "Deleting Datablock Storage contents for 2 projects"
-        assert_empty DASHBOARD_DB[:datablock_storage_tables].where(project_id: project_id_a)
-        assert_empty DASHBOARD_DB[:datablock_storage_tables].where(project_id: project_id_b)
-        assert_empty DASHBOARD_DB[:datablock_storage_records].where(project_id: project_id_a)
-        assert_empty DASHBOARD_DB[:datablock_storage_records].where(project_id: project_id_b)
-      end
-    end
-  end
-
-  # Table: dashboard.datablock_storage_kvps
-  test "Datablock Storage: hard-deletes all of user's project kvps" do
-    student = create :student
-    with_channel_for student do |project_id_a, _|
-      with_channel_for student do |project_id_b, _|
-        DASHBOARD_DB[:datablock_storage_kvps].insert(project_id: project_id_a, key: "key_a", value: '"value_a"')
-        DASHBOARD_DB[:datablock_storage_kvps].insert(project_id: project_id_b, key: "key_b", value: '"value_b"')
-
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_kvps].where(project_id: project_id_a).count
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_kvps].where(project_id: project_id_b).count
-
-        purge_user student
-        assert_logged "Deleting Datablock Storage contents for 2 projects"
-        assert_empty DASHBOARD_DB[:datablock_storage_kvps].where(project_id: project_id_a)
-        assert_empty DASHBOARD_DB[:datablock_storage_kvps].where(project_id: project_id_b)
       end
     end
   end

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -72,17 +72,10 @@ class DeleteAccountsHelper
     end
 
     # Clear Firebase contents for user's channels
+    # TODO: unfirebase, write a version of this for Datablock Storage: #57004
     # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
     @log.puts "Deleting Firebase contents for #{channel_count} channels"
     FirebaseHelper.delete_channels encrypted_channel_ids
-
-    # Clear Datablock Storage contents for user's projects
-    @log.puts "Deleting Datablock Storage contents for #{project_ids.count} projects"
-    project_ids.each do |project_id|
-      DASHBOARD_DB[:datablock_storage_tables].where(project_id: project_id).delete
-      DASHBOARD_DB[:datablock_storage_kvps].where(project_id: project_id).delete
-      DASHBOARD_DB[:datablock_storage_records].where(project_id: project_id).delete
-    end
 
     @log.puts "Deleted #{channel_count} channels" if channel_count > 0
   end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#58999

The way we're using projects in tests here is causing other PRs to break (e.g. https://drone.cdn-code.org/code-dot-org/code-dot-org/10033/1/6): https://codedotorg.slack.com/archives/C0T0PNTM3/p1720624805278149