### PR TITLE
Oceans: K-5 updates

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -199,7 +199,7 @@
     "@code-dot-org/js-interpreter": "1.3.13",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "2.16.0",
-    "@code-dot-org/ml-activities": "0.0.26",
+    "@code-dot-org/ml-activities": "0.0.29",
     "@code-dot-org/ml-playground": "0.0.47",
     "@code-dot-org/p5.play": "1.3.21-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.13",

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import {TestResults} from '@cdo/apps/constants';
 
 import {getStore} from '../redux';
@@ -116,8 +117,9 @@ Fish.prototype.onContinue = function () {
 };
 
 Fish.prototype.initMLActivities = function () {
-  const {mode} = this.level;
+  const {mode, guides} = this.level;
   const onContinue = this.onContinue.bind(this);
+  const textToSpeechLocale = queryParams('tts');
 
   // Set up initial state
   const canvas = document.getElementById('activity-canvas');
@@ -132,6 +134,8 @@ Fish.prototype.initMLActivities = function () {
     canvas,
     backgroundCanvas,
     appMode: mode,
+    guides,
+    textToSpeechLocale,
     onContinue,
     registerSound: this.studioApp_.registerAudio.bind(this.studioApp_),
     playSound: this.studioApp_.playAudio.bind(this.studioApp_),

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -2743,9 +2743,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@code-dot-org/ml-activities@npm:0.0.26":
-  version: 0.0.26
-  resolution: "@code-dot-org/ml-activities@npm:0.0.26"
+"@code-dot-org/ml-activities@npm:0.0.29":
+  version: 0.0.29
+  resolution: "@code-dot-org/ml-activities@npm:0.0.29"
   dependencies:
     "@fortawesome/fontawesome-svg-core": ^1.2.25
     "@fortawesome/free-solid-svg-icons": ^5.11.2
@@ -2755,9 +2755,9 @@ __metadata:
   peerDependencies:
     lodash: ^4.17.5
     radium: ^0.25.2
-    react: ~15.4.0
-    react-dom: ~15.4.0
-  checksum: 48ac8045e0e6d074e3f6778c0efaafeac07f4704e2c0f3fffc886e36acc1426187a89d0d485a32607ec92f30d46dc55c15594b90d020f821d948c5a568277c45
+    react: ~16.14.0
+    react-dom: ~16.14.0
+  checksum: 18f7cbb741273eb10cb380572b01492ac3f7f9027c0a1869e85ba2330f203e65a503bb95ade5bfc34b1fac6f1b01c5e6ef140f1500a2c60620e5cc40c756e3ee
   languageName: node
   linkType: hard
 
@@ -8180,7 +8180,7 @@ __metadata:
     "@code-dot-org/js-interpreter": 1.3.13
     "@code-dot-org/js-numbers": 0.1.0-cdo.0
     "@code-dot-org/maze": 2.16.0
-    "@code-dot-org/ml-activities": 0.0.26
+    "@code-dot-org/ml-activities": 0.0.29
     "@code-dot-org/ml-playground": 0.0.47
     "@code-dot-org/p5.play": 1.3.21-cdo
     "@code-dot-org/piskel": 0.13.0-cdo.13

--- a/dashboard/app/models/levels/fish.rb
+++ b/dashboard/app/models/levels/fish.rb
@@ -32,6 +32,7 @@ class Fish < Level
     submittable
     mode
     background
+    guides
   )
 
   def self.create_from_level_builder(params, level_params)

--- a/dashboard/config/levels/custom/fish/Oceans_CreaturesVTrashDemo_2024.level
+++ b/dashboard/config/levels/custom/fish/Oceans_CreaturesVTrashDemo_2024.level
@@ -6,6 +6,8 @@
   "user_id": 155,
   "properties": {
     "mode": "creaturesvtrashdemo",
+    "guides": "K5",
+    "background": "oceans-blue",
     "parent_level_id": 19641,
     "name_suffix": "_2024"
   },

--- a/dashboard/config/levels/custom/fish/Oceans_CreaturesVTrash_2024.level
+++ b/dashboard/config/levels/custom/fish/Oceans_CreaturesVTrash_2024.level
@@ -6,6 +6,8 @@
   "user_id": 155,
   "properties": {
     "mode": "creaturesvtrash",
+    "guides": "K5",
+    "background": "oceans-blue",
     "parent_level_id": 19640,
     "name_suffix": "_2024"
   },

--- a/dashboard/config/levels/custom/fish/Oceans_FishVTrash_2024.level
+++ b/dashboard/config/levels/custom/fish/Oceans_FishVTrash_2024.level
@@ -6,6 +6,8 @@
   "user_id": 155,
   "properties": {
     "mode": "fishvtrash",
+    "guides": "K5",
+    "background": "oceans-blue",
     "parent_level_id": 19642,
     "name_suffix": "_2024"
   },

--- a/dashboard/config/levels/custom/fish/Oceans_Long_2024.level
+++ b/dashboard/config/levels/custom/fish/Oceans_Long_2024.level
@@ -6,6 +6,8 @@
   "user_id": 155,
   "properties": {
     "mode": "long",
+    "guides": "K5",
+    "background": "oceans-blue",
     "parent_level_id": 19643,
     "name_suffix": "_2024"
   },

--- a/dashboard/config/levels/custom/fish/Oceans_Short_2024.level
+++ b/dashboard/config/levels/custom/fish/Oceans_Short_2024.level
@@ -6,6 +6,8 @@
   "user_id": 155,
   "properties": {
     "mode": "short",
+    "guides": "K5",
+    "background": "oceans-blue",
     "parent_level_id": 19645,
     "name_suffix": "_2024"
   },

--- a/dashboard/config/levels/custom/standalone_video/Oceans_Video_Elementary_Machine_Learning_2024.level
+++ b/dashboard/config/levels/custom/standalone_video/Oceans_Video_Elementary_Machine_Learning_2024.level
@@ -15,7 +15,8 @@
     "parent_level_id": 19646,
     "name_suffix": "_2024",
     "encrypted": "false",
-    "instructions_important": "false"
+    "instructions_important": "false",
+    "background": "oceans-blue"
   },
   "notes": "",
   "audit_log": "[{\"changed_at\":\"2024-07-02T21:40:46.220+00:00\",\"changed\":[\"cloned from \\\"Oceans_Video_Machine_Learning_2024\\\"\"],\"cloned_from\":\"Oceans_Video_Machine_Learning_2024\"},{\"changed_at\":\"2024-07-02 21:40:51 +0000\",\"changed\":[],\"changed_by_id\":16899,\"changed_by_email\":\"emma.wingreen+teacher@code.org\"},{\"changed_at\":\"2024-07-02 21:41:04 +0000\",\"changed\":[\"video_key\"],\"changed_by_id\":16899,\"changed_by_email\":\"emma.wingreen+teacher@code.org\"}]",


### PR DESCRIPTION
This updates AI for Oceans with some changes for the K-5 AI module.

- It bumps the version of `ml-activities` to `0.0.29`, which enables the following:
  - Levels with `"guides": "K5"` will use the new Guides variant added with https://github.com/code-dot-org/ml-activities/pull/402 and https://github.com/code-dot-org/ml-activities/pull/406.
  - Levels with `"guides": "K5"` will get the new animated reminder to click added in https://github.com/code-dot-org/ml-activities/pull/405.
  - Levels loaded with URL parameter of `tts=en` or `tts=it` will preview browser-based text-to-speech support added in https://github.com/code-dot-org/ml-activities/pull/403.
- It updates the levels starting at `/s/k5-ai-data-2024/lessons/2/levels/2` to use `"guides": "K5"`.
- It updates the levels starting with the video level at  `/s/k5-ai-data-2024/lessons/2/levels/1` to use the dark blue background.