### PR TITLE
Datablock Storage: Don't enforce MAX_TABLE_COUNT if adding a shared table.

### DIFF
--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -347,7 +347,7 @@ class DatablockStorageTable < ApplicationRecord
   end
 
   private def validate_max_table_count
-    if DatablockStorageTable.where(project_id: project_id).count >= MAX_TABLE_COUNT
+    if DatablockStorageTable.where(project_id: project_id).count >= MAX_TABLE_COUNT && project_id != SHARED_TABLE_PROJECT_ID
       raise StudentFacingError.new(:MAX_TABLES_EXCEEDED), "Cannot create more than #{MAX_TABLE_COUNT} tables"
     end
   end

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -34,4 +34,20 @@ class DatasetsControllerTest < ActionController::TestCase
 
     assert_equal JSON.parse(@test_manifest.to_json), DatablockStorageLibraryManifest.instance.library_manifest
   end
+
+  test 'update: can exceed max table count' do
+    original_max_table_count = DatablockStorageTable::MAX_TABLE_COUNT
+    DatablockStorageTable.const_set(:MAX_TABLE_COUNT, 1)
+
+    csv_data = <<~CSV
+      id,name,age
+      1,fluffy,7
+    CSV
+
+    post :update, params: {dataset_name: 'cats', csv_data: csv_data}
+    post :update, params: {dataset_name: 'dogs', csv_data: csv_data}
+
+  ensure
+    DatablockStorageTable.const_set(:MAX_TABLE_COUNT, original_max_table_count)
+  end
 end

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -45,8 +45,12 @@ class DatasetsControllerTest < ActionController::TestCase
     CSV
 
     post :update, params: {dataset_name: 'cats', csv_data: csv_data}
-    post :update, params: {dataset_name: 'dogs', csv_data: csv_data}
+    assert_response :success
 
+    post :update, params: {dataset_name: 'dogs', csv_data: csv_data}
+    assert_response :success
+
+    assert_equal 2, DatablockStorageTable.get_shared_table_names.count
   ensure
     DatablockStorageTable.const_set(:MAX_TABLE_COUNT, original_max_table_count)
   end

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -35,7 +35,8 @@ class DatasetsControllerTest < ActionController::TestCase
     assert_equal JSON.parse(@test_manifest.to_json), DatablockStorageLibraryManifest.instance.library_manifest
   end
 
-  test 'update: can exceed max table count' do
+  # Exceeding max table count allows curriculum writers to add new shared datasets in levelbuilder mode
+  test 'update: can exceed max table count for shared tables' do
     original_max_table_count = DatablockStorageTable::MAX_TABLE_COUNT
     DatablockStorageTable.const_set(:MAX_TABLE_COUNT, 1)
 


### PR DESCRIPTION
Fixes #59732 

The MAX_TABLE_COUNT constraint applies to applab projects to limit the number of data tables students can create and import in their project. Since we store shared tables (from the Data Library) alongside other project tables in the DB with a unique project Id, they were being erroneously subject to the same constraint when new shared tables are added to the data library by level builders.

Changes in this PR:
- Do not apply MAX_TABLE_COUNT constraint if table being created is a shared table. (Note, this is when a new shared table is added by a curriculum writer through levelbuilder. The constraint is still in place for students importing shared tables to their projects.)
- Add test coverage to validate that adding shared datasets through levelbuilder will work

Note: This will also fix local seeding of shared tables.