### PR TITLE
Merge revert from PR #59903 with jest changes from PR #59565

### DIFF
--- a/apps/test/unit/storage/DatablockStorageTest.js
+++ b/apps/test/unit/storage/DatablockStorageTest.js
@@ -33,7 +33,7 @@ describe('DatablockStorage', () => {
       }
 
       // This should be over the rate limit
-      expect(() => rateLimit(now + RATE_LIMIT)).to.throw(Error);
+      expect(() => rateLimit(now + RATE_LIMIT)).toThrow(Error);
 
       done();
     });


### PR DESCRIPTION
We pushed a revert in PR #59903, which had to be done manually be it wasn't clear why. The reason was that PR #59565 changed the same line and was applied a few hours later.

As a consequence PR #59903 didn't pass tests:
```
Summary of all failing tests
FAIL test/unit/storage/DatablockStorageTest.js
  â— DatablockStorage â€º rate limiting â€º fails if called one more time than the rate limit

    TypeError: Cannot read properties of undefined (reading 'throw')

      34 |
      35 |       // This should be over the rate limit
    > 36 |       expect(() => rateLimit(now + RATE_LIMIT)).to.throw(Error);
         |                                                   ^
      37 |
      38 |       done();
      39 |     });

      at Object.<anonymous> (test/unit/storage/DatablockStorageTest.js:36:51)
```

The issue being that `to.throw` is no longer valid, and must now be `toThrow`, remedied in this PR.

Now `npx jest test/unit/storage/DatablockStorageTest.js` passes:
```
 PASS  test/unit/storage/DatablockStorageTest.js
  DatablockStorage
    rate limiting
      ✓ succeeds if calling less times than the rate limit (1 ms)
      ✓ fails if called one more time than the rate limit (3 ms)
      ✓ it succeeds if called more than the rate limit, but after waiting rate limit interval

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```