### PR TITLE
improve error message when adding unit to course fails

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -221,11 +221,10 @@ class UnitGroup < ApplicationRecord
     unremovable_unit_names = units_to_remove.select(&:prevent_course_version_change?).map(&:name)
     raise "Cannot remove units that have resources or vocabulary: #{unremovable_unit_names}" if unremovable_unit_names.any?
 
-    if new_units_objects.any? do |s|
+    unaddable_unit_names = new_units_objects.select do |s|
       s.unit_group != self && s.prevent_course_version_change?
-    end
-      raise 'Cannot add units that have resources or vocabulary'
-    end
+    end.map(&:name)
+    raise "Cannot add units with resources or vocabulary: #{unaddable_unit_names}" if unaddable_unit_names.any?
 
     new_units_objects.each_with_index do |unit, index|
       unit_group_unit = UnitGroupUnit.find_or_create_by!(unit_group: self, script: unit) do |ugu|

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -224,7 +224,7 @@ class UnitGroup < ApplicationRecord
     unaddable_unit_names = new_units_objects.select do |s|
       s.unit_group != self && s.prevent_course_version_change?
     end.map(&:name)
-    raise "Cannot add units with resources or vocabulary: #{unaddable_unit_names}" if unaddable_unit_names.any?
+    raise "Cannot add units that have resources or vocabulary: #{unaddable_unit_names}" if unaddable_unit_names.any?
 
     new_units_objects.each_with_index do |unit, index|
       unit_group_unit = UnitGroupUnit.find_or_create_by!(unit_group: self, script: unit) do |ugu|

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -439,7 +439,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       error = assert_raises RuntimeError do
         unit_group1.update_scripts(['unit1', 'unit2'])
       end
-      assert_includes error.message, 'Cannot add units that have resources or vocabulary'
+      assert_includes error.message, 'Cannot add units that have resources or vocabulary: ["unit2"]'
 
       unit_group1.reload
       assert_equal 1, unit_group1.default_unit_group_units.length


### PR DESCRIPTION
After tinkering with my local database and then running `rake seed:all`, I ran into an ambiguous error message which said I couldn't add a unit to csp-2024, but didn't say which one. This PR improves the error message to include the name(s) of the problematic units.

### before
```
Finished seed:scripts (10 minutes and 54 seconds)
rake aborted!
Exception: in course: csp-2024: Cannot add units that have resources or vocabulary
/Users/dsb/src/cdo2/dashboard/app/models/unit_group.rb:227:in `update_scripts'
/Users/dsb/src/cdo2/dashboard/app/models/unit_group.rb:128:in `seed_from_hash'
/Users/dsb/src/cdo2/dashboard/app/models/unit_group.rb:114:in `load_from_path'
```

### after
```
Exception: in course: csp-2024: Cannot add units with resources or vocabulary: ["csp2-2024"]
/Users/dsb/src/cdo2/dashboard/app/models/unit_group.rb:227:in `update_scripts'
/Users/dsb/src/cdo2/dashboard/app/models/unit_group.rb:128:in `seed_from_hash'
/Users/dsb/src/cdo2/dashboard/app/models/unit_group.rb:114:in `load_from_path'
```

## Testing story
* existing test coverage
* manual verification shown above