### PR TITLE
Renames And I Wait For the Page To Fully Load to be more specific

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/hoc_guide_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/hoc_guide_dialog.feature
@@ -11,7 +11,7 @@ Feature: HOC Guide Email Conversion Dialog
     Then I am on "http://studio.code.org/s/allthethings/lessons/37/levels/2?noautoplay=true"
     And I see no difference for "signedInGuide"
     And I dismiss the hoc guide dialog
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I close my eyes
 
   Scenario: Send Email as signed In Instructor
@@ -24,7 +24,7 @@ Feature: HOC Guide Email Conversion Dialog
   Scenario: View Dialog and send Email as signed out User
     When I open my eyes to test "dialogForSignedOutInstructor"
     Given I am on "http://studio.code.org/s/allthethings/lessons/37/levels/2?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for 3 seconds
     And I wait until I don't see selector "#p5_loading"
     And I select age 21 in the age dialog

--- a/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor.feature
+++ b/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor.feature
@@ -3,7 +3,7 @@ Feature: Modal Function Editor
 
 Background:
   Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/3?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait for 3 seconds
   And I wait until I don't see selector "#p5_loading"
   And I close the instructions overlay if it exists

--- a/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor_eyes.feature
+++ b/dashboard/test/ui/features/code_tools/google_blockly/modal_function_editor_eyes.feature
@@ -4,7 +4,7 @@ Feature: Modal Function Editor Eyes
 
 Background:
   Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/3?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait for 3 seconds
   And I wait until I don't see selector "#p5_loading"
   And I close the instructions overlay if it exists

--- a/dashboard/test/ui/features/code_tools/google_blockly/spritelab_eyes.feature
+++ b/dashboard/test/ui/features/code_tools/google_blockly/spritelab_eyes.feature
@@ -4,7 +4,7 @@ Feature: Google Blockly Sprite Lab Eyes
 
 Background:
   Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/4?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait for 3 seconds
   And I wait until I don't see selector "#p5_loading"
   And I close the instructions overlay if it exists

--- a/dashboard/test/ui/features/eyes.feature
+++ b/dashboard/test/ui/features/eyes.feature
@@ -47,14 +47,14 @@ Scenario:
 Scenario:
   When I open my eyes to test "maze"
   Given I am on "http://studio.code.org/s/allthethings/lessons/2/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press "runButton"
   And I wait until element ".uitest-topInstructions-inline-feedback" is visible
   And element ".uitest-topInstructions-inline-feedback" is visible
   And I see no difference for "maze feedback with blocks"
 
   Then I am on "http://studio.code.org/s/allthethings/lessons/2/levels/1/lang/ar-sa"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And The header is finished animating
   And I see no difference for "maze RTL"
   Given I am on "http://studio.code.org/reset_session/lang/en"

--- a/dashboard/test/ui/features/foundations/footer.feature
+++ b/dashboard/test/ui/features/foundations/footer.feature
@@ -4,7 +4,7 @@ Feature: Checking the footer appearance
   Scenario: Desktop puzzle using light small footer
     When I open my eyes to test "Desktop puzzle using light small footer"
     Given I am on "http://studio.code.org/s/allthethings/lessons/2/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
     Then I see no difference for "small footer"
 
@@ -39,7 +39,7 @@ Feature: Checking the footer appearance
   Scenario: Desktop Minecraft puzzle using dark small footer
     When I open my eyes to test "Desktop Minecraft puzzle using dark small footer"
     Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
     Then I see no difference for "small footer"
 
@@ -53,7 +53,7 @@ Feature: Checking the footer appearance
   Scenario: Desktop Star Wars share small footer
     When I open my eyes to test "Desktop Star Wars share small footer"
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/15?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I press "runButton"
     And I wait until element "#finishButton" is visible
     And I press "finishButton"
@@ -88,7 +88,7 @@ Feature: Checking the footer appearance
   Scenario: Desktop Minecraft share small footer
     When I open my eyes to test "Desktop Minecraft share small footer"
     Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I press "runButton"
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
@@ -144,7 +144,7 @@ Feature: Checking the footer appearance
   Scenario: Mobile Star Wars share small footer
     When I open my eyes to test "Mobile Star Wars share small footer"
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/15?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I press "runButton"
     And I wait until element "#finishButton" is visible
     And I press "finishButton"
@@ -173,7 +173,7 @@ Feature: Checking the footer appearance
   Scenario: Mobile Minecraft share small footer
     When I open my eyes to test "Mobile Minecraft share small footer"
     Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I press "runButton"
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I rotate to portrait

--- a/dashboard/test/ui/features/foundations/i18n.feature
+++ b/dashboard/test/ui/features/foundations/i18n.feature
@@ -3,7 +3,7 @@ Feature: Hour of Code, Frozen, and Minecraft:Agent tutorials in various language
 
 Scenario: HoC tutorial in Spanish
   Given I am on "http://studio.code.org/hoc/15/lang/es-MX"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".csf-top-instructions p" has "es-MX" text from key "data.level.instructions.maze_2_14"
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
@@ -11,7 +11,7 @@ Scenario: HoC tutorial in Spanish
 
 Scenario: Frozen tutorial in Spanish
   Given I am on "http://studio.code.org/s/frozen/lessons/1/levels/2/lang/es-MX"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".csf-top-instructions p" has "es-MX" text from key "data.short_instructions.frozen perpendicular"
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
@@ -19,7 +19,7 @@ Scenario: Frozen tutorial in Spanish
 
 Scenario: Minecraft:Agent tutorial in Spanish
   Given I am on "http://studio.code.org/s/hero/lessons/1/levels/1/lang/es-MX"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element "#toggleButton" is visible
   And I click selector "#toggleButton"
   And I wait until element ".csf-top-instructions p" is visible
@@ -27,7 +27,7 @@ Scenario: Minecraft:Agent tutorial in Spanish
 
 Scenario: Toolbox Categories in Spanish
   Given I am on "http://studio.code.org/s/allthethings/lessons/3/levels/7/lang/es-MX"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".blocklyTreeRoot #\\\:1" has "es-MX" text from key "data.block_categories.Actions"
   Then element ".blocklyTreeRoot #\\\:2" has "es-MX" text from key "data.block_categories.Color"
   Then element ".blocklyTreeRoot #\\\:3" has "es-MX" text from key "data.block_categories.Category"
@@ -40,7 +40,7 @@ Scenario: Toolbox Categories in Spanish
 
 Scenario: Translated function names in Spanish
   Given I am on "http://studio.code.org/s/allthethings/lessons/3/levels/3/lang/es-MX"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   # Toolbox call block is translated
   Then element "[block-id=6] .blocklyText" has "es-MX" text from key "data.function_definitions.2-3 Artist Functions 4.draw a square.name"
   # Workspace call block is translated
@@ -50,7 +50,7 @@ Scenario: Translated function names in Spanish
 
 Scenario: HoC tutorial in Portuguese
   Given I am on "http://studio.code.org/hoc/15/lang/pt-br"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".csf-top-instructions p" has "pt-BR" text from key "data.level.instructions.maze_2_14"
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
@@ -59,7 +59,7 @@ Scenario: HoC tutorial in Portuguese
 @no_circle
 Scenario: Frozen tutorial in Portuguese
   Given I am on "http://studio.code.org/s/frozen/lessons/1/levels/2/lang/pt-br"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".csf-top-instructions p" has "pt-BR" text from key "data.short_instructions.frozen perpendicular"
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
@@ -67,7 +67,7 @@ Scenario: Frozen tutorial in Portuguese
 
 Scenario: Minecraft:Agent tutorial in Portuguese
   Given I am on "http://studio.code.org/s/hero/lessons/1/levels/1/lang/pt-br"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element "#toggleButton" is visible
   And I click selector "#toggleButton"
   And I wait until element ".csf-top-instructions p" is visible
@@ -75,7 +75,7 @@ Scenario: Minecraft:Agent tutorial in Portuguese
 
 Scenario: Toolbox Categories in Portuguese
   Given I am on "http://studio.code.org/s/allthethings/lessons/3/levels/7/lang/pt-br"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".blocklyTreeRoot #\\:1" has "pt-BR" text from key "data.block_categories.Actions"
   Then element ".blocklyTreeRoot #\\:2" has "pt-BR" text from key "data.block_categories.Color"
   Then element ".blocklyTreeRoot #\\:3" has "pt-BR" text from key "data.block_categories.Category"
@@ -88,7 +88,7 @@ Scenario: Toolbox Categories in Portuguese
 
 Scenario: Translated function names in Portuguese
   Given I am on "http://studio.code.org/s/allthethings/lessons/3/levels/3/lang/pt-BR"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   # Toolbox call block is translated
   Then element "[block-id=6] .blocklyText" has "pt-BR" text from key "data.function_definitions.2-3 Artist Functions 4.draw a square.name"
   # Workspace call block is translated
@@ -98,7 +98,7 @@ Scenario: Translated function names in Portuguese
 
 Scenario: HoC tutorial in Arabic (RTL)
   Given I am on "http://studio.code.org/hoc/15/lang/ar-sa"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".csf-top-instructions p" has "ar-SA" text from key "data.level.instructions.maze_2_14"
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
@@ -106,7 +106,7 @@ Scenario: HoC tutorial in Arabic (RTL)
 
 Scenario: Frozen tutorial in Arabic (RTL)
   Given I am on "http://studio.code.org/s/frozen/lessons/1/levels/2/lang/ar-sa"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".csf-top-instructions p" has "ar-SA" text from key "data.short_instructions.frozen perpendicular"
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
@@ -114,7 +114,7 @@ Scenario: Frozen tutorial in Arabic (RTL)
 
 Scenario: Minecraft:Agent tutorial in Arabic (RTL)
   Given I am on "http://studio.code.org/s/hero/lessons/1/levels/1/lang/ar-sa"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element "#toggleButton" is visible
   And I click selector "#toggleButton"
   And I wait until element ".csf-top-instructions p" is visible
@@ -122,7 +122,7 @@ Scenario: Minecraft:Agent tutorial in Arabic (RTL)
 
 Scenario: Translated function names in Arabic
   Given I am on "http://studio.code.org/s/allthethings/lessons/3/levels/3/lang/ar-SA"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   # Toolbox call block is translated
   Then element "[block-id=6] .blocklyText" has "ar-SA" text from key "data.function_definitions.2-3 Artist Functions 4.draw a square.name"
   # Workspace call block is translated
@@ -132,7 +132,7 @@ Scenario: Translated function names in Arabic
 
 Scenario: Toolbox Categories in Arabic (RTL)
   Given I am on "http://studio.code.org/s/allthethings/lessons/3/levels/7/lang/ar-sa"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".blocklyTreeRoot #\\:1" has "ar-SA" text from key "data.block_categories.Actions"
   Then element ".blocklyTreeRoot #\\:2" has "ar-SA" text from key "data.block_categories.Color"
   Then element ".blocklyTreeRoot #\\:3" has "ar-SA" text from key "data.block_categories.Category"

--- a/dashboard/test/ui/features/foundations/markdown_rendering.feature
+++ b/dashboard/test/ui/features/foundations/markdown_rendering.feature
@@ -11,13 +11,13 @@ Feature: Markdown rendering across the website
   Scenario: Viewing a level with blockly embedded in instructions
     When I open my eyes to test "Blockly in instructions"
     And I am on "http://studio.code.org/s/allthethings/lessons/21/levels/2?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I see no difference for "basic embedded blockly"
     And I close my eyes
 
     When I open my eyes to test "Blockly in K1 instructions"
     And I am on "http://studio.code.org/s/allthethings/lessons/21/levels/3?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I see no difference for "K1 embedded blockly"
     And I close my eyes
 

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
@@ -5,7 +5,7 @@ Background:
 
 Scenario: Solving puzzle 1, proceeding to puzzle 2, verifying that puzzle 1 appears as solved
   Given I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I drag block "moveForward" to block "startBlock"
   And I press "runButton"
   Then I wait to see ".modal"
@@ -14,7 +14,7 @@ Scenario: Solving puzzle 1, proceeding to puzzle 2, verifying that puzzle 1 appe
   ## Verify that closing doesn't redirect to the next level
   Then check that I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
   Then I am on "http://studio.code.org/hoc/2?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I verify progress in the header of the current page is "perfect" for level 1
   # Course overview should also show progress
   Then I navigate to the course page for "hourofcode"
@@ -26,22 +26,22 @@ Scenario: Solving puzzle 1, proceeding to puzzle 2, verifying that puzzle 1 appe
   # Level source is saved
   Then I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
   Then I wait until I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And block "moveForward" is child of block "startBlock"
   # Level source is reset
   Then I am on "http://studio.code.org/hoc/reset"
   Then I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
   Then I wait until I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element "g[data-id=\'startBlock\'] g[data-id=\'moveForward\']" does not exist
 
 Scenario: Failing at puzzle 1, refreshing puzzle 1, bubble should show up as attempted
   Given I am on "http://studio.code.org/hoc/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press "runButton"
   Then I wait to see ".uitest-topInstructions-inline-feedback"
   Then I reload the page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I verify progress in the header of the current page is "attempted" for level 1
   And I navigate to the course page for "hourofcode"
   And I verify progress for lesson 1 level 1 is "attempted"
@@ -53,20 +53,20 @@ Scenario: Go to puzzle 10, see video, go somewhere else, return to puzzle 10, sh
   Then I close the dialog
   Then I am on "http://studio.code.org/hoc/11"
   Then I wait until I am on "http://studio.code.org/hoc/11"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I am on "http://studio.code.org/hoc/10"
   Then I wait until I am on "http://studio.code.org/hoc/10"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I click selector ".reference_area a:last"
 
 Scenario: Go to puzzle 9, see callouts, go somewhere else, return to puzzle 9, should not see callouts
   Given I am on "http://studio.code.org/hoc/9?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".qtip-content:contains('Blocks that are grey')" is visible
   Then I am on "http://studio.code.org/hoc/10?noautoplay=true"
   Then I wait until I am on "http://studio.code.org/hoc/10?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I am on "http://studio.code.org/hoc/9?noautoplay=true"
   Then I wait until I am on "http://studio.code.org/hoc/9?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".qtip-content:contains('Blocks that are grey')" does not exist

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
@@ -3,14 +3,14 @@ Feature: Hour of Code tests for users that are signed in
 
 Scenario:
   Given I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I drag block "moveForward" to block "startBlock"
   And I press "runButton"
   Then I wait to see ".modal"
   And element ".modal .congrats" contains text "You completed Puzzle 1."
   And I press "continue-button"
   Then I wait until I am on "http://studio.code.org/hoc/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I verify progress in the header of the current page is "perfect" for level 1
   # Course overview should also show progress
   Then I navigate to the course page for "hourofcode"
@@ -20,26 +20,26 @@ Scenario:
   And I verify progress in the header of the current page is "not_tried" for level 1
   # Level source is saved
   Then I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And block "moveForward" is child of block "startBlock"
   # Level source is reset
   Then I am on "http://studio.code.org/hoc/reset"
   Then I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And block "moveForward" is child of block "startBlock"
 
 Scenario: Failing at puzzle 6, refreshing puzzle 6, bubble should show up as attempted
   Given I am on "http://studio.code.org/hoc/6?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press "runButton"
   Then I wait to see ".uitest-topInstructions-inline-feedback"
   Then I reload the page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I verify progress in the header of the current page is "attempted" for level 6
 
 Scenario: Progress on the server that is not on the client
   Given I am on "http://studio.code.org/hoc/20?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I verify progress in the header of the current page is "not_tried" for level 20
   And I press "runButton"
   Then I am on "http://studio.code.org/hoc/reset"
