### PR TITLE
Show YouTube titles on videos

### DIFF
--- a/apps/src/util/loadVideos.js
+++ b/apps/src/util/loadVideos.js
@@ -71,7 +71,7 @@ function setupVideos(player) {
             'style="position:absolute; top: 0; left: 0; width: 100%; height: 100%" ' +
             `data-src="https://www.youtube-nocookie.com/embed/${$(this).data(
               'video-code'
-            )}?iv_load_policy=3&rel=0&autohide=1&showinfo=0&enablejsapi=1" ` +
+            )}?iv_load_policy=3&rel=0&autohide=1&enablejsapi=1" ` +
             'frameborder="0" ' +
             'allowfullscreen=true' +
             `>`

--- a/pegasus/sites.v3/code.org/public/congrats/splat.haml
+++ b/pegasus/sites.v3/code.org/public/congrats/splat.haml
@@ -9,7 +9,7 @@ social:
   "twitter:title": "The Hour of Code is here"
   "twitter:description": "Over 400 million Hours of Code have been served in 180+ countries and 45+ languages. Anyone can learn an hour of computer science."
   "twitter:image:src": "http://csedweek.org/images/code-video-thumbnail.jpg"
-  "twitter:player": "https://www.youtube.com/embed/rH7AjDMz_dc?iv_load_policy=3&rel=0&autohide=1&showinfo=0"
+  "twitter:player": "https://www.youtube.com/embed/rH7AjDMz_dc?iv_load_policy=3&rel=0&autohide=1"
   "twitter:player:width": 1920
   "twitter:player:height": 1080
 max_age: 60

--- a/pegasus/sites.v3/code.org/views/employee_engagement_video.haml
+++ b/pegasus/sites.v3/code.org/views/employee_engagement_video.haml
@@ -6,9 +6,9 @@
     %div{style: "position:relative"}
       %img{style: "display:block; width:100%; height:auto", src: "/images/16x9.png"}/
       -if custom_video_key
-        %iframe{style: "position:absolute; top: 0; left: 0; width: 100%; height: 100%", src: "https://www.youtube-nocookie.com/embed/#{custom_video_key}?iv_load_policy=3&rel=0&autohide=1&showinfo=0", frameborder: "0", allowfullscreen: true}
+        %iframe{style: "position:absolute; top: 0; left: 0; width: 100%; height: 100%", src: "https://www.youtube-nocookie.com/embed/#{custom_video_key}?iv_load_policy=3&rel=0&autohide=1", frameborder: "0", allowfullscreen: true}
       -else
-        %iframe{style: "position:absolute; top: 0; left: 0; width: 100%; height: 100%", src: "https://www.youtube-nocookie.com/embed/#{default_video_key}?iv_load_policy=3&rel=0&autohide=1&showinfo=0", frameborder: "0", allowfullscreen: true}
+        %iframe{style: "position:absolute; top: 0; left: 0; width: 100%; height: 100%", src: "https://www.youtube-nocookie.com/embed/#{default_video_key}?iv_load_policy=3&rel=0&autohide=1", frameborder: "0", allowfullscreen: true}
   -unless custom_video_key
     %a.mobile-feature{href: default_download_url}
       %img{style: "width: 34px; padding-top: 2px;", src: "/images/download.png"}/

--- a/pegasus/sites.v3/code.org/views/index_video.haml
+++ b/pegasus/sites.v3/code.org/views/index_video.haml
@@ -5,6 +5,6 @@
   %div{style: "width:100%; height: 100%; margin: 0 auto;"}
     %div{style: "position:relative"}
       %img{style: "display:block; width:100%; height:auto", src: "/images/16x9.png"}/
-      %iframe{style: "position:absolute; top: 0; left: 0; width: 100%; height: 100%", src: "https://www.youtube-nocookie.com/embed/#{video_code}?iv_load_policy=3&rel=0&autohide=1&showinfo=0", frameborder: "0", allowfullscreen: true}
+      %iframe{style: "position:absolute; top: 0; left: 0; width: 100%; height: 100%", src: "https://www.youtube-nocookie.com/embed/#{video_code}?iv_load_policy=3&rel=0&autohide=1", frameborder: "0", allowfullscreen: true}
   %a.mobile-feature{href: "http://videos.code.org/social/#{download_filename}"}
     %img{style: "width: 34px; padding-top: 2px;", src: "/images/download.png"}/

