### PR TITLE
AI Tutor: use levelId in AITutorTester

### DIFF
--- a/apps/src/aiTutor/chatApi.ts
+++ b/apps/src/aiTutor/chatApi.ts
@@ -41,23 +41,14 @@ export async function postOpenaiChatCompletion(
   messagesToSend: OpenaiChatCompletionMessage[],
   levelId?: number,
   tutorType?: AITutorTypesValue,
-  levelInstructions?: string,
   systemPrompt?: string
 ): Promise<OpenaiChatCompletionMessage | null> {
-  const payload = levelId
-    ? {
-        levelId: levelId,
-        messages: messagesToSend,
-        type: tutorType,
-        levelInstructions,
-        systemPrompt,
-      }
-    : {
-        messages: messagesToSend,
-        type: tutorType,
-        levelInstructions,
-        systemPrompt,
-      };
+  const payload = {
+    messages: messagesToSend,
+    levelId: levelId,
+    type: tutorType,
+    systemPrompt: systemPrompt,
+  };
 
   const response = await HttpClient.post(
     CHAT_COMPLETION_URL,
@@ -91,8 +82,7 @@ export async function getChatCompletionMessage(
   chatMessages: ChatCompletionMessage[],
   systemPrompt?: string,
   levelId?: number,
-  tutorType?: AITutorTypesValue,
-  levelInstructions?: string
+  tutorType?: AITutorTypesValue
 ): Promise<ChatCompletionResponse> {
   const messagesToSend = [
     ...formatForChatCompletion(chatMessages),
@@ -105,7 +95,6 @@ export async function getChatCompletionMessage(
       messagesToSend,
       levelId,
       tutorType,
-      levelInstructions,
       systemPrompt
     );
   } catch (error) {

--- a/apps/src/aiTutor/chatApi.ts
+++ b/apps/src/aiTutor/chatApi.ts
@@ -76,7 +76,7 @@ export async function getChatCompletionMessage(
   formattedQuestion: string,
   chatMessages: ChatCompletionMessage[],
   systemPrompt?: string,
-  levelId?: number,
+  levelId?: number
 ): Promise<ChatCompletionResponse> {
   const messagesToSend = [
     ...formatForChatCompletion(chatMessages),

--- a/apps/src/aiTutor/chatApi.ts
+++ b/apps/src/aiTutor/chatApi.ts
@@ -2,7 +2,6 @@ import {
   Role,
   AITutorInteractionStatus as Status,
   AITutorInteractionStatusValue,
-  AITutorTypesValue,
   ChatCompletionMessage,
 } from '@cdo/apps/aiTutor/types';
 import {MetricEvent} from '@cdo/apps/lib/metrics/events';
@@ -34,19 +33,15 @@ const logViolationDetails = (response: OpenaiChatCompletionMessage) => {
 
 /**
  * This function sends a POST request to the chat completion backend controller.
- * Note: This function needs access to the tutorType so it can decide whether to include
- * validation code on the backend.
  */
 export async function postOpenaiChatCompletion(
   messagesToSend: OpenaiChatCompletionMessage[],
   levelId?: number,
-  tutorType?: AITutorTypesValue,
   systemPrompt?: string
 ): Promise<OpenaiChatCompletionMessage | null> {
   const payload = {
     messages: messagesToSend,
     levelId: levelId,
-    type: tutorType,
     systemPrompt: systemPrompt,
   };
 
@@ -82,7 +77,6 @@ export async function getChatCompletionMessage(
   chatMessages: ChatCompletionMessage[],
   systemPrompt?: string,
   levelId?: number,
-  tutorType?: AITutorTypesValue
 ): Promise<ChatCompletionResponse> {
   const messagesToSend = [
     ...formatForChatCompletion(chatMessages),
@@ -94,7 +88,6 @@ export async function getChatCompletionMessage(
     response = await postOpenaiChatCompletion(
       messagesToSend,
       levelId,
-      tutorType,
       systemPrompt
     );
   } catch (error) {

--- a/apps/src/aiTutor/redux/aiTutorRedux.ts
+++ b/apps/src/aiTutor/redux/aiTutorRedux.ts
@@ -10,7 +10,6 @@ import {
   ChatCompletionMessage,
   Level,
   ChatContext,
-  AITutorTypes,
 } from '../types';
 
 const registerReducers = require('@cdo/apps/redux').registerReducers;
@@ -22,10 +21,6 @@ export interface AITutorState {
   chatMessages: ChatCompletionMessage[];
   isWaitingForChatResponse: boolean;
   isChatOpen: boolean;
-}
-
-export interface InstructionsState {
-  longInstructions: string;
 }
 
 const initialChatMessages: ChatCompletionMessage[] = [
@@ -46,15 +41,15 @@ const initialState: AITutorState = {
 };
 
 export const formatQuestionForAITutor = (chatContext: ChatContext) => {
-  if (chatContext.actionType === AITutorTypes.GENERAL_CHAT) {
-    return chatContext.studentInput;
+  let formattedQuestion = chatContext.studentInput;
+
+  if (chatContext.studentCode) {
+    const separator = '\n\n---\n\n';
+    const codePrefix = "Here is the student's code:\n\n```\n";
+    const codePostfix = '\n```';
+    formattedQuestion = `${chatContext.studentInput}${separator}${codePrefix}${chatContext.studentCode}${codePostfix}`;
   }
 
-  const separator = '\n\n---\n\n';
-  const codePrefix = "Here is the student's code:\n\n```\n";
-  const codePostfix = '\n```';
-
-  const formattedQuestion = `${chatContext.studentInput}${separator}${codePrefix}${chatContext.studentCode}${codePostfix}`;
   return formattedQuestion;
 };
 
@@ -64,13 +59,10 @@ export const askAITutor = createAsyncThunk(
   async (chatContext: ChatContext, thunkAPI) => {
     const state = thunkAPI.getState();
     const aiTutorState = state as {aiTutor: AITutorState};
-    const instructionsState = state as {instructions: InstructionsState};
     const levelContext = {
       levelId: aiTutorState.aiTutor.level?.id,
       scriptId: aiTutorState.aiTutor.scriptId,
     };
-
-    const levelInstructions = instructionsState.instructions.longInstructions;
 
     const storedMessages = aiTutorState.aiTutor.chatMessages;
     const newMessage: ChatCompletionMessage = {
@@ -81,13 +73,14 @@ export const askAITutor = createAsyncThunk(
     thunkAPI.dispatch(addChatMessage(newMessage));
 
     const formattedQuestion = formatQuestionForAITutor(chatContext);
+    // We currently use the default system prompt stored on the server,
+    // so don't pass in an override here.
+    const systemPrompt = undefined;
     const chatApiResponse = await getChatCompletionMessage(
       formattedQuestion,
       storedMessages,
-      '',
-      levelContext.levelId,
-      chatContext.actionType,
-      levelInstructions
+      systemPrompt,
+      levelContext.levelId
     );
     thunkAPI.dispatch(
       updateLastChatMessage({

--- a/apps/src/lib/levelbuilder/ai-tutor/AITutorTester.tsx
+++ b/apps/src/lib/levelbuilder/ai-tutor/AITutorTester.tsx
@@ -13,7 +13,8 @@ import AITutorTesterSampleColumns from './AITutorTesterSampleColumns';
  */
 
 interface AIInteraction extends ChatContext {
-  systemPrompt: string | undefined;
+  systemPrompt?: string | undefined;
+  levelId?: number | undefined;
   aiResponse: string | undefined;
 }
 
@@ -58,7 +59,8 @@ const AITutorTester: React.FC<AITutorTesterProps> = ({allowed}) => {
     const chatApiResponse = await getChatCompletionMessage(
       formatQuestionForAITutor(row),
       [],
-      row.systemPrompt
+      row.systemPrompt,
+      row.levelId
     );
     row.aiResponse = chatApiResponse.assistantResponse;
     setResponseCount(prevResponseCount => prevResponseCount + 1);

--- a/apps/src/lib/levelbuilder/ai-tutor/AITutorTesterSampleColumns.tsx
+++ b/apps/src/lib/levelbuilder/ai-tutor/AITutorTesterSampleColumns.tsx
@@ -14,6 +14,8 @@ const AITutorTesterSampleColumns: React.FC = () => {
       systemPrompt:
         'OPTIONAL. If not included, the default system prompt is used.',
       studentCode: "OPTIONAL. The student's code.",
+      levelId:
+        "OPTIONAL. If provided, will be used to fetch the level's instructions and test files if applicable. Reminder: it needs to be the levelId for the level in the environment in which you're running the tester.",
     },
   ];
   return (
@@ -31,6 +33,9 @@ const AITutorTesterSampleColumns: React.FC = () => {
             <td className={style.cell}>
               <div>studentCode</div>
             </td>
+            <td className={style.cell}>
+              <div>levelId</div>
+            </td>
           </tr>
         </thead>
         <tbody>
@@ -39,6 +44,7 @@ const AITutorTesterSampleColumns: React.FC = () => {
               <td className={style.cell}>{row.studentInput}</td>
               <td className={style.cell}>{row.systemPrompt}</td>
               <td className={style.cell}>{row.studentCode}</td>
+              <td className={style.cell}>{row.levelId}</td>
             </tr>
           ))}
         </tbody>

--- a/dashboard/app/controllers/openai_chat_controller.rb
+++ b/dashboard/app/controllers/openai_chat_controller.rb
@@ -116,14 +116,16 @@ class OpenaiChatController < ApplicationController
       return render(status: :bad_request, json: {message: "Couldn't find level with id=#{level_id}."})
     end
 
-    if level.validation.values.empty?
-      return render(status: :bad_request, json: {message: "There are no test files associated with level id=#{level_id}."})
-    else
-      test_file_contents = ""
-      level.validation.each_value do |validation|
-        test_file_contents += validation["text"]
+    test_file_contents = ""
+    if !!level.validation
+      if level.validation.values.empty?
+        return render(status: :bad_request, json: {message: "There are no test files associated with level id=#{level_id}."})
+      else
+        level.validation.each_value do |validation|
+          test_file_contents += validation["text"]
+        end
       end
-      return test_file_contents
     end
+    return test_file_contents
   end
 end


### PR DESCRIPTION
[CT-689](https://codedotorg.atlassian.net/browse/CT-689)
[CT-682](https://codedotorg.atlassian.net/browse/CT-682)
[CT-690](https://codedotorg.atlassian.net/browse/CT-690)

Continuation of https://github.com/code-dot-org/code-dot-org/pull/59767

This work allows the user to include `levelId` as a column in the AI Tutor Tester uploaded csv. The backend will then use that `levelId` to fetch the level's instructions and test files where applicable. As a result we no longer need to pass around `levelInstructions` on the frontend because we fetch them from the backend now. 

Along the way I tackled a couple of other issues: 
- `actionType` (generalChat, validation or compilation) isn't relevant to AI. The question and system prompt dictate the AI's response. I decided to no longer pass around `actionType` in the request for the AI response. 
- Relatedly, even in general chat scenarios, the AI often needs access to the student's code and test files (if they are available) to be able to answer effectively so we default to sending those along in all scenarios.


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Testing story
I verified locally that I can still get AI responses for general chat, validation and compilation scenarios within the context of a level locally. 

Here's the flow from the csv upload including `levelId` using a small sample of [validation prompts](https://docs.google.com/spreadsheets/d/1BeUT3u_mMFdEz7fOFvNWI0ukw5WcX9OGIn2S3YOYjh8/edit?gid=81872701#gid=81872701).

https://github.com/user-attachments/assets/a62f0970-3e3f-40de-bd6e-e41fb6dee410



<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
- The `actionType` distinctions are somewhat artificial on the backend since a user could (and often does) ask a compilation or test-related question in the "general chat" scenario. `actionType` is still currently used for suggested prompts and analytics, so I kept it around in UI components and logging for now; but, we may want to reconsider this as we refine AI Tutor use cases.

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
