### PR TITLE
Curriculum Launch 2024 - Clean up - School pages

### DIFF
--- a/pegasus/sites.v3/code.org/views/elementary_school_curricula_video.haml
+++ b/pegasus/sites.v3/code.org/views/elementary_school_curricula_video.haml
@@ -1,5 +1,3 @@
-- show_game_design_curriculum = !!DCDO.get('curriculum-launch-2024', false)
-
 - video_curricula_index = 6
 
 - video_curricula_tags = [hoc_s(:module_grade_k_5), hoc_s(:module_grade_3_5), hoc_s(:module_grade_3_12), hoc_s(:module_grade_3_12), hoc_s(:module_grade_3_12), hoc_s(:module_grade_k_12)]
@@ -15,26 +13,24 @@
 
 
 - video_curricula_index.times do |index|
-  - unless index == 4 && !show_game_design_curriculum
-    .action-block.action-block--two-col.video-101__text
-      - if [0, 1, 2, 3].include?(index)
-        %figure.video-101__video.col-50
-          = view :display_video_thumbnail, id: video_id[index], video_code: video_code[index], play_button: 'center', letterbox: 'false'
-      - if index === 4
-        .video-101__image
-          %img{src: "/images/game-design-illustration.png", style: "width: 100%" }
-      - if index === 5
-        .video-101__image
-          %img{src: "/images/hoc2022-banner.png", style: "width: 100%" }
-      .text-wrapper.col-50
-        %p.overline
-          Grades:
-          = video_curricula_tags[index]
-        %h3
-          = video_curricula_title[index]
-        %p.heading-sm
-          = video_curricula_desc[index]
+  .action-block.action-block--two-col.video-101__text
+    - if [0, 1, 2, 3].include?(index)
+      %figure.video-101__video.col-50
+        = view :display_video_thumbnail, id: video_id[index], video_code: video_code[index], play_button: 'center', letterbox: 'false'
+    - if index === 4
+      .video-101__image
+        %img{src: "/images/game-design-illustration.png", style: "width: 100%" }
+    - if index === 5
+      .video-101__image
+        %img{src: "/images/hoc2022-banner.png", style: "width: 100%" }
+    .text-wrapper.col-50
+      %p.overline
+        Grades:
+        = video_curricula_tags[index]
+      %h3
+        = video_curricula_title[index]
+      %p.heading-sm
+        = video_curricula_desc[index]
 
-        %a.link-button{href: video_link[index]}
-          = hoc_s(video_link_title[index])
-
+      %a.link-button{href: video_link[index]}
+        = hoc_s(video_link_title[index])

--- a/pegasus/sites.v3/code.org/views/high_school_curricula_video.haml
+++ b/pegasus/sites.v3/code.org/views/high_school_curricula_video.haml
@@ -1,5 +1,3 @@
-- show_game_design_curriculum = !!DCDO.get('curriculum-launch-2024', false)
-
 - video_curricula_index = 7
 
 - video_curricula_tags = [hoc_s(:module_grade_6_10), hoc_s(:module_grade_9_12), hoc_s(:module_grade_9_12), hoc_s(:module_grade_3_12), hoc_s(:module_grade_3_12), hoc_s(:module_grade_3_12), hoc_s(:module_grade_k_12)]
@@ -15,25 +13,24 @@
 
 
 - video_curricula_index.times do |index|
-  - unless index == 5 && !show_game_design_curriculum
-    .action-block.action-block--two-col.video-101__text
-      - if index === 0 || index === 1 || index === 2 || index === 3 || index === 4
-        %figure.video-101__video.col-50
-          = view :display_video_thumbnail, id: video_id[index], video_code: video_code[index], play_button: 'center', letterbox: 'false'
-      - if index === 5
-        .video-101__image
-          %img{src: "/images/game-design-illustration.png", style: "width: 100%" }
-      - if index === 6
-        .video-101__image
-          %img{src: "/images/hoc2022-banner.png", style: "width: 100%" }
-      .text-wrapper.col-50
-        %p.overline
-          Grades:
-          = video_curricula_tags[index]
-        %h3
-          = video_curricula_title[index]
-        %p.heading-sm
-          = video_curricula_desc[index]
+  .action-block.action-block--two-col.video-101__text
+    - if index === 0 || index === 1 || index === 2 || index === 3 || index === 4
+      %figure.video-101__video.col-50
+        = view :display_video_thumbnail, id: video_id[index], video_code: video_code[index], play_button: 'center', letterbox: 'false'
+    - if index === 5
+      .video-101__image
+        %img{src: "/images/game-design-illustration.png", style: "width: 100%" }
+    - if index === 6
+      .video-101__image
+        %img{src: "/images/hoc2022-banner.png", style: "width: 100%" }
+    .text-wrapper.col-50
+      %p.overline
+        Grades:
+        = video_curricula_tags[index]
+      %h3
+        = video_curricula_title[index]
+      %p.heading-sm
+        = video_curricula_desc[index]
 
