### PR TITLE
Remove remaining advocacy.code.org references from the codebase

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -11,7 +11,7 @@ Parameters:
   # Domain Names - Each Stack operates 5 sites (examples are for production):
   # 1) Learning Platform ("Dashboard") - https://studio.code.org
   # 2) Corporate Website ("Pegasus") - https://code.org
-  # 3) Advocacy Website (runs on Pegasus) - https://advocacy.code.org
+  # 3) Advocacy Website (runs on LeadPages) - https://advocacy.code.org
   # 4) Hour of Code (runs on Pegasus) - https://hourofcode.com
   # 5) Code Projects (host user created content) - https://codeprojects.org
   # ---------------------------------------------

--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -20,7 +20,6 @@ Dashboard::Application.configure do
   config.hosts << "localhost.code.org"
   config.hosts << "localhost.hourofcode.com"
   config.hosts << "localhost.codeprojects.org"
-  config.hosts << "localhost-advocacy.code.org"
 
   # Do not eager load code on boot.
   config.eager_load = false

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -66,6 +66,7 @@ def replace_hostname(url)
     dashboard_host: ENV.fetch('DASHBOARD_TEST_DOMAIN', nil),
     pegasus_host: ENV.fetch('PEGASUS_TEST_DOMAIN', nil),
     hourofcode_host: ENV.fetch('HOUROFCODE_TEST_DOMAIN', nil),
+    csedweek_host: ENV.fetch('CSEDWEEK_TEST_DOMAIN', nil),
   ).replace_origin(url)
 end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -66,8 +66,6 @@ def replace_hostname(url)
     dashboard_host: ENV.fetch('DASHBOARD_TEST_DOMAIN', nil),
     pegasus_host: ENV.fetch('PEGASUS_TEST_DOMAIN', nil),
     hourofcode_host: ENV.fetch('HOUROFCODE_TEST_DOMAIN', nil),
-    csedweek_host: ENV.fetch('CSEDWEEK_TEST_DOMAIN', nil),
-    advocacy_host: ENV.fetch('ADVOCACY_TEST_DOMAIN', nil)
   ).replace_origin(url)
 end
 

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -737,7 +737,6 @@ def run_feature(browser, feature, options)
   run_environment['PEGASUS_TEST_DOMAIN'] = options.pegasus_domain if options.pegasus_domain
   run_environment['DASHBOARD_TEST_DOMAIN'] = options.dashboard_domain if options.dashboard_domain
   run_environment['HOUROFCODE_TEST_DOMAIN'] = options.hourofcode_domain if options.hourofcode_domain
-  run_environment['CSEDWEEK_TEST_DOMAIN'] = options.csedweek_domain if options.csedweek_domain
   run_environment['TEST_LOCAL'] = options.local ? "true" : "false"
   run_environment['TEST_LOCAL_HEADLESS'] = options.local_headless ? "true" : "false"
   run_environment['MAXIMIZE_LOCAL'] = options.maximize ? "true" : "false"

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -737,6 +737,7 @@ def run_feature(browser, feature, options)
   run_environment['PEGASUS_TEST_DOMAIN'] = options.pegasus_domain if options.pegasus_domain
   run_environment['DASHBOARD_TEST_DOMAIN'] = options.dashboard_domain if options.dashboard_domain
   run_environment['HOUROFCODE_TEST_DOMAIN'] = options.hourofcode_domain if options.hourofcode_domain
+  run_environment['CSEDWEEK_TEST_DOMAIN'] = options.csedweek_domain if options.csedweek_domain
   run_environment['TEST_LOCAL'] = options.local ? "true" : "false"
   run_environment['TEST_LOCAL_HEADLESS'] = options.local_headless ? "true" : "false"
   run_environment['MAXIMIZE_LOCAL'] = options.maximize ? "true" : "false"

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -83,10 +83,6 @@ module Cdo
       canonical_hostname('hourofcode.com')
     end
 
-    def advocacy_hostname
-      canonical_hostname('advocacy.code.org')
-    end
-
     def codeprojects_hostname
       canonical_hostname('codeprojects.org')
     end
@@ -130,10 +126,6 @@ module Cdo
 
     def code_org_url(path = '', scheme = '')
       site_url('code.org', path, scheme)
