### PR TITLE
AI Chat: add tooltips to presentation view

### DIFF
--- a/apps/src/aichat/views/InfoTooltipIcon.tsx
+++ b/apps/src/aichat/views/InfoTooltipIcon.tsx
@@ -1,0 +1,40 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
+import {TooltipProps, WithTooltip} from '@cdo/apps/componentLibrary/tooltip';
+
+import styles from './info-tooltip-icon.module.scss';
+
+interface InfoTooltipIconProps {
+  id: string;
+  tooltipText: string;
+  direction?: TooltipProps['direction'];
+}
+
+const InfoTooltipIcon: React.FunctionComponent<InfoTooltipIconProps> = ({
+  id,
+  tooltipText,
+  direction,
+}) => {
+  return (
+    <WithTooltip
+      tooltipProps={{
+        text: tooltipText,
+        size: 's',
+        tooltipId: `${id}-tooltip`,
+        direction,
+        className: classNames(
+          styles.tooltip,
+          direction && styles[`tooltip-${direction}`]
+        ),
+      }}
+    >
+      <button type="button" className={styles.iconButton}>
+        <FontAwesomeV6Icon iconName={'info-circle'} className={styles.icon} />
+      </button>
+    </WithTooltip>
+  );
+};
+
+export default InfoTooltipIcon;

--- a/apps/src/aichat/views/info-tooltip-icon.module.scss
+++ b/apps/src/aichat/views/info-tooltip-icon.module.scss
@@ -1,0 +1,27 @@
+@import 'color.scss';
+@import '../../mixins.scss';
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.tooltip {
+  animation: fade-in 0.3s;
+  &-onRight {
+    text-align: left;
+  }
+}
+
+.iconButton {
+  @include remove-button-styles;
+  font-size: 13px;
+}
+
+.icon {
+  color: $light_gray_500;
+}

--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -97,35 +97,12 @@
   margin: 10px 0;
 }
 
