### PR TITLE
Update some versioned curriculum links on code.org

### DIFF
--- a/pegasus/sites.v3/code.org/views/faq_csf.haml
+++ b/pegasus/sites.v3/code.org/views/faq_csf.haml
@@ -2,12 +2,12 @@
   %summary=hoc_s(:csf_page_faq_question_01)
   %p=hoc_s(:csf_page_faq_answer_01_01)
   %ul
-    %li=hoc_s(:csf_page_faq_answer_01_list_01, markdown: :inline, locals: {course_a_url: CDO.studio_url("/s/coursea-2023/standards")})
-    %li=hoc_s(:csf_page_faq_answer_01_list_02, markdown: :inline, locals: {course_b_url: CDO.studio_url("/s/courseb-2023/standards")})
-    %li=hoc_s(:csf_page_faq_answer_01_list_03, markdown: :inline, locals: {course_c_url: CDO.studio_url("/s/coursec-2023/standards")})
-    %li=hoc_s(:csf_page_faq_answer_01_list_04, markdown: :inline, locals: {course_d_url: CDO.studio_url("/s/coursed-2023/standards")})
-    %li=hoc_s(:csf_page_faq_answer_01_list_05, markdown: :inline, locals: {course_e_url: CDO.studio_url("/s/coursee-2023/standards")})
-    %li=hoc_s(:csf_page_faq_answer_01_list_06, markdown: :inline, locals: {course_f_url: CDO.studio_url("/s/coursef-2023/standards")})
+    %li=hoc_s(:csf_page_faq_answer_01_list_01, markdown: :inline, locals: {course_a_url: CDO.studio_url("/s/coursea-2024/standards")})
+    %li=hoc_s(:csf_page_faq_answer_01_list_02, markdown: :inline, locals: {course_b_url: CDO.studio_url("/s/courseb-2024/standards")})
+    %li=hoc_s(:csf_page_faq_answer_01_list_03, markdown: :inline, locals: {course_c_url: CDO.studio_url("/s/coursec-2024/standards")})
+    %li=hoc_s(:csf_page_faq_answer_01_list_04, markdown: :inline, locals: {course_d_url: CDO.studio_url("/s/coursed-2024/standards")})
+    %li=hoc_s(:csf_page_faq_answer_01_list_05, markdown: :inline, locals: {course_e_url: CDO.studio_url("/s/coursee-2024/standards")})
+    %li=hoc_s(:csf_page_faq_answer_01_list_06, markdown: :inline, locals: {course_f_url: CDO.studio_url("/s/coursef-2024/standards")})
   %p=hoc_s(:csf_page_faq_answer_01_02, markdown: :inline, locals: {csf_standards_url: "https://docs.google.com/spreadsheets/d/1-cJlBMbxIM_f9cALv1QYHXe6zJz9MPW49FnjK7tMS3E/edit#gid=901318184"})
 %details
   %summary=hoc_s(:csf_page_faq_question_02)

--- a/pegasus/sites.v3/code.org/views/game_design/game_design_curriculum_mid_high.haml
+++ b/pegasus/sites.v3/code.org/views/game_design/game_design_curriculum_mid_high.haml
@@ -6,7 +6,7 @@
       img: "/images/action-blocks/action-block-interactive-animation.png",
       desc: hoc_s("game_design_page.mid_high_curricula.interactive.desc"),
       duration: hoc_s("game_design_page.mid_high_curricula.interactive.duration"),
-      url: CDO.studio_url("/s/interactive-games-animations-2023"),
+      url: CDO.studio_url("/s/interactive-games-animations"),
       aria_label: hoc_s("game_design_page.mid_high_curricula.interactive.aria_label"),
       button_label: hoc_s("game_design_page.mid_high_curricula.interactive.button"),
     },


### PR DESCRIPTION
- The /s/coursea-2023/standards URLs can't use the automatic redirects, so I'm just updating them manually
- I think we want /s/interactive-games-animations over the versioned link. As Moshe pointed out, signed out users are automatically redirected anyway!

