### PR TITLE
Add amplitude events for metadata

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -138,6 +138,13 @@ const EVENTS = {
   PROGRESS_V2_DELAY_INVITATION:
     'Section Progress Invitation Modal Remind Later',
   PROGRESS_V2_SEEN_INVITATION: 'Section Progress Invitation Modal seen by user',
+  PROGRESS_V2_ONE_ROW_EXPANDED: 'Section New Progress One Student Row Expanded',
+  PROGRESS_V2_ALL_ROWS_EXPANDED:
+    'Section New Progress All Student Rows Expanded',
+  PROGRESS_V2_ONE_ROW_COLLAPSED:
+    'Section New Progress One Student Row Collapsed',
+  PROGRESS_V2_ALL_ROWS_COLLAPSED:
+    'Section New Progress All Student Rows Collapsed',
 
   // Levels
   FEEDBACK_SUBMITTED: 'Level Feedback Submitted',

--- a/apps/src/templates/sectionProgressV2/MoreOptionsDropdown.jsx
+++ b/apps/src/templates/sectionProgressV2/MoreOptionsDropdown.jsx
@@ -141,6 +141,7 @@ export const UnconnectedMoreOptionsDropdown = MoreOptionsDropdown;
 export default connect(
   state => ({
     students: state.teacherSections.selectedStudents,
+    sectionId: state.teacherSections.selectedSectionId,
   }),
   dispatch => ({
     expandMetadataForStudents: studentIds =>

--- a/apps/src/templates/sectionProgressV2/MoreOptionsDropdown.jsx
+++ b/apps/src/templates/sectionProgressV2/MoreOptionsDropdown.jsx
@@ -4,6 +4,8 @@ import React, {useState, useEffect, useRef} from 'react';
 import {connect} from 'react-redux';
 
 import PopUpMenu from '@cdo/apps/lib/ui/PopUpMenu';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {studentShape} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import i18n from '@cdo/locale';
 
@@ -21,6 +23,7 @@ function MoreOptionsDropdown({
   students,
   expandMetadataForStudents,
   collapseMetadataForStudents,
+  sectionId,
 }) {
   const [opened, setOpened] = useState(false);
   const [menuLocation, setMenuLocation] = useState({menuTop: 0, menuLeft: 0});
@@ -33,11 +36,17 @@ function MoreOptionsDropdown({
   );
 
   const expandMetaDataForAllStudents = () => {
+    analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_ALL_ROWS_EXPANDED, {
+      sectionId: sectionId,
+    });
     expandMetadataForStudents(getAllStudentIds);
     setOpened(false);
   };
 
   const collapseMetaDataForAllStudents = () => {
+    analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_ALL_ROWS_COLLAPSED, {
+      sectionId: sectionId,
+    });
     collapseMetadataForStudents(getAllStudentIds);
     setOpened(false);
   };
@@ -124,6 +133,7 @@ MoreOptionsDropdown.propTypes = {
   students: PropTypes.arrayOf(studentShape),
   expandMetadataForStudents: PropTypes.func,
   collapseMetadataForStudents: PropTypes.func,
+  sectionId: PropTypes.number,
 };
 
 export const UnconnectedMoreOptionsDropdown = MoreOptionsDropdown;

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -77,9 +77,7 @@ function SectionProgressV2({
           {i18n.lessonsIn()}
 
           <UnitSelectorV2 className={styles.titleUnitSelectorDropdown} />
-          {expandedMetadataEnabled && (
-            <MoreOptionsDropdown sectionId={sectionId} />
-          )}
+          {expandedMetadataEnabled && <MoreOptionsDropdown />}
         </Heading6>
       </div>
       <ProgressTableV2 isSkeleton={!levelDataInitialized} />

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -77,7 +77,9 @@ function SectionProgressV2({
           {i18n.lessonsIn()}
 
           <UnitSelectorV2 className={styles.titleUnitSelectorDropdown} />
-          {expandedMetadataEnabled && <MoreOptionsDropdown />}
+          {expandedMetadataEnabled && (
+            <MoreOptionsDropdown sectionId={sectionId} />
+          )}
         </Heading6>
       </div>
       <ProgressTableV2 isSkeleton={!levelDataInitialized} />

--- a/apps/src/templates/sectionProgressV2/StudentColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/StudentColumn.jsx
@@ -5,6 +5,8 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 import DCDO from '@cdo/apps/dcdo';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import i18n from '@cdo/locale';
 
 import FontAwesome from '../FontAwesome';
@@ -58,11 +60,25 @@ function StudentColumn({
     </div>
   );
 
+  const collapseRow = studentId => {
+    analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_ONE_ROW_COLLAPSED, {
+      sectionId: sectionId,
+    });
+    collapseMetadataForStudents([studentId]);
+  };
+
+  const expandRow = studentId => {
+    analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_ONE_ROW_EXPANDED, {
+      sectionId: sectionId,
+    });
+    expandMetadataForStudents([studentId]);
+  };
+
   const getUnexpandedRow = (student, ind) => (
     <button
       className={styles.studentColumnName}
       key={ind}
-      onClick={() => expandMetadataForStudents([student.id])}
+      onClick={() => expandRow(student.id)}
       type="button"
       aria-expanded={false}
     >
@@ -79,7 +95,7 @@ function StudentColumn({
     <div className={styles.studentColumnExpandedHeader} key={ind}>
       <button
         className={styles.studentColumnName}
-        onClick={() => collapseMetadataForStudents([student.id])}
+        onClick={() => collapseRow(student.id)}
         type="button"
         aria-expanded={true}
       >


### PR DESCRIPTION
Added amplitude events for:

- Opening all and expanding all meta data
- Opening and closing a single row of meta data

Video below.

https://github.com/user-attachments/assets/8ac49e97-6259-4427-91ef-aef3003274b5



Note: You will see some warnings in the console about styling of the dropdown.  This is because we are overriding some styles from the pop-up menu.  We know an action menu is on the table for our design system that we can use for this component when it is done OR repurpose what Liam is working on for hiding and pinning student responses in the summary view.

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1182)

