### PR TITLE
Converts the Email Hoc Guide to new design system buttons

### DIFF
--- a/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
+++ b/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
@@ -2,11 +2,11 @@ import cookies from 'js-cookie';
 import PropTypes from 'prop-types';
 import React, {useState, useEffect} from 'react';
 
+import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
 import {Heading2, Heading3} from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
-import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
 import {isEmail} from '@cdo/apps/util/formatValidation';
 import i18n from '@cdo/locale';
 

--- a/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
+++ b/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
@@ -6,7 +6,7 @@ import {Heading2, Heading3} from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
-import Button from '@cdo/apps/templates/Button';
+import Button from '@cdo/apps/componentLibrary/button/Button';
 import {isEmail} from '@cdo/apps/util/formatValidation';
 import i18n from '@cdo/locale';
 
@@ -138,15 +138,15 @@ function HourOfCodeGuideEmailDialog({isSignedIn, unitId}) {
           <div className={style.buttonsBottom}>
             <Button
               id="uitest-no-email-guide"
+              className={style.whiteButton}
               text={continueWithoutEmailButtonText}
               onClick={onClose}
-              color={Button.ButtonColor.white}
+              color={'white'}
             />
             <Button
               id="uitest-email-guide"
               text={isSendInProgress ? i18n.inProgress() : emailGuideButtonText}
               onClick={validateAndSave}
-              color={Button.ButtonColor.brandSecondaryDefault}
               disabled={isSendInProgress}
             />
           </div>

--- a/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
+++ b/apps/src/templates/HourOfCodeGuideEmailDialog.jsx
@@ -6,7 +6,7 @@ import {Heading2, Heading3} from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
-import Button from '@cdo/apps/componentLibrary/button/Button';
+import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
 import {isEmail} from '@cdo/apps/util/formatValidation';
 import i18n from '@cdo/locale';
 
@@ -141,7 +141,8 @@ function HourOfCodeGuideEmailDialog({isSignedIn, unitId}) {
               className={style.whiteButton}
               text={continueWithoutEmailButtonText}
               onClick={onClose}
-              color={'white'}
+              color={buttonColors.gray}
+              type="secondary"
             />
             <Button
               id="uitest-email-guide"

--- a/apps/src/templates/hoc-guide-dialogue.module.scss
+++ b/apps/src/templates/hoc-guide-dialogue.module.scss
@@ -45,7 +45,6 @@
 };
 
 .whiteButton {
-  outline: auto;
   margin-inline: 10px;
 }
 

--- a/apps/src/templates/hoc-guide-dialogue.module.scss
+++ b/apps/src/templates/hoc-guide-dialogue.module.scss
@@ -44,6 +44,11 @@
   font-weight: bold; 
 };
 
+.whiteButton {
+  outline: auto;
+  margin-inline: 10px;
+}
+
 .label {
   font-size: 16px;
 


### PR DESCRIPTION
The context: I was copying over this code for the AccessibleDialog and ended up mistakenly using the old Button component because of it. This is just a bit of cleanup so that if this file is copied again, it has the latest!

If I didn't add the new style in the stylesheet, the buttons would be side by side (no space at all). I elected to use the secondary grey style, as it seems the closest to the old version of the button.

Before:
<img width="834" alt="old" src="https://github.com/user-attachments/assets/9972b303-9cd0-4b2f-8e68-a2d097a8c158">

After:
<img width="678" alt="Screenshot 2024-07-11 at 6 56 49 PM" src="https://github.com/user-attachments/assets/3ad72d53-f78f-4062-b23c-4f23b1191483">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2055

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
