### PR TITLE
Wrap MailJet call in a begin/rescue on sign up

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -126,7 +126,17 @@ class RegistrationsController < Devise::RegistrationsController
     if current_user && current_user.errors.blank?
       if current_user.teacher?
         if MailJet.enabled? && request.locale != 'es-MX'
-          MailJet.create_contact_and_send_welcome_email(current_user)
+          begin
+            MailJet.create_contact_and_send_welcome_email(current_user)
+          rescue => exception
+            # If the welcome email fails to send, we don't want to disrupt
+            # sign up, but we do want to know about it.
+            Honeybadger.notify(
+              exception,
+              error_message: 'Failed to send MailJet welcome email',
+              context: {}
+            )
+          end
         else
           TeacherMailer.new_teacher_email(current_user, request.locale).deliver_now
         end


### PR DESCRIPTION
Wrap the MailJet call in a begin/rescue. We've seen a couple of sporadic MailJet errors, normally transient issues. When those happen, it creates a weird user experience where the account is created but the user isn't logged in. 

As I was testing the translated welcome emails, I realized I didn't want to test with production keys, but that leaves the possibility of errors in production (most likely, an incorrect template ID). This solves that as _most_ testing can be done without production keys, but I can feel confident that if there is a production-specific issue, it won't create a lot of user pain.

