### PR TITLE
PythonLab: draggable graph popup 

### DIFF
--- a/apps/src/codebridge/Console/GraphModal.tsx
+++ b/apps/src/codebridge/Console/GraphModal.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, {useState} from 'react';
+import Draggable, {DraggableEventHandler} from 'react-draggable';
 
-import AccessibleDialog from '@cdo/apps/templates/AccessibleDialog';
+import CloseButton from '@cdo/apps/componentLibrary/closeButton/CloseButton';
+import i18n from '@cdo/locale';
 
-import moduleStyles from '@cdo/apps/templates/accessible-dialogue.module.scss';
+import styles from './console.module.scss';
+import dialogStyles from '@cdo/apps/templates/accessible-dialogue.module.scss';
 
 /**
  * Renders a modal that displays data visualizations from Python Lab console output.
@@ -17,18 +20,28 @@ const GraphModal: React.FunctionComponent<GraphModalProps> = ({
   onClose,
   src,
 }) => {
+  const [positionX, setPositionX] = useState(0);
+  const [positionY, setPositionY] = useState(0);
+
+  const onStopHandler: DraggableEventHandler = (e, data) => {
+    setPositionX(data.x);
+    setPositionY(data.y);
+  };
+
   return (
-    <AccessibleDialog onClose={onClose} closeOnClickBackdrop={true}>
-      <button
-        type="button"
-        onClick={onClose}
-        className={moduleStyles.xCloseButton}
-      >
-        <i id="x-close" className="fa-solid fa-xmark" aria-hidden={true} />
-        <span className="sr-only">Close</span>
-      </button>
-      <img src={src} alt="matplotlib_image" />
-    </AccessibleDialog>
+    <Draggable
+      defaultPosition={{x: positionX, y: positionY}}
+      onStop={onStopHandler}
+    >
+      <div className={styles.popOutGraph}>
+        <CloseButton
+          className={dialogStyles.xCloseButton}
+          aria-label={i18n.closeDialog()}
+          onClick={onClose}
+        />
+        <img src={src} alt="matplotlib_image" />
+      </div>
+    </Draggable>
   );
 };
 

--- a/apps/src/codebridge/Console/console.module.scss
+++ b/apps/src/codebridge/Console/console.module.scss
@@ -18,3 +18,11 @@
 .errorLine {
   color: $lightest_red;
 }
+
+.popOutGraph {
+  position: fixed;
+  left: 30%;
+  bottom: 30%;
+  z-index: 2000;
+  width: 600px;
+}

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -19,6 +19,7 @@ const Console: React.FunctionComponent = () => {
   const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
   const [graphModalOpen, setGraphModalOpen] = useState(false);
+  const [activeGraphIndex, setActiveGraphIndex] = useState(0);
 
   // TODO: Update this with other apps that use the console as needed.
   const systemMessagePrefix = appName === 'pythonlab' ? '[PYTHON LAB] ' : '';
@@ -33,6 +34,12 @@ const Console: React.FunctionComponent = () => {
 
   const clearOutput = () => {
     dispatch(resetOutput());
+    setGraphModalOpen(false);
+  };
+
+  const popOutGraph = (index: number) => {
+    setActiveGraphIndex(index);
+    setGraphModalOpen(true);
   };
 
   const headerButton = () => {
@@ -72,12 +79,12 @@ const Console: React.FunctionComponent = () => {
                   disabled={false}
                   icon={{iconName: 'up-right-from-square', iconStyle: 'solid'}}
                   isIconOnly={true}
-                  onClick={() => setGraphModalOpen(true)}
+                  onClick={() => popOutGraph(index)}
                   size="xs"
                   type="primary"
                   aria-label="open matplotlib_image in pop-up"
                 />
-                {graphModalOpen && (
+                {activeGraphIndex === index && graphModalOpen && (
                   <GraphModal
                     src={`data:image/png;base64,${outputLine.contents}`}
                     onClose={() => setGraphModalOpen(false)}


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/59517
[CT-668](https://codedotorg.atlassian.net/browse/CT-668) partial

This PR makes the graph popup in PythonLab draggable. Only one graph is able to be open at a time. 

https://github.com/user-attachments/assets/19e8782d-a3dd-4d96-8fcb-247b41093b89

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
