### PR TITLE
Tidy: assert_nil instead of assert_equal nil

### DIFF
--- a/dashboard/test/controllers/user_levels_controller_test.rb
+++ b/dashboard/test/controllers/user_levels_controller_test.rb
@@ -234,6 +234,6 @@ class UserLevelsControllerTest < ActionController::TestCase
     get :get_level_source, params: {script_id: script.id, level_id: level.id}
     assert_response :success
     body = JSON.parse(response.body)
-    assert_equal nil, body['data']
+    assert_nil body['data']
   end
 end

--- a/dashboard/test/lib/policies/lti_test.rb
+++ b/dashboard/test/lib/policies/lti_test.rb
@@ -72,7 +72,7 @@ class Policies::LtiTest < ActiveSupport::TestCase
 
   test 'lti_provided_email should NOT return an email given a non-LTI user' do
     user = create :teacher
-    assert_equal nil, Policies::Lti.lti_provided_email(user)
+    assert_nil Policies::Lti.lti_provided_email(user)
   end
 
   test 'lti_teacher returns false if administrator' do
@@ -188,7 +188,7 @@ class Policies::LtiTest < ActiveSupport::TestCase
     test 'returns nil unless early access' do
       @early_access.returns(false)
 
-      assert_equal nil, Policies::Lti.early_access_closed?
+      assert_nil Policies::Lti.early_access_closed?
     end
 
     test 'returns true when DCDO `lti_early_access_limit` is true' do


### PR DESCRIPTION
This is one of those "if it takes less than 2 minutes, just do it" updates. I was reading Drone logs to diagnose a separate test failure. Searching the output on "fail" turned up this: 
![Screenshot 2024-07-17 at 3 34 15 PM](https://github.com/user-attachments/assets/136cb490-9d23-4d75-8e59-4499570d7344)

I fixed it. 

I don't think we're moving to Minitest 6 any time soon given the current rate at which we update dependencies 🙃 but, you know, baby steps... 