### PR TITLE
Update Teach AI banner on /ai

### DIFF
--- a/pegasus/sites.v3/code.org/public/ai/index.haml
+++ b/pegasus/sites.v3/code.org/public/ai/index.haml
@@ -162,7 +162,7 @@ theme: responsive_full_width
         =hoc_s('teach_ai_banner_july_2024.headline')
       %p.body-three
         =hoc_s('teach_ai_banner_july_2024.description')
-      %a.link-button.has-external-link{href: "https://teachai.org/policy", target: "_blank", rel: "noopener noreferrer"}
+      %a.link-button.has-external-link{href: "https://teachai.org/cs", target: "_blank", rel: "noopener noreferrer"}
         =hoc_s('teach_ai_banner_july_2024.button_text')
   .clear
 

--- a/pegasus/sites.v3/code.org/public/ai/index.haml
+++ b/pegasus/sites.v3/code.org/public/ai/index.haml
@@ -154,16 +154,16 @@ theme: responsive_full_width
 %section.bg-neutral-light
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     %figure.col-45{style: "margin-bottom: 1rem"}
-      %img{src: "/images/ai/pl/101/TeachAI.png", alt: "", style: "width: 100%"}
+      %img{src: "/images/ai/pl/101/teach-ai-future-of-cs.png", alt: "", style: "width: 100%"}
     .text-wrapper.col-50{style: "margin-bottom: 1rem"}
       %p.new
-        =hoc_s(:new)
+        =hoc_s('teach_ai_banner_july_2024.subtitle')
       %h2.heading-lg
-        =hoc_s(:ai_promote_literacy)
+        =hoc_s('teach_ai_banner_july_2024.headline')
       %p.body-three
-        =hoc_s(:ai_section_body)
+        =hoc_s('teach_ai_banner_july_2024.description')
       %a.link-button.has-external-link{href: "https://teachai.org/policy", target: "_blank", rel: "noopener noreferrer"}
-        =hoc_s(:ai_explore_the_resources)
+        =hoc_s('teach_ai_banner_july_2024.button_text')
   .clear
 
 %section.no-padding-bottom

--- a/pegasus/sites.v3/code.org/public/images/ai/pl/101/teach-ai-future-of-cs.png
+++ b/pegasus/sites.v3/code.org/public/images/ai/pl/101/teach-ai-future-of-cs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67a61aa97b136b70c309c865283459304245d13da66f41f6e4a925948106a7d1
+size 177409


### PR DESCRIPTION
Updates the Teach AI banner on code.org/ai.

![Screenshot 2024-07-10 at 4 34 50 PM](https://github.com/code-dot-org/code-dot-org/assets/46464143/e7e335a3-b5f0-4de2-b66a-9e6db728f89f)


