### PR TITLE
fix: do not propagate the copyright flyout event to prevent a double close

### DIFF
--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -121,6 +121,7 @@ export default class SmallFooter extends React.Component {
 
   clickBaseCopyright = e => {
     e.preventDefault();
+    e.stopPropagation();
 
     if (this.state.menuState === MenuState.MINIMIZING) {
       return;


### PR DESCRIPTION
After the react 17 upgrade, the copyright flyout's button's click event was emitted twice resulting in an open and close (net effect is nothing is opened). This was due to react 17's event propagation change. This particular test was missed as it was only tested using an eyes visual comparison (testing that the copyright showed up).


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

1. Go to http://127.0.0.1:3000/s/starwars/lessons/1/levels/15?noautoplay=true
2. Click the bottom left copyright logo

Expected: Copyright flyout appears

![image](https://github.com/user-attachments/assets/857a61c9-2f75-4167-a61f-17b045d8aa5c)

3. Click again (inside and outside of the flyout)

Expected: Copyright flyout dismisses

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