@@ -51,7 +51,7 @@ Scenario: Progress on the server that is not on the client
 @no_mobile
 Scenario: Go to puzzle 10, see video, go somewhere else, return to puzzle 10, should not see video
   Given I am on "http://studio.code.org/hoc/10"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I wait until element ".video-modal" is visible
   Then I close the dialog
   Then I am on "http://studio.code.org/hoc/11"
@@ -59,7 +59,7 @@ Scenario: Go to puzzle 10, see video, go somewhere else, return to puzzle 10, sh
 
 Scenario: Go to puzzle 9, see callouts, go somewhere else, return to puzzle 9, should not see callouts
   Given I am on "http://studio.code.org/hoc/9?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element ".qtip-content:contains('Blocks that are grey')" is visible
   Then I am on "http://studio.code.org/hoc/10?noautoplay=true"
   Then I am on "http://studio.code.org/hoc/9?noautoplay=true"

--- a/dashboard/test/ui/features/hour_of_code/minecraft_codebuilder.feature
+++ b/dashboard/test/ui/features/hour_of_code/minecraft_codebuilder.feature
@@ -10,7 +10,7 @@ Scenario: Importing an Agent level from a share link
   # Create a new level source
   #
   Given I am on "http://studio.code.org/s/allthethings/lessons/25/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element "#runButton" is visible
 
   Then I drag block "13" to block "10"
@@ -25,7 +25,7 @@ Scenario: Importing an Agent level from a share link
   #
   When I am on "http://studio.code.org/projects/minecraft_codebuilder/"
   And I get redirected to "/projects/minecraft_codebuilder/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element "#runButton" is visible
 
   # We expect this to load the "Minecraft not connected" dialog, so close it
@@ -41,7 +41,7 @@ Scenario: Importing an Agent level from a share link
   # Verify import succeeded
   #
   When I get redirected away from the current page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element "#runButton" is visible
 
   Then block "2" is child of block "1"
@@ -52,7 +52,7 @@ Scenario: Importing an Agent level from a project link
   #
   Given I am on "http://studio.code.org/projects/minecraft_hero/"
   And I get redirected to "/projects/minecraft_hero/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press "x-close"
   And I close the instructions overlay if it exists
   And element "#runButton" is visible
@@ -68,7 +68,7 @@ Scenario: Importing an Agent level from a project link
   #
   When I am on "http://studio.code.org/projects/minecraft_codebuilder/"
   And I get redirected to "/projects/minecraft_codebuilder/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element "#runButton" is visible
 
   # We expect this to load the "Minecraft not connected" dialog, so close it
@@ -84,7 +84,7 @@ Scenario: Importing an Agent level from a project link
   # Verify import succeeded
   #
   When I get redirected away from the current page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element "#runButton" is visible
 
   Then block "2" is child of block "1"

--- a/dashboard/test/ui/features/hour_of_code/starwars.feature
+++ b/dashboard/test/ui/features/hour_of_code/starwars.feature
@@ -7,20 +7,20 @@ Feature: Hour of Code 2015 tutorial is completable
     And execute JavaScript expression "window.localStorage.clear()"
     And I am on "http://studio.code.org/s/starwars/lessons/1/levels/1?noautoplay=true"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     When I drag droplet block "moveRight" to line 2
     And I press "runButton"
     And I wait to see ".modal"
     Then element "#continue-button" is visible
     And I press "continue-button"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "perfect" for level 1
 
   Scenario: Solving puzzle 1 in text mode
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/1?noautoplay=true"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/1?noautoplay=true"
-    Then I wait for the page to fully load
+    Then I wait for the lab page to fully load
     When I ensure droplet is in text mode
     And I append text to droplet "moveRight();\n"
     And I press "runButton"
@@ -28,13 +28,13 @@ Feature: Hour of Code 2015 tutorial is completable
     Then element "#continue-button" is visible
     And I press "continue-button"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "perfect" for level 1
 
   Scenario: Solving puzzle 2 in text mode
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/2?noautoplay=true"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/2?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     When I ensure droplet is in text mode
     And I append text to droplet "moveRight();\n"
     And I append text to droplet "moveDown();\n"
@@ -46,7 +46,7 @@ Feature: Hour of Code 2015 tutorial is completable
   Scenario: Solving puzzle 3 in text mode
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/3?noautoplay=true"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/3?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait until element "#continue-button" is not visible
     When I ensure droplet is in text mode
     And I append text to droplet "moveUp();\n"
@@ -61,7 +61,7 @@ Feature: Hour of Code 2015 tutorial is completable
   Scenario: Solving puzzle 4 in text mode
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/4?noautoplay=true"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/4?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     When I append text to droplet "moveLeft();\n"
     And I append text to droplet "moveLeft();\n"
     And I append text to droplet "moveDown();\n"
@@ -74,7 +74,7 @@ Feature: Hour of Code 2015 tutorial is completable
   Scenario: Solving puzzle 5 in text mode
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/5?noautoplay=true"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/5?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I append text to droplet "moveRight();\n"
     And I append text to droplet "moveDown();\n"
     And I append text to droplet "moveDown();\n"
@@ -87,7 +87,7 @@ Feature: Hour of Code 2015 tutorial is completable
   Scenario: Solving puzzle 6 in text mode
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/6?noautoplay=true"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/6?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     When I ensure droplet is in text mode
     And I append text to droplet "moveDown();\n"
     And I append text to droplet "moveUp();\n"
@@ -106,7 +106,7 @@ Feature: Hour of Code 2015 tutorial is completable
   Scenario: Failing puzzle 5 by touching hazard
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/5?noautoplay=true"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/5?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I append text to droplet "moveLeft();\n"
     And I append text to droplet "moveLeft();\n"
     And I append text to droplet "moveDown();\n"
@@ -128,7 +128,7 @@ Feature: Hour of Code 2015 tutorial is completable
     And execute JavaScript expression "window.localStorage.clear()"
     And I am on "http://studio.code.org/s/starwars/lessons/1/levels/1?noautoplay=true"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     When I drag droplet block "moveUp" to line 2
     And I drag droplet block "moveLeft" to line 3
     And I drag droplet block "moveDown" to line 4
@@ -141,7 +141,7 @@ Feature: Hour of Code 2015 tutorial is completable
     And execute JavaScript expression "window.localStorage.clear()"
     And I am on "http://studio.code.org/s/starwars/lessons/1/levels/1?noautoplay=true"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     When I ensure droplet is in text mode
     And I append text to droplet "moveUp();\n"
     And I append text to droplet "moveLeft();\n"

--- a/dashboard/test/ui/features/initial_page_views.feature
+++ b/dashboard/test/ui/features/initial_page_views.feature
@@ -9,7 +9,7 @@ Feature: Looking at a few things with Applitools Eyes - Part 1
     And I am a student
     When I open my eyes to test "<test_name>"
     And I am on "<url>"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I see no difference for "initial load"
     And I close my eyes
     And I sign out

--- a/dashboard/test/ui/features/initial_page_views_csf.feature
+++ b/dashboard/test/ui/features/initial_page_views_csf.feature
@@ -9,7 +9,7 @@ Feature: Looking at a few things with Applitools Eyes - CSF Levels
     And I am a student
     When I open my eyes to test "<test_name>"
     And I am on "<url>"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I see no difference for "initial load"
     And I close my eyes
     And I sign out

--- a/dashboard/test/ui/features/javalab/console_only.feature
+++ b/dashboard/test/ui/features/javalab/console_only.feature
@@ -6,7 +6,7 @@ Feature: Console only level
     When I open my eyes to test "Javalab Console Only Level"
     Given I create a levelbuilder named "Simone"
     And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I dismiss the teacher panel
     Then I press "#levelbuilder-menu-toggle" using jQuery
     And I see no difference for "initial page load" using stitch mode "none"

--- a/dashboard/test/ui/features/javalab/javalab_demo_mode.feature
+++ b/dashboard/test/ui/features/javalab/javalab_demo_mode.feature
@@ -10,7 +10,7 @@ Feature: Javalab Demo Mode
     When I open my eyes to test "Javalab Demo Mode"
     Given I create a teacher named "Ms_Frizzle"
     And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/4"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I dismiss the teacher panel
     When I press "runButton"
     And I wait to see a modal containing text "Please confirm you're human"

--- a/dashboard/test/ui/features/javalab/javalab_submittable.feature
+++ b/dashboard/test/ui/features/javalab/javalab_submittable.feature
@@ -46,7 +46,7 @@ Scenario: Submit anything, teacher is able to unsubmit
   And I press "#unsubmit-button-uitest" using jQuery to load a new page
 
   # Unsubmit should be disabled now
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait to see ".show-handle"
   And I wait until element ".student-table" is visible
   Then I wait until element "#unsubmit-button-uitest" is visible

--- a/dashboard/test/ui/features/javalab/neighborhood.feature
+++ b/dashboard/test/ui/features/javalab/neighborhood.feature
@@ -6,7 +6,7 @@ Feature: NeighborhoodPainting
     When I open my eyes to test "Javalab Neighborhood Paint Glomming"
     Given I create a levelbuilder named "Simone"
     And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/7"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I dismiss the teacher panel
     Then I press "#levelbuilder-menu-toggle" using jQuery
     Then I set slider speed to fast
@@ -20,7 +20,7 @@ Feature: NeighborhoodPainting
   #Scenario: Stop Button Closes Connection
     #Given I create a levelbuilder named "Simone"
     #And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/7"
-    #And I wait for the page to fully load
+    #And I wait for the lab page to fully load
     #Then element "#runButton" is visible
     #Then I press "runButton"
     ## Check here for a "connection closed" message

--- a/dashboard/test/ui/features/javalab/prompter.feature
+++ b/dashboard/test/ui/features/javalab/prompter.feature
@@ -6,7 +6,7 @@ Feature: Prompter
     When I open my eyes to test "Javalab Prompter Image Upload"
     Given I create a levelbuilder named "Simone"
     And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/10"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I dismiss the teacher panel
     Then I press "#levelbuilder-menu-toggle" using jQuery
     And I see no difference for "initial page load" using stitch mode "none"

--- a/dashboard/test/ui/features/javalab/theater.feature
+++ b/dashboard/test/ui/features/javalab/theater.feature
@@ -6,7 +6,7 @@ Feature: Theater
     When I open my eyes to test "Javalab Theater GIF Playback"
     Given I create a levelbuilder named "Simone"
     And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/4"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I dismiss the teacher panel
     Then I press "#levelbuilder-menu-toggle" using jQuery
     And I see no difference for "initial page load" using stitch mode "none"

--- a/dashboard/test/ui/features/star_labs/applab/clipping.feature
+++ b/dashboard/test/ui/features/star_labs/applab/clipping.feature
@@ -3,7 +3,7 @@ Feature: App Lab Clipping
 
   Scenario: Load an app to edit and see the blocks unclipped in design mode
     Given I am on "http://studio.code.org/projects/applab"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I reload the page
     And I switch to design mode
     And selector "#designModeViz" has class "clip-content"

--- a/dashboard/test/ui/features/star_labs/applab/data_blocks.feature
+++ b/dashboard/test/ui/features/star_labs/applab/data_blocks.feature
@@ -6,7 +6,7 @@ Feature: App Lab Data Blocks
     # This level evaluates the create/read/update/deleteRecord and set/getKeyValue blocks
     # when run, and prints success if the data storage APIs are working properly.
     Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/8?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And element "#runButton" is visible
     And I open the debug console
     Then I press "runButton"

--- a/dashboard/test/ui/features/star_labs/applab/data_tab.feature
+++ b/dashboard/test/ui/features/star_labs/applab/data_tab.feature
@@ -5,7 +5,7 @@ Feature: App Lab Data Tab
   Background:
     # Navigate to data tab from a new Applab project
     Given I start a new Applab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I click selector "#dataModeButton"
     And I wait until element "#dataTablesBody" is visible
 

--- a/dashboard/test/ui/features/star_labs/applab/embed.feature
+++ b/dashboard/test/ui/features/star_labs/applab/embed.feature
@@ -4,7 +4,7 @@ Feature: App Lab Embed
 
   Background:
     Given I start a new Applab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
 
   Scenario: App Lab Embed
@@ -25,7 +25,7 @@ Feature: App Lab Embed
     Then I wait until element "a:contains('How it Works (View Code)')" is visible
     And I click selector "a:contains('How it Works (View Code)')" to load a new tab
 
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait to see Applab code mode
 
   Scenario: App Lab Embed without Source

--- a/dashboard/test/ui/features/star_labs/applab/eyes1.feature
+++ b/dashboard/test/ui/features/star_labs/applab/eyes1.feature
@@ -5,7 +5,7 @@ Feature: App Lab Eyes -  Part 1
 Scenario: Design elements are visible in local and shared projects
   When I open my eyes to test "applab eyes"
   Given I start a new Applab project
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I see no difference for "initial load" using stitch mode "none"
   And I press "show-code-header"
   And I add code for a canvas and a button
@@ -24,7 +24,7 @@ Scenario: App Lab UI elements from initial code and html
   # this level displays each ui element by generating it dynamically as well as
   # displaying design-mode-created elements.
   And I am on "http://studio.code.org/s/allthethings/lessons/18/levels/9?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element "#runButton" is visible
   Then I see no difference for "design mode elements in code mode"
   And I press "runButton"
@@ -32,7 +32,7 @@ Scenario: App Lab UI elements from initial code and html
   And I wait to see "#radioid"
   Then I see no difference for "dynamically generated elements in code mode"
   And I press "designModeButton"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I see no difference for "design mode elements in design mode"
   And I close my eyes
 
@@ -74,7 +74,7 @@ Scenario: Text area with multiple lines, radio button, checkbox
 Scenario: Applab Instructions Resize
   When I open my eyes to test "Applab instructions resize"
   And I am on "http://studio.code.org/s/allthethings/lessons/18/levels/9"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "base case"
   Then I drag the instructions grippy by -150 pixels
   And I see no difference for "small instructions"

--- a/dashboard/test/ui/features/star_labs/applab/eyes2.feature
+++ b/dashboard/test/ui/features/star_labs/applab/eyes2.feature
@@ -5,7 +5,7 @@ Feature: App Lab Eyes - Part 2
 Scenario: Applab visualization scaling
   When I open my eyes to test "Applab visualization scaling"
   And I am on "http://studio.code.org/projects/applab/new"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I switch to design mode
 
   Then I drag a TEXT_AREA into the app
@@ -43,7 +43,7 @@ Scenario: Applab widget mode
 Scenario: Applab Instructions in Top Pane
   When I open my eyes to test "Applab Instructions in top pane"
   And I am on "http://studio.code.org/s/allthethings/lessons/18/levels/9"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "top instructions enabled on standard level"
   Then I click selector ".fa-chevron-circle-up"
   And I see no difference for "top instructions collapsed"
@@ -53,10 +53,10 @@ Scenario: Applab Instructions in Top Pane
   And I see no difference for "toolbox collapsed"
 
   When I am on "http://studio.code.org/s/allthethings/lessons/18/levels/10"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "top instructions enabled on instructionless level"
 
   When I am on "http://studio.code.org/s/allthethings/lessons/18/levels/12"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "top instructions enabled on embed level"
   Then I close my eyes

--- a/dashboard/test/ui/features/star_labs/applab/html_sanitization.feature
+++ b/dashboard/test/ui/features/star_labs/applab/html_sanitization.feature
@@ -3,7 +3,7 @@ Feature: App Lab HTML Sanitization
 
   Background:
     Given I start a new Applab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
   Scenario: Elements do not become nested
     Given I switch to design mode

