### PR TITLE
P20-1055: CAP data migration Phase 2

### DIFF
--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         ai_tutor_access_denied: !!current_user.ai_tutor_access_denied,
         has_seen_progress_table_v2_invitation: current_user.has_seen_progress_table_v2_invitation?,
         date_progress_table_invitation_last_delayed: current_user.date_progress_table_invitation_last_delayed,
-        child_account_compliance_state: current_user.child_account_compliance_state,
+        child_account_compliance_state: current_user.cap_state,
         country_code: helpers.country_code(current_user, request),
         us_state_code: current_user.us_state_code,
         in_section: current_user.student? ? current_user.sections_as_student.present? : nil,

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         ai_tutor_access_denied: !!current_user.ai_tutor_access_denied,
         has_seen_progress_table_v2_invitation: current_user.has_seen_progress_table_v2_invitation?,
         date_progress_table_invitation_last_delayed: current_user.date_progress_table_invitation_last_delayed,
-        child_account_compliance_state: current_user.cap_state,
+        child_account_compliance_state: current_user.cap_status,
         country_code: helpers.country_code(current_user, request),
         us_state_code: current_user.us_state_code,
         in_section: current_user.student? ? current_user.sections_as_student.present? : nil,

--- a/dashboard/app/controllers/policy_compliance_controller.rb
+++ b/dashboard/app/controllers/policy_compliance_controller.rb
@@ -23,7 +23,7 @@ class PolicyComplianceController < ApplicationController
     Services::ChildAccount.grant_permission_request!(permission_request)
     @permission_granted = true
     user = permission_request.user
-    @permission_granted_date = user.cap_state_date
+    @permission_granted_date = user.cap_status_date
     @student_id = user.id
   end
 

--- a/dashboard/app/controllers/policy_compliance_controller.rb
+++ b/dashboard/app/controllers/policy_compliance_controller.rb
@@ -23,7 +23,7 @@ class PolicyComplianceController < ApplicationController
     Services::ChildAccount.grant_permission_request!(permission_request)
     @permission_granted = true
     user = permission_request.user
-    @permission_granted_date = user.child_account_compliance_state_last_updated
+    @permission_granted_date = user.cap_state_date
     @student_id = user.id
   end
 

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -406,7 +406,7 @@ class RegistrationsController < Devise::RegistrationsController
   # GET /users/edit
   #
   def edit
-    @permission_status = current_user.cap_state
+    @permission_status = current_user.cap_status
 
     # Get the request location
     location = Geocoder.search(request.ip).try(:first)

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -406,7 +406,7 @@ class RegistrationsController < Devise::RegistrationsController
   # GET /users/edit
   #
   def edit
-    @permission_status = current_user.child_account_compliance_state
+    @permission_status = current_user.cap_state
 
     # Get the request location
     location = Geocoder.search(request.ip).try(:first)

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -74,7 +74,7 @@ class SessionsController < Devise::SessionsController
     end
 
     # Determine the deletion date as the lockout date of the account + 7 days
-    @delete_date = DateTime.parse(current_user.child_account_compliance_lock_out_date).since(7.days)
+    @delete_date = current_user.cap_state_date&.since(7.days)
 
     # Find any existing permission request for this user
     # Students might have issued a few requests. We render the latest one.
@@ -86,7 +86,7 @@ class SessionsController < Devise::SessionsController
       @request_date = permission_request.updated_at
     end
 
-    @permission_status = current_user.child_account_compliance_state
+    @permission_status = current_user.cap_state
     @in_section = current_user.sections_as_student.present?
   end
 

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -74,7 +74,7 @@ class SessionsController < Devise::SessionsController
     end
 
     # Determine the deletion date as the lockout date of the account + 7 days
-    @delete_date = current_user.cap_state_date&.since(7.days)
+    @delete_date = current_user.cap_status_date&.since(7.days)
 
     # Find any existing permission request for this user
     # Students might have issued a few requests. We render the latest one.
@@ -86,7 +86,7 @@ class SessionsController < Devise::SessionsController
       @request_date = permission_request.updated_at
     end
 
-    @permission_status = current_user.cap_state
+    @permission_status = current_user.cap_status
     @in_section = current_user.sections_as_student.present?
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2253,7 +2253,7 @@ class User < ApplicationRecord
       has_ever_signed_in: has_ever_signed_in?,
       ai_tutor_access_denied: !!ai_tutor_access_denied,
       at_risk_age_gated: Policies::ChildAccount.parent_permission_required?(self),
-      child_account_compliance_state: cap_state,
+      child_account_compliance_state: cap_status,
       latest_permission_request_sent_at: latest_parental_permission_request&.updated_at,
     }
   end

