### PR TITLE
DSCO swap: replace `ToggleSwitch` with DSCO `Toggle` in `AdvancedSettingToggles`

### DIFF
--- a/apps/src/componentLibrary/toggle/Toggle.tsx
+++ b/apps/src/componentLibrary/toggle/Toggle.tsx
@@ -8,6 +8,8 @@ import Typography from '@cdo/apps/componentLibrary/typography';
 import moduleStyles from './toggle.module.scss';
 
 export interface ToggleProps {
+  /** Toggle id selector, used for UI tests */
+  id?: string;
   /** Toggle checked state */
   checked: boolean;
   /** Toggle onChange handler */
@@ -30,6 +32,7 @@ export interface ToggleProps {
 }
 
 const Toggle: React.FunctionComponent<ToggleProps> = ({
+  id,
   checked,
   onChange,
   name,
@@ -49,7 +52,7 @@ const Toggle: React.FunctionComponent<ToggleProps> = ({
         position === 'right' && moduleStyles['toggle-right']
       )}
     >
-      <div>
+      <div id={id}>
         <input
           type="checkbox"
           name={name}

--- a/apps/src/templates/sectionsRefresh/AdvancedSettingToggles.jsx
+++ b/apps/src/templates/sectionsRefresh/AdvancedSettingToggles.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import ToggleSwitch from '@cdo/apps/code-studio/components/ToggleSwitch';
+import Toggle from '@cdo/apps/componentLibrary/toggle/Toggle';
 import InfoHelpTip from '@cdo/apps/lib/ui/InfoHelpTip';
 import i18n from '@cdo/locale';
 
@@ -44,10 +44,10 @@ export default function AdvancedSettingToggles({
   return (
     <div>
       <div className={style.toolTipContainer}>
-        <ToggleSwitch
+        <Toggle
           id={'uitest-pair-toggle'}
-          isToggledOn={section.pairingAllowed}
-          onToggle={e => {
+          checked={section.pairingAllowed}
+          onChange={e => {
             handlePairProgrammingToggle(e);
           }}
           label={i18n.pairProgramming()}
@@ -58,10 +58,12 @@ export default function AdvancedSettingToggles({
         />
       </div>
       <div className={style.toolTipContainer}>
-        <ToggleSwitch
+        <Toggle
           id={'uitest-lock-toggle'}
-          isToggledOn={section.restrictSection}
-          onToggle={e => handleLockSectionToggle(e)}
+          checked={section.restrictSection}
+          onChange={e => {
+            handleLockSectionToggle(e);
+          }}
           label={i18n.restrictSectionAccess()}
         />
         <InfoHelpTip
@@ -71,10 +73,10 @@ export default function AdvancedSettingToggles({
       </div>
       {hasTextToSpeech && (
         <div className={style.toolTipContainer}>
-          <ToggleSwitch
+          <Toggle
             id={'uitest-tts-toggle'}
-            isToggledOn={section.ttsAutoplayEnabled}
-            onToggle={e => handleTtsAutoplayEnabledToggle(e)}
+            checked={section.ttsAutoplayEnabled}
+            onChange={e => handleTtsAutoplayEnabledToggle(e)}
             label={i18n.enableTtsAutoplayToggle()}
           />
           <InfoHelpTip
@@ -85,10 +87,10 @@ export default function AdvancedSettingToggles({
       )}
       {hasLessonExtras && (
         <div className={style.toolTipContainer}>
-          <ToggleSwitch
+          <Toggle
             id={'uitest-lesson-extras-toggle'}
-            isToggledOn={section.lessonExtras}
-            onToggle={e => handleLessonExtrasToggle(e)}
+            checked={section.lessonExtras}
+            onChange={e => handleLessonExtrasToggle(e)}
             label={i18n.enableLessonExtrasToggle()}
           />
           <InfoHelpTip
@@ -99,10 +101,10 @@ export default function AdvancedSettingToggles({
       )}
       {aiTutorAvailable && (
         <div className={style.toolTipContainer}>
-          <ToggleSwitch
+          <Toggle
             id={'uitest-ai-tutor-toggle'}
-            isToggledOn={section.aiTutorEnabled}
-            onToggle={e => handleAITutorEnabledToggle(e)}
+            checked={section.aiTutorEnabled}
+            onChange={e => handleAITutorEnabledToggle(e)}
             label={i18n.enableAITutor()}
           />
           <InfoHelpTip

--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -223,6 +223,7 @@ button.advancedSettingsButton {
 .toolTipContainer {
   display: flex;
   align-items: center;
+  margin-bottom: 8px;
 
   button {
     .toggle-display {

--- a/apps/test/unit/templates/sectionsRefresh/AdvancedSettingTogglesTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/AdvancedSettingTogglesTest.jsx
@@ -1,101 +1,74 @@
-import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
-import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import AdvancedSettingToggles from '@cdo/apps/templates/sectionsRefresh/AdvancedSettingToggles';
-
-import {expect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
+import i18n from '@cdo/locale';
 
 describe('AdvancedSettingToggles', () => {
   it('renders PairProgramming and LockThisSection toggles to true and false as default respectively', () => {
-    // Later we might want to set up helper sections to test all of these
-    const wrapper = shallow(
+    render(
       <AdvancedSettingToggles
         updateSection={() => {}}
         section={{pairingAllowed: true, restrictSection: false}}
       />
     );
-    expect(
-      wrapper.find('ToggleSwitch[id="uitest-pair-toggle"]').props().isToggledOn
-    ).to.be.true;
-    expect(
-      wrapper.find('ToggleSwitch[id="uitest-lock-toggle"]').props().isToggledOn
-    ).to.be.false;
+    const pairingToggle = screen.getByLabelText(i18n.pairProgramming());
+    expect(pairingToggle).toHaveAttribute('checked');
+    const lockToggle = screen.getByLabelText(i18n.restrictSectionAccess());
+    expect(lockToggle).not.toHaveAttribute('checked');
+    // Check that the other toggles do not appear.
+    const ttsToggle = screen.queryByText(i18n.enableTtsAutoplayToggle());
+    expect(ttsToggle).toBeNull();
+    const lessonExtrasToggle = screen.queryByText(
+      i18n.enableLessonExtrasToggle()
+    );
+    expect(lessonExtrasToggle).toBeNull();
+    const aiTutorToggle = screen.queryByText(i18n.enableAITutor());
+    expect(aiTutorToggle).toBeNull();
   });
 
-  it('renders Lesson Extras Toggle when available', () => {
-    const wrapper = shallow(
+  it('renders Lesson Extras toggle when available, enabled', () => {
+    render(
       <AdvancedSettingToggles
         updateSection={() => {}}
         section={{
-          pairingAllowed: true,
-          restrictSection: false,
-          ttsAutoplayEnabled: false,
           lessonExtras: true,
         }}
         hasLessonExtras={true}
       />
     );
-    expect(
-      wrapper.find('ToggleSwitch[id="uitest-lesson-extras-toggle"]')
-    ).to.have.lengthOf(1);
+    const lessonExtrasToggle = screen.getByLabelText(
+      i18n.enableLessonExtrasToggle()
+    );
+    expect(lessonExtrasToggle).toHaveAttribute('checked');
   });
 
-  it('renders TTS Toggle when available', () => {
-    const wrapper = shallow(
+  it('renders TTS toggle when available, disabled', () => {
+    render(
       <AdvancedSettingToggles
         updateSection={() => {}}
         section={{
-          pairingAllowed: true,
-          restrictSection: false,
           ttsAutoplayEnabled: false,
-          lessonExtras: true,
         }}
         hasTextToSpeech={true}
       />
     );
-    expect(
-      wrapper.find('ToggleSwitch[id="uitest-tts-toggle"]')
-    ).to.have.lengthOf(1);
+    const ttsToggle = screen.getByLabelText(i18n.enableTtsAutoplayToggle());
+    expect(ttsToggle).not.toHaveAttribute('checked');
   });
 
-  it('renders TTS Toggle when available', () => {
-    const wrapper = shallow(
+  it('renders enable AI Tutor toggle when available, enabled', () => {
+    render(
       <AdvancedSettingToggles
         updateSection={() => {}}
         section={{
-          pairingAllowed: true,
-          restrictSection: false,
-          ttsAutoplayEnabled: false,
-          lessonExtras: true,
+          aiTutorEnabled: true,
         }}
-        hasTextToSpeech={true}
+        aiTutorAvailable={true}
       />
     );
-    expect(
-      wrapper.find('ToggleSwitch[id="uitest-tts-toggle"]')
-    ).to.have.lengthOf(1);
-  });
-
-  it('changes the status of pair programming setting when clicked', () => {
-    let updateSection = sinon.fake();
-
-    const wrapper = shallow(
-      <AdvancedSettingToggles
-        updateSection={updateSection}
-        section={{
-          pairingAllowed: true,
-          restrictSection: false,
-          ttsAutoplayEnabled: false,
-          lessonExtras: true,
-        }}
-      />
-    );
-    const pairProgramming = wrapper
-      .find('ToggleSwitch[id="uitest-pair-toggle"]')
-      .at(0);
-    pairProgramming.simulate('toggle', {preventDefault: () => {}});
-    expect(updateSection).to.have.been.calledOnce;
-    expect(updateSection).to.have.been.calledWith('pairingAllowed', false);
+    const aiTutorToggle = screen.getByLabelText(i18n.enableAITutor());
+    expect(aiTutorToggle).toHaveAttribute('checked');
   });
 });

--- a/apps/test/unit/templates/sectionsRefresh/AdvancedSettingTogglesTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/AdvancedSettingTogglesTest.jsx
@@ -1,5 +1,4 @@
 import {render, screen} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import AdvancedSettingToggles from '@cdo/apps/templates/sectionsRefresh/AdvancedSettingToggles';


### PR DESCRIPTION
### Description

We have beautiful new Design System components. Let's use them! This PR updates the "Advanced Settings" area of the Section Edit area of the Teacher Dashboard to use the DSCO `Toggle` component. Functionality is the same as before, but the visuals are now more consistent with the rest of the page and new styles across the site. 

**Before** 

![Screenshot 2024-07-29 at 4 18 32 PM](https://github.com/user-attachments/assets/e56572c2-acdd-40be-9b0f-eb90c1345c5a)

**After**  (I didn't add new toggles, I just artificially made all the possible toggles show to ensure they worked well together)

![Screenshot 2024-07-29 at 3 45 07 PM](https://github.com/user-attachments/assets/a9ce3c99-56f9-4238-afdf-129cbc14e140)

### Follow up

There are 3 threads of work related to this PR: 

1.) Efforts to deprecate legacy components in favor of using Design System Components, tracked for Toggle in [XTEAM-440](https://codedotorg.atlassian.net/browse/XTEAM-440) 
- Swap out other usages of `ToggleSwitch` for `Toggle` in SectionAccessToggle and CodeReviewGroupsStatus
- remove `ToggleSwitch` when it's fully deprecated

2.) Updating frontend tests to use React Testing Library, tracked [here](https://docs.google.com/spreadsheets/d/1OWwkmfAdoZkFc6apW2qtcjPmPaCv00jUvTCpOkZc-dc/edit?gid=1456256702#gid=1456256702)

3.) AI Tutor, tracked [CT-707](https://codedotorg.atlassian.net/browse/CT-707)
- Update info text of "Enable AI Tutor" toggle to no longer specifically reference CSA 
- Update logic for `aiTutorAvailable` in `SectionsSetUpContainer` to no longer specifically reference CSA 
- add UI tests for "Enable AI Tutor" toggle [CT-571](https://codedotorg.atlassian.net/browse/CT-571)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
