### PR TITLE
Speculative fix for flakey `Chrome_star_labs_applab_eyes3_eyes_Data Browser` test

### DIFF
--- a/dashboard/test/ui/features/star_labs/applab/eyes3.feature
+++ b/dashboard/test/ui/features/star_labs/applab/eyes3.feature
@@ -14,6 +14,7 @@ Scenario: Data Browser
   When I press keys "foo" for element "#data-browser input"
   And I click selector "#data-browser button:contains(Add)"
   And I wait until element "#dataTable" is visible
+  And I wait for 1 second
   Then I see no difference for "data table"
 
   When I press enter key


### PR DESCRIPTION
Wait 1 second before pressing the enter key, in case the "column rename" fake-input is not ready to receive input immediately. [See the corresponding issue for detail](https://github.com/code-dot-org/code-dot-org/issues/59834#issuecomment-2232823970) on what we know, and why this fix might work.

Fixes #59834