### PR TITLE
chore: remove unused `react-addons-test-utils` dependency

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -139,7 +139,6 @@
     "prettier": "2.8.7",
     "process": "^0.11.10",
     "progress-bar-webpack-plugin": "^2.1.0",
-    "react-addons-test-utils": "~15.4.0",
     "react-refresh": "^0.14.0",
     "react-refresh-typescript": "^2.0.9",
     "redux-mock-store": "^1.2.3",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8384,7 +8384,6 @@ __metadata:
     query-string: 4.1.0
     radium: ^0.25.2
     react: ^17.0.2
-    react-addons-test-utils: ~15.4.0
     react-beautiful-dnd: ^13.1.0
     react-bootstrap: ^0.33.1
     react-bootstrap-2: "npm:react-bootstrap@^2.7.4"
@@ -12791,21 +12790,6 @@ es6-shim@latest:
   dependencies:
     bser: 2.1.1
   checksum: b15a124cef28916fe07b400eb87cbc73ca082c142abf7ca8e8de6af43eca79ca7bd13eb4d4d48240b3bd3136eaac40d16e42d6edf87a8e5d1dd8070626860c78
-  languageName: node
-  linkType: hard
-
-"fbjs@npm:^0.8.4":
-  version: 0.8.18
-  resolution: "fbjs@npm:0.8.18"
-  dependencies:
-    core-js: ^1.0.0
-    isomorphic-fetch: ^2.1.1
-    loose-envify: ^1.0.0
-    object-assign: ^4.1.0
-    promise: ^7.1.1
-    setimmediate: ^1.0.5
-    ua-parser-js: ^0.7.30
-  checksum: 668731b946a765908c9cbe51d5160f973abb78004b3d122587c3e930e3e1ddcc0ce2b17f2a8637dc9d733e149aa580f8d3035a35cc2d3bc78b78f1b19aab90e2
   languageName: node
   linkType: hard
 
@@ -21286,18 +21270,6 @@ es6-shim@latest:
   bin:
     rc: ./cli.js
   checksum: 2e26e052f8be2abd64e6d1dabfbd7be03f80ec18ccbc49562d31f617d0015fbdbcf0f9eed30346ea6ab789e0fdfe4337f033f8016efdbee0df5354751842080e
-  languageName: node
-  linkType: hard
-
-"react-addons-test-utils@npm:~15.4.0":
-  version: 15.4.2
-  resolution: "react-addons-test-utils@npm:15.4.2"
-  dependencies:
-    fbjs: ^0.8.4
-    object-assign: ^4.1.0
-  peerDependencies:
-    react-dom: ^15.4.2
-  checksum: 5855faac602d21b7c5be16d90fea6d1998d635182ec1a10d52034db1868b4b1f9da9e54cf967004dd42637b0b2fdfdfffc7b597af08465407b495675c21307dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`react-addons-test-utils` as added as part of the [webpack 5 upgrade](https://github.com/code-dot-org/code-dot-org/commit/1b14c3772c4049dd0a0ad5492d63e8765315925f) but the code base does not import any of the libraries from `react-addons-test-utils`. Additionally, the package is now deprecated and supplemented by `react-dom/test-utils` which is also not used in the repository. As such, remove the dependency.

## Links

N/A

## Testing story

Drone

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
