### PR TITLE
[Google Blockly] monkey-patch Gesture.handleTouchMove

### DIFF
--- a/apps/src/blockly/addons/cdoGesture.js
+++ b/apps/src/blockly/addons/cdoGesture.js
@@ -1,0 +1,25 @@
+export function overrideHandleTouchMove(blocklyWrapper) {
+  const cdoGesture = blocklyWrapper.Gesture.prototype;
+
+  // Override handleTouchMove function
+  cdoGesture.handleTouchMove = function (e) {
+    const pointerId = Blockly.Touch.getTouchIdentifierFromEvent(e);
+
+    this.cachedPoints.set(pointerId, this.getTouchPoint(e));
+
+    if (this.isPinchZoomEnabled && this.cachedPoints.size === 2) {
+      this.handlePinch(e);
+    } else {
+      // Google Blockly would call handleMove here which can create an inifite loop.
+      // We handle multi-touch move logic here without calling handleMove again
+      this.updateFromEvent(e);
+      if (this.workspaceDragger) {
+        this.workspaceDragger.drag(this.currentDragDeltaXY);
+      } else if (this.dragger) {
+        this.dragger.onDrag(this.mostRecentEvent, this.currentDragDeltaXY);
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+}

--- a/apps/src/blockly/addons/cdoGesture.js
+++ b/apps/src/blockly/addons/cdoGesture.js
@@ -10,7 +10,7 @@ export function overrideHandleTouchMove(blocklyWrapper) {
     if (this.isPinchZoomEnabled && this.cachedPoints.size === 2) {
       this.handlePinch(e);
     } else {
-      // Google Blockly would call handleMove here which can create an inifite loop.
+      // Google Blockly would call handleMove here which can create an infinite loop.
       // We handle multi-touch move logic here without calling handleMove again
       this.updateFromEvent(e);
       if (this.workspaceDragger) {

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -198,6 +198,7 @@ export const READ_ONLY_PROPERTIES = [
   'gamelab_locale',
   'Generator',
   'geras',
+  'Gesture',
   'getRelativeXY',
   'googlecode',
   'hasCategories',

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -23,6 +23,7 @@ import {
   SETTABLE_PROPERTIES,
   WORKSPACE_EVENTS,
 } from '@cdo/apps/blockly/constants';
+import DCDO from '@cdo/apps/dcdo';
 import {MetricEvent} from '@cdo/apps/lib/metrics/events';
 import {getStore} from '@cdo/apps/redux';
 import {setFailedToGenerateCode} from '@cdo/apps/redux/blockly';
@@ -48,6 +49,7 @@ import CdoFieldParameter from './addons/cdoFieldParameter';
 import CdoFieldToggle from './addons/cdoFieldToggle';
 import CdoFieldVariable from './addons/cdoFieldVariable';
 import initializeGenerator from './addons/cdoGenerator';
+import {overrideHandleTouchMove} from './addons/cdoGesture';
 import CdoMetricsManager from './addons/cdoMetricsManager';
 import CdoRendererGeras from './addons/cdoRendererGeras';
 import CdoRendererThrasos from './addons/cdoRendererThrasos';
@@ -534,6 +536,10 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   extendedVariableMap.addVariables = function (variableList) {
     variableList.forEach(varName => this.createVariable(varName));
   };
+
+  if (DCDO.get('blockly-move', true)) {
+    overrideHandleTouchMove(blocklyWrapper);
+  }
 
   // Used for spritelab behavior blocks.
   // We can remove this once we are ready to no longer support sprite lab on CDO Blockly.


### PR DESCRIPTION
Since flipping Maze and Star Wars to Google Blockly on Monday https://github.com/code-dot-org/code-dot-org/pull/59354 we have been noticing an increase above threshold of certain JS errors:

- https://codedotorg.slack.com/archives/C0T0PNTM3/p1721174335253969
- https://codedotorg.slack.com/archives/C0T0PNTM3/p1721264792361799

It was difficult to find the cause. All URLs were Google Blockly labs, but not all were Maze or Star Wars. We were seeing very many errors for very few users. @unlox775-code-dot-org shared a stack trace that was hard to make sense of due to minimized code files:
![Screenshot 2024-07-16 at 5 55 00 PM](https://github.com/user-attachments/assets/15c39c1c-63bb-4f8e-9652-8f700bc64d42)

The next evening, @wilkie shared a different stack trace that revealed the names `handleMove` and `handleTouchMove`:
![image](https://github.com/user-attachments/assets/84c03ae6-ddd3-4c29-a161-8ed41d24e88b)

We found that these functions are defined in Blockly's Gesture class and indeed they had the potential for infinite recursion:

https://github.com/google/blockly/blob/71f094b901a01f87af73f24eb0ba9c55b58025af/core/gesture.ts#L490-L513

https://github.com/google/blockly/blob/71f094b901a01f87af73f24eb0ba9c55b58025af/core/gesture.ts#L593-L610



### Analyzing the Original Code

1. **`handleMove` Function:**
   - The `handleMove` function checks if the gesture is a drag or a multi-touch event.
   - If it's a multi-touch event, it calls `handleTouchMove`.

2. **Original `handleTouchMove` Function:**
   - The `handleTouchMove` function updates cached touch points and checks for pinch zoom conditions.
   - If the conditions for pinch zoom are not met, it calls `handleMove` again.

### Identifying the Potential Infinite Loop

- The original `handleTouchMove` calls `handleMove` when the conditions for pinch zoom are not met.
- Since `handleMove` calls `handleTouchMove` for multi-touch events, this creates a recursive call between `handleMove` and `handleTouchMove` under certain conditions, leading to an infinite loop.
I was finally able to get a repro on Safari iPad by dragging a block with two fingers:

https://github.com/user-attachments/assets/9d318f6d-db8a-4fdf-b310-e3d63fe134d9

At this point, the working theory is that the bug exists in Blockly and not in code-dot-org specifically. Furthermore, it's likely been present for a long time. The reason that we only just started seeing the errors pass the threshold this week is that we have a LOT of maze levels. Now that that levels are on Google Blockly, there are more opportunities for users to hit this bug.

### Formulating the Fix

To prevent the infinite loop, I needed to ensure that `handleTouchMove` does not call `handleMove` again. Instead, it should handle the multi-touch move logic directly within the function.

### Solution
We need to handle multi-touch events without causing an infinite loop. Both `handleMove` and `handleTouchMove` perform similar tasks: updating events and handling drags. By moving the update and drag logic directly into `handleTouchMove`, the function can independently handle the touch events without needing to call `handleMove` again. This breaks the recursive call chain, thus preventing the infinite loop.

With the fix implemented, I was able to drag blocks as normal, even using a multi-touch gesture, without errors.

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/CT-700
Blockly issue: https://github.com/google/blockly/issues/8396

Slack threads:
- https://codedotorg.slack.com/archives/C0T0PNTM3/p1721174335253969
- https://codedotorg.slack.com/archives/C0T0PNTM3/p1721264792361799

## Testing story

I manually tested these changes on iPad Safari with additional logging that was not committed.

With a 1:1 override of `handleTouchMove` with logging, I could observe the recursive call and the maximum call stack error. This happened within seconds of dragging a block *with two fingers*. (See video above and JS console below)
![image (208)](https://github.com/user-attachments/assets/d169738a-4564-40c5-adff-9605995a5e5f)

After implementing the fix, I could observe (with extra logging) that the function was only called each time the block moved.


## Deployment strategy

To be on the safe side, I'm putting this behind a DCDO flag. If for some reason this makes anything worse, it can be turned off on each environment with
`DCDO.set('blockly-move', false)`.

## Follow-up work

I will file an issue with the Blockly team and work with them to fix this in the core repo. This could potentially be a good opportunity for an upstream contribution.
Once the issue is resolved and the proper Blockly fix is released, we will work to get us onto that new latest Blockly version. Once that is done, we should be able to revert this change.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