--- a/dashboard/app/serializers/child_account/pending_permission_request_serializer.rb
+++ b/dashboard/app/serializers/child_account/pending_permission_request_serializer.rb
@@ -6,6 +6,6 @@ class ChildAccount::PendingPermissionRequestSerializer < ActiveModel::Serializer
   end
 
   def consent_status
-    object.user.child_account_compliance_state
+    object.user.cap_state
   end
 end

--- a/dashboard/app/serializers/child_account/pending_permission_request_serializer.rb
+++ b/dashboard/app/serializers/child_account/pending_permission_request_serializer.rb
@@ -6,6 +6,6 @@ class ChildAccount::PendingPermissionRequestSerializer < ActiveModel::Serializer
   end
 
   def consent_status
-    object.user.cap_state
+    object.user.cap_status
   end
 end

--- a/dashboard/lib/email_reminder.rb
+++ b/dashboard/lib/email_reminder.rb
@@ -37,7 +37,7 @@ class EmailReminder
       select(:id).
       where(created_at: @max_reminder_age..@min_reminder_age).
       where(reminders_sent: ...MAX_LIFETIME_REMINDERS).
-      where.not(users: {cap_state: Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED})
+      where.not(users: {cap_status: Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED})
 
     CDO.log.info "Found #{reqs.length} requests needing reminders"
     reqs

--- a/dashboard/lib/email_reminder.rb
+++ b/dashboard/lib/email_reminder.rb
@@ -37,7 +37,7 @@ class EmailReminder
       select(:id).
       where(created_at: @max_reminder_age..@min_reminder_age).
       where(reminders_sent: ...MAX_LIFETIME_REMINDERS).
-      where("JSON_EXTRACT(users.properties, '$.child_account_compliance_state') != ?", Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED)
+      where.not(users: {cap_state: Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED})
 
     CDO.log.info "Found #{reqs.length} requests needing reminders"
     reqs

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -3,7 +3,7 @@ require 'cpa'
 require 'date'
 
 class Policies::ChildAccount
-  # Values for the `child_account_compliance_state` attribute
+  # Values for the `cap_state` attribute
   module ComplianceState
     # The period for "existing" users before their accounts locked out.
     GRACE_PERIOD = SharedConstants::CHILD_ACCOUNT_COMPLIANCE_STATES.GRACE_PERIOD
@@ -19,7 +19,7 @@ class Policies::ChildAccount
     # def self.permission_granted?(student)
     SharedConstants::CHILD_ACCOUNT_COMPLIANCE_STATES.to_h.each do |key, value|
       define_singleton_method("#{key.downcase}?") do |student|
-        student.child_account_compliance_state == value
+        student.cap_state == value
       end
     end
   end
@@ -86,7 +86,7 @@ class Policies::ChildAccount
     grace_period_duration = user_state_policy[:grace_period_duration]
     return unless grace_period_duration
 
-    start_date = DateTime.parse(user.child_account_compliance_state_last_updated) if ComplianceState.grace_period?(user)
+    start_date = user.cap_state_date if ComplianceState.grace_period?(user)
     start_date = user_state_policy[:lockout_date] if approximate && start_date.nil?
 
     start_date&.since(grace_period_duration)

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -3,7 +3,7 @@ require 'cpa'
 require 'date'
 
 class Policies::ChildAccount
-  # Values for the `cap_state` attribute
+  # Values for the `cap_status` attribute
   module ComplianceState
     # The period for "existing" users before their accounts locked out.
     GRACE_PERIOD = SharedConstants::CHILD_ACCOUNT_COMPLIANCE_STATES.GRACE_PERIOD
@@ -19,7 +19,7 @@ class Policies::ChildAccount
     # def self.permission_granted?(student)
     SharedConstants::CHILD_ACCOUNT_COMPLIANCE_STATES.to_h.each do |key, value|
       define_singleton_method("#{key.downcase}?") do |student|
-        student.cap_state == value
+        student.cap_status == value
       end
     end
   end
@@ -86,7 +86,7 @@ class Policies::ChildAccount
     grace_period_duration = user_state_policy[:grace_period_duration]
     return unless grace_period_duration
 
-    start_date = user.cap_state_date if ComplianceState.grace_period?(user)
+    start_date = user.cap_status_date if ComplianceState.grace_period?(user)
     start_date = user_state_policy[:lockout_date] if approximate && start_date.nil?
 
     start_date&.since(grace_period_duration)

