### PR TITLE
Datablock Storage: Allow getColumn to be called without requiring login

### DIFF
--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -33,6 +33,7 @@ class DatablockStorageController < ApplicationController
     :read_records,
     :update_record,
     :delete_record,
+    :get_library_manifest,
   ]
 
   before_action :validate_channel_id

--- a/dashboard/app/controllers/datablock_storage_controller.rb
+++ b/dashboard/app/controllers/datablock_storage_controller.rb
@@ -28,6 +28,7 @@ class DatablockStorageController < ApplicationController
   METHODS_CALLED_BY_DATA_BLOCKS = [
     :set_key_value,
     :get_key_value,
+    :get_column,
     :create_record,
     :read_records,
     :update_record,


### PR DESCRIPTION
Fixes #59339

Follow-up to #59877 which was missing getColumn from the list of allowable methods to be called without sign-in.

Tested locally that a project can use the getColumn block successfully when accessing shared project from a signed out session.