### PR TITLE
delete learning goal ai evals and feedbacks when user account is purged

### DIFF
--- a/dashboard/app/models/learning_goal_ai_evaluation.rb
+++ b/dashboard/app/models/learning_goal_ai_evaluation.rb
@@ -28,6 +28,7 @@ class LearningGoalAiEvaluation < ApplicationRecord
   has_one :rubric, through: :learning_goal
   has_one :lesson, through: :rubric
   has_one :level, through: :rubric
+  has_many :learning_goal_ai_evaluation_feedbacks, inverse_of: :learning_goal_ai_evaluation, dependent: :destroy
 
   AI_CONFIDENCE_LEVELS = {
     LOW: 1,

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1604,6 +1604,50 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   end
 
   #
+  # Table: dashboard.rubric_ai_evaluations
+  # Table: dashboard.learning_goal_ai_evaluations
+  # Table: dashboard.learning_goal_ai_evaluation_feedbacks
+  # Table: dashboard.learning_goal_teacher_evaluations
+  #
+
+  test "deletes all of a purged user's ai evaluations and teacher evaluations as student" do
+    student = create :student
+    rubric_ai_evaluation = create :rubric_ai_evaluation, user: student, requester: student
+    learning_goal_ai_evaluation = create :learning_goal_ai_evaluation, user: student, rubric_ai_evaluation: rubric_ai_evaluation
+    create :learning_goal_ai_evaluation_feedback, learning_goal_ai_evaluation: learning_goal_ai_evaluation
+    create :learning_goal_teacher_evaluation, user: student
+
+    assert_changes -> {RubricAiEvaluation.where(user: student).count}, from: 1, to: 0 do
+      assert_changes -> {LearningGoalAiEvaluation.where(rubric_ai_evaluation: rubric_ai_evaluation).count}, from: 1, to: 0 do
+        assert_changes -> {LearningGoalAiEvaluationFeedback.where(learning_goal_ai_evaluation: learning_goal_ai_evaluation).count}, from: 1, to: 0 do
+          assert_changes -> {LearningGoalTeacherEvaluation.where(user: student).count}, from: 1, to: 0 do
+            purge_user student
+          end
+        end
+      end
+    end
+  end
+
+  test "deletes all of a purged user's ai evaluations and teacher evaluations as teacher" do
+    student = create :student
+    teacher = create :teacher
+    rubric_ai_evaluation = create :rubric_ai_evaluation, user: student, requester: teacher
+    learning_goal_ai_evaluation = create :learning_goal_ai_evaluation, user: student, rubric_ai_evaluation: rubric_ai_evaluation
+    create :learning_goal_ai_evaluation_feedback, learning_goal_ai_evaluation: learning_goal_ai_evaluation
+    create :learning_goal_teacher_evaluation, user: student, teacher: teacher
+
+    assert_changes -> {RubricAiEvaluation.where(requester_id: teacher).count}, from: 1, to: 0 do
+      assert_changes -> {LearningGoalAiEvaluation.where(rubric_ai_evaluation: rubric_ai_evaluation).count}, from: 1, to: 0 do
+        assert_changes -> {LearningGoalAiEvaluationFeedback.where(learning_goal_ai_evaluation: learning_goal_ai_evaluation).count}, from: 1, to: 0 do
+          assert_changes -> {LearningGoalTeacherEvaluation.where(teacher: teacher).count}, from: 1, to: 0 do
+            purge_user teacher
+          end
+        end
+      end
+    end
+  end
+
+  #
   # Table: dashboard.projects
   #
 

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -323,11 +323,17 @@ class DeleteAccountsHelper
   end
 
   def delete_rubric_ai_evaluations(user_id)
+    # This finds all RubricAiEvaluation records which evalute this user's work,
+    # whether they were implicitly requested by the student when they submitted
+    # the project, or explicitly requested by their teacher.
     as_student = RubricAiEvaluation.where(user_id: user_id)
     as_student_count = as_student.count
     as_student.each(&:destroy)
     @log.puts "Deleted #{as_student_count} RubricAiEvaluation as student" if as_student_count > 0
 
+    # We've already deleted all evaluations of this user's work as a student.
+    # Any remaining evaluations requested by this user are requests made
+    # by a teacher to evaluate a student's work.
     as_teacher = RubricAiEvaluation.where(requester_id: user_id)
     as_teacher_count = as_teacher.count
     as_teacher.each(&:destroy)

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -322,6 +322,30 @@ class DeleteAccountsHelper
     @log.puts "Deleted #{count} AI Tutor Interactions" if count > 0
   end
 
+  def delete_rubric_ai_evaluations(user_id)
+    as_student = RubricAiEvaluation.where(user_id: user_id)
+    as_student_count = as_student.count
+    as_student.each(&:destroy)
+    @log.puts "Deleted #{as_student_count} RubricAiEvaluation as student" if as_student_count > 0
+
+    as_teacher = RubricAiEvaluation.where(requester_id: user_id)
+    as_teacher_count = as_teacher.count
+    as_teacher.each(&:destroy)
+    @log.puts "Deleted #{as_teacher_count} RubricAiEvaluation as teacher" if as_teacher_count > 0
+  end
+
+  def delete_learning_goal_teacher_evaluations(user_id)
+    as_student = LearningGoalTeacherEvaluation.where(user_id: user_id)
+    as_student_count = as_student.count
+    as_student.each(&:destroy)
+    @log.puts "Deleted #{as_student_count} LearningGoalTeacherEvaluation as student" if as_student_count > 0
+
+    as_teacher = LearningGoalTeacherEvaluation.where(teacher_id: user_id)
+    as_teacher_count = as_teacher.count
+    as_teacher.each(&:destroy)
+    @log.puts "Deleted #{as_teacher_count} LearningGoalTeacherEvaluation as teacher" if as_teacher_count > 0
+  end
+
   def clean_and_destroy_code_reviews(user_id)
     # anonymize notes the user wrote
     comments_written = CodeReviewComment.where(commenter_id: user_id)
@@ -442,6 +466,8 @@ class DeleteAccountsHelper
     clean_pegasus_forms_for_user(user)
     delete_project_backed_progress(user)
     delete_ai_tutor_interactions(user.id)
+    delete_rubric_ai_evaluations(user.id)
+    delete_learning_goal_teacher_evaluations(user.id)
     clean_and_destroy_pd_content(user.id, user_email)
     clean_user_sections(user.id)
     remove_user_from_sections_as_student(user)


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-426. The requirement is to wipe any PII for any user who either deletes their account or explicitly requests data to be wiped, and the easiest way for us to do that is to delete all ai-eval-related objects related to the user, whether they are a teacher or a student. See [slack](https://codedotorg.slack.com/archives/CFTFD6BPV/p1720740468262979) for discussion. 

## Testing story

new unit tests

## Follow-up work

If we add any more database tables,  remember to create a work item to add a similar method to delete them. CC @cearachew for differentiation chat (I've added a note to the tech spec)