--- a/dashboard/lib/queries/child_account.rb
+++ b/dashboard/lib/queries/child_account.rb
@@ -11,8 +11,8 @@ class Queries::ChildAccount
     # Filter for accounts which don't have parent permission then filter for
     # accounts which have been locked out before the expiration_date
     scope.where(
-      cap_state: Policies::ChildAccount::ComplianceState::LOCKED_OUT,
-      cap_state_date: ..expiration_date
+      cap_status: Policies::ChildAccount::ComplianceState::LOCKED_OUT,
+      cap_status_date: ..expiration_date
     )
   end
 end

--- a/dashboard/lib/queries/child_account.rb
+++ b/dashboard/lib/queries/child_account.rb
@@ -10,14 +10,9 @@ class Queries::ChildAccount
   def self.expired_accounts(scope: User.all, expiration_date: 7.days.ago)
     # Filter for accounts which don't have parent permission then filter for
     # accounts which have been locked out before the expiration_date
-    scope.
-      where(
-        "JSON_EXTRACT(properties, '$.child_account_compliance_state') != ?",
-        Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED
-      ).
-      where(
-        "CAST(properties->>'$.child_account_compliance_lock_out_date' AS DATETIME) <= ?",
-        expiration_date
-      )
+    scope.where(
+      cap_state: Policies::ChildAccount::ComplianceState::LOCKED_OUT,
+      cap_state_date: ..expiration_date
+    )
   end
 end

--- a/dashboard/lib/services/child_account.rb
+++ b/dashboard/lib/services/child_account.rb
@@ -26,12 +26,12 @@ module Services::ChildAccount
     Services::ChildAccount::EventLogger.log_compliance_removing(user)
   end
 
-  # Updates the cap_state attribute to the given state.
+  # Updates the cap_status attribute to the given state.
   # @param {String} new_state - A constant from Policies::ChildAccount::ComplianceState
   def self.update_compliance(user, new_state)
     return unless user
-    user.cap_state = new_state
-    user.cap_state_date = DateTime.now
+    user.cap_status = new_state
+    user.cap_status_date = DateTime.now
   end
 
   # Updates the User in the given PermissionRequest to indicate that their

--- a/dashboard/lib/services/child_account.rb
+++ b/dashboard/lib/services/child_account.rb
@@ -15,7 +15,6 @@ module Services::ChildAccount
       user,
       Policies::ChildAccount::ComplianceState::LOCKED_OUT
     )
-    user.child_account_compliance_lock_out_date = DateTime.now
     user.save!
     Services::ChildAccount::EventLogger.log_account_locking(user)
   end
@@ -27,13 +26,12 @@ module Services::ChildAccount
     Services::ChildAccount::EventLogger.log_compliance_removing(user)
   end
 
-  # Updates the child_account_compliance_state attribute to the given state.
+  # Updates the cap_state attribute to the given state.
   # @param {String} new_state - A constant from Policies::ChildAccount::ComplianceState
   def self.update_compliance(user, new_state)
     return unless user
-    user.child_account_compliance_state = new_state
-    user.child_account_compliance_state_last_updated = DateTime.now
-    user.child_account_compliance_lock_out_date = nil
+    user.cap_state = new_state
+    user.cap_state_date = DateTime.now
   end
 
   # Updates the User in the given PermissionRequest to indicate that their

--- a/dashboard/lib/services/child_account/event_logger.rb
+++ b/dashboard/lib/services/child_account/event_logger.rb
@@ -31,8 +31,8 @@ module Services
           user: user,
           policy: policy,
           name: event_name,
-          state_before: user.cap_state_previously_was,
-          state_after: user.cap_state
+          state_before: user.cap_status_previously_was,
+          state_after: user.cap_status
         )
       end
 

--- a/dashboard/lib/services/child_account/event_logger.rb
+++ b/dashboard/lib/services/child_account/event_logger.rb
@@ -27,11 +27,13 @@ module Services
       def call
         return unless policy
 
-        # Get the value of the property before the user was last saved.
-        # This will be the current value if the value was not updated.
-        state_before = user.property_before_save('child_account_compliance_state')
-
-        CAP::UserEvent.create!(user: user, policy: policy, name: event_name, state_before: state_before, state_after: user.child_account_compliance_state)
+        CAP::UserEvent.create!(
+          user: user,
+          policy: policy,
+          name: event_name,
+          state_before: user.cap_state_previously_was,
+          state_after: user.cap_state
+        )
       end
 
       private def policy

--- a/dashboard/test/controllers/policy_compliance_controller_test.rb
+++ b/dashboard/test/controllers/policy_compliance_controller_test.rb
@@ -25,8 +25,8 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
     end
     user.reload
     assert_response :ok
-    assert_equal Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED, user.cap_state
-    refute_nil user.cap_state_date
+    assert_equal Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED, user.cap_status
+    refute_nil user.cap_status_date
   end
 
   test "making the same request twice is ok and email is sent once" do
