### PR TITLE
stop serializing self_paced_pl_course_offering_id to course_offerings json

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -371,7 +371,6 @@ class CourseOffering < ApplicationRecord
       professional_learning_program: professional_learning_program,
       video: video,
       published_date: published_date,
-      self_paced_pl_course_offering_id: self_paced_pl_course_offering_id,
       self_paced_pl_course_offering_key: self_paced_pl_course_offering&.key,
     }
   end


### PR DESCRIPTION
One-line change to eliminate some clutter from our local git clients after running `rake seed` with levelbuilder_mode enabled:
![Screenshot 2024-07-24 at 8 28 29 PM](https://github.com/user-attachments/assets/e0381b12-691f-4c0f-8878-88f600aa6683)

the hard work was already done in earlier PRs to change what we use in the course_offerings json from `self_paced_pl_course_offering_id` to `self_paced_pl_course_offering_key`, since only the key is stable across environments:
* https://github.com/code-dot-org/code-dot-org/pull/53739
* https://github.com/code-dot-org/code-dot-org/pull/53765

This PR is just a cleanup PR to eliminate the unused field from the serialized format.

## Testing story

* `rake seed:course_offerings` and `rake seed:course_offering_ui_tests` are passing locally
* existing test coverage

# Follow-up work

- [x] wait for this change to reach levelbuilder, then run `CourseOffering.all.each(&:write_serialization)`, to remove self_paced_pl_course_offering_id from all existing serialization files