### PR TITLE
Make Required ENV Values for `rds` Rake Tasks Actually Required

### DIFF
--- a/lib/rake/rds.rake
+++ b/lib/rake/rds.rake
@@ -12,7 +12,7 @@ namespace :rds do
   desc 'Clone SOURCE_CLUSTER_ID to optional CLONE_CLUSTER_ID with optional INSTANCE_TYPE.'
   timed_task_with_logging :clone_cluster do
     options = {
-      source_cluster_id: ENV.fetch('SOURCE_CLUSTER_ID', nil),
+      source_cluster_id: ENV.fetch('SOURCE_CLUSTER_ID'),
       clone_cluster_id: ENV.fetch('CLONE_CLUSTER_ID', nil),
       instance_type: ENV.fetch('INSTANCE_TYPE', nil)
     }
@@ -22,6 +22,6 @@ namespace :rds do
   desc 'Delete CLUSTER_ID'
   timed_task_with_logging :delete_cluster do
     raise StandardError.new("CLUSTER_ID environment variable is required.") unless ENV['CLUSTER_ID'].present?
-    Cdo::RDS.delete_cluster(ENV.fetch('CLUSTER_ID', nil))
+    Cdo::RDS.delete_cluster(ENV.fetch('CLUSTER_ID'))
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/59523, which made it more explicit when we expect the values we attempt to fetch from ENV to silently default to `nil` when not present versus when we actually want to insist on the value being set.

In the Rake tasks for cloning database clusters and deleting clones of those clusters, we have a couple of required environment variables that it turns out we were not actually adequately enforcing as required. The clone operation will now throw a `KeyError` when it cannot find the required values; the delete operation already had a manual check in place for this possibility, which I left in place.

## Testing story

Tested locally (with the change from https://github.com/code-dot-org/code-dot-org/pull/59735 also in place)

Creation:

```
[~/code-dot-org (make-rds-required-env-values-actually-required)]$ bundle exec rake rds:clone_cluster CLONE_CLUSTER_ID=clone-script-tweak-testing
GetSecretValue: development/cdo/slack_bot_token
rake aborted!
KeyError: key not found: "SOURCE_CLUSTER_ID"
Did you mean?  "CLONE_CLUSTER_ID"
/home/elijah/projects/work/code-dot-org/lib/rake/rds.rake:15:in `fetch'
/home/elijah/projects/work/code-dot-org/lib/rake/rds.rake:15:in `block (2 levels) in <top (required)>'
/home/elijah/projects/work/code-dot-org/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `block in execute'
/home/elijah/projects/work/code-dot-org/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `execute'
/home/elijah/.rbenv/versions/3.0.5/bin/bundle:23:in `load'
/home/elijah/.rbenv/versions/3.0.5/bin/bundle:23:in `<main>'
Tasks: TOP => rds:clone_cluster
(See full trace by running task with --trace)

[~/code-dot-org (make-rds-required-env-values-actually-required)]$ bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=test-cluster CLONE_CLUSTER_ID=clone-script-tweak-testing
GetSecretValue: development/cdo/slack_bot_token
Creating clone of database cluster - test-cluster
Done creating database cluster - clone-script-tweak-testing
Finished rds:clone_cluster (12 minutes)
```

Deletion:

```
[~/code-dot-org (make-rds-required-env-values-actually-required)]$ bundle exec rake rds:delete_cluster
GetSecretValue: development/cdo/slack_bot_token
rake aborted!
StandardError: CLUSTER_ID environment variable is required.
/home/elijah/projects/work/code-dot-org/lib/rake/rds.rake:24:in `block (2 levels) in <top (required)>'
/home/elijah/projects/work/code-dot-org/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `block in execute'
/home/elijah/projects/work/code-dot-org/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `execute'
/home/elijah/.rbenv/versions/3.0.5/bin/bundle:23:in `load'
/home/elijah/.rbenv/versions/3.0.5/bin/bundle:23:in `<main>'
Tasks: TOP => rds:delete_cluster
(See full trace by running task with --trace)

[~/code-dot-org (make-rds-required-env-values-actually-required)]$ bundle exec rake rds:delete_cluster CLUSTER_ID=clone-script-tweak-testing
GetSecretValue: development/cdo/slack_bot_token
Database Cluster clone-script-tweak-testing has been deleted. DBCluster clone-script-tweak-testing not found.
Finished rds:delete_cluster (16 minutes)
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
