### PR TITLE
Curriculum Launch 2024 - Clean up - Self-paced PL

### DIFF
--- a/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_elementary.haml
+++ b/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_elementary.haml
@@ -12,52 +12,46 @@
       aria_label_primary: hoc_s(:aria_label_call_to_action_ai_101),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_ai_101),
       new: true
-    }
-  ]
-  if !!DCDO.get('curriculum-launch-2024', false)
-    block_items +=[
-      {
-        overline: hoc_s(:module_grade_3_5_teachers),
-        title: hoc_s(:module_label_teaching_how_ai_makes_decisions),
-        image: '/images/self-paced-pl-tile-how-ai-makes-decisions.jpg',
-        curriculum: hoc_s(:curriculum_name_how_ai_makes_decisions),
-        duration: hoc_s(:module_duration_1_hr),
-        prerequisites: hoc_s(:module_prerequisites_none),
-        url_primary: CDO.studio_url("/courses/elementaryai-2024"),
-        url_secondary: CDO.studio_url('/s/k5-ai-data-2024?viewAs=Instructor'),
-        aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_how_ai_makes_decisions),
-        aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_how_ai_makes_decisions),
-        new: true
-      },
-      {
-        overline: hoc_s(:module_grade_3_5_teachers),
-        title: hoc_s(:module_label_teaching_elementary_game_design),
-        image: '/images/self-paced-pl-tile-elementary-game-design.jpg',
-        curriculum: hoc_s(:curriculum_name_elementary_game_design),
-        duration: hoc_s(:module_duration_1_hr_30_minutes),
-        prerequisites: hoc_s(:module_prerequisites_none),
-        url_primary: CDO.studio_url("/courses/3-5gamedesign-2024"),
-        url_secondary: CDO.studio_url('/s/elem-game-design-2024?viewAs=Instructor'),
-        aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_elementary_game_design),
-        aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_elementary_game_design),
-        new: true
-      },
-      {
-        overline: hoc_s(:module_grade_2_5_teachers),
-        title: hoc_s(:module_label_teaching_microbit_maker_module),
-        image: "/images/self-paced-pl-tile-micro-bit-maker.png",
-        curriculum: hoc_s(:curriculum_name_microbit_maker_modules),
-        duration: hoc_s(:module_duration_1_hr_30_minutes),
-        prerequisites: hoc_s(:module_prerequisites_none),
-        url_primary: CDO.studio_url("/courses/microbitmakermodule-2024"),
-        url_secondary: "/maker#curriculum-link-microbit",
-        aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_microbit_maker_module),
-        aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_microbit_maker_module),
-        new: true
-      }
-    ]
-  end
-  block_items += [
+    },
+    {
+      overline: hoc_s(:module_grade_3_5_teachers),
+      title: hoc_s(:module_label_teaching_how_ai_makes_decisions),
+      image: '/images/self-paced-pl-tile-how-ai-makes-decisions.jpg',
+      curriculum: hoc_s(:curriculum_name_how_ai_makes_decisions),
+      duration: hoc_s(:module_duration_1_hr),
+      prerequisites: hoc_s(:module_prerequisites_none),
+      url_primary: CDO.studio_url("/courses/elementaryai-2024"),
+      url_secondary: CDO.studio_url('/s/k5-ai-data-2024?viewAs=Instructor'),
+      aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_how_ai_makes_decisions),
+      aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_how_ai_makes_decisions),
+      new: true
+    },
+    {
+      overline: hoc_s(:module_grade_3_5_teachers),
+      title: hoc_s(:module_label_teaching_elementary_game_design),
+      image: '/images/self-paced-pl-tile-elementary-game-design.jpg',
+      curriculum: hoc_s(:curriculum_name_elementary_game_design),
+      duration: hoc_s(:module_duration_1_hr_30_minutes),
+      prerequisites: hoc_s(:module_prerequisites_none),
+      url_primary: CDO.studio_url("/courses/3-5gamedesign-2024"),
+      url_secondary: CDO.studio_url('/s/elem-game-design-2024?viewAs=Instructor'),
+      aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_elementary_game_design),
+      aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_elementary_game_design),
+      new: true
+    },
+    {
+      overline: hoc_s(:module_grade_2_5_teachers),
+      title: hoc_s(:module_label_teaching_microbit_maker_module),
+      image: "/images/self-paced-pl-tile-micro-bit-maker.png",
+      curriculum: hoc_s(:curriculum_name_microbit_maker_modules),
+      duration: hoc_s(:module_duration_1_hr_30_minutes),
+      prerequisites: hoc_s(:module_prerequisites_none),
+      url_primary: CDO.studio_url("/courses/microbitmakermodule-2024"),
+      url_secondary: "/maker#curriculum-link-microbit",
+      aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_microbit_maker_module),
+      aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_microbit_maker_module),
+      new: true
+    },
     {
       overline: hoc_s(:module_grade_k_5_teachers),
       title: hoc_s(:module_label_teaching_k5_basics),

--- a/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_high.haml
+++ b/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_high.haml
@@ -11,40 +11,34 @@
       url_secondary: '/ai#ai-curricula',
       aria_label_primary: hoc_s(:aria_label_call_to_action_ai_101),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_ai_101),
