### PR TITLE
Install Nginx from Ubuntu Repositories

### DIFF
--- a/cookbooks/cdo-nginx/recipes/default.rb
+++ b/cookbooks/cdo-nginx/recipes/default.rb
@@ -1,5 +1,5 @@
 # We had previously manually added a repository here to install nginx, but
-# nginx is distributed by default in Ubuntu 24 so we no longer need to do so.
+# nginx is distributed by default in Ubuntu 20+ so we no longer need to do so.
 # Instead, we remove that addition from any persistent managed servers which
 # currently have it.
 #

--- a/cookbooks/cdo-nginx/recipes/default.rb
+++ b/cookbooks/cdo-nginx/recipes/default.rb
@@ -1,6 +1,11 @@
+# We had previously manually added a repository here to install nginx, but
+# nginx is distributed by default in Ubuntu 24 so we no longer need to do so.
+# Instead, we remove that addition from any persistent managed servers which
+# currently have it.
+#
+# TODO infra: remove this once all existing servers have been cleaned up.
 apt_repository 'nginx' do
-  uri          'ppa:nginx/mainline'
-  retries 3
+  action :remove
 end
 
 apt_package 'nginx'

--- a/cookbooks/cdo-nginx/recipes/default.rb
+++ b/cookbooks/cdo-nginx/recipes/default.rb
@@ -1,6 +1,5 @@
 apt_repository 'nginx' do
-  uri          'ppa:nginx/development'
-  distribution 'trusty'
+  uri          'ppa:nginx/mainline'
   retries 3
 end
 


### PR DESCRIPTION
Specifically, remove the logic we currently have to configure a PPA from which to install nginx, both because the PPA we were using is deprecated and because nginx is now distributed by default with Ubuntu; see for example [the official Ubuntu docs on installing nginx](https://ubuntu.com/tutorials/install-and-configure-nginx#2-installing-nginx).

Notably, it appears that we are currently not even actually using the PPA for our existing `nginx` installations:

```bash
ubuntu@staging:~$ apt-cache policy nginx
nginx:
  Installed: 1.18.0-0ubuntu1.4
  Candidate: 1.18.0-0ubuntu1.5
  Version table:
     1.18.0-0ubuntu1.5 500
        500 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages
 *** 1.18.0-0ubuntu1.4 500
        500 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages
        100 /var/lib/dpkg/status
     1.17.10-0ubuntu1 500
        500 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal/main amd64 Packages
```

```bash
ubuntu@production-console:~$ apt-cache policy nginx
nginx:
  Installed: 1.18.0-0ubuntu1.4
  Candidate: 1.18.0-0ubuntu1.5
  Version table:
     1.18.0-0ubuntu1.5 500
        500 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages
 *** 1.18.0-0ubuntu1.4 500
        500 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages
        100 /var/lib/dpkg/status
     1.17.10-0ubuntu1 500
        500 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal/main amd64 Packages
```

## Context

We discovered this issue when the levelbuilder server's Chef execution failed recently with the error

```
Repository 'http://ppa.launchpad.net/nginx/development/ubuntu trusty InRelease' changed its 'Label' value from 'NGINX Mainline' to 'NGINX Mainline (1.15.x)'
```

This actual error doesn't seem like a problem itself, but it does highlight that we are for some reason trying to install nginx from sources intended for a decade-old version of Ubuntu. Based on [the original PR](https://github.com/code-dot-org/code-dot-org/pull/6970), I don't think it was intentional for us to remain pinned to this version in the long term.

## Links

- [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1722013982324279)
- https://github.com/code-dot-org/code-dot-org/pull/6970

## Testing story

Verified on an adhoc that this change can be cleanly applied to a server that already has the old version of nginx installed.

```bash
ubuntu@adhoc-nginx-repo-removal-testing:~$ apt-cache policy nginx
nginx:
  Installed: 1.18.0-0ubuntu1.5
  Candidate: 1.18.0-0ubuntu1.5
  Version table:
 *** 1.18.0-0ubuntu1.5 500
        500 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages
        100 /var/lib/dpkg/status
     1.18.0-0ubuntu1.4 500
        500 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages
     1.17.10-0ubuntu1 500
        500 http://us-east-1.ec2.archive.ubuntu.com/ubuntu focal/main amd64 Packages
ubuntu@adhoc-nginx-repo-removal-testing:~$ nginx -v
nginx version: nginx/1.18.0 (Ubuntu)
```

Also verified that it applies cleanly to a newly-provisioned adhoc.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
