### PR TITLE
remove old DCDO flags for CFUs

### DIFF
--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -34,7 +34,7 @@
     );
 
 .free-response{:class => ('left-aligned' if left_align)}
-  - if DCDO.get("show_level_summary_entry_point", false) && !in_level_group
+  - if !in_level_group
     %div#summaryEntryPoint
   - title = level.get_property(:title)
   - if title.present? && (!in_level_group || is_contained_level)

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -36,7 +36,7 @@
       = render partial: 'levels/teacher_markdown', locals: {data: level.properties}
 
 .multi{id: "level_#{level.id}", class: layout_class}
-  - if DCDO.get("show_multi_level_summary_entry_point", false) && !in_level_group
+  - if !in_level_group
     %div#summaryEntryPoint
   - question_content_blank = data['content1'].blank? && data['content2'].blank? && data['content3'].blank? && data['markdown'].blank?
   - if question_content_blank


### PR DESCRIPTION
This PR removes DCDO flags that were at one point used to set up summary view of Checks for Understandings.  It appears as if these flags were not removed in these spaces. 

I did the following:

- Removed them in these two spaces
- Searched the codebase for other places we used them (couldn't find any)
- Made sure that we could still see the summary views as expected locally when the removed DCDO flags were set to "default"

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1193)