### PR TITLE
P20-1066: Use Noto Sans as fallback font for BSC

### DIFF
--- a/shared/css/font.scss
+++ b/shared/css/font.scss
@@ -123,8 +123,8 @@ $black-font-weight: 900;
   font-style: italic;
 }
 
-$barlowSemiCondensed-semibold: 'Barlow Semi Condensed Semibold', sans-serif;
-$barlowSemiCondensed-medium: 'Barlow Semi Condensed Medium', sans-serif;
+$barlowSemiCondensed-semibold: 'Barlow Semi Condensed Semibold', $noto-sans-fonts, sans-serif;
+$barlowSemiCondensed-medium: 'Barlow Semi Condensed Medium', $noto-sans-fonts, sans-serif;
 
 $code-font: 'Source Code Pro', Monaco, 'Bitstream Vera Sans Mono', 'Lucida Console', Terminal, monospace;
 


### PR DESCRIPTION
## Screenshot
<img src="https://github.com/user-attachments/assets/0449b130-105d-4df7-8533-3ba2f762e707">

## Links
- JIRA task: [P20-1066](https://codedotorg.atlassian.net/browse/P20-1066)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/59782