### PR TITLE
Revert "Revert "Datablock Storage: only allow up to 3x concurrent fetch() connections from data blocks (#59879)""

### DIFF
--- a/apps/jest.config.js
+++ b/apps/jest.config.js
@@ -25,6 +25,21 @@ Object.entries(APPLICATION_ALIASES).forEach(([alias, localPath]) => {
 });
 
 /**
+ * List of node_modules to transform with babel-jest.
+ *
+ * Packages that include ESM import/export statements in their distributed JS
+ * will need to be added to this list.
+ */
+const nodeModulesToTransform = [
+  'vmsg',
+  '@code-dot-org/johnny-five',
+  '@code-dot-org/js-interpreter',
+  'blockly/core',
+  'p-queue', // uses ESM
+  'p-timeout', // uses ESM
+];
+
+/**
  * For a detailed explanation regarding each configuration property, visit:
  * https://jestjs.io/docs/configuration
  */
@@ -233,7 +248,9 @@ const config = {
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   transformIgnorePatterns: [
-    'node_modules/(?!vmsg|@code-dot-org/johnny-five|@code-dot-org/js-interpreter|blockly/core)',
+    // Don't transform node_modules, with the exception of the `nodeModulesToTransform` list.
+    // Packages that use import/export statements will need to be added to this list.
+    `node_modules/(?!${nodeModulesToTransform.join('|')})`,
   ],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them

--- a/apps/package.json
+++ b/apps/package.json
@@ -264,6 +264,7 @@
     "ml-knn": "^3.0.0",
     "moment": "^2.29.4",
     "object-fit-images": "^3.2.3",
+    "p-queue": "^8.0.1",
     "pa11y-ci": "^2.3.0",
     "path-browserify": "^1.0.1",
     "pepjs": "^0.4.3",

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -1763,12 +1763,11 @@ applabCommands.createRecord = function (opts) {
   }
   var onSuccess = applabCommands.handleCreateRecord.bind(this, opts);
   var onError = opts.onError || getAsyncOutputWarning();
-  try {
-    rateLimit();
-    Applab.storage.createRecord(opts.table, opts.record, onSuccess, onError);
-  } catch (e) {
+  rateLimit(() =>
+    Applab.storage.createRecord(opts.table, opts.record, onSuccess, onError)
+  ).catch(e => {
     outputError(e.message);
-  }
+  });
 };
 
 applabCommands.handleCreateRecord = function (opts, record) {
@@ -1791,12 +1790,12 @@ applabCommands.getKeyValue = function (opts) {
   );
   var onSuccess = applabCommands.handleReadValue.bind(this, opts);
   var onError = opts.onError || getAsyncOutputWarning();
-  try {
-    rateLimit();
-    Applab.storage.getKeyValue(opts.key, onSuccess, onError);
-  } catch (e) {
+
+  rateLimit(() =>
+    Applab.storage.getKeyValue(opts.key, onSuccess, onError)
+  ).catch(e => {
     outputError(e.message);
-  }
+  });
 };
 
 applabCommands.handleReadValue = function (opts, value) {
@@ -1809,12 +1808,12 @@ applabCommands.getKeyValueSync = function (opts) {
   apiValidateType(opts, 'getKeyValueSync', 'key', opts.key, 'string');
   var onSuccess = handleGetKeyValueSync.bind(this, opts);
   var onError = handleGetKeyValueSyncError.bind(this, opts);
-  try {
-    rateLimit();
-    Applab.storage.getKeyValue(opts.key, onSuccess, onError);
-  } catch (e) {
+
+  rateLimit(() =>
+    Applab.storage.getKeyValue(opts.key, onSuccess, onError)
+  ).catch(e => {
     outputError(e.message);
-  }
+  });
 };
 
 var handleGetKeyValueSync = function (opts, value) {
@@ -1849,12 +1848,12 @@ applabCommands.setKeyValue = function (opts) {
   );
   var onSuccess = applabCommands.handleSetKeyValue.bind(this, opts);
   var onError = opts.onError || getAsyncOutputWarning();
-  try {
-    rateLimit();
-    Applab.storage.setKeyValue(opts.key, opts.value, onSuccess, onError);
-  } catch (e) {
+
+  rateLimit(() =>
+    Applab.storage.setKeyValue(opts.key, opts.value, onSuccess, onError)
+  ).catch(e => {
     outputError(e.message);
-  }
+  });
 };
 
 applabCommands.handleSetKeyValue = function (opts) {
@@ -1868,12 +1867,12 @@ applabCommands.setKeyValueSync = function (opts) {
   apiValidateType(opts, 'setKeyValueSync', 'value', opts.value, 'primitive');
   var onSuccess = handleSetKeyValueSync.bind(this, opts);
   var onError = handleSetKeyValueSyncError.bind(this, opts);
-  try {
-    rateLimit();
-    Applab.storage.setKeyValue(opts.key, opts.value, onSuccess, onError);
-  } catch (e) {
+
+  rateLimit(() =>
+    Applab.storage.setKeyValue(opts.key, opts.value, onSuccess, onError)
+  ).catch(e => {
     outputError(e.message);
-  }
+  });
 };
 
 var handleSetKeyValueSync = function (opts) {
@@ -1890,17 +1889,17 @@ var handleSetKeyValueSyncError = function (opts, message) {
 applabCommands.getColumn = function (opts) {
   apiValidateType(opts, 'getColumn', 'table', opts.table, 'string');
   apiValidateType(opts, 'getColumn', 'column', opts.column, 'string');
-  try {
-    rateLimit();
+
+  rateLimit(() =>
     Applab.storage.getColumn(
       opts.table,
       opts.column,
       handleGetColumn.bind(this, opts),
       handleGetColumnError.bind(this, opts)
-    );
-  } catch (e) {
+    )
+  ).catch(e => {
     outputError(e.message);
-  }
+  });
 };
 
 var handleGetColumn = function (opts, columnValues) {
@@ -1949,17 +1948,17 @@ applabCommands.readRecords = function (opts) {
   }
   var onSuccess = applabCommands.handleReadRecords.bind(this, opts);
   var onError = opts.onError || getAsyncOutputWarning();
-  try {
-    rateLimit();
+
+  rateLimit(() =>
     Applab.storage.readRecords(
       opts.table,
       opts.searchParams,
       onSuccess,
       onError
-    );
-  } catch (e) {
+    )
+  ).catch(e => {
     outputError(e.message);
-  }
+  });
 };
 
 applabCommands.handleReadRecords = function (opts, records) {
@@ -2024,12 +2023,11 @@ applabCommands.updateRecord = function (opts) {
     getAsyncOutputWarning()(error);
     onComplete(null, false);
   };
-  try {
-    rateLimit();
-    Applab.storage.updateRecord(opts.table, opts.record, onComplete, onError);
-  } catch (e) {
+  rateLimit(() =>
+    Applab.storage.updateRecord(opts.table, opts.record, onComplete, onError)
+  ).catch(e => {
     outputError(e.message);
-  }
+  });
 };
 
 applabCommands.handleUpdateRecord = function (opts, record, success) {
@@ -2090,12 +2088,11 @@ applabCommands.deleteRecord = function (opts) {
     getAsyncOutputWarning()(error);
     onComplete(false);
   };
-  try {
-    rateLimit();
-    Applab.storage.deleteRecord(opts.table, opts.record, onComplete, onError);
-  } catch (e) {
+  rateLimit(() =>
+    Applab.storage.deleteRecord(opts.table, opts.record, onComplete, onError)
+  ).catch(e => {
     outputError(e.message);
-  }
+  });
 };
 
 applabCommands.handleDeleteRecord = function (opts, success) {
@@ -2287,9 +2284,9 @@ applabCommands.drawChartFromRecords = function (opts) {
     outputError(error.message);
   };
 
-  try {
-    rateLimit();
-    startLoadingSpinnerFor(opts.chartId);
+  startLoadingSpinnerFor(opts.chartId);
+
+  rateLimit(() =>
     chartApi
       .drawChartFromRecords(
         opts.chartId,
@@ -2298,10 +2295,10 @@ applabCommands.drawChartFromRecords = function (opts) {
         opts.columns,
         opts.options
       )
-      .then(onSuccess, onError);
-  } catch (e) {
+      .then(onSuccess, onError)
+  ).catch(e => {
     outputError(e.message);
-  }
+  });
 };
 
 /**

--- a/apps/src/storage/datablockStorage.js
+++ b/apps/src/storage/datablockStorage.js
@@ -58,7 +58,7 @@ DatablockStorage.getKeyValue = function (key, onSuccess, onError) {
 
 DatablockStorage.setKeyValue = function (key, value, onSuccess, onError) {
   value = value === undefined ? null : value;
-  _fetch('set_key_value', 'POST', {
+  return _fetch('set_key_value', 'POST', {
     key,
     value: JSON.stringify(value),
   }).then(() => onSuccess(), onError);
@@ -78,7 +78,7 @@ DatablockStorage.createRecord = function (
   onSuccess,
   onError
 ) {
-  createRecord(tableName, record).then(onSuccess, onError);
+  return createRecord(tableName, record).then(onSuccess, onError);
 };
 
 DatablockStorage.updateRecord = function (
@@ -87,7 +87,7 @@ DatablockStorage.updateRecord = function (
   onSuccess,
   onError
 ) {
-  _fetch('update_record', 'PUT', {
+  return _fetch('update_record', 'PUT', {
     table_name: tableName,
     record_id: record.id,
     record_json: JSON.stringify(record),
@@ -144,7 +144,7 @@ DatablockStorage.deleteRecord = function (
   onSuccess,
   onError
 ) {
-  _fetch('delete_record', 'DELETE', {
+  return _fetch('delete_record', 'DELETE', {
     table_name: tableName,
     record_id: record.id,
   }).then(() => onSuccess(true), onError);

--- a/apps/src/storage/rateLimit.js
+++ b/apps/src/storage/rateLimit.js
@@ -1,9 +1,17 @@
+import PQueue from 'p-queue';
+
+export const MAX_CONCURRENT_BLOCK_IOPS = 3;
+const blockIOQueue = new PQueue({concurrency: MAX_CONCURRENT_BLOCK_IOPS});
+
 // rateLimit() throws an error if called more than RATE_LIMIT times per RATE_LIMIT_INTERVAL_MS
 // we use this in Applab commands.js to rate limit access to Datablock Storage from student code
+//
+// Additionally, rateLimit throttles IO operations to MAX_CONCURRENT_BLOCK_IOPS concurrently
+// to prevent student data blocks from overwhelming the server with parallel connections.
 let rateLimitAccessLog = [];
 export const RATE_LIMIT = 600;
 export const RATE_LIMIT_INTERVAL_MS = 60000;
-export function rateLimit(now = Date.now()) {
+export async function rateLimit(operation = () => undefined, now = Date.now()) {
   const timeSinceEarliestLog = () => now - rateLimitAccessLog[0];
 
   // Drop log entries older than RATE_LIMIT_INTERVAL_MS
@@ -24,10 +32,15 @@ export function rateLimit(now = Date.now()) {
         'The app is reading/writing data too many times per second. ' +
         "If you were trying to write data, it wasn't written."
     );
-  } else {
-    // Log the current access
-    rateLimitAccessLog.push(now);
   }
+
+  // Log the current access
+  rateLimitAccessLog.push(now);
+
+  // Throttle rateLimit-ed operations to ${MAX_CONCURRENT_BLOCK_IOPS}x concurrency
+  // this prevents students from overwhelming the server with too many simultaneous
+  // requests from data blocks.
+  return blockIOQueue.add(operation);
 }
 
 export function resetRateLimit() {

--- a/apps/test/unit/storage/DatablockStorageTest.js
+++ b/apps/test/unit/storage/DatablockStorageTest.js
@@ -5,6 +5,8 @@ import {
   RATE_LIMIT_INTERVAL_MS,
 } from '../../../src/storage/rateLimit';
 
+const NO_OP = () => undefined;
+
 describe('DatablockStorage', () => {
   beforeEach(() => {
     resetRateLimit();
@@ -14,43 +16,38 @@ describe('DatablockStorage', () => {
   });
 
   describe('rate limiting', () => {
-    it('succeeds if calling less times than the rate limit', done => {
+    it('succeeds if calling less times than the rate limit', async () => {
       const now = Date.now();
 
       for (let i = 0; i < RATE_LIMIT; i++) {
         const time = now + i;
-        rateLimit(time);
+        await rateLimit(NO_OP, time);
       }
-
-      done();
     });
-    it('fails if called one more time than the rate limit', done => {
+    it('fails if called one more time than the rate limit', async () => {
       const now = Date.now();
 
       for (let i = 0; i < RATE_LIMIT; i++) {
         const time = now + i;
-        rateLimit(time);
+        await rateLimit(NO_OP, time);
       }
 
       // This should be over the rate limit
-      expect(() => rateLimit(now + RATE_LIMIT)).to.throw(Error);
-
-      done();
+      await expect(rateLimit(NO_OP, now + RATE_LIMIT)).rejects.toThrow(Error);
     });
-    it('it succeeds if called more than the rate limit, but after waiting rate limit interval', done => {
+    it('it succeeds if called more than the rate limit, but after waiting rate limit interval', async () => {
       let now = Date.now();
 
       for (let i = 0; i < RATE_LIMIT; i++) {
         const time = now + i;
-        rateLimit(time);
+        await rateLimit(NO_OP, time);
       }
 
       now += RATE_LIMIT_INTERVAL_MS;
       for (let i = 0; i < RATE_LIMIT; i++) {
         const time = now + i;
-        rateLimit(time);
+        await rateLimit(NO_OP, time);
       }
-      done();
     });
   });
 });

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -61,6 +61,7 @@ const nodeModulesToTranspile = [
   'ml-array-min',
   'ml-array-rescale',
   'ml-distance-euclidean',
+  'p-queue',
   '@codemirror',
   'style-mod',
   '@lezer',

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8357,6 +8357,7 @@ __metadata:
     moment: ^2.29.4
     node-js-marker-clusterer: ^1.0.0
     object-fit-images: ^3.2.3
+    p-queue: ^8.0.1
     pa11y-ci: ^2.3.0
     path-browserify: ^1.0.1
     pepjs: ^0.4.3
@@ -12493,6 +12494,13 @@ es6-shim@latest:
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
+  languageName: node
+  linkType: hard
+
+"eventemitter3@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eventemitter3@npm:5.0.1"
+  checksum: 543d6c858ab699303c3c32e0f0f47fc64d360bf73c3daf0ac0b5079710e340d6fe9f15487f94e66c629f5f82cd1a8678d692f3dbb6f6fcd1190e1b97fcad36f8
   languageName: node
   linkType: hard
 
@@ -19947,6 +19955,16 @@ es6-shim@latest:
   languageName: node
   linkType: hard
 
+"p-queue@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "p-queue@npm:8.0.1"
+  dependencies:
+    eventemitter3: ^5.0.1
+    p-timeout: ^6.1.2
+  checksum: 84a27a5b1faf2dcc96b8c0e423c34b5984b241acc07353d3cc6d8d3d1dadefb250b4ec84ce278cb1c946466999c6bf2a36ff718a75810bad8e11c7ca47ce80f5
+  languageName: node
+  linkType: hard
+
 "p-retry@npm:^6.2.0":
   version: 6.2.0
   resolution: "p-retry@npm:6.2.0"
@@ -19964,6 +19982,13 @@ es6-shim@latest:
   dependencies:
     p-finally: ^1.0.0
   checksum: 9205a661173f03adbeabda8e02826de876376b09c99768bdc33e5b25ae73230e3ac00e520acedbe3cf05fbd3352fb02efbd3811a9a021b148fb15eb07e7accac
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "p-timeout@npm:6.1.2"
+  checksum: 887b805eb72c217dbc3c55a60a7f3b89a46cab14f04af62224f253ec84716cbd0880758be13b35444a4fa12d64d37d4c8a300f0b12a57c004d289f0a574cfe91
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#59903, which reverted  https://github.com/code-dot-org/code-dot-org/pull/59879

Use of `p-queue` appears to have generated test failures, see: https://codedotorg.slack.com/archives/C0T0PNTM3/p1721436717644599?thread_ts=1721432041.055659&cid=C0T0PNTM3

node_modules/p-queue/index.js contains a variety of "modern JS", including in this case use of the # characters in its to denote javascript private fields (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties). I believe #pending = 0; is being minified as "#p", and its causing issues in Safari (?).

Probably the easiest course of action at this point is to rework the PR with a different package dependency (that is compiled all the way down to boring-old-es5 or es6), or just write the code ourselves.