### PR TITLE
Added redirect for marketing banner.

### DIFF
--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -1,8 +1,9 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, {useCallback} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {connect} from 'react-redux';
 
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import Link from '@cdo/apps/componentLibrary/link';
 import DCDO from '@cdo/apps/dcdo';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
@@ -27,7 +28,24 @@ function SectionProgressSelector({
   sectionId,
   hasSeenProgressTableInvite,
 }) {
-  const [hasJustToggledViews, setHasJustToggledViews] = React.useState(false);
+  const [hasJustToggledViews, setHasJustToggledViews] = useState(false);
+
+  useEffect(() => {
+    const params = queryParams('view');
+    if (params === 'v2') {
+      setShowProgressTableV2(true);
+      setHasJustToggledViews(true);
+    }
+  }, [setShowProgressTableV2, setHasJustToggledViews]);
+
+  const removeQueryParams = () => {
+    const url =
+      window.location.protocol +
+      '//' +
+      window.location.host +
+      window.location.pathname;
+    window.history.pushState({path: url}, '', url);
+  };
 
   const onShowProgressTableV2Change = useCallback(() => {
     const shouldShowV2 = !showProgressTableV2;
@@ -43,6 +61,7 @@ function SectionProgressSelector({
       analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW_OLD_PROGRESS, {
         sectionId: sectionId,
       });
+      removeQueryParams();
     }
   }, [showProgressTableV2, setShowProgressTableV2, sectionId]);
 
@@ -80,7 +99,14 @@ function SectionProgressSelector({
   // If the user has not selected manually the v1 or v2 table, show the DCDO defined default.
   // If a user has selected manually, show that version.
   const isPreferenceSet = showProgressTableV2 !== undefined;
-  const displayV2 = isPreferenceSet
+  const params = queryParams('view');
+
+  // If there is a url pram, use that param to determine to show V2.
+  const displayV2FromUrl = params === 'v2';
+
+  const displayV2 = displayV2FromUrl
+    ? true
+    : isPreferenceSet
     ? showProgressTableV2
     : DCDO.get('progress-table-v2-default-v2', false);
 

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -35,6 +35,7 @@ function SectionProgressSelector({
     if (params === 'v2') {
       setShowProgressTableV2(true);
       setHasJustToggledViews(true);
+      new UserPreferences().setShowProgressTableV2(true);
     }
   }, [setShowProgressTableV2, setHasJustToggledViews]);
 
@@ -104,11 +105,11 @@ function SectionProgressSelector({
   // If there is a url pram, use that param to determine to show V2.
   const displayV2FromUrl = params === 'v2';
 
-  const displayV2 = displayV2FromUrl
-    ? true
-    : isPreferenceSet
-    ? showProgressTableV2
-    : DCDO.get('progress-table-v2-default-v2', false);
+  const displayV2 =
+    displayV2FromUrl ||
+    (isPreferenceSet
+      ? showProgressTableV2
+      : DCDO.get('progress-table-v2-default-v2', false));
 
   const toggleV1OrV2Link = () => (
     <div className={styles.toggleViews}>

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -8,6 +8,15 @@ class TeacherDashboardController < ApplicationController
     view_options(full_width: true, no_padding_container: true)
   end
 
+  def redirect_to_newest_section
+    if current_user.sections_instructed.empty?
+      redirect_to "https://support.code.org/hc/en-us/articles/25195525766669-Getting-Started-New-Progress-View"
+    else
+      section_id = current_user.sections_instructed.order(created_at: :desc).first.id
+      redirect_to "/teacher_dashboard/sections/#{section_id}/progress?view=v2"
+    end
+  end
+
   def parent_letter
     @section_summary = @section.selected_section_summarize
     @sections = current_user.sections_instructed.map(&:concise_summarize)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -7,8 +7,8 @@ Dashboard::Application.routes.draw do
   # Redirect studio.code.org/courses to code.org/students
   get "/courses", to: redirect(CDO.code_org_url("/students"))
 
-  # Redirect studio.code.org/mysection to most recent section section
-  get '/teacher_dashboard/sections/firstSectionProgress', to: "teacher_dashboard#redirect_to_newest_section"
+  # Redirect studio.code.org/sections/teacher_dashboard/first_section_progress to most recent section
+  get '/teacher_dashboard/sections/first_section_progress', to: "teacher_dashboard#redirect_to_newest_section"
 
   constraints host: CDO.codeprojects_hostname do
     # Routes needed for the footer on weblab share links on codeprojects

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -7,6 +7,9 @@ Dashboard::Application.routes.draw do
   # Redirect studio.code.org/courses to code.org/students
   get "/courses", to: redirect(CDO.code_org_url("/students"))
 
+  # Redirect studio.code.org/mysection to most recent section section
+  get '/teacher_dashboard/sections/firstSectionProgress', to: "teacher_dashboard#redirect_to_newest_section"
+
   constraints host: CDO.codeprojects_hostname do
     # Routes needed for the footer on weblab share links on codeprojects
     get '/weblab/footer', to: 'projects#weblab_footer'

--- a/dashboard/test/controllers/teacher_dashboard_controller_test.rb
+++ b/dashboard/test/controllers/teacher_dashboard_controller_test.rb
@@ -43,4 +43,22 @@ class TeacherDashboardControllerTest < ActionController::TestCase
     get :show, params: {section_id: cotaught_section.id}
     assert_response :success
   end
+
+  test 'redirect_to_newest_section: redirects to support URL if no sections instructed' do
+    other_teacher = create(:teacher)
+    sign_in other_teacher
+
+    get :redirect_to_newest_section
+
+    assert_redirected_to 'https://support.code.org/hc/en-us/articles/25195525766669-Getting-Started-New-Progress-View'
+  end
+
+  test 'redirect_to_newest_section: redirects to newest section progress page if sections instructed' do
+    sign_in @section_owner
+
+    get :redirect_to_newest_section
+
+    newest_section = @section_owner.sections_instructed.order(created_at: :desc).first
+    assert_redirected_to "/teacher_dashboard/sections/#{newest_section.id}/progress?view=v2"
+  end
 end

--- a/dashboard/test/controllers/teacher_dashboard_controller_test.rb
+++ b/dashboard/test/controllers/teacher_dashboard_controller_test.rb
@@ -58,7 +58,6 @@ class TeacherDashboardControllerTest < ActionController::TestCase
 
     get :redirect_to_newest_section
 
-    newest_section = @section_owner.sections_instructed.order(created_at: :desc).first
-    assert_redirected_to "/teacher_dashboard/sections/#{newest_section.id}/progress?view=v2"
+    assert_redirected_to "/teacher_dashboard/sections/#{@section.id}/progress?view=v2"
   end
 end


### PR DESCRIPTION
The deliverable here is just a URL that can be given to the marketing team for an announcement banner on the site when a teacher is logged in.  This banner should allow a user to try the new view by redirecting them to the V2 version of the first section in their section list.  If they have not created a section yet, it will redirect them to a support article. 

The URL is: studio.code.org/teacher_dashboard/sections/first_section_progress

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65)

## Testing story

Tested locally and wrote a test for it.