-        %a.link-button{href: video_link[index]}
-          = hoc_s(video_link_title[index])
+      %a.link-button{href: video_link[index]}
+        = hoc_s(video_link_title[index])

--- a/pegasus/sites.v3/code.org/views/middle_school_curricula_video.haml
+++ b/pegasus/sites.v3/code.org/views/middle_school_curricula_video.haml
@@ -1,5 +1,3 @@
-- show_game_design_curriculum = !!DCDO.get('curriculum-launch-2024', false)
-
 - video_curricula_index = 5
 
 - video_curricula_tags = [hoc_s(:module_grade_6_10), hoc_s(:module_grade_3_12), hoc_s(:module_grade_3_12), hoc_s(:module_grade_3_12), hoc_s(:module_grade_k_12)]
@@ -14,25 +12,24 @@
 - video_code = ["uQim0hBHco0", "dWRnCXbUDgA", "sLIJNEIE0Rs"]
 
 - video_curricula_index.times do |index|
-  - unless index == 3 && !show_game_design_curriculum
-    .action-block.action-block--two-col.video-101__text
-      - if index === 0 || index === 1 || index === 2
-        %figure.video-101__video.col-50
-          = view :display_video_thumbnail, id: video_id[index], video_code: video_code[index], play_button: 'center', letterbox: 'false'
-      - if index === 3
-        .video-101__image
-          %img{src: "/images/game-design-illustration.png", style: "width: 100%" }
-      - if index === 4
-        .video-101__image
-          %img{src: "/images/hoc2022-banner.png", style: "width: 100%" }
-      .text-wrapper.col-50
-        %p.overline
-          Grades:
-          = video_curricula_tags[index]
-        %h3
-          = video_curricula_title[index]
-        %p.heading-sm
-          = video_curricula_desc[index]
+  .action-block.action-block--two-col.video-101__text
+    - if index === 0 || index === 1 || index === 2
+      %figure.video-101__video.col-50
+        = view :display_video_thumbnail, id: video_id[index], video_code: video_code[index], play_button: 'center', letterbox: 'false'
+    - if index === 3
+      .video-101__image
+        %img{src: "/images/game-design-illustration.png", style: "width: 100%" }
+    - if index === 4
+      .video-101__image
+        %img{src: "/images/hoc2022-banner.png", style: "width: 100%" }
+    .text-wrapper.col-50
+      %p.overline
+        Grades:
+        = video_curricula_tags[index]
+      %h3
+        = video_curricula_title[index]
+      %p.heading-sm
+        = video_curricula_desc[index]
 
-        %a.link-button{href: video_link[index]}
-          = hoc_s(video_link_title[index])
+      %a.link-button{href: video_link[index]}
+        = hoc_s(video_link_title[index])


### PR DESCRIPTION
Removes DCDO logic on video views on student pages after the 2024 curriculum launch:
- [code.org/curriculum/elementary-school](http://code.org/curriculum/elementary-school) 
- [code.org/curriculum/middle-school](http://code.org/curriculum/middle-school) 
- [code.org/curriculum/high-school](http://code.org/curriculum/high-school)

**Note for reviewer:** hide whitespace to make changes easier to see.

## Links
Jira ticket: [ACQ-2079](https://codedotorg.atlassian.net/browse/ACQ-2079)

## Testing story
Tested locally to make sure nothing on the pages changed.

----

## code.org/curriculum/elementary-school

https://github.com/user-attachments/assets/3e411367-4fde-4713-8367-9ad39255dd5d

## code.org/curriculum/middle-school

https://github.com/user-attachments/assets/5f6e7392-610d-40fa-bfbd-8a3191ed1f8a

## code.org/curriculum/high-school

https://github.com/user-attachments/assets/8037662a-69f5-4d8d-bbf8-15bb6ecf3037
