### PR TITLE
Revert "Revert "Remove inline attribute from blocks in levels""

### DIFF
--- a/dashboard/config/levels/custom/maze/Course 4 Binary 1.level
+++ b/dashboard/config/levels/custom/maze/Course 4 Binary 1.level
@@ -28,7 +28,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -38,7 +38,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -161,7 +161,7 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -186,7 +186,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -196,7 +196,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>

--- a/dashboard/config/levels/custom/maze/Course 4 Binary 2.level
+++ b/dashboard/config/levels/custom/maze/Course 4 Binary 2.level
@@ -30,7 +30,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -155,7 +155,7 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -180,7 +180,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/maze/Course 4 Binary 3.level
+++ b/dashboard/config/levels/custom/maze/Course 4 Binary 3.level
@@ -135,7 +135,7 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/maze/Course 4 Binary 4 (copy 1).level
+++ b/dashboard/config/levels/custom/maze/Course 4 Binary 4 (copy 1).level
@@ -134,7 +134,7 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/maze/Course 4 Binary 4.level
+++ b/dashboard/config/levels/custom/maze/Course 4 Binary 4.level
@@ -134,7 +134,7 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -156,7 +156,7 @@
       <xml>
         <block type="when_run" movable="false" deletable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>

--- a/dashboard/config/levels/custom/maze/Course 4 Binary 5 (copy 1).level
+++ b/dashboard/config/levels/custom/maze/Course 4 Binary 5 (copy 1).level
@@ -136,7 +136,7 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/maze/Course 4 Binary 5.level
+++ b/dashboard/config/levels/custom/maze/Course 4 Binary 5.level
@@ -136,7 +136,7 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/maze/Course 4 Binary 6 (copy 1).level
+++ b/dashboard/config/levels/custom/maze/Course 4 Binary 6 (copy 1).level
@@ -136,7 +136,7 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/maze/Course 4 Binary 6.level
+++ b/dashboard/config/levels/custom/maze/Course 4 Binary 6.level
@@ -136,7 +136,7 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/maze/Course 4 Binary 7.level
+++ b/dashboard/config/levels/custom/maze/Course 4 Binary 7.level
@@ -136,7 +136,7 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/maze/Course 4 Binary 8.level
+++ b/dashboard/config/levels/custom/maze/Course 4 Binary 8.level
@@ -136,7 +136,7 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/studio/Bubble Sort.level
+++ b/dashboard/config/levels/custom/studio/Bubble Sort.level
@@ -78,7 +78,7 @@
                                 </block>
                               </value>
                               <statement name="DO">
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="grabL">
                                     <arg name="number"/>
                                   </mutation>
@@ -88,7 +88,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="grabR">
                                         <arg name="number"/>
                                       </mutation>
@@ -894,23 +894,23 @@
           </block>
         </category>
         <category name="Functions">
-          <block type="procedures_callnoreturn" inline="true">
+          <block type="procedures_callnoreturn">
             <mutation name="grabL">
               <arg name="number"/>
             </mutation>
           </block>
-          <block type="procedures_callnoreturn" inline="true">
+          <block type="procedures_callnoreturn">
             <mutation name="grabR">
               <arg name="number"/>
             </mutation>
           </block>
-          <block type="procedures_callnoreturn" inline="true">
+          <block type="procedures_callnoreturn">
             <mutation name="swap"/>
           </block>
-          <block type="procedures_callnoreturn" inline="true">
+          <block type="procedures_callnoreturn">
             <mutation name="dropL"/>
           </block>
-          <block type="procedures_callnoreturn" inline="true">
+          <block type="procedures_callnoreturn">
             <mutation name="dropR"/>
           </block>
         </category>

--- a/dashboard/config/levels/custom/studio/Play Lab Bubble Sort.level
+++ b/dashboard/config/levels/custom/studio/Play Lab Bubble Sort.level
@@ -71,7 +71,7 @@
                     </block>
                   </value>
                   <statement name="DO">
-                    <block type="procedures_callnoreturn" inline="true" uservisible="false">
+                    <block type="procedures_callnoreturn" uservisible="false">
                       <mutation name="move down">
                         <arg name="actor"/>
                       </mutation>
@@ -93,12 +93,12 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true" uservisible="false">
+                        <block type="procedures_callnoreturn" uservisible="false">
                           <mutation name="say number">
                             <arg name="actor"/>
                           </mutation>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true" uservisible="false">
+                            <block type="procedures_callnoreturn" uservisible="false">
                               <mutation name="move down">
                                 <arg name="actor"/>
                               </mutation>
@@ -130,7 +130,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true" uservisible="false">
+                                <block type="procedures_callnoreturn" uservisible="false">
                                   <mutation name="say number">
                                     <arg name="actor"/>
                                   </mutation>
@@ -235,7 +235,7 @@
                                         </block>
                                       </statement>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true" uservisible="false">
+                                        <block type="procedures_callnoreturn" uservisible="false">
                                           <mutation name="move up">
                                             <arg name="actor"/>
                                           </mutation>
@@ -257,7 +257,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true" uservisible="false">
+                                            <block type="procedures_callnoreturn" uservisible="false">
                                               <mutation name="move up">
                                                 <arg name="actor"/>
                                               </mutation>
@@ -310,7 +310,7 @@
                         </block>
                       </value>
                       <statement name="DO0">
-                        <block type="procedures_callnoreturn" inline="true" uservisible="false">
+                        <block type="procedures_callnoreturn" uservisible="false">
                           <mutation name="bubble sort">
                             <arg name="toSort"/>
                           </mutation>
@@ -442,7 +442,7 @@
                 </block>
               </value>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="say number">
                     <arg name="actor"/>
                   </mutation>