--- a/dashboard/test/ui/features/star_labs/applab/level_options.feature
+++ b/dashboard/test/ui/features/star_labs/applab/level_options.feature
@@ -3,7 +3,7 @@ Feature: App Lab Level Options
 @as_student
 Scenario: Table data in level definition appears in data browser
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/16"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press "dataModeButton"
   And I wait until element "#data-library-container" is visible
   And I wait until element "a:contains(table_name2)" is visible
@@ -15,17 +15,17 @@ Scenario: Level defaults to design mode, students see design mode and teachers s
   # As student
   Given I create a teacher-associated student named "Lillian"
   And I am on "http://studio.code.org/s/allthethings/lessons/18/levels/21"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait to see Applab design mode
   And I wait to see "#runButton"
 
   # As teacher
   Then I sign in as "Teacher_Lillian"
   Then I am on "http://studio.code.org/s/allthethings/lessons/18/levels/21"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
   And I wait until element ".student-table" is visible
   And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait to see Applab code mode

--- a/dashboard/test/ui/features/star_labs/applab/libraries.feature
+++ b/dashboard/test/ui/features/star_labs/applab/libraries.feature
@@ -13,7 +13,7 @@ Feature: Libraries
 
     # Unpublish library
     Then I navigate to the saved URL
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I open the library publish dialog
     And I click selector "#ui-test-unpublish-library" once I see it
     And I wait until element "b:contains('Successfully unpublished your library')" is visible
@@ -27,20 +27,20 @@ Feature: Libraries
     # Student2 imports Student1's library
     Given I create a student named "Student2"
     And I start a new Applab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "h2:contains('Import library from ID')" is visible
     And I type the saved channel id into element "#ui-test-import-library > input"
     And I click selector "#ui-test-import-library > button" to load a new page
 
     # Confirm Student1's library is in Student2's project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "a:contains('UntitledProject')" is visible
 
     # Remove Student1's library from Student2's project
     And I click selector ".ui-test-remove-library:eq(0)" to load a new page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "div:contains('You have no libraries in your project')" is visible
 
@@ -64,7 +64,7 @@ Feature: Libraries
     Given I create a student named "Library_Student"
     And I join the section
     And I start a new Applab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "a:contains('UntitledProject')" is visible
     And I wait until element "span:contains('Library_Teacher')" is visible

--- a/dashboard/test/ui/features/star_labs/applab/scenarios.feature
+++ b/dashboard/test/ui/features/star_labs/applab/scenarios.feature
@@ -3,7 +3,7 @@ Feature: App Lab Scenarios
 
   Background:
     Given I start a new Applab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
   Scenario:
     # Project Template Workspace Icon should not appear since this is not a project template backed level.

--- a/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
@@ -4,7 +4,7 @@ Feature: App Lab Scenarios
 
   Background:
     Given I start a new Applab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
   Scenario: App Lab Share
     Given I ensure droplet is in text mode

--- a/dashboard/test/ui/features/star_labs/applab/template_backed.feature
+++ b/dashboard/test/ui/features/star_labs/applab/template_backed.feature
@@ -5,7 +5,7 @@ Feature: App Lab Scenarios
   Scenario: Template backed level
     # One of two levels backed by the same template
     Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/10?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I debug channel id
 
     Then I reset the puzzle to the starting version
@@ -22,7 +22,7 @@ Feature: App Lab Scenarios
 
     # Next level, backed by the same template
     Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/11?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait to see ".projectTemplateWorkspaceIcon"
 
     Then the palette has 2 blocks

--- a/dashboard/test/ui/features/star_labs/applab/versions.feature
+++ b/dashboard/test/ui/features/star_labs/applab/versions.feature
@@ -4,7 +4,7 @@ Feature: App Lab Versions
 
 Scenario: Script Level Versions
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I ensure droplet is in block mode
   And I switch to text mode
   And I add code "// comment 1" to ace editor
@@ -13,7 +13,7 @@ Scenario: Script Level Versions
 
   # reloading here creates a previous version containing only comment 1
   And I reload the page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   # this particular level is set to always start in block mode
   And I ensure droplet is in block mode
   And I switch to text mode
@@ -27,22 +27,22 @@ Scenario: Script Level Versions
   And element "button.btn-info" is visible
   And I make all links open in the current tab
   And I click selector "button.btn-info:eq(0)" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then ace editor code is equal to "// comment 1"
   And element "#workspace-header-span" contains text "View only"
 
   When I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then ace editor code is equal to "// comment 2// comment 1"
 
 Scenario: Project Load and Reload
   Given I am on "http://studio.code.org/projects/applab/new"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   # The initial load results in save only because this is a new project.
   And I wait for initial project save to complete
 
   When I reload the page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press "versions-header"
   And I wait until element "div:contains(Latest Version)" is visible
   And I save the text from ".versionRow:nth-child(1) p"
@@ -74,7 +74,7 @@ Scenario: Project Load and Reload
 @no_mobile
 Scenario: Project Version Checkpoints
   Given I am on "http://studio.code.org/projects/applab/new"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   # The initial load results in save only because this is a new project.
   And I wait for initial project save to complete
   And I ensure droplet is in block mode
@@ -106,7 +106,7 @@ Scenario: Project Version Checkpoints
 Scenario: Project page refreshes when other client adds a newer version
   Given I am on "http://studio.code.org/projects/applab/new"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".project_updated_at" eventually contains text "Saved"
   And I ensure droplet is in block mode
   And I switch to text mode
@@ -119,7 +119,7 @@ Scenario: Project page refreshes when other client adds a newer version
   When I go to a new tab
   And I am on "http://studio.code.org/projects/applab/"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".project_updated_at" eventually contains text "Saved"
   Then ace editor code is equal to "// comment X"
 
@@ -136,14 +136,14 @@ Scenario: Project page refreshes when other client adds a newer version
   # written a newer version (Y) than tab 0's last known version (X).
   When I add code "// comment Z" to ace editor
   And I click selector "#runButton" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then ace editor code is equal to "// comment Y// comment X"
 
 @no_mobile
 Scenario: Project page refreshes when other client replaces current version
   Given I am on "http://studio.code.org/projects/applab/new"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".project_updated_at" eventually contains text "Saved"
   And I ensure droplet is in block mode
   And I switch to text mode
@@ -158,7 +158,7 @@ Scenario: Project page refreshes when other client replaces current version
   When I go to a new tab
   And I am on "http://studio.code.org/projects/applab/"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".project_updated_at" eventually contains text "Saved"
   And ace editor code is equal to "// Alpha"
 
@@ -179,5 +179,5 @@ Scenario: Project page refreshes when other client replaces current version
   And ace editor code is equal to "// Alpha"
   And I add code "// Charlie" to ace editor
   And I click selector "#runButton" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then ace editor code is equal to "// Alpha// Bravo"

--- a/dashboard/test/ui/features/star_labs/applab_submittable.feature
+++ b/dashboard/test/ui/features/star_labs/applab_submittable.feature
@@ -44,7 +44,7 @@ Scenario: Submit anything, teacher is able to unsubmit
   And I press "#unsubmit-button-uitest" using jQuery to load a new page
 
   # Unsubmit should be disabled now
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait to see ".show-handle"
   And I wait until element ".student-table" is visible
   Then I wait until element "#unsubmit-button-uitest" is visible

--- a/dashboard/test/ui/features/star_labs/artist.feature
+++ b/dashboard/test/ui/features/star_labs/artist.feature
@@ -2,7 +2,7 @@ Feature: Playing the Artist Game
 
 Background:
   Given I am on "http://studio.code.org/s/20-hour/lessons/5/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I dismiss the login reminder
   Then element "#runButton" is visible
   And element "#resetButton" is hidden

--- a/dashboard/test/ui/features/star_labs/bee.feature
+++ b/dashboard/test/ui/features/star_labs/bee.feature
@@ -2,7 +2,7 @@ Feature: Complete a bee level
 
 Scenario: Complete Bee Conditions 4-5 Level 3
   Given I am on "http://studio.code.org/s/course3/lessons/7/levels/3?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   When I dismiss the login reminder
   # repeat to when run
   And I drag block "repeat" to block "whenRun"

--- a/dashboard/test/ui/features/star_labs/block_trashing.feature
+++ b/dashboard/test/ui/features/star_labs/block_trashing.feature
@@ -3,7 +3,7 @@ Feature: Blocks can be trashed in certain circumstances
 
 Background:
   Given I am on "http://studio.code.org/s/course2/lessons/19/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I dismiss the login reminder
   Then element "#runButton" is visible
   And element "#resetButton" is hidden

--- a/dashboard/test/ui/features/star_labs/blocklayout.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayout.feature
@@ -1,7 +1,7 @@
 Feature: Block auto-layout
 Background:
   Given I am on "http://studio.code.org/flappy/10?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
 Scenario: Auto-placing malformed start blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle with extra newlines
@@ -15,7 +15,7 @@ Scenario: Auto-placing blocks
 
 Scenario: Auto-placing blocks with XML positioning
   Given I am on "http://studio.code.org/s/allthethings/lessons/5/levels/4?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   When I've initialized the workspace with a manually-positioned playlab puzzle
 

--- a/dashboard/test/ui/features/star_labs/bounce.feature
+++ b/dashboard/test/ui/features/star_labs/bounce.feature
@@ -3,7 +3,7 @@ Feature: Complete a bounce level
 
 Scenario: Complete Level 1
   Given I am on "http://studio.code.org/s/events/lessons/1/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I drag block "moveLeft" to block "whenLeft"
   Then block "moveLeft" is child of block "whenLeft"
   And I press "runButton"
@@ -14,7 +14,7 @@ Scenario: Complete Level 1
 
 Scenario: Complete Level 3
   Given I am on "http://studio.code.org/s/events/lessons/1/levels/3?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I drag block "moveUp" to block "whenUp"
   Then block "moveUp" is child of block "whenUp"
   And I press "runButton"
@@ -26,7 +26,7 @@ Scenario: Complete Level 3
 @no_mobile
 Scenario: Incomplete Level 5
   Given I am on "http://studio.code.org/s/events/lessons/1/levels/5?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press "runButton"
   And I wait to see ".uitest-topInstructions-inline-feedback"
   And element ".uitest-topInstructions-inline-feedback" is visible
@@ -34,7 +34,7 @@ Scenario: Incomplete Level 5
 
 Scenario: Complete Level 5
   Given I am on "http://studio.code.org/s/events/lessons/1/levels/5?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I drag block "bounceBall" to block "whenPaddleCollided"
   Then block "bounceBall" is child of block "whenPaddleCollided"
   And I press "runButton"
@@ -44,7 +44,7 @@ Scenario: Complete Level 5
 
 Scenario: Complete Bounce freeplay level
   Given I am on "http://studio.code.org/s/course3/lessons/15/levels/10?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I dismiss the login reminder
   And element "#finishButton" is not visible
   And I press "runButton"

--- a/dashboard/test/ui/features/star_labs/bouncedrag.feature
+++ b/dashboard/test/ui/features/star_labs/bouncedrag.feature
@@ -4,7 +4,7 @@ Background:
   Given I am on "http://studio.code.org/s/events/lessons/1/levels/1?noautoplay=true"
 
 Scenario: Connect two blocks from toolbox
-  When I wait for the page to fully load
+  When I wait for the lab page to fully load
   And I drag block "moveLeft" to block "whenLeft"
   And I drag block "moveRight" to block "moveLeft"
   And I wait for 1 seconds

--- a/dashboard/test/ui/features/star_labs/clearpuzzle.feature
+++ b/dashboard/test/ui/features/star_labs/clearpuzzle.feature
@@ -2,7 +2,7 @@ Feature: Clear Puzzle
 
 Background:
   Given I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
 

--- a/dashboard/test/ui/features/star_labs/copypaste.feature
+++ b/dashboard/test/ui/features/star_labs/copypaste.feature
@@ -4,7 +4,7 @@ Feature: Blocks can be copied and pasted using the keyboard
 
 Background:
   Given I am on "http://studio.code.org/s/20-hour/lessons/7/levels/6?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
 Scenario: Copy and paste a block
   When I drag block "1" to offset "300, 150"

--- a/dashboard/test/ui/features/star_labs/craft/aquatic.feature
+++ b/dashboard/test/ui/features/star_labs/craft/aquatic.feature
@@ -5,7 +5,7 @@ Feature: Minecraft aquatic
 
   Background:
     Given I am on "http://studio.code.org/s/allthethings/lessons/25/levels/3"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait until the Minecraft game is loaded
     Then element "#runButton" is visible
     And element "#resetButton" is hidden

--- a/dashboard/test/ui/features/star_labs/craft/dialogs.feature
+++ b/dashboard/test/ui/features/star_labs/craft/dialogs.feature
@@ -10,7 +10,7 @@ Feature: Minecraft dialog levels
 #    And I open my eyes to test "Minecraft Level 1 dialogs"
     And "when run" refers to block "4"
     And "move forward" refers to block "1"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I wait to see a "#getting-started-header"
 #    And I see no difference for "Character select dialog"
     And I press "x-close"
@@ -46,7 +46,7 @@ Feature: Minecraft dialog levels
     And "toolbox repeat" refers to block "6"
     And "dragged repeat" refers to block "17"
     And "inner repeat" refers to block "13"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I wait to see a "#getting-started-header"
 #    And I see no difference for "House select dialog"
     And I press "close-house-select"

--- a/dashboard/test/ui/features/star_labs/craft/hero_logged_in.feature
+++ b/dashboard/test/ui/features/star_labs/craft/hero_logged_in.feature
@@ -3,7 +3,7 @@ Feature: Minecraft hero logged in
   @as_student
   Scenario: Signed in finish dialog
     Given I am on "http://studio.code.org/s/hero/lessons/1/levels/12?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait until the Minecraft game is loaded
     And I press "runButton"
     And I click selector "button:contains(Finish)" once I see it

--- a/dashboard/test/ui/features/star_labs/craft/hero_logged_out.feature
+++ b/dashboard/test/ui/features/star_labs/craft/hero_logged_out.feature
@@ -2,7 +2,7 @@ Feature: Minecraft hero logged out
 
   Scenario: Signed out finish dialog
     Given I am on "http://studio.code.org/s/hero/lessons/1/levels/12?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait until the Minecraft game is loaded
     And I press "runButton"
     And I click selector "button:contains(Finish)" once I see it

--- a/dashboard/test/ui/features/star_labs/dance/age_filter.feature
+++ b/dashboard/test/ui/features/star_labs/dance/age_filter.feature
@@ -2,7 +2,7 @@ Feature: Dance Lab Age Filter
   Scenario: Song selector is visible and doesn't display pg13 songs for age < 13
     Given I create a young student named "Harry"
     And I am on "http://studio.code.org/s/allthethings/lessons/37/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for 3 seconds
     And I wait until I don't see selector "#p5_loading"
     And I close the instructions overlay if it exists
@@ -17,7 +17,7 @@ Feature: Dance Lab Age Filter
   Scenario: Song selector is visible and displays all songs for age > 13 and teacher flag turns filter on
     Given I create a student named "Ron"
     And I am on "http://studio.code.org/s/allthethings/lessons/37/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for 3 seconds
     And I wait until I don't see selector "#p5_loading"
     And I close the instructions overlay if it exists
@@ -28,7 +28,7 @@ Feature: Dance Lab Age Filter
 
     Then I am on "http://studio.code.org/s/allthethings/lessons/37/levels/1?noautoplay=true&songfilter=on"
     And I reload the page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait until I don't see selector "#p5_loading"
     And I wait for the song selector to load
     #Local PG-13 option should not be visible after filter in any environment
