### PR TITLE
Fix safe chaining for new workshop surveys and multiple survey links

### DIFF
--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -101,8 +101,8 @@ module Pd
     # GET /pd/workshop_survey/post/:enrollment_code
     # If Build Your Own, redirect to its specific survey link. Otherwise, use Foorm.
     def new_post
-      course = get_workshop_by_enrollment_or_course_and_subject(enrollment_code: params[:enrollment_code], course: nil, subject: nil)&.course
-      if course == COURSE_BUILD_YOUR_OWN
+      workshop = get_workshop_by_enrollment_or_course_and_subject(enrollment_code: params[:enrollment_code], course: nil, subject: nil)
+      if workshop && workshop.course == COURSE_BUILD_YOUR_OWN
         redirect_to CDO.studio_url SURVEY_LINKS[:COURSE_BUILD_YOUR_OWN_TEACHER], CDO.default_scheme
       else
         # If the post-survey has been already completed, will redirect to thanks page.

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -101,8 +101,8 @@ module Pd
     # GET /pd/workshop_survey/post/:enrollment_code
     # If Build Your Own, redirect to its specific survey link. Otherwise, use Foorm.
     def new_post
-      workshop = get_workshop_by_enrollment_or_course_and_subject(enrollment_code: params[:enrollment_code], course: nil, subject: nil)
-      if workshop && workshop.course == COURSE_BUILD_YOUR_OWN
+      course = Pd::Enrollment.find_by(code: params[:enrollment_code], user: current_user)&.workshop&.course
+      if course == COURSE_BUILD_YOUR_OWN
         redirect_to CDO.studio_url SURVEY_LINKS[:COURSE_BUILD_YOUR_OWN_TEACHER], CDO.default_scheme
       else
         # If the post-survey has been already completed, will redirect to thanks page.

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -803,6 +803,7 @@ Dashboard::Application.routes.draw do
       get 'workshop_daily_survey/day/:day', to: 'workshop_daily_survey#new_daily_foorm'
       get 'workshop_pre_survey', to: 'workshop_daily_survey#new_pre_foorm'
       post 'workshop_survey/submit', to: 'workshop_daily_survey#submit_general'
+      get 'workshop_post_survey', to: 'workshop_daily_survey#new_post'
       get 'workshop_survey/post/:enrollment_code', to: 'workshop_daily_survey#new_post', as: 'new_workshop_survey'
       get 'workshop_survey/new_facilitator_post', to: 'workshop_daily_survey#new_facilitator_post'
       get 'workshop_survey/csf/post101(/:enrollment_code)', to: 'workshop_daily_survey#new_csf_post101'


### PR DESCRIPTION
Following [this HoneyBadger error](https://app.honeybadger.io/projects/3240/faults/109837158), it looked like the safe chaining [here](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb#L104) wasn't working as expected. The `get_workshop_by_enrollment_or_course_and_subject` method actually returns `false` if it doesn't get a result (rather than `nil` which is what the safe chaining is waiting for). I dug a bit deeper and actually realized this is later called within `new_general_foorm` so it doesn't really make sense to call it here since it can return a `render` if there's an error. Since I was only using this to get the workshop, I just updated it to be an actual query.

In addition, we were seeing lots of [sad bees](https://codedotorg.slack.com/archives/C04540KNGDQ/p1722271354567879) for post-workshop emails that had been sent out before the different post-survey routes [were consolidated](https://github.com/code-dot-org/code-dot-org/pull/59875/files#diff-3fffe83c5f87f14c4c59c00fc3556305f7d4a28ee7748b688700228b3c64e70d) from both `workshop_post_survey?enrollment_code=[:enrollment_code]` and `workshop_survey/post/:enrollment_code` to just `workshop_survey/post/:enrollment_code` (meaning any email that was still pointing to `workshop_post_survey?enrollment_code=[:enrollment_code]` would have an invalid survey link). This PR adds that route back in but just points it to `workshop_survey/post/:enrollment_code`. We can remove this line as cleanup in the future since it's a tiny change and doesn't feel worth keeping (if we kept it, we would have to figure out all the workshops affected and re-send the post-workshop email with the new url).

## Links
Honeybadger link: [here](https://app.honeybadger.io/projects/3240/faults/109837158)
Slack discussion about sad bees: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1722271354567879)

## Testing story
- Checked that tests still passed for obtaining the right post-workshop link
- Locally tested that both versions of the post-workshop link show the same page (note: Foorm is not set up locally for me so this is the page I'm expecting to see when I navigate to a new Foorm):

With `workshop_post_survey?enrollment_code=[:enrollment_code]`:
![workshop_post_survey](https://github.com/user-attachments/assets/840b7ee3-1449-4142-8641-8550e5e17875)

With `workshop_survey/post/:enrollment_code`:
![new url](https://github.com/user-attachments/assets/aea5fac1-bee9-44b6-9791-e4dc03555593)


