### PR TITLE
Create Account Button A/B Test - Fix Statsig config load issue

### DIFF
--- a/apps/src/userHeaderStatsigReporter/userHeaderStatsigReporter.js
+++ b/apps/src/userHeaderStatsigReporter/userHeaderStatsigReporter.js
@@ -1,15 +1,5 @@
 import statsigReporter from '../lib/util/StatsigReporter';
 
-const isInCreateAccountButtonExperiment = statsigReporter.getIsInExperiment(
-  'create_account_button',
-  'showCreateAccountButton',
-  false
-);
-
-export function showCreateAccountButton() {
-  return isInCreateAccountButtonExperiment;
-}
-
 document.addEventListener('DOMContentLoaded', function () {
   const createAccountButton = document.querySelector('#create_account_button');
   const createAccountButtonDesktop = document.querySelector(
@@ -18,6 +8,16 @@ document.addEventListener('DOMContentLoaded', function () {
   const signInButtonDesktop = document.querySelector('#signin_button.desktop');
   const hamburgerButtons = document.querySelector('#hamburger-sign-up-buttons');
   const signUpPage = window.location.pathname.includes('/users/sign_up');
+
+  const isInCreateAccountButtonExperiment = statsigReporter.getIsInExperiment(
+    'create_account_button_2',
+    'showCreateAccountButton',
+    false
+  );
+
+  function showCreateAccountButton() {
+    return isInCreateAccountButtonExperiment;
+  }
 
   // This function is only called for the Create Account A/B Test experiment
   function handleWindowResize() {


### PR DESCRIPTION
Moves the Statsig config code into the event listener on `userHeaderStatsigReporter.js` so the user is put into a bucket right away. Previously this was outside of the event listener and not firing on the first load of a page. The Statsig code was loading after our code causing the button not to show up unless they visited another page (if in the test bucket).

This should also prevent _Uninitialized_ and _Not started_ rules from appearing 🙌 

**Things started working as expected once I moved the code into the event listener:**
<img width="742" alt="Screenshot 2024-07-26 at 2 15 07 PM" src="https://github.com/user-attachments/assets/b0e50b2b-6274-4ae8-8996-3eb6df76f4f9">

## Links
Jira ticket: [ACQ-2134](https://codedotorg.atlassian.net/browse/ACQ-2134)

## Testing story
Tested locally on incognito browser.