@@ -39,7 +39,7 @@ Feature: Dance Lab Age Filter
 
   Scenario: Selecting <13 in age dialog turns filter on
     Given I am on "http://studio.code.org/s/allthethings/lessons/37/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for 3 seconds
     And I wait until I don't see selector "#p5_loading"
     And I select age 10 in the age dialog
@@ -54,7 +54,7 @@ Feature: Dance Lab Age Filter
 
   Scenario: Selecting 13 in age dialog turns filter off
     Given I am on "http://studio.code.org/s/allthethings/lessons/37/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for 3 seconds
     And I wait until I don't see selector "#p5_loading"
     And I select age 13 in the age dialog
@@ -67,7 +67,7 @@ Feature: Dance Lab Age Filter
 
     # session cookie should persist and no dialog should show up
     Then I am on "http://studio.code.org/s/dance/lessons/1/levels/9"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for 3 seconds
     And I wait until I don't see selector "#p5_loading"
     And element ".age-dialog" is hidden
@@ -79,7 +79,7 @@ Feature: Dance Lab Age Filter
 
   Scenario: Song selector is hidden when initializing with teacher flag on and teacher flag stays on after level complete
     Given I am on "http://studio.code.org/s/allthethings/lessons/37/levels/1?noautoplay=true&songfilter=on"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for 3 seconds
     And I wait until I don't see selector "#p5_loading"
     And element ".age-dialog" is not visible
@@ -96,7 +96,7 @@ Feature: Dance Lab Age Filter
     And I press "continue-button"
     # Make sure continue takes us to next level
     And I wait until current URL contains "/lessons/37/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I close the instructions overlay if it exists
     And I wait for the song selector to load
     #Local PG-13 option should not be visible after filter in any environment
@@ -108,7 +108,7 @@ Feature: Dance Lab Age Filter
 
   Scenario: Song selector is hidden when initializing with teacher flag on for signed in student
     Given I am on "http://studio.code.org/s/allthethings/lessons/37/levels/1?noautoplay=true&songfilter=on"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for 3 seconds
     And I wait until I don't see selector "#p5_loading"
     And element ".age-dialog" is not visible

--- a/dashboard/test/ui/features/star_labs/dance/dance_ai_modal.feature
+++ b/dashboard/test/ui/features/star_labs/dance/dance_ai_modal.feature
@@ -2,7 +2,7 @@ Feature: Dance Party
 
   Scenario: Dance AI Modal
     Given I am on "http://studio.code.org/s/allthethings/lessons/37/levels/3"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I select age 10 in the age dialog
     And I drag block "dance_ai" to block "setup"
     And I click block field "[data-id='setup'] > [data-id='dance_ai'] > .blocklyEditableText"

--- a/dashboard/test/ui/features/star_labs/dance/dance_ai_modal_eyes.feature
+++ b/dashboard/test/ui/features/star_labs/dance/dance_ai_modal_eyes.feature
@@ -5,7 +5,7 @@ Feature: Dance Party AI Modal Eyes
   Scenario: Dance AI Modal
     # In LTR language
     Given I am on "http://studio.code.org/s/allthethings/lessons/37/levels/4"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I select age 10 in the age dialog
     # Toggle to code
     When I open my eyes to test "open Dance AI modal"
@@ -27,7 +27,7 @@ Feature: Dance Party AI Modal Eyes
 
     # In RTL language
     Then I am on "http://studio.code.org/s/allthethings/lessons/37/levels/4/lang/ar-sa"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     # Toggle to code in RTL
     And I click block field "[data-id='setup'] > [data-id='dance_ai'] > .blocklyEditableText"
     And I wait until element "#use-button" is visible    

--- a/dashboard/test/ui/features/star_labs/dance/dance_party.feature
+++ b/dashboard/test/ui/features/star_labs/dance/dance_party.feature
@@ -6,14 +6,14 @@ Feature: Dance Party
     Then page text does not contain "placeholder for testing"
 
     When I am on "http://studio.code.org/s/dance/lessons/1/levels/1"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I am on "http://studio.code.org/restricted/placeholder.txt"
     Then page text does contain "placeholder for testing"
 
   @no_mobile
   Scenario: Can toggle run/reset in Dance Party
     Given I am on "http://studio.code.org/s/allthethings/lessons/37/levels/2?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for 3 seconds
     And I wait until I don't see selector "#p5_loading"
     And I select age 10 in the age dialog
@@ -33,7 +33,7 @@ Feature: Dance Party
   @no_mobile
   Scenario: Can get to level success in Dance Party
     Given I am on "http://studio.code.org/s/allthethings/lessons/37/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for 3 seconds
     And I wait until I don't see selector "#p5_loading"
     And I select age 10 in the age dialog
@@ -46,11 +46,11 @@ Feature: Dance Party
   @no_mobile
   Scenario: Dance Party 12 loads
     Given I am on "http://studio.code.org/s/dance/lessons/1/levels/12?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
   Scenario: Dance Party 8 runs new set tint block
     Given I am on "http://studio.code.org/s/dance/lessons/1/levels/8?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I select age 10 in the age dialog
     And I close the instructions overlay if it exists
     # drag the "set tint" block from the toolbox to below "after 4 measures"
@@ -63,7 +63,7 @@ Feature: Dance Party
   @no_safari
   Scenario: Dance Party Share
     Given I am on "http://studio.code.org/s/dance/lessons/1/levels/13?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for the song selector to load
     And element "#song_selector" has value "cheapthrills_sia"
 
@@ -102,7 +102,7 @@ Feature: Dance Party
   @no_mobile
   Scenario: Dance Party can share while logged out
     Given I am on "http://studio.code.org/s/dance/lessons/1/levels/13?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
     When I navigate to the shared version of my project
     Then I wait until element "#runButton" is visible

--- a/dashboard/test/ui/features/star_labs/dropdown.feature
+++ b/dashboard/test/ui/features/star_labs/dropdown.feature
@@ -5,7 +5,7 @@ Background:
 
 @no_mobile
 Scenario: Drag a dropdown and select a different option.
-  When I wait for the page to fully load
+  When I wait for the lab page to fully load
   And I dismiss the login reminder
   And I drag block "1" to offset "300, 250"
   And I press dropdown number 45

--- a/dashboard/test/ui/features/star_labs/droplet.feature
+++ b/dashboard/test/ui/features/star_labs/droplet.feature
@@ -2,7 +2,7 @@
 Feature: Droplet levels work as expected
   Background:
     Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/5?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
   Scenario: Open editcode level and write some autocompleted, tooltipped code
     When I ensure droplet is in text mode

--- a/dashboard/test/ui/features/star_labs/farmer.feature
+++ b/dashboard/test/ui/features/star_labs/farmer.feature
@@ -2,7 +2,7 @@ Feature: Playing the Farmer Game
 
 Background:
   Given I am on "http://studio.code.org/s/20-hour/lessons/9/levels/1?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I dismiss the login reminder
   And element ".instructions-markdown p" has text "Hi, I'm a farmer. I need your help to flatten the field on my farm so it's ready for planting. Move me to the pile of dirt and use the \"remove\" block to remove it."
   Then element "#runButton" is visible

--- a/dashboard/test/ui/features/star_labs/flappy.feature
+++ b/dashboard/test/ui/features/star_labs/flappy.feature
@@ -3,7 +3,7 @@ Feature: Flappy puzzles can be solved
 Scenario: Solving puzzle 1
   Given I am on "http://studio.code.org/flappy/1?noautoplay=true"
   Then I wait until I am on "http://studio.code.org/flappy/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I drag block "flap" to block "whenClick"
   And I press "runButton"
   Then evaluate JavaScript expression "Flappy.gravity = -1, Flappy.onMouseDown(), true;"
@@ -13,7 +13,7 @@ Scenario: Solving puzzle 1
 Scenario: Solving puzzle 2
   Given I am on "http://studio.code.org/flappy/2?noautoplay=true"
   Then I wait until I am on "http://studio.code.org/flappy/2?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I drag block "endGame" to block "whenCollideGround"
   And I press "runButton"
   Then evaluate JavaScript expression "Flappy.onMouseDown(), true;"
@@ -24,7 +24,7 @@ Scenario: Solving puzzle 2
 Scenario: Failing puzzle 2
   Given I am on "http://studio.code.org/flappy/2?noautoplay=true"
   Then I wait until I am on "http://studio.code.org/flappy/2?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press "runButton"
   Then evaluate JavaScript expression "Flappy.onMouseDown(), true;"
   Then I wait to see ".uitest-topInstructions-inline-feedback"

--- a/dashboard/test/ui/features/star_labs/flappydrag.feature
+++ b/dashboard/test/ui/features/star_labs/flappydrag.feature
@@ -2,7 +2,7 @@ Feature: Flappy blocks can be dragged
 
 Scenario: Connect two blocks from toolbox
   Given I am on "http://studio.code.org/flappy/1?noautoplay=true"
-  When I wait for the page to fully load
+  When I wait for the lab page to fully load
   And I dismiss the login reminder
   And I wait to see ".blocklySvg"
   And I drag block "flap" to block "whenClick"

--- a/dashboard/test/ui/features/star_labs/function_editor.feature
+++ b/dashboard/test/ui/features/star_labs/function_editor.feature
@@ -2,7 +2,7 @@ Feature: Opening / closing the function editor
 
 Background:
   Given I am on "http://studio.code.org/s/course4/lessons/14/levels/12?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I dismiss the login reminder
   Then element "#runButton" is visible
   And element "#resetButton" is hidden

--- a/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
@@ -11,7 +11,7 @@ Scenario: Export library animation
   And I press "runButton"
 
   Then I switch to the animation tab
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait until element ".icon-settings-export-white" is visible within element "iframe[src='/blockly/js/piskel/index.html']"
   And I switch to the first iframe
   And I wait until I don't see selector "#loadingMask"

--- a/dashboard/test/ui/features/star_labs/gamelab/libraries.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/libraries.feature
@@ -13,7 +13,7 @@ Feature: Libraries
 
     # Unpublish library
     Then I navigate to the saved URL
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I open the library publish dialog
     And I click selector "#ui-test-unpublish-library" once I see it
     And I wait until element "b:contains('Successfully unpublished your library')" is visible
@@ -27,20 +27,20 @@ Feature: Libraries
     # Student2 imports Student1's library
     Given I create a student named "Student2"
     And I start a new Game Lab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "h2:contains('Import library from ID')" is visible
     And I type the saved channel id into element "#ui-test-import-library > input"
     And I click selector "#ui-test-import-library > button" to load a new page
 
     # Confirm Student1's library is in Student2's project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "a:contains('UntitledProject')" is visible
 
     # Remove Student1's library from Student2's project
     And I click selector ".ui-test-remove-library:eq(0)" to load a new page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "div:contains('You have no libraries in your project')" is visible
 
@@ -64,7 +64,7 @@ Feature: Libraries
     Given I create a student named "Library_Student"
     And I join the section
     And I start a new Game Lab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I open the Manage Libraries dialog
     And I wait until element "a:contains('UntitledProject')" is visible
     And I wait until element "span:contains('Library_Teacher')" is visible

--- a/dashboard/test/ui/features/star_labs/gamelab/loading_animations.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/loading_animations.feature
@@ -13,5 +13,5 @@ Scenario: Check Piskel loads and reload the project with a blank animation
   And I press "runButton"
 
   Then I reload the page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".modal-body" does not contain text "Sorry, we couldn't load animation"

--- a/dashboard/test/ui/features/star_labs/groupdrag.feature
+++ b/dashboard/test/ui/features/star_labs/groupdrag.feature
@@ -2,7 +2,7 @@ Feature: Blocks dragged in groups can have children attach to other blocks
 
 Background:
   Given I am on "http://studio.code.org/s/20-hour/lessons/7/levels/6?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
 Scenario: Connect two blocks from toolbox
   When I drag block "1" to offset "300, 150"

--- a/dashboard/test/ui/features/star_labs/jigsaw.feature
+++ b/dashboard/test/ui/features/star_labs/jigsaw.feature
@@ -2,7 +2,7 @@ Feature: Visiting a jigsaw page
 
 Background:
   Given I am on "http://studio.code.org/s/course1/lessons/3/levels/1?noautoplay=1"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
 Scenario: Loading the first jigsaw level
   Then there's an image "jigsaw/blank.png"

--- a/dashboard/test/ui/features/star_labs/jigsaw2.feature
+++ b/dashboard/test/ui/features/star_labs/jigsaw2.feature
@@ -2,7 +2,7 @@ Feature: Solving a jigsaw puzzle
 
 Background:
   Given I am on "http://studio.code.org/s/course1/lessons/3/levels/2?noautoplay=1"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
 Scenario: Solving puzzle
   And I drag block "2" to block "1"

--- a/dashboard/test/ui/features/star_labs/legacy_share_remix.feature
+++ b/dashboard/test/ui/features/star_labs/legacy_share_remix.feature
@@ -4,7 +4,7 @@ Feature: Legacy Share Remix
 
   Background:
     Given I am on "http://studio.code.org/s/artist/lessons/1/levels/10?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And element "#runButton" is visible
     And element "#resetButton" is hidden
 

--- a/dashboard/test/ui/features/star_labs/maker_projects.feature
+++ b/dashboard/test/ui/features/star_labs/maker_projects.feature
@@ -5,17 +5,17 @@ Feature: Projects Maker API enabling
 Scenario: /projects/makerlab enables maker toolkit categories
   Given I am on "http://studio.code.org/projects/makerlab"
   And I get redirected to "/projects/makerlab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait until element ".droplet-palette-group-header:contains(Maker)" is visible
 
 Scenario: /projects/makerlab/new enables maker toolkit categories
   Given I am on "http://studio.code.org/projects/makerlab/new"
   And I get redirected to "/projects/makerlab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait until element ".droplet-palette-group-header:contains(Maker)" is visible
 
 Scenario: /projects/applab does not enable maker toolkit categories
   Given I am on "http://studio.code.org/projects/applab"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait until element ".droplet-palette-group-header:contains(Maker)" is not visible

--- a/dashboard/test/ui/features/star_labs/manage_assets.feature
+++ b/dashboard/test/ui/features/star_labs/manage_assets.feature
@@ -8,14 +8,14 @@ Feature: Manage Assets
   Scenario: The manage assets dialog contains the option to record audio on Chrome
     Given I am a student
     And I start a new Game Lab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I open the Manage Assets dialog
     And I wait until element "#record-asset" is visible
 
   Scenario: The manage assets dialog displays the audio preview, and toggles between play and pause button.
     Given I am a student
     And I start a new Game Lab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I open the Manage Assets dialog
     And I wait to see a dialog titled "Manage Assets"
     And I wait until element "#upload-asset" is visible
@@ -27,7 +27,7 @@ Feature: Manage Assets
   Scenario: The manage assets dialog displays an image thumbnail and opens in a new tab when clicked
     Given I am a student
     And I start a new Game Lab project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I open the Manage Assets dialog
     And I wait to see a dialog titled "Manage Assets"
     And I wait until element "#upload-asset" is visible

--- a/dashboard/test/ui/features/star_labs/maze.feature
+++ b/dashboard/test/ui/features/star_labs/maze.feature
@@ -3,7 +3,7 @@ Feature: Complete a complicated maze level
 Background:
   Given I am on "http://studio.code.org/reset_session"
   Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/15?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I dismiss the login reminder
   And element ".csf-top-instructions p" has text "Ok, this is just like the last puzzle, but you need to remember how you used the \"if\" block and the \"repeat\" block together."
 
@@ -25,7 +25,7 @@ Scenario: Submit an invalid solution
 
 @no_mobile
 Scenario: Submit a valid solution
