### PR TITLE
Default to `r5.large` Instance Rather Than Unsupported `db.t3.2xlarge`

### DIFF
--- a/lib/cdo/aws/rds.rb
+++ b/lib/cdo/aws/rds.rb
@@ -15,7 +15,7 @@ module Cdo
     def self.clone_cluster(
       source_cluster_id: CDO.db_cluster_id,
       clone_cluster_id: "#{source_cluster_id}-clone",
-      instance_type: 'db.t3.2xlarge',
+      instance_type: 'db.r5.large',
       max_attempts: 30,  # It takes ~15 minutes to clone the production cluster, so default to 30 minutes.
       delay: 60
     )


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/59493

I should have actually tested with `t3` rather than just reading the documentation. Unforunately, attempting to clone a cluster with our new defaults fails with:

    rake aborted!
    Aws::RDS::Errors::InvalidParameterCombination: RDS does not support creating a DB instance with the following combination: DBInstanceClass=db.t3.2xlarge, Engine=aurora-mysql, EngineVersion=8.0.mysql_aurora.3.05.2, LicenseModel=general-public-license. For supported combinations of instance class and database engine version, see the documentation.
    /home/elijah/projects/work/code-dot-org/lib/cdo/aws/rds.rb:59:in `clone_cluster'
    /home/elijah/projects/work/code-dot-org/lib/rake/rds.rake:19:in `block (2 levels) in <top (required)>'
    /home/elijah/projects/work/code-dot-org/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `block in execute'
    /home/elijah/projects/work/code-dot-org/lib/cdo/data/logging/timed_task_with_logging.rb:12:in `execute'
    /home/elijah/.rbenv/versions/3.0.5/bin/bundle:23:in `load'
    /home/elijah/.rbenv/versions/3.0.5/bin/bundle:23:in `<main>'
    Tasks: TOP => rds:clone_cluster

Just like it did for the old `r4` default. Updating to default to `r5` instead, which I have actually tested and does indeed work.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
