### PR TITLE
[JIMT]defer-codebridge-clickhandler - add the document event listener at the next tick of the event loop

### DIFF
--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -39,6 +39,8 @@ export const PopUpButton = ({
       setIsOpen(oldIsOpen => {
         const newIsOpen = !oldIsOpen;
         if (newIsOpen) {
+          // React 17 changed the location where clickhandlers are added, so we want to defer adding the close
+          // handler until the next tick of the event loop, otherwise it'll fire immediately and re-close the pop up.'
           setTimeout(
             () => document.addEventListener('click', setIsOpenFalse),
             0

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -39,7 +39,10 @@ export const PopUpButton = ({
       setIsOpen(oldIsOpen => {
         const newIsOpen = !oldIsOpen;
         if (newIsOpen) {
-          document.addEventListener('click', setIsOpenFalse);
+          setTimeout(
+            () => document.addEventListener('click', setIsOpenFalse),
+            0
+          );
         } else {
           document.removeEventListener('click', setIsOpenFalse);
         }


### PR DESCRIPTION
React 17 added in #59699 changed how clickhandlers are attached to the dom.

Further explanation is here: https://blog.saeloun.com/2021/07/08/react-17-event-delagation/

In turn, this broke the pop up menus in the file browser in codebridge. Here's what happened:

React 17 changed where react’s event listeners are tacked on (to the app root vs the document), and even that only manifests as an issue if other event handlers are tacked on outside of react’s knowledge.

So the old scenario is that a click event on the document might fire before react’s event handlers, and that click handler might call stopPropagation itself, and that in turn would prevent React’s handlers from firing.

here’s what was happening here - the codebridge button click is showing a pop up menu, and I was attaching a click handler to the document to allow clicks away on the window to close the popup. So my click handler itself was attaching a new click handler to the doc.

My document click handler didn’t call stopPropagation  so it shouldn’t manifest any problems.

Prior to react 17, it’d fire any non-react handlers, then the react handler (including mine!), which would attach a new handler to the document. Since the document’s click handlers had already been invoked, it was ignored on this pass through the loop and all worked well.

After react 17, my handler would wake up and attach to the document. Then, because the invocation order is different, the document click handler that I just attached would wake up and fire, immediately re-closing the pop up.

Stopping propagation would fix it (because it’d prevent the newly attached handler from firing), but a better fix is to just defer the attachment of the new click handler to the next tick of the event loop so it isn’t called as part of this invocation cycle and is just present in the future.

All of this taken together makes me wonder if we’ve got similar patterns elsewhere in the code where new click handlers were attached on the fly and we just need to defer it to the next tick so it doesn’t get muddied up.

#59699 added several `stopPropagation` calls to get around the issue by preventing any clickhandlers attached at the document level from firing at all. Indeed, that would work in this case as well. However, simply deferring the addition of the clickhandler to the next tick also resolved the issue and would not prevent any other external click handlers from firing.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
