### PR TITLE
Datablock Storage: port current_table cron scripts from Firebase

### DIFF
--- a/bin/cron/applab_datasets/covid19
+++ b/bin/cron/applab_datasets/covid19
@@ -1,9 +1,11 @@
 #!/usr/bin/env ruby
 
+require_relative '../only_one'
+abort 'Script already running' unless only_one_running?(__FILE__)
+
 # This script fetches covid19 data and uploads it to a datablock storage shared_table.
 require_relative '../../../dashboard/config/environment'
 require_relative '../../../deployment'
-require 'cdo/only_one'
 require 'net/http'
 require 'csv'
 require 'date'

--- a/bin/cron/applab_datasets/covid19
+++ b/bin/cron/applab_datasets/covid19
@@ -1,18 +1,13 @@
 #!/usr/bin/env ruby
 
-# TODO: unfirebase, also update datablock storage: #56993
-# TODO: post-firebase-cleanup, remove the firebase version: #56994
-
-# This script fetches covid19 data and uploads to the shared firebase channel.
+# This script fetches covid19 data and uploads it to a datablock storage shared_table.
+require_relative '../../../dashboard/config/environment'
 require_relative '../../../deployment'
 require 'cdo/only_one'
 require 'net/http'
 require 'csv'
 require 'date'
 require 'datapackage'
-
-# TODO: post-firebase-cleanup, remove the firebase reference: #56994
-require_relative '../../../dashboard/legacy/middleware/helpers/firebase_helper'
 
 US_DATA_URL = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv"
 MAX_DAYS = 90 # there are 55 states/territories, and the table must be less than 5000 total rows (5000/55 = 90.9)
@@ -45,27 +40,16 @@ def get_us_covid19_data
            daily_data.keys
          end
 
-  # Add id to each record
-  columns = ['id', 'Date', 'State', 'Total Confirmed Cases', 'Total Deaths']
-  records = {}
-  id = 1
-  days.each do |day|
-    day_records = daily_data[day]
-    day_records.each do |record|
-      record['id'] = id
-      records[id] = record.to_json
-      id += 1
-    end
-  end
-
-  return records, columns
+  records = days.flat_map {|day| daily_data[day]}
+  return records
 end
 
 def main
-  # TODO: post-firebase-cleanup, remove the firebase reference: #56994
-  fb = FirebaseHelper.new('shared')
-  records, columns = get_us_covid19_data
-  fb.upload_live_table('COVID-19 Cases per US State', records, columns)
+  records = get_us_covid19_data
+
+  ActiveRecord::Base.transaction do
+    DatablockStorageTable.update_shared_table('COVID-19 Cases per US State', records)
+  end
 end
 
 main if only_one_running?(__FILE__)

--- a/bin/cron/applab_datasets/daily_weather
+++ b/bin/cron/applab_datasets/daily_weather
@@ -1,20 +1,16 @@
 #!/usr/bin/env ruby
 
-# TODO: unfirebase, also update datablock storage: #56993
-# TODO: post-firebase-cleanup, remove the firebase version: #56994
-
-require_relative '../only_one'
-abort 'Script already running' unless only_one_running?(__FILE__)
-
-# This script fetches weather forecast data from api.openweathermap and uploads to the shared firebase channel.
+# This script fetches weather forecast data from api.openweathermap and uploads to the shared datablock storage table.
+require_relative '../../../dashboard/config/environment'
 require_relative '../../../deployment'
+require 'cdo/only_one'
 require 'net/http'
 require 'json'
 require 'ostruct'
 require 'date'
-# TODO: post-firebase-cleanup, remove the firebase reference: #56994
-require_relative '../../../dashboard/legacy/middleware/helpers/firebase_helper' # TODO: unfirebase, remaining firebase reference
 require 'honeybadger/ruby'
+
+abort 'Script already running' unless only_one_running?(__FILE__)
 
 WeatherForecastOffice = Struct.new(:city, :state, :zip_code)
 
@@ -152,13 +148,8 @@ def get_weather_data
     WeatherForecastOffice.new('Seattle', 'Washington', '98115'),
     WeatherForecastOffice.new('Spokane', 'Washington', '99224')
   ]
