### PR TITLE
Update toggle switch to DSCO toggle

### DIFF
--- a/apps/src/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/src/templates/levelSummary/SummaryResponses.jsx
@@ -143,7 +143,6 @@ const SummaryResponses = ({
           {showAnswerToggle && (
             <div className={styles.toggleContainer}>
               <Toggle
-                id={'ui-test-correct-answer-toggle'}
                 onChange={() => {
                   setShowCorrectAnswer(!showCorrectAnswer);
                 }}

--- a/apps/src/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/src/templates/levelSummary/SummaryResponses.jsx
@@ -3,7 +3,6 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {connect} from 'react-redux';
 
 import SectionSelector from '@cdo/apps/code-studio/components/progress/SectionSelector';
-import ToggleSwitch from '@cdo/apps/code-studio/components/ToggleSwitch';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import Toggle from '@cdo/apps/componentLibrary/toggle';
 import DCDO from '@cdo/apps/dcdo';
@@ -143,13 +142,15 @@ const SummaryResponses = ({
           {/* Correct answer toggle */}
           {showAnswerToggle && (
             <div className={styles.toggleContainer}>
-              <ToggleSwitch
-                isToggledOn={showCorrectAnswer}
-                onToggle={() => {
+              <Toggle
+                onChange={() => {
                   setShowCorrectAnswer(!showCorrectAnswer);
                 }}
+                checked={showCorrectAnswer}
                 label={i18n.showAnswer()}
-                expands="summary-correct-answer"
+                position={'right'}
+                size={'s'}
+                name={'summary-correct-answer'}
               />
             </div>
           )}

--- a/apps/src/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/src/templates/levelSummary/SummaryResponses.jsx
@@ -143,6 +143,7 @@ const SummaryResponses = ({
           {showAnswerToggle && (
             <div className={styles.toggleContainer}>
               <Toggle
+                id={'ui-test-correct-answer-toggle'}
                 onChange={() => {
                   setShowCorrectAnswer(!showCorrectAnswer);
                 }}

--- a/apps/test/unit/templates/levelSummary/SummaryResponsesTest.jsx
+++ b/apps/test/unit/templates/levelSummary/SummaryResponsesTest.jsx
@@ -38,7 +38,7 @@ const INITIAL_STATE = {
   },
 };
 
-const renderWithProviders = (state = {}, jsData = {}) => {
+const renderDefault = (state = {}, jsData = {}) => {
   const store = createStore(
     combineReducers({
       isRtl,
@@ -58,7 +58,7 @@ const renderWithProviders = (state = {}, jsData = {}) => {
 
 describe('SummaryResponses', () => {
   it('renders elements', () => {
-    renderWithProviders();
+    renderDefault();
 
     // Student responses
     screen.getByText('1/1 students answered');
@@ -69,7 +69,7 @@ describe('SummaryResponses', () => {
   });
 
   it('does not render response counter/text if no section selected', () => {
-    renderWithProviders({
+    renderDefault({
       teacherSections: {
         selectedStudents: [{id: 0}],
         selectedSectionId: null,
@@ -82,7 +82,7 @@ describe('SummaryResponses', () => {
   });
 
   it('renders toggle when appropriate', () => {
-    renderWithProviders(
+    renderDefault(
       {},
       {
         level: {
@@ -100,7 +100,7 @@ describe('SummaryResponses', () => {
   });
 
   it('does not render toggle for Free Response', () => {
-    renderWithProviders(
+    renderDefault(
       {},
       {
         level: {
@@ -118,7 +118,7 @@ describe('SummaryResponses', () => {
   });
 
   it('does not render toggle without policy permission', () => {
-    renderWithProviders(
+    renderDefault(
       {},
       {
         level: {

--- a/apps/test/unit/templates/levelSummary/SummaryResponsesTest.jsx
+++ b/apps/test/unit/templates/levelSummary/SummaryResponsesTest.jsx
@@ -1,4 +1,4 @@
-import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {Provider} from 'react-redux';
 import {combineReducers, createStore} from 'redux';
@@ -8,8 +8,6 @@ import progress from '@cdo/apps/code-studio/progressRedux';
 import viewAs from '@cdo/apps/code-studio/viewAsRedux';
 import SummaryResponses from '@cdo/apps/templates/levelSummary/SummaryResponses';
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-
-import styles from '@cdo/apps/templates/levelSummary/summary.module.scss';
 
 const JS_DATA = {
   level: {
@@ -40,7 +38,7 @@ const INITIAL_STATE = {
   },
 };
 
-const setUpWrapper = (state = {}, jsData = {}) => {
+const renderWithProviders = (state = {}, jsData = {}) => {
   const store = createStore(
     combineReducers({
       isRtl,
@@ -51,53 +49,27 @@ const setUpWrapper = (state = {}, jsData = {}) => {
     {...INITIAL_STATE, ...state}
   );
 
-  const wrapper = mount(
+  return render(
     <Provider store={store}>
       <SummaryResponses scriptData={{...JS_DATA, ...jsData}} />
     </Provider>
   );
-
-  return wrapper;
 };
 
 describe('SummaryResponses', () => {
   it('renders elements', () => {
-    const wrapper = setUpWrapper();
+    renderWithProviders();
 
-    // Student responses.
-    expect(wrapper.find(`.${styles.studentsSubmittedRight}`).text()).toBe(
-      '1/1 students answered'
-    );
-    expect(wrapper.find(`div.${styles.studentAnswer}`).length).toBe(1);
-    // Section selector, with one section.
-    expect(wrapper.find('SectionSelector').length).toBe(1);
-    expect(wrapper.find('SectionSelector option').length).toBe(2);
-  });
-
-  it('applies correct classes when rtl', () => {
-    const wrapper = setUpWrapper({
-      isRtl: true,
-      progress: {
-        currentLessonId: 0,
-        currentLevelId: '0',
-        lessons: [
-          {
-            id: 0,
-            levels: [
-              {activeId: '0', position: 1},
-              {activeId: '1', position: 2},
-            ],
-          },
-        ],
-      },
-    });
-
-    expect(wrapper.find(`.${styles.studentsSubmittedRight}`).length).toBe(0);
-    expect(wrapper.find(`.${styles.studentsSubmittedLeft}`).length).toBe(1);
+    // Student responses
+    screen.getByText('1/1 students answered');
+    screen.getByText('student answer');
+    // // Section selector, with one section.
+    screen.getByRole('combobox');
+    expect(screen.getAllByRole('option')).toHaveLength(2);
   });
 
   it('does not render response counter/text if no section selected', () => {
-    const wrapper = setUpWrapper({
+    renderWithProviders({
       teacherSections: {
         selectedStudents: [{id: 0}],
         selectedSectionId: null,
@@ -106,12 +78,11 @@ describe('SummaryResponses', () => {
       },
     });
 
-    expect(wrapper.find(`.${styles.studentsSubmittedRight}`).length).toBe(0);
-    expect(wrapper.find(`.${styles.studentsSubmittedLeft}`).length).toBe(0);
+    expect(screen.queryByText('/')).toBeNull();
   });
 
   it('renders toggle when appropriate', () => {
-    const wrapper = setUpWrapper(
+    renderWithProviders(
       {},
       {
         level: {
@@ -125,11 +96,11 @@ describe('SummaryResponses', () => {
       }
     );
 
-    expect(wrapper.find('Toggle').length).toBe(1);
+    screen.getByText('Show answer');
   });
 
   it('does not render toggle for Free Response', () => {
-    const wrapper = setUpWrapper(
+    renderWithProviders(
       {},
       {
         level: {
@@ -143,11 +114,11 @@ describe('SummaryResponses', () => {
       }
     );
 
-    expect(wrapper.find('Toggle').length).toBe(0);
+    expect(screen.queryByText('Show answer')).toBeNull();
   });
 
   it('does not render toggle without policy permission', () => {
-    const wrapper = setUpWrapper(
+    renderWithProviders(
       {},
       {
         level: {
@@ -160,6 +131,6 @@ describe('SummaryResponses', () => {
       }
     );
 
-    expect(wrapper.find('Toggle').length).toBe(0);
+    expect(screen.queryByText('Show answer')).toBeNull();
   });
 });

--- a/apps/test/unit/templates/levelSummary/SummaryResponsesTest.jsx
+++ b/apps/test/unit/templates/levelSummary/SummaryResponsesTest.jsx
@@ -125,7 +125,7 @@ describe('SummaryResponses', () => {
       }
     );
 
-    expect(wrapper.find('ToggleSwitch').length).toBe(1);
+    expect(wrapper.find('Toggle').length).toBe(1);
   });
 
   it('does not render toggle for Free Response', () => {
@@ -143,7 +143,7 @@ describe('SummaryResponses', () => {
       }
     );
 
-    expect(wrapper.find('ToggleSwitch').length).toBe(0);
+    expect(wrapper.find('Toggle').length).toBe(0);
   });
 
   it('does not render toggle without policy permission', () => {
@@ -160,6 +160,6 @@ describe('SummaryResponses', () => {
       }
     );
 
-    expect(wrapper.find('ToggleSwitch').length).toBe(0);
+    expect(wrapper.find('Toggle').length).toBe(0);
   });
 });

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -45,7 +45,8 @@ Scenario: Multi level 1
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
   Then I see no difference for "multi level summary 1"
-  And I click selector "#ui-test-correct-answer-toggle'"
+  And I dismiss the teacher panel
+  Then I click selector "span:contains(Show answer)"
   And I see no difference for "multi level summary 1 show answer"
   And I close my eyes
 
@@ -59,6 +60,7 @@ Scenario: Multi level 2
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
   Then I see no difference for "multi level summary 2"
-  And I click selector "#ui-test-correct-answer-toggle'"
+  And I dismiss the teacher panel
+  Then I click selector "span:contains(Show answer)"
   And I see no difference for "multi level summary 2 show answer"
   And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -45,7 +45,7 @@ Scenario: Multi level 1
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
   Then I see no difference for "multi level summary 1"
-  And I click selector "button.toggle-input"
+  And I click selector "#ui-test-correct-answer-toggle'"
   And I see no difference for "multi level summary 1 show answer"
   And I close my eyes
 
@@ -59,6 +59,6 @@ Scenario: Multi level 2
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
   Then I see no difference for "multi level summary 2"
-  And I click selector "button.toggle-input"
+  And I click selector "#ui-test-correct-answer-toggle'"
   And I see no difference for "multi level summary 2 show answer"
   And I close my eyes


### PR DESCRIPTION
There are two different toggles in this component.  This PR updates the toggle used for the MultiChoice summary pages to be the DSCO component.

Old way on left, new on right

<img width="950" alt="image" src="https://github.com/user-attachments/assets/b2a5364f-8631-4eb1-9b88-686baf660c7d">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
