### PR TITLE
change how passed levels are presented

### DIFF
--- a/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LevelDataCell.jsx
@@ -97,7 +97,8 @@ function LevelDataCell({
       studentLevelProgress.status === LevelStatus.perfect ||
       studentLevelProgress.status === LevelStatus.submitted ||
       studentLevelProgress.status === LevelStatus.free_play_complete ||
-      studentLevelProgress.status === LevelStatus.completed_assessment
+      studentLevelProgress.status === LevelStatus.completed_assessment ||
+      studentLevelProgress.status === LevelStatus.passed
     ) {
       if (level.isValidated) {
         return ITEM_TYPE.VALIDATED;
@@ -105,10 +106,7 @@ function LevelDataCell({
         return ITEM_TYPE.SUBMITTED;
       }
     }
-    if (
-      studentLevelProgress.status === LevelStatus.attempted ||
-      studentLevelProgress.status === LevelStatus.passed
-    ) {
+    if (studentLevelProgress.status === LevelStatus.attempted) {
       return ITEM_TYPE.IN_PROGRESS;
     }
     return ITEM_TYPE.NO_PROGRESS;

--- a/apps/test/unit/templates/sectionProgressV2/LevelDataCellTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/LevelDataCellTest.jsx
@@ -92,11 +92,23 @@ describe('LevelDataCell', () => {
     screen.getByRole('link', {name: ITEM_TYPE.NO_PROGRESS.title});
   });
 
-  it('Validated level', () => {
+  it('Validated perfect level', () => {
     renderDefault({
       studentLevelProgress: {
         ...PROGRESS,
         status: LevelStatus.perfect,
+      },
+      level: {isValidated: true, id: 1, url: TEST_URL},
+    });
+
+    screen.getByRole('link', {name: ITEM_TYPE.VALIDATED.title});
+  });
+
+  it('Validated passed level', () => {
+    renderDefault({
+      studentLevelProgress: {
+        ...PROGRESS,
+        status: LevelStatus.passed,
       },
       level: {isValidated: true, id: 1, url: TEST_URL},
     });


### PR DESCRIPTION
This PR shows levels that have "passed" as "validated" rather than "in progress". 

Old view:
<img width="603" alt="image" src="https://github.com/user-attachments/assets/6504bee6-cabe-4816-a134-0f37c091e962">


New view after this PR:
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/8c198d72-77d6-4d64-9b2b-bf4af521cc11">


This seemed too easy :) - which made me make it harder by doing a bit more research about `LevelStatus`, specifically the `passed` LevelStatus.  While I couldn't find any good documentation in the code or in past PRs, this is the best I could find:
- Levels completed with "too many blocks"[ have a green border and light green background](https://github.com/code-dot-org/code-dot-org/blob/905da3a18f1ebb22ac646a670e35690c9650352d/apps/test/unit/templates/progress/ProgressBubbleTest.js#L124).  
- That matches how we were displaying this [level in the past.](https://github.com/code-dot-org/code-dot-org/blob/d04de8256eb7797e715867c167b8ff2a60bd11bb/apps/src/templates/progress/progressStyles.js#L129)
[- This Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1709234230802669) also indicated there would be some assumptions made about `LevelStatus` 

## Links

-[ ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1036)

## Testing story
Added tests and tested locally with this level: https://studio.code.org/s/coursec-2023/lessons/3/levels/6