-    end
-
-    def advocacy_url(path = '', scheme = '')
-      site_url('advocacy.code.org', path, scheme)
     end
 
     def hourofcode_url(path = '', scheme = '')

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -38,7 +38,7 @@ module AWS
       pegasus: {
         # NOTE: Keep this list in sync with the call to AWS::CloudFront.distribution_config in cloud_formation_stack.yml.erb.
         # CloudFormation stack should be refactored to reference this configuration in the future.
-        aliases: [CDO.pegasus_hostname, CDO.advocacy_hostname] + CDO.partners.map {|x| CDO.canonical_hostname("#{x}.code.org")},
+        aliases: [CDO.pegasus_hostname] + CDO.partners.map {|x| CDO.canonical_hostname("#{x}.code.org")},
         origin: "#{ENV.fetch('RACK_ENV', nil)}-pegasus.code.org",
         # ACM domain name
         ssl_cert: 'code.org',

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -187,7 +187,7 @@ To specify an alternate branch name, run `rake adhoc:start branch=BRANCH`."
         subdomain('origin'),
         app == 'Dashboard' ?
           [studio_subdomain] :
-          [subdomain] + (CDO.partners).map {|x| subdomain(nil, x)},
+          [subdomain] + CDO.partners.map {|x| subdomain(nil, x)},
         {
           AcmCertificateArn: certificate_arn,
           MinimumProtocolVersion: 'TLSv1',

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -187,7 +187,7 @@ To specify an alternate branch name, run `rake adhoc:start branch=BRANCH`."
         subdomain('origin'),
         app == 'Dashboard' ?
           [studio_subdomain] :
-          [subdomain] + (CDO.partners + ['advocacy']).map {|x| subdomain(nil, x)},
+          [subdomain] + (CDO.partners).map {|x| subdomain(nil, x)},
         {
           AcmCertificateArn: certificate_arn,
           MinimumProtocolVersion: 'TLSv1',

--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -59,8 +59,8 @@ module Cdo
       host_parts.sub!('-', '.') unless rack_env?(:production)
       parts = host_parts.split('.')
 
-      if parts.count >= 3
-        domains = (%w(studio learn advocacy) + CDO.partners).map {|x| x + '.code.org'}
+      if parts.count >= 2
+        domains = (%w(studio learn) + CDO.partners).map {|x| x + '.code.org'}
         domain = parts.last(3).join('.').split(':').first
         return domain if domains.include? domain
       end

--- a/lib/cdo/url_converter.rb
+++ b/lib/cdo/url_converter.rb
@@ -6,7 +6,6 @@ class UrlConverter
   HOUROFCODE_COM_REGEX = /#{'//hourofcode.com'}(?=$|\/)/
   CSEDWEEK_ORG_REGEX = /#{'//csedweek.org'}(?=$|\/)/
   DASHBOARD_REGEX = /#{'//studio.code.org'}(?=$|\/)/
-  ADVOCACY_REGEX = /#{'//advocacy.code.org'}(?=$|\/)/
 
   # For reference, a 'host' is a domain and (optionally) port without a protocol.
   # Examples: code.org, studio.code.org, localhost-studio.code.org:3000
@@ -31,8 +30,6 @@ class UrlConverter
       url = url.gsub(HOUROFCODE_COM_REGEX, "//" + @hourofcode_host)
     elsif @csedweek_host && CSEDWEEK_ORG_REGEX =~ url
       url = url.gsub(CSEDWEEK_ORG_REGEX, "//" + @csedweek_host)
-    elsif @advocacy_host && ADVOCACY_REGEX =~ url
-      url = url.gsub(ADVOCACY_REGEX, "//" + @advocacy_host)
     elsif @dashboard_host && DASHBOARD_REGEX =~ url
       url = url.gsub(DASHBOARD_REGEX, "//" + @dashboard_host)
     elsif @pegasus_host

--- a/lib/cdo/url_converter.rb
+++ b/lib/cdo/url_converter.rb
@@ -4,15 +4,18 @@ class UrlConverter
   # It prevents us from matching something like //code.org.example.com
   LEARN_CODE_ORG_REGEX = /#{'//learn.code.org'}(?=$|\/)/
   HOUROFCODE_COM_REGEX = /#{'//hourofcode.com'}(?=$|\/)/
+  CSEDWEEK_ORG_REGEX = /#{'//csedweek.org'}(?=$|\/)/
   DASHBOARD_REGEX = /#{'//studio.code.org'}(?=$|\/)/
 
   # For reference, a 'host' is a domain and (optionally) port without a protocol.
   # Examples: code.org, studio.code.org, localhost-studio.code.org:3000
   # @see https://developer.mozilla.org/en-US/docs/Web/API/Location
-  def initialize(dashboard_host: nil, pegasus_host: nil, hourofcode_host: nil)
+  def initialize(dashboard_host: nil, pegasus_host: nil, hourofcode_host: nil, csedweek_host: nil, advocacy_host: nil)
+    @csedweek_host = csedweek_host
     @dashboard_host = dashboard_host
     @pegasus_host = pegasus_host
     @hourofcode_host = hourofcode_host
+    @csedweek_host = csedweek_host
   end
 
   # An 'origin' is a protocol, domain, and (optional) port.  This method may
@@ -24,6 +27,8 @@ class UrlConverter
 
     if @hourofcode_host && HOUROFCODE_COM_REGEX =~ url
       url = url.gsub(HOUROFCODE_COM_REGEX, "//" + @hourofcode_host)
+    elsif @csedweek_host && CSEDWEEK_ORG_REGEX =~ url
+      url = url.gsub(CSEDWEEK_ORG_REGEX, "//" + @csedweek_host)
     elsif @dashboard_host && DASHBOARD_REGEX =~ url
       url = url.gsub(DASHBOARD_REGEX, "//" + @dashboard_host)
     elsif @pegasus_host

--- a/lib/cdo/url_converter.rb
+++ b/lib/cdo/url_converter.rb
@@ -10,8 +10,8 @@ class UrlConverter
   # For reference, a 'host' is a domain and (optionally) port without a protocol.
   # Examples: code.org, studio.code.org, localhost-studio.code.org:3000
   # @see https://developer.mozilla.org/en-US/docs/Web/API/Location
-  def initialize(dashboard_host: nil, pegasus_host: nil, hourofcode_host: nil, csedweek_host: nil, advocacy_host: nil)
-    @csedweek_host = csedweek_host
+  def initialize(dashboard_host: nil, pegasus_host: nil, hourofcode_host: nil,
+    csedweek_host: nil, advocacy_host: nil)
     @dashboard_host = dashboard_host
     @pegasus_host = pegasus_host
     @hourofcode_host = hourofcode_host

--- a/lib/cdo/url_converter.rb
+++ b/lib/cdo/url_converter.rb
@@ -4,19 +4,15 @@ class UrlConverter
   # It prevents us from matching something like //code.org.example.com
   LEARN_CODE_ORG_REGEX = /#{'//learn.code.org'}(?=$|\/)/
   HOUROFCODE_COM_REGEX = /#{'//hourofcode.com'}(?=$|\/)/
-  CSEDWEEK_ORG_REGEX = /#{'//csedweek.org'}(?=$|\/)/
   DASHBOARD_REGEX = /#{'//studio.code.org'}(?=$|\/)/
 
   # For reference, a 'host' is a domain and (optionally) port without a protocol.
   # Examples: code.org, studio.code.org, localhost-studio.code.org:3000
   # @see https://developer.mozilla.org/en-US/docs/Web/API/Location
-  def initialize(dashboard_host: nil, pegasus_host: nil, hourofcode_host: nil,
-    csedweek_host: nil, advocacy_host: nil)
+  def initialize(dashboard_host: nil, pegasus_host: nil, hourofcode_host: nil)
     @dashboard_host = dashboard_host
     @pegasus_host = pegasus_host
     @hourofcode_host = hourofcode_host
-    @csedweek_host = csedweek_host
-    @advocacy_host = advocacy_host
   end
 
   # An 'origin' is a protocol, domain, and (optional) port.  This method may
@@ -28,8 +24,6 @@ class UrlConverter
 
     if @hourofcode_host && HOUROFCODE_COM_REGEX =~ url
       url = url.gsub(HOUROFCODE_COM_REGEX, "//" + @hourofcode_host)
-    elsif @csedweek_host && CSEDWEEK_ORG_REGEX =~ url
-      url = url.gsub(CSEDWEEK_ORG_REGEX, "//" + @csedweek_host)
     elsif @dashboard_host && DASHBOARD_REGEX =~ url
       url = url.gsub(DASHBOARD_REGEX, "//" + @dashboard_host)
     elsif @pegasus_host

--- a/lib/test/cdo/test_url_converter.rb
+++ b/lib/test/cdo/test_url_converter.rb
@@ -38,7 +38,6 @@ class UrlConverterTest < Minitest::Test
       pegasus_host: 'test.code.org',
       dashboard_host: 'test-studio.code.org',
       hourofcode_host: 'test.hourofcode.com',
-      csedweek_host: 'test.csedweek.org'
     )
   end
 
@@ -71,7 +70,6 @@ class UrlConverterTest < Minitest::Test
       pegasus_host: 'localhost.code.org:3000',
       dashboard_host: 'localhost-studio.code.org:3000',
       hourofcode_host: 'localhost.hourofcode.com:3000',
-      csedweek_host: 'localhost.csedweek.org:3000'
     )
   end
 

--- a/lib/test/cdo/test_url_converter.rb
+++ b/lib/test/cdo/test_url_converter.rb
@@ -38,6 +38,7 @@ class UrlConverterTest < Minitest::Test
       pegasus_host: 'test.code.org',
       dashboard_host: 'test-studio.code.org',
       hourofcode_host: 'test.hourofcode.com',
+      csedweek_host: 'test.csedweek.org'
     )
   end
 
