### PR TITLE
[LABS 927] Fixes flaky test (star_labs_applab_eyes3)

### DIFF
--- a/dashboard/test/ui/features/star_labs/applab/eyes3.feature
+++ b/dashboard/test/ui/features/star_labs/applab/eyes3.feature
@@ -20,6 +20,7 @@ Scenario: Data Browser
   When I press enter key
   And I wait until element "th .test-tableNameDiv:contains(column1)" is visible
   And I press "addColumnButton"
+  And I wait until element "#addDataTableRow :nth-child(3) input" is visible
   And I press enter key
   And I press keys "1" for element "#addDataTableRow :nth-child(2) input"
   And I press keys "2" for element "#addDataTableRow :nth-child(3) input"


### PR DESCRIPTION
This purports to fix the flakiness of the test steps of the applab data view eyes test that does not wait for the input field for a new column to appear before typing into it.

![image](https://github.com/user-attachments/assets/b75db694-6a66-46e4-8f4f-9ac6007df16d)

## Links

- jira ticket: [LABS-927](https://codedotorg.atlassian.net/browse/LABS-927)

## Testing story

Tested with `[test eyes]` to run the test steps during the CI process and they passed.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