--- a/pegasus/sites.v3/hourofcode.com/views/front_video.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/front_video.haml
@@ -2,6 +2,6 @@
   %div{style: "width:100%; height: 100%; margin: 0 auto;"}
     %div{style: "position:relative"}
       %img{style: "display:block; width:100%; height:auto", src: "/images/16x9.png"}/
-      %iframe{style: "position:absolute; top: 0; left: 0; width: 100%; height: 100%", src: "https://www.youtube-nocookie.com/embed/rH7AjDMz_dc?iv_load_policy=3&rel=0&autohide=1&showinfo=0", frameborder: "0", allowfullscreen: true}
+      %iframe{style: "position:absolute; top: 0; left: 0; width: 100%; height: 100%", src: "https://www.youtube-nocookie.com/embed/rH7AjDMz_dc?iv_load_policy=3&rel=0&autohide=1", frameborder: "0", allowfullscreen: true}
   %a.mobile-feature{href: "http://s3.amazonaws.com/cdo-videos/Code-5-minute.mov"}
     %img{style: "width: 34px; padding-top: 2px;", src: "/images/download.png"}/

--- a/pegasus/sites.v3/hourofcode.com/views/index_video.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/index_video.haml
@@ -4,4 +4,4 @@
 
 %figure.video-responsive
   %div
-    %iframe{allowFullScreen: 'true', frameborder: '0', src: "https://www.youtube-nocookie.com/embed/#{video_link}?iv_load_policy=3&rel=0&autohide=1&showinfo=0&cc_load_policy=1"}
+    %iframe{allowFullScreen: 'true', frameborder: '0', src: "https://www.youtube-nocookie.com/embed/#{video_link}?iv_load_policy=3&rel=0&autohide=1&cc_load_policy=1"}

--- a/pegasus/sites.v3/hourofcode.com/views/promote_videos.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/promote_videos.haml
@@ -2,7 +2,7 @@
 %h2= hoc_s(:videos_title)
 
 .video
-  %iframe{:width => "350", :height => "195", :src => "https://www.youtube-nocookie.com/embed/VYqHGIR7a_k?iv_load_policy=3&rel=0&autohide=1&showinfo=0", :frameborder => "0", :allowFullScreen => "true"}
+  %iframe{:width => "350", :height => "195", :src => "https://www.youtube-nocookie.com/embed/VYqHGIR7a_k?iv_load_policy=3&rel=0&autohide=1", :frameborder => "0", :allowFullScreen => "true"}
   %br
   %a{:href => "https://www.youtube.com/watch?v=VYqHGIR7a_k"}= hoc_s(:videos_creativity)
   %a{:href => "//videos.code.org/social/creativity-is.mp4"}
@@ -17,26 +17,26 @@
 %div{style: "clear:both"}
 
 .video
-  %iframe{:width => "350", :height => "195", :src => "https://www.youtube-nocookie.com/embed/nKIu9yen5nc?iv_load_policy=3&rel=0&autohide=1&showinfo=0", :frameborder => "0", :allowFullScreen => "true"}
+  %iframe{:width => "350", :height => "195", :src => "https://www.youtube-nocookie.com/embed/nKIu9yen5nc?iv_load_policy=3&rel=0&autohide=1", :frameborder => "0", :allowFullScreen => "true"}
   %br
   %a{:href => "https://www.youtube.com/watch?v=nKIu9yen5nc"}= hoc_s(:videos_what_most_schools_dont_teach)
   %a{:href => "https://dl.dropbox.com/sh/6sdjczibjih6x8s/Rjs8XgYNzr/Code-5-minute.mov?dl=1"}
     %img{:src => "/images/download.png", :width => "30px"}
 
 .video
-  %iframe{:width => "350", :height => "195", :src => "https://www.youtube-nocookie.com/embed/FC5FbmsH4fw?iv_load_policy=3&rel=0&autohide=1&showinfo=0", :frameborder => "0", :allowFullScreen => "true"}
+  %iframe{:width => "350", :height => "195", :src => "https://www.youtube-nocookie.com/embed/FC5FbmsH4fw?iv_load_policy=3&rel=0&autohide=1", :frameborder => "0", :allowFullScreen => "true"}
   %br
   %a{:href => "https://youtu.be/FC5FbmsH4fw"}= hoc_s(:videos_hoc_2014)
   %a{:href => "https://dl.dropbox.com/s/6yn0pr5gvkhhqcf/HoC-video-15mb.mp4?dl=1"}
     %img{:src => "/images/download.png", :width => "30px"}
 
 .video
