### PR TITLE
chore: remove dependency on csv-parse as it no longer used

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -232,7 +232,6 @@
     "classnames": "^2.3.2",
     "codemirror": "5.5",
     "codemirror-spell-checker": "^1.1.2",
-    "csv-parse": "^4.4.6",
     "dapjs": "^2.3.0",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "ejs": "^3.1.10",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8284,7 +8284,6 @@ __metadata:
     codemirror-spell-checker: ^1.1.2
     copy-webpack-plugin: ^9.0.1
     css-loader: ^6.2.0
-    csv-parse: ^4.4.6
     dapjs: ^2.3.0
     dedent: ^1.5.1
     details-element-polyfill: "https://github.com/javan/details-element-polyfill"
@@ -10194,13 +10193,6 @@ canvg@gabelerner/canvg:
   version: 3.0.8
   resolution: "csstype@npm:3.0.8"
   checksum: 5939a003858a31a32cbc52a8f45496aa0c2bcb4629b21c5bc14a7ddcac1a3d4adfd655f56843dc14940f60563378e9444af2c9c373b3f212601b9eeb6740b8db
-  languageName: node
-  linkType: hard
-
-"csv-parse@npm:^4.4.6":
-  version: 4.4.6
-  resolution: "csv-parse@npm:4.4.6"
-  checksum: 09c37cd2f0179dd420338eb21823bf3cae221ae25e3558d6cecccc0654e6c5e019f34f0f3ce5c7f84cee2cd833e42d48b53e1993c0bcbddfdb7ce07a6760e19c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
csv-parse was used for firebase storage but firebase has now been removed.


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

Original usage of `csv-parse` (one location only): https://github.com/code-dot-org/code-dot-org/blob/a010a9a32358c0b4e5669dc33fecc405b01e989b/apps/src/storage/firebaseStorage.js#L3

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
