### PR TITLE
[AI Chat] Include for temp and selected model id changed value in analytics logging

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -215,11 +215,20 @@ export const onSaveComplete =
         })
       );
 
+      // Report to analytics the changed value for only selected model id and temperature properties.
+      // Do not include the free text changes (system prompt and retrieval contexts).
+      const propertiesChangedValueToReport = ['selectedModelId', 'temperature'];
+      const propertyChangedTo = propertiesChangedValueToReport.includes(
+        typedProperty
+      )
+        ? currentAiCustomizations[typedProperty]
+        : 'NULL';
       if (currentSaveType) {
         analyticsReporter.sendEvent(
           saveTypeToAnalyticsEvent[currentSaveType],
           {
             propertyUpdated: property,
+            propertyChangedTo,
             levelPath: window.location.pathname,
           },
           PLATFORMS.BOTH


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the analytics event logging for AI chat customization updates to include the value changed to for temperature and selected model id properties.
Note that for system prompt and retrieval context updates (free text) value changed to is set to 'NULL' as requested by @samantha-code .

## After update

Screencast showing Amplitude/Statsig logging in dev console when model customization updates are made.


https://github.com/user-attachments/assets/abc4e2d9-c57e-4882-92d8-0617d41c31af



## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-909)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally in aichat levels in /allthethings.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