@@ -65,7 +65,7 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
   test "given a user already has parental permission, should just redirect back" do
     permission = create :parental_permission_request, :granted
     user = permission.user
-    user.cap_state = Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED
+    user.cap_status = Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED
 
     sign_in user
 
@@ -233,7 +233,7 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
   class PendingPermissionRequestTest < ActionDispatch::IntegrationTest
     test 'json format - returns pending permission request data when exists' do
       consent_status = 'p'
-      user = create(:young_student, cap_state: consent_status)
+      user = create(:young_student, cap_status: consent_status)
       parent_email = 'parent@example.com'
       requested_at = DateTime.now.utc.iso8601(3)
       resends_sent = 999
@@ -275,7 +275,7 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
   class ChildAccountConsentRequest < ActionDispatch::IntegrationTest
     test 'json format - returns permission request data on success' do
       consent_status = 'p'
-      child_account = create(:young_student, cap_state: consent_status)
+      child_account = create(:young_student, cap_status: consent_status)
       parent_email = 'parent@example.com'
       requested_at = DateTime.now.utc.iso8601(3)
       resends_sent = 999

--- a/dashboard/test/controllers/policy_compliance_controller_test.rb
+++ b/dashboard/test/controllers/policy_compliance_controller_test.rb
@@ -25,8 +25,8 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
     end
     user.reload
     assert_response :ok
-    assert_equal Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED, user.child_account_compliance_state
-    refute_empty user.child_account_compliance_state_last_updated
+    assert_equal Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED, user.cap_state
+    refute_nil user.cap_state_date
   end
 
   test "making the same request twice is ok and email is sent once" do
@@ -65,7 +65,7 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
   test "given a user already has parental permission, should just redirect back" do
     permission = create :parental_permission_request, :granted
     user = permission.user
-    user.child_account_compliance_state = Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED
+    user.cap_state = Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED
 
     sign_in user
 
@@ -232,8 +232,8 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
 
   class PendingPermissionRequestTest < ActionDispatch::IntegrationTest
     test 'json format - returns pending permission request data when exists' do
-      consent_status = 'expected_consent_status'
-      user = create(:young_student, child_account_compliance_state: consent_status)
+      consent_status = 'p'
+      user = create(:young_student, cap_state: consent_status)
       parent_email = 'parent@example.com'
       requested_at = DateTime.now.utc.iso8601(3)
       resends_sent = 999
@@ -274,8 +274,8 @@ class PolicyComplianceControllerTest < ActionDispatch::IntegrationTest
 
   class ChildAccountConsentRequest < ActionDispatch::IntegrationTest
     test 'json format - returns permission request data on success' do
-      consent_status = 'expected_consent_status'
-      child_account = create(:young_student, child_account_compliance_state: consent_status)
+      consent_status = 'p'
+      child_account = create(:young_student, cap_state: consent_status)
       parent_email = 'parent@example.com'
       requested_at = DateTime.now.utc.iso8601(3)
       resends_sent = 999

--- a/dashboard/test/controllers/sessions_controller_test.rb
+++ b/dashboard/test/controllers/sessions_controller_test.rb
@@ -324,7 +324,7 @@ class SessionsControllerTest < ActionController::TestCase
 
     before do
       Policies::ChildAccount::ComplianceState.stubs(:locked_out?).with(user).returns(user_is_locked_out)
-      user.update(cap_state_date: DateTime.now)
+      user.update(cap_status_date: DateTime.now)
 
       sign_in user
     end
@@ -341,7 +341,7 @@ class SessionsControllerTest < ActionController::TestCase
 
     it 'assigns @delete_date with 7 day after user lockout date' do
       get :lockout
-      _(assigns[:delete_date]).must_equal user.cap_state_date.since(7.days)
+      _(assigns[:delete_date]).must_equal user.cap_status_date.since(7.days)
     end
 
     it 'renders lockout page' do

--- a/dashboard/test/controllers/sessions_controller_test.rb
+++ b/dashboard/test/controllers/sessions_controller_test.rb
@@ -324,7 +324,7 @@ class SessionsControllerTest < ActionController::TestCase
 
     before do
       Policies::ChildAccount::ComplianceState.stubs(:locked_out?).with(user).returns(user_is_locked_out)
-      user.update(child_account_compliance_lock_out_date: DateTime.now)
+      user.update(cap_state_date: DateTime.now)
 
       sign_in user
     end
@@ -341,7 +341,7 @@ class SessionsControllerTest < ActionController::TestCase
 
     it 'assigns @delete_date with 7 day after user lockout date' do
       get :lockout
