### PR TITLE
Fix Aichat session matching bug

### DIFF
--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -128,9 +128,15 @@ class AichatController < ApplicationController
       end
     end
 
-    if params[:aichatModelCustomizations] != JSON.parse(session.model_customizations) ||
-        params[:storedMessages] != JSON.parse(session.messages)
+    if params[:aichatModelCustomizations] != JSON.parse(session.model_customizations)
       return false
+    end
+    
+    # Compare stored messages excluding timestamps
+    sessions_stored_messages = JSON.parse(session.messages).map { |message| message.except('timestamp') }
+    frontend_stored_messages = params[:storedMessages].map { |message| message.except('timestamp') }
+    if sessions_stored_messages != frontend_stored_messages
+      return false      
     end
 
     true

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -131,12 +131,13 @@ class AichatController < ApplicationController
     if params[:aichatModelCustomizations] != JSON.parse(session.model_customizations)
       return false
     end
-    
-    # Compare stored messages excluding timestamps
-    sessions_stored_messages = JSON.parse(session.messages).map { |message| message.except('timestamp') }
-    frontend_stored_messages = params[:storedMessages].map { |message| message.except('timestamp') }
+
+    # Compare stored messages in sessions table with stored message from front-end
+    # for the following fields only: chatMessageText, role, and status.
+    sessions_stored_messages = JSON.parse(session.messages).map {|message| message.slice('chatMessageText', 'role', 'status')}
+    frontend_stored_messages = params[:storedMessages].map {|message| message.slice('chatMessageText', 'role', 'status')}
     if sessions_stored_messages != frontend_stored_messages
-      return false      
+      return false
     end
 
     true

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -218,7 +218,6 @@ class AichatControllerTest < ActionController::TestCase
 
     post :chat_completion, params: @valid_params, as: :json
     session = AichatSession.find(json_response['session_id'])
-    current_session_id = session.id
 
     post :chat_completion, params: @valid_params.merge(
       {

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -20,8 +20,8 @@ class AichatControllerTest < ActionController::TestCase
         channelId: "test"
       }
     }
-    valid_message = {role: 'user', chatMessageText: 'hello'}
-    @profanity_violation_message = {role: 'user', chatMessageText: 'Damn you, robot'}
+    valid_message = {role: 'user', chatMessageText: 'hello', status: 'unknown', timestamp: Time.now.to_i}
+    @profanity_violation_message = {role: 'user', chatMessageText: 'Damn you, robot', status: 'unknown', timestamp: Time.now.to_i}
     @valid_params = @common_params.merge(newMessage: valid_message)
     @profanity_violation_params = @common_params.merge(
       newMessage: @profanity_violation_message
@@ -211,5 +211,26 @@ class AichatControllerTest < ActionController::TestCase
     ),
       as: :json
     refute_equal session.id, json_response['session_id']
+  end
+
+  test 'updates existing chat session when session id provided and a message field outside of chatMessageText, role, and status do not match' do
+    sign_in(@genai_pilot_teacher)
+
+    post :chat_completion, params: @valid_params, as: :json
+    session = AichatSession.find(json_response['session_id'])
+    current_session_id = session.id
+
+    post :chat_completion, params: @valid_params.merge(
+      {
+        sessionId: session.id,
+        storedMessages: [
+          @valid_params[:newMessage].merge(status: 'ok').stringify_keys,
+          {role: 'assistant', chatMessageText: @assistant_response, status: 'ok', timestamp: Time.now.to_i}.stringify_keys
+        ],
+        aichatModelCustomizations: @default_model_customizations
+      }
+    ),
+      as: :json
+    assert_equal session.id, json_response['session_id']
   end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR fixes a logging bug for the `AichatSessions` table. Currently, a new session is created whenever a new message is added to stored messages. This results in multiple table entries with duplicate messages. A new session should be created only when the chat history is cleared or model customizations are updated which resets the conversation history. This regression is due to the removal of a frontend util function which stripped extra fields from chat messages. https://github.com/code-dot-org/code-dot-org/pull/59341/files

The bug was resolved by updating the `matches_existing_session` method in `aichat_controller` so that only the message fields 'role', 'status', and 'chatMessageText' are compared. 


## Before update
Note that the session id is incremented by one in the third request although the model customizations were not reset.

https://github.com/user-attachments/assets/66699155-8ab6-4e52-9c09-34c2b7e23b8f


## After update

Session id remains the same between 2nd and 3rd requests as expected.

https://github.com/user-attachments/assets/9c9abdaf-2df9-4ded-a829-706010858cbe





## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-933)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I added a unit test that checks if another field is updated from frontend stored messages (like `timestamp`), the stored messages are still considering matching as long as `chatMessageText`, `role`, and `status` values match.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