-.fieldLabel {
-  margin: 0;
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.tooltip {
-  animation: fade-in 0.3s;
-  text-align: left;
-}
-
 .fieldLabelContainer {
   display: flex;
   gap: 6px;
-  align-items: flex-start;
+  align-items: baseline;
+}
 
-  .iconButton {
-    @include remove-button-styles;
-
-    .icon {
-      font-size: 13px;
-      color: $light_gray_500;
-    }
-  }
+.fieldLabel {
+  margin: 0;
 }

--- a/apps/src/aichat/views/modelCustomization/FieldLabel.tsx
+++ b/apps/src/aichat/views/modelCustomization/FieldLabel.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
-import {WithTooltip} from '@cdo/apps/componentLibrary/tooltip';
 import {BodyThreeText, StrongText} from '@cdo/apps/componentLibrary/typography';
+
+import InfoTooltipIcon from '../InfoTooltipIcon';
 
 import styles from '../model-customization-workspace.module.scss';
 
@@ -24,19 +24,7 @@ const FieldLabel: React.FunctionComponent<FieldLabelProps> = ({
           <StrongText>{label}</StrongText>
         </BodyThreeText>
       </label>
-      <WithTooltip
-        tooltipProps={{
-          text: tooltipText,
-          size: 's',
-          tooltipId: `${id}-tooltip`,
-          direction: 'onRight',
-          className: styles.tooltip,
-        }}
-      >
-        <button type="button" className={styles.iconButton}>
-          <FontAwesomeV6Icon iconName={'info-circle'} className={styles.icon} />
-        </button>
-      </WithTooltip>
+      <InfoTooltipIcon id={id} tooltipText={tooltipText} direction="onRight" />
     </div>
   );
 };

--- a/apps/src/aichat/views/modelCustomization/constants.ts
+++ b/apps/src/aichat/views/modelCustomization/constants.ts
@@ -18,12 +18,13 @@ export const MODEL_CARD_FIELDS_LABELS_ICONS: {
   label: string;
   icon?: string;
   editTooltip: string;
-  displayTooltip?: string;
+  displayTooltip: string;
 }[] = [
   {
     property: 'botName',
     label: 'Chatbot Name',
     editTooltip: 'Give your chatbot a unique name.',
+    displayTooltip: '',
   },
   {
     property: 'description',

--- a/apps/src/aichat/views/presentation/ModelCardRow.tsx
+++ b/apps/src/aichat/views/presentation/ModelCardRow.tsx
@@ -1,7 +1,10 @@
 import React, {useMemo} from 'react';
 
-import {BodyThreeText} from '@cdo/apps/componentLibrary/typography';
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
+import {BodyThreeText, Heading6} from '@cdo/apps/componentLibrary/typography';
 import CollapsibleSection from '@cdo/apps/templates/CollapsibleSection';
+
+import InfoTooltipIcon from '../InfoTooltipIcon';
 
 import moduleStyles from './model-card-row.module.scss';
 
@@ -9,14 +12,14 @@ interface ModelCardRowProps {
   title: string;
   titleIcon?: string;
   expandedContent: string | string[];
-  tooltipText?: string;
+  tooltipText: string;
 }
 
 const ModelCardRow: React.FunctionComponent<ModelCardRowProps> = ({
   title,
   titleIcon,
   expandedContent,
-  tooltipText, // TODO: Use tooltip text
+  tooltipText,
 }) => {
   const expandedContentToDisplay = useMemo(() => {
     if (Array.isArray(expandedContent)) {
@@ -42,12 +45,29 @@ const ModelCardRow: React.FunctionComponent<ModelCardRowProps> = ({
     <>
       <div className={moduleStyles.modelCardAttributes}>
         <CollapsibleSection
-          title={title}
-          titleSemanticTag="h6"
-          titleVisualAppearance="heading-xs"
-          titleIcon={titleIcon}
           collapsedIcon="caret-right"
           expandedIcon="caret-down"
+          headerContent={
+            <div className={moduleStyles.sectionHeader}>
+              {titleIcon && (
+                <FontAwesomeV6Icon
+                  iconName={titleIcon}
+                  className={moduleStyles.titleIcon}
+                />
+              )}
+              <Heading6
+                visualAppearance="heading-xs"
+                className={moduleStyles.sectionTitle}
+              >
+                {title}
+              </Heading6>
+              <InfoTooltipIcon
+                id={title}
+                tooltipText={tooltipText}
+                direction="onRight"
+              />
+            </div>
+          }
         >
           <BodyThreeText className={moduleStyles.expandedContent}>
             <div>{expandedContentToDisplay}</div>

--- a/apps/src/aichat/views/presentation/model-card-row.module.scss
+++ b/apps/src/aichat/views/presentation/model-card-row.module.scss
@@ -1,13 +1,37 @@
 @import 'color';
+@import '../../../mixins.scss';
 
 .expandedContent {
-    margin-left: 35px;
+  margin-left: 35px;
 }
 
 .modelCardAttributes {
-    margin-left: 20px;
+  margin-left: 20px;
 }
 
-.borderLine {   
-    border-color: $neutral_dark10;
+.borderLine {
+  border-color: $neutral_dark10;
+}
+
+.sectionHeader {
+  display: flex;
+  gap: 10px;
+  margin: 0 25px 0 15px;
+  align-items: center;
+  width: 100%;
+}
+
+.sectionTitle {
+  margin-bottom: 0;
+  transition: color 0.2s ease;
+  text-align: left;
+
+  &:hover {
+    color: $teal;
+  }
+}
+
+.titleIcon {
+  color: $teal;
+  font-size: 18px;
 }

--- a/apps/src/lab2/levelEditors/aichatSettings/EditAichatSettings.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/EditAichatSettings.tsx
@@ -225,7 +225,7 @@ const EditAichatSettings: React.FunctionComponent<{
         />
         <div className={moduleStyles.fieldSection}>
           <hr />
-          <CollapsibleSection title="Model Card">
+          <CollapsibleSection headerContent="Model Card">
             <div className={moduleStyles.fieldRow}>
               <ModelCardFields />
               <VisibilityDropdown
@@ -237,7 +237,7 @@ const EditAichatSettings: React.FunctionComponent<{
         </div>
         <div className={moduleStyles.fieldSection}>
           <hr />
-          <CollapsibleSection title="Additional Configuration">
+          <CollapsibleSection headerContent="Additional Configuration">
             <BodyFourText>
               <i>
                 Students always have access to the Edit View, where they can

--- a/apps/src/lab2/levelEditors/aichatSettings/FieldSection.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/FieldSection.tsx
@@ -34,7 +34,7 @@ const FieldSection: React.FunctionComponent<FieldSectionProps> = ({
   return (
     <div className={moduleStyles.fieldSection}>
       <hr />
-      <CollapsibleSection title={labelText}>
+      <CollapsibleSection headerContent={labelText}>
         {description && (
           <BodyFourText>
             <i>{description}</i>

--- a/apps/src/templates/CollapsibleSection.tsx
+++ b/apps/src/templates/CollapsibleSection.tsx
@@ -1,35 +1,20 @@
 import React, {useState, useCallback} from 'react';
 
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
-import {
-  SemanticTag as TypographyElementSemanticTag,
-  VisualAppearance as TypographyElementVisualAppearance,
-} from '@cdo/apps/componentLibrary/typography/types';
-import Typography from '@cdo/apps/componentLibrary/typography/Typography';
 
 import moduleStyles from './collapsible-section.module.scss';
 
 interface CollapsibleSectionProps {
-  title: string;
   children: React.ReactNode;
-  titleSemanticTag?: TypographyElementSemanticTag;
-  titleVisualAppearance?: TypographyElementVisualAppearance;
-  titleStyle?: string;
-  titleIcon?: string;
-  titleIconStyle?: string;
+  headerContent: React.ReactNode;
   initiallyCollapsed?: boolean;
   collapsedIcon?: string;
   expandedIcon?: string;
 }
 
 const CollapsibleSection: React.FunctionComponent<CollapsibleSectionProps> = ({
-  title,
   children,
-  titleSemanticTag = 'p',
-  titleVisualAppearance = 'body-one',
-  titleStyle = moduleStyles.title,
-  titleIcon,
-  titleIconStyle = moduleStyles.titleIcon,
+  headerContent,
   initiallyCollapsed = true,
   collapsedIcon = 'chevron-down',
   expandedIcon = 'chevron-up',
@@ -38,48 +23,20 @@ const CollapsibleSection: React.FunctionComponent<CollapsibleSectionProps> = ({
   const toggleCollapsed = useCallback(() => {
     setCollapsed(!collapsed);
   }, [collapsed, setCollapsed]);
-  const hasTitleIcon = titleIcon !== undefined;
 
   return (
     <>
-      <div className={moduleStyles.titleRow}>
-        <button
-          type="button"
-          onClick={toggleCollapsed}
-          className={moduleStyles.expandCollapseButton}
-        >
-          <FontAwesomeV6Icon
-            iconName={collapsed ? collapsedIcon : expandedIcon}
-            iconStyle="solid"
-          />
-        </button>
-        {hasTitleIcon && (
-          <button
-            type="button"
-            onClick={toggleCollapsed}
-            className={moduleStyles.expandCollapseButton}
-          >
-            <FontAwesomeV6Icon
-              iconName={titleIcon}
-              iconStyle="solid"
-              className={titleIconStyle}
-            />
-          </button>
-        )}
-        <button
-          type="button"
-          onClick={toggleCollapsed}
-          className={moduleStyles.expandCollapseButton}
-        >
-          <Typography
-            semanticTag={titleSemanticTag}
-            visualAppearance={titleVisualAppearance}
-            className={titleStyle}
-          >
-            {title}
-          </Typography>
-        </button>
-      </div>
+      <button
+        type="button"
+        onClick={toggleCollapsed}
+        className={moduleStyles.expandCollapseButton}
+      >
+        <FontAwesomeV6Icon
+          iconName={collapsed ? collapsedIcon : expandedIcon}
+          iconStyle="solid"
+        />
+        {headerContent}
+      </button>
       {!collapsed && children}
     </>
   );

--- a/apps/src/templates/collapsible-section.module.scss
+++ b/apps/src/templates/collapsible-section.module.scss
@@ -1,27 +1,12 @@
 @import '@cdo/apps/mixins.scss';
 @import 'color.scss';
 
-.titleRow {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    margin-bottom: 10px;
-  }
-  
-.title {
-    margin-left: 10px;
-    margin-bottom: 0;
-}
-.title:hover {
-    color: $teal;
-}
-
-.titleIcon {
-    margin-left: 25px;
-    margin-bottom: 0;
-    color: $teal;
-}
-
 .expandCollapseButton {
-    @include remove-button-styles;
+  @include remove-button-styles;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: 10px;
+  gap: 10px;
+  width: 100%;
 }


### PR DESCRIPTION
Add tooltips to the Presentation View (model card page). I pulled out the tooltip info icon into its own component so it could be shared across the different pages. Also a made a change `CollapsibleSection` where I removed the specific `titleVisualAppearance`/`titleIcon`/etc props in favor of passing in custom header content that consumers can style however they want. This way, the presentation view can pass in a custom header that includes an icon, text, and an icon with a tooltip without needing specific support for each distinct element inside `CollapsibleSection`. And other consumers of `CollapsibleSection` (like the edit AI chat settings components) can continue just passing in text.

https://github.com/code-dot-org/code-dot-org/assets/85528507/08712279-98cc-4874-ad04-ecd77ea29a9e

## Testing story

Tested on Gen AI pilot levels.