-  When I wait for the page to fully load
+  When I wait for the lab page to fully load
   Then element "#resetButton" is hidden
   Then I drag block "repeatForever" to block "topBlock"
   And I drag block "moveForward" into first position in repeat block "repeatForever"
@@ -45,7 +45,7 @@ Scenario: Submit a valid solution
 
   # Make sure the work on level 15 was saved.
   When I am on "http://studio.code.org/s/20-hour/lessons/2/levels/15?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I press "runButton"
   Then I wait until element ".congrats" is visible
   And element ".congrats" has text "Congratulations! You completed Puzzle 15."

--- a/dashboard/test/ui/features/star_labs/maze2.feature
+++ b/dashboard/test/ui/features/star_labs/maze2.feature
@@ -3,7 +3,7 @@ Feature: Complete a simple maze level
   Background:
     Given I am on "http://studio.code.org/reset_session"
     Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/11?noautoplay=true&blocklyVersion=google"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I dismiss the login reminder
     Then element ".csf-top-instructions p" has text "Ok, one last time for practice - can you solve this one using only 4 blocks?"
 

--- a/dashboard/test/ui/features/star_labs/mobile_portait.feature
+++ b/dashboard/test/ui/features/star_labs/mobile_portait.feature
@@ -9,10 +9,10 @@ Feature: Look at mobile portait view
   # times. This test is meant to prevent doing so again.
   Scenario Outline: Simple blockly level page view
     Given I am on "<url>"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I open my eyes to test "<test_name>"
     And I rotate to portrait
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I see no difference for "initial load"
     And I close my eyes
     Examples:

--- a/dashboard/test/ui/features/star_labs/popoutdrag.feature
+++ b/dashboard/test/ui/features/star_labs/popoutdrag.feature
@@ -2,7 +2,7 @@ Feature: Blocks can be dragged from popouts
 
 Background:
   Given I am on "http://studio.code.org/s/20-hour/lessons/11/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I dismiss the login reminder
 
 Scenario: Connect two blocks from toolbox

--- a/dashboard/test/ui/features/star_labs/share_buttons.feature
+++ b/dashboard/test/ui/features/star_labs/share_buttons.feature
@@ -6,14 +6,14 @@ Feature: Share Buttons
 
   Scenario: How It Works Button appears for Sprite Lab share page
     Given I am on "http://studio.code.org/projects/spritelab"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     When I navigate to the shared version of my project
     And I wait until element "#open-workspace" is visible
     Then I see "#open-workspace"
 
   Scenario: How It Works Button does not appear for Game Lab share page
     Given I am on "http://studio.code.org/projects/gamelab"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     When I navigate to the shared version of my project
     And I wait until element "#gameButtons" is visible
     And element "#open-workspace" does not exist
@@ -29,7 +29,7 @@ Feature: Share Buttons
   @only_phone
   Scenario: Dpad does not appear for Sprite Lab Share
     Given I am on "http://studio.code.org/projects/spritelab/"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     When I navigate to the shared version of my project
     And I wait until element "#gameButtons" is visible
     And element "#studio-dpad-rim" is not displayed
@@ -37,7 +37,7 @@ Feature: Share Buttons
   @only_phone
   Scenario: Dpad appears for Game Lab Share
     Given I am on "http://studio.code.org/projects/gamelab/"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     When I navigate to the shared version of my project
     And I wait until element "#gameButtons" is visible
     And element "#studio-dpad-rim" is displayed

--- a/dashboard/test/ui/features/star_labs/sharepage.feature
+++ b/dashboard/test/ui/features/star_labs/sharepage.feature
@@ -3,7 +3,7 @@ Feature: Puzzle share page
 
 Scenario: Share a flappy game, visit the share page, and visit the workspace
   Given I am on "http://studio.code.org/flappy/10?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I've initialized the workspace with my flappy puzzle.
 
   Then I press "runButton"
@@ -37,7 +37,7 @@ Scenario: Share a flappy game, visit the share page, and visit the workspace
 @as_student
 Scenario: Share and save an artist level to the project gallery
   Given I am on "http://studio.code.org/s/artist/lessons/1/levels/10"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I drag block "1" to block "12"
 
   When I press "runButton"

--- a/dashboard/test/ui/features/star_labs/sharepage_logo.feature
+++ b/dashboard/test/ui/features/star_labs/sharepage_logo.feature
@@ -5,7 +5,7 @@ Feature: Lab share page logo
   @no_mobile
   Scenario: Select the logo on an applab share page while logged in and visit the homepage
     Given I am on "http://studio.code.org/projects/applab"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I click selector ".project_share"
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
@@ -17,7 +17,7 @@ Feature: Lab share page logo
   @no_mobile
   Scenario: Select the logo on a playlab share page while logged in and visit the homepage
     Given I am on "http://studio.code.org/projects/playlab"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I click selector ".project_share"
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
@@ -29,7 +29,7 @@ Feature: Lab share page logo
   @no_mobile
   Scenario: Select the logo on a gamelab share page while logged in and visit the homepage
     Given I am on "http://studio.code.org/projects/gamelab"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I click selector ".project_share"
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
@@ -41,7 +41,7 @@ Feature: Lab share page logo
   @no_mobile
   Scenario: Select the logo on an artist share page while logged in and visit the homepage
     Given I am on "http://studio.code.org/projects/artist"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I click selector ".project_share"
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
@@ -53,7 +53,7 @@ Feature: Lab share page logo
   @no_mobile
   Scenario: Select the logo on a playlab share page while logged out and visit the homepage
     Given I am on "http://studio.code.org/projects/playlab"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I click selector ".project_share"
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
@@ -68,7 +68,7 @@ Feature: Lab share page logo
   @no_mobile
   Scenario: Select the logo on a gamelab share page while logged out and visit the homepage
     Given I am on "http://studio.code.org/projects/gamelab"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I click selector ".project_share"
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
@@ -83,7 +83,7 @@ Feature: Lab share page logo
   @only_mobile
   Scenario: Select the logo on a playlab share page while logged out and visit the homepage
     Given I am on "http://studio.code.org/projects/applab"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I click selector ".project_share"
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
@@ -93,7 +93,7 @@ Feature: Lab share page logo
   @only_mobile
   Scenario: Select the logo on a playlab share page while logged out and visit the homepage
     Given I am on "http://studio.code.org/projects/gamelab"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I click selector ".project_share"
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL

--- a/dashboard/test/ui/features/star_labs/signin_callout.feature
+++ b/dashboard/test/ui/features/star_labs/signin_callout.feature
@@ -3,38 +3,38 @@ Feature: Viewing and dismissing the login callout
 
 Scenario: Should see callout on 20-hour farmer lesson
   Given I am on "http://studio.code.org/s/20-hour/lessons/9/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-login-callout" is visible
 
 @no_mobile
 Scenario: Should be able to clear cookies and session storage to see callout again
   Given I am on "http://studio.code.org/s/20-hour/lessons/9/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-login-callout" is visible
   And I dismiss the login reminder
   And I reload the page
   And I delete the cookie named "hide_signin_callout"
   And I clear session storage
   And I reload the page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-login-callout" is visible
 
 @as_student
 Scenario: Should not see callout on farmer lesson if logged in
   Given I am on "http://studio.code.org/s/20-hour/lessons/9/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-login-callout" is not visible
 
 @as_student
 Scenario: Should not see callout on CSF coursea lesson if logged in
   Given I am on "http://studio.code.org/s/coursea-2020/lessons/4/levels/2?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-login-callout" is not visible
 
 @no_mobile
 Scenario: Clicking anywhere should dismiss the login reminder
   Given I am on "http://studio.code.org/s/20-hour/lessons/9/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-login-callout" is visible
   And I dismiss the login reminder
   And element ".instructions-markdown p" has text "Hi, I'm a farmer. I need your help to flatten the field on my farm so it's ready for planting. Move me to the pile of dirt and use the \"remove\" block to remove it."
@@ -44,7 +44,7 @@ Scenario: Clicking anywhere should dismiss the login reminder
 
 Scenario: See age callout, not signin callout on hour of code
   Given I am on "http://studio.code.org/s/allthethings/lessons/37/levels/2?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait for 3 seconds
   And I wait until I don't see selector "#p5_loading"
   And I select age 10 in the age dialog
@@ -52,7 +52,7 @@ Scenario: See age callout, not signin callout on hour of code
 @no_mobile
 Scenario: After dismissing the callout, it should not reappear upon refresh
   Given I am on "http://studio.code.org/s/20-hour/lessons/9/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-login-callout" is visible
   And I dismiss the login reminder
   Then I reload the page
@@ -63,7 +63,7 @@ Scenario: After dismissing the callout, it should not reappear upon refresh
 @no_mobile
 Scenario: Nested callouts should work as expected
   Given I am on "http://studio.code.org/s/coursea-2020/lessons/2/levels/2?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-login-callout" is visible
   And I dismiss the login reminder
   And I wait until element ".csf-top-instructions p" is visible
@@ -72,7 +72,7 @@ Scenario: Nested callouts should work as expected
 
 Scenario: Should be immediately redirected to sign in if pressing sign in button
   Given I am on "http://studio.code.org/s/20-hour/lessons/9/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-login-callout" is visible
   And I click selector ".header_button" if I see it
   Then I am on "http://studio.code.org/users/sign_in"

--- a/dashboard/test/ui/features/star_labs/simpledrag.feature
+++ b/dashboard/test/ui/features/star_labs/simpledrag.feature
@@ -2,7 +2,7 @@ Feature: Blocks can be dragged
 
 Scenario: Connect two blocks from toolbox
   Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/5?noautoplay=true&blocklyVersion=google"
-  When I wait for the page to fully load
+  When I wait for the lab page to fully load
   And I dismiss the login reminder
   And I wait to see ".blocklySvg"
   And I drag block "turnLeft" to offset "160, 100"

--- a/dashboard/test/ui/features/star_labs/spritelab/loading_costumes.feature
+++ b/dashboard/test/ui/features/star_labs/spritelab/loading_costumes.feature
@@ -4,7 +4,7 @@ Feature: Sprite Lab Loading Animations
   Scenario: Load the project with default animations and load Piskel
     Given I start a new Sprite Lab project
     And I switch to the animation tab
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I switch to the first iframe
     And element ".icon-tool-pen" is visible
     And I switch to the default content

--- a/dashboard/test/ui/features/star_labs/spritelab/spritelab.feature
+++ b/dashboard/test/ui/features/star_labs/spritelab/spritelab.feature
@@ -2,7 +2,7 @@ Feature: Sprite Lab
 
 Background:
   Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait for 3 seconds
   And I wait until I don't see selector "#p5_loading"
   And I close the instructions overlay if it exists

--- a/dashboard/test/ui/features/star_labs/step_mode.feature
+++ b/dashboard/test/ui/features/star_labs/step_mode.feature
@@ -3,7 +3,7 @@ Feature: Step Mode
 
 Scenario: Step Only - Failure
   Given I am on "http://studio.code.org/s/step/lessons/1/levels/1?blocklyVersion=google"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
   Then element "#runButton" is hidden
     And element "#resetButton" is hidden
     And element "#stepButton" is visible
@@ -36,7 +36,7 @@ Scenario: Step Only - Failure
 
 Scenario: Step Only - Success
   Given I am on "http://studio.code.org/s/step/lessons/1/levels/1?blocklyVersion=google"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
   Then element "#runButton" is hidden
     And element "#resetButton" is hidden
     And element "#stepButton" is visible
@@ -56,7 +56,7 @@ Scenario: Step Only - Success
 
 Scenario: Step Only - Reset while stepping
   Given I am on "http://studio.code.org/s/step/lessons/1/levels/1?blocklyVersion=google"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
   Then element "#runButton" is hidden
     And element "#resetButton" is hidden
     And element "#stepButton" is visible
@@ -79,7 +79,7 @@ Scenario: Step Only - Reset while stepping
 
 Scenario: Step and Run - Stepping
   Given I am on "http://studio.code.org/s/step/lessons/1/levels/2?blocklyVersion=google"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
   Then element "#runButton" is visible
     And element "#resetButton" is hidden
     And element "#stepButton" is visible
@@ -104,7 +104,7 @@ Scenario: Step and Run - Stepping
 
 Scenario: Step and Run - Running
   Given I am on "http://studio.code.org/s/step/lessons/1/levels/2?blocklyVersion=google"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
   Then element "#runButton" is visible
     And element "#resetButton" is hidden
     And element "#stepButton" is visible

--- a/dashboard/test/ui/features/star_labs/studio.feature
+++ b/dashboard/test/ui/features/star_labs/studio.feature
@@ -3,7 +3,7 @@ Feature: Visiting a studio page
 @no_mobile
 Scenario: Using a studio dropdown
   Given I am on "http://studio.code.org/s/course1/lessons/16/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I dismiss the login reminder
   Then there's an SVG image "studio/dog_thumb.png"
   Then there's not an SVG image "studio/cat_thumb.png"
@@ -20,7 +20,7 @@ Scenario: Using a studio dropdown
 
 Scenario: Resizing Sprites
   Given I am on "http://studio.code.org/s/allthethings/lessons/22/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   Then the 0th sprite image has height "100"
   And the 15th sprite image has height "100"

--- a/dashboard/test/ui/features/step_definitions/applab.rb
+++ b/dashboard/test/ui/features/step_definitions/applab.rb
@@ -22,7 +22,7 @@ end
 Given /^I start a new Applab project/ do
   steps <<-GHERKIN
     And I am on "http://studio.code.org/projects/applab/new"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And element "#runButton" is visible
     And element "#codeModeButton" is visible
     And element "#designModeButton" is visible
@@ -33,7 +33,7 @@ end
 Given /^I am on the (\d+)(?:st|nd|rd|th)? App ?Lab test level$/ do |level_index|
   steps <<-GHERKIN
     And I am on "http://studio.code.org/s/allthethings/lessons/#{APPLAB_ALLTHETHINGS_LESSON}/levels/#{level_index}"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
   GHERKIN
 end
 

--- a/dashboard/test/ui/features/step_definitions/check_finish_button.rb
+++ b/dashboard/test/ui/features/step_definitions/check_finish_button.rb
@@ -32,7 +32,7 @@ end
 When /^I set up the (blockly|droplet|minecraft) free play level for "([^"]*)"/i do |level_type, level_name|
   individual_steps <<-STEPS
     And I am on "#{free_play_level_urls[level_type][level_name]}"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I bypass the age dialog
     And I close the instructions overlay if it exists
   STEPS

--- a/dashboard/test/ui/features/step_definitions/droplet_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/droplet_steps.rb
@@ -122,7 +122,7 @@ end
 Given /^I publish a basic library in (Applab|Game Lab)$/ do |lab_type|
   steps <<-STEPS
     And I start a new #{lab_type} project
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for initial project save to complete
     And I switch to text mode
     When I add code for a library function

--- a/dashboard/test/ui/features/step_definitions/gamelab.rb
+++ b/dashboard/test/ui/features/step_definitions/gamelab.rb
@@ -7,14 +7,14 @@ GAMELAB_ALLTHETHINGS_LESSON = 19
 Given /^I start a new Game ?Lab project$/ do
   steps <<-STEPS
     And I am on "http://studio.code.org/projects/gamelab/new"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
   STEPS
 end
 
 Given /^I am on the (\d+)(?:st|nd|rd|th)? Game ?Lab test level$/ do |level_index|
   steps <<-STEPS
     And I am on "http://studio.code.org/s/allthethings/lessons/#{GAMELAB_ALLTHETHINGS_LESSON}/levels/#{level_index}"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
   STEPS
 end
 

