### PR TITLE
Accessibility: use updated Button component in PersonalProjectsTableActionsCell

### DIFF
--- a/apps/src/templates/projects/PersonalProjectsTableActionsCell.jsx
+++ b/apps/src/templates/projects/PersonalProjectsTableActionsCell.jsx
@@ -2,12 +2,12 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 
+import Button, {buttonColors} from '@cdo/apps/componentLibrary/button';
 import PopUpMenu, {MenuBreak} from '@cdo/apps/lib/ui/PopUpMenu';
 import i18n from '@cdo/locale';
 
 import NameFailureDialog from '../../code-studio/components/NameFailureDialog';
 import color from '../../util/color';
-import Button from '../Button';
 import FontAwesome from '../FontAwesome';
 import QuickActionsCell from '../tables/QuickActionsCell';
 
@@ -93,19 +93,20 @@ export class PersonalProjectsTableActionsCell extends Component {
         {isEditing && (
           <div>
             <Button
-              __useDeprecatedTag
               onClick={this.onSave}
-              color={Button.ButtonColor.brandSecondaryDefault}
               text={i18n.save()}
+              size="s"
+              color={buttonColors.purple}
               disabled={isSaving}
-              className="ui-projects-rename-save"
+              id="ui-projects-rename-save"
+              className={moduleStyles.buttonMargin}
             />
-            <br />
             <Button
-              __useDeprecatedTag
               onClick={this.onCancel}
-              color={Button.ButtonColor.gray}
               text={i18n.cancel()}
+              size="s"
+              type="secondary"
+              color={buttonColors.gray}
             />
           </div>
         )}

--- a/apps/src/templates/projects/personal-projects-table-actions-cell.module.scss
+++ b/apps/src/templates/projects/personal-projects-table-actions-cell.module.scss
@@ -3,5 +3,5 @@
 }
 
 .buttonMargin {
-      margin-right: 5px;
+      margin-right: 8px;
 }

--- a/apps/src/templates/projects/personal-projects-table-actions-cell.module.scss
+++ b/apps/src/templates/projects/personal-projects-table-actions-cell.module.scss
@@ -1,3 +1,7 @@
 .xIcon {
       padding-right: 5px;
 }
+
+.buttonMargin {
+      margin-right: 5px;
+}

--- a/dashboard/test/ui/features/teacher_tools/projects/personal_project_gallery.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/personal_project_gallery.feature
@@ -24,8 +24,8 @@ Scenario: Can Rename a Project
   And I wait until element "#ui-project-rename-input" is visible
   And I clear the text from element "#ui-project-rename-input"
   And I press keys "New Name" for element "#ui-project-rename-input"
-  Then I click selector ".ui-projects-rename-save"
-  And I wait until element ".ui-projects-rename-save" is not visible
+  Then I click selector "#ui-projects-rename-save"
+  And I wait until element "#ui-projects-rename-save" is not visible
   And the first project in the table is named "New Name"
 
 Scenario: Can Remix a Project


### PR DESCRIPTION
[A11Y-97](https://codedotorg.atlassian.net/browse/A11Y-97)

Updating more buttons to use the `Button` component from the DSCO component library both for aesthetics and because the newer button is accessible. There are slight visual improvements, and the functionality remains the same. 

BEFORE 
<img width="1042" alt="Screenshot 2024-07-22 at 1 05 06 PM" src="https://github.com/user-attachments/assets/9f7918a4-c206-43e6-8b0e-797637b776a9">

AFTER 
<img width="1034" alt="Screenshot 2024-07-22 at 1 30 22 PM" src="https://github.com/user-attachments/assets/869d600a-d991-417e-aa14-d5ee4163c54e">

Tested that saving and cancelling still work as expected. 

https://github.com/user-attachments/assets/72c9b88d-10d6-471d-a15a-a0beec3c2489

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
