### PR TITLE
[CodeBridge] Rename source to start_sources

### DIFF
--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -17,7 +17,7 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 export const useInitialSources = (defaultSources: ProjectSources) => {
   const labInitialSources = useAppSelector(state => state.lab.initialSources);
   const levelStartSource = useAppSelector(
-    state => state.lab.levelProperties?.source
+    state => state.lab.levelProperties?.startSources
   );
   const exemplarSources = useAppSelector(
     state => state.lab.levelProperties?.exemplarSources

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -29,7 +29,7 @@ export const useSource = (defaultSources: ProjectSources) => {
   const isEditingExemplarMode = getAppOptionsEditingExemplar();
   const initialSources = useInitialSources(defaultSources);
   const levelStartSource = useAppSelector(
-    state => state.lab.levelProperties?.source
+    state => state.lab.levelProperties?.startSources
   );
   const previousLevelIdRef = useRef<number | null>(null);
   const levelId = useAppSelector(state => state.lab.levelProperties?.id);

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -59,7 +59,7 @@ export const useSource = (defaultSources: ProjectSources) => {
   useEffect(() => {
     if (isStartMode) {
       header.showLevelBuilderSaveButton(() => {
-        return {source};
+        return {start_sources: source};
       });
     } else if (isEditingExemplarMode) {
       header.showLevelBuilderSaveButton(

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -144,7 +144,7 @@ export interface LevelProperties {
   isK1?: boolean;
   skin?: string;
   toolboxBlocks?: string;
-  source?: MultiFileSource;
+  startSources?: MultiFileSource;
   sharedBlocks?: BlockDefinition[];
   validations?: Validation[];
   // An optional URL that allows the user to skip the progression.

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -844,9 +844,9 @@ class Level < ApplicationRecord
     properties_camelized[:appName] = game&.app
     properties_camelized[:useRestrictedSongs] = game.use_restricted_songs?
     properties_camelized[:usesProjects] = try(:is_project_level) || channel_backed?
-    if try(:project_template_level).try(:source) || try(:source)
+    if try(:project_template_level).try(:start_sources) || try(:start_sources)
       # Override start sources with project template level sources if they exist
-      properties_camelized['source'] = try(:project_template_level).try(:source) || try(:source)
+      properties_camelized['startSources'] = try(:project_template_level).try(:start_sources) || try(:start_sources)
     end
     # Localized properties
     properties_camelized["validations"] = localized_validations if properties_camelized["validations"]

--- a/dashboard/app/models/levels/pythonlab.rb
+++ b/dashboard/app/models/levels/pythonlab.rb
@@ -25,7 +25,7 @@
 #
 class Pythonlab < Level
   serialized_attrs %w(
-    source
+    start_sources
     encrypted_exemplar_sources
     encrypted_validation
     hide_share_and_remix

--- a/dashboard/app/models/levels/weblab2.rb
+++ b/dashboard/app/models/levels/weblab2.rb
@@ -25,7 +25,7 @@
 #
 class Weblab2 < Level
   serialized_attrs %w(
-    source
+    start_sources
     hide_share_and_remix
     is_project_level
     encrypted_exemplar_sources

--- a/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 1.level
+++ b/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 1.level
@@ -7,7 +7,7 @@
   "user_id": 6959,
   "properties": {
     "encrypted": "false",
-    "source": {
+    "start_sources": {
       "files": {
         "0": {
           "id": "0",

--- a/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 2.level
+++ b/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 2.level
@@ -8,7 +8,7 @@
     "encrypted": "false",
     "long_instructions": "## Python Lab with Validation\r\n\r\nThis level has some built-in validation code.",
     "hide_share_and_remix": "false",
-    "source": {
+    "start_sources": {
       "files": {
         "1": {
           "id": "1",

--- a/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 5.level
+++ b/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 5.level
@@ -7,7 +7,7 @@
   "user_id": 6959,
   "properties": {
     "encrypted": "false",
-    "source": {
+    "start_sources": {
       "files": {
         "0": {
           "id": "0",

--- a/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 6.level
+++ b/dashboard/config/levels/custom/pythonlab/Allthethings Python Lab 6.level
@@ -7,7 +7,7 @@
   "user_id": 6959,
   "properties": {
     "encrypted": "false",
-    "source": {
+    "start_sources": {
       "files": {
         "0": {
           "id": "0",

--- a/dashboard/config/levels/custom/pythonlab/Line.level
+++ b/dashboard/config/levels/custom/pythonlab/Line.level
@@ -11,7 +11,7 @@
     "predict_settings": {
       "isPredictLevel": false
     },
-    "source": {
+    "start_sources": {
       "files": {
         "0": {
           "id": "0",

--- a/dashboard/config/levels/custom/pythonlab/Python Lab2 Showcase.level
+++ b/dashboard/config/levels/custom/pythonlab/Python Lab2 Showcase.level
@@ -6,7 +6,7 @@
   "user_id": 6959,
   "properties": {
     "encrypted": "false",
-    "source": {
+    "start_sources": {
       "files": {
         "0": {
           "id": "0",

--- a/dashboard/config/levels/custom/pythonlab/data-science-sample-1.level
+++ b/dashboard/config/levels/custom/pythonlab/data-science-sample-1.level
@@ -10,7 +10,7 @@
     "long_instructions": "## Step 1: Import Necessary Libraries\r\nLet's start by importing the Python libraries `pandas` and `matplotlib`.\r\n\r\n### Do This\r\n1. Import `pandas` as `pd`\r\n2. Import `matplotlib.pyplot` as `plt`",
     "hide_share_and_remix": "false",
     "teacher_markdown": "Remind students of the purpose of each library: `pandas` for data manipulation and `matplotlib` for plotting graphs.\r\n",
-    "source": {
+    "start_sources": {
       "files": {
         "0": {
           "id": "0",

--- a/dashboard/config/levels/custom/pythonlab/data-science-sample-pbt-1.level
+++ b/dashboard/config/levels/custom/pythonlab/data-science-sample-pbt-1.level
@@ -7,7 +7,7 @@
   "properties": {
     "encrypted": "false",
     "hide_share_and_remix": "false",
-    "source": {
+    "start_sources": {
       "files": {
         "0": {
           "id": "0",

--- a/dashboard/config/levels/custom/pythonlab/ken_python_test.level
+++ b/dashboard/config/levels/custom/pythonlab/ken_python_test.level
@@ -11,7 +11,7 @@
     "predict_settings": {
       "isPredictLevel": false
     },
-    "source": {
+    "start_sources": {
       "files": {
         "0": {
           "id": "0",

--- a/dashboard/config/levels/custom/pythonlab/pythonlab_test_project_template.level
+++ b/dashboard/config/levels/custom/pythonlab/pythonlab_test_project_template.level
@@ -8,7 +8,7 @@
     "encrypted": "false",
     "long_instructions": "## Sample Python Lab Project Template Level",
     "hide_share_and_remix": "false",
-    "source": {
+    "start_sources": {
       "files": {
         "0": {
           "id": "0",


### PR DESCRIPTION
From [ticket](https://codedotorg.atlassian.net/browse/CT-644):
> When we added start sources to web lab 2 and python lab we started using `source` rather than `start_sources` in the level configuration. Java Lab uses `start_sources`. In order to make things simpler to eventually migrate Java Lab levels to the same system, we should rename this field in Python Lab and Web Lab 2. Since there's few levels right now and they are all test levels it's easier to do this sooner rather than later.

This renames the property in the 10 existing PythonLab levels. It renames the property in code where we would read this property and when we save start blocks.

## Process used
1. I first manually edited the levels and re-seeded them (to avoid extra diff for the audit log, etc.). After reloading one of the levels, I confirmed we were falling back to the default source.
2. After renaming the `levelProperties` key, I confirmed that we were once again using the (renamed) start sources.
3. I also renamed the value that gets returned by the levelbuilder save button and confirmed that start mode still works.

Once this merges, I would recommend all CodeBridge engineers re-seed these custom levels before modifying them using levelbuilder/start mode. If the levels aren't reseeded locally, changes will potentially re-introduce the deprecated `source` property. (`start_sources` would still be added as expected, but it won't overwrite the existing `source` in your locally seeded copy.

## Links

https://codedotorg.atlassian.net/browse/CT-644

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I didn't see any test coverage that expects a particular spelling for this property.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
