### PR TITLE
Use new success dialog on My PL page

### DIFF
--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -35,6 +35,7 @@ import {
   COURSE_CSP,
   COURSE_CSA,
 } from '../workshop_dashboard/workshopConstants';
+import WorkshopEnrollmentCelebrationDialog from '../workshop_enrollment/WorkshopEnrollmentCelebrationDialog';
 
 import {EnrolledWorkshops, WorkshopsTable} from './EnrolledWorkshops';
 import SelfPacedProgressTable from './SelfPacedProgressTable';
@@ -103,8 +104,8 @@ function LandingPage({
 }) {
   const availableTabs = getAvailableTabs(userPermissions);
   const [currentTab, setCurrentTab] = useState(availableTabs[0].value);
-  const [showEnrollmentSuccessMessage, setShowEnrollmentSuccessMessage] =
-    useState(false);
+  const [enrollSuccessWorkshopName, setEnrollSuccessWorkshopName] =
+    useState(null);
   const headerContainerStyles =
     availableTabs.length > 1
       ? style.headerWithTabsContainer
@@ -115,7 +116,9 @@ function LandingPage({
 
   // If sent here from successfully enrolling in a workshop, log WORKSHOP_ENROLLMENT_COMPLETED_EVENT.
   const urlParams = queryParams();
-  if (urlParams && Object.keys(urlParams).includes('rpName')) {
+  if (urlParams && Object.keys(urlParams).includes('wsCourse')) {
+    setEnrollSuccessWorkshopName(urlParams['wsCourse']);
+
     analyticsReporter.sendEvent(EVENTS.WORKSHOP_ENROLLMENT_COMPLETED_EVENT, {
       'regional partner': urlParams['rpName'],
       'workshop course': urlParams['wsCourse'],
@@ -125,8 +128,6 @@ function LandingPage({
     updateQueryParam('rpName', undefined, false);
     updateQueryParam('wsCourse', undefined, false);
     updateQueryParam('wsSubject', undefined, false);
-
-    setShowEnrollmentSuccessMessage(true);
   }
 
   // Load PL section info into redux
@@ -367,22 +368,10 @@ function LandingPage({
   const RenderMyPlTab = () => {
     return (
       <>
-        {showEnrollmentSuccessMessage && (
-          <div style={successMessageStyling.successContainer}>
-            <div style={successMessageStyling.successMessage}>
-              <p style={successMessageStyling.text}>
-                You successfully enrolled in a Build Your Own workshop!
-              </p>
-              <button
-                aria-label="close success message"
-                onClick={() => setShowEnrollmentSuccessMessage(false)}
-                type="button"
-                style={successMessageStyling.button}
-              >
-                <strong>X</strong>
-              </button>
-            </div>
-          </div>
+        {enrollSuccessWorkshopName && (
+          <WorkshopEnrollmentCelebrationDialog
+            workshopName={enrollSuccessWorkshopName}
+          />
         )}
         {RenderBanner()}
         {plCoursesStarted?.length >= 1 && RenderSelfPacedPL()}
@@ -499,35 +488,6 @@ function LandingPage({
     </>
   );
 }
-
-const successMessageStyling = {
-  successContainer: {
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  successMessage: {
-    display: 'flex',
-    minWidth: '250px',
-    backgroundColor: 'green',
-    textAlign: 'center',
-    borderRadius: '5px',
-    position: 'fixed',
-    zIndex: 4,
-    top: '240px',
-  },
-  button: {
-    maxHeight: '1.5em',
-    margin: '3px 6px',
-    padding: 0,
-    backgroundColor: 'transparent',
-    border: 'none',
-    fontSize: '12px',
-  },
-  text: {
-    margin: '16px',
-    color: 'black',
-  },
-};
 
 export const UnconnectedLandingPage = LandingPage;
 

--- a/apps/src/code-studio/pd/workshop_enrollment/WorkshopEnrollmentCelebrationDialog.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/WorkshopEnrollmentCelebrationDialog.jsx
@@ -12,9 +12,13 @@ const CelebrationImage = require('@cdo/static/pd/EnrollmentCelebration.png');
 
 export default function WorkshopEnrollmentCelebrationDialog({
   workshopName = 'a new workshop',
+  onClose,
 }) {
   const [isOpen, setIsOpen] = useState(true);
-  const onClose = () => {
+  const onCloseDialog = () => {
+    if (onClose) {
+      onClose();
+    }
     setIsOpen(false);
   };
 
@@ -22,7 +26,7 @@ export default function WorkshopEnrollmentCelebrationDialog({
     isOpen && (
       <AccessibleDialog
         className={style.celebrationContainer}
-        onClose={onClose}
+        onClose={onCloseDialog}
         closeOnClickBackdrop={true}
       >
         <div className={style.containerMargin}>
@@ -34,7 +38,7 @@ export default function WorkshopEnrollmentCelebrationDialog({
             </BodyTwoText>
           </div>
           <Button
-            onClick={onClose}
+            onClick={onCloseDialog}
             text={i18n.enrollmentCelebrationCallToAction()}
           />
         </div>
@@ -45,4 +49,5 @@ export default function WorkshopEnrollmentCelebrationDialog({
 
 WorkshopEnrollmentCelebrationDialog.propTypes = {
   workshopName: PropTypes.string,
+  onClose: PropTypes.func,
 };

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
@@ -14,6 +14,10 @@ import {
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import i18n from '@cdo/locale';
 
+import {
+  setWindowLocation,
+  resetWindowLocation,
+} from '../../../../src/code-studio/utils';
 import {expect} from '../../../../util/reconfiguredChai';
 
 const TEST_WORKSHOP = {
@@ -65,6 +69,7 @@ describe('LandingPage', () => {
 
   afterEach(() => {
     restoreRedux();
+    resetWindowLocation();
   });
 
   function renderDefault(propOverrides = {}) {
@@ -337,5 +342,25 @@ describe('LandingPage', () => {
 
     // Workshop Organizer workshop table
     screen.getByText('In Progress and Upcoming Workshops');
+  });
+
+  it('page does not show success dialog when not redirected here from successful enrollment', () => {
+    renderDefault();
+
+    expect(
+      screen.queryByText(
+        i18n.enrollmentCelebrationBody({workshopName: 'a new workshop'})
+      )
+    ).to.be.null;
+  });
+
+  it('page shows success dialog when redirected here from successful enrollment', () => {
+    const workshopCourseName = 'TEST COURSE';
+    setWindowLocation({search: `?wsCourse=${workshopCourseName}`});
+    renderDefault();
+
+    screen.getByText(
+      i18n.enrollmentCelebrationBody({workshopName: workshopCourseName})
+    );
   });
 });

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
@@ -69,7 +69,6 @@ describe('LandingPage', () => {
 
   afterEach(() => {
     restoreRedux();
-    resetWindowLocation();
   });
 
   function renderDefault(propOverrides = {}) {
@@ -362,5 +361,6 @@ describe('LandingPage', () => {
     screen.getByText(
       i18n.enrollmentCelebrationBody({workshopName: workshopCourseName})
     );
+    resetWindowLocation();
   });
 });

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
@@ -6,6 +6,10 @@ import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import {selfPacedCourseConstants} from '@cdo/apps/code-studio/pd/professional_learning_landing/constants.js';
 import {UnconnectedLandingPage as LandingPage} from '@cdo/apps/code-studio/pd/professional_learning_landing/LandingPage';
 import {
+  setWindowLocation,
+  resetWindowLocation,
+} from '@cdo/apps/code-studio/utils';
+import {
   getStore,
   registerReducers,
   stubRedux,
@@ -14,10 +18,6 @@ import {
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import i18n from '@cdo/locale';
 
-import {
-  setWindowLocation,
-  resetWindowLocation,
-} from '../../../../src/code-studio/utils';
 import {expect} from '../../../../util/reconfiguredChai';
 
 const TEST_WORKSHOP = {


### PR DESCRIPTION
Implements [Hannah's enrollment success dialog](https://github.com/code-dot-org/code-dot-org/pull/59662) for the My PL page and removes the filler success dialog I created in [this PR](https://github.com/code-dot-org/code-dot-org/pull/59538).

Works for Build Your Own workshop auto-enrollment:

https://github.com/user-attachments/assets/4da284bf-a6d8-45a1-a212-5accac9d5fb4

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2051)

## Testing story
Local testing and adding unit tests.
