### PR TITLE
Implement New Rotation Pattern in New Recipe

### DIFF
--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -38,6 +38,8 @@ FOLDERS = {
 INTERVAL_SECONDS = 5
 TOTAL_SECONDS = 55 - INTERVAL_SECONDS
 
+LOG_DIR = '/home/ubuntu'.freeze
+
 logger = HighFrequencyReporter.new(Slack, 'sync-dropbox-staging', File.join(LOG_DIR, 'dropbox_sync_error_log.csv'))
 logger.load # load errors from most recent sync
 
@@ -51,7 +53,7 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     command = [
       "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value}",
       '-silent -ignore "Name .dropbox" -auto -perms 0 -dontchmod',
-      "-log -logfile /home/ubuntu/unison.log"
+      "-log -logfile #{File.join(LOG_DIR, 'unison.log')}"
     ].join(' ')
     stdout, stderr, _ = Open3.capture3(command)
     next unless stdout == "" && stderr == ""

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -47,23 +47,12 @@ end
 apt_package 'enscript'
 
 # Install dependencies required to sync content between our Code.org shared
-# Dropbox folder and our git repository. Also check whether the tool that
-# performs the sync is installed, and display instructions for how to do so if
-# it isn't. Ideally, we would be able to install the tool with this code, but
-# the process is sufficiently interactive and we have to do it sufficiently
-# rarely that we think documentation will suffice for now.
+# Dropbox folder and our git repository only on the staging server. In the long
+# run, we'd like to have this happen in a separate - ideally ephemeral -
+# environment, independent of any of our build pipeline servers; but for now,
+# the staging server is where it lives.
 if node.chef_environment == 'staging'
-  apt_package 'unison'
-  dropbox_daemon_file = File.join(node[:home], '.dropbox-dist/dropboxd')
-  unless File.exist?(dropbox_daemon_file)
-    environment_name = node.chef_environment.inspect
-    Chef.event_handler do
-      on :run_completed do
-        Chef::Log.warn("Chef environment #{environment_name} expects the Dropbox Daemon to be configured.")
-        Chef::Log.warn('Follow the instructions at https://www.dropbox.com/install-linux to do so')
-      end
-    end
-  end
+  include_recipe 'cdo-apps::dropbox_sync'
 end
 
 # Debian-family packages for building Ruby C extensions

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -48,10 +48,9 @@ apt_package 'enscript'
 
 # Install dependencies required to sync content between our Code.org shared
 # Dropbox folder and our git repository only on the staging server. In the long
-# run, we'd like to have this happen in a separate - ideally ephemeral -
-# environment, independent of any of our build pipeline servers; but for now,
-# the staging server is where it lives.
-if node.chef_environment == 'adhoc'
+# run, we'd like to have this happen in a separate environment independent of
+# any of our build pipeline servers; but for now, we default to staging.
+if node.chef_environment == 'staging'
   include_recipe 'cdo-apps::dropbox_sync'
 end
 

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -51,7 +51,7 @@ apt_package 'enscript'
 # run, we'd like to have this happen in a separate - ideally ephemeral -
 # environment, independent of any of our build pipeline servers; but for now,
 # the staging server is where it lives.
-if node.chef_environment == 'staging'
+if node.chef_environment == 'adhoc'
   include_recipe 'cdo-apps::dropbox_sync'
 end
 

--- a/cookbooks/cdo-apps/recipes/dropbox_sync.rb
+++ b/cookbooks/cdo-apps/recipes/dropbox_sync.rb
@@ -1,0 +1,38 @@
+# Install the tool that syncs content between the Dropbox directory and the git
+# repository. Also configure rotation for the tool's fairly verbose logs.
+apt_package 'unison'
+file '/etc/logrotate.d/unison' do
+  content <<~LOGROTATE
+    #{File.join(node[:home], 'unison.log')} {
+      daily
+      rotate 15
+      compress
+      missingok
+      notifempty
+      copytruncate
+      postrotate
+        INSTANCE_ID="`wget -q -O - http://instance-data/latest/meta-data/instance-id`"
+        /usr/local/bin/aws s3 cp $1 "s3://cdo-logs/#{node.chef_environment}-misc-logs/${INSTANCE_ID}-$1"
+      endscript
+    }
+  LOGROTATE
+  mode '0644'
+  owner 'root'
+  group 'root'
+end
+
+# Check whether the tool that syncs content between Dropbox's servers and our
+# local Dropbox directory is installed, and display instructions for how to do
+# so if it isn't. Ideally, we would be able to install the tool with this code,
+# but the process is sufficiently interactive and we have to do it sufficiently
+# rarely that we think documentation will suffice for now.
+dropbox_daemon_file = File.join(node[:home], '.dropbox-dist/dropboxd')
+unless File.exist?(dropbox_daemon_file)
+  environment_name = node.chef_environment.inspect
+  Chef.event_handler do
+    on :run_completed do
+      Chef::Log.warn("Chef environment #{environment_name} expects the Dropbox Daemon to be configured.")
+      Chef::Log.warn('Follow the instructions at https://www.dropbox.com/install-linux to do so')
+    end
+  end
+end

