### PR TITLE
Sanitize introjs UI strings by wrapping them with React

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2364,6 +2364,7 @@
   "rubricTourStepTwoText": "Your AI Teaching Assistant analyzes students’ code for each learning goal, then suggests one or two rubric scores. It will suggest one score for learning goals where it has trained extensively and two scores where more training data is needed. The final score is always up to you. In each case, your AI Teaching Assistant will provide evidence for its suggestion.",
   "rubricTourStepThreeTitle": "Using Evidence",
   "rubricTourStepThreeText": "Where possible, your AI Teaching Assistant will highlight the relevant lines of code in the student’s project so it is easy for you to double-check.",
+  "rubricTourStepThreeAltText": "An example of the AI Teaching Assistant highlighting relevant lines of code in a student's project.",
   "rubricTourStepFourTitle": "Understanding AI Confidence",
   "rubricTourStepFourText": "The confidence rating gives you an idea of how often your AI Teaching Assistant agreed with other teachers when scoring this learning goal. Just like humans, your AI Teaching Assistant isn't perfect.",
   "rubricTourStepFiveTitle": "Assigning a Rubric Score",

--- a/apps/src/templates/rubrics/productTourHelpers.js
+++ b/apps/src/templates/rubrics/productTourHelpers.js
@@ -1,40 +1,61 @@
+import React from 'react';
+
 import i18n from '@cdo/locale';
 import evidenceDemo from '@cdo/static/ai-evidence-demo.gif';
+
+// intro.js-react allows a string or a react component for the intro prop.
+// Providing a string that was written by a translator is risky, because it
+// could contain malicious HTML. This helper method wraps the string in a react
+// component, which will take care of sanitizing the string.
+const sanitize = unsafe => <span>{unsafe}</span>;
 
 export const INITIAL_STEP = 0;
 export const STEPS = [
   {
     element: '#ui-floatingActionButton',
     title: i18n.rubricTourStepOneTitle(),
-    intro: i18n.rubricTourStepOneText(),
+    intro: sanitize(i18n.rubricTourStepOneText()),
   },
   {
     element: '#tour-ai-assessment',
     title: i18n.rubricTourStepTwoTitle(),
-    intro: i18n.rubricTourStepTwoText(),
+    intro: sanitize(i18n.rubricTourStepTwoText()),
   },
   {
     element: '#tour-ai-evidence',
-    title: i18n.rubricTourStepThreeTitle(),
+    title: i18n.rubricTourStepThreeTitle() + ' sanitized',
     position: 'top',
-    intro: `<p>${i18n.rubricTourStepThreeText()}</p><img src=${evidenceDemo}>`,
+    intro: (
+      <span>
+        <p>{i18n.rubricTourStepThreeText()}</p>
+        <img src={evidenceDemo} alt="evidence highlighting example" />
+      </span>
+    ),
   },
   {
     element: '#tour-ai-confidence',
     title: i18n.rubricTourStepFourTitle(),
-    intro: i18n.rubricTourStepFourText(),
+    intro: sanitize(i18n.rubricTourStepFourText()),
   },
   {
     element: '#tour-evidence-levels',
     title: i18n.rubricTourStepFiveTitle(),
-    intro: i18n.rubricTourStepFiveText(),
+    intro: sanitize(i18n.rubricTourStepFiveText()),
   },
   {
     element: '#tour-ai-assessment-feedback',
     title: i18n.rubricTourStepSixTitle(),
-    intro: i18n.rubricTourStepSixText(),
+    intro: sanitize(i18n.rubricTourStepSixText()),
   },
 ];
+
+STEPS.forEach((step, index) => {
+  if (typeof step.intro === 'string') {
+    throw new Error(
+      `Step ${index} intro has type 'string'. Please wrap it in a react component or a call to sanitize().`
+    );
+  }
+});
 
 // Dummy props for product tour
 export const DUMMY_PROPS = {

--- a/apps/src/templates/rubrics/productTourHelpers.js
+++ b/apps/src/templates/rubrics/productTourHelpers.js
@@ -49,14 +49,6 @@ export const STEPS = [
   },
 ];
 
