### PR TITLE
DatablockStorage.addSharedTable(): don't refresh view until async callback

### DIFF
--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -56,8 +56,9 @@ class DataLibraryPane extends React.Component {
         );
       }
     } else {
-      storageBackend().addSharedTable(datasetInfo.name);
-      refreshCurrentDataView();
+      storageBackend()
+        .addSharedTable(datasetInfo.name)
+        .then(() => refreshCurrentDataView());
     }
   };
 

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -390,7 +390,7 @@ DatablockStorage.clearAllData = function (onSuccess, onError) {
 
 // This is a new method for DatablockStorage which replaces the above APIs
 DatablockStorage.addSharedTable = function (tableName, onSuccess, onError) {
-  _fetch('add_shared_table', 'POST', {
+  return _fetch('add_shared_table', 'POST', {
     table_name: tableName,
   }).then(onSuccess, onError);
 };


### PR DESCRIPTION
We were calling `refreshCurrentDataView()` before DatablockStorage.addSharedTable() had returned. On local, this seemed to work, but with prod latency, this resulted in the Data browser "Import" button not seeming to work until you refreshed.

Fixes [#58456](https://github.com/code-dot-org/code-dot-org/issues/58456)

Now the calls are sequential:
<img width="793" alt="image" src="https://github.com/user-attachments/assets/51a8e9ac-8300-49e9-aa0e-8f8db6a2682b">