### PR TITLE
Update docs to use jest test options

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -58,9 +58,9 @@ It's also possible to run a subset of tests:
 * `yarn lint`
 * `yarn test:unit`
 * `yarn test:integration`
-* `yarn test:unit ./test/unit/gridUtilsTest.js`
+* `yarn test:unit test/unit/gridUtilsTest.js`
 
-For more details, see [apps/README.md](./apps/README.md#running-tests).
+For more details, see [apps/README.md](./apps/README.md#testing).
 
 ### Dashboard Tests
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -58,9 +58,7 @@ It's also possible to run a subset of tests:
 * `yarn lint`
 * `yarn test:unit`
 * `yarn test:integration`
-* `yarn test:unit --entry=./test/unit/gridUtilsTest.js`
-
-To debug tests in Chrome, append `--browser=Chrome --watchTests` to any test command.
+* `yarn test:unit ./test/unit/gridUtilsTest.js`
 
 For more details, see [apps/README.md](./apps/README.md#running-tests).
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -82,7 +82,7 @@ Apps unit tests are run using [jest](https://jestjs.io/) and integration tests a
 | Integration tests for maze levels       | `yarn test:integration --levelType=maze`                  |
 | **Other useful flags:**                 | **Example Command**                                       |
 | Stream pass/fail to stdout/stderr       | `yarn test:unit --verbose`                                |
-| Rerun tests when files change           | `yarn test:unit --watchTests`                             |
+| Rerun tests when files change           | `yarn test:unit --watch`                                  |
 | Debug tests in Chrome                   | `yarn test:integration --browser=Chrome --watchTests`     |
 | Directly invoke Karma (same flags)      | `npx karma start --testType=integration --browser=Chrome` |
 | Directly invoke jest                    | `npx jest`                                                |


### PR DESCRIPTION
Found a few more places we need to update our docs to use the appropriate flags for `jest` after #57940 .