-  %iframe{:width => "350", :height => "195", :src => "https://www.youtube-nocookie.com/embed/6XvmhE1J9PY?iv_load_policy=3&rel=0&autohide=1&showinfo=0", :frameborder => "0", :allowFullScreen => "true"}
+  %iframe{:width => "350", :height => "195", :src => "https://www.youtube-nocookie.com/embed/6XvmhE1J9PY?iv_load_policy=3&rel=0&autohide=1", :frameborder => "0", :allowFullScreen => "true"}
   %br
   %a{:href => "https://youtu.be/6XvmhE1J9PY"}= hoc_s(:videos_obama_cs)
 
 .video
-  %iframe{:width => "350", :height => "195", :src => "https://www.youtube-nocookie.com/embed/qYZF6oIZtfc?iv_load_policy=3&rel=0&autohide=1&showinfo=0", :frameborder => "0", :allowFullScreen => "true"}
+  %iframe{:width => "350", :height => "195", :src => "https://www.youtube-nocookie.com/embed/qYZF6oIZtfc?iv_load_policy=3&rel=0&autohide=1", :frameborder => "0", :allowFullScreen => "true"}
   %br
   %a{:href => "https://youtu.be/qYZF6oIZtfc"}= hoc_s(:videos_anybody_can_learn)
   %a{:href => "https://dl.dropbox.com/sh/6sdjczibjih6x8s/_0RSOSY8oW/Code-1-min.mov?dl=1"}

--- a/pegasus/sites/all/views/index_video.haml
+++ b/pegasus/sites/all/views/index_video.haml
@@ -5,6 +5,6 @@
   %div{style: "width:100%; height: 100%; margin: 0 auto;"}
     %div{style: "position:relative"}
       %img{style: "display:block; width:100%; height:auto", src: "/images/16x9.png"}/
-      %iframe{style: "position:absolute; top: 0; left: 0; width: 100%; height: 100%", src: "https://www.youtube-nocookie.com/embed/#{video_code}?iv_load_policy=3&rel=0&autohide=1&showinfo=0", frameborder: "0", allowfullscreen: true}
+      %iframe{style: "position:absolute; top: 0; left: 0; width: 100%; height: 100%", src: "https://www.youtube-nocookie.com/embed/#{video_code}?iv_load_policy=3&rel=0&autohide=1", frameborder: "0", allowfullscreen: true}
   %a.mobile-feature{href: "http://s3.amazonaws.com/cdo-videos/#{download_filename}"}
     %img{style: "width: 34px; padding-top: 2px;", src: "/images/download.png"}/

--- a/pegasus/sites/code.org/views/video_grid.haml
+++ b/pegasus/sites/code.org/views/video_grid.haml
@@ -3,7 +3,7 @@
   %div{style: "float:left; padding:10px; width:440px"}
     - unless video[:title].nil_or_empty?
       %h3= video[:title]
-    %iframe{width: "350", height: "195", src: "https://www.youtube-nocookie.com/embed/#{video[:yt]}?iv_load_policy=3&rel=0&autohide=1&showinfo=0", frameborder: "0", allowfullscreen: ""}
+    %iframe{width: "350", height: "195", src: "https://www.youtube-nocookie.com/embed/#{video[:yt]}?iv_load_policy=3&rel=0&autohide=1", frameborder: "0", allowfullscreen: ""}
     %p
       %a{href: video[:dl]}
         =video[:dltext]


### PR DESCRIPTION
YouTube deprecated the use of `showinfo=0` which hides the video title bar at the top of imported videos in 2018. There seems to be intermittent support for it so it was showing up randomly in Eyes tests on pages that have video Swiper carousels since these don't use the `display_video_thumbnail` view which overlays video embeds with an image. 

While this isn't ideal UI-wise, it will result in less flaky tests and doesn't take away any functionality. This shouldn't have any effect on the fallback videos.

## Links
Jira ticket: [ACQ-2137](https://codedotorg.atlassian.net/browse/ACQ-2137)
Slack convo: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1722031778345279?thread_ts=1722031778.345279&cid=C0T0PNTM3)

## Testing story
Tested locally on code.org and hourofcode.com

----

## code.org/videos
<img width="1147" alt="Screenshot 2024-07-29 at 2 00 41 PM" src="https://github.com/user-attachments/assets/f33dc2e2-e713-44f3-919e-5ce86be48df0">

## hourofcode.com
<img width="1019" alt="Screenshot 2024-07-29 at 2 00 20 PM" src="https://github.com/user-attachments/assets/1a1ec54b-3a4d-423e-9602-d39f58b21370">
