### PR TITLE
Always reload when navigating from summary page

### DIFF
--- a/apps/src/code-studio/browserNavigation.js
+++ b/apps/src/code-studio/browserNavigation.js
@@ -10,6 +10,15 @@ import {getStore} from '../redux';
 // Returns whether we can safely navigate between the two given levels
 // without reloading the whole page.
 export function canChangeLevelInPage(currentLevel, newLevel) {
+  // If we are on the summary page, we can't navigate to a new level without
+  // reloading the page. Summary is used for viewing student responses to
+  // predict levels.
+  const path = new URL(document.location).pathname;
+  const pathComponents = path.split('/');
+  if (pathComponents.includes('summary')) {
+    return false;
+  }
+  // Otherwise, we can navigate between any 2 lab2 levels.
   return currentLevel?.usesLab2 && newLevel?.usesLab2;
 }
 


### PR DESCRIPTION
Follow up to #59653.

In lab2, we allow navigating between any 2 lab2 levels. However, the summary page is a haml page masquerading as a lab2 level. This updates the browser navigation logic to not allow navigation without page reload if we are currently on a summary page.

## Links

- jira ticket: [CT-679](https://codedotorg.atlassian.net/browse/CT-679)

## Testing story
Tested locally that we now reload when going between a summary page and another lab2 level, but navigation between lab2 levels still occurs without page reload.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
