### PR TITLE
Add ui tests for CFU updates

### DIFF
--- a/apps/src/templates/levelSummary/FreeResponseResponses.jsx
+++ b/apps/src/templates/levelSummary/FreeResponseResponses.jsx
@@ -34,11 +34,7 @@ const FreeResponseResponses = ({responses, showStudentNames}) => {
     pinResponse = undefined,
     unpinResponse = undefined
   ) => (
-    <div
-      key={response.user_id}
-      className={styles.studentResponseBlock}
-      id="student-response"
-    >
+    <div key={response.user_id} className={styles.studentResponseBlock}>
       <div key={response.user_id} className={styles.studentAnswer}>
         <div
           className={classNames(
@@ -134,7 +130,6 @@ const FreeResponseResponses = ({responses, showStudentNames}) => {
             numHiddenResponses: hiddenResponses.length,
           })}
           type="gray"
-          id="hidden-responses-alert"
         />
       )}
     </div>

--- a/apps/src/templates/levelSummary/FreeResponseResponses.jsx
+++ b/apps/src/templates/levelSummary/FreeResponseResponses.jsx
@@ -34,7 +34,11 @@ const FreeResponseResponses = ({responses, showStudentNames}) => {
     pinResponse = undefined,
     unpinResponse = undefined
   ) => (
-    <div key={response.user_id} className={styles.studentResponseBlock}>
+    <div
+      key={response.user_id}
+      className={styles.studentResponseBlock}
+      id="student-response"
+    >
       <div key={response.user_id} className={styles.studentAnswer}>
         <div
           className={classNames(
@@ -130,6 +134,7 @@ const FreeResponseResponses = ({responses, showStudentNames}) => {
             numHiddenResponses: hiddenResponses.length,
           })}
           type="gray"
+          id="hidden-responses-alert"
         />
       )}
     </div>

