### PR TITLE
Python Lab: More improvements to parsing error messages

### DIFF
--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -1,6 +1,9 @@
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
 import {loadPyodide, version} from 'pyodide';
 
+import {MAIN_PYTHON_FILE} from '@cdo/apps/lab2/constants';
+
+import {HOME_FOLDER} from './pythonHelpers/constants';
 import {
   getUpdatedSourceAndDeleteFiles,
   importPackagesFromFiles,
@@ -22,7 +25,7 @@ async function loadPyodideAndPackages() {
       `/blockly/js/pyodide/${version}/pythonlab_setup-0.0.1-py3-none-any.whl`,
     ],
     env: {
-      HOME: '/Files/',
+      HOME: `/${HOME_FOLDER}/`,
     },
   });
   self.pyodide.setStdout(getStreamHandlerOptions('sysout'));
@@ -51,7 +54,7 @@ self.onmessage = async event => {
     writeSource(source, DEFAULT_FOLDER_ID, '', self.pyodide);
     await importPackagesFromFiles(source, self.pyodide);
     results = await self.pyodide.runPythonAsync(python, {
-      filename: '/Files/main.py',
+      filename: `/${HOME_FOLDER}/${MAIN_PYTHON_FILE}`,
     });
   } catch (error) {
     self.postMessage({type: 'error', message: error.message, id});

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -21,6 +21,9 @@ async function loadPyodideAndPackages() {
       'matplotlib',
       `/blockly/js/pyodide/${version}/pythonlab_setup-0.0.1-py3-none-any.whl`,
     ],
+    env: {
+      HOME: '/',
+    },
   });
   self.pyodide.setStdout(getStreamHandlerOptions('sysout'));
   self.pyodide.setStderr(getStreamHandlerOptions('syserr'));

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -50,7 +50,9 @@ self.onmessage = async event => {
   try {
     writeSource(source, DEFAULT_FOLDER_ID, '', self.pyodide);
     await importPackagesFromFiles(source, self.pyodide);
-    results = await self.pyodide.runPythonAsync(python);
+    results = await self.pyodide.runPythonAsync(python, {
+      filename: '/Files/main.py',
+    });
   } catch (error) {
     self.postMessage({type: 'error', message: error.message, id});
   }

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -22,7 +22,7 @@ async function loadPyodideAndPackages() {
       `/blockly/js/pyodide/${version}/pythonlab_setup-0.0.1-py3-none-any.whl`,
     ],
     env: {
-      HOME: '/',
+      HOME: '/Files/',
     },
   });
   self.pyodide.setStdout(getStreamHandlerOptions('sysout'));

--- a/apps/src/pythonlab/pythonHelpers/constants.ts
+++ b/apps/src/pythonlab/pythonHelpers/constants.ts
@@ -2,3 +2,7 @@
 // .matplotlib is auto-generated when matplotlib is imported, and is not
 // something that shows up in "normal" python.
 export const HIDDEN_FOLDERS = ['.matplotlib'];
+
+// The folder that user files are written to in the pyodide
+// virtual file system.
+export const HOME_FOLDER = 'Files';

--- a/apps/src/pythonlab/pythonHelpers/messageHelpers.ts
+++ b/apps/src/pythonlab/pythonHelpers/messageHelpers.ts
@@ -1,3 +1,6 @@
+import {MAIN_PYTHON_FILE} from '@cdo/apps/lab2/constants';
+
+import {HOME_FOLDER} from './constants';
 import {ALL_PATCHES} from './patches';
 
 /**
@@ -17,7 +20,6 @@ import {ALL_PATCHES} from './patches';
  * @param errorMessage - the error message from pyodide
  **/
 export function parseErrorMessage(errorMessage: string) {
-  console.log({errorMessage});
   // Special case for an unsupported module.
   const importErrorRegex =
     /ModuleNotFoundError: The module '([^']+)' is included in the Pyodide distribution, but it is not installed./;
