### PR TITLE
chore: remove unused `node-js-marker-clusterer` dep

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -135,7 +135,6 @@
     "magicast": "^0.3.3",
     "mocha": "^10.6.0",
     "mock-firmata": "0.2.0",
-    "node-js-marker-clusterer": "^1.0.0",
     "prettier": "2.8.7",
     "process": "^0.11.10",
     "progress-bar-webpack-plugin": "^2.1.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8366,7 +8366,6 @@ __metadata:
     mocha: ^10.6.0
     mock-firmata: 0.2.0
     moment: ^2.29.4
-    node-js-marker-clusterer: ^1.0.0
     object-fit-images: ^3.2.3
     pa11y-ci: ^2.3.0
     path-browserify: ^1.0.1
@@ -19025,13 +19024,6 @@ es6-shim@latest:
   version: 0.4.0
   resolution: "node-int64@npm:0.4.0"
   checksum: d0b30b1ee6d961851c60d5eaa745d30b5c95d94bc0e74b81e5292f7c42a49e3af87f1eb9e89f59456f80645d679202537de751b7d72e9e40ceea40c5e449057e
-  languageName: node
-  linkType: hard
-
-"node-js-marker-clusterer@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "node-js-marker-clusterer@npm:1.0.0"
-  checksum: 6474cc2a082f76915fc49cb3a72c6d4a8b87a26206fd074c04266f613288c6b9e0ec63e23f5f0f173ba66627f8094077472dd67eca8c5a1594ff8c8fa7641c5d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This dependency was used in the workshop search feature but was removed a while back. 


## Links

Only usage was removed in 2020: 

https://github.com/code-dot-org/code-dot-org/commit/c2937bc9478e8bed477920ed87621efb75a8db12

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