@@ -70,6 +71,7 @@ class UrlConverterTest < Minitest::Test
       pegasus_host: 'localhost.code.org:3000',
       dashboard_host: 'localhost-studio.code.org:3000',
       hourofcode_host: 'localhost.hourofcode.com:3000',
+      csedweek_host: 'localhost.csedweek.org:3000'
     )
   end
 

--- a/pegasus/helpers/page_helpers.rb
+++ b/pegasus/helpers/page_helpers.rb
@@ -58,12 +58,7 @@ end
 # Returns a concatenated, minified CSS string from all CSS files in the given paths,
 # along with a digest of same.
 def combine_css(*paths)
-  # Special case in which we want advocacy.code.org to receive styling from code.org.
-  # We still serve up the combined CSS from advocacy.code.org, rather than reach across to code.org,
-  # to avoid CORS errors for the web font that is included in this combined CSS.
-  request_site = request.site == "advocacy.code.org" ? "code.org" : request.site
-
-  files = paths.map {|path| Dir.glob(pegasus_dir('sites.v3', request_site, path, '*.css'))}.flatten
+  files = paths.map {|path| Dir.glob(pegasus_dir('sites.v3', request.site, path, '*.css'))}.flatten
   css = files.sort_by {|file| File.basename(file)}.map do |i|
     File.read(i)
   end.join("\n\n")