--- a/cookbooks/cdo-apps/templates/default/logrotate.erb
+++ b/cookbooks/cdo-apps/templates/default/logrotate.erb
@@ -31,17 +31,3 @@ copytruncate
 # Set user/group permissions for archived log files.
 su <%= node[:current_user] %> <%= node[:current_user] %>
 }
-
-# Even though this only applies in staging, the `missingok` directive above will prevent errors in production.
-/home/ubuntu/unison.log {
-    daily
-    rotate 15
-    compress
-    missingok
-    notifempty
-    copytruncate
-    postrotate
-        INSTANCE_ID="`wget -q -O - http://instance-data/latest/meta-data/instance-id`"
-        /usr/local/bin/aws s3 cp $1 "s3://cdo-logs/<%= @env %>-misc-logs/${INSTANCE_ID}-$1"
-    endscript
-}


### PR DESCRIPTION
Alternative to (and based on) https://github.com/code-dot-org/code-dot-org/pull/59878; implement the new rotation pattern in a new standalone recipe specific to the Dropbox sync. Follow-up to https://github.com/code-dot-org/code-dot-org/pull/59636

Specifically, we return the `unison.log` file to its original location in the home directory, and configure logrotation for just that file. We also include logic to upload the last day's worth of logs to S3 before rotating, to a path unique to that server and that day, so the logs can be preserved even after rotation has deleted them from the local filesystem.

Also extract our existing Chef code related to the dropbox sync to its own recipe, since it was starting to get a little long.

## Links

[Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1720468091032489)

## Testing story

Tested on an adhoc by [temporarily updating this functionality to apply to adhocs](https://github.com/code-dot-org/code-dot-org/pull/59880/commits/52a729b05e74cfeaa4d20d8cc93cb2796e0a31dd), populating the log with some random data, and manually triggering rotation:

```bash
ubuntu@adhoc-unison-log-rotate-to-s3-alternative:~$ ls
adhoc
ubuntu@adhoc-unison-log-rotate-to-s3-alternative:~$ dd if=/dev/urandom of=~/unison.log bs=1k count=1
1+0 records in
1+0 records out
1024 bytes (1.0 kB, 1.0 KiB) copied, 0.000103349 s, 9.9 MB/s
ubuntu@adhoc-unison-log-rotate-to-s3-alternative:~$ sudo logrotate --force /etc/logrotate.d/unison
upload: ./unison.log to s3://cdo-logs/adhoc-misc-logs/i-0df93e7e518beb9bc/2024-07-20/home/ubuntu/unison.log
ubuntu@adhoc-unison-log-rotate-to-s3-alternative:~$ ls
adhoc  unison.log  unison.log-20240720.gz
```

I then verified that [the uploaded file](https://us-east-1.console.aws.amazon.com/s3/object/cdo-logs?region=us-east-1&bucketType=general&prefix=adhoc-misc-logs/i-0df93e7e518beb9bc/2024-07-20/home/ubuntu/unison.log) contained the generated data.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
