### PR TITLE
fix(sourcemaps): disable extractComments in terser due to bug

### DIFF
--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -423,6 +423,9 @@ function createWebpackConfig({
           // Excludes these from minification to avoid breaking functionality,
           // but still adds .min to the output filename suffix.
           exclude: [/\/blockly.js$/, /\/brambleHost.js$/],
+          // Temporarily disable due to
+          // https://github.com/webpack-contrib/terser-webpack-plugin/issues/589
+          extractComments: false,
           terserOptions: {
             sourceMap: envConstants.DEBUG_MINIFIED,
             // Handle Safari 10.x issues: [See FND-2108 / FND-2109]


### PR DESCRIPTION
`extractComments` is enabled by default but appears to have a bug which breaks source maps. This bug causes an incorrect reference to `types.ts` which causes source maps to not be useful at all. Disabling `extractComments` appears to be the workaround to use until terser fixes on their end.

ref: https://github.com/webpack-contrib/terser-webpack-plugin/issues/589

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Before:

![Screenshot from 2024-07-26 12-49-59](https://github.com/user-attachments/assets/e90da7e4-8470-40f6-92db-6981f3770ee9)

After:

![Screenshot from 2024-07-26 12-56-07](https://github.com/user-attachments/assets/03638454-f181-4882-8728-74faf33e9412)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
