### PR TITLE
Iterating on landing pages flakiness

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_2.feature
+++ b/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_2.feature
@@ -15,5 +15,3 @@ Examples:
   | http://code.org/athletes                                          | athletes tutorial landing  |
   | http://code.org/tools/applab                                      | app lab tutorial landing   |
   | http://code.org/dance                                             | dance tutorial landing     |
-# | http://code.org/educate/resources/videos                          | video resources landing    |
-# | http://code.org/educate/resources/videos?force_youtube_fallback=1 | resources yt fallback      |

--- a/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_2.feature
+++ b/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_2.feature
@@ -15,5 +15,5 @@ Examples:
   | http://code.org/athletes                                          | athletes tutorial landing  |
   | http://code.org/tools/applab                                      | app lab tutorial landing   |
   | http://code.org/dance                                             | dance tutorial landing     |
-  # | http://code.org/educate/resources/videos                          | video resources landing    |
-  # | http://code.org/educate/resources/videos?force_youtube_fallback=1 | resources yt fallback      |
+# | http://code.org/educate/resources/videos                          | video resources landing    |
+# | http://code.org/educate/resources/videos?force_youtube_fallback=1 | resources yt fallback      |

--- a/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_2.feature
+++ b/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_2.feature
@@ -6,7 +6,7 @@ Scenario Outline: Simple page view
   When I open my eyes to test "<test_name>"
   And I am on "<url>"
   And I dismiss the language selector
-  And I wait for the document to load
+  And I wait for the video thumbnails to load
   Then I see no difference for "initial load"
   And I close my eyes
   And I sign out
@@ -15,5 +15,5 @@ Examples:
   | http://code.org/athletes                                          | athletes tutorial landing  |
   | http://code.org/tools/applab                                      | app lab tutorial landing   |
   | http://code.org/dance                                             | dance tutorial landing     |
-  | http://code.org/educate/resources/videos                          | video resources landing    |
-  | http://code.org/educate/resources/videos?force_youtube_fallback=1 | resources yt fallback      |
+  # | http://code.org/educate/resources/videos                          | video resources landing    |
+  # | http://code.org/educate/resources/videos?force_youtube_fallback=1 | resources yt fallback      |

--- a/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_2.feature
+++ b/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_2.feature
@@ -6,7 +6,7 @@ Scenario Outline: Simple page view
   When I open my eyes to test "<test_name>"
   And I am on "<url>"
   And I dismiss the language selector
-  And I wait for the video thumbnails to load
+  And I wait for the document to load
   Then I see no difference for "initial load"
   And I close my eyes
   And I sign out
@@ -16,4 +16,4 @@ Examples:
   | http://code.org/tools/applab                                      | app lab tutorial landing   |
   | http://code.org/dance                                             | dance tutorial landing     |
   | http://code.org/educate/resources/videos                          | video resources landing    |
-#  | http://code.org/educate/resources/videos?force_youtube_fallback=1 | resources yt fallback      |
+  | http://code.org/educate/resources/videos?force_youtube_fallback=1 | resources yt fallback      |

--- a/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_4.feature
+++ b/dashboard/test/ui/features/acquisition_products/pegasus_landing_pages_4.feature
@@ -13,6 +13,6 @@ Scenario Outline: Simple page view
 Examples:
   | url                                                               | test_name                  |
   | http://code.org/student/middle-high                               | middle high student page   |
-  | http://code.org/learn                                             | learn landing page         |
+  | http://hourofcode.com/us/learn                                    | learn landing page         |
   | http://code.org/ai                                                | ai landing page            |
   | http://code.org/teach                                             | teach landing page         |

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -962,11 +962,6 @@ Then /^I wait for the video thumbnails to load$/ do
   wait.until {@browser.execute_script("return Array.from(document.querySelectorAll('img.thumbnail-image')).filter((img) => !img.complete).length == 0;")}
 end
 
-Then /^I wait for the document to load $/ do
-  wait = Selenium::WebDriver::Wait.new(timeout: DEFAULT_WAIT_TIMEOUT)
-  wait.until {@browser.execute_script("return document.readyState == 'complete';")}
-end
-
 Then /^I see jquery selector (.*)$/ do |selector|
   exists = @browser.execute_script("return $(\"#{selector}\").length != 0;")
   expect(exists).to eq(true)

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -962,6 +962,11 @@ Then /^I wait for the video thumbnails to load$/ do
   wait.until {@browser.execute_script("return Array.from(document.querySelectorAll('img.thumbnail-image')).filter((img) => !img.complete).length == 0;")}
 end
 
+Then /^I wait for the document to load $/ do
+  wait = Selenium::WebDriver::Wait.new(timeout: DEFAULT_WAIT_TIMEOUT)
+  wait.until {@browser.execute_script("return document.readyState == 'complete';")}
+end
+
 Then /^I see jquery selector (.*)$/ do |selector|
   exists = @browser.execute_script("return $(\"#{selector}\").length != 0;")
   expect(exists).to eq(true)


### PR DESCRIPTION
The first update is to change the url in one of the files to go straight to the redirected link. This is slightly speculative, but it is where the test consistently fails and I suspect Saucelabs is having a tough time with the cross-domain test.

Additionally, I'm disabling the second video resources test for now, as it's still blocking folks who are dotd and we would see any universal YT integration failure in the other landing page tests.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
