### PR TITLE
Added better error message for save timeout

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -387,6 +387,14 @@ class UnitEditor extends React.Component {
         }
       })
       .fail(error => {
+        if (error.status === 504) {
+          this.setState({
+            isSaving: false,
+            error:
+              'The save request timed out. Please refresh the page and verify your changes have been saved correctly.',
+          });
+          return;
+        }
         this.setState({isSaving: false, error: error.responseText});
       });
   };

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -399,7 +399,7 @@ describe('UnitEditor', () => {
       server.restore();
     });
 
-    it('shows error when save and keep editing has error saving', () => {
+    it('Timeout error shows custom error message to refresh and check it saved', () => {
       const wrapper = createWrapper({});
       const unitEditor = wrapper.find('UnitEditor');
 
@@ -430,7 +430,11 @@ describe('UnitEditor', () => {
       );
       expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
       expect(
-        wrapper.find('.saveBar').contains('Error Saving: There was an error')
+        wrapper
+          .find('.saveBar')
+          .contains(
+            'Error Saving: The save request timed out. Please refresh the page and verify your changes have been saved correctly.'
+          )
       ).to.be.true;
 
       server.restore();

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -399,6 +399,43 @@ describe('UnitEditor', () => {
       server.restore();
     });
 
+    it('shows error when save and keep editing has error saving', () => {
+      const wrapper = createWrapper({});
+      const unitEditor = wrapper.find('UnitEditor');
+
+      let server = sinon.fakeServer.create();
+      server.respondWith('PUT', `/s/1`, [
+        504,
+        {'Content-Type': 'application/json'},
+        'Error: Gateway Timeout',
+      ]);
+
+      const saveBar = wrapper.find('SaveBar');
+
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
+      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+        .true;
+      saveAndKeepEditingButton.simulate('click');
+
+      // check the the spinner is showing
+      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
+      expect(unitEditor.state().isSaving).to.equal(true);
+
+      server.respond();
+      unitEditor.update();
+      expect(utils.navigateToHref).to.not.have.been.called;
+      expect(unitEditor.state().isSaving).to.equal(false);
+      expect(unitEditor.state().error).to.equal(
+        'The save request timed out. Please refresh the page and verify your changes have been saved correctly.'
+      );
+      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
+      expect(
+        wrapper.find('.saveBar').contains('Error Saving: There was an error')
+      ).to.be.true;
+
+      server.restore();
+    });
+
     it('shows error when showCalendar is true and weeklyInstructionalMinutes not provided', () => {
       sinon.stub($, 'ajax');
       const wrapper = createWrapper({initialShowCalendar: true});


### PR DESCRIPTION
Saving a unit seems to frequently hit a 504 timeout error, but still saves correctly. This just makes the error message a bit nicer so that levelbuilders don't panic when they see the error.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1186
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
