### PR TITLE
Revert "Revert "Delete all datablock storage tables and kvps for user on account deletion""

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1923,22 +1923,22 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     with_channel_for student do |project_id_a, _|
       with_channel_for student do |project_id_b, _|
         timestamp = DateTime.now
-        DASHBOARD_DB[:datablock_storage_tables].insert(project_id: project_id_a, table_name: "table_a", columns: '["id", "name"]', created_at: timestamp, updated_at: timestamp)
-        DASHBOARD_DB[:datablock_storage_records].insert(project_id: project_id_a, table_name: "table_a", record_id: 1, record_json: '{"id": 1, "name": "Bob"}')
-        DASHBOARD_DB[:datablock_storage_tables].insert(project_id: project_id_b, table_name: "table_b", columns: '["id", "name"]', created_at: timestamp, updated_at: timestamp)
-        DASHBOARD_DB[:datablock_storage_records].insert(project_id: project_id_b, table_name: "table_b", record_id: 1, record_json: '{"id": 1, "name": "Alice"}')
+        DatablockStorageTable.create(project_id: project_id_a, table_name: "table_a", columns: '["id", "name"]', created_at: timestamp, updated_at: timestamp)
+        DatablockStorageRecord.create(project_id: project_id_a, table_name: "table_a", record_id: 1, record_json: '{"id": 1, "name": "Bob"}')
+        DatablockStorageTable.create(project_id: project_id_b, table_name: "table_b", columns: '["id", "name"]', created_at: timestamp, updated_at: timestamp)
+        DatablockStorageRecord.create(project_id: project_id_b, table_name: "table_b", record_id: 1, record_json: '{"id": 1, "name": "Alice"}')
 
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_tables].where(project_id: project_id_a).count
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_tables].where(project_id: project_id_b).count
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_records].where(project_id: project_id_a).count
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_records].where(project_id: project_id_b).count
+        assert_equal 1, DatablockStorageTable.where(project_id: project_id_a).count
+        assert_equal 1, DatablockStorageTable.where(project_id: project_id_b).count
+        assert_equal 1, DatablockStorageRecord.where(project_id: project_id_a).count
+        assert_equal 1, DatablockStorageRecord.where(project_id: project_id_b).count
 
         purge_user student
         assert_logged "Deleting Datablock Storage contents for 2 projects"
-        assert_empty DASHBOARD_DB[:datablock_storage_tables].where(project_id: project_id_a)
-        assert_empty DASHBOARD_DB[:datablock_storage_tables].where(project_id: project_id_b)
-        assert_empty DASHBOARD_DB[:datablock_storage_records].where(project_id: project_id_a)
-        assert_empty DASHBOARD_DB[:datablock_storage_records].where(project_id: project_id_b)
+        assert_empty DatablockStorageTable.where(project_id: project_id_a)
+        assert_empty DatablockStorageTable.where(project_id: project_id_b)
+        assert_empty DatablockStorageRecord.where(project_id: project_id_a)
+        assert_empty DatablockStorageRecord.where(project_id: project_id_b)
       end
     end
   end
@@ -1948,16 +1948,16 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     student = create :student
     with_channel_for student do |project_id_a, _|
       with_channel_for student do |project_id_b, _|
-        DASHBOARD_DB[:datablock_storage_kvps].insert(project_id: project_id_a, key: "key_a", value: '"value_a"')
-        DASHBOARD_DB[:datablock_storage_kvps].insert(project_id: project_id_b, key: "key_b", value: '"value_b"')
+        DatablockStorageKvp.set_kvp(project_id_a, "key_a", '"value_a"')
+        DatablockStorageKvp.set_kvp(project_id_b, "key_b", '"value_b"')
 
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_kvps].where(project_id: project_id_a).count
-        assert_equal 1, DASHBOARD_DB[:datablock_storage_kvps].where(project_id: project_id_b).count
+        assert_equal 1, DatablockStorageKvp.where(project_id: project_id_a).count
+        assert_equal 1, DatablockStorageKvp.where(project_id: project_id_b).count
 
         purge_user student
         assert_logged "Deleting Datablock Storage contents for 2 projects"
