### PR TITLE
Enable strongly consistent reads in the test DynamoDBAdapter

### DIFF
--- a/lib/dynamic_config/adapters/dynamodb_adapter.rb
+++ b/lib/dynamic_config/adapters/dynamodb_adapter.rb
@@ -5,9 +5,10 @@ require 'oj'
 
 class DynamoDBAdapter
   # @param table_name [String] the name of the dynamodb table to use
-  def initialize(table_name)
+  def initialize(table_name, consistent_read: false)
     @table_name = table_name
     @client = Aws::DynamoDB::Client.new
+    @consistent_read = consistent_read
   end
 
   # @param key [String]
@@ -16,7 +17,8 @@ class DynamoDBAdapter
     resp = @client.get_item(
       {
         table_name: @table_name,
-        key: {'data-key' => key}
+        key: {'data-key' => key},
+        consistent_read: @consistent_read
       }
     )
     return nil if resp.item.nil?

--- a/lib/dynamic_config/environment_aware_dynamic_config_helper.rb
+++ b/lib/dynamic_config/environment_aware_dynamic_config_helper.rb
@@ -6,11 +6,14 @@ module EnvironmentAwareDynamicConfigHelper
       # Use the memory adapter if we're running unit tests, but not if we're
       # running the web application server.
       adapter = MemoryAdapter.new
-    elsif rack_or_rails_env == 'production' || managed_test_server?
+    elsif rack_or_rails_env == 'production'
       # Production and the managed test system web application servers
       # (test.code.org / studio.code.org) use DynamoDB.
       cache_expiration = 30
       adapter = DynamoDBAdapter.new(identifier)
+    elsif managed_test_server?
+      cache_expiration = 30
+      adapter = DynamoDBAdapter.new(identifier, consistent_read: true)
     else
       # Everything else writes out to the local filesystem
       file_path = "#{dashboard_dir(identifier)}_temp.json"


### PR DESCRIPTION
One of the tests for setting a DCDO value has been deemed flaky:

```
  test 'storing hashes' do
    to_store = {
      'b' => 'yo dude',
      'c' => [1, 2, 3]
    }
    key = 'random'
    DCDO.set(key, to_store)
    assert_equal DCDO.get(key, nil), to_store
  end
```

I doubt that the test could possibly flake locally or in staging, since the in-memory cache adapter is used, meaning all operations will complete synchronously. The test environment, however, uses DynamoDB, which is eventually consistent by default. This means that read operations that occur in quick succession after a write operation may return stale results.

This PR adds a new param to the `DynamoDBAdapter` to enable strongly consistent reads. Since strongly consistent reads consume double the normal amount of read units, this will increase our DynamoDB usage. I don't think this will be a big deal since we're using provisioned capacity, and we appear to be way over-provisioned on the test DCDO table:

<img width="1559" alt="Screenshot 2024-07-25 at 2 03 39 PM" src="https://github.com/user-attachments/assets/bd8edc90-e218-4e6b-ae31-374906a114d3">


## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1064)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
