### PR TITLE
Fix assessments 2 ui test by adding a wait

### DIFF
--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -47,6 +47,7 @@ Then /^I submit the assessment on "([^"]*)"$/ do |puzzle_url|
   steps %{
     And I am on "#{append_noautoplay(puzzle_url)}"
     And I click selector ".answers:nth(0) .answerbutton[index=1]" once I see it
+    And I wait for 5 seconds
     And I click selector ".submitButton" once I see it
     And I wait until element ".modal" is visible
     And I click selector ".modal #ok-button" to load a new page


### PR DESCRIPTION

In the flaky UI test assessments2, ([example flake](https://app.saucelabs.com/tests/08ad93d8a03045349051af62380873b8#250)) 5 students fill out and submit an assessment. In this case, all students except for student 4 successfully did this. You can see at the video timestamp `1:33` that student 4 doesn't have the purple box

The milestone call http://localhost-studio.code.org:3000/milestone/27/193186/59178 was called twice for each student. But student 4 had arguments `submitted: true` THEN `submitted: false`, all other students had the reverse.

We therefore think that there is a race condition in assessment submission using the milestone endpoint where if a student submits too soon after another save of some kind (autosave or maybe initial page load), that there will be inconsistent behavior.

## Links
https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?assignee=712020%3A46198677-9cdd-4af6-9c83-5acf60ca8db6&selectedIssue=TEACH-1191
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
