### PR TITLE
Persist stableIDs across subdomains on StatsigReporter.js

### DIFF
--- a/apps/src/lib/util/StatsigReporter.js
+++ b/apps/src/lib/util/StatsigReporter.js
@@ -134,7 +134,10 @@ class StatsigReporter {
     let stableId = cookies.get(stableIdKey);
     if (!stableId) {
       stableId = createUuid();
-      cookies.set(stableIdKey, stableId, {expires: 60, domain: 'code.org'});
+      cookies.set(stableIdKey, stableId, {
+        expires: 400,
+        domain: 'code.org',
+      });
     }
     return stableId;
   }

--- a/apps/src/lib/util/StatsigReporter.js
+++ b/apps/src/lib/util/StatsigReporter.js
@@ -14,6 +14,7 @@ import {
 // A flag that can be toggled to send events regardless of environment
 const ALWAYS_SEND = false;
 const NO_EVENT_NAME = 'NO_VALID_EVENT_NAME_LOG_ERROR';
+const STABLE_ID_KEY = 'statsig_stable_id';
 
 class StatsigReporter {
   constructor() {
@@ -130,11 +131,10 @@ class StatsigReporter {
   }
 
   findOrCreateStableId() {
-    const stableIdKey = 'statsig_stable_id';
-    let stableId = cookies.get(stableIdKey);
+    let stableId = cookies.get(STABLE_ID_KEY);
     if (!stableId) {
       stableId = createUuid();
-      cookies.set(stableIdKey, stableId, {
+      cookies.set(STABLE_ID_KEY, stableId, {
         expires: 400,
         domain: 'code.org',
       });


### PR DESCRIPTION
Sets up a function to send a persistent stableID to Statsig for experiments. 

## Links
Jira ticket: [ACQ-2074](https://codedotorg.atlassian.net/browse/ACQ-2074)

## Testing story
Tested locally and confirmed the same stableID's were showing up across code.org, studio.code.org, and in Statsig. 

----

## code.org
<img width="593" alt="Screenshot 2024-07-23 at 2 26 56 PM" src="https://github.com/user-attachments/assets/42b328d6-35b9-43e4-8c5b-2026ee26410b">

## studio.code.org
<img width="595" alt="Screenshot 2024-07-23 at 2 27 33 PM" src="https://github.com/user-attachments/assets/65e6983c-84e3-4a00-8a0c-93f28c9c69f4">

## Statsig
<img width="1153" alt="Screenshot 2024-07-23 at 2 30 38 PM" src="https://github.com/user-attachments/assets/04432f54-af22-4858-86f4-69c4f1328760">
