### PR TITLE
chore(deps): force globule to 1.3.4 to mitigate globule vulnerability

### DIFF
--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -14014,13 +14014,13 @@ es6-shim@latest:
   linkType: hard
 
 "globule@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "globule@npm:1.1.0"
+  version: 1.3.4
+  resolution: "globule@npm:1.3.4"
   dependencies:
     glob: ~7.1.1
-    lodash: ~4.16.4
+    lodash: ^4.17.21
     minimatch: ~3.0.2
-  checksum: 12a69c18ccb231d11a4f9669c9502fd8a1bb6b781b725795582fe82f7da35bb4adcf9acf1b4699a3cfc6274adcc21d86e2565a856841d9ff46e24377ddf0b864
+  checksum: 258b6865c77d54fbd4c91dd6931d99baf81b1485fdf4bd2c053b1a10eab015163cb646e6c96812d5c8b027fb07adfc0b7c7fb13bbbb571f3c12ea60bd7fda2f5
   languageName: node
   linkType: hard
 
@@ -17810,13 +17810,6 @@ es6-shim@latest:
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
-  languageName: node
-  linkType: hard
-
-"lodash@npm:~4.16.4":
-  version: 4.16.6
-  resolution: "lodash@npm:4.16.6"
-  checksum: ed498278295a842a07c0b095d0a6775a1461afb622a189bc8e798ad4f50a07eb53a77a64338938fff5cc5b0d9bcce306c9e531785529a2f1c5c5780d6c517e0f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
globule is an indirect dependency to grunt-contrib-watch. However, grunt-contrib-watch appears to be an abandoned dependency. To mitigate the lodash vulnerability, I forced the globule dependency to be updated.

The following commands were executed to accomplish this:

1. `yarn add globule@^1.3.4` - to add globule as a direct dependency
2. `yarn dedupe globule` - to have yarn force all indirect versions of minimist to 1.3.4
3. `yarn remove globule` - to remove the direct dependency

The net result is that globule is pinned to 1.3.4 for all dependencies globally.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

```
npx grunt watch
```

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
