### PR TITLE
log thumbs up / down feedback for ai evals to cloudwatch

### DIFF
--- a/dashboard/app/controllers/learning_goal_ai_evaluation_feedbacks_controller.rb
+++ b/dashboard/app/controllers/learning_goal_ai_evaluation_feedbacks_controller.rb
@@ -3,6 +3,7 @@ class LearningGoalAiEvaluationFeedbacksController < ApplicationController
 
   def create
     @learning_goal_ai_evaluation_feedback.update!(ai_eval_feedback_params.merge(teacher_id: current_user.id))
+    AiRubricMetrics.log_feedback(@learning_goal_ai_evaluation_feedback)
     render json: @learning_goal_ai_evaluation_feedback
   end
 

--- a/dashboard/app/jobs/concerns/ai_rubric_metrics.rb
+++ b/dashboard/app/jobs/concerns/ai_rubric_metrics.rb
@@ -53,11 +53,12 @@ class AiRubricMetrics
       [
         {
           metric_name: 'LearningGoalAiEvaluationFeedback',
-          value: feedback.ai_feedback_approval ? 1 : 0,
+          value: 1,
           dimensions: [
             {name: 'Environment', value: CDO.rack_env},
             {name: 'Unit', value: lesson&.script&.name || ''},
             {name: 'Lesson', value: lesson&.relative_position&.to_s || ''},
+            {name: 'Approval', value: feedback.ai_feedback_approval ? 'thumbs_up' : 'thumbs_down'}
           ],
           unit: 'Count',
         }

--- a/dashboard/app/jobs/concerns/ai_rubric_metrics.rb
+++ b/dashboard/app/jobs/concerns/ai_rubric_metrics.rb
@@ -46,8 +46,6 @@ class AiRubricMetrics
   # Log thumbs up / down feedback for AI evaluation
   # @param [LearningGoalAiEvaluationFeedback] feedback
   def self.log_feedback(feedback)
-    lesson = feedback.learning_goal_ai_evaluation&.learning_goal&.rubric&.lesson
-
     Cdo::Metrics.push(
       AI_RUBRIC_METRICS_NAMESPACE,
       [
@@ -56,8 +54,6 @@ class AiRubricMetrics
           value: 1,
           dimensions: [
             {name: 'Environment', value: CDO.rack_env},
-            {name: 'Unit', value: lesson&.script&.name || ''},
-            {name: 'Lesson', value: lesson&.relative_position&.to_s || ''},
             {name: 'Approval', value: feedback.ai_feedback_approval ? 'thumbs_up' : 'thumbs_down'}
           ],
           unit: 'Count',

--- a/dashboard/app/jobs/concerns/ai_rubric_metrics.rb
+++ b/dashboard/app/jobs/concerns/ai_rubric_metrics.rb
@@ -53,11 +53,11 @@ class AiRubricMetrics
       [
         {
           metric_name: 'LearningGoalAiEvaluationFeedback',
-          value: feedback.ai_feedback_approval,
+          value: feedback.ai_feedback_approval ? 1 : 0,
           dimensions: [
             {name: 'Environment', value: CDO.rack_env},
-            {name: 'Unit', value: lesson&.script&.name},
-            {name: 'Lesson', value: lesson&.relative_position},
+            {name: 'Unit', value: lesson&.script&.name || ''},
+            {name: 'Lesson', value: lesson&.relative_position&.to_s || ''},
           ],
           unit: 'Count',
         }

--- a/dashboard/app/jobs/concerns/ai_rubric_metrics.rb
+++ b/dashboard/app/jobs/concerns/ai_rubric_metrics.rb
@@ -43,6 +43,28 @@ class AiRubricMetrics
     )
   end
 
+  # Log thumbs up / down feedback for AI evaluation
+  # @param [LearningGoalAiEvaluationFeedback] feedback
+  def self.log_feedback(feedback)
+    lesson = feedback.learning_goal_ai_evaluation&.learning_goal&.rubric&.lesson
+
+    Cdo::Metrics.push(
+      AI_RUBRIC_METRICS_NAMESPACE,
+      [
+        {
+          metric_name: 'LearningGoalAiEvaluationFeedback',
+          value: feedback.ai_feedback_approval,
+          dimensions: [
+            {name: 'Environment', value: CDO.rack_env},
+            {name: 'Unit', value: lesson&.script&.name},
+            {name: 'Lesson', value: lesson&.relative_position},
+          ],
+          unit: 'Count',
+        }
+      ]
+    )
+  end
+
   def self.log_to_firehose(job:, error:, event_name:, agent: nil)
     options = job.arguments.first
     script_level = ScriptLevel.find(options[:script_level_id])


### PR DESCRIPTION
Starts https://codedotorg.atlassian.net/browse/AITT-410:
* logs to cloudwatch when thumbs up / down are pressed

### screenshots (updated)

verified by running a snippet of the code directly on production-console that I can get events to show up in cloudwatch:
![Screenshot 2024-07-30 at 3 21 03 PM](https://github.com/user-attachments/assets/a6c4836f-7d1e-4cc0-8ae6-af6f186b3adb)
https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~(expression~'m1*2fSUM*28METRICS*28*29*29~label~'Expression1~id~'e1))~(~'AiRubric~'LearningGoalAiEvaluationFeedback~'Environment~'production~'Unit~'interactive-games-animations-2023~'Approval~'thumbs_down~'Lesson~'11~(id~'m1))~(~'...~'thumbs_up~'.~'.~(id~'m2))~(~'.~'.~'.~'development~'Approval~'thumbs_down~(id~'m3))~(~'...~'thumbs_up~(id~'m4)))~view~'timeSeries~stacked~false~region~'us-east-1~stat~'Average~period~300~start~'-PT1H~end~'P0D)&query=~'*7bAiRubric*2cApproval*2cEnvironment*7d*20approval

## Testing story

- manual verification shown in screenshots
- new unit tests

## Follow-up work

* configure CloudWatch to alarm on this metric
* make sure we log an event as soon as thumbs down is pressed, even if the user does not go on to submit the resulting form 