### PR TITLE
P20-538: I18n sync-in course `field` tag content

### DIFF
--- a/bin/i18n/resources/dashboard/course_content/sync_in.rb
+++ b/bin/i18n/resources/dashboard/course_content/sync_in.rb
@@ -204,7 +204,7 @@ module I18n
                 functions = blocks.xpath("//block[@type=\"procedures_defnoreturn\"]")
                 i18n_strings['function_definitions'] = Hash.new unless functions.empty?
                 functions.each do |function|
-                  name = function.at_xpath('./title[@name="NAME"]')
+                  name = function.at_xpath('./title[@name="NAME"] | ./field[@name="NAME"]')
                   # The name is used to uniquely identify the function. Skip if there is no name.
                   next unless name
                   description = function.at_xpath('./mutation/description')
@@ -225,7 +225,7 @@ module I18n
                   i18n_strings['behavior_descriptions'] = Hash.new
                 end
                 behaviors.each do |behavior|
-                  name = behavior.at_xpath('./title[@name="NAME"]')
+                  name = behavior.at_xpath('./title[@name="NAME"] | ./field[@name="NAME"]')
                   description = behavior.at_xpath('./mutation/description')
                   i18n_strings['behavior_names'][name.content] = name.content if name
                   i18n_strings['behavior_descriptions'][description.content] = description.content if description
@@ -237,7 +237,7 @@ module I18n
                 variables = variables_get + variables_set
                 i18n_strings[VARIABLE_NAMES_TYPE] = Hash.new unless variables.empty?
                 variables.each do |variable|
-                  name = variable.at_xpath('./title[@name="VAR"]')
+                  name = variable.at_xpath('./title[@name="VAR"] | ./field[@name="VAR"]')
                   i18n_strings[VARIABLE_NAMES_TYPE][name.content] = name.content if name
                 end
 
@@ -245,7 +245,7 @@ module I18n
                 parameters = blocks.xpath("//block[@type=\"parameters_get\"]")
                 i18n_strings[PARAMETER_NAMES_TYPE] = Hash.new unless parameters.empty?
                 parameters.each do |parameter|
-                  name = parameter.at_xpath('./title[@name="VAR"]')
+                  name = parameter.at_xpath('./title[@name="VAR"] | ./field[@name="VAR"]')
                   i18n_strings[PARAMETER_NAMES_TYPE][name.content] = name.content if name
                 end
 

--- a/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
+++ b/bin/test/i18n/resources/dashboard/course_content/test_sync_in.rb
@@ -1000,7 +1000,7 @@ describe I18n::Resources::Dashboard::CourseContent::SyncIn do
         let(:start_blocks) do
           <<~XML.strip
             <xml>
-              <block type="variables_get" />
+              <block type="variables_set" />
             </xml>
           XML
         end


### PR DESCRIPTION
Blocks i18n works as expected:
| Block i18n | Block content |
| ---------- | ------------- |
| ![Screenshot 2024-07-29 at 03 03 02](https://github.com/user-attachments/assets/fcfcb57b-c245-436f-970b-a8839bc6b5d1) | <img width="310" alt="Screenshot 2024-07-29 at 03 51 25" src="https://github.com/user-attachments/assets/42a8e85c-ba72-42d4-837f-4c04853ea128"> |

The only issue was that we i18n synced-in the only content of the `title` XML tag, but the content might also be in the `field` XML tag:

https://github.com/code-dot-org/code-dot-org/blob/272e371b95e4dbd7448f8f5257f211ef75a84b00/dashboard/config/levels/custom/spritelab/csc_ecosystems_ocean_coral_health_2023.level#L375-L380
https://github.com/code-dot-org/code-dot-org/blob/b27bc3da49beb03f1669b95ce042adf4a800c26a/dashboard/app/models/levels/blockly.rb#L921-L922

https://github.com/code-dot-org/code-dot-org/blob/b27bc3da49beb03f1669b95ce042adf4a800c26a/dashboard/app/models/levels/blockly.rb#L929-L943

## After fixing i18n sync-in:
![Screenshot 2024-07-29 at 03 04 36](https://github.com/user-attachments/assets/658f2df9-bc33-445a-8751-f6d131d2d613)

## Links
- JIRA task: [P20-538](https://codedotorg.atlassian.net/browse/P20-538)