### PR TITLE
Fix foorm not parsing boolean questions

### DIFF
--- a/dashboard/lib/pd/foorm/constants.rb
+++ b/dashboard/lib/pd/foorm/constants.rb
@@ -7,7 +7,8 @@ module Pd::Foorm
       TYPE_DROPDOWN = 'dropdown'.freeze,
       TYPE_RATING = 'rating'.freeze,
       TYPE_MATRIX = 'matrix'.freeze,
-      TYPE_COMMENT = 'comment'.freeze
+      TYPE_COMMENT = 'comment'.freeze,
+      TYPE_BOOLEAN = 'boolean'.freeze
     ].freeze
 
     PANEL_TYPES = [
@@ -21,6 +22,7 @@ module Pd::Foorm
       ANSWER_MULTI_SELECT = 'multiSelect'.freeze,
       ANSWER_MATRIX = 'matrix'.freeze,
       ANSWER_RATING = 'scale'.freeze,
+      ANSWER_BOOLEAN = 'boolean'.freeze,
       # No answer, just question metadata, e.g. matrix heading
       ANSWER_NONE = 'none'.freeze,
       # Don't know answer type of a question
@@ -35,7 +37,8 @@ module Pd::Foorm
       TYPE_CHECKBOX => ANSWER_MULTI_SELECT,
       TYPE_RATING => ANSWER_SINGLE_SELECT,
       TYPE_MATRIX => ANSWER_MATRIX,
-      TYPE_RATING => ANSWER_RATING
+      TYPE_RATING => ANSWER_RATING,
+      TYPE_BOOLEAN => ANSWER_BOOLEAN
     }
 
     ROLLUP_CONFIGURATION_FILE = 'config/foorm/rollups/rollups_by_course.json'

--- a/dashboard/test/lib/pd/foorm/foorm_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/foorm_parser_test.rb
@@ -151,6 +151,38 @@ module Pd::Foorm
       assert_equal expected_choice_3, form_data['question3']['choices']
     end
 
+
+    test 'parses boolean questions correctly' do
+      panel_form_data = {
+        pages: [
+          name: 'sample',
+          elements: [
+            {
+              type: "boolean",
+              name: "question1",
+              title: "True or false?"
+            },
+          ]
+        ]
+      }.to_json
+      form = Foorm::Form.create(name: 'sample', version: 0, questions: panel_form_data)
+      parsed_form = FoormParser.parse_forms([form]).with_indifferent_access
+
+      expected_form = {
+        general: {
+          'sample.0': {
+            question1: {
+              title: "True or false?",
+              type: "boolean",
+            },
+          }
+        },
+        facilitator: {}
+      }
+
+      assert_equal expected_form.with_indifferent_access, parsed_form.with_indifferent_access
+    end
+
     test 'correctly parses form with facilitator panel' do
       parsed_form = FoormParser.parse_forms([@csf_survey]).with_indifferent_access
 

--- a/dashboard/test/lib/pd/foorm/foorm_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/foorm_parser_test.rb
@@ -151,7 +151,6 @@ module Pd::Foorm
       assert_equal expected_choice_3, form_data['question3']['choices']
     end
 
-
     test 'parses boolean questions correctly' do
       panel_form_data = {
         pages: [


### PR DESCRIPTION
Fixes a bug where boolean type Foorm questions were not getting parsed into `foorm_forms_reshaped` correctly.

Boolean questions were just not included in a couple of question and answer type enums that filter out input foorms.

## Links
[TEACH-1185](https://codedotorg.atlassian.net/browse/TEACH-1185)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Unit test added

Verified manually by:
```
form = Foorm::Form.find_by_name('surveys/pd/custom_workshop_post_facilitators')
Pd::Foorm::FoormParser.parse_forms([form])
```
And noting that the boolean question was in the parsed output

Output: 
```
{:general=>
  {"surveys/pd/custom_workshop_post_facilitators.0"=>
    {...
     "custom_workshop_new"=>
      {:title=>
        "Is this the first time you have facilitated a custom workshop focused on {pd_content}?",
       :type=>"boolean"},
...
     }}},
 :facilitator=>{}}
```
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
