### PR TITLE
Make dsl editor fit content

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
@@ -4,7 +4,11 @@
   $lighter_cyan: #a6daed;
   $lightest_cyan: #d9eff7;
 
-  .script_text textarea { width: 100%; height: 100px}
+  .script_text textarea {
+    field-sizing: content;
+    max-width: 100%;
+    min-width: 95%;}
+
   .markdown {
     border: 5px solid gray;
     border-radius: 5px;

--- a/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
@@ -6,8 +6,9 @@
 
   .script_text textarea {
     field-sizing: content;
-    max-width: 100%;
-    min-width: 95%;}
+    width: 100%;
+    box-sizing: border-box;
+  }
 
   .markdown {
     border: 5px solid gray;


### PR DESCRIPTION

This change will allow the dsl editor field to auto fit it's content. This should work on all browsers except Firefox.

![dsleditor](https://github.com/user-attachments/assets/fd95e746-50be-4a7d-ab6f-fe1fd4830895)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
