### PR TITLE
[DRAFT] Include notifications in messages sent to aichat_controller and logged in AichatSessions

### DIFF
--- a/apps/src/aiComponentLibrary/chatItems/types.ts
+++ b/apps/src/aiComponentLibrary/chatItems/types.ts
@@ -2,4 +2,5 @@
 export enum Role {
   USER = 'user',
   ASSISTANT = 'assistant',
+  NOTIFICATION = 'notification',
 }

--- a/apps/src/aichat/aichatCompletionApi.ts
+++ b/apps/src/aichat/aichatCompletionApi.ts
@@ -6,18 +6,19 @@ import {
   AichatModelCustomizations,
   ChatApiResponse,
   ChatMessage,
+  ChatItem,
 } from './types';
 
 const CHAT_COMPLETION_URL = '/aichat/chat_completion';
 
 /**
- * This function formats chat completion messages and aichatParameters, sends a POST request
+ * This function formats chat completion messages and aichat parameters, sends a POST request
  * to the aichat completion backend controller, then returns the status of the response
  * and assistant message if successful.
  */
 export async function postAichatCompletionMessage(
   newMessage: ChatMessage,
-  storedMessages: ChatMessage[],
+  storedMessages: ChatItem[],
   aiCustomizations: AiCustomizations,
   aichatContext: AichatContext,
   sessionId?: number

--- a/apps/src/aichat/redux/utils.ts
+++ b/apps/src/aichat/redux/utils.ts
@@ -1,20 +1,24 @@
 import moment from 'moment';
 
+import {Role} from '@cdo/apps/aiComponentLibrary/chatItems/types';
 import {getTypedKeys} from '@cdo/apps/types/utils';
+import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
+import {modelDescriptions} from '../constants';
 import {
   AiCustomizations,
   FieldVisibilities,
   ModelCardInfo,
   Visibility,
 } from '../types';
+import {AI_CUSTOMIZATIONS_LABELS} from '../views/modelCustomization/constants';
 
-// This variable keeps track of the most recent message ID so that we can
-// assign a unique message id in increasing sequence to a new message.
-let latestMessageId = 0;
-export const getNewMessageId = () => {
-  latestMessageId += 1;
-  return latestMessageId;
+// This variable keeps track of the most recent notification ID so that we can
+// assign a unique notification id in increasing sequence to a new notification.
+let latestNotificationId = 0;
+export const getNewNotificationId = () => {
+  latestNotificationId += 1;
+  return latestNotificationId;
 };
 
 export const timestampToDateTime = (timestamp: number) =>
@@ -79,3 +83,35 @@ export const allFieldsHidden = (fieldVisibilities: FieldVisibilities) =>
   getTypedKeys(fieldVisibilities).every(
     key => fieldVisibilities[key] === Visibility.HIDDEN
   );
+
+export const formatModelUpdateText = (
+  updatedField: keyof AiCustomizations,
+  updatedValue: AiCustomizations[keyof AiCustomizations]
+): string => {
+  const fieldLabel = AI_CUSTOMIZATIONS_LABELS[updatedField];
+
+  let updatedToText = undefined;
+  if (updatedField === 'temperature') {
+    updatedToText = updatedValue as number;
+  }
+  if (updatedField === 'selectedModelId') {
+    updatedToText = modelDescriptions.find(
+      model => model.id === updatedValue
+    )?.name;
+  }
+
+  const updatedText = updatedToText
+    ? ` has been updated to ${updatedToText}.`
+    : ' has been updated.';
+
+  return `${fieldLabel} ${updatedText}`;
+};
+
+export const getHiddenClearChatMessagesNotification = () => ({
+  id: getNewNotificationId(),
+  role: Role.NOTIFICATION,
+  status: Status.OK,
+  text: 'Chat history has been cleared.',
+  timestamp: Date.now(),
+  hidden: true,
+});

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -1,4 +1,5 @@
 import {LevelProperties} from '@cdo/apps/lab2/types';
+import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
 import {Role} from '../aiComponentLibrary/chatItems/types';
 
@@ -8,24 +9,18 @@ export type AichatInteractionStatusValue = string;
 export interface ChatItem {
   // UTC timestamp in milliseconds
   timestamp: number;
-}
-
-export interface ChatMessage extends ChatItem {
-  chatMessageText: string;
   role: Role;
   status: AichatInteractionStatusValue;
 }
 
-export interface ModelUpdate extends ChatItem {
-  id: number;
-  updatedField: keyof AiCustomizations;
-  updatedValue: AiCustomizations[keyof AiCustomizations];
+export interface ChatMessage extends ChatItem {
+  chatMessageText: string;
 }
 
 export interface Notification extends ChatItem {
   id: number;
   text: string;
-  notificationType: 'error' | 'success';
+  hidden?: boolean;
 }
 
 // Type Predicates: checks if a ChatItem is a given type, and more helpfully,
@@ -34,12 +29,15 @@ export function isChatMessage(item: ChatItem): item is ChatMessage {
   return (item as ChatMessage).chatMessageText !== undefined;
 }
 
-export function isModelUpdate(item: ChatItem): item is ModelUpdate {
-  return (item as ModelUpdate).updatedField !== undefined;
+export function isNotification(item: ChatItem): item is Notification {
+  return (item as Notification).id !== undefined;
 }
 
-export function isNotification(item: ChatItem): item is Notification {
-  return (item as Notification).notificationType !== undefined;
+export function isLoggedChatItem(item: ChatItem) {
+  if (isNotification(item) && item.status === Status.ERROR) {
+    return false;
+  }
+  return true;
 }
 
 export interface ChatApiResponse {

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -2,6 +2,7 @@
 
 import React, {useCallback, useContext, useEffect} from 'react';
 
+import {Role} from '@cdo/apps/aiComponentLibrary/chatItems/types';
 import {sendSuccessReport} from '@cdo/apps/code-studio/progressRedux';
 import Button from '@cdo/apps/componentLibrary/button/Button';
 import SegmentedButtons, {
@@ -20,6 +21,7 @@ import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import ProjectTemplateWorkspaceIcon from '@cdo/apps/templates/ProjectTemplateWorkspaceIcon';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
 import aichatI18n from '../locale';
 import {
@@ -34,7 +36,10 @@ import {
   setViewMode,
   updateAiCustomization,
 } from '../redux/aichatRedux';
-import {getNewMessageId} from '../redux/utils';
+import {
+  getNewNotificationId,
+  getHiddenClearChatMessagesNotification,
+} from '../redux/utils';
 import {AichatLevelProperties, Notification, ViewMode} from '../types';
 
 import ChatWorkspace from './ChatWorkspace';
@@ -45,9 +50,10 @@ import PresentationView from './presentation/PresentationView';
 import moduleStyles from './aichatView.module.scss';
 
 const getResetModelNotification = (): Notification => ({
-  id: getNewMessageId(),
+  id: getNewNotificationId(),
   text: 'Model customizations and model card information have been reset to default settings.',
-  notificationType: 'success',
+  status: Status.OK,
+  role: Role.NOTIFICATION,
   timestamp: Date.now(),
 });
 
@@ -179,6 +185,8 @@ const AichatView: React.FunctionComponent = () => {
 
   const onClear = useCallback(() => {
     dispatch(clearChatMessages());
+    // Add hidden notification when user clicks on 'Clear chat' button.
+    dispatch(addNotification(getHiddenClearChatMessagesNotification()));
     analyticsReporter.sendEvent(
       EVENTS.CHAT_ACTION,
       {

--- a/apps/src/aichat/views/ChatItemView.tsx
+++ b/apps/src/aichat/views/ChatItemView.tsx
@@ -3,43 +3,14 @@ import React from 'react';
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatItems/ChatMessage';
 import Alert from '@cdo/apps/componentLibrary/alert/Alert';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
-import {modelDescriptions} from '../constants';
-import {removeUpdateMessage} from '../redux/aichatRedux';
+import {hideNotification} from '../redux/aichatRedux';
 import {timestampToLocalTime} from '../redux/utils';
-import {
-  ChatItem,
-  ModelUpdate,
-  isChatMessage,
-  isNotification,
-  isModelUpdate,
-} from '../types';
-
-import {AI_CUSTOMIZATIONS_LABELS} from './modelCustomization/constants';
+import {ChatItem, isChatMessage, isNotification} from '../types';
 
 interface ChatItemViewProps {
   item: ChatItem;
-}
-
-function formatModelUpdateText(update: ModelUpdate): string {
-  const {updatedField, updatedValue, timestamp} = update;
-  const fieldLabel = AI_CUSTOMIZATIONS_LABELS[updatedField];
-
-  let updatedToText = undefined;
-  if (updatedField === 'temperature') {
-    updatedToText = updatedValue as number;
-  }
-  if (updatedField === 'selectedModelId') {
-    updatedToText = modelDescriptions.find(
-      model => model.id === updatedValue
-    )?.name;
-  }
-
-  const updatedText = updatedToText
-    ? ` has been updated to ${updatedToText}.`
-    : ' has been updated.';
-
-  return `${fieldLabel} ${updatedText} ${timestampToLocalTime(timestamp)}`;
 }
 
 /**
@@ -52,24 +23,17 @@ const ChatItemView: React.FunctionComponent<ChatItemViewProps> = ({item}) => {
     return <ChatMessage {...item} />;
   }
 
-  if (isNotification(item)) {
-    const {id, text, notificationType, timestamp} = item;
+  if (isNotification(item) && !item.hidden) {
+    const {id, text, status, timestamp} = item;
     return (
       <Alert
         text={`${text} ${timestampToLocalTime(timestamp)}`}
-        type={notificationType === 'error' ? 'danger' : 'success'}
-        onClose={() => dispatch(removeUpdateMessage(id))}
-        size="s"
-      />
-    );
-  }
-
-  if (isModelUpdate(item)) {
-    return (
-      <Alert
-        text={formatModelUpdateText(item)}
-        type="success"
-        onClose={() => dispatch(removeUpdateMessage(item.id))}
+        type={
+          status === Status.OK || status === Status.UNKNOWN
+            ? 'success'
+            : 'danger'
+        }
+        onClose={() => dispatch(hideNotification(id))}
         size="s"
       />
     );

--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -9,9 +9,7 @@ import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
 import {timestampToDateTime} from '../redux/utils';
-import {ChatItem, isChatMessage, isModelUpdate, isNotification} from '../types';
-
-import {AI_CUSTOMIZATIONS_LABELS} from './modelCustomization/constants';
+import {ChatItem, isChatMessage, isNotification} from '../types';
 
 const CopyButton: React.FunctionComponent = () => {
   const messages = useSelector(selectAllMessages);
@@ -54,12 +52,6 @@ function chatItemToFormattedString(chatItem: ChatItem) {
         ? '[FLAGGED AS PROFANITY]'
         : chatItem.chatMessageText
     }`;
-  }
-
-  if (isModelUpdate(chatItem)) {
-    return `[${formattedTimestamp} - Model Update] ${
-      AI_CUSTOMIZATIONS_LABELS[chatItem.updatedField]
-    } updated.`;
   }
 
   if (isNotification(chatItem)) {

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -6,7 +6,9 @@ class AichatController < ApplicationController
 
   # params are
   # newMessage: {role: 'user'; chatMessageText: string; status: string}
-  # storedMessages: Array of {role: <'user', 'system', or 'assistant'>; chatMessageText: string; status: string} - does not include user's new message
+  # storedMessages: Array of ChatItems - Does not include user's new message
+  #   {role: <'user', 'notification', or 'assistant'>; status: string;
+  #   chatMessageText: string; for ChatMessages OR text: string; for Notifications }
   # aichatModelCustomizations: {temperature: number; retrievalContexts: string[]; systemPrompt: string;}
   # aichatContext: {currentLevelId: number; scriptId: number; channelId: string;}
   # POST /aichat/chat_completion


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This PR lays the initial groundwork for allowing teacher view of student chat history including model updates and other notifications.
Currently, we only log chat messages from the user and assistant on the backend in the `AichatSessions` table, and do not log notifications or model updates.

This PR adds logging of Chat Items which include notifications and includes a bit of refactoring of types.
- Since model updates are a type of notification, I removed the `ModelUpdate` type as this simplified the code a bit. I first thought of doing this since the `Notification` displayed when `getResetModelNotification` is called resets the model customizations and is a model update.
- Instead of removing model updates, I added an optional field titled `hidden` so that we can hide notifications from display.
- I added a hidden clear chat history notification when a user clicks on the 'Clear chat' button since this resets the session and may be useful information for a teacher when viewing student chat history.

## After update

Screencast video of dev console showing the stored messages sent to backend including notifications. Note that when the 'clear chat' button is clicked, the hidden notification is added.

https://github.com/user-attachments/assets/d8c1d8d5-9431-4ed1-807c-c2109ab25124

However, if any notifications were added/displayed before the user clicks on 'clear chat', those will not be sent since they will be wiped from `chatItemsCurrent`. Also, if model card information/customizations are updated and the user doesn't submit a chat message (user navigates to next level after finishing model card information, etc), then these notifications will not be logged either.

Screenshot of AichatSessions table with 2 entries that include notifications:
<img width="1336" alt="Screenshot 2024-07-19 at 10 59 26 AM" src="https://github.com/user-attachments/assets/9fa7a336-2812-443c-bd1d-11f6168cbffc">

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-798)
[Slack thread discussion](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1719356890606439)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally in aichat levels from /allthethings and viewed `AichatSessions` table with latest entries to confirm logging included notifications.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