--- a/apps/src/templates/levelSummary/ResponseMenuDropdown.jsx
+++ b/apps/src/templates/levelSummary/ResponseMenuDropdown.jsx
@@ -40,12 +40,11 @@ const ResponseMenuDropdown = ({
       return (
         <button
           type="button"
-          className={styles.dropdownOption}
+          className={classNames(styles.dropdownOption, 'uitest-pin-response')}
           onClick={() => {
             setIsOpen(false);
             pinResponse(response.user_id);
           }}
-          id="pin-response-button"
         >
           <FontAwesomeV6Icon iconName="thumbtack" />
           {i18n.pinResponse()}
@@ -59,7 +58,7 @@ const ResponseMenuDropdown = ({
       <Button
         onClick={() => setIsOpen(!isOpen)}
         isIconOnly={true}
-        icon={{iconName: 'ellipsis-vertical', title: i18n.additionalOptions()}}
+        icon={{iconName: 'ellipsis-vertical'}}
         color={buttonColors.purple}
         size="xs"
         type="tertiary"
@@ -67,24 +66,23 @@ const ResponseMenuDropdown = ({
           styles.studentAnswerMenuButton,
           unpinResponse && styles.studentAnswerMenuButtonPinned
         )}
-        id="student-response-menu-button"
+        aria-label={i18n.additionalOptions()}
       />
       {isOpen && (
-        <div
-          className={styles.studentAnswerMenuDropdown}
-          id="student-response-menu"
-        >
+        <div className={styles.studentAnswerMenuDropdown}>
           <ul>
             <li>{getPinnedDropdownOption()}</li>
             <li>
               <button
-                className={styles.dropdownOption}
+                className={classNames(
+                  styles.dropdownOption,
+                  'uitest-hide-response'
+                )}
                 type="button"
                 onClick={() => {
                   setIsOpen(false);
                   hideResponse(response.user_id);
                 }}
-                id="hide-response-button"
               >
                 <FontAwesomeV6Icon iconName="eye-slash" />
                 {i18n.hideResponse()}

--- a/apps/src/templates/levelSummary/ResponseMenuDropdown.jsx
+++ b/apps/src/templates/levelSummary/ResponseMenuDropdown.jsx
@@ -45,6 +45,7 @@ const ResponseMenuDropdown = ({
             setIsOpen(false);
             pinResponse(response.user_id);
           }}
+          id="pin-response-button"
         >
           <FontAwesomeV6Icon iconName="thumbtack" />
           {i18n.pinResponse()}

--- a/apps/src/templates/levelSummary/ResponseMenuDropdown.jsx
+++ b/apps/src/templates/levelSummary/ResponseMenuDropdown.jsx
@@ -66,9 +66,13 @@ const ResponseMenuDropdown = ({
           styles.studentAnswerMenuButton,
           unpinResponse && styles.studentAnswerMenuButtonPinned
         )}
+        id="student-response-menu-button"
       />
       {isOpen && (
-        <div className={styles.studentAnswerMenuDropdown}>
+        <div
+          className={styles.studentAnswerMenuDropdown}
+          id="student-response-menu"
+        >
           <ul>
             <li>{getPinnedDropdownOption()}</li>
             <li>
@@ -79,6 +83,7 @@ const ResponseMenuDropdown = ({
                   setIsOpen(false);
                   hideResponse(response.user_id);
                 }}
+                id="hide-response-button"
               >
                 <FontAwesomeV6Icon iconName="eye-slash" />
                 {i18n.hideResponse()}

--- a/apps/test/unit/templates/levelSummary/FreeResponseResponsesTest.jsx
+++ b/apps/test/unit/templates/levelSummary/FreeResponseResponsesTest.jsx
@@ -57,7 +57,7 @@ describe('FreeResponseResponses', () => {
 
     screen.getByText('student response 1');
 
-    const dropdownButton = screen.getAllByTitle('Additional options')[0];
+    const dropdownButton = screen.getAllByLabelText('Additional options')[0];
 
     dropdownButton.click();
 
@@ -87,7 +87,7 @@ describe('FreeResponseResponses', () => {
     expect(screen.queryByText('Pinned responses')).toBeNull();
 
     // pin response
-    const dropdownButton = screen.getAllByTitle('Additional options')[4];
+    const dropdownButton = screen.getAllByLabelText('Additional options')[4];
     dropdownButton.click();
 
     const pinResponseButton = screen.getByRole('button', {

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -1,91 +1,91 @@
 @dashboard_db_access
 Feature: Level summary
-#
-#@eyes
-#Scenario: Free Response level 1
-#  # Turn on cfu pin and hide until it is on by default.
-#  Given I am on "http://studio.code.org"
-#  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
-#
-#  # Complex level with many different features in use, including a title h1.
-#  When I open my eyes to test "free response summary 1"
-#  Given I am a teacher
-#  And I create a new student section
-#  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
-#  And I wait until element "#summary-container" is visible
-#  And I wait to see ".uitest-sectionselect"
-#  Then I see no difference for "free response level summary 1"
-#  And I close my eyes
-#
-#@eyes
-#Scenario: Free Response level 2
-#  # Turn on cfu pin and hide until it is on by default.
-#  Given I am on "http://studio.code.org"
-#  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
-#
-#  # Simpler level with an h2 in the markdown.
-#  When I open my eyes to test "free response summary 2"
-#  Given I am a teacher
-#  And I create a new student section
-#  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/2/summary"
-#  And I wait until element "#summary-container" is visible
-#  And I wait to see ".uitest-sectionselect"
-#  Then I see no difference for "free response level summary 2"
-#  And I close my eyes
-#
-#@eyes
-#Scenario: Free Response level 3
-#  # Turn on cfu pin and hide until it is on by default.
-#  Given I am on "http://studio.code.org"
-#  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
-#
-#  # Minimal level with no heading, just text and a textarea.
-#  When I open my eyes to test "free response summary 3"
-#  Given I am a teacher
-#  And I create a new student section
-#  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/3/summary"
-#  And I wait until element "#summary-container" is visible
-#  And I wait to see ".uitest-sectionselect"
-#  Then I see no difference for "free response level summary 3"
-#  And I close my eyes
-#
-#@eyes
-#Scenario: Multi level 1
-#  # Turn on cfu pin and hide until it is on by default.
-#  Given I am on "http://studio.code.org"
-#  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
-#
-#  # Multiple content blocks, images in question and answers
-#  When I open my eyes to test "multi summary 1"
-#  Given I create a teacher named "Teacher_1"
-#  And I give user "Teacher_1" authorized teacher permission
-#  And I create a new student section
-#  And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/1/summary"
-#  And I wait until element "#summary-container" is visible
-#  And I wait to see ".uitest-sectionselect"
-#  Then I see no difference for "multi level summary 1"
-#  Then I click selector "span:contains(Show answer)"
-#  And I see no difference for "multi level summary 1 show answer"
-#  And I close my eyes
-#
-#@eyes
-#Scenario: Multi level 2
-#  # Turn on cfu pin and hide until it is on by default.
-#  Given I am on "http://studio.code.org"
-#  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
-#
-#  # Markdown in question, images and text in answers, more than 4 answers
-#  When I open my eyes to test "multi summary 2"
-#  Given I create a teacher named "Teacher_1"
-#  And I give user "Teacher_1" authorized teacher permission
-#  And I create a new student section
-#  And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/4/summary"
-#  And I wait until element "#summary-container" is visible
-#  And I wait to see ".uitest-sectionselect"
-#  Then I see no difference for "multi level summary 2"
-#  Then I click selector "span:contains(Show answer)"
-#  And I see no difference for "multi level summary 2 show answer"
-#  And I close my eyes
+
+@eyes
+Scenario: Free Response level 1
+  # Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://studio.code.org"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
+  # Complex level with many different features in use, including a title h1.
+  When I open my eyes to test "free response summary 1"
+  Given I am a teacher
+  And I create a new student section
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"
+  Then I see no difference for "free response level summary 1"
+  And I close my eyes
+
+@eyes
+Scenario: Free Response level 2
+  # Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://studio.code.org"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
+  # Simpler level with an h2 in the markdown.
+  When I open my eyes to test "free response summary 2"
+  Given I am a teacher
+  And I create a new student section
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/2/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"
+  Then I see no difference for "free response level summary 2"
+  And I close my eyes
+
+@eyes
+Scenario: Free Response level 3
+  # Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://studio.code.org"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
+  # Minimal level with no heading, just text and a textarea.
+  When I open my eyes to test "free response summary 3"
+  Given I am a teacher
+  And I create a new student section
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/3/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"
+  Then I see no difference for "free response level summary 3"
+  And I close my eyes
+
+@eyes
+Scenario: Multi level 1
+  # Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://studio.code.org"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
+  # Multiple content blocks, images in question and answers
+  When I open my eyes to test "multi summary 1"
+  Given I create a teacher named "Teacher_1"
+  And I give user "Teacher_1" authorized teacher permission
+  And I create a new student section
+  And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/1/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"
+  Then I see no difference for "multi level summary 1"
+  Then I click selector "span:contains(Show answer)"
+  And I see no difference for "multi level summary 1 show answer"
+  And I close my eyes
+
+@eyes
+Scenario: Multi level 2
+  # Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://studio.code.org"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
+  # Markdown in question, images and text in answers, more than 4 answers
+  When I open my eyes to test "multi summary 2"
+  Given I create a teacher named "Teacher_1"
+  And I give user "Teacher_1" authorized teacher permission
+  And I create a new student section
+  And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/4/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"
+  Then I see no difference for "multi level summary 2"
+  Then I click selector "span:contains(Show answer)"
+  And I see no difference for "multi level summary 2 show answer"
+  And I close my eyes
 
 Scenario: Check for Understanding summaries
   # Turn on cfu pin and hide until it is on by default.

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -3,6 +3,10 @@
 Feature: Level summary
 
 Scenario: Free Response level 1
+  # Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://code.org/test_dcdo"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
   # Complex level with many different features in use, including a title h1.
   When I open my eyes to test "free response summary 1"
   Given I am a teacher
@@ -14,6 +18,10 @@ Scenario: Free Response level 1
   And I close my eyes
 
 Scenario: Free Response level 2
+  # Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://code.org/test_dcdo"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
   # Simpler level with an h2 in the markdown.
   When I open my eyes to test "free response summary 2"
   Given I am a teacher
@@ -25,6 +33,10 @@ Scenario: Free Response level 2
   And I close my eyes
 
 Scenario: Free Response level 3
+  # Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://code.org/test_dcdo"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
   # Minimal level with no heading, just text and a textarea.
   When I open my eyes to test "free response summary 3"
   Given I am a teacher
@@ -36,6 +48,10 @@ Scenario: Free Response level 3
   And I close my eyes
 
 Scenario: Multi level 1
+  # Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://code.org/test_dcdo"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
   # Multiple content blocks, images in question and answers
   When I open my eyes to test "multi summary 1"
   Given I create a teacher named "Teacher_1"
@@ -50,6 +66,10 @@ Scenario: Multi level 1
   And I close my eyes
 
 Scenario: Multi level 2
+  # Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://code.org/test_dcdo"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
   # Markdown in question, images and text in answers, more than 4 answers
   When I open my eyes to test "multi summary 2"
   Given I create a teacher named "Teacher_1"

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -82,3 +82,62 @@ Scenario: Multi level 2
   Then I click selector "span:contains(Show answer)"
   And I see no difference for "multi level summary 2 show answer"
   And I close my eyes
+
+Scenario: Check for Understanding summaries
+  # Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://code.org/test_dcdo"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
+  Given I create an authorized teacher-associated student named "Sally"
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/"
+  And I type "sample response" into ".free-response > textarea"
+  And I press ".submitButton" using jQuery to load a new page
+
+  When I sign in as "Teacher_Sally" and go home
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
+
+  And I wait until element "#summary-container" is visible
+  And I dismiss the teacher panel
+  And element "#student-response" is visible
+  And element "#student-response" does not contain text "Sally"
+
+  And I click selector "label:contains('Show student names')" once I see it
+  And I wait until the first element "#student-response" contains text "Sally"
+
+  Then I press the first "#student-response-menu-button" element
+  And I wait until element "#student-response-menu" is visible
+
+  Then I press the first "#hide-response-button" element
+  And element "#student-response" is not visible
+  And I wait until element "a:contains('Show hidden responses')" is visible
+
+Scenario: Check for Understanding summaries eyes
+# Turn on cfu pin and hide until it is on by default.
+  Given I am on "http://code.org/test_dcdo"
+  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+
+  When I open my eyes to test "Check for Understanding summaries"
+
+  Given I create an authorized teacher-associated student named "Sally"
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/"
+  And I type "sample response" into ".free-response > textarea"
+  And I press ".submitButton" using jQuery to load a new page
+
+  And I create a student named "Student2"
+  And I join the section
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/"
+  And I type "sample response 2" into ".free-response > textarea"
+  And I press ".submitButton" using jQuery to load a new page
+
+  When I sign in as "Teacher_Sally" and go home
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
+
+  And I wait until element "#summary-container" is visible
+  And I dismiss the teacher panel
+
+  And I see no difference for "Student names hidden"
+
+  And I click selector "label:contains('Show student names')" once I see it
+  And I wait until the first element "#student-response" contains text "Sally"
+
+  And I see no difference for "Student names shown"

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -1,87 +1,91 @@
 @dashboard_db_access
-@eyes
 Feature: Level summary
-
-Scenario: Free Response level 1
-  # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org"
-  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
-
-  # Complex level with many different features in use, including a title h1.
-  When I open my eyes to test "free response summary 1"
-  Given I am a teacher
-  And I create a new student section
-  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
-  And I wait until element "#summary-container" is visible
-  And I wait to see ".uitest-sectionselect"
-  Then I see no difference for "free response level summary 1"
-  And I close my eyes
-
-Scenario: Free Response level 2
-  # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org"
-  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
-
-  # Simpler level with an h2 in the markdown.
-  When I open my eyes to test "free response summary 2"
-  Given I am a teacher
-  And I create a new student section
-  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/2/summary"
-  And I wait until element "#summary-container" is visible
-  And I wait to see ".uitest-sectionselect"
-  Then I see no difference for "free response level summary 2"
-  And I close my eyes
-
-Scenario: Free Response level 3
-  # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org"
-  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
-
-  # Minimal level with no heading, just text and a textarea.
-  When I open my eyes to test "free response summary 3"
-  Given I am a teacher
-  And I create a new student section
-  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/3/summary"
-  And I wait until element "#summary-container" is visible
-  And I wait to see ".uitest-sectionselect"
-  Then I see no difference for "free response level summary 3"
-  And I close my eyes
-
-Scenario: Multi level 1
-  # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org"
-  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
-
-  # Multiple content blocks, images in question and answers
-  When I open my eyes to test "multi summary 1"
-  Given I create a teacher named "Teacher_1"
-  And I give user "Teacher_1" authorized teacher permission
-  And I create a new student section
-  And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/1/summary"
-  And I wait until element "#summary-container" is visible
-  And I wait to see ".uitest-sectionselect"
-  Then I see no difference for "multi level summary 1"
-  Then I click selector "span:contains(Show answer)"
-  And I see no difference for "multi level summary 1 show answer"
-  And I close my eyes
-
-Scenario: Multi level 2
-  # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org"
-  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
-
-  # Markdown in question, images and text in answers, more than 4 answers
-  When I open my eyes to test "multi summary 2"
-  Given I create a teacher named "Teacher_1"
-  And I give user "Teacher_1" authorized teacher permission
-  And I create a new student section
-  And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/4/summary"
-  And I wait until element "#summary-container" is visible
-  And I wait to see ".uitest-sectionselect"
-  Then I see no difference for "multi level summary 2"
-  Then I click selector "span:contains(Show answer)"
-  And I see no difference for "multi level summary 2 show answer"
-  And I close my eyes
+#
+#@eyes
+#Scenario: Free Response level 1
+#  # Turn on cfu pin and hide until it is on by default.
+#  Given I am on "http://studio.code.org"
+#  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+#
+#  # Complex level with many different features in use, including a title h1.
+#  When I open my eyes to test "free response summary 1"
+#  Given I am a teacher
+#  And I create a new student section
+#  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
+#  And I wait until element "#summary-container" is visible
+#  And I wait to see ".uitest-sectionselect"
+#  Then I see no difference for "free response level summary 1"
+#  And I close my eyes
+#
+#@eyes
+#Scenario: Free Response level 2
+#  # Turn on cfu pin and hide until it is on by default.
+#  Given I am on "http://studio.code.org"
+#  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+#
+#  # Simpler level with an h2 in the markdown.
+#  When I open my eyes to test "free response summary 2"
+#  Given I am a teacher
+#  And I create a new student section
+#  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/2/summary"
+#  And I wait until element "#summary-container" is visible
+#  And I wait to see ".uitest-sectionselect"
+#  Then I see no difference for "free response level summary 2"
+#  And I close my eyes
+#
+#@eyes
+#Scenario: Free Response level 3
+#  # Turn on cfu pin and hide until it is on by default.
+#  Given I am on "http://studio.code.org"
+#  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+#
+#  # Minimal level with no heading, just text and a textarea.
+#  When I open my eyes to test "free response summary 3"
+#  Given I am a teacher
+#  And I create a new student section
+#  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/3/summary"
+#  And I wait until element "#summary-container" is visible
+#  And I wait to see ".uitest-sectionselect"
+#  Then I see no difference for "free response level summary 3"
+#  And I close my eyes
+#
+#@eyes
+#Scenario: Multi level 1
+#  # Turn on cfu pin and hide until it is on by default.
+#  Given I am on "http://studio.code.org"
+#  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+#
+#  # Multiple content blocks, images in question and answers
+#  When I open my eyes to test "multi summary 1"
+#  Given I create a teacher named "Teacher_1"
+#  And I give user "Teacher_1" authorized teacher permission
+#  And I create a new student section
+#  And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/1/summary"
+#  And I wait until element "#summary-container" is visible
+#  And I wait to see ".uitest-sectionselect"
+#  Then I see no difference for "multi level summary 1"
+#  Then I click selector "span:contains(Show answer)"
+#  And I see no difference for "multi level summary 1 show answer"
+#  And I close my eyes
+#
+#@eyes
+#Scenario: Multi level 2
+#  # Turn on cfu pin and hide until it is on by default.
+#  Given I am on "http://studio.code.org"
+#  When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
+#
+#  # Markdown in question, images and text in answers, more than 4 answers
+#  When I open my eyes to test "multi summary 2"
+#  Given I create a teacher named "Teacher_1"
+#  And I give user "Teacher_1" authorized teacher permission
+#  And I create a new student section
+#  And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/4/summary"
+#  And I wait until element "#summary-container" is visible
+#  And I wait to see ".uitest-sectionselect"
+#  Then I see no difference for "multi level summary 2"
+#  Then I click selector "span:contains(Show answer)"
+#  And I see no difference for "multi level summary 2 show answer"
+#  And I close my eyes
 
 Scenario: Check for Understanding summaries
   # Turn on cfu pin and hide until it is on by default.
@@ -98,19 +102,21 @@ Scenario: Check for Understanding summaries
 
   And I wait until element "#summary-container" is visible
   And I dismiss the teacher panel
-  And element "#student-response" is visible
-  And element "#student-response" does not contain text "Sally"
+  And element "p:contains('sample response')" is visible
+  And element "p:contains('Sally')" does not exist
 
   And I click selector "label:contains('Show student names')" once I see it
-  And I wait until the first element "#student-response" contains text "Sally"
+  And element "p:contains('Sally')" is visible
 
-  Then I press the first "#student-response-menu-button" element
-  And I wait until element "#student-response-menu" is visible
+  Then I press the first "button[aria-label='Additional options']" element
+  And I wait until element ".uitest-hide-response" is visible
 
-  Then I press the first "#hide-response-button" element
-  And element "#student-response" is not visible
+  Then I press the first ".uitest-hide-response" element
+  And element "p:contains('sample response')" does not exist
+  And element "p:contains('Sally')" does not exist
   And I wait until element "a:contains('Show hidden responses')" is visible
 
+@eyes
 Scenario: Check for Understanding summaries eyes
 # Turn on cfu pin and hide until it is on by default.
   Given I am on "http://studio.code.org"
@@ -138,13 +144,14 @@ Scenario: Check for Understanding summaries eyes
   And I see no difference for "student names hidden"
 
   And I click selector "label:contains('Show student names')" once I see it
-  And I wait until the first element "#student-response" contains text "Sally"
+  And I wait until element "p:contains('Sally')" is visible
 
   And I see no difference for "student names shown"
 
-  Then I press the first "#student-response-menu-button" element
-  And I wait until element "#student-response-menu" is visible
+  Then I press the first "button[aria-label='Additional options']" element
+  And I wait until element ".uitest-hide-response" is visible
 
-  Then I press the first "#pin-response-button" element
+  Then I press the first ".uitest-pin-response" element
 
   And I see no difference for "pinned response"
+  And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -135,9 +135,16 @@ Scenario: Check for Understanding summaries eyes
   And I wait until element "#summary-container" is visible
   And I dismiss the teacher panel
 
-  And I see no difference for "Student names hidden"
+  And I see no difference for "student names hidden"
 
   And I click selector "label:contains('Show student names')" once I see it
   And I wait until the first element "#student-response" contains text "Sally"
 
-  And I see no difference for "Student names shown"
+  And I see no difference for "student names shown"
+
+  Then I press the first "#student-response-menu-button" element
+  And I wait until element "#student-response-menu" is visible
+
+  Then I press the first "#pin-response-button" element
+
+  And I see no difference for "pinned response"

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -4,7 +4,7 @@ Feature: Level summary
 
 Scenario: Free Response level 1
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org/test_dcdo"
+  Given I am on "http://studio.code.org"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   # Complex level with many different features in use, including a title h1.
@@ -19,7 +19,7 @@ Scenario: Free Response level 1
 
 Scenario: Free Response level 2
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org/test_dcdo"
+  Given I am on "http://studio.code.org"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   # Simpler level with an h2 in the markdown.
@@ -34,7 +34,7 @@ Scenario: Free Response level 2
 
 Scenario: Free Response level 3
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org/test_dcdo"
+  Given I am on "http://studio.code.org"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   # Minimal level with no heading, just text and a textarea.
@@ -49,7 +49,7 @@ Scenario: Free Response level 3
 
 Scenario: Multi level 1
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org/test_dcdo"
+  Given I am on "http://studio.code.org"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   # Multiple content blocks, images in question and answers
@@ -67,7 +67,7 @@ Scenario: Multi level 1
 
 Scenario: Multi level 2
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org/test_dcdo"
+  Given I am on "http://studio.code.org"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   # Markdown in question, images and text in answers, more than 4 answers
@@ -85,7 +85,7 @@ Scenario: Multi level 2
 
 Scenario: Check for Understanding summaries
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org/test_dcdo"
+  Given I am on "http://studio.code.org"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   Given I create an authorized teacher-associated student named "Sally"
@@ -113,7 +113,7 @@ Scenario: Check for Understanding summaries
 
 Scenario: Check for Understanding summaries eyes
 # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://studio.code.org/test_dcdo"
+  Given I am on "http://studio.code.org"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   When I open my eyes to test "Check for Understanding summaries"

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -139,7 +139,6 @@ Scenario: Check for Understanding summaries eyes
   And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
 
   And I wait until element "#summary-container" is visible
-  And I dismiss the teacher panel
 
   And I see no difference for "student names hidden"
 

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -4,7 +4,7 @@ Feature: Level summary
 
 Scenario: Free Response level 1
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://code.org/test_dcdo"
+  Given I am on "http://studio.code.org/test_dcdo"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   # Complex level with many different features in use, including a title h1.
@@ -19,7 +19,7 @@ Scenario: Free Response level 1
 
 Scenario: Free Response level 2
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://code.org/test_dcdo"
+  Given I am on "http://studio.code.org/test_dcdo"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   # Simpler level with an h2 in the markdown.
@@ -34,7 +34,7 @@ Scenario: Free Response level 2
 
 Scenario: Free Response level 3
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://code.org/test_dcdo"
+  Given I am on "http://studio.code.org/test_dcdo"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   # Minimal level with no heading, just text and a textarea.
@@ -49,7 +49,7 @@ Scenario: Free Response level 3
 
 Scenario: Multi level 1
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://code.org/test_dcdo"
+  Given I am on "http://studio.code.org/test_dcdo"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   # Multiple content blocks, images in question and answers
@@ -67,7 +67,7 @@ Scenario: Multi level 1
 
 Scenario: Multi level 2
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://code.org/test_dcdo"
+  Given I am on "http://studio.code.org/test_dcdo"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   # Markdown in question, images and text in answers, more than 4 answers
@@ -85,7 +85,7 @@ Scenario: Multi level 2
 
 Scenario: Check for Understanding summaries
   # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://code.org/test_dcdo"
+  Given I am on "http://studio.code.org/test_dcdo"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   Given I create an authorized teacher-associated student named "Sally"
@@ -113,7 +113,7 @@ Scenario: Check for Understanding summaries
 
 Scenario: Check for Understanding summaries eyes
 # Turn on cfu pin and hide until it is on by default.
-  Given I am on "http://code.org/test_dcdo"
+  Given I am on "http://studio.code.org/test_dcdo"
   When I use a cookie to mock the DCDO key "cfu-pin-hide-enabled" as "true"
 
   When I open my eyes to test "Check for Understanding summaries"


### PR DESCRIPTION
* Adds the `cfu-pin-hide-enabled` DCDO flag to existing tests for the summaries page
* Adds a ui test for showing student names and hiding
* Adds an eyes test for showing student names, 2 responses and pinning one response

## Links
[TEACH-1209](https://codedotorg.atlassian.net/browse/TEACH-1209)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
