### PR TITLE
[Design2-137] DSCO - add Destructive color to Button

### DIFF
--- a/apps/src/componentLibrary/button/Button.story.tsx
+++ b/apps/src/componentLibrary/button/Button.story.tsx
@@ -98,6 +98,12 @@ GroupOfColorsOfButtons.args = {
       onClick: () => null,
     },
     {
+      text: 'Button Primary Destructive',
+      color: buttonColors.destructive,
+      size: 'm',
+      onClick: () => null,
+    },
+    {
       text: 'Button Secondary Black',
       color: buttonColors.black,
       type: 'secondary',
@@ -114,6 +120,13 @@ GroupOfColorsOfButtons.args = {
     {
       text: 'Button Secondary White',
       color: buttonColors.white,
+      type: 'secondary',
+      size: 'm',
+      onClick: () => null,
+    },
+    {
+      text: 'Button Secondary Destructive',
+      color: buttonColors.destructive,
       type: 'secondary',
       size: 'm',
       onClick: () => null,
@@ -140,6 +153,13 @@ GroupOfColorsOfButtons.args = {
       onClick: () => null,
     },
     {
+      text: 'Button Tertiary Destructive',
+      color: buttonColors.destructive,
+      type: 'tertiary',
+      size: 'm',
+      onClick: () => null,
+    },
+    {
       icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.purple,
       type: 'primary',
@@ -158,6 +178,14 @@ GroupOfColorsOfButtons.args = {
     {
       icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.white,
+      type: 'primary',
+      isIconOnly: true,
+      size: 'm',
+      onClick: () => null,
+    },
+    {
+      icon: {iconName: 'smile', iconStyle: 'solid'},
+      color: buttonColors.destructive,
       type: 'primary',
       isIconOnly: true,
       size: 'm',
@@ -189,6 +217,14 @@ GroupOfColorsOfButtons.args = {
     },
     {
       icon: {iconName: 'smile', iconStyle: 'solid'},
+      color: buttonColors.destructive,
+      type: 'secondary',
+      isIconOnly: true,
+      size: 'm',
+      onClick: () => null,
+    },
+    {
+      icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.purple,
       type: 'tertiary',
       isIconOnly: true,
@@ -206,6 +242,14 @@ GroupOfColorsOfButtons.args = {
     {
       icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.white,
+      type: 'tertiary',
+      isIconOnly: true,
+      size: 'm',
+      onClick: () => null,
+    },
+    {
+      icon: {iconName: 'smile', iconStyle: 'solid'},
+      color: buttonColors.destructive,
       type: 'tertiary',
       isIconOnly: true,
       size: 'm',

--- a/apps/src/componentLibrary/button/Button.tsx
+++ b/apps/src/componentLibrary/button/Button.tsx
@@ -11,6 +11,7 @@ export const buttonColors: {[key in ButtonColor]: ButtonColor} = {
   black: 'black',
   gray: 'gray',
   white: 'white',
+  destructive: 'destructive',
 };
 
 export interface ButtonProps extends CoreButtonProps, ButtonSpecificProps {}

--- a/apps/src/componentLibrary/button/CHANGELOG.md
+++ b/apps/src/componentLibrary/button/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.5.0]()
+## [0.5.0](https://github.com/code-dot-org/code-dot-org/pull/59966)
 * added `destructive` button color option
 
 ## [0.4.1](https://github.com/code-dot-org/code-dot-org/pull/59610)

--- a/apps/src/componentLibrary/button/CHANGELOG.md
+++ b/apps/src/componentLibrary/button/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.5.0](https://github.com/code-dot-org/code-dot-org/pull/59966)
+
 * added `destructive` button color option
 
 ## [0.4.1](https://github.com/code-dot-org/code-dot-org/pull/59610)

--- a/apps/src/componentLibrary/button/CHANGELOG.md
+++ b/apps/src/componentLibrary/button/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0]()
+* added `destructive` button color option
+
 ## [0.4.1](https://github.com/code-dot-org/code-dot-org/pull/59610)
 
 * updated BaseButton props to support native HTML element attributes

--- a/apps/src/componentLibrary/button/LinkButton.story.tsx
+++ b/apps/src/componentLibrary/button/LinkButton.story.tsx
@@ -104,6 +104,12 @@ GroupOfColorsOfLinkButtons.args = {
       href: 'https://www.google.com',
     },
     {
+      text: 'Button Primary Destructive',
+      color: buttonColors.destructive,
+      size: 'm',
+      href: 'https://www.google.com',
+    },
+    {
       text: 'Button Secondary Black',
       color: buttonColors.black,
       type: 'secondary',
@@ -120,6 +126,13 @@ GroupOfColorsOfLinkButtons.args = {
     {
       text: 'Button Secondary White',
       color: buttonColors.white,
+      type: 'secondary',
+      size: 'm',
+      href: 'https://www.google.com',
+    },
+    {
+      text: 'Button Secondary Destructive',
+      color: buttonColors.destructive,
       type: 'secondary',
       size: 'm',
       href: 'https://www.google.com',
@@ -146,6 +159,13 @@ GroupOfColorsOfLinkButtons.args = {
       href: 'https://www.google.com',
     },
     {
+      text: 'Button Tertiary Destructive',
+      color: buttonColors.destructive,
+      type: 'tertiary',
+      size: 'm',
+      href: 'https://www.google.com',
+    },
+    {
       icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.purple,
       type: 'primary',
@@ -164,6 +184,14 @@ GroupOfColorsOfLinkButtons.args = {
     {
       icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.white,
+      type: 'primary',
+      isIconOnly: true,
+      size: 'm',
+      href: 'https://www.google.com',
+    },
+    {
+      icon: {iconName: 'smile', iconStyle: 'solid'},
+      color: buttonColors.destructive,
       type: 'primary',
       isIconOnly: true,
       size: 'm',
@@ -195,6 +223,14 @@ GroupOfColorsOfLinkButtons.args = {
     },
     {
       icon: {iconName: 'smile', iconStyle: 'solid'},
+      color: buttonColors.destructive,
+      type: 'secondary',
+      isIconOnly: true,
+      size: 'm',
+      href: 'https://www.google.com',
+    },
+    {
+      icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.purple,
       type: 'tertiary',
       isIconOnly: true,
@@ -212,6 +248,14 @@ GroupOfColorsOfLinkButtons.args = {
     {
       icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.white,
+      type: 'tertiary',
+      isIconOnly: true,
+      size: 'm',
+      href: 'https://www.google.com',
+    },
+    {
+      icon: {iconName: 'smile', iconStyle: 'solid'},
+      color: buttonColors.destructive,
       type: 'tertiary',
       isIconOnly: true,
       size: 'm',

--- a/apps/src/componentLibrary/button/_baseButton/_BaseButton.story.tsx
+++ b/apps/src/componentLibrary/button/_baseButton/_BaseButton.story.tsx
@@ -133,6 +133,12 @@ GroupOfColorsOf_BaseButtons.args = {
       onClick: () => null,
     },
     {
+      text: 'Button Primary Destructive',
+      color: buttonColors.destructive,
+      size: 'm',
+      onClick: () => null,
+    },
+    {
       text: 'Button Secondary Black',
       color: buttonColors.black,
       type: 'secondary',
@@ -149,6 +155,13 @@ GroupOfColorsOf_BaseButtons.args = {
     {
       text: 'Button Secondary White',
       color: buttonColors.white,
+      type: 'secondary',
+      size: 'm',
+      onClick: () => null,
+    },
+    {
+      text: 'Button Secondary Destructive',
+      color: buttonColors.destructive,
       type: 'secondary',
       size: 'm',
       onClick: () => null,
@@ -175,6 +188,13 @@ GroupOfColorsOf_BaseButtons.args = {
       onClick: () => null,
     },
     {
+      text: 'Button Tertiary Destructive',
+      color: buttonColors.destructive,
+      type: 'tertiary',
+      size: 'm',
+      onClick: () => null,
+    },
+    {
       icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.purple,
       type: 'primary',
@@ -193,6 +213,14 @@ GroupOfColorsOf_BaseButtons.args = {
     {
       icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.white,
+      type: 'primary',
+      isIconOnly: true,
+      size: 'm',
+      onClick: () => null,
+    },
+    {
+      icon: {iconName: 'smile', iconStyle: 'solid'},
+      color: buttonColors.destructive,
       type: 'primary',
       isIconOnly: true,
       size: 'm',
@@ -224,6 +252,14 @@ GroupOfColorsOf_BaseButtons.args = {
     },
     {
       icon: {iconName: 'smile', iconStyle: 'solid'},
+      color: buttonColors.destructive,
+      type: 'secondary',
+      isIconOnly: true,
+      size: 'm',
+      onClick: () => null,
+    },
+    {
+      icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.purple,
       type: 'tertiary',
       isIconOnly: true,
@@ -241,6 +277,14 @@ GroupOfColorsOf_BaseButtons.args = {
     {
       icon: {iconName: 'smile', iconStyle: 'solid'},
       color: buttonColors.white,
+      type: 'tertiary',
+      isIconOnly: true,
+      size: 'm',
+      onClick: () => null,
+    },
+    {
+      icon: {iconName: 'smile', iconStyle: 'solid'},
+      color: buttonColors.destructive,
       type: 'tertiary',
       isIconOnly: true,
       size: 'm',

--- a/apps/src/componentLibrary/button/_baseButton/_baseButton.module.scss
+++ b/apps/src/componentLibrary/button/_baseButton/_baseButton.module.scss
@@ -101,6 +101,20 @@ a.button-primary {
       color: $light_gray_900;
     }
   }
+
+  &.button-destructive {
+    background-color: $light_negative_500;
+    color: $light_white;
+
+    &:hover {
+      background-color: $light_negative_700;
+    }
+
+    &:disabled, &[aria-disabled="true"] {
+      background-color: $light_gray_200;
+      color: $light_white;
+    }
+  }
 }
 
 .button-secondary,
@@ -196,6 +210,28 @@ a.button-secondary {
       background-color: unset;
     }
   }
+
+  &.button-destructive {
+    border: 1px solid $light_negative_500;
+    color: $light_negative_500;
+
+    &:hover {
+      background-color: $light_negative_100;
+      border: 1px solid $light_negative_500;
+      color: $light_negative_500;
+    }
+
+    &:active {
+      // !important is used here to override the ./apps/style/common.scss line 655 styles
+      border: 1px solid $light_negative_500 !important;
+    }
+
+    &:disabled, &[aria-disabled="true"] {
+      border-color: $light_gray_200 !important;
+      color: $light_gray_200;
+      background-color: unset;
+    }
+  }
 }
 
 .button-tertiary,
@@ -253,6 +289,25 @@ a.button-tertiary {
 
     &:disabled, &[aria-disabled="true"] {
       color: $light_gray_800;
+      background-color: unset;
+    }
+  }
+
+  &.button-destructive {
+    color: $light_negative_500;
+
+    &:hover {
+      background-color: $light_negative_100;
+      color: $light_negative_500;
+    }
+
+    &:active {
+      background-color: $light_negative_100;
+      color: $light_negative_700;
+    }
+
+    &:disabled, &[aria-disabled="true"] {
+      color: $light_gray_200;
       background-color: unset;
     }
   }

--- a/apps/src/componentLibrary/button/types.ts
+++ b/apps/src/componentLibrary/button/types.ts
@@ -1,3 +1,3 @@
 export type ButtonType = 'primary' | 'secondary' | 'tertiary';
 
-export type ButtonColor = 'purple' | 'black' | 'gray' | 'white';
+export type ButtonColor = 'purple' | 'black' | 'gray' | 'white' | 'destructive';


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [Design2-137] DSCO - add Destructive color to Button

* added `destructive` color to buttons

Before:
<img width="1084" alt="Знімок екрана 2024-07-24 о 13 14 45" src="https://github.com/user-attachments/assets/6211fb31-6e87-4d6d-902e-7f03da66e47a">

After:
<img width="1084" alt="Знімок екрана 2024-07-24 о 13 36 12" src="https://github.com/user-attachments/assets/d48de41b-4cb1-4950-9fb3-fade85f95d37">


## Links
- jira ticket: [Design2-137](https://codedotorg.atlassian.net/browse/DESIGN2-137)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
