### PR TITLE
remove hiding the panel from UI test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -45,7 +45,6 @@ Scenario: Multi level 1
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
   Then I see no difference for "multi level summary 1"
-  And I dismiss the teacher panel
   Then I click selector "span:contains(Show answer)"
   And I see no difference for "multi level summary 1 show answer"
   And I close my eyes
@@ -60,7 +59,6 @@ Scenario: Multi level 2
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
   Then I see no difference for "multi level summary 2"
-  And I dismiss the teacher panel
   Then I click selector "span:contains(Show answer)"
   And I see no difference for "multi level summary 2 show answer"
   And I close my eyes


### PR DESCRIPTION
This eyes test was showing the teacher panel off the screen.  By NOT dismissing the panel we should avoid having the panel off the screen.

<img width="272" alt="image" src="https://github.com/user-attachments/assets/2ca55abd-41c1-4ba4-84a0-f6c4a0ae9911">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
