### PR TITLE
Move Devise Customization into Subdirectory

### DIFF
--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -337,9 +337,9 @@ Devise.setup do |config|
   #   manager.intercept_401 = false
   #   manager.default_strategies(:scope => :user).unshift :some_external_strategy
   # end
-  require 'custom_devise_failure'
+  require 'devise/custom_failure'
   config.warden do |manager|
-    manager.failure_app = CustomDeviseFailure
+    manager.failure_app = Devise::CustomFailure
   end
 
   require 'cdo/cookie_helpers'

--- a/dashboard/lib/custom_devise_failure.rb
+++ b/dashboard/lib/custom_devise_failure.rb
@@ -1,9 +1,0 @@
-# Overrides the locale for Devise failures to use the same logic as our app.
-class CustomDeviseFailure < Devise::FailureApp
-  include LocaleHelper
-
-  protected def i18n_options(options)
-    options[:locale] = locale
-    options
-  end
-end

--- a/dashboard/lib/devise/custom_failure.rb
+++ b/dashboard/lib/devise/custom_failure.rb
@@ -1,0 +1,11 @@
+# Overrides the locale for Devise failures to use the same logic as our app.
+module Devise
+  class CustomFailure < Devise::FailureApp
+    include LocaleHelper
+
+    protected def i18n_options(options)
+      options[:locale] = locale
+      options
+    end
+  end
+end


### PR DESCRIPTION
In preparation for some upcoming work-in-progress changes to [enable automatic lockout for teachers](https://github.com/code-dot-org/code-dot-org/pull/57515) and [allow users to log out of all existing sessions](https://github.com/code-dot-org/code-dot-org/pull/59763), we'd like to move our existing customization to Devise functionality into a subdirectory and associated Module so that the upcoming functionality can be organized into the same place.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