--- a/shared/middleware/pegasus_sites.rb
+++ b/shared/middleware/pegasus_sites.rb
@@ -13,6 +13,7 @@ class PegasusSites
     @pegasus_app = Rack::Builder.parse_file(config_ru).first
     pegasus_domains = %w(
       code.org
+      csedweek.org
       hourofcode.com
     ).concat(CDO.partners.map {|partner| "#{partner}.code.org"})
     @pegasus_hosts = pegasus_domains.map {|i| CDO.canonical_hostname(i)}

--- a/shared/middleware/pegasus_sites.rb
+++ b/shared/middleware/pegasus_sites.rb
@@ -13,9 +13,7 @@ class PegasusSites
     @pegasus_app = Rack::Builder.parse_file(config_ru).first
     pegasus_domains = %w(
       code.org
-      csedweek.org
       hourofcode.com
-      advocacy.code.org
     ).concat(CDO.partners.map {|partner| "#{partner}.code.org"})
     @pegasus_hosts = pegasus_domains.map {|i| CDO.canonical_hostname(i)}
     @config = HttpCache.config(rack_env)


### PR DESCRIPTION
Removes the remaining references to advocacy.code.org in the codebase.

## Links
Jira ticket: [ACQ-2086](https://codedotorg.atlassian.net/browse/ACQ-2086)
Related PRs: 
- https://github.com/code-dot-org/code-dot-org/pull/59844
- https://github.com/code-dot-org/code-dot-org/pull/59892

## Testing story
Made sure drone passes