-      new: true
-    }
-  ]
-  if !!DCDO.get('curriculum-launch-2024', false)
-    block_items += [
-      {
-        overline: hoc_s(:module_grade_6_12_teachers),
-        title: hoc_s(:module_label_teaching_coding_with_ai),
-        image: '/images/self-paced-pl-tile-coding-with-ai.png',
-        curriculum: hoc_s(:curriculum_name_coding_with_ai),
-        duration: hoc_s(:module_duration_2_hrs),
-        prerequisites: hoc_s(:module_prerequisites_none),
-        url_primary: CDO.studio_url("/courses/self-paced-pl-coding-with-ai-2024"),
-        url_secondary: '/curriculum/coding-with-ai',
-        aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_coding_with_ai),
-        aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_coding_with_ai),
-        new: true,
-      },
-      {
-        overline: hoc_s(:module_grade_9_12_teachers),
-        title: hoc_s(:module_label_teaching_computer_vision),
-        image: '/images/self-paced-pl-tile-computer-vision.png',
-        curriculum: hoc_s(:curriculum_name_computer_vision),
-        duration: hoc_s(:module_duration_1_hr_30_minutes),
-        prerequisites: hoc_s(:module_prerequisites_none),
-        url_primary: CDO.studio_url("/courses/self-paced-pl-computer-vision-2024"),
-        url_secondary: '/curriculum/computer-vision',
-        aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_computer_vision),
-        aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_computer_vision),
-        new: true,
-      }
-    ]
-  end
-  block_items += [
+      new: true,
+    },
+    {
+      overline: hoc_s(:module_grade_6_12_teachers),
+      title: hoc_s(:module_label_teaching_coding_with_ai),
+      image: '/images/self-paced-pl-tile-coding-with-ai.png',
+      curriculum: hoc_s(:curriculum_name_coding_with_ai),
+      duration: hoc_s(:module_duration_2_hrs),
+      prerequisites: hoc_s(:module_prerequisites_none),
+      url_primary: CDO.studio_url("/courses/self-paced-pl-coding-with-ai-2024"),
+      url_secondary: '/curriculum/coding-with-ai',
+      aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_coding_with_ai),
+      aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_coding_with_ai),
+      new: true,
+    },
+    {
+      overline: hoc_s(:module_grade_9_12_teachers),
+      title: hoc_s(:module_label_teaching_computer_vision),
+      image: '/images/self-paced-pl-tile-computer-vision.png',
+      curriculum: hoc_s(:curriculum_name_computer_vision),
+      duration: hoc_s(:module_duration_1_hr_30_minutes),
+      prerequisites: hoc_s(:module_prerequisites_none),
+      url_primary: CDO.studio_url("/courses/self-paced-pl-computer-vision-2024"),
+      url_secondary: '/curriculum/computer-vision',
+      aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_computer_vision),
+      aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_computer_vision),
+      new: true,
+    },
     {
       overline: hoc_s(:module_grade_9_12_teachers),
       title: hoc_s(:module_label_teaching_csp),

--- a/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_middle.haml
+++ b/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_middle.haml
@@ -13,25 +13,19 @@
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_ai_101),
       new: true
     },
-  ]
-  if !!DCDO.get('curriculum-launch-2024', false)
-    block_items.push(
-      {
-        overline: hoc_s(:module_grade_6_12_teachers),
-        title: hoc_s(:module_label_teaching_coding_with_ai),
-        image: '/images/self-paced-pl-tile-coding-with-ai.png',
-        curriculum: hoc_s(:curriculum_name_coding_with_ai),
-        duration: hoc_s(:module_duration_2_hrs),
-        prerequisites: hoc_s(:module_prerequisites_none),
-        url_primary: CDO.studio_url("/courses/self-paced-pl-coding-with-ai-2024"),
-        url_secondary: '/curriculum/coding-with-ai',
-        aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_coding_with_ai),
-        aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_coding_with_ai),
-        new: true,
-      }
-    )
-  end
-  block_items += [
+    {
+      overline: hoc_s(:module_grade_6_12_teachers),
+      title: hoc_s(:module_label_teaching_coding_with_ai),
+      image: '/images/self-paced-pl-tile-coding-with-ai.png',
+      curriculum: hoc_s(:curriculum_name_coding_with_ai),
+      duration: hoc_s(:module_duration_2_hrs),
+      prerequisites: hoc_s(:module_prerequisites_none),
+      url_primary: CDO.studio_url("/courses/self-paced-pl-coding-with-ai-2024"),
+      url_secondary: '/curriculum/coding-with-ai',
+      aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_coding_with_ai),
+      aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_coding_with_ai),
+      new: true,
+    },
     {
       overline: hoc_s(:module_grade_6_10_teachers),
       title: hoc_s(:curriculum_name_teaching_animation),


### PR DESCRIPTION
Updates carousel object order on https://code.org/professional-learning/self-paced after the 2024 curriculum launch.

**Note for reviewer:** hide whitespace to make changes easier to see.

## Links
Jira ticket: [ACQ-2078](https://codedotorg.atlassian.net/browse/ACQ-2078)

## Testing story
Tested locally to make sure nothing on the page changed.

----

## Elementary

https://github.com/user-attachments/assets/249e4b1e-6c91-445d-802d-75ffef25cbf0

## Middle

https://github.com/user-attachments/assets/f742cbca-e7ad-4223-84d1-353c42d9ffa9

## High

https://github.com/user-attachments/assets/56d137f0-a8a5-45be-b90c-5814851c350a

