### PR TITLE
AI Chat: move copy button below message editor

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -38,7 +38,6 @@ import {getNewMessageId} from '../redux/utils';
 import {AichatLevelProperties, Notification, ViewMode} from '../types';
 
 import ChatWorkspace from './ChatWorkspace';
-import CopyButton from './CopyButton';
 import {isDisabled} from './modelCustomization/utils';
 import ModelCustomizationWorkspace from './ModelCustomizationWorkspace';
 import PresentationView from './presentation/PresentationView';
@@ -256,11 +255,6 @@ const AichatView: React.FunctionComponent = () => {
             headerContent={chatWorkspaceHeader}
             className={moduleStyles.panelContainer}
             headerClassName={moduleStyles.panelHeader}
-            rightHeaderContent={
-              <div className={moduleStyles.chatHeaderRight}>
-                <CopyButton />
-              </div>
-            }
           >
             <ChatWorkspace onClear={onClear} />
           </PanelContainer>

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -11,6 +11,7 @@ import {Button} from '@cdo/apps/componentLibrary/button';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import ChatItemView from './ChatItemView';
+import CopyButton from './CopyButton';
 import UserChatMessageEditor from './UserChatMessageEditor';
 
 import moduleStyles from './chatWorkspace.module.scss';
@@ -91,6 +92,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
           color="gray"
           onClick={onClear}
         />
+        <CopyButton />
       </div>
     </div>
   );

--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -37,10 +37,10 @@ const CopyButton: React.FunctionComponent = () => {
   return (
     <Button
       onClick={handleCopy}
-      text="Copy Chat"
+      text="Copy chat"
       iconLeft={{iconName: 'clipboard'}}
-      size="xs"
-      color="white"
+      size="s"
+      color="gray"
       type="secondary"
     />
   );

--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -28,13 +28,7 @@ const UserChatMessageEditor: React.FunctionComponent = () => {
 
   const disabled = isWaitingForChatResponse || saveInProgress;
 
-  return (
-    <UserMessageEditor
-      onSubmit={handleSubmit}
-      disabled={disabled}
-      showSubmitLabel
-    />
-  );
+  return <UserMessageEditor onSubmit={handleSubmit} disabled={disabled} />;
 };
 
 export default UserChatMessageEditor;

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -29,5 +29,6 @@ $default-spacing: 16px;
 
 .buttonRow {
   display: flex;
+  gap: 8px;
   padding: 0 10px 10px 10px;
 }


### PR DESCRIPTION
Move the copy button below the message editor in line with the Clear chat button, as per product/design.

<img width="582" alt="Screenshot 2024-07-11 at 11 45 11 AM" src="https://github.com/code-dot-org/code-dot-org/assets/85528507/13bb32ff-74d9-4807-bf2a-9fbfbce041e9">

## Links

https://codedotorg.atlassian.net/browse/LABS-908

## Testing story

Tested on Gen AI pilot levels & allthethings.