### PR TITLE
Datablock Storage: shared projects work for unlogged-in users

### DIFF
--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -24,8 +24,22 @@
 # https://github.com/code-dot-org/code-dot-org/pull/56279
 
 class DatablockStorageController < ApplicationController
+  # These methods can be called by data blocks in applab/gamelab
+  METHODS_CALLED_BY_DATA_BLOCKS = [
+    :set_key_value,
+    :get_key_value,
+    :create_record,
+    :read_records,
+    :update_record,
+    :delete_record,
+  ]
+
   before_action :validate_channel_id
-  before_action :authenticate_user!
+
+  # Methods that are called directly by data blocks need to be accessible
+  # even when the applab/gamelab project is shared. In this case we won't
+  # necessarily have a logged-in user.
+  before_action :authenticate_user!, except: METHODS_CALLED_BY_DATA_BLOCKS
 
   StudentFacingError = DatablockStorageTable::StudentFacingError
 


### PR DESCRIPTION
Allow shared student projects to access limited methods on datablock_storage_controller without requiring login. This allows projects that use data blocks to be shared, which matches the firebase design.

We only allow access to the methods that are actually invoked by data blocks.

Fixes #59339 

Co-authored-by: Cassi Brenci <cnbrenci@users.noreply.github.com>