-      _(assigns[:delete_date]).must_equal DateTime.parse(user.child_account_compliance_lock_out_date).since(7.days)
+      _(assigns[:delete_date]).must_equal user.cap_state_date.since(7.days)
     end
 
     it 'renders lockout page' do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -427,13 +427,13 @@ FactoryBot.define do
       end
 
       trait :with_parent_permission do
-        child_account_compliance_state {Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED}
-        child_account_compliance_state_last_updated {DateTime.now}
+        cap_state {Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED}
+        cap_state_date {DateTime.now}
       end
 
       trait :without_parent_permission do
-        child_account_compliance_state {nil}
-        child_account_compliance_state_last_updated {DateTime.now}
+        cap_state {nil}
+        cap_state_date {DateTime.now}
       end
 
       factory :cpa_non_compliant_student, traits: [:U13, :in_colorado], aliases: %i[non_compliant_child] do
@@ -442,16 +442,15 @@ FactoryBot.define do
         end
 
         trait :in_grace_period do
-          child_account_compliance_state {Policies::ChildAccount::ComplianceState::GRACE_PERIOD}
-          child_account_compliance_state_last_updated {DateTime.now}
+          cap_state {Policies::ChildAccount::ComplianceState::GRACE_PERIOD}
+          cap_state_date {DateTime.now}
         end
 
         factory :locked_out_child do
-          child_account_compliance_state {Policies::ChildAccount::ComplianceState::LOCKED_OUT}
-          child_account_compliance_state_last_updated {DateTime.now}
-          child_account_compliance_lock_out_date {DateTime.now}
+          cap_state {Policies::ChildAccount::ComplianceState::LOCKED_OUT}
+          cap_state_date {DateTime.now}
           trait :expired do
-            child_account_compliance_lock_out_date {7.days.ago}
+            cap_state_date {7.days.ago}
           end
         end
       end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -427,13 +427,13 @@ FactoryBot.define do
       end
 
       trait :with_parent_permission do
-        cap_state {Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED}
-        cap_state_date {DateTime.now}
+        cap_status {Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED}
+        cap_status_date {DateTime.now}
       end
 
       trait :without_parent_permission do
-        cap_state {nil}
-        cap_state_date {DateTime.now}
+        cap_status {nil}
+        cap_status_date {DateTime.now}
       end
 
       factory :cpa_non_compliant_student, traits: [:U13, :in_colorado], aliases: %i[non_compliant_child] do
@@ -442,15 +442,15 @@ FactoryBot.define do
         end
 
         trait :in_grace_period do
-          cap_state {Policies::ChildAccount::ComplianceState::GRACE_PERIOD}
-          cap_state_date {DateTime.now}
+          cap_status {Policies::ChildAccount::ComplianceState::GRACE_PERIOD}
+          cap_status_date {DateTime.now}
         end
 
         factory :locked_out_child do
-          cap_state {Policies::ChildAccount::ComplianceState::LOCKED_OUT}
-          cap_state_date {DateTime.now}
+          cap_status {Policies::ChildAccount::ComplianceState::LOCKED_OUT}
+          cap_status_date {DateTime.now}
           trait :expired do
-            cap_state_date {7.days.ago}
+            cap_status_date {7.days.ago}
           end
         end
       end

--- a/dashboard/test/integration/cap/cpa/lockout_test.rb
+++ b/dashboard/test/integration/cap/cpa/lockout_test.rb
@@ -235,9 +235,8 @@ module CAP
           assert_equal home_path, path
 
           assert_attributes student.reload, {
-            child_account_compliance_state: Policies::ChildAccount::ComplianceState::GRACE_PERIOD,
-            child_account_compliance_state_last_updated: DateTime.now.iso8601(3),
-            child_account_compliance_lock_out_date: nil,
+            cap_state: Policies::ChildAccount::ComplianceState::GRACE_PERIOD,
+            cap_state_date: DateTime.now,
           }
         end
 
@@ -250,7 +249,7 @@ module CAP
         end
 
         private def assert_student_is_locked_out_until_permission_granted
-          initial_cap_compliance_state = student.child_account_compliance_state
+          initial_cap_compliance_state = student.cap_state
 
           get home_path
 