-  records = {}
-  columns = ['id', 'State', 'City', 'Forecast Number', 'Date', 'Main Condition', 'Condition Description', 'Icon',
-             'Low Temperature', 'High Temperature', 'Humidity Percentage', 'Wind MPH', 'Wind Direction', 'Rain Inches',
-             'Snow Inches', 'Pressure', 'Cloud Percent', 'UTC Timestamp', 'Timezone Offset']
 
-  id = 1
-  forecast_offices.each do |office|
+  records = forecast_offices.flat_map do |office|
     forecast_number = 1
 
     url = "http://api.openweathermap.org/data/2.5/forecast/daily?zip=#{office.zip_code},us&cnt=#{NUM_DAYS}&units=imperial&appid=#{API_KEY}"
@@ -173,9 +164,8 @@ def get_weather_data
 
     parsed_response = JSON.parse(response.body)
     measurements = parsed_response['list']
-    measurements.each do |measurement|
+    measurements.map do |measurement|
       record = OpenStruct.new
-      record.id = id
       record.State = office.state
       record.City = office.city
       record['Forecast Number'] = forecast_number
@@ -203,25 +193,27 @@ def get_weather_data
       record['UTC Timestamp'] = measurement['dt']
       record['Timezone Offset'] = parsed_response['city']['timezone']
 
-      records[id] = record.to_h.to_json
-      id += 1
       forecast_number += 1
+
+      record.to_h
     end
-  end
-  return records, columns
+  end.compact
+  return records
 end
 
 def main
-  # TODO: post-firebase-cleanup, remove the firebase reference: #56994
-  fb = FirebaseHelper.new('shared')
-  records, columns = get_weather_data
+  records = get_weather_data
   if records.empty?
+    puts "No data returned from OpenWeather API. No records will be written to datablock storage."
     Honeybadger.notify(
-      error_message: "No data returned from OpenWeather API. No records will be written to firebase."
+      error_message: "No data returned from OpenWeather API. No records will be written to datablock storage."
       )
     return
   end
-  fb.upload_live_table('Daily Weather', records, columns)
+
+  ActiveRecord::Base.transaction do
+    DatablockStorageTable.update_shared_table('Daily Weather', records)
+  end
 end
 
 main

--- a/bin/cron/applab_datasets/daily_weather
+++ b/bin/cron/applab_datasets/daily_weather
@@ -1,16 +1,16 @@
 #!/usr/bin/env ruby
 
+require_relative '../only_one'
+abort 'Script already running' unless only_one_running?(__FILE__)
+
 # This script fetches weather forecast data from api.openweathermap and uploads to the shared datablock storage table.
 require_relative '../../../dashboard/config/environment'
 require_relative '../../../deployment'
-require 'cdo/only_one'
 require 'net/http'
 require 'json'
 require 'ostruct'
 require 'date'
 require 'honeybadger/ruby'
-
-abort 'Script already running' unless only_one_running?(__FILE__)
 
 WeatherForecastOffice = Struct.new(:city, :state, :zip_code)
 

--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -1,22 +1,18 @@
 #!/usr/bin/env ruby
 
-# TODO: unfirebase, also update datablock storage: #56993
-# TODO: post-firebase-cleanup, remove the firebase version: #56994
-
 require_relative '../only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
 
-# This script fetches spotify data from api.spotify and uploads to the shared firebase channel.
+# This script fetches spotify data from api.spotify and uploads to the shared datablock storage table.
 #
 # TESTING LOCALLY (Code.org engineers only)
 # In order to run this file locally, you'll need to temporarily configure your locals.yml file to include
 # development/cdo/spotify_api_client_id and development/cdo/spotify_api_client_secret values
 #
 
+require_relative '../../../dashboard/config/environment'
 require_relative '../../../deployment'
 require 'ostruct'
-# TODO: post-firebase-cleanup, remove the firebase reference: #56994
-require_relative '../../../dashboard/legacy/middleware/helpers/firebase_helper'
 require 'cdo/profanity_filter'
 require 'rest-client'
 
@@ -94,29 +90,26 @@ def get_playlist_data(chart_type, playlist_id)
   end
 
   items = JSON.parse(response)['tracks']['items']
-  columns = ['id', 'Track Name', 'Artist', 'Position']
-  columns.insert(4, 'Popularity') if chart_type == CHART_TYPE[:TOP] # Only include Popularity for Top Charts
 
   regex = generate_profanity_regex(items)
-  records = {}
-  id = 1
 