@@ -28,7 +30,9 @@ export function parseErrorMessage(errorMessage: string) {
 
   // Parse to find the main.py error line.
   const errorLines = errorMessage.trim().split('\n');
-  const mainErrorRegex = /File "\/Files\/main.py", line \d+.*/;
+  const mainErrorRegex = new RegExp(
+    `File "\/${HOME_FOLDER}\/${MAIN_PYTHON_FILE}", line \\d+.*`
+  );
   const mainErrorLineRegex = /line (\d+)/;
   let mainErrorLine = 0;
   while (
@@ -46,7 +50,9 @@ export function parseErrorMessage(errorMessage: string) {
     mainErrorLineRegex
   );
   let currentLine = mainErrorLine + 1;
-  const lineRegex = /File "\/Files\/([^"]+)", line (\d+).*/;
+  const lineRegex = new RegExp(
+    `File "\/${HOME_FOLDER}\/([^"]+)", line (\\d+).*`
+  );
   let hasMultiFileStackTrace = false;
   while (currentLine < errorLines.length) {
     let newLine = errorLines[currentLine];

--- a/apps/src/pythonlab/pythonHelpers/messageHelpers.ts
+++ b/apps/src/pythonlab/pythonHelpers/messageHelpers.ts
@@ -44,15 +44,14 @@ export function parseErrorMessage(errorMessage: string) {
     errorLines[mainErrorLine].match(mainErrorLineRegex)![1]
   );
   const correctedMainErrorLine = getMainErrorLine(mainLineNumber);
-  let parsedError = `main.py, line ${correctedMainErrorLine}`;
+  let parsedError = `File "/Files/main.py", line ${correctedMainErrorLine}`;
   let currentLine = mainErrorLine + 1;
-  const lineRegex = /File "\/home\/pyodide\/([^"]+)", line (\d+).*/;
+  const lineRegex = /File "\/Files\/([^"]+)", line (\d+).*/;
   let hasMultiFileStackTrace = false;
   while (currentLine < errorLines.length) {
     if (lineRegex.test(errorLines[currentLine])) {
-      // If the error message refers to another file, remove the reference to the pyodide folder.
-      const [, file, line] = errorLines[currentLine].match(lineRegex)!;
-      parsedError += `\n${file}, line ${line}`;
+      // If the error message refers to another file, we know this is a multi-file stack trace.
+      parsedError += `\n${errorLines[currentLine]}`;
       hasMultiFileStackTrace = true;
     } else {
       if (


### PR DESCRIPTION
Follow up to #58958
Some cleanup to make handling error messages and stack traces a bit cleaner in Python Lab. The background for this change is by default pyodide puts all files in the `/home/pyodide` folder in the virtual filesystem. I was then parsing our error messages and removing references to `/home/pyodide`, to make it look like user's files are at the root of the filesystem. However, as I was looking at validation tests I found another case where I would have to do this, and wondered if there was a better way.

I came up with the following solution, and confirmed with curriculum it would make sense to students. Since the student files appear under a `Files` header, I named the default folder `Files`. This is similar behavior to a filesystem on a computer: your downloads folder has a "Downloads" header at the top. Now the filesystem and stack traces look as follows:

### File system
![Screenshot 2024-07-23 at 1 57 51 PM](https://github.com/user-attachments/assets/39d75cd9-a135-4d65-9da8-a4f84255e861)

### Stack Trace
![Screenshot 2024-07-23 at 2 02 26 PM](https://github.com/user-attachments/assets/73659073-3e41-43a0-8316-b5c618fb988f)


By making this change I was able to remove some of the code to customize error messages. I also discovered there was a setting in [pyodide](https://pyodide.org/en/stable/usage/api/js-api.html#pyodide.runPythonAsync) where we could set the name of the main file, rather than it being `<exec>` by default. So I could also remove the custom code to replace `<exec>` with `main.py`.

We still need to adjust the line numbers in the stack trace for any lines coming from `main.py`. This is because we add custom code before the student's code in order to apply our custom patches. We also remove the internal pyodide stack trace, which is confusing.

## Testing story
Tested locally with a variety of errors to ensure the messages still looked correct.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
