### PR TITLE
Add missing "And I close my eyes" statements in Acquisition eyes tests

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/sign_up.feature
+++ b/dashboard/test/ui/features/acquisition_products/sign_up.feature
@@ -18,3 +18,4 @@ Scenario: Teacher can create an account with the new school association flow
   When I press "user_email_preference_opt_in_no"
   And I press "#signup_finish_submit" using jQuery
   And I wait until I see selector "#uitest-accept-section-creation"
+  And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
@@ -195,3 +195,5 @@ Scenario: Teacher can view choice levels
   # View expanded choice level
   And I click selector "button:contains(b)"
   And I see no difference for "unexpanded choice level - closed"
+
+  And I close my eyes


### PR DESCRIPTION
Some Acquisitions eyes tests (specifically `School Association` and `V2 Progress - Choice Levels`) were hanging and neither one had "And I close my eyes" present so this is a speculative fix to ensure those tests finish.

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1721069583341559)
