### PR TITLE
Add text and image for progress launch banner

### DIFF
--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -46,6 +46,14 @@
       "buttonText": "See what's new",
       "buttonUrl": "",
       "buttonId": "curriculum-launch-2024"
+    },
+    "progress-launch": {
+      "image": "/shared/images/banners/banner-progress-launch.png",
+      "title": "Progress tracking just leveled up!",
+      "body": "Effortlessly monitor student work, provide timely feedback, and simplify grading with our fast, teacher-tested interface. Save time and gain valuable insights into your students' performance, all in one intuitive tool.",
+      "buttonText": "Try it now",
+      "buttonUrl": "",
+      "buttonId": "progress-launch"
     }
   }
 }

--- a/shared/images/banners/banner-progress-launch.png
+++ b/shared/images/banners/banner-progress-launch.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:080335479cfa7061b136e0f568de405e3d45e6d519300e6a7824c8f5fea3d80e
+size 219038


### PR DESCRIPTION
Adds text and image for the progress teacher homepage banner. I'm still waiting on a link and whether this needs to be behind a DCDO flag, but this change will get the banner ready for translations.

