### PR TITLE
Avoiding curl pipe, using our own protected repo fork

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -246,7 +246,7 @@ Note: Virtual Machine Users should check the [Alternative note](#alternative-use
         1. `mkdir -p "$(rbenv root)"/plugins`
         1. `git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build`
     1. Use the rbenv-doctor from the [`rbenv` installation instructions](https://github.com/rbenv/rbenv#basic-github-checkout) to verify rbenv is set up correctly:
-        1. `curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash`
+        1. `curl -fsSL https://raw.githubusercontent.com/code-dot-org/rbenv-installer/main/bin/rbenv-doctor | bash`
     1. If there are any errors (they appear red), follow the [`rbenv` installation instructions] (https://github.com/rbenv/rbenv#basic-github-checkout) to properly configure `rbenv`, following steps for **Ubuntu Desktop** so that config changes go into `.bashrc`.
     1. **Note:** Ubuntu 22.04 ships with versions of `libssl` and `openssl` that are incompatible with `ruby-build`; see https://github.com/rbenv/ruby-build/discussions/1940 for context
         1. As a result, attempts to run `rbenv install` will fail. To resolve, compile a valid version of `openssl` locally and direct `rbenv` to configure ruby to use it as described here: https://github.com/rbenv/ruby-build/discussions/1940#discussioncomment-2663209

--- a/docker/dev_setup.sh
+++ b/docker/dev_setup.sh
@@ -7,7 +7,7 @@
 set -xe
 
 eval "$(rbenv init -)"
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
+curl -fsSL https://raw.githubusercontent.com/code-dot-org/rbenv-installer/main/bin/rbenv-doctor | bash
 
 bundle install --verbose
 

--- a/docker/ui_tests.sh
+++ b/docker/ui_tests.sh
@@ -25,7 +25,7 @@ export CIRCLE_ARTIFACTS=/home/circleci/artifacts
 mkdir $CIRCLE_ARTIFACTS
 
 # rbenv-doctor https://github.com/rbenv/rbenv-installer#readme
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
+curl -fsSL https://raw.githubusercontent.com/code-dot-org/rbenv-installer/main/bin/rbenv-doctor | bash
 
 # set up locals.yml
 # Need to actually write all the commented out lines also


### PR DESCRIPTION
## Summary

This removes a few "curl pipe" cases of the rbenv-installer repo.  These are in cases where `rbenv-doctor` is being run to make sure your local rbenv is setup right.  rbenv does not appear to ship this utility with it's apt-get package, and the docs just show the curpipe we are using.  Especially where that is a small repo/project (only 45 commits in 9 years), it may not have good community visibility.  A single rogue commit to `main` would instantly be arbitrary command execution on each of our servers, or on our developer's workstations.  With the nature of curlpipes, you don't even see what code is being run, so on a low-traffic repo it could go unnoticed exfiltrating access keys, etc for a while.

## Security Context - Why curlpipes are bad

Using curl to directly pipe scripts into bash for execution is a risky practice, as it can expose systems to significant security vulnerabilities. This method, often referred to as “curl | bash” or “pipe install,” involves fetching a script from a remote server and immediately running it on a local machine. While convenient, this approach bypasses the usual safeguards and vetting processes that are in place when using package managers and versioned repositories. By executing code fetched directly from the internet without any verification, you risk running malicious code if the source server is compromised or if an unauthorized change is merged into the repository. This is particularly problematic when the scripts are fetched from dynamic sources like a GitHub repository’s main branch, where changes can be made frequently and potentially without thorough review.

In general, it’s recommended to use versioned package management systems, such as apt, npm, or gem, which ensure that you are using stable, vetted versions of the software. These systems typically provide cryptographic verification of packages, ensuring that the code has not been tampered with. Furthermore, package management systems allow for dependency locking, where the exact versions of all dependencies are recorded, preventing unexpected updates that could introduce vulnerabilities.  When no package-management solution is available (as in this case), the only option is to fork and use your own "paused" version to protect against supply-chain attacks.  This practice aligns with supply chain security best practices and reduces the risk of introducing vulnerabilities into your system through unverified code execution.

## Other curlpipes I'm not addressing here:

These are less worrysome to me as they are pulling from a package management source or vendor target asset:
- In `SETUP.md` - `curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash`
- In `aws/chef-bootstrap.sh` - `curl -L https://omnitruck.chef.io/install.sh | bash -s -- -v ${CHEF_VERSION}`
- In `docker/dockerfiles/Dockerfile`
   - `RUN curl -sS https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash`
   - `RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -`

## Links

Branch protection rule I set up: https://github.com/code-dot-org/rbenv-installer/settings/rules/1202315

## Testing story

Manual test I ran, on this docker instance `i-03241e37f86b3ff89`:
```
$ sudo docker exec -it drone-wfedzI3SaqNzoZt9Vw1A bash
circleci@5456e9597386:/drone/src$ which rbenv
/usr/bin/rbenv
circleci@5456e9597386:/drone/src$ curl -fsSL https://raw.githubusercontent.com/code-dot-org/rbenv-installer/main/bin/rbenv-doctor | bash
Checking for `rbenv' in PATH: /usr/bin/rbenv
Checking for rbenv shims in PATH: OK
Checking `rbenv install' support: /home/circleci/.rbenv/plugins/ruby-build/bin/rbenv-install (ruby-build 20240530.1-1-g15bdff9b)
Counting installed Ruby versions: 1 versions
Auditing installed plugins: OK
circleci@5456e9597386:/drone/src$
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [X] Privacy and Security impacts have been assessed
- [X] User impact is well-understood and desirable