--- a/dashboard/test/ui/features/step_definitions/minecraft.rb
+++ b/dashboard/test/ui/features/step_definitions/minecraft.rb
@@ -11,7 +11,7 @@ Then /^I load the last Minecraft HoC level$/ do
   ) do
     steps <<-STEPS
       Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true&customSlowMotion=0.1"
-      And I wait for the page to fully load
+      And I wait for the lab page to fully load
       And I wait until the Minecraft game is loaded
     STEPS
   end

--- a/dashboard/test/ui/features/step_definitions/project_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/project_steps.rb
@@ -21,7 +21,7 @@ Then(/^I make a "([^"]*)" project named "([^"]*)"$/) do |project_type, name|
   steps <<~GHERKIN
     Then I am on "http://studio.code.org/projects/#{project_type}/new"
     And I get redirected to "/projects/#{project_type}/([^/]*?)/edit" via "dashboard"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And element "#runButton" is visible
     And element ".project_updated_at" eventually contains text "Saved"
     And I click selector ".project_edit"
@@ -69,7 +69,7 @@ end
 Then /^I reload the project page/ do
   steps <<-GHERKIN
     And I reload the page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And element ".project_updated_at" eventually contains text "Saved"
   GHERKIN
 end

--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -25,7 +25,7 @@ end
 Then /^I complete the level on "([^"]*)"$/ do |puzzle_url|
   steps %{
     And I am on "#{append_noautoplay(puzzle_url)}"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
   }
   steps PUZZLE_SOLUTIONS[puzzle_url]
   steps %{

--- a/dashboard/test/ui/features/step_definitions/spritelab.rb
+++ b/dashboard/test/ui/features/step_definitions/spritelab.rb
@@ -1,6 +1,6 @@
 Given /^I start a new Sprite ?Lab project$/ do
   steps <<-STEPS
     And I am on "http://studio.code.org/projects/spritelab/new"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
   STEPS
 end

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -183,7 +183,7 @@ When /^I close the instructions overlay if it exists$/ do
   steps 'When I click selector "#overlay" if it exists'
 end
 
-When /^I wait for the page to fully load$/ do
+When /^I wait for the lab page to fully load$/ do
   steps <<-GHERKIN
     When I wait to see "#runButton"
     And I wait to see ".header_user"

--- a/dashboard/test/ui/features/teacher_tools/below_visualization.feature
+++ b/dashboard/test/ui/features/teacher_tools/below_visualization.feature
@@ -3,7 +3,7 @@ Feature: Ensure correct #belowVisualization position
   @eyes @as_student
   Scenario: Check correct position of video thumbnails
     Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
     When I open my eyes to test "Video thumbnail position"
     Then I see no difference for "default visualization width" using stitch mode "none"

--- a/dashboard/test/ui/features/teacher_tools/built_level.feature
+++ b/dashboard/test/ui/features/teacher_tools/built_level.feature
@@ -4,5 +4,5 @@ Background:
   Given I am on "http://studio.code.org/s/course1/lessons/4/levels/2"
 
 Scenario: The level loads
-  When I wait for the page to fully load
+  When I wait for the lab page to fully load
   Then element "#codeWorkspace" is visible

--- a/dashboard/test/ui/features/teacher_tools/callouts.feature
+++ b/dashboard/test/ui/features/teacher_tools/callouts.feature
@@ -6,7 +6,7 @@ Feature: Callouts
 
   Scenario Outline: Callouts having correct content and being dismissable via the target element
     Given I am on "<url>"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And callout "<callout_id>" is visible
     And callout "<callout_id>" has text: <text>
     And I send click events to selector "<close_target>"
@@ -26,7 +26,7 @@ Feature: Callouts
   @no_mobile
   Scenario Outline: Callouts having correct content and being dismissable via the x-button
     Given I am on "<url>"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I dismiss the login reminder
     And callout "<callout_id>" is visible
     And callout "<callout_id>" has text: <text>
@@ -39,12 +39,12 @@ Feature: Callouts
 
   Scenario: Modal ordering
     Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And callout "0" is visible
 
   Scenario: Closing using "x" button
     Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I dismiss the login reminder
     And element ".tooltip-x-close" is visible
     And callout "0" is visible
@@ -57,17 +57,17 @@ Feature: Callouts
 
   Scenario: Only showing seen callouts once
     Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And callout "0" exists
     Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And callout "0" does not exist
 
   # Show Code button is hidden on small screens.
   @no_mobile
   Scenario: Opening the Show Code dialog
     Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/1?noautoplay=true"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I dismiss the login reminder
     When I press "show-code-header"
     Then ".modal-backdrop" should be in front of "#qtip-0"

--- a/dashboard/test/ui/features/teacher_tools/challenge_level.feature
+++ b/dashboard/test/ui/features/teacher_tools/challenge_level.feature
@@ -3,7 +3,7 @@ Feature: Challenge level shows different dialogs
 Background:
   Given I am on "http://studio.code.org/reset_session"
   Given I am on "http://studio.code.org/s/allthethings/lessons/2/levels/6?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
 Scenario: Submit passing and perfect solutions
   Given I wait until element "#uitest-challenge-title" is visible

--- a/dashboard/test/ui/features/teacher_tools/contextual_hints.feature
+++ b/dashboard/test/ui/features/teacher_tools/contextual_hints.feature
@@ -2,7 +2,7 @@ Feature: Contextual Hints
 
 Scenario: Blocks render in contextual hints
   Given I am on "http://studio.code.org/s/allthethings/lessons/6/levels/2?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait to see "#lightbulb"
 
   When I press "runButton"
@@ -18,7 +18,7 @@ Scenario: Blocks render in contextual hints
 
 Scenario: Contextual hints in level without Authored Hints
   Given I am on "http://studio.code.org/s/allthethings/lessons/3/levels/6?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   Then element "#lightbulb" does not exist
 

--- a/dashboard/test/ui/features/teacher_tools/disallowedsharing.feature
+++ b/dashboard/test/ui/features/teacher_tools/disallowedsharing.feature
@@ -3,7 +3,7 @@ Feature: Shared content restrictions
 
 Background:
   Given I am on "http://studio.code.org/s/playlab/lessons/1/levels/10?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
 @webpurify
 Scenario: Sharing a profane studio game
@@ -14,7 +14,7 @@ Scenario: Sharing a profane studio game
 
 Scenario: Sharing a phone number studio game
   Given I am on "http://studio.code.org/s/playlab/lessons/1/levels/10?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I've initialized the workspace with a studio say block saying "800.555.5555"
   Then I press "runButton"
   Then I press ".share" using jQuery
@@ -22,7 +22,7 @@ Scenario: Sharing a phone number studio game
 
 Scenario: Sharing an email studio game
   Given I am on "http://studio.code.org/s/playlab/lessons/1/levels/10?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I've initialized the workspace with a studio say block saying "brian@code.org"
   Then I press "runButton"
   Then I press ".share" using jQuery

--- a/dashboard/test/ui/features/teacher_tools/feedback.feature
+++ b/dashboard/test/ui/features/teacher_tools/feedback.feature
@@ -3,7 +3,7 @@ Feature: Recommended/Required Blocks Feedback
 
 Scenario: Solve without recommended blocks
   Given I am on "http://studio.code.org/s/allthethings/lessons/4/levels/5?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   When I press "runButton"
   And I wait to see ".congrats"

--- a/dashboard/test/ui/features/teacher_tools/fun_o_meter.feature
+++ b/dashboard/test/ui/features/teacher_tools/fun_o_meter.feature
@@ -3,7 +3,7 @@ Feature: Fun-O-Meter
 
 Scenario: Rate a Puzzle
   Given I am on "http://studio.code.org/s/allthethings/lessons/4/levels/4?noautoplay=true&blocklyVersion=google"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   When I drag block "getNectar" to block "ifNectar" plus offset 35, 30
   And I press "runButton"
@@ -12,7 +12,7 @@ Scenario: Rate a Puzzle
   Then element "#puzzleRatingButtons" is visible
 
   When I reload the page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press "runButton"
   And I wait to see ".congrats"
 
@@ -25,7 +25,7 @@ Scenario: Rate a Puzzle
   And I wait until "puzzleRatings" in localStorage equals "[]"
 
   Given I am on "http://studio.code.org/s/allthethings/lessons/4/levels/4?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   When I press "runButton"
   And I wait to see ".congrats"

--- a/dashboard/test/ui/features/teacher_tools/instructions/csp_instructions.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/csp_instructions.feature
@@ -7,7 +7,7 @@ Background:
 
 Scenario: 'Help & Tips' and 'Instruction' tabs are visible if level has videos
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   When I click selector ".uitest-helpTab" once I see it
   And I wait until ".editor-column" contains text "Turtle Programming"
   And I click selector ".uitest-instructionsTab"
@@ -15,7 +15,7 @@ Scenario: 'Help & Tips' and 'Instruction' tabs are visible if level has videos
 
 Scenario: 'Help & Tips' and 'Instruction' tabs are visible if the level has a map reference
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/18"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   When I click selector ".uitest-helpTab" once I see it
   And I wait until ".editor-column" contains text "Circuit Playground"
   And I click selector ".uitest-instructionsTab"
@@ -23,7 +23,7 @@ Scenario: 'Help & Tips' and 'Instruction' tabs are visible if the level has a ma
 
 Scenario: 'Help & Tips' and 'Instruction' tabs are visible if the level has reference links
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/19"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   When I click selector ".uitest-helpTab" once I see it
   And I wait until ".editor-column" contains text "The Circuit Playground is a simple single board computer with many built in Inputs and Outputs for us to explore."
   And I click selector ".uitest-instructionsTab"
@@ -31,12 +31,12 @@ Scenario: 'Help & Tips' and 'Instruction' tabs are visible if the level has refe
 
 Scenario: Do not display resources tab when there are no videos, map references, or reference links
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/3"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-helpTab" is not visible
 
 Scenario: Resources tab displays videos, map references, and reference links with correct text and link
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/20"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   When I click selector ".uitest-helpTab" once I see it
   And I wait until ".editor-column" contains text "App Lab - Make It Interactive"
   And I wait until ".editor-column" contains text "Welcome to the Circuit Playground"
@@ -45,7 +45,7 @@ Scenario: Resources tab displays videos, map references, and reference links wit
   
 Scenario: Instructions can be collapsed and expanded
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/20"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press "ui-test-collapser"
   And element ".instructions-markdown" is hidden
   And I press "ui-test-collapser"
@@ -53,17 +53,17 @@ Scenario: Instructions can be collapsed and expanded
 
 Scenario: Instructions have a resizer for non-embedded levels
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/20"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element "#ui-test-resizer" is visible
 
 Scenario: Instructions do not show a resizer on embedded levels
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/12"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element "#ui-test-resizer" is not visible
 
 Scenario: Resources tab is clickable and displays correct text for contained levels
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/15"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   When I click selector ".uitest-helpTab" once I see it
   And I wait until ".editor-column" contains text "Welcome to the Circuit Playground"
   And I click selector ".uitest-instructionsTab"

--- a/dashboard/test/ui/features/teacher_tools/instructions/csp_top_instructions_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/csp_top_instructions_eyes.feature
@@ -5,7 +5,7 @@ Feature: Eyes Tests for Top Instructions CSP
 Scenario: CSD and CSP Top Instructions
   When I open my eyes to test "top instructions in CSP"
   And I am on "http://studio.code.org/s/allthethings/lessons/38/levels/1"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I see no difference for "teacher in applab level with rubric"
   Then I click selector ".uitest-feedback"
   Then I see no difference for "teacher in applab level viewing rubric"
@@ -37,12 +37,12 @@ Scenario: Resizing CSD and CSP Top Instructions
   Then I save the section id from row 0 of the section table
 
   And I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
   And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   Then I see no difference for "teacher in feedback tab"
   Then I click selector ".uitest-instructionsTab"

--- a/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab.feature
@@ -33,16 +33,16 @@ Otherwise don't show feedback tab
 
   #Not automatically visible on contained levels with no mini rubric
   Then I am on "http://studio.code.org/s/allthethings/lessons/18/levels/15"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-feedback" is not visible
 
   #Not automatically visible on un-contained levels with no mini rubric
   Then I am on "http://studio.code.org/s/allthethings/lessons/18/levels/7"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".uitest-feedback" is not visible
 
   And I am on "http://studio.code.org/s/allthethings/lessons/38/levels/1"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait to see ".uitest-feedback"
   And element ".editor-column" contains text "Rubric"
   Then I click selector ".uitest-feedback"
@@ -76,7 +76,7 @@ Otherwise don't show feedback tab
 
   #As teacher, refresh page and latest feedback is visible
   And I reload the page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait until ".editor-column" contains text "Nice!"
   And I wait to see "#rubric-input-performanceLevel1"
   And element "#rubric-input-performanceLevel1" is checked

--- a/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/feedback_tab_eyes.feature
@@ -13,7 +13,7 @@ Feature: Feedback Tab Visibility
   Scenario: As student 'Feedback' tab is the 'Key Concept' tab if no feedback
     When I open my eyes to test "student with no feedback"
     And I am on "http://studio.code.org/s/allthethings/lessons/38/levels/1"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I see no difference for "student with no feedback tab"
     Then I sign out
     And I close my eyes
@@ -29,7 +29,7 @@ Feature: Feedback Tab Visibility
     And I give user "Teacher_Lillian" authorized teacher permission
 
     And I am on "http://studio.code.org/s/allthethings/lessons/38/levels/1"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I see no difference for "teacher rubric feedback tab"
 
   #As teacher, reviewing work, submit feedback
@@ -37,7 +37,7 @@ Feature: Feedback Tab Visibility
     Then I click selector ".show-handle .fa-chevron-left"
     And I wait until element ".student-table" is visible
     And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I see no difference for "teacher giving feedback tab load"
 
     And I wait to see "#rubric-input-performanceLevel1"
@@ -53,7 +53,7 @@ Feature: Feedback Tab Visibility
 
   #As teacher, refresh page and latest feedback is visible
     And I reload the page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I see no difference for "teacher gave feedback"
 
   #As student, latest feedback from teacher is displayed

--- a/dashboard/test/ui/features/teacher_tools/instructions/help_and_tips.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/help_and_tips.feature
@@ -6,7 +6,7 @@ Feature: Help and Tips Map Link
 
   Scenario: 'Help & Tips' and 'Instruction' tabs are visible if the level has a map reference
     Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/18"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     When I click selector ".uitest-helpTab" once I see it
     And I wait until ".editor-column" contains text "Circuit Playground"
     When I click selector "a:contains(Circuit Playground)"

--- a/dashboard/test/ui/features/teacher_tools/instructions/teacher_only_markdown.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/teacher_only_markdown.feature
@@ -5,11 +5,11 @@ Scenario: Applab level with teacher only markdown
   When I open my eyes to test "teacher only markdown"
   Given I create an authorized teacher-associated student named "Manuel"
   Then I am on "http://studio.code.org/s/allthethings/lessons/18/levels/11"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "student doesnt see teacher markdown"
   Then I sign out
   And I sign in as "Teacher_Manuel"
   Then I am on "http://studio.code.org/s/allthethings/lessons/18/levels/11"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "authorized teacher does see teacher markdown"
   Then I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/instructions/top_instructions.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructions/top_instructions.feature
@@ -5,22 +5,22 @@ Feature: Eyes Tests for Top Instructions
 Scenario: CSF Top Instructions
   When I open my eyes to test "top instructions in CSF"
   And I am on "http://studio.code.org/s/course1/lessons/4/levels/11?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I see no difference for "maze short instructions"
 
   And I am on "http://studio.code.org/s/course4/lessons/3/levels/5?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "artist long instructions"
 
   Then I am on "http://studio.code.org/s/allthethings/lessons/2/levels/7?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "maze short instructions with ani gif"
 
   Then I press "ani-gif-preview"
   And I see no difference for "maze ani gif dialog"
 
   Then I am on "http://studio.code.org/s/allthethings/lessons/6/levels/2?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press "runButton"
   And I wait to see ".uitest-topInstructions-inline-feedback"
   And I see no difference for "farmer with hints"
@@ -44,23 +44,23 @@ Scenario: CSF Top Instructions
   And I see no difference for "farmer with video hint"
 
   Then I am on "http://studio.code.org/s/course4/lessons/19/levels/3?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "Bee with starting hints"
 
   Then I am on "http://studio.code.org/s/course1/lessons/3/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "Jigsaw with anigif"
 
   Then I am on "http://studio.code.org/s/mc/lessons/1/levels/4?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "minecraft top instructions" using stitch mode "none"
 
   Then I am on "http://studio.code.org/s/starwars/lessons/1/levels/15?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "starwars top instructions"
 
   Then I am on "http://studio.code.org/s/frozen/lessons/1/levels/5?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "frozen top instructions"
 
   And execute JavaScript expression "window.localStorage.clear()"

--- a/dashboard/test/ui/features/teacher_tools/instructor_in_training.feature
+++ b/dashboard/test/ui/features/teacher_tools/instructor_in_training.feature
@@ -6,7 +6,7 @@ Feature: Self Paced PL Instructor in Training
     And I sign in as "Universal Instructor"
     And I get universal instructor access
     Then I am on "http://studio.code.org/s/alltheselfpacedplthings/lessons/1/levels/1"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
     Then I press the first ".uitest-teacherOnlyTab" element
     And I wait to see ".editor-column"
@@ -19,7 +19,7 @@ Feature: Self Paced PL Instructor in Training
     Given I create an authorized teacher-associated student named "Manuel"
     And I sign in as "Teacher_Manuel"
     Then I am on "http://studio.code.org/s/alltheselfpacedplthings/lessons/1/levels/1"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
     Then I press the first ".uitest-teacherOnlyTab" element
     And I wait to see ".editor-column"
@@ -31,7 +31,7 @@ Feature: Self Paced PL Instructor in Training
   Scenario: View Instructor In Training Applab Level as Unverified Teacher
     Given I create a teacher named "Ms_Frizzle"
     Then I am on "http://studio.code.org/s/alltheselfpacedplthings/lessons/1/levels/1"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
     And element ".uitest-instructionsTab" is visible
     And element ".uitest-teacherOnlyTab" is not visible
@@ -43,7 +43,7 @@ Feature: Self Paced PL Instructor in Training
     And I get universal instructor access
     Then I am on "http://studio.code.org/s/alltheselfpacedplthings/lessons/1/levels/2"
     And I dismiss the hoc guide dialog
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
     Then I press the first ".uitest-teacherOnlyTab" element
     And I wait to see ".editor-column"
@@ -56,7 +56,7 @@ Feature: Self Paced PL Instructor in Training
     And I sign in as "Teacher_Manuel"
     Then I am on "http://studio.code.org/s/alltheselfpacedplthings/lessons/1/levels/2"
     And I dismiss the hoc guide dialog
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
     Then I press the first ".uitest-teacherOnlyTab" element
     And I wait to see ".editor-column"
@@ -67,7 +67,7 @@ Feature: Self Paced PL Instructor in Training
   Scenario: View Instructor In Training Dance Level as Unverified Teacher
     Given I create a teacher named "Ms_Frizzle"
     Then I am on "http://studio.code.org/s/alltheselfpacedplthings/lessons/1/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
     And element ".uitest-instructionsTab" is visible
     And element ".uitest-teacherOnlyTab" is not visible

--- a/dashboard/test/ui/features/teacher_tools/lesson_extras_teacher_panel.feature
+++ b/dashboard/test/ui/features/teacher_tools/lesson_extras_teacher_panel.feature
@@ -17,7 +17,7 @@ Feature: Lesson extras teacher panel
 
     # Lesson extras individual puzzle page
     And I click selector ".sublevel-card-title-uitest" once I see it to load a new page
-    When I wait for the page to fully load
+    When I wait for the lab page to fully load
     And I wait until element "#teacher-panel-container" is visible
     And check that the URL contains "section_id="
     And check that the URL contains "user_id="

--- a/dashboard/test/ui/features/teacher_tools/level_completion.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_completion.feature
@@ -7,7 +7,7 @@ Background:
 Scenario:
   When I open my eyes to test "bounce game"
   And I am on "http://studio.code.org/s/events/lessons/1/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "initial load"
   And I drag block "moveLeft" to block "whenLeft"
   Then block "moveLeft" is child of block "whenLeft"
@@ -22,7 +22,7 @@ Scenario:
 Scenario:
   When I open my eyes to test "freeplay artist sharing"
   And I am on "http://studio.code.org/s/course3/lessons/21/levels/15?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I dismiss the login reminder
   And I see no difference for "initial load"
   And I press "runButton"
@@ -35,7 +35,7 @@ Scenario:
 Scenario:
   When I open my eyes to test "freeplay playlab sharing"
   And I am on "http://studio.code.org/s/playlab/lessons/1/levels/10?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "initial load"
   And I press "runButton"
   And I press "finishButton"

--- a/dashboard/test/ui/features/teacher_tools/level_navigation.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_navigation.feature
@@ -21,5 +21,5 @@ Scenario: Complete an auto-success level signed-out, continue, the auto-success 
   And I wait to see ".submitButton"
   Then I click ".submitButton" to load a new page
   And I wait until I am on "http://studio.code.org/s/allthethings/lessons/18/levels/15"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I verify progress in the header of the current page is "perfect" for level 14

--- a/dashboard/test/ui/features/teacher_tools/level_types/free_response_contained_levels.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/free_response_contained_levels.feature
@@ -8,7 +8,7 @@ Feature: Free Response Contained Levels
 Scenario: Applab with free response contained level
   When I open my eyes to test "applab contained level"
   Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/15"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I see no difference for "initial load"
   Then I press keys "This is my answer" for element ".response"
   And I see no difference for "answer entered"
@@ -17,7 +17,7 @@ Scenario: Applab with free response contained level
   # At this point, we should have submitted our result to the server, do
   # a reload and make sure we have the submission
   Then I am on "http://studio.code.org/s/allthethings/lessons/18/levels/15"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "reloaded with contained level answered"
   Then I press "runButton"
   And I press "finishButton"
@@ -55,7 +55,7 @@ Scenario: Authorized Teacher on Maze with free response contained level
   When I open my eyes to test "maze free response contained level"
   Given I sign in as "Teacher_Lillian"
   And I am on "http://studio.code.org/s/allthethings/lessons/41/levels/6"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I see no difference for "initial load"
   And I press keys "Here is my response!" for element ".response"
   And I see no difference for "answer entered"
@@ -73,7 +73,7 @@ Scenario: Authorized Teacher on App Lab with free response contained level
   When I open my eyes to test "applab free response contained level"
   Given I sign in as "Teacher_Lillian"
   And I am on "http://studio.code.org/s/allthethings/lessons/41/levels/3"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I see no difference for "initial load"
   And I press keys "Here is my response!" for element ".response"
   And I see no difference for "answer entered"
@@ -89,7 +89,7 @@ Scenario: Authorized Teacher on App Lab with free response contained level
 Scenario: Teacher can reset progress on free response contained level
   Given I sign in as "Teacher_Lillian"
   And I am on "http://studio.code.org/s/allthethings/lessons/41/levels/3"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press keys "Here is my response!" for element ".response"
   And element ".response" has value "Here is my response!"
   Then I press "runButton"
@@ -108,7 +108,7 @@ Scenario: Teacher can reset progress on free response contained level
 Scenario: Student can attempt retriable free response contained level multiple times
   Given I am on "http://studio.code.org/s/allthethings/lessons/41/levels/9"
   And I rotate to landscape
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I press keys "Here is my response!" for element ".response"
   And element ".response" has value "Here is my response!"
   Then I press "runButton"

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_swap.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_swap.feature
@@ -24,7 +24,7 @@ Feature: Swapped levels
     And I am on "http://studio.code.org/s/allthethings/lessons/29/levels/5?level_name=ramp_video_loopsArtist&noautoplay=true"
     And I wait until element ".submitButton" is visible
     When I click selector ".submitButton" to load a new page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I verify progress in the header of the current page is "perfect" for level 1
     And I verify the bubble for level 1 is an activity bubble
     And I verify progress in the header of the current page is "perfect" for level 4

--- a/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
@@ -8,7 +8,7 @@ Feature: Multiple Choice Contained Levels
 Scenario: GameLab with a submittable contained level
   When I open my eyes to test "gamelab submittable contained level"
   Given I am on "http://studio.code.org/s/allthethings/lessons/41/levels/7"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I see no difference for "initial load" using stitch mode "none"
   Then I press "unchecked_0"
   And I see no difference for "answer entered" using stitch mode "none"
@@ -23,7 +23,7 @@ Scenario: GameLab with a submittable contained level
 Scenario: Gamelab with multiple choice contained level
   When I open my eyes to test "gamelab multiple choice contained level"
   Given I am on "http://studio.code.org/s/allthethings/lessons/41/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I see no difference for "initial load" using stitch mode "none"
   Then I press "unchecked_0"
   And I see no difference for "answer entered" using stitch mode "none"
@@ -32,7 +32,7 @@ Scenario: Gamelab with multiple choice contained level
   # At this point, we should have submitted our result to the server, do
   # a reload and make sure we have the submission
   Then I am on "http://studio.code.org/s/allthethings/lessons/41/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "reloaded with contained level answered" using stitch mode "none"
   Then I press "runButton"
   And I press "finishButton"
@@ -48,7 +48,7 @@ Scenario: Unauthorized Teacher on Maze with multiple choice contained level
   Given I create a teacher-associated student named "Sally"
   And I sign in as "Teacher_Sally" and go home
   Then I am on "http://studio.code.org/s/coursee-2019/lessons/4/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I see no difference for "initial load"
   Then I press "unchecked_0"
   And I see no difference for "answer entered"
@@ -64,7 +64,7 @@ Scenario: Unauthorized Teacher on Maze with multiple choice contained level
 Scenario: Teacher can reset progress on multiple choice contained level
   Given I sign in as "Teacher_Lillian"
   And I am on "http://studio.code.org/s/allthethings/lessons/41/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I press "unchecked_0"
   And I wait up to 5 seconds for element "#checked_0" to be visible
   Then I press "runButton"
@@ -83,7 +83,7 @@ Scenario: Teacher can reset progress on multiple choice contained level
 Scenario: Student can retry multiple choice contained level that allows multiple attempts
   Given I am on "http://studio.code.org/s/allthethings/lessons/41/levels/10"
   And I rotate to landscape
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then I press "unchecked_0"
   And I wait up to 5 seconds for element "#checked_0" to be visible
   Then I press "runButton"
@@ -96,5 +96,5 @@ Scenario: Student can retry multiple choice contained level that allows multiple
   And I verify progress in the header of the current page is "perfect" for level 10
   Then I am on "http://studio.code.org/s/allthethings/lessons/41/levels/10"
   And I rotate to landscape
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait up to 5 seconds for element "#checked_1" to be visible

--- a/dashboard/test/ui/features/teacher_tools/pairing.feature
+++ b/dashboard/test/ui/features/teacher_tools/pairing.feature
@@ -7,7 +7,7 @@ Feature: Student pairing
     Given I create a student named "Thing_Two"
     And I join the section
     Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/7"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I initiate pairing
     And I verify the user menu shows "Thing_One" and "Thing_Two" are in a pairing group
     # complete the level
@@ -18,14 +18,14 @@ Feature: Student pairing
     Then I wait to see ".modal"
     And I wait until element "#confirm-button" is visible
     And I click selector "#confirm-button" to load a new page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And check that the URL contains "/s/allthethings/lessons/18/levels/8"
     And I verify progress in the header of the current page is "perfect_assessment" for level 7
     And I sign out
     # verify the level is completed for the other student
     When I sign in as "Thing_One"
     Given I am on "http://studio.code.org/s/allthethings/lessons/18/levels/7"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "perfect_assessment" for level 7
 
   Scenario: Pair Programming attempts levels for both students
@@ -36,7 +36,7 @@ Feature: Student pairing
     Given I create a student named "Thing_Two"
     And I join the section
     Given I am on "http://studio.code.org/s/allthethings/lessons/2/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I initiate pairing
     And I verify the user menu shows "Thing_One" and "Thing_Two" are in a pairing group
     # complete the level
@@ -48,7 +48,7 @@ Feature: Student pairing
     # verify the level is completed for the other student
     When I sign in as "Thing_One"
     Given I am on "http://studio.code.org/s/allthethings/lessons/2/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "attempted" for level 2
 
   Scenario: Pairing group is correctly displayed in user menu on cached levels
@@ -59,7 +59,7 @@ Feature: Student pairing
     Given I create a student named "Thing_Two"
     And I join the section
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/5"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I initiate pairing
     And I verify the user menu shows "Thing_One" and "Thing_Two" are in a pairing group
     Then I reload the page

--- a/dashboard/test/ui/features/teacher_tools/progress.feature
+++ b/dashboard/test/ui/features/teacher_tools/progress.feature
@@ -8,7 +8,7 @@ Feature: Level Progress
     And I verify progress in the header of the current page is "not_tried" for level 2
 
     When I am on "http://studio.code.org/s/allthethings/lessons/2/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I verify progress in the header of the current page is "perfect" for level 1
     And I verify progress in the header of the current page is "not_tried" for level 2
 
@@ -25,7 +25,7 @@ Feature: Level Progress
     And I verify progress in the header of the current page is "not_tried" for level 2
 
     When I am on "http://studio.code.org/s/allthethings/lessons/2/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I verify progress in the header of the current page is "perfect" for level 1
     And I verify progress in the header of the current page is "not_tried" for level 2
 

--- a/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature
@@ -7,7 +7,7 @@ Feature: Applab Project
 Scenario: Applab Flow
   Given I am on "http://studio.code.org/projects/applab"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then evaluate JavaScript expression "localStorage.setItem('is13Plus', 'true'), true"
   And I switch to text mode
   And I add code "image('id', 'https://code.org/images/logo.png')" to ace editor
@@ -74,7 +74,7 @@ Scenario: Save Project After Signing Out
   Given I create a student named "Sally Student"
   And I am on "http://studio.code.org/projects/applab/new"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait for initial project save to complete
   And I ensure droplet is in block mode
   And I switch to text mode
@@ -91,7 +91,7 @@ Scenario: Save Project After Signing Out
 
   When I sign in as "Sally Student" from the sign in page
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I ensure droplet is in text mode
   Then ace editor code is equal to "// comment 1"
 
@@ -100,7 +100,7 @@ Scenario: Save Script Level After Signing Out
   Given I create a student named "Sally Student"
   Given I am assigned to unit "csp3-2017"
   And I am on "http://studio.code.org/s/csp3-2017/lessons/5/levels/3"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait for initial project save to complete
   And I ensure droplet is in block mode
   And I switch to text mode
@@ -117,7 +117,7 @@ Scenario: Save Script Level After Signing Out
 
   When I sign in as "Sally Student" from the sign in page
   And I get redirected to "/s/csp3-2017/lessons/5/levels/3" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I ensure droplet is in text mode
   Then ace editor code is equal to "// turtle 1"
 
@@ -126,7 +126,7 @@ Scenario: Save Script Level After Signing Out
 Scenario: Remix project creates and redirects to new channel
   Given I am on "http://studio.code.org/projects/applab"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then evaluate JavaScript expression "localStorage.setItem('is13Plus', 'true'), true"
   And element "#runButton" is visible
   And element ".project_updated_at" eventually contains text "Saved"
@@ -138,7 +138,7 @@ Scenario: Remix project creates and redirects to new channel
   And I save the URL
 
   Then I click selector ".project_remix" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I should see title includes "Remix: Code Ninja - App Lab - Code.org"
   And check that the URL contains "/edit"
   And check that the URL contains "http://studio.code.org/projects/applab"

--- a/dashboard/test/ui/features/teacher_tools/projects/artist_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/artist_project.feature
@@ -3,7 +3,7 @@ Feature: Artist Project
 Scenario: Save Artist Project
   Given I am on "http://studio.code.org/projects/artist"
   And I get redirected to "/projects/artist/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element "#runButton" is visible
   And element ".project_updated_at" eventually contains text "Saved"
   Then I open the topmost blockly category "Brushes"

--- a/dashboard/test/ui/features/teacher_tools/projects/gamelab_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/gamelab_project.feature
@@ -4,7 +4,7 @@ Feature: Gamelab Projects
 Scenario: Gamelab Flow
   Given I am on "http://studio.code.org/projects/gamelab"
   And I get redirected to "/projects/gamelab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then evaluate JavaScript expression "localStorage.setItem('is13Plus', 'true'), true"
   And element "#runButton" is visible
   And element ".project_updated_at" eventually contains text "Saved"
@@ -83,7 +83,7 @@ Scenario: Gamelab Flow
 Scenario: Remix project creates and redirects to new channel
   Given I am on "http://studio.code.org/projects/gamelab"
   And I get redirected to "/projects/gamelab/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then evaluate JavaScript expression "localStorage.setItem('is13Plus', 'true'), true"
   And element "#runButton" is visible
   And element ".project_updated_at" eventually contains text "Saved"
@@ -95,7 +95,7 @@ Scenario: Remix project creates and redirects to new channel
   And I save the URL
 
   Then I click selector ".project_remix" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I should see title includes "Remix: Code Ninja - Game Lab - Code.org"
   And check that the URL contains "/edit"
   And check that the URL contains "http://studio.code.org/projects/gamelab"

--- a/dashboard/test/ui/features/teacher_tools/projects/projects.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/projects.feature
@@ -20,14 +20,14 @@ Scenario: My Projects
 
 Scenario: Project Ownership
   Given I am on "http://studio.code.org/projects/artist/new"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And check that the URL matches "/edit$"
   And I save the URL
 
   # Make sure that project ownership persists via storage_id cookie.
 
   And I reload the page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And check that the URL matches "/edit$"
 
   # The storage_id cookie is sent with this account creation request,
@@ -35,12 +35,12 @@ Scenario: Project Ownership
 
   When I create a student named "Takeover"
   And I navigate to the saved URL
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And check that the URL matches "/edit$"
 
   # After takeover, the signed-out user no longer owns the project.
 
   When I sign out
   And I navigate to the saved URL
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And check that the URL matches "/view$"

--- a/dashboard/test/ui/features/teacher_tools/projects/starwars_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/starwars_project.feature
@@ -4,7 +4,7 @@ Feature: Starwars Project
 Scenario: Starwars Flow
   Given I am on "http://studio.code.org/projects/starwars"
   And I get redirected to "/projects/starwars/([^\/]*?)/edit" via "dashboard"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   Then evaluate JavaScript expression "localStorage.setItem('is13Plus', 'true'), true"
   And element "#runButton" is visible
   And element ".project_updated_at" eventually contains text "Saved"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -15,7 +15,7 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element "#homepage-container" is visible
     And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "not_tried" for level 2
 
     # Student submits code
@@ -35,10 +35,10 @@ Feature: Evaluate student code against rubrics using AI
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
     And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And element ".teacher-panel td:eq(1)" contains text "Aiden"
     And I click selector ".teacher-panel td:eq(1)" to load a new page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I click selector ".introjs-skipbutton" if it exists
     Then I verify progress in the header of the current page is "perfect_assessment" for level 2
     And element "#ui-floatingActionButton" is visible
@@ -65,7 +65,7 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element "#homepage-container" is visible
     And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "not_tried" for level 2
 
     # Student runs code
@@ -82,10 +82,10 @@ Feature: Evaluate student code against rubrics using AI
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
     And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And element ".teacher-panel td:eq(1)" contains text "Aiden"
     And I click selector ".teacher-panel td:eq(1)" to load a new page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
     And I click selector ".introjs-skipbutton" if it exists
     And I wait until element ".congrats" is gone
@@ -117,7 +117,7 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element "#homepage-container" is visible
     And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "not_tried" for level 2
 
     # Student runs code
@@ -134,10 +134,10 @@ Feature: Evaluate student code against rubrics using AI
     And I get debug info for the current user
     And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And element ".teacher-panel td:eq(1)" contains text "Aiden"
     And I click selector ".teacher-panel td:eq(1)" to load a new page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
     And I click selector ".introjs-skipbutton" if it exists
     And I wait until element ".congrats" is gone

--- a/dashboard/test/ui/features/teacher_tools/rubrics/student_completes_rubric_level.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/student_completes_rubric_level.feature
@@ -3,7 +3,7 @@ Feature: Student can complete rubric-enabled level
     # Create student not in an experiment
     Given I create a teacher-associated student named "Reuben"
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "not_tried" for level 2
 
     # Student submits code
@@ -18,7 +18,7 @@ Feature: Student can complete rubric-enabled level
 
     # Student can see new progress in header
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I verify progress in the header of the current page is "perfect_assessment" for level 2
 
   Scenario: AI pilot student can complete rubric-enabled level
@@ -26,7 +26,7 @@ Feature: Student can complete rubric-enabled level
     Given I create a teacher-associated student named "Reuben"
     And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "not_tried" for level 2
 
     # Student submits code
@@ -41,7 +41,7 @@ Feature: Student can complete rubric-enabled level
 
     # Student can see new progress in header
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I verify progress in the header of the current page is "perfect_assessment" for level 2
 
   Scenario: Non-AI pilot student can complete rubric-enabled level
@@ -49,7 +49,7 @@ Feature: Student can complete rubric-enabled level
     Given I create a teacher-associated student named "Reuben"
     And I add the current user to the "non-ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "not_tried" for level 2
 
     # Student submits code
@@ -64,5 +64,5 @@ Feature: Student can complete rubric-enabled level
 
     # Student can see new progress in header
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I verify progress in the header of the current page is "perfect_assessment" for level 2

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -24,7 +24,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".student-table" is visible
   And I click selector ".student-table tr:nth(1)" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
   And I click selector ".introjs-skipbutton" once I see it
   And I wait for 2 seconds
@@ -64,10 +64,10 @@ Scenario: Teacher views rubric product tour
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
   And I add the current user to the "ai-rubrics" single user experiment
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".teacher-panel td:eq(1)" contains text "Aiden"
   And I click selector ".teacher-panel td:eq(1)" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   # Teacher views product tour step 1
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
@@ -136,7 +136,7 @@ Scenario: Teacher views rubric product tour
 
   # Teacher does not see tour after completing and reloading page
   Then I reload the page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait until element "h5:contains(Code Quality)" is visible
 
 @eyes
@@ -148,10 +148,10 @@ Scenario: Teacher views Rubric and Settings tabs
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
   And I add the current user to the "ai-rubrics" single user experiment
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".teacher-panel td:eq(1)" contains text "Aiden"
   And I click selector ".teacher-panel td:eq(1)" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I click selector ".introjs-skipbutton" if it exists
 
   When I open my eyes to test "teaching assistant rubric"
@@ -184,10 +184,10 @@ Scenario: Teacher views product tour
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
   And I add the current user to the "ai-rubrics" single user experiment
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And element ".teacher-panel td:eq(1)" contains text "Aiden"
   And I click selector ".teacher-panel td:eq(1)" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   # Teacher views product tour step 1
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible

--- a/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_not_started_level_warning.feature
@@ -10,12 +10,12 @@ Scenario: Game lab level where student has not started
   And I wait until element ".uitest-owned-sections" is visible
 
   And I am on "http://studio.code.org/s/allthethings/lessons/38/levels/3"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
   And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" contains text "This student has not started the level."
   Then I see no difference for "student not started warning"
@@ -27,12 +27,12 @@ Scenario: Maze level where student has not started
   And I wait until element ".uitest-owned-sections" is visible
 
   And I am on "http://studio.code.org/s/allthethings/lessons/4/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
   And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" contains text "This student has not started the level."
   Then I see no difference for "student not started warning"
@@ -44,12 +44,12 @@ Scenario: Contained level
   And I wait until element ".uitest-owned-sections" is visible
 
   And I am on "http://studio.code.org/s/allthethings/lessons/41/levels/1"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
   And I wait until element ".student-table" is visible
   And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   And I wait until element ".editor-column" does not contain text "This student has not started the level."
   Then I see no difference for "no student not started warning"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/assessment_feedback_download.feature
@@ -8,7 +8,7 @@ Feature: Using the assessments tab in the teacher dashboard to get feedback for 
     # Assign a unit with a survey but no assessment
     When I sign in as "Teacher_Sally"
     Then I am on "http://studio.code.org/s/allthethings/lessons/18/levels/15"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     Then I am on "http://studio.code.org/home"
     And I click selector ".ui-test-section-dropdown" once I see it
     And I click selector ".edit-section-details-link"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
@@ -130,7 +130,7 @@ Feature: Using the teacher dashboard
     # Create an applab project and generate a thumbnail
 
     When I am on "http://studio.code.org/projects/applab/new"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I ensure droplet is in text mode
     And I append text to droplet "createCanvas('id', 320, 450);\nsetFillColor('red');\ncircle(160, 225, 160);"
     And I press "runButton"
@@ -144,7 +144,7 @@ Feature: Using the teacher dashboard
     # Create a gamelab project and generate a thumbnail
 
     When I am on "http://studio.code.org/projects/gamelab/new"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I ensure droplet is in text mode
     And I append text to droplet "\nfill('orange');\nellipse(200,200,400,400);"
     And I press "runButton"
@@ -168,12 +168,12 @@ Feature: Using the teacher dashboard
     # until it is resolved we want to make sure thumbnails include predraw.
 
     When I am on "http://studio.code.org/s/allthethings/lessons/3/levels/8"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I press "runButton"
     And I wait until element ".project_updated_at" contains text "Saved"
     And I wait until initial thumbnail capture is complete
     And I press the first ".project_remix" element to load a new page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
 
     # Create a dance party project level and generate a thumbnail.
 
@@ -181,13 +181,13 @@ Feature: Using the teacher dashboard
     # an existing project-backed level, and then run the project.
 
     When I am on "http://studio.code.org/s/dance/lessons/1/levels/13"
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I wait for 3 seconds
     And I wait until I don't see selector "#p5_loading"
     And I click selector "#x-close" once I see it
     And I close the instructions overlay if it exists
     And I press the first ".project_remix" element to load a new page
-    And I wait for the page to fully load
+    And I wait for the lab page to fully load
     And I press "runButton"
     And I wait until element ".project_updated_at" contains text "Saved"
     And I wait until initial thumbnail capture is complete

--- a/dashboard/test/ui/features/teacher_tools/teacher_student_toggle.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_student_toggle.feature
@@ -31,7 +31,7 @@ Scenario: Toggle on Hidden Maze Level
   And I wait to see ".uitest-togglehidden"
   Then I click selector ".uitest-togglehidden:nth(1) div:contains('Hidden')"
   Then I am on "http://studio.code.org/s/allthethings/lessons/2/levels/1?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I see no difference for "page load"
   Then I click selector ".show-handle .fa-chevron-left"
   Then I click selector ".uitest-viewAsStudent"

--- a/dashboard/test/ui/features/teacher_tools/text_to_speech.feature
+++ b/dashboard/test/ui/features/teacher_tools/text_to_speech.feature
@@ -6,7 +6,7 @@ Feature: Text To Speech
 Scenario: Check that TTS player is displayed
   Given I am a student
   And I am on "http://studio.code.org/s/allthettsthings/lessons/1/levels/1"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   Then I wait until element ".inline-audio" is visible
   Then I see 1 of jquery selector .inline-audio
@@ -14,7 +14,7 @@ Scenario: Check that TTS player is displayed
 @chrome
 Scenario: Listen to TTS Audio in CSF
   Given I am on "http://studio.code.org/s/allthethings/lessons/6/levels/3?noautoplay=true"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   # note: we expect no audio for the instructions, because this test
   # level is not in course1.
@@ -48,7 +48,7 @@ Scenario: Listen to TTS Audio in CSF
 Scenario: Listen to TTS Audio in CSF contained level
   Given I am a student
   And I am on "http://studio.code.org/s/allthettsthings/lessons/1/levels/1"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   # note: we expect audio for csf instructions
   Then I wait until element ".inline-audio" is visible
@@ -60,7 +60,7 @@ Scenario: Listen to TTS Audio in CSF contained level
 Scenario: Listen to TTS Audio in CSD
   Given I am a student
   And I am on "http://studio.code.org/s/allthettsthings/lessons/1/levels/2"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   # note: we expect audio for csd instructions
   Then I wait until element ".inline-audio" is visible
@@ -72,7 +72,7 @@ Scenario: Listen to TTS Audio in CSD
 Scenario: Listen to TTS Audio in CSP and CSP contained level
   Given I am a student
   And I am on "http://studio.code.org/s/allthettsthings/lessons/1/levels/4"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   # note: we expect audio for csp instructions
   Then I wait until element ".inline-audio" is visible
@@ -81,7 +81,7 @@ Scenario: Listen to TTS Audio in CSP and CSP contained level
   And I listen to the 0th inline audio element
 
   And I am on "http://studio.code.org/s/allthettsthings/lessons/1/levels/3"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
 
   # note: we expect audio for csp instructions
   Then I wait until element ".inline-audio" is visible

--- a/dashboard/test/ui/features/teacher_tools/version_history.feature
+++ b/dashboard/test/ui/features/teacher_tools/version_history.feature
@@ -5,7 +5,7 @@ Scenario: Teacher can view student versions
   Given I create an authorized teacher-associated student named "Ron"
   Then I sign in as "Ron"
   And I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1"
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I click selector "#runButton"
   And I press "show-code-header"
 
@@ -31,7 +31,7 @@ Scenario: Teacher can view student versions
   And I am on "http://studio.code.org/s/allthethings/lessons/18/levels/1"
   And I wait until element ".student-table" is visible
   And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
-  And I wait for the page to fully load
+  And I wait for the lab page to fully load
   And I dismiss the teacher panel
   And I press "versions-header"
   And I wait until element "div:contains(Latest Version)" is visible


### PR DESCRIPTION
The step definition 'and I wait fo the page to fully load' is used very widely across our .feature files (as evidenced by the files changed count here). However, I think the name doesn't quite capture what the step does. It waits for the run button, checks for a user header, and dismisses instructions if they exist. While this is super useful, it doesn't work on pages that aren't on a lab (that example, has no run button), and will fail if engineers try to use it elsewhere. 

This PR renames the step (and updates the files that call it) to 'and I wait for the lab page to fully load' so that an engineer will be less likely to try (and fail) to use it elsewhere.

I did this via a find and replace in vscode. 

<img width="454" alt="Screenshot 2024-07-25 at 10 49 31 AM" src="https://github.com/user-attachments/assets/0d418379-306a-4bf7-ad40-f33f41addee6">

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2131

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
