### PR TITLE
Add aichat logging controller action

### DIFF
--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -43,13 +43,17 @@ class AichatController < ApplicationController
       _, project_id = storage_decrypt_channel_id(context[:channelId])
     end
 
-    logged_event = AichatEvent.create!(
-      user_id: current_user.id,
-      level_id: context[:currentLevelId],
-      script_id: context[:scriptId],
-      project_id: project_id,
-      aichat_event: event.to_json
-    )
+    begin
+      logged_event = AichatEvent.create!(
+        user_id: current_user.id,
+        level_id: context[:currentLevelId],
+        script_id: context[:scriptId],
+        project_id: project_id,
+        aichat_event: event.to_json
+      )
+    rescue StandardError => exception
+      return render status: :bad_request, json: {error: exception.message}
+    end
 
     response_body = {
       chat_event_id: logged_event.id,

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -30,13 +30,13 @@ class AichatController < ApplicationController
   # POST /aichat/log_chat_event
   def log_chat_event
     begin
-      params.require([:newAichatEvent, :aichatContext])
+      params.require([:newChatEvent, :aichatContext])
     rescue ActionController::ParameterMissing
       return render status: :bad_request, json: {}
     end
 
     context = params[:aichatContext]
-    event = params[:newAichatEvent]
+    event = params[:newChatEvent]
 
     project_id = nil
     if context[:channelId]

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -481,6 +481,7 @@ class Ability
           (!user.teachers.empty? &&
           user.teachers.any? {|teacher| teacher.has_pilot_experiment?(GENAI_PILOT)})
         can :chat_completion, :aichat
+        can :log_aichat_event, :aichat
       end
     end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1163,7 +1163,7 @@ Dashboard::Application.routes.draw do
     post '/openai/chat_completion', to: 'openai_chat#chat_completion'
 
     post '/aichat/chat_completion', to: 'aichat#chat_completion'
-    post '/aichat/log_aichat_event', to: 'aichat#log_aichat_event'
+    post '/aichat/log_chat_event', to: 'aichat#log_chat_event'
 
     resources :ai_tutor_interactions, only: [:create, :index] do
       resources :feedbacks, controller: 'ai_tutor_interaction_feedbacks', only: [:create]

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1163,6 +1163,7 @@ Dashboard::Application.routes.draw do
     post '/openai/chat_completion', to: 'openai_chat#chat_completion'
 
     post '/aichat/chat_completion', to: 'aichat#chat_completion'
+    post '/aichat/log_aichat_event', to: 'aichat#log_aichat_event'
 
     resources :ai_tutor_interactions, only: [:create, :index] do
       resources :feedbacks, controller: 'ai_tutor_interaction_feedbacks', only: [:create]


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Following up on the creation of the db table `AichatEvents` by https://github.com/code-dot-org/code-dot-org/pull/60052, this PR adds a a new aichat controller action `log_aichat_event` that will log to the new table and new api endpoint. The sending of a request for an assistant response from Sagemaker will be decoupled from and the logging of aichat user events. More context in [this doc](https://docs.google.com/document/d/1OJCDc9t5DPu08gt8U52q8aa7dInUYvlzd1TvJq2PEzY/edit).

Note that we will continue to log to 'AichatSessions' during this transition until we confirm that the logging to 'AichatEvents' is successful on production. Included in follow-up work will be to remove the logging to the 'AichatSessions' table.


## After update

In order to test this controller action, I added some test front-end code in [this separate, working branch](https://github.com/code-dot-org/code-dot-org/tree/alice/log-aichat-events).

Screencast video of dev network tab showing the request/response to the new

https://github.com/user-attachments/assets/c37ed41c-b7ce-4c59-b58b-c0776b44733f






 
## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-939)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally on aichat levels in /allthethings. See After update section above.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