-STEPS.forEach((step, index) => {
-  if (typeof step.intro === 'string') {
-    throw new Error(
-      `Step ${index} intro has type 'string'. Please wrap it in a react component or a call to sanitize().`
-    );
-  }
-});
-
 // Dummy props for product tour
 export const DUMMY_PROPS = {
   rubricDummy: {

--- a/apps/src/templates/rubrics/productTourHelpers.js
+++ b/apps/src/templates/rubrics/productTourHelpers.js
@@ -6,8 +6,8 @@ import evidenceDemo from '@cdo/static/ai-evidence-demo.gif';
 // intro.js-react allows a string or a react component for the intro prop.
 // Providing a string that was written by a translator is risky, because it
 // could contain malicious HTML. This helper method wraps the string in a react
-// component, which will take care of sanitizing the string.
-const sanitize = unsafe => <span>{unsafe}</span>;
+// fragment, which will take care of sanitizing the string.
+const sanitize = unsafe => <>{unsafe}</>;
 
 export const INITIAL_STEP = 0;
 export const STEPS = [
@@ -23,13 +23,13 @@ export const STEPS = [
   },
   {
     element: '#tour-ai-evidence',
-    title: i18n.rubricTourStepThreeTitle() + ' sanitized',
+    title: i18n.rubricTourStepThreeTitle(),
     position: 'top',
     intro: (
-      <span>
+      <>
         <p>{i18n.rubricTourStepThreeText()}</p>
-        <img src={evidenceDemo} alt="evidence highlighting example" />
-      </span>
+        <img src={evidenceDemo} alt={i18n.rubricTourStepThreeAltText()} />
+      </>
     ),
   },
   {

--- a/apps/src/templates/rubrics/productTourHelpers.js
+++ b/apps/src/templates/rubrics/productTourHelpers.js
@@ -1,3 +1,4 @@
+import {stripHtml} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 import evidenceDemo from '@cdo/static/ai-evidence-demo.gif';
 
@@ -5,34 +6,36 @@ export const INITIAL_STEP = 0;
 export const STEPS = [
   {
     element: '#ui-floatingActionButton',
-    title: i18n.rubricTourStepOneTitle(),
-    intro: i18n.rubricTourStepOneText(),
+    title: stripHtml(i18n.rubricTourStepOneTitle()),
+    intro: stripHtml(i18n.rubricTourStepOneText()),
   },
   {
     element: '#tour-ai-assessment',
-    title: i18n.rubricTourStepTwoTitle(),
-    intro: i18n.rubricTourStepTwoText(),
+    title: stripHtml(i18n.rubricTourStepTwoTitle()),
+    intro: stripHtml(i18n.rubricTourStepTwoText()),
   },
   {
     element: '#tour-ai-evidence',
-    title: i18n.rubricTourStepThreeTitle(),
+    title: stripHtml(i18n.rubricTourStepThreeTitle()),
     position: 'top',
-    intro: `<p>${i18n.rubricTourStepThreeText()}</p><img src=${evidenceDemo}>`,
+    intro: `<p>${stripHtml(
+      i18n.rubricTourStepThreeText()
+    )}</p><img src=${evidenceDemo}>`,
   },
   {
     element: '#tour-ai-confidence',
-    title: i18n.rubricTourStepFourTitle(),
-    intro: i18n.rubricTourStepFourText(),
+    title: stripHtml(i18n.rubricTourStepFourTitle()),
+    intro: stripHtml(i18n.rubricTourStepFourText()),
   },
   {
     element: '#tour-evidence-levels',
-    title: i18n.rubricTourStepFiveTitle(),
-    intro: i18n.rubricTourStepFiveText(),
+    title: stripHtml(i18n.rubricTourStepFiveTitle()),
+    intro: stripHtml(i18n.rubricTourStepFiveText()),
   },
   {
     element: '#tour-ai-assessment-feedback',
-    title: i18n.rubricTourStepSixTitle(),
-    intro: i18n.rubricTourStepSixText(),
+    title: stripHtml(i18n.rubricTourStepSixTitle()),
+    intro: stripHtml(i18n.rubricTourStepSixText()),
   },
 ];
 
@@ -44,7 +47,7 @@ export const DUMMY_PROPS = {
       {
         id: 1,
         key: '1',
-        learningGoal: i18n.catVariables(),
+        learningGoal: stripHtml(i18n.catVariables()),
         aiEnabled: true,
         evidenceLevels: [
           {

--- a/apps/src/templates/rubrics/productTourHelpers.js
+++ b/apps/src/templates/rubrics/productTourHelpers.js
@@ -1,4 +1,3 @@
-import {stripHtml} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 import evidenceDemo from '@cdo/static/ai-evidence-demo.gif';
 
@@ -6,36 +5,34 @@ export const INITIAL_STEP = 0;
 export const STEPS = [
   {
     element: '#ui-floatingActionButton',
-    title: stripHtml(i18n.rubricTourStepOneTitle()),
-    intro: stripHtml(i18n.rubricTourStepOneText()),
+    title: i18n.rubricTourStepOneTitle(),
+    intro: i18n.rubricTourStepOneText(),
   },
   {
     element: '#tour-ai-assessment',
-    title: stripHtml(i18n.rubricTourStepTwoTitle()),
-    intro: stripHtml(i18n.rubricTourStepTwoText()),
+    title: i18n.rubricTourStepTwoTitle(),
+    intro: i18n.rubricTourStepTwoText(),
   },
   {
     element: '#tour-ai-evidence',
-    title: stripHtml(i18n.rubricTourStepThreeTitle()),
+    title: i18n.rubricTourStepThreeTitle(),
     position: 'top',
-    intro: `<p>${stripHtml(
-      i18n.rubricTourStepThreeText()
-    )}</p><img src=${evidenceDemo}>`,
+    intro: `<p>${i18n.rubricTourStepThreeText()}</p><img src=${evidenceDemo}>`,
   },
   {
     element: '#tour-ai-confidence',
-    title: stripHtml(i18n.rubricTourStepFourTitle()),
-    intro: stripHtml(i18n.rubricTourStepFourText()),
+    title: i18n.rubricTourStepFourTitle(),
+    intro: i18n.rubricTourStepFourText(),
   },
   {
     element: '#tour-evidence-levels',
-    title: stripHtml(i18n.rubricTourStepFiveTitle()),
-    intro: stripHtml(i18n.rubricTourStepFiveText()),
+    title: i18n.rubricTourStepFiveTitle(),
+    intro: i18n.rubricTourStepFiveText(),
   },
   {
     element: '#tour-ai-assessment-feedback',
-    title: stripHtml(i18n.rubricTourStepSixTitle()),
-    intro: stripHtml(i18n.rubricTourStepSixText()),
+    title: i18n.rubricTourStepSixTitle(),
+    intro: i18n.rubricTourStepSixText(),
   },
 ];
 
@@ -47,7 +44,7 @@ export const DUMMY_PROPS = {
       {
         id: 1,
         key: '1',
-        learningGoal: stripHtml(i18n.catVariables()),
+        learningGoal: i18n.catVariables(),
         aiEnabled: true,
         evidenceLevels: [
           {

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -2,6 +2,7 @@ import Immutable from 'immutable';
 import $ from 'jquery';
 import md5 from 'md5';
 import RGBColor from 'rgbcolor';
+import sanitizeHtml from 'sanitize-html';
 
 import {Position} from './constants';
 import {dataURIFromURI} from './imageUtils';
@@ -114,6 +115,16 @@ export function escapeHtml(unsafe) {
         .replace(/'/g, '&#39;')
         .replace(/\//g, '&#47;')
     : '';
+}
+
+/**
+ * Removes all HTML tags from a string.
+ * @param {string} unsafe - The string to sanitize.
+ */
+export function stripHtml(unsafe) {
+  return sanitizeHtml(unsafe, {
+    allowedTags: [],
+  });
 }
 
 /**

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -2,7 +2,6 @@ import Immutable from 'immutable';
 import $ from 'jquery';
 import md5 from 'md5';
 import RGBColor from 'rgbcolor';
-import sanitizeHtml from 'sanitize-html';
 
 import {Position} from './constants';
 import {dataURIFromURI} from './imageUtils';
@@ -115,16 +114,6 @@ export function escapeHtml(unsafe) {
         .replace(/'/g, '&#39;')
         .replace(/\//g, '&#47;')
     : '';
-}
-
-/**
- * Removes all HTML tags from a string.
- * @param {string} unsafe - The string to sanitize.
- */
-export function stripHtml(unsafe) {
-  return sanitizeHtml(unsafe, {
-    allowedTags: [],
-  });
 }
 
 /**

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -17,6 +17,7 @@ import {
   restoreRedux,
 } from '@cdo/apps/redux';
 import currentUser from '@cdo/apps/templates/currentUserRedux';
+import {STEPS} from '@cdo/apps/templates/rubrics/productTourHelpers';
 import RubricContainer from '@cdo/apps/templates/rubrics/RubricContainer';
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {RubricAiEvaluationStatus} from '@cdo/generated-scripts/sharedConstants';
@@ -1126,5 +1127,14 @@ describe('RubricContainer', () => {
         {}
       )
     );
+  });
+
+  it('sanitizes all intro text rendered by introjs', () => {
+    STEPS.forEach((step, index) => {
+      expect(typeof step.intro).to.equal(
+        'object',
+        `STEP[${index}].intro should be wrapped in a react component or a call to sanitize(): ${step.intro}`
+      );
+    });
   });
 });

--- a/apps/test/unit/utilsTest.js
+++ b/apps/test/unit/utilsTest.js
@@ -13,7 +13,6 @@ const {
   stripEncapsulatingDoubleQuotes,
   wrapNumberValidatorsForLevelBuilder,
   escapeHtml,
-  stripHtml,
   escapeText,
   unescapeText,
   makeEnum,
@@ -322,31 +321,6 @@ describe('utils modules', () => {
 
     it('should not escape regular characters', function () {
       assert.strictEqual(escapeHtml('abc123'), 'abc123');
-    });
-  });
-
-  describe('stripHtml', function () {
-    it('preserves strings without HTML tags', function () {
-      assert.equal('abc 123', stripHtml('abc 123'));
-    });
-
-    it('strips div tags', function () {
-      assert.equal('abc 123', stripHtml('<div>abc</div> 123'));
-    });
-
-    it('strips iframe tags', function () {
-      assert.equal('abc 123', stripHtml('<iframe>abc</iframe> 123'));
-    });
-
-    it('strips b tags', function () {
-      assert.equal('abc 123', stripHtml('<b>abc</b> 123'));
-    });
-
-    it('strips script tag and contents', function () {
-      assert.equal(
-        'abc 123',
-        stripHtml("abc<script>alert('hello')</script> 123")
-      );
     });
   });
 

--- a/apps/test/unit/utilsTest.js
+++ b/apps/test/unit/utilsTest.js
@@ -13,6 +13,7 @@ const {
   stripEncapsulatingDoubleQuotes,
   wrapNumberValidatorsForLevelBuilder,
   escapeHtml,
+  stripHtml,
   escapeText,
   unescapeText,
   makeEnum,
@@ -321,6 +322,31 @@ describe('utils modules', () => {
 
     it('should not escape regular characters', function () {
       assert.strictEqual(escapeHtml('abc123'), 'abc123');
+    });
+  });
+
+  describe('stripHtml', function () {
+    it('preserves strings without HTML tags', function () {
+      assert.equal('abc 123', stripHtml('abc 123'));
+    });
+
+    it('strips div tags', function () {
+      assert.equal('abc 123', stripHtml('<div>abc</div> 123'));
+    });
+
+    it('strips iframe tags', function () {
+      assert.equal('abc 123', stripHtml('<iframe>abc</iframe> 123'));
+    });
+
+    it('strips b tags', function () {
+      assert.equal('abc 123', stripHtml('<b>abc</b> 123'));
+    });
+
+    it('strips script tag and contents', function () {
+      assert.equal(
+        'abc 123',
+        stripHtml("abc<script>alert('hello')</script> 123")
+      );
     });
   });
 


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-612

Per discussion in [slack](https://codedotorg.slack.com/archives/CFTFD6BPV/p1721852673658879), the normal way to guard against potentially malicious HTML is to render it via React. today we are rendering some introjs strings without react, which exposes us to an XSS vulnerability (see screenshots). Fortunately, introjs also provides the option to pass a React component instead, which will take care of sanitizing the string.

## Screenshots

To see how this change addresses the issue, I temporarily added some malicious HTML to one of the product tour translations:
```diff
-  "rubricTourStepOneText": "Launch your AI Teaching Assistant from the bottom left corner of the screen.",
+  "rubricTourStepOneText": "Launch your AI Teaching Assistant from the bottom left corner of the screen. <img src=\"bogus\" onerror=\"alert('XSS')\" />",
```

### before

![Screenshot 2024-07-25 at 1 55 20 PM](https://github.com/user-attachments/assets/4f0d6b1c-f592-49fd-bcfa-7572e3791d9e)

### after

![Screenshot 2024-07-25 at 1 56 25 PM](https://github.com/user-attachments/assets/cc9dddbd-48f6-403c-a110-c57683cbc676)

## Testing story

* verified this protects against malicious HTML, as shown in screenshots
* added validation to ensure introjs step `intro` values are always wrapped in React components
* manually verified that the product tour still looks the same with this change, including step 3 which includes some legit HTML