-  items.each do |item|
+  chart_position = 1
+  records = items.filter_map do |item|
     track = item['track']
     next if track.nil? || regex&.match?(get_track_info_string(track)) # Skip track if it is nil or contains profanity
 
     record = OpenStruct.new
-    record.id = id
-    record.Position = id
+    record.Position = chart_position
     record['Track Name'] = track['name']
     record.Artist = track['artists'][0]['name'] # First will be main artist, featured artists included in record name
     record.Popularity = track['popularity'] if chart_type == CHART_TYPE[:TOP]
 
-    records[id] = record.to_h.to_json
-    id += 1
+    chart_position += 1
+
+    record.to_h
   end
 
-  return records, columns
+  return records
 end
 
 # Only check artist and track names for profanity
@@ -135,8 +128,6 @@ end
 
 def main
   get_token
-  # TODO: post-firebase-cleanup, remove the firebase reference: #56994
-  fb = FirebaseHelper.new('shared')
 
   if $token.nil? || $token.empty?
     Honeybadger.notify_cronjob_error(error_message: "Did not to retrieve Spotify playlist data due to missing authentication token.")
@@ -144,7 +135,7 @@ def main
   end
 
   SPOTIFY_CHARTS.each do |chart|
-    records, columns = get_playlist_data(chart['type'], chart['id'])
+    records = get_playlist_data(chart['type'], chart['id'])
     if records.nil? || records.empty?
       Honeybadger.notify_cronjob_error(
         error_message: "Did not to upload Spotify playlist data due to nil or empty list of records.",
@@ -156,7 +147,10 @@ def main
       )
       next
     end
-    fb.upload_live_table(chart['title'], records, columns)
+
+    ActiveRecord::Base.transaction do
+      DatablockStorageTable.update_shared_table(chart['title'], records)
+    end
   end
 end
 

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -79,10 +79,6 @@ class DatablockStorageTable < ApplicationRecord
 
     shared_table.create_records(records)
     shared_table.save!
-
-    shared_table.records.each do |record|
-      puts record.inspect
-    end
   end
 
   def self.find_shared_table(table_name)

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -71,6 +71,20 @@ class DatablockStorageTable < ApplicationRecord
     get_table_names(SHARED_TABLE_PROJECT_ID)
   end
 
+  def self.update_shared_table(table_name, records)
+    shared_table = DatablockStorageTable.find_or_create_by!(project_id: SHARED_TABLE_PROJECT_ID, table_name: table_name)
+    shared_table.records.delete_all
+    shared_table.columns = ['id']
+    shared_table.save!
+
+    shared_table.create_records(records)
+    shared_table.save!
+
+    shared_table.records.each do |record|
+      puts record.inspect
+    end
+  end
+
   def self.find_shared_table(table_name)
     shared_table = DatablockStorageTable.find_by(project_id: SHARED_TABLE_PROJECT_ID, table_name: table_name)
     raise "Shared table '#{table_name}' does not exist" unless shared_table

--- a/dashboard/app/models/datablock_storage_table.rb
+++ b/dashboard/app/models/datablock_storage_table.rb
@@ -79,6 +79,8 @@ class DatablockStorageTable < ApplicationRecord
 
     shared_table.create_records(records)
     shared_table.save!
+
+    shared_table
   end
 
   def self.find_shared_table(table_name)


### PR DESCRIPTION
This PR implements `DatablockStorageTable.update_shared_table(table_name, records)`, and uses it to port the cron jobs that update "current tables" from Firebase to Datablock Storage.

Port these cron scripts from Firebase to datablock storage:
- [x] Convert covid19 cron job: updates shared table_name `'COVID-19 Cases per US State'`
- [x] Convert daily_weather cron job: updates shared table_name `'Daily Weather'`
- [x] Convert spotify cron job: updates 5x different tables `'Top 50 Worldwide'`, `'Top 50 USA'`, `'Viral 50 Worldwide'`, `'Viral 50 USA'`

Tested for each cron script:
- Created records are valid and matches REST fetched record data
- Updates existing stale data records
- Creates table if table itself doesn't exist
- Updates if all records are deleted
- Updates if only some records are deleted
- Updates `DatablockStorageTable.lastUpdated` time

Fixes #56993

Co-authored-by: Cassi Brenci <cnbrenci@users.noreply.github.com>