### PR TITLE
Escape single quote in level group title when cloning

### DIFF
--- a/dashboard/app/dsl/level_group_dsl.rb
+++ b/dashboard/app/dsl/level_group_dsl.rb
@@ -94,7 +94,7 @@ class LevelGroupDSL < LevelDSL
   def self.serialize(level)
     properties = level.properties
     new_dsl = "name '#{level.name}'"
-    new_dsl << "\ntitle '#{properties['title']}'" if properties['title']
+    new_dsl << "\ntitle '#{properties['title'].gsub("'", %q(\\\'))}'" if properties['title']
     new_dsl << "\nsubmittable '#{properties['submittable']}'" if properties['submittable']
     new_dsl << "\nanonymous '#{properties['anonymous']}'" if properties['anonymous']
 

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -317,7 +317,7 @@ MARKDOWN
     # DSL for the level_group.
     level_group_input_dsl = "
   name 'level_group_test long assessment'
-  title 'Long Assessment'
+  title 'Long\\'s Assessment'
   submittable 'true'
 
   page
@@ -334,7 +334,7 @@ MARKDOWN
   "
 
     expected_copy_dsl = "name 'level_group_test long assessment_copy'
-title 'Long Assessment'
+title 'Long\\'s Assessment'
 submittable 'true'
 
 page


### PR DESCRIPTION
Serialization for cloned level groups with single quotes in the title was not previously escaping those quotes, which caused seeding to fail when attempting to import those level groups. More context in the Slack thread linked from the JIRA ticket.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/TEACH-1170)

## Testing story

Updated existing level group cloning test to use an escaped single quote in the input, and verify it comes back out in the cloned level group output.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