@@ -259,9 +258,8 @@ module CAP
           assert_equal lockout_path, path
 
           assert_attributes student.reload, {
-            child_account_compliance_state: Policies::ChildAccount::ComplianceState::LOCKED_OUT,
-            child_account_compliance_state_last_updated: DateTime.now.iso8601(3),
-            child_account_compliance_lock_out_date: DateTime.now.iso8601(3),
+            cap_state: Policies::ChildAccount::ComplianceState::LOCKED_OUT,
+            cap_state_date: DateTime.now,
           }
 
           assert_latest_student_cap_event(
@@ -279,9 +277,8 @@ module CAP
           assert_equal home_path, path
 
           assert_attributes student.reload, {
-            child_account_compliance_state: Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED,
-            child_account_compliance_state_last_updated: DateTime.now.iso8601(3),
-            child_account_compliance_lock_out_date: nil,
+            cap_state: Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED,
+            cap_state_date: DateTime.now,
           }
 
           assert_latest_student_cap_event(

--- a/dashboard/test/integration/cap/cpa/lockout_test.rb
+++ b/dashboard/test/integration/cap/cpa/lockout_test.rb
@@ -235,8 +235,8 @@ module CAP
           assert_equal home_path, path
 
           assert_attributes student.reload, {
-            cap_state: Policies::ChildAccount::ComplianceState::GRACE_PERIOD,
-            cap_state_date: DateTime.now,
+            cap_status: Policies::ChildAccount::ComplianceState::GRACE_PERIOD,
+            cap_status_date: DateTime.now,
           }
         end
 
@@ -249,7 +249,7 @@ module CAP
         end
 
         private def assert_student_is_locked_out_until_permission_granted
-          initial_cap_compliance_state = student.cap_state
+          initial_cap_compliance_state = student.cap_status
 
           get home_path
 
@@ -258,8 +258,8 @@ module CAP
           assert_equal lockout_path, path
 
           assert_attributes student.reload, {
-            cap_state: Policies::ChildAccount::ComplianceState::LOCKED_OUT,
-            cap_state_date: DateTime.now,
+            cap_status: Policies::ChildAccount::ComplianceState::LOCKED_OUT,
+            cap_status_date: DateTime.now,
           }
 
           assert_latest_student_cap_event(
@@ -277,8 +277,8 @@ module CAP
           assert_equal home_path, path
 
           assert_attributes student.reload, {
-            cap_state: Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED,
-            cap_state_date: DateTime.now,
+            cap_status: Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED,
+            cap_status_date: DateTime.now,
           }
 
           assert_latest_student_cap_event(

--- a/dashboard/test/lib/email_reminder_test.rb
+++ b/dashboard/test/lib/email_reminder_test.rb
@@ -4,7 +4,7 @@ require 'mocha/mini_test'
 
 class EmailReminderTest < ActiveSupport::TestCase
   setup do
-    @student = create(:student, cap_state: 'p')
+    @student = create(:student, cap_status: 'p')
     @request = create(:parental_permission_request, user_id: @student.id, parent_email: 'foo-parent@code.org')
 
     Cdo::Metrics.expects(:push).never

--- a/dashboard/test/lib/email_reminder_test.rb
+++ b/dashboard/test/lib/email_reminder_test.rb
@@ -4,7 +4,7 @@ require 'mocha/mini_test'
 
 class EmailReminderTest < ActiveSupport::TestCase
   setup do
-    @student = create(:student, child_account_compliance_state: 'not_g')
+    @student = create(:student, cap_state: 'p')
     @request = create(:parental_permission_request, user_id: @student.id, parent_email: 'foo-parent@code.org')
 
     Cdo::Metrics.expects(:push).never

--- a/dashboard/test/lib/forms/child_account/parental_permission_request_test.rb
+++ b/dashboard/test/lib/forms/child_account/parental_permission_request_test.rb
@@ -186,7 +186,7 @@ class Forms::ChildAccount::ParentalPermissionRequestTest < ActiveSupport::TestCa
       expected_mail_error = 'expected_mail_error'
       ParentMailer.expects(:parent_permission_request).raises(expected_mail_error)
 
-      assert_no_change -> {@child_account.reload.cap_state}  do
+      assert_no_change -> {@child_account.reload.cap_status}  do
         assert_raises(expected_mail_error) {@permission_request_form.request}
       end
     end

--- a/dashboard/test/lib/forms/child_account/parental_permission_request_test.rb
+++ b/dashboard/test/lib/forms/child_account/parental_permission_request_test.rb
@@ -186,7 +186,7 @@ class Forms::ChildAccount::ParentalPermissionRequestTest < ActiveSupport::TestCa
       expected_mail_error = 'expected_mail_error'
       ParentMailer.expects(:parent_permission_request).raises(expected_mail_error)
 
-      assert_no_change -> {@child_account.reload.child_account_compliance_state}  do
+      assert_no_change -> {@child_account.reload.cap_state}  do
         assert_raises(expected_mail_error) {@permission_request_form.request}
       end
     end

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -9,19 +9,19 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
 
     test 'grace_period?' do
       assert_changes -> {Policies::ChildAccount::ComplianceState.grace_period?(@student)}, from: false, to: true do
-        @student.child_account_compliance_state = 'p'
+        @student.cap_state = 'p'
       end
     end
 
     test 'locked_out?' do
       assert_changes -> {Policies::ChildAccount::ComplianceState.locked_out?(@student)}, from: false, to: true do
-        @student.child_account_compliance_state = 'l'
+        @student.cap_state = 'l'
       end
     end
 
     test 'permission_granted?' do
       assert_changes -> {Policies::ChildAccount::ComplianceState.permission_granted?(@student)}, from: false, to: true do
-        @student.child_account_compliance_state = 'g'
+        @student.cap_state = 'g'
       end
     end
   end
@@ -184,8 +184,8 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
     let(:user) do
       build_stubbed(
         :non_compliant_child,
-        child_account_compliance_state: user_cap_compliance_state,
-        child_account_compliance_state_last_updated: user_cap_compliance_state_updated_at
+        cap_state: user_cap_compliance_state,
+        cap_state_date: user_cap_compliance_state_updated_at
       )
     end
 

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -9,19 +9,19 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
 
     test 'grace_period?' do
       assert_changes -> {Policies::ChildAccount::ComplianceState.grace_period?(@student)}, from: false, to: true do
-        @student.cap_state = 'p'
+        @student.cap_status = 'p'
       end
     end
 
     test 'locked_out?' do
       assert_changes -> {Policies::ChildAccount::ComplianceState.locked_out?(@student)}, from: false, to: true do
-        @student.cap_state = 'l'
+        @student.cap_status = 'l'
       end
     end
 
     test 'permission_granted?' do
       assert_changes -> {Policies::ChildAccount::ComplianceState.permission_granted?(@student)}, from: false, to: true do
-        @student.cap_state = 'g'
+        @student.cap_status = 'g'
       end
     end
   end
@@ -184,8 +184,8 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
     let(:user) do
       build_stubbed(
         :non_compliant_child,
-        cap_state: user_cap_compliance_state,
-        cap_state_date: user_cap_compliance_state_updated_at
+        cap_status: user_cap_compliance_state,
+        cap_status_date: user_cap_compliance_state_updated_at
       )
     end
 

--- a/dashboard/test/lib/services/child_account/event_logger_test.rb
+++ b/dashboard/test/lib/services/child_account/event_logger_test.rb
@@ -9,7 +9,7 @@ class Services::ChildAccount::EventLoggerTest < ActiveSupport::TestCase
     event_name = CAP::UserEvent::ACCOUNT_LOCKING
 
     # Simulate updating the state to 'granted'
-    @user.cap_state = 'g'
+    @user.cap_status = 'g'
     @user.save
 
     # Should record the prior and current state

--- a/dashboard/test/lib/services/child_account/event_logger_test.rb
+++ b/dashboard/test/lib/services/child_account/event_logger_test.rb
@@ -9,7 +9,7 @@ class Services::ChildAccount::EventLoggerTest < ActiveSupport::TestCase
     event_name = CAP::UserEvent::ACCOUNT_LOCKING
 
     # Simulate updating the state to 'granted'
-    @user.child_account_compliance_state = 'g'
+    @user.cap_state = 'g'
     @user.save
 
     # Should record the prior and current state

--- a/dashboard/test/lib/services/child_account_test.rb
+++ b/dashboard/test/lib/services/child_account_test.rb
@@ -19,16 +19,16 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
       new_state = Policies::ChildAccount::ComplianceState::LOCKED_OUT
       Services::ChildAccount.update_compliance(user, new_state)
 
-      assert_equal new_state, user.cap_state
-      refute_nil user.cap_state_date
+      assert_equal new_state, user.cap_status
+      refute_nil user.cap_status_date
 
-      last_updated = user.cap_state_date
+      last_updated = user.cap_status_date
       Timecop.travel 5.minutes
       new_state = Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED
       Services::ChildAccount.update_compliance(user, new_state)
 
-      assert_equal new_state, user.cap_state
-      refute_equal last_updated, user.cap_state_date
+      assert_equal new_state, user.cap_status
+      refute_equal last_updated, user.cap_status_date
     end
   end
 
@@ -67,8 +67,8 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
         Services::ChildAccount.grant_permission_request! permission
       end
       user.reload
-      assert_equal Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED, user.cap_state
-      refute_nil user.cap_state_date
+      assert_equal Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED, user.cap_status
+      refute_nil user.cap_status_date
     end
 
     test 'granting permission twice only makes changes once' do
@@ -78,8 +78,8 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
         Services::ChildAccount.grant_permission_request! permission
       end
       user.reload
-      assert_equal Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED, user.cap_state
-      last_updated = user.cap_state_date
+      assert_equal Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED, user.cap_status
+      last_updated = user.cap_status_date
       Timecop.travel 5.minutes
       refute_nil last_updated
 
@@ -89,7 +89,7 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
       end
       user.reload
       # The date shouldn't be updated
-      assert_equal last_updated, user.cap_state_date
+      assert_equal last_updated, user.cap_status_date
     end
 
     context 'when something goes wrong during user saving' do
@@ -119,8 +119,8 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
       start_grace_period
 
       assert_attributes user, {
-        cap_state: 'p',
-        cap_state_date: Time.now.change(usec: 0),
+        cap_status: 'p',
+        cap_status_date: Time.now.change(usec: 0),
       }
     end
 
@@ -168,8 +168,8 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
       lock_out
 
       assert_attributes user.reload, {
-        cap_state: 'l',
-        cap_state_date: Time.now.change(usec: 0),
+        cap_status: 'l',
+        cap_status_date: Time.now.change(usec: 0),
       }
     end
 
@@ -211,7 +211,7 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
     let(:user) do
       create(
         :non_compliant_child, :in_grace_period,
-        cap_state_date: user_cap_compliance_updated_at,
+        cap_status_date: user_cap_compliance_updated_at,
       )
     end
 
@@ -220,13 +220,13 @@ class Services::ChildAccountTest < ActiveSupport::TestCase
     end
 
     it 'removes user CAP compliance state' do
-      assert_changes -> {user.reload.cap_state}, from: Policies::ChildAccount::ComplianceState::GRACE_PERIOD, to: nil do
+      assert_changes -> {user.reload.cap_status}, from: Policies::ChildAccount::ComplianceState::GRACE_PERIOD, to: nil do
         remove_user_cap_compliance_state
       end
     end
 
     it 'updates user CAP compliance state last updated date' do
-      assert_changes -> {user.reload.cap_state_date}, from: user_cap_compliance_updated_at, to: Time.now.change(usec: 0) do
+      assert_changes -> {user.reload.cap_status_date}, from: user_cap_compliance_updated_at, to: Time.now.change(usec: 0) do
         remove_user_cap_compliance_state
       end
     end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4017,7 +4017,7 @@ class UserTest < ActiveSupport::TestCase
         has_ever_signed_in: @student.has_ever_signed_in?,
         ai_tutor_access_denied: !!@student.ai_tutor_access_denied,
         at_risk_age_gated: false,
-        child_account_compliance_state: @student.cap_state,
+        child_account_compliance_state: @student.cap_status,
         latest_permission_request_sent_at: latest_permission_request_sent_at,
       },
       @student.summarize

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4017,7 +4017,7 @@ class UserTest < ActiveSupport::TestCase
         has_ever_signed_in: @student.has_ever_signed_in?,
         ai_tutor_access_denied: !!@student.ai_tutor_access_denied,
         at_risk_age_gated: false,
-        child_account_compliance_state: @student.child_account_compliance_state,
+        child_account_compliance_state: @student.cap_state,
         latest_permission_request_sent_at: latest_permission_request_sent_at,
       },
       @student.summarize
@@ -5457,26 +5457,6 @@ class UserTest < ActiveSupport::TestCase
 
       it 'returns resend parental permission request' do
         _(latest_parental_permission_request).must_equal user_permission_request1
-      end
-    end
-  end
-
-  describe 'new CAP columns data assigning before save' do
-    let(:user) {create(:student)}
-
-    it 'assigns "cap_status" with data from "child_account_compliance_state"' do
-      expected_cap_status = Policies::ChildAccount::ComplianceState::LOCKED_OUT
-
-      assert_changes -> {user.reload.cap_status}, from: nil, to: expected_cap_status do
-        user.update!(child_account_compliance_state: expected_cap_status)
-      end
-    end
-
-    it 'assigns "cap_status_date" with data from "child_account_compliance_state_last_updated"' do
-      expected_cap_status_date = Time.now.change(usec: 0)
-
-      assert_changes -> {user.reload.cap_status_date}, from: nil, to: expected_cap_status_date do
-        user.update!(child_account_compliance_state_last_updated: expected_cap_status_date)
       end
     end
   end


### PR DESCRIPTION
Replaced user JSON properties `child_account_compliance_state`, `child_account_compliance_state_last_updated ` and `child_account_compliance_lock_out_date` with new indexed columns `cap_status` and `cap_status_date`.

### Note: This should be merged only after the new CAP columns have been populated with data.

## Links
- JIRA task: [P20-1055](https://codedotorg.atlassian.net/browse/P20-1055)
- Migration PR: https://github.com/code-dot-org/code-dot-org/pull/60218
- Phase 1 PR: https://github.com/code-dot-org/code-dot-org/pull/59962
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/52244