### PR TITLE
Lab2: fix viewAsUserId type

### DIFF
--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -56,7 +56,7 @@ export interface ProgressState {
   lessons: Lesson[] | null;
   lessonGroups: LessonGroup[] | null;
   scriptId: number | null;
-  viewAsUserId: string | null;
+  viewAsUserId: number | null;
   scriptName: string | null;
   scriptDisplayName: string | undefined;
   unitTitle: string | null;
@@ -281,7 +281,7 @@ const progressSlice = createSlice({
     setLessonExtrasEnabled(state, action: PayloadAction<boolean>) {
       state.lessonExtrasEnabled = action.payload;
     },
-    setViewAsUserId(state, action: PayloadAction<string>) {
+    setViewAsUserId(state, action: PayloadAction<number>) {
       state.viewAsUserId = action.payload;
     },
   },

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -102,7 +102,7 @@ export const setUpWithLevel = createAsyncThunk(
       scriptId?: number;
       levelPropertiesPath: string;
       channelId?: string;
-      userId?: string;
+      userId?: number;
       scriptLevelId?: string;
     },
     thunkAPI

--- a/apps/src/lab2/projects/ChannelsStore.ts
+++ b/apps/src/lab2/projects/ChannelsStore.ts
@@ -15,7 +15,7 @@ export interface ChannelsStore {
     levelId: number,
     scriptId?: number,
     scriptLevelId?: string,
-    userId?: string
+    userId?: number
   ) => Promise<Response>;
 
   save: (channel: Channel) => Promise<Response>;
@@ -77,7 +77,7 @@ export class RemoteChannelsStore implements ChannelsStore {
     levelId: number,
     scriptId?: number,
     scriptLevelId?: string,
-    userId?: string
+    userId?: number
   ) {
     return projectsApi.getChannelForLevel(
       levelId,

--- a/apps/src/lab2/projects/ProjectManagerFactory.ts
+++ b/apps/src/lab2/projects/ProjectManagerFactory.ts
@@ -43,7 +43,7 @@ export default class ProjectManagerFactory {
   static async getProjectManagerForLevel(
     projectManagerStorageType: ProjectManagerStorageType,
     levelId: number,
-    userId?: string,
+    userId?: number,
     scriptId?: number,
     scriptLevelId?: string
   ): Promise<ProjectManager | null> {

--- a/apps/src/lab2/projects/projectsApi.ts
+++ b/apps/src/lab2/projects/projectsApi.ts
@@ -10,7 +10,7 @@ export async function getChannelForLevel(
   levelId: number,
   scriptId?: number,
   scriptLevelId?: string,
-  userId?: string
+  userId?: number
 ): Promise<Response> {
   let requestString = rootUrl;
   if (scriptId !== undefined) {


### PR DESCRIPTION
Quick prefactor for Music Lab analytics work - correct the `viewAsUserId` type to `number` since that's what it's actually assigned in [TeacherPanel.jsx](https://github.com/code-dot-org/code-dot-org/blob/ca9e655d39aa0b2cd183344966e7f6390b8a2f66/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx#L94). Helps with consistency and preventing unnecessary type conversion in other components.