### PR TITLE
Curriculum Launch 2024 - Clean up - AI pages

### DIFF
--- a/apps/src/sites/code.org/pages/views/swiper_page_ai.js
+++ b/apps/src/sites/code.org/pages/views/swiper_page_ai.js
@@ -83,14 +83,9 @@ const setSwiperParams = (swiper, params) => {
 
 const swipers = [
   {swiper: swiperActionBlocksMiddleHigh, params: actionBlocksParams},
+  {swiper: swiperActionBlocksPl, params: actionBlocksParams},
   {swiper: swiperQuotes, params: quotesParams},
   {swiper: swiperVideos, params: videosParams},
 ];
-
-// TODO - Move this object to the array above once the
-// DCDO flag curriculum-launch-2024 is launched
-if (swiperActionBlocksPl) {
-  swipers.push({swiper: swiperActionBlocksPl, params: actionBlocksParams});
-}
 
 swipers.forEach(({swiper, params}) => setSwiperParams(swiper, params));

--- a/pegasus/sites.v3/code.org/public/ai/index.haml
+++ b/pegasus/sites.v3/code.org/public/ai/index.haml
@@ -90,54 +90,7 @@ theme: responsive_full_width
   .wrapper
     %h2=hoc_s(:ai_pl_heading)
     %p=hoc_s("ai_page.pl.desc")
-    -# TODO - Remove this DCDO flag logic once the 2024 curriculum is live
-    -# and remove everything below the else statement
-    - if !!DCDO.get('curriculum-launch-2024', false)
-      = view :"ai_landing_page/ai_carousel_pl"
-    - else
-      .action-block__wrapper.action-block__wrapper--three-col
-        .action-block.action-block--one-col.flex-space-between
-          .content-wrapper
-            %p.overline
-              =hoc_s(:module_label_self_paced)
-            %h3=hoc_s(:ai_pl_101_title)
-            %img{src: "/images/self-paced-pl-tile-ai-101.jpg", alt: ""}
-            %p=hoc_s(:ai_pl_101_desc)
-          .content-footer
-            %p
-              %strong
-                =hoc_s(:module_label_duration)
-              =hoc_s(:module_duration_5_hrs)
-            %a.link-button{href: CDO.studio_url("/courses/self-paced-pl-ai-101")}
-              =hoc_s(:call_to_action_start_module)
-        .action-block.action-block--one-col.flex-space-between
-          .content-wrapper
-            %p.overline
-              =hoc_s(:module_label_video_series)
-            %h3=hoc_s(:ai_pl_101_hero_heading)
-            %img{src: "/shared/images/announcement/announcement_ai_pl_2023.png", alt: ""}
-            %p=hoc_s(:ai_pl_101_hero_desc)
-          .content-footer
-            %p
-              %strong
-                =hoc_s(:module_label_duration)
-              =hoc_s(:module_duration_5_hrs)
-            %a.link-button{href: "/ai/pl/101"}
-              =hoc_s(:call_to_action_watch_videos)
-        .action-block.action-block--one-col.flex-space-between
-          .content-wrapper
-            %p.overline
-              =hoc_s(:module_label_self_paced)
-            %h3=hoc_s(:ai_pl_title)
-            %img{src: "/images/ai/ai-professional-learning.png", alt: ""}
-            %p=hoc_s(:ai_pl_desc)
-          .content-footer
-            %p
-              %strong
-                =hoc_s(:module_label_duration)
-              =hoc_s(:module_duration_2_hrs)
-            %a.link-button{href: CDO.studio_url("/courses/self-paced-pl-aiml")}
-              =hoc_s(:call_to_action_start_module)
+    = view :"ai_landing_page/ai_carousel_pl"
 
 %section#ai-integrations.bg-neutral-light
   .wrapper

--- a/pegasus/sites.v3/code.org/public/curriculum/coding-with-ai.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/coding-with-ai.haml
@@ -49,14 +49,10 @@ theme: responsive_full_width
     %p=hoc_s("coding_with_ai_page.lessons.desc")
     = view :"coding_with_ai/coding_with_ai_lessons"
 
--# TODO remove DCDO logic after the 2024 curriculum launch
-- if !!DCDO.get('curriculum-launch-2024', false)
-  %section.bg-neutral-light
-    .wrapper
-      %h2=hoc_s("coding_with_ai_page.teach.heading")
-      = view :"coding_with_ai/coding_with_ai_teach"
-- else
-  = view :section_divider_line
+%section.bg-neutral-light
+  .wrapper
+    %h2=hoc_s("coding_with_ai_page.teach.heading")
+    = view :"coding_with_ai/coding_with_ai_teach"
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_curricula_elementary.haml
+++ b/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_curricula_elementary.haml
@@ -1,6 +1,17 @@
 :ruby
   block_items = [
     {
+      overline: hoc_s("ai_page.curricula.tile.decisions.overline"),
+      title: hoc_s("ai_page.curricula.tile.decisions.title"),
+      img: "/images/action-blocks/action-block-ai-decisions.png",
+      desc: hoc_s("ai_page.curricula.tile.decisions.desc"),
+      duration: hoc_s("ai_page.curricula.tile.decisions.duration"),
+      url: CDO.studio_url("/s/k5-ai-data-2024"),
+      aria_label: hoc_s("ai_page.curricula.tile.decisions.aria_label"),
+      button_label: hoc_s("ai_page.curricula.tile.decisions.button"),
+      new: true,
+    },
+    {
       overline: hoc_s(:module_grade_3_12),
       title: hoc_s(:ai_curriculum_title_03),
       img: "/images/ai/ai-curriclum-oceans.png",
@@ -22,23 +33,7 @@
     },
   ]
 
-  # TODO - Remove this DCDO logic once the 2024 curriculum is live and add this to the top of the main list
-  if !!DCDO.get('curriculum-launch-2024', false)
-    block_items.unshift(
-      overline: hoc_s("ai_page.curricula.tile.decisions.overline"),
-      title: hoc_s("ai_page.curricula.tile.decisions.title"),
-      img: "/images/action-blocks/action-block-ai-decisions.png",
-      desc: hoc_s("ai_page.curricula.tile.decisions.desc"),
-      duration: hoc_s("ai_page.curricula.tile.decisions.duration"),
-      url: CDO.studio_url("/s/k5-ai-data-2024"),
-      aria_label: hoc_s("ai_page.curricula.tile.decisions.aria_label"),
-      button_label: hoc_s("ai_page.curricula.tile.decisions.button"),
-      new: true,
-    )
-  end
-
--# TODO - Remove this DCDO logic once the 2024 curriculum is live and keep the three-col class
-.action-block__wrapper{class: !!DCDO.get('curriculum-launch-2024', false) ? "action-block__wrapper--three-col" : "action-block__wrapper--two-col"}
+.action-block__wrapper.action-block__wrapper--three-col
   - block_items.each do |block_item|
     .action-block.action-block--one-col.flex-space-between
       .content-wrapper

--- a/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_curricula_middle_high.haml
+++ b/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_curricula_middle_high.haml
@@ -1,6 +1,17 @@
 :ruby
   block_items = [
     {
+      overline: hoc_s("ai_page.curricula.tile.humanities.overline"),
+      title: hoc_s("ai_page.curricula.tile.humanities.title"),
+      img: "/images/action-blocks/action-block-ai-humanities.png",
+      desc: hoc_s("ai_page.curricula.tile.humanities.desc"),
+      duration: hoc_s("ai_page.curricula.tile.humanities.duration"),
+      url: CDO.studio_url("/s/gen-ai-humanities"),
+      aria_label: hoc_s("ai_page.curricula.tile.humanities.aria_label"),
+      button_label: hoc_s("ai_page.curricula.tile.humanities.button"),
+      new: true,
+    },
+    {
       overline: hoc_s(:module_grade_6_12),
       title: hoc_s("coding_with_ai_tile.title"),
       img: "/images/action-blocks/action-block-coding-with-ai.png",
@@ -81,21 +92,6 @@
       button_label: hoc_s(:call_to_action_try_activity),
     },
   ]
-
-  # TODO - Remove this DCDO logic once the 2024 curriculum is live and add this to the top of the main list
-  if !!DCDO.get('curriculum-launch-2024', false)
-    block_items.unshift(
-      overline: hoc_s("ai_page.curricula.tile.humanities.overline"),
-      title: hoc_s("ai_page.curricula.tile.humanities.title"),
-      img: "/images/action-blocks/action-block-ai-humanities.png",
-      desc: hoc_s("ai_page.curricula.tile.humanities.desc"),
-      duration: hoc_s("ai_page.curricula.tile.humanities.duration"),
-      url: CDO.studio_url("/s/gen-ai-humanities"),
-      aria_label: hoc_s("ai_page.curricula.tile.humanities.aria_label"),
-      button_label: hoc_s("ai_page.curricula.tile.humanities.button"),
-      new: true,
-    )
-  end
 
 .carousel-wrapper
   %swiper-container.swiper-middle-high{navigation: "true", "navigation-next-el": ".nav-next-middle-high", "navigation-prev-el": ".nav-prev-middle-high", pagination: "true", init: "false"}


### PR DESCRIPTION
Updates carousels on https://code.org/ai and removes outdated code on https://code.org/curriculum/coding-with-ai.

**Note for reviewer:** hide whitespace to make changes easier to see.

## Links
Jira ticket: [ACQ-2077](https://codedotorg.atlassian.net/browse/ACQ-2077)

## Testing story
Tested locally to make sure nothing on the page changed.

----

## code.org/ai carousels

https://github.com/user-attachments/assets/a58acdba-499f-4747-a46e-4438365fea02


## code.org/curriculum/coding-with-ai PL section

<img width="1064" alt="Screenshot 2024-07-16 at 1 16 59 PM" src="https://github.com/user-attachments/assets/254213c6-bc62-41dc-849f-d1fd70a51e64">
