### PR TITLE
Fix browser null error on LTI launch

### DIFF
--- a/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
+++ b/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
@@ -69,13 +69,15 @@ $(document).ready(function () {
     }
 
     // Log if the Sign in button is clicked
-    signInButton.addEventListener('click', () => {
-      analyticsReporter.sendEvent(
-        EVENTS.SIGNED_OUT_USER_CLICKS_SIGN_IN,
-        {pageUrl: pageUrl},
-        PLATFORMS.STATSIG
-      );
-    });
+    if (signInButton) {
+      signInButton.addEventListener('click', () => {
+        analyticsReporter.sendEvent(
+          EVENTS.SIGNED_OUT_USER_CLICKS_SIGN_IN,
+          {pageUrl: pageUrl},
+          PLATFORMS.STATSIG
+        );
+      });
+    }
 
     // Log if the Help icon menu is clicked
     helpIcon.addEventListener('click', () => {


### PR DESCRIPTION
[An event listener was recently added ](https://github.com/code-dot-org/code-dot-org/pull/59810/files)that depends on signInButton existing. In at least one case (launching from the LMS as a roster synced user), the button doesn't exist, so a JS error is thrown trying to add an event listener to a null object. This adds a guard to ensure the listener is only added if the button exists.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1056)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