@@ -528,7 +528,7 @@
                                             </block>
                                           </value>
                                           <statement name="DO">
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="move right">
                                                 <arg name="actor"/>
                                               </mutation>
@@ -537,7 +537,7 @@
                                         </block>
                                       </statement>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="bubble sort">
                                             <arg name="toSort"/>
                                           </mutation>
@@ -1067,7 +1067,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="move left">
                             <arg name="actor"/>
                           </mutation>
@@ -1089,7 +1089,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="move right">
                                 <arg name="actor"/>
                               </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 1.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 1.level
@@ -1,7 +1,8 @@
 <Artist>
   <config><![CDATA[{
+  "published": true,
   "game_id": 23,
-  "created_at": "2014-11-10T20:01:42.000Z",
+  "created_at": "2022-02-16T19:37:58.000Z",
   "level_num": "custom",
   "user_id": 1,
   "properties": {
@@ -34,11 +35,19 @@
     "discard_background": "false",
     "instructions_important": "false",
     "hide_share_and_remix": "false",
-    "hint_prompt_attempts_threshold": 2,
-    "contained_level_names": null
+    "hint_prompt_attempts_threshold": "2",
+    "encrypted": "false",
+    "encrypted_examples": [
+
+    ],
+    "disable_if_else_editing": "false",
+    "show_type_hints": "false",
+    "validation_enabled": "false",
+    "enable_download_image": "false",
+    "preload_asset_list": null
   },
-  "published": true,
   "notes": "",
+  "audit_log": "[{\"changed_at\":\"2024-07-24 19:32:53 -0400\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"solution_blocks\",\"hint_prompt_attempts_threshold\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"mike@code.org\"}]",
   "level_concept_difficulty": {
     "sequencing": 1,
     "repeat_loops": 1
@@ -52,7 +61,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -62,7 +71,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -287,7 +296,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -310,7 +319,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -320,7 +329,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 1a.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 1a.level
@@ -40,7 +40,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -50,7 +50,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -275,7 +275,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -298,7 +298,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -308,7 +308,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -541,7 +541,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">4</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -551,7 +551,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 2.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 2.level
@@ -49,7 +49,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -291,7 +291,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 3.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 3.level
@@ -49,7 +49,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -272,7 +272,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -301,7 +301,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 4.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 4.level
@@ -46,7 +46,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true" deletable="false">
+            <block type="procedures_callnoreturn" deletable="false">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -56,7 +56,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                <block type="procedures_callnoreturn" deletable="false">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -66,7 +66,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                    <block type="procedures_callnoreturn" deletable="false">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -76,7 +76,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                        <block type="procedures_callnoreturn" deletable="false">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -86,7 +86,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true" deletable="false">
+                            <block type="procedures_callnoreturn" deletable="false">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -96,7 +96,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                <block type="procedures_callnoreturn" deletable="false">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -106,7 +106,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                    <block type="procedures_callnoreturn" deletable="false">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -116,7 +116,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                        <block type="procedures_callnoreturn" deletable="false">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -365,7 +365,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -375,7 +375,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -385,7 +385,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -395,7 +395,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -405,7 +405,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -415,7 +415,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -425,7 +425,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 5.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 5.level
@@ -259,7 +259,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" editable="false">
+        <block type="procedures_callnoreturn" editable="false">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -288,7 +288,7 @@
             <block type="controls_repeat">
               <title name="TIMES">11</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 6.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 6.level
@@ -260,7 +260,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -289,7 +289,7 @@
             <block type="controls_repeat">
               <title name="TIMES">13</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 7.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary 7.level
@@ -44,7 +44,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -54,7 +54,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -64,7 +64,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -74,7 +74,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -301,7 +301,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -327,7 +327,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -337,7 +337,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -347,7 +347,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -357,7 +357,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -367,7 +367,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -377,7 +377,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -387,7 +387,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -397,7 +397,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary Free Play 2.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary Free Play 2.level
@@ -305,7 +305,7 @@
         <block type="text">
           <title name="TEXT">0</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary Free Play 2a.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary Free Play 2a.level
@@ -68,7 +68,7 @@
                     </block>
                   </value>
                   <statement name="DO">
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -97,7 +97,7 @@
                         </block>
                       </value>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -361,7 +361,7 @@
         <block type="math_arithmetic" inline="true">
           <title name="OP">ADD</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary Free Play 2b.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary Free Play 2b.level
@@ -79,7 +79,7 @@
                     </block>
                   </value>
                   <statement name="DO">
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -108,7 +108,7 @@
                         </block>
                       </value>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -388,7 +388,7 @@
         <block type="text">
           <title name="TEXT">0</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary Free Play.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary Free Play.level
@@ -243,7 +243,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary pre1.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary pre1.level
@@ -55,7 +55,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -276,7 +276,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -286,7 +286,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -311,7 +311,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>

--- a/dashboard/config/levels/custom/turtle/Course 4 Artist Binary ryan.level
+++ b/dashboard/config/levels/custom/turtle/Course 4 Artist Binary ryan.level
@@ -38,7 +38,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -259,7 +259,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -269,7 +269,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -294,7 +294,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>

--- a/dashboard/config/levels/custom/turtle/course4_artist_binary_challenge1.level
+++ b/dashboard/config/levels/custom/turtle/course4_artist_binary_challenge1.level
@@ -256,7 +256,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -266,7 +266,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -297,7 +297,7 @@
             <block type="controls_repeat">
               <title name="TIMES">10</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -310,7 +310,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">6</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>

--- a/dashboard/config/levels/custom/turtle/course4_artist_binary_challenge2.level
+++ b/dashboard/config/levels/custom/turtle/course4_artist_binary_challenge2.level
@@ -48,7 +48,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -58,7 +58,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -68,7 +68,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -78,7 +78,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -88,7 +88,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -98,7 +98,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -108,7 +108,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -118,7 +118,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -128,7 +128,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -138,7 +138,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -155,7 +155,7 @@
                                                         </block>
                                                       </value>
                                                       <statement name="DO">
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -167,7 +167,7 @@
                                                         </block>
                                                       </statement>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -177,7 +177,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -187,7 +187,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -492,7 +492,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -506,7 +506,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -516,7 +516,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -529,7 +529,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">3</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -541,7 +541,7 @@
                         </block>
                       </statement>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -551,7 +551,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -561,7 +561,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -571,7 +571,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -581,7 +581,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -591,7 +591,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -601,7 +601,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -611,7 +611,7 @@
                                                     </block>
                                                   </value>
                                                   <next>
-                                                    <block type="procedures_callnoreturn" inline="true">
+                                                    <block type="procedures_callnoreturn">
                                                       <mutation name="draw">
                                                         <arg name="binary"/>
                                                       </mutation>
@@ -621,7 +621,7 @@
                                                         </block>
                                                       </value>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -631,7 +631,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -641,7 +641,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary1.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary1.level
@@ -261,7 +261,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -271,7 +271,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -296,7 +296,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary1_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary1_2018.level
@@ -266,7 +266,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -276,7 +276,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -304,7 +304,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary1_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary1_2019.level
@@ -266,7 +266,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -276,7 +276,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -304,7 +304,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary1_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary1_2020.level
@@ -266,7 +266,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -276,7 +276,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -304,7 +304,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary1_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary1_2021.level
@@ -261,7 +261,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -271,7 +271,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -299,7 +299,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary2.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary2.level
@@ -55,7 +55,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -65,7 +65,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -290,7 +290,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -313,7 +313,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -323,7 +323,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary2_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary2_2018.level
@@ -57,7 +57,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -67,7 +67,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -292,7 +292,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -318,7 +318,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -328,7 +328,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary2_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary2_2019.level
@@ -57,7 +57,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -67,7 +67,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -292,7 +292,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -318,7 +318,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -328,7 +328,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary2_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary2_2020.level
@@ -57,7 +57,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -67,7 +67,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -292,7 +292,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -318,7 +318,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -328,7 +328,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary2_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary2_2021.level
@@ -52,7 +52,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -62,7 +62,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -287,7 +287,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -313,7 +313,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -323,7 +323,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary3.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary3.level
@@ -262,7 +262,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -310,7 +310,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary3_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary3_2018.level
@@ -58,7 +58,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -311,7 +311,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary3_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary3_2019.level
@@ -59,7 +59,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary3_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary3_2020.level
@@ -59,7 +59,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary3_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary3_2021.level
@@ -53,7 +53,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary4.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary4.level
@@ -54,7 +54,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -277,7 +277,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -306,7 +306,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary4_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary4_2018.level
@@ -57,7 +57,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -280,7 +280,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -312,7 +312,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary4_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary4_2019.level
@@ -57,7 +57,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -280,7 +280,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -312,7 +312,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary4_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary4_2020.level
@@ -57,7 +57,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -280,7 +280,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -312,7 +312,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary4_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary4_2021.level
@@ -51,7 +51,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -274,7 +274,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -306,7 +306,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary5.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary5.level
@@ -50,7 +50,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true" deletable="false">
+            <block type="procedures_callnoreturn" deletable="false">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -60,7 +60,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                <block type="procedures_callnoreturn" deletable="false">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -70,7 +70,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                    <block type="procedures_callnoreturn" deletable="false">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -80,7 +80,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                        <block type="procedures_callnoreturn" deletable="false">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -90,7 +90,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true" deletable="false">
+                            <block type="procedures_callnoreturn" deletable="false">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -100,7 +100,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                <block type="procedures_callnoreturn" deletable="false">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -110,7 +110,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                    <block type="procedures_callnoreturn" deletable="false">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -120,7 +120,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                        <block type="procedures_callnoreturn" deletable="false">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -369,7 +369,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -379,7 +379,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -389,7 +389,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -399,7 +399,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -409,7 +409,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -419,7 +419,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -429,7 +429,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary5_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary5_2018.level
@@ -53,7 +53,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true" deletable="false">
+            <block type="procedures_callnoreturn" deletable="false">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -63,7 +63,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                <block type="procedures_callnoreturn" deletable="false">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -73,7 +73,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                    <block type="procedures_callnoreturn" deletable="false">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -83,7 +83,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                        <block type="procedures_callnoreturn" deletable="false">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -93,7 +93,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true" deletable="false">
+                            <block type="procedures_callnoreturn" deletable="false">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -103,7 +103,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                <block type="procedures_callnoreturn" deletable="false">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -113,7 +113,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                    <block type="procedures_callnoreturn" deletable="false">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -123,7 +123,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                        <block type="procedures_callnoreturn" deletable="false">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -372,7 +372,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -382,7 +382,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -392,7 +392,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -402,7 +402,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -412,7 +412,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -422,7 +422,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -432,7 +432,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary5_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary5_2019.level
@@ -53,7 +53,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true" deletable="false">
+            <block type="procedures_callnoreturn" deletable="false">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -63,7 +63,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                <block type="procedures_callnoreturn" deletable="false">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -73,7 +73,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                    <block type="procedures_callnoreturn" deletable="false">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -83,7 +83,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                        <block type="procedures_callnoreturn" deletable="false">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -93,7 +93,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true" deletable="false">
+                            <block type="procedures_callnoreturn" deletable="false">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -103,7 +103,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                <block type="procedures_callnoreturn" deletable="false">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -113,7 +113,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                    <block type="procedures_callnoreturn" deletable="false">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -123,7 +123,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                        <block type="procedures_callnoreturn" deletable="false">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -372,7 +372,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -382,7 +382,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -392,7 +392,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -402,7 +402,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -412,7 +412,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -422,7 +422,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -432,7 +432,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary5_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary5_2020.level
@@ -53,7 +53,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true" deletable="false">
+            <block type="procedures_callnoreturn" deletable="false">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -63,7 +63,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                <block type="procedures_callnoreturn" deletable="false">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -73,7 +73,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                    <block type="procedures_callnoreturn" deletable="false">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -83,7 +83,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                        <block type="procedures_callnoreturn" deletable="false">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -93,7 +93,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true" deletable="false">
+                            <block type="procedures_callnoreturn" deletable="false">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -103,7 +103,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                <block type="procedures_callnoreturn" deletable="false">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -113,7 +113,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                    <block type="procedures_callnoreturn" deletable="false">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -123,7 +123,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                        <block type="procedures_callnoreturn" deletable="false">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -372,7 +372,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -382,7 +382,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -392,7 +392,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -402,7 +402,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -412,7 +412,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -422,7 +422,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -432,7 +432,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary5_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary5_2021.level
@@ -48,7 +48,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true" deletable="false">
+            <block type="procedures_callnoreturn" deletable="false">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -58,7 +58,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                <block type="procedures_callnoreturn" deletable="false">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -68,7 +68,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                    <block type="procedures_callnoreturn" deletable="false">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -78,7 +78,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                        <block type="procedures_callnoreturn" deletable="false">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -88,7 +88,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true" deletable="false">
+                            <block type="procedures_callnoreturn" deletable="false">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -98,7 +98,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                <block type="procedures_callnoreturn" deletable="false">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -108,7 +108,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                    <block type="procedures_callnoreturn" deletable="false">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -118,7 +118,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                        <block type="procedures_callnoreturn" deletable="false">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -367,7 +367,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -377,7 +377,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -387,7 +387,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -397,7 +397,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -407,7 +407,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -417,7 +417,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -427,7 +427,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary6.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary6.level
@@ -265,7 +265,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" editable="false">
+        <block type="procedures_callnoreturn" editable="false">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -294,7 +294,7 @@
             <block type="controls_repeat">
               <title name="TIMES">11</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary6_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary6_2018.level
@@ -268,7 +268,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" editable="false">
+        <block type="procedures_callnoreturn" editable="false">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -300,7 +300,7 @@
             <block type="controls_repeat">
               <title name="TIMES">11</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary6_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary6_2019.level
@@ -268,7 +268,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" editable="false">
+        <block type="procedures_callnoreturn" editable="false">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -300,7 +300,7 @@
             <block type="controls_repeat">
               <title name="TIMES">11</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary6_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary6_2020.level
@@ -268,7 +268,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" editable="false">
+        <block type="procedures_callnoreturn" editable="false">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -300,7 +300,7 @@
             <block type="controls_repeat">
               <title name="TIMES">11</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary6_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary6_2021.level
@@ -262,7 +262,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" editable="false">
+        <block type="procedures_callnoreturn" editable="false">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -294,7 +294,7 @@
             <block type="controls_repeat">
               <title name="TIMES">11</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary7.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary7.level
@@ -265,7 +265,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -294,7 +294,7 @@
             <block type="controls_repeat">
               <title name="TIMES">13</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary7_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary7_2018.level
@@ -300,7 +300,7 @@
             <block type="controls_repeat">
               <title name="TIMES">13</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary7_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary7_2019.level
@@ -300,7 +300,7 @@
             <block type="controls_repeat">
               <title name="TIMES">13</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary7_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary7_2020.level
@@ -300,7 +300,7 @@
             <block type="controls_repeat">
               <title name="TIMES">13</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary7_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary7_2021.level
@@ -294,7 +294,7 @@
             <block type="controls_repeat">
               <title name="TIMES">13</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary8.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary8.level
@@ -51,7 +51,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -61,7 +61,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -71,7 +71,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -81,7 +81,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -308,7 +308,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -334,7 +334,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -344,7 +344,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -354,7 +354,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -364,7 +364,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -374,7 +374,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -384,7 +384,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -394,7 +394,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -404,7 +404,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary8_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary8_2018.level
@@ -54,7 +54,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -64,7 +64,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -74,7 +74,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -84,7 +84,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -311,7 +311,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -340,7 +340,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -350,7 +350,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -360,7 +360,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -370,7 +370,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -380,7 +380,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -390,7 +390,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -400,7 +400,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -410,7 +410,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary8_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary8_2019.level
@@ -54,7 +54,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -64,7 +64,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -74,7 +74,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -84,7 +84,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -311,7 +311,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -340,7 +340,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -350,7 +350,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -360,7 +360,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -370,7 +370,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -380,7 +380,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -390,7 +390,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -400,7 +400,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -410,7 +410,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary8_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary8_2020.level
@@ -54,7 +54,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -64,7 +64,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -74,7 +74,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -84,7 +84,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -311,7 +311,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -340,7 +340,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -350,7 +350,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -360,7 +360,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -370,7 +370,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -380,7 +380,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -390,7 +390,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -400,7 +400,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -410,7 +410,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary8_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary8_2021.level
@@ -49,7 +49,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -59,7 +59,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -69,7 +69,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -79,7 +79,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -306,7 +306,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -335,7 +335,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -345,7 +345,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -355,7 +355,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -365,7 +365,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -375,7 +375,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -385,7 +385,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -395,7 +395,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -405,7 +405,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary8_predict1.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary8_predict1.level
@@ -54,7 +54,7 @@
             <block type="controls_repeat">
               <title name="TIMES">9</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -277,7 +277,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary8_predict1_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary8_predict1_2018.level
@@ -51,7 +51,7 @@
             <block type="controls_repeat">
               <title name="TIMES">9</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -274,7 +274,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary8_predict1_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary8_predict1_2019.level
@@ -63,7 +63,7 @@
             <block type="controls_repeat">
               <title name="TIMES">9</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -286,7 +286,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary8_predict1_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary8_predict1_2020.level
@@ -60,7 +60,7 @@
             <block type="controls_repeat">
               <title name="TIMES">9</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -283,7 +283,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary8_predict1_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary8_predict1_2021.level
@@ -58,7 +58,7 @@
             <block type="controls_repeat">
               <title name="TIMES">9</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -281,7 +281,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP.level
@@ -65,7 +65,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP8.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP8.level
@@ -52,7 +52,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP_2018.level
@@ -323,7 +323,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP_2019.level
@@ -323,7 +323,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP_2020.level
@@ -323,7 +323,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binaryFP_2021.level
@@ -318,7 +318,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge0.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge0.level
@@ -255,7 +255,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -265,7 +265,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -299,7 +299,7 @@
                 <block type="controls_repeat">
                   <title name="TIMES">7</title>
                   <statement name="DO">
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -311,7 +311,7 @@
                     </block>
                   </statement>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge1.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge1.level
@@ -259,7 +259,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -269,7 +269,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -300,7 +300,7 @@
             <block type="controls_repeat">
               <title name="TIMES">10</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -313,7 +313,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">6</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge1_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge1_2018.level
@@ -264,7 +264,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -274,7 +274,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -305,7 +305,7 @@
             <block type="controls_repeat">
               <title name="TIMES">10</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -318,7 +318,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">6</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge1_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge1_2019.level
@@ -264,7 +264,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -274,7 +274,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -305,7 +305,7 @@
             <block type="controls_repeat">
               <title name="TIMES">10</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -318,7 +318,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">6</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge1_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge1_2020.level
@@ -264,7 +264,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -274,7 +274,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -305,7 +305,7 @@
             <block type="controls_repeat">
               <title name="TIMES">10</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -318,7 +318,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">6</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge1_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge1_2021.level
@@ -258,7 +258,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -268,7 +268,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true" limit="2">
+        <block type="procedures_callnoreturn" limit="2">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -299,7 +299,7 @@
             <block type="controls_repeat">
               <title name="TIMES">10</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -312,7 +312,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">6</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge2.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge2.level
@@ -52,7 +52,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -62,7 +62,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -72,7 +72,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -82,7 +82,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -92,7 +92,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -102,7 +102,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -112,7 +112,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -122,7 +122,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -132,7 +132,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -142,7 +142,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -159,7 +159,7 @@
                                                         </block>
                                                       </value>
                                                       <statement name="DO">
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -171,7 +171,7 @@
                                                         </block>
                                                       </statement>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -181,7 +181,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -191,7 +191,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -496,7 +496,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -510,7 +510,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -520,7 +520,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -533,7 +533,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">3</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -545,7 +545,7 @@
                         </block>
                       </statement>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -555,7 +555,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -565,7 +565,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -575,7 +575,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -585,7 +585,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -595,7 +595,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -605,7 +605,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -615,7 +615,7 @@
                                                     </block>
                                                   </value>
                                                   <next>
-                                                    <block type="procedures_callnoreturn" inline="true">
+                                                    <block type="procedures_callnoreturn">
                                                       <mutation name="draw">
                                                         <arg name="binary"/>
                                                       </mutation>
@@ -625,7 +625,7 @@
                                                         </block>
                                                       </value>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -635,7 +635,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -645,7 +645,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge2_2018.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge2_2018.level
@@ -57,7 +57,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -67,7 +67,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -77,7 +77,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -87,7 +87,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -97,7 +97,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -107,7 +107,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -117,7 +117,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -127,7 +127,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -137,7 +137,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -147,7 +147,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -164,7 +164,7 @@
                                                         </block>
                                                       </value>
                                                       <statement name="DO">
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -176,7 +176,7 @@
                                                         </block>
                                                       </statement>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -186,7 +186,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -196,7 +196,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -501,7 +501,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -515,7 +515,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -525,7 +525,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -538,7 +538,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">3</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -550,7 +550,7 @@
                         </block>
                       </statement>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -560,7 +560,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -570,7 +570,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -580,7 +580,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -590,7 +590,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -600,7 +600,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -610,7 +610,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -620,7 +620,7 @@
                                                     </block>
                                                   </value>
                                                   <next>
-                                                    <block type="procedures_callnoreturn" inline="true">
+                                                    <block type="procedures_callnoreturn">
                                                       <mutation name="draw">
                                                         <arg name="binary"/>
                                                       </mutation>
@@ -630,7 +630,7 @@
                                                         </block>
                                                       </value>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -640,7 +640,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -650,7 +650,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge2_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge2_2019.level
@@ -57,7 +57,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -67,7 +67,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -77,7 +77,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -87,7 +87,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -97,7 +97,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -107,7 +107,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -117,7 +117,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -127,7 +127,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -137,7 +137,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -147,7 +147,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -164,7 +164,7 @@
                                                         </block>
                                                       </value>
                                                       <statement name="DO">
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -176,7 +176,7 @@
                                                         </block>
                                                       </statement>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -186,7 +186,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -196,7 +196,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -501,7 +501,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -515,7 +515,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -525,7 +525,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -538,7 +538,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">3</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -550,7 +550,7 @@
                         </block>
                       </statement>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -560,7 +560,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -570,7 +570,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -580,7 +580,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -590,7 +590,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -600,7 +600,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -610,7 +610,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -620,7 +620,7 @@
                                                     </block>
                                                   </value>
                                                   <next>
-                                                    <block type="procedures_callnoreturn" inline="true">
+                                                    <block type="procedures_callnoreturn">
                                                       <mutation name="draw">
                                                         <arg name="binary"/>
                                                       </mutation>
@@ -630,7 +630,7 @@
                                                         </block>
                                                       </value>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -640,7 +640,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -650,7 +650,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge2_2020.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge2_2020.level
@@ -57,7 +57,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -67,7 +67,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -77,7 +77,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -87,7 +87,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -97,7 +97,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -107,7 +107,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -117,7 +117,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -127,7 +127,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -137,7 +137,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -147,7 +147,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -164,7 +164,7 @@
                                                         </block>
                                                       </value>
                                                       <statement name="DO">
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -176,7 +176,7 @@
                                                         </block>
                                                       </statement>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -186,7 +186,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -196,7 +196,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -501,7 +501,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -515,7 +515,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -525,7 +525,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -538,7 +538,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">3</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -550,7 +550,7 @@
                         </block>
                       </statement>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -560,7 +560,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -570,7 +570,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -580,7 +580,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -590,7 +590,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -600,7 +600,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -610,7 +610,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -620,7 +620,7 @@
                                                     </block>
                                                   </value>
                                                   <next>
-                                                    <block type="procedures_callnoreturn" inline="true">
+                                                    <block type="procedures_callnoreturn">
                                                       <mutation name="draw">
                                                         <arg name="binary"/>
                                                       </mutation>
@@ -630,7 +630,7 @@
                                                         </block>
                                                       </value>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -640,7 +640,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -650,7 +650,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge2_2021.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge2_2021.level
@@ -51,7 +51,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -61,7 +61,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -71,7 +71,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -81,7 +81,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -91,7 +91,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -101,7 +101,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -111,7 +111,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -121,7 +121,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -131,7 +131,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -141,7 +141,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -158,7 +158,7 @@
                                                         </block>
                                                       </value>
                                                       <statement name="DO">
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -170,7 +170,7 @@
                                                         </block>
                                                       </statement>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -180,7 +180,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -190,7 +190,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -495,7 +495,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -509,7 +509,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -519,7 +519,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -532,7 +532,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">3</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -544,7 +544,7 @@
                         </block>
                       </statement>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -554,7 +554,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -564,7 +564,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -574,7 +574,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -584,7 +584,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -594,7 +594,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -604,7 +604,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -614,7 +614,7 @@
                                                     </block>
                                                   </value>
                                                   <next>
-                                                    <block type="procedures_callnoreturn" inline="true">
+                                                    <block type="procedures_callnoreturn">
                                                       <mutation name="draw">
                                                         <arg name="binary"/>
                                                       </mutation>
@@ -624,7 +624,7 @@
                                                         </block>
                                                       </value>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -634,7 +634,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -644,7 +644,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge3.level
+++ b/dashboard/config/levels/custom/turtle/courseD_artist_binary_challenge3.level
@@ -49,7 +49,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -59,7 +59,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -69,7 +69,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -79,7 +79,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -89,7 +89,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -99,7 +99,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -109,7 +109,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -119,7 +119,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -129,7 +129,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -139,7 +139,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -156,7 +156,7 @@
                                                         </block>
                                                       </value>
                                                       <statement name="DO">
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -168,7 +168,7 @@
                                                         </block>
                                                       </statement>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -178,7 +178,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -188,7 +188,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -493,7 +493,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -507,7 +507,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -517,7 +517,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -530,7 +530,7 @@
                     <block type="controls_repeat">
                       <title name="TIMES">3</title>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -542,7 +542,7 @@
                         </block>
                       </statement>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -552,7 +552,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -562,7 +562,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -572,7 +572,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -582,7 +582,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -592,7 +592,7 @@
                                             </block>
                                           </value>
                                           <next>
-                                            <block type="procedures_callnoreturn" inline="true">
+                                            <block type="procedures_callnoreturn">
                                               <mutation name="draw">
                                                 <arg name="binary"/>
                                               </mutation>
@@ -602,7 +602,7 @@
                                                 </block>
                                               </value>
                                               <next>
-                                                <block type="procedures_callnoreturn" inline="true">
+                                                <block type="procedures_callnoreturn">
                                                   <mutation name="draw">
                                                     <arg name="binary"/>
                                                   </mutation>
@@ -612,7 +612,7 @@
                                                     </block>
                                                   </value>
                                                   <next>
-                                                    <block type="procedures_callnoreturn" inline="true">
+                                                    <block type="procedures_callnoreturn">
                                                       <mutation name="draw">
                                                         <arg name="binary"/>
                                                       </mutation>
@@ -622,7 +622,7 @@
                                                         </block>
                                                       </value>
                                                       <next>
-                                                        <block type="procedures_callnoreturn" inline="true">
+                                                        <block type="procedures_callnoreturn">
                                                           <mutation name="draw">
                                                             <arg name="binary"/>
                                                           </mutation>
@@ -632,7 +632,7 @@
                                                             </block>
                                                           </value>
                                                           <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>
@@ -642,7 +642,7 @@
                                                             </block>
                                                             </value>
                                                             <next>
-                                                            <block type="procedures_callnoreturn" inline="true">
+                                                            <block type="procedures_callnoreturn">
                                                             <mutation name="draw">
                                                             <arg name="binary"/>
                                                             </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_autorun_binary5_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_autorun_binary5_2019.level
@@ -55,7 +55,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true" deletable="false">
+            <block type="procedures_callnoreturn" deletable="false">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -65,7 +65,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                <block type="procedures_callnoreturn" deletable="false">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -75,7 +75,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                    <block type="procedures_callnoreturn" deletable="false">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -85,7 +85,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                        <block type="procedures_callnoreturn" deletable="false">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -95,7 +95,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true" deletable="false">
+                            <block type="procedures_callnoreturn" deletable="false">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -105,7 +105,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                <block type="procedures_callnoreturn" deletable="false">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -115,7 +115,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                    <block type="procedures_callnoreturn" deletable="false">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -125,7 +125,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                        <block type="procedures_callnoreturn" deletable="false">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -421,7 +421,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -431,7 +431,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -441,7 +441,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -451,7 +451,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -461,7 +461,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -471,7 +471,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -481,7 +481,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_autorun_binary6_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_autorun_binary6_2019.level
@@ -350,7 +350,7 @@
             <block type="controls_repeat">
               <title name="TIMES">11</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_autorun_binary7_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_autorun_binary7_2019.level
@@ -338,7 +338,7 @@
             <block type="controls_repeat">
               <title name="TIMES">13</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_autorun_binary8_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_autorun_binary8_2019.level
@@ -55,7 +55,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -65,7 +65,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -75,7 +75,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -85,7 +85,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -390,7 +390,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -400,7 +400,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -410,7 +410,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -420,7 +420,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -430,7 +430,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -440,7 +440,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -450,7 +450,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -460,7 +460,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>

--- a/dashboard/config/levels/custom/turtle/courseD_autorun_binary8_predict1_2019.level
+++ b/dashboard/config/levels/custom/turtle/courseD_autorun_binary8_predict1_2019.level
@@ -58,7 +58,7 @@
             <block type="controls_repeat">
               <title name="TIMES">9</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -328,7 +328,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/grade5_artist_binary1.level
+++ b/dashboard/config/levels/custom/turtle/grade5_artist_binary1.level
@@ -45,7 +45,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -313,7 +313,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -323,7 +323,7 @@
             </block>
           </value>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -360,7 +360,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>

--- a/dashboard/config/levels/custom/turtle/grade5_artist_binary10.level
+++ b/dashboard/config/levels/custom/turtle/grade5_artist_binary10.level
@@ -69,7 +69,7 @@
                     </block>
                   </value>
                   <statement name="DO">
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -98,7 +98,7 @@
                         </block>
                       </value>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -425,7 +425,7 @@
         <block type="text">
           <title name="TEXT">0</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/config/levels/custom/turtle/grade5_artist_binary2.level
+++ b/dashboard/config/levels/custom/turtle/grade5_artist_binary2.level
@@ -47,7 +47,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -57,7 +57,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -316,7 +316,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -351,7 +351,7 @@
             <block type="controls_repeat">
               <title name="TIMES">4</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -361,7 +361,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>

--- a/dashboard/config/levels/custom/turtle/grade5_artist_binary3.level
+++ b/dashboard/config/levels/custom/turtle/grade5_artist_binary3.level
@@ -46,7 +46,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -347,7 +347,7 @@
             <block type="controls_repeat">
               <title name="TIMES">8</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/grade5_artist_binary4.level
+++ b/dashboard/config/levels/custom/turtle/grade5_artist_binary4.level
@@ -46,7 +46,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -316,7 +316,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -345,7 +345,7 @@
             <block type="controls_repeat">
               <title name="TIMES">21</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/grade5_artist_binary5.level
+++ b/dashboard/config/levels/custom/turtle/grade5_artist_binary5.level
@@ -43,7 +43,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true" deletable="false">
+            <block type="procedures_callnoreturn" deletable="false">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -53,7 +53,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                <block type="procedures_callnoreturn" deletable="false">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -63,7 +63,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                    <block type="procedures_callnoreturn" deletable="false">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -73,7 +73,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                        <block type="procedures_callnoreturn" deletable="false">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -83,7 +83,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true" deletable="false">
+                            <block type="procedures_callnoreturn" deletable="false">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -93,7 +93,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                <block type="procedures_callnoreturn" deletable="false">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -103,7 +103,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                    <block type="procedures_callnoreturn" deletable="false">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -113,7 +113,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true" deletable="false">
+                                        <block type="procedures_callnoreturn" deletable="false">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>
@@ -409,7 +409,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -419,7 +419,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -429,7 +429,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -439,7 +439,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -449,7 +449,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -459,7 +459,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -469,7 +469,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>

--- a/dashboard/config/levels/custom/turtle/grade5_artist_binary6.level
+++ b/dashboard/config/levels/custom/turtle/grade5_artist_binary6.level
@@ -304,7 +304,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true" editable="false">
+        <block type="procedures_callnoreturn" editable="false">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -333,7 +333,7 @@
             <block type="controls_repeat">
               <title name="TIMES">11</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/grade5_artist_binary7.level
+++ b/dashboard/config/levels/custom/turtle/grade5_artist_binary7.level
@@ -302,7 +302,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -331,7 +331,7 @@
             <block type="controls_repeat">
               <title name="TIMES">13</title>
               <statement name="DO">
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>

--- a/dashboard/config/levels/custom/turtle/grade5_artist_binary8.level
+++ b/dashboard/config/levels/custom/turtle/grade5_artist_binary8.level
@@ -43,7 +43,7 @@
       <xml>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -53,7 +53,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -63,7 +63,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -73,7 +73,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -347,7 +347,7 @@
         <block type="controls_repeat">
           <title name="TIMES">???</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>
@@ -373,7 +373,7 @@
         </block>
         <block type="when_run" deletable="false" movable="false">
           <next>
-            <block type="procedures_callnoreturn" inline="true">
+            <block type="procedures_callnoreturn">
               <mutation name="draw">
                 <arg name="binary"/>
               </mutation>
@@ -383,7 +383,7 @@
                 </block>
               </value>
               <next>
-                <block type="procedures_callnoreturn" inline="true">
+                <block type="procedures_callnoreturn">
                   <mutation name="draw">
                     <arg name="binary"/>
                   </mutation>
@@ -393,7 +393,7 @@
                     </block>
                   </value>
                   <next>
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -403,7 +403,7 @@
                         </block>
                       </value>
                       <next>
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -413,7 +413,7 @@
                             </block>
                           </value>
                           <next>
-                            <block type="procedures_callnoreturn" inline="true">
+                            <block type="procedures_callnoreturn">
                               <mutation name="draw">
                                 <arg name="binary"/>
                               </mutation>
@@ -423,7 +423,7 @@
                                 </block>
                               </value>
                               <next>
-                                <block type="procedures_callnoreturn" inline="true">
+                                <block type="procedures_callnoreturn">
                                   <mutation name="draw">
                                     <arg name="binary"/>
                                   </mutation>
@@ -433,7 +433,7 @@
                                     </block>
                                   </value>
                                   <next>
-                                    <block type="procedures_callnoreturn" inline="true">
+                                    <block type="procedures_callnoreturn">
                                       <mutation name="draw">
                                         <arg name="binary"/>
                                       </mutation>
@@ -443,7 +443,7 @@
                                         </block>
                                       </value>
                                       <next>
-                                        <block type="procedures_callnoreturn" inline="true">
+                                        <block type="procedures_callnoreturn">
                                           <mutation name="draw">
                                             <arg name="binary"/>
                                           </mutation>

--- a/dashboard/config/levels/custom/turtle/grade5_artist_binary9.level
+++ b/dashboard/config/levels/custom/turtle/grade5_artist_binary9.level
@@ -67,7 +67,7 @@
                     </block>
                   </value>
                   <statement name="DO">
-                    <block type="procedures_callnoreturn" inline="true">
+                    <block type="procedures_callnoreturn">
                       <mutation name="draw">
                         <arg name="binary"/>
                       </mutation>
@@ -96,7 +96,7 @@
                         </block>
                       </value>
                       <statement name="DO">
-                        <block type="procedures_callnoreturn" inline="true">
+                        <block type="procedures_callnoreturn">
                           <mutation name="draw">
                             <arg name="binary"/>
                           </mutation>
@@ -407,7 +407,7 @@
         <block type="math_arithmetic" inline="true">
           <title name="OP">ADD</title>
         </block>
-        <block type="procedures_callnoreturn" inline="true">
+        <block type="procedures_callnoreturn">
           <mutation name="draw">
             <arg name="binary"/>
           </mutation>

--- a/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
@@ -71,7 +71,7 @@ Feature: Using the Lesson Edit Page
     And I press ".fa-search" using jQuery
     # We will know the search has completed after the following step, because we
     # confirmed earlier that there were no Artist levels in the initial view.
-    And I wait until element ".uitest-level-dialog-content td" contains text "Artist"
+    And I wait until element ".uitest-level-dialog-content td" contains text "Standalone_Artist_1"
     And element ".uitest-level-dialog-content td .fa-plus" is visible
     And I press ".uitest-level-dialog-content td .fa-plus:first" using jQuery
     And I click selector ".save-add-levels-button"

--- a/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
@@ -69,8 +69,8 @@ Feature: Using the Lesson Edit Page
     And I press keys "Standalone_Artist_1" for element ".uitest-add-level-name-input"
     And element ".fa-search" is visible
     And I press ".fa-search" using jQuery
-    # We will know the search has completed after the following step, because we
-    # confirmed earlier that there were no Artist levels in the initial view.
+    # We will know the search has completed after the following step, because the
+    # test level does not show up in the initial view.
     And I wait until element ".uitest-level-dialog-content td" contains text "Standalone_Artist_1"
     And element ".uitest-level-dialog-content td .fa-plus" is visible
     And I press ".uitest-level-dialog-content td .fa-plus:first" using jQuery


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#60027

Redoes https://github.com/code-dot-org/code-dot-org/pull/59993

The first attempt at this work caused a UI test to become flaky. The Lesson Edit Page test checks that we can add an Artist level to a lesson plan. The steps for that test make the assumption that the search results for that level have completed based on the string `"Artist"` showing up in any cell of the table. The assumption was based on the observation that no Artist levels were in the initial view. However, the initial lesson shows the most recently updated levels by default. This means this test was destined to break as soon as an Artist level was edited.

The solution here is to update this test to look for the string `"Standalone_Artist_1"` to determine that we have finished loading the results. This is less risky because we're unlikely to update this level, which means it should not get promoted to the initial view.

Slack threads:
Initial work proposal and eventual test fix: https://codedotorg.slack.com/archives/C060J3A3BBK/p1722014901565169?thread_ts=1721864106.889939&cid=C060J3A3BBK
Test failure and revert thread: https://codedotorg.slack.com/archives/C0T0PNTM3/p1722010208479609