### PR TITLE
[Google] move number validators to cdoUtils (+ show "invisible" blocks in start mode)

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -213,7 +213,9 @@ export function moveHiddenBlocks(
 
   source.blocks.blocks.forEach(block => {
     const {invisible, procedureId} = block.extraState || {};
-    const hideBlock = procedureTypesToHide.includes(block.type) || invisible;
+    const hideBlock =
+      procedureTypesToHide.includes(block.type) ||
+      (invisible && !Blockly.isStartMode);
     const destination = hideBlock ? hiddenDefinitionSource : mainSource;
     destination.blocks.blocks.push(block);
 
@@ -443,6 +445,37 @@ export function getCode(workspace: WorkspaceSvg, getSourceAsJson: boolean) {
   }
 }
 
+/**
+ * Ensure that only a number may be entered.
+ * @param {string} text The user's text.
+ * @returns {?string} A string representing a valid number, or null if invalid.
+ *   Returns 0 for null or empty string.
+ * @static
+ */
+export function numberValidator(text: string): string | null {
+  text = text || '';
+  // TODO: Handle cases like 'ten', '1.203,14', etc.
+  // 'O' is sometimes mistaken for '0' by inexperienced users.
+  text = text.replace(/O/gi, '0');
+  // Strip out thousands separators.
+  text = text.replace(/,/g, '');
+  const n = parseFloat(text || '0');
+  return isNaN(n) ? null : String(n);
+}
+
+/**
+ * Ensure that only a nonnegative integer may be entered.
+ * @param {string} text The user's text.
+ * @returns {?string} A string representing a valid int, or null if invalid.
+ * @static
+ */
+export function nonnegativeIntegerValidator(text: string): string | null {
+  const n = numberValidator(text);
+  if (n) {
+    return String(Math.max(0, Math.floor(parseFloat(n))));
+  }
+  return n;
+}
 export function soundField(
   onClick: () => void,
   transformText?: (text: string) => string,

--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -467,6 +467,7 @@ export function numberValidator(text: string): string | null {
  * Ensure that only a nonnegative integer may be entered.
  * @param {string} text The user's text.
  * @returns {?string} A string representing a valid int, or null if invalid.
+ *   Returns '0' for negative numbers and null for truthy strings that do not contain numbers.
  * @static
  */
 export function nonnegativeIntegerValidator(text: string): string | null {

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -290,6 +290,12 @@ function initializeBlocklyWrapper(blocklyInstance) {
     bindBrowserEvent: function (element, name, thisObject, func, useCapture) {
       return Blockly.bindEvent_(element, name, thisObject, func, useCapture);
     },
+    nonnegativeIntegerValidator: function (text) {
+      return Blockly.FieldTextInput.nonnegativeIntegerValidator(text);
+    },
+    numberValidator: function (text) {
+      return Blockly.FieldTextInput.numberValidator(text);
+    },
     getField: function (type) {
       return new Blockly.FieldTextInput('', getFieldInputChangeHandler(type));
     },

--- a/apps/src/blocksCommon.js
+++ b/apps/src/blocksCommon.js
@@ -53,7 +53,7 @@ function installControlsRepeatSimplified(blockly, skin) {
         .appendField(
           new blockly.FieldTextInput(
             '10',
-            blockly.FieldTextInput.nonnegativeIntegerValidator
+            blockly.cdoUtils.nonnegativeIntegerValidator
           ),
           'TIMES'
         );

--- a/apps/src/flappy/blocks.js
+++ b/apps/src/flappy/blocks.js
@@ -641,10 +641,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.appendDummyInput()
         .appendField(msg.setScore())
         .appendField(
-          new blockly.FieldTextInput(
-            '0',
-            blockly.FieldTextInput.numberValidator
-          ),
+          new blockly.FieldTextInput('0', blockly.cdoUtils.numberValidator),
           'VALUE'
         );
       this.setInputsInline(true);

--- a/apps/src/maze/beeBlocks.js
+++ b/apps/src/maze/beeBlocks.js
@@ -340,7 +340,7 @@ function addConditionalComparisonBlock(blockly, generator, name, type, arg1) {
       );
       this.appendDummyInput().appendField(' ');
       this.appendDummyInput().appendField(
-        new blockly.FieldTextInput('0', blockly.FieldTextInput.numberValidator),
+        new blockly.FieldTextInput('0', blockly.cdoUtils.numberValidator),
         'ARG2'
       );
       this.setInputsInline(true);

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -143,10 +143,7 @@ exports.install = function (blockly, blockInstallOptions) {
       );
       this.appendDummyInput()
         .appendField(
-          new blockly.FieldTextInput(
-            '100',
-            blockly.FieldTextInput.numberValidator
-          ),
+          new blockly.FieldTextInput('100', blockly.cdoUtils.numberValidator),
           'VALUE'
         )
         .appendField(msg.dots());
@@ -1115,10 +1112,7 @@ exports.install = function (blockly, blockInstallOptions) {
       );
       this.appendDummyInput()
         .appendField(
-          new blockly.FieldTextInput(
-            '100',
-            blockly.FieldTextInput.numberValidator
-          ),
+          new blockly.FieldTextInput('100', blockly.cdoUtils.numberValidator),
           'VALUE'
         )
         .appendField(msg.dots());
@@ -1220,19 +1214,13 @@ exports.install = function (blockly, blockInstallOptions) {
         msg.jumpToOverDown(),
         () => {
           this.appendDummyInput().appendField(
-            new blockly.FieldTextInput(
-              '0',
-              blockly.FieldTextInput.numberValidator
-            ),
+            new blockly.FieldTextInput('0', blockly.cdoUtils.numberValidator),
             'XPOS'
           );
         },
         () => {
           this.appendDummyInput().appendField(
-            new blockly.FieldTextInput(
-              '0',
-              blockly.FieldTextInput.numberValidator
-            ),
+            new blockly.FieldTextInput('0', blockly.cdoUtils.numberValidator),
             'YPOS'
           );
         },
@@ -1341,7 +1329,7 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setInputsInline(true);
       this.appendDummyInput().appendField(msg.setWidth());
       this.appendDummyInput().appendField(
-        new blockly.FieldTextInput('1', blockly.FieldTextInput.numberValidator),
+        new blockly.FieldTextInput('1', blockly.cdoUtils.numberValidator),
         'WIDTH'
       );
       this.setPreviousStatement(true);
@@ -1610,10 +1598,7 @@ exports.install = function (blockly, blockInstallOptions) {
       block
         .appendDummyInput()
         .appendField(
-          new blockly.FieldTextInput(
-            '0',
-            blockly.FieldTextInput.numberValidator
-          ),
+          new blockly.FieldTextInput('0', blockly.cdoUtils.numberValidator),
           'SIZE'
         )
         .appendField(msg.pixels());
@@ -1704,10 +1689,7 @@ exports.install = function (blockly, blockInstallOptions) {
       block
         .appendDummyInput()
         .appendField(
-          new blockly.FieldTextInput(
-            '0',
-            blockly.FieldTextInput.numberValidator
-          ),
+          new blockly.FieldTextInput('0', blockly.cdoUtils.numberValidator),
           'SIZE'
         )
         .appendField(msg.pixels());

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -182,17 +182,17 @@ Function.prototype.inherits = function (parent) {
  * done so that level builders can specify required blocks with wildcard fields.
  */
 export function wrapNumberValidatorsForLevelBuilder() {
-  var nonNeg = Blockly.FieldTextInput.nonnegativeIntegerValidator;
-  var numVal = Blockly.FieldTextInput.numberValidator;
+  var nonNeg = Blockly.cdoUtils.nonnegativeIntegerValidator;
+  var numVal = Blockly.cdoUtils.numberValidator;
 
-  Blockly.FieldTextInput.nonnegativeIntegerValidator = function (text) {
+  Blockly.cdoUtils.nonnegativeIntegerValidator = function (text) {
     if (text === '???') {
       return text;
     }
     return nonNeg(text);
   };
 
-  Blockly.FieldTextInput.numberValidator = function (text) {
+  Blockly.cdoUtils.numberValidator = function (text) {
     if (text === '???') {
       return text;
     }

--- a/apps/test/unit/utilsTest.js
+++ b/apps/test/unit/utilsTest.js
@@ -268,7 +268,7 @@ describe('utils modules', () => {
 
     it('will allow ??? in number validators after being wrapped', function () {
       global.Blockly = {
-        FieldTextInput: {
+        cdoUtils: {
           // fake our validators
           nonnegativeIntegerValidator: function (text) {
             return isNaN(text) ? null : text;
@@ -279,27 +279,15 @@ describe('utils modules', () => {
         },
       };
 
-      assert.equal(
-        Blockly.FieldTextInput.nonnegativeIntegerValidator('123'),
-        123
-      );
-      assert.equal(Blockly.FieldTextInput.numberValidator('123'), 123);
-      assert.equal(
-        Blockly.FieldTextInput.nonnegativeIntegerValidator('???'),
-        null
-      );
-      assert.equal(Blockly.FieldTextInput.numberValidator('???'), null);
+      assert.equal(Blockly.cdoUtils.nonnegativeIntegerValidator('123'), 123);
+      assert.equal(Blockly.cdoUtils.numberValidator('123'), 123);
+      assert.equal(Blockly.cdoUtils.nonnegativeIntegerValidator('???'), null);
+      assert.equal(Blockly.cdoUtils.numberValidator('???'), null);
       wrapNumberValidatorsForLevelBuilder();
-      assert.equal(
-        Blockly.FieldTextInput.nonnegativeIntegerValidator('123'),
-        123
-      );
-      assert.equal(Blockly.FieldTextInput.numberValidator('123'), 123);
-      assert.equal(
-        Blockly.FieldTextInput.nonnegativeIntegerValidator('???'),
-        '???'
-      );
-      assert.equal(Blockly.FieldTextInput.numberValidator('???'), '???');
+      assert.equal(Blockly.cdoUtils.nonnegativeIntegerValidator('123'), 123);
+      assert.equal(Blockly.cdoUtils.numberValidator('123'), 123);
+      assert.equal(Blockly.cdoUtils.nonnegativeIntegerValidator('???'), '???');
+      assert.equal(Blockly.cdoUtils.numberValidator('???'), '???');
     });
   });
 


### PR DESCRIPTION
While trying to grab a screenshot of some blocks for another branch, I realized that "invisible" blocks are always moved to the hidden workspace, even if we're in start mode. This makes it impossible for them to be managed by levelbuilders outside of editing the XML on the level edit page. After adding a quick `isStartMode` check to fix this, I was hit by an error relating to `wrapNumberValidatorsForLevelBuilder`. The number validators are part of the `FieldTextInput` class in CDO Blockly and are used to ensure that students don't enter invalid values in number blocks. They are wrapped for levelbuilders so that the string `'???'` can be used where a number would normally be expected. This is a common practice for default field values in the toolbox and/or start blocks.
These validators are not part of the Google Blockly class of the same name, likely because there's now a separate `FieldNumber` class to use for this sort of thing. We _could_ add these validators ourselves if we extended `GoogleBlockly.FieldTextInput`, but they don't really make sense to be there any more. Instead I moved the functions to `cdoUtils`. The CDO Blockly versions (in the CDO wrapper) just call the originals. The Google Blockly versions (in `cdoUtils.ts`) do the same things. 
Starting with the levelbuilder example, I updated each place where we call or access one of these functions off of `FieldTextInput` to use `cdoUtils` instead.
I quickly found other instances of these validators being used, most often being supplied as validators when creating a new instance of the field class. Interestingly, some of these instances were happening in Google Blockly blocks. Because the functions were undefined, the validators weren't working. For example, loops in the recently migrated K1 Maze, and the `set score` block in Flappy (migrated in 2021) have both been accepting strings since the labs were flipped:
![image](https://github.com/user-attachments/assets/3d051ea1-22df-41ac-a69e-c41afe4bafb1)![image](https://github.com/user-attachments/assets/e11d08a0-949f-45a4-8af1-8d4bc22f3395)

The validators for all of these blocks are now working as expected.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
