### PR TITLE
Make last_name not required for enrollment creation

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -55,10 +55,6 @@ class Pd::Enrollment < ApplicationRecord
 
   validates_presence_of :first_name, unless: :deleted?
 
-  # Some old enrollments, from before the first/last name split, don't have last names.
-  # Require on all new enrollments.
-  validates_presence_of :last_name, unless: -> {deleted? || created_before_name_split?}
-
   validates_presence_of :email, unless: :deleted?
   validates_confirmation_of :email, unless: :deleted?
   validates_email_format_of :email, allow_blank: true

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -244,20 +244,10 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     end
   end
 
-  test 'old enrollments with no last name are still valid' do
-    old_enrollment = create :pd_enrollment
-    old_enrollment.update!(created_at: '2016-11-09', last_name: '')
-    assert old_enrollment.valid?
-  end
-
-  test 'last name is required on new enrollments, create and update' do
-    e = assert_raises ActiveRecord::RecordInvalid do
-      create :pd_enrollment, last_name: ''
-    end
-    assert_includes(e.message, 'Validation failed: Last name is required')
-
+  test 'enrollments with no last name are still valid' do
     enrollment = create :pd_enrollment
-    refute enrollment.update(last_name: '')
+    enrollment.update!(last_name: '')
+    assert enrollment.valid?
   end
 
   test 'email must be unique on enrollments within a workshop' do

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -93,7 +93,6 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   test 'required field validations with country' do
     enrollment = Pd::Enrollment.new
     enrollment.first_name = 'FirstName'
-    enrollment.last_name = 'LastName'
     enrollment.email = 'teacher@example.net'
     assert enrollment.valid?
   end


### PR DESCRIPTION
When setting up the auto-enrollment process for the Build Your Own workshop, we had to [get rid of the back-end presence validation](https://github.com/code-dot-org/code-dot-org/pull/59538/files#diff-b628772b45f6dd4a03f6f4842ced36ec4e6098ebf40de42217067d06fed1c1d4L68) for `school_info` for each enrollment created (as the user would submit that info in the enroll form we were skipping for Build Your Own workshops). Recently, I found out that the `last_name` field has the same issue, so this PR removes that requirement. Filling in the Last Name field in the enroll form is still required on the front-end, this just allows us to skip the enroll form and not raise any errors on the back-end when creating the enrollment for Build Your Own workshops.

### Can auto-enroll in a Build Your Own workshop with no last name set

https://github.com/user-attachments/assets/c1527949-11bd-4758-8e54-12d93029bf80

### Can display an enrollment that has no last name with no errors
![can have no last name](https://github.com/user-attachments/assets/fadcde87-3bab-4d02-a9e7-5aff38d359b7)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2130)

## Testing story
Local testing and updating unit tests.