-        assert_empty DASHBOARD_DB[:datablock_storage_kvps].where(project_id: project_id_a)
-        assert_empty DASHBOARD_DB[:datablock_storage_kvps].where(project_id: project_id_b)
+        assert_empty DatablockStorageKvp.where(project_id: project_id_a)
+        assert_empty DatablockStorageKvp.where(project_id: project_id_b)
       end
     end
   end

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -50,6 +50,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     end
 
     # Skip real Firebase operations
+    # TODO: unfirebase, write a version of this for Datablock Storage: #57004
     # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
     FirebaseHelper.stubs(:delete_channel)
     FirebaseHelper.stubs(:delete_channels)

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -72,6 +72,7 @@ class DeleteAccountsHelper
     end
 
     # Clear Firebase contents for user's channels
+    # TODO: unfirebase, write a version of this for Datablock Storage: #57004
     # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
     @log.puts "Deleting Firebase contents for #{channel_count} channels"
     FirebaseHelper.delete_channels encrypted_channel_ids

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -79,9 +79,9 @@ class DeleteAccountsHelper
     # Clear Datablock Storage contents for user's projects
     @log.puts "Deleting Datablock Storage contents for #{project_ids.count} projects"
     project_ids.each do |project_id|
-      DASHBOARD_DB[:datablock_storage_tables].where(project_id: project_id).delete
-      DASHBOARD_DB[:datablock_storage_kvps].where(project_id: project_id).delete
-      DASHBOARD_DB[:datablock_storage_records].where(project_id: project_id).delete
+      DatablockStorageTable.where(project_id: project_id).delete_all
+      DatablockStorageKvp.where(project_id: project_id).delete_all
+      DatablockStorageRecord.where(project_id: project_id).delete_all
     end
 
     @log.puts "Deleted #{channel_count} channels" if channel_count > 0

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -72,10 +72,17 @@ class DeleteAccountsHelper
     end
 
     # Clear Firebase contents for user's channels
-    # TODO: unfirebase, write a version of this for Datablock Storage: #57004
     # TODO: post-firebase-cleanup, switch to the datablock storage version: #56994
     @log.puts "Deleting Firebase contents for #{channel_count} channels"
     FirebaseHelper.delete_channels encrypted_channel_ids
+
+    # Clear Datablock Storage contents for user's projects
+    @log.puts "Deleting Datablock Storage contents for #{project_ids.count} projects"
+    project_ids.each do |project_id|
+      DASHBOARD_DB[:datablock_storage_tables].where(project_id: project_id).delete
+      DASHBOARD_DB[:datablock_storage_kvps].where(project_id: project_id).delete
+      DASHBOARD_DB[:datablock_storage_records].where(project_id: project_id).delete
+    end
 
     @log.puts "Deleted #{channel_count} channels" if channel_count > 0
   end


### PR DESCRIPTION
Restores: https://github.com/code-dot-org/code-dot-org/pull/58999

Which we reverted because it broke other tests in that "accessing projects causes SQL timeouts" sort of way:
```
deletes_all_of_user's_project_kvps", "DeleteAccountsHelperTest", 1420.216571637]
 test_Datablock_Storage:_hard-deletes_all_of_user's_project_kvps#DeleteAccountsHelperTest (1420.22s)
Minitest::UnexpectedError:         Sequel::DatabaseDisconnectError: Mysql2::Error::ConnectionError: Lost connection to MySQL server during query
            test/testing/projects_test_utils.rb:14:in `ensure in block in with_channel_for'
```

This type of issue usually occurs because of using both ActiveRecord /and/ "direct SQL" to access the projects table. Usually its caused by getting a project, but in this case, we're directly doing non-activerecord sql(`DASHBOARD_DB[:datablock_storage_tables]`) and I wonder if we're causing it that way.... this might just go away if we rewrite using activerecord (even if we keep it as raw sql, if we use activerecord's sql connection rather than DASHBOARD_DB)