### PR TITLE
Speculative fix to send Facilitator post-workshop email for Build Your Own workshops

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -581,7 +581,7 @@ class Pd::Workshop < ApplicationRecord
 
   # Send Post-surveys to facilitators of CSD and CSP workshops
   def send_facilitator_post_surveys
-    if course == COURSE_CSD || course == COURSE_CSP || course == COURSE_CSA || course == COURSE_CSF
+    if course == COURSE_CSD || course == COURSE_CSP || course == COURSE_CSA || course == COURSE_CSF || course == COURSE_BUILD_YOUR_OWN
       facilitators.each do |facilitator|
         next unless facilitator.email
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -309,6 +309,26 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     Pd::Workshop.process_ends
   end
 
+  test 'end workshop sends exit surveys to facilitators for Build Your Own workshops' do
+    byo_workshop = create :pd_workshop,
+      :ended,
+      funded: false,
+      course: Pd::Workshop::COURSE_BUILD_YOUR_OWN,
+      subject: nil,
+      course_offerings: [] << (create :course_offering),
+      num_facilitators: 1
+    byo_workshop.start!
+
+    Pd::Workshop.any_instance.expects(:send_exit_surveys)
+    Pd::WorkshopMailer.any_instance.expects(:facilitator_post_workshop)
+
+    byo_workshop.end!
+
+    # This is normally called by a cron job on production-daemon, but in this test
+    # we call it synchronously.
+    Pd::Workshop.process_ends
+  end
+
   test 'end workshop second time attempts sending exit surveys but they do not send again' do
     workshop = create :workshop
     workshop.start!


### PR DESCRIPTION
Now that all the "Build Your Own workshop" content is in production, I was able to start testing some of it (since I wasn't able to test a lot of email and Foorm stuff locally). When testing, I noticed that the Facilitator post-workshop survey wasn't sending for "Build Your Own workshop" workshops. This adds "Build Your Own" workshop as a course type that sends emails.

## Testing story
Adding unit test.
