### PR TITLE
[Bockly] Use handleColorAndStyle for remaining Artist blocks

### DIFF
--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -1654,7 +1654,11 @@ exports.install = function (blockly, blockInstallOptions) {
     return {
       helpUrl: '',
       init: function () {
-        this.setHSV(184, 1.0, 0.74);
+        Blockly.cdoUtils.handleColorAndStyle(
+          this,
+          BlockColors.DEFAULT,
+          BlockStyles.DEFAULT
+        );
         var dropdown;
         var input = this.appendDummyInput();
         input.appendField(msg.drawShape());

--- a/apps/src/turtle/customLevelBlocks.js
+++ b/apps/src/turtle/customLevelBlocks.js
@@ -2,6 +2,8 @@
  * A set of blocks used by some of our custom levels (i.e. built by level builder)
  */
 
+import {BlockColors, BlockStyles} from '../blockly/constants';
+
 var msg = require('./locale');
 
 exports.install = function (blockly, generator, gensym) {
@@ -57,7 +59,11 @@ function createACircleCode(size, gensym, indent) {
 function makeBlockInitializer(title, parameter) {
   return {
     init: function () {
-      this.setHSV(94, 0.84, 0.6);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.PROCEDURE,
+        BlockStyles.PROCEDURE
+      );
 
       this.appendDummyInput().appendField(title);
 
@@ -577,7 +583,11 @@ function installCreateASnowflakeDropdown(blockly, generator, gensym) {
     // We use custom initialization (instead of makeBlockInitializer) here
     // because each initialization needs a new instance of the FieldDropdown.
     init: function () {
-      this.setHSV(94, 0.84, 0.6);
+      Blockly.cdoUtils.handleColorAndStyle(
+        this,
+        BlockColors.PROCEDURE,
+        BlockStyles.PROCEDURE
+      );
 
       var title = new blockly.FieldDropdown(snowflakes);
       this.appendDummyInput().appendField(title, 'TYPE');


### PR DESCRIPTION
Similar to:
- https://github.com/code-dot-org/code-dot-org/pull/56684

Earlier this year we added handling for block colors and styles in un-migrated Blockly labs. Rather than calling `this.setHSV` on a block, we use a util so that we can instead potentially set a style with Google Blockly. This is preferable because styles are compatible with themes while hard-coded HSV colors are not.

This branch just refactors the colors and styles for a couple block definitions that were missed in February.

This shows the changed blocks in the darker high-contrast theme to demonstrate that they know have styles.

**Star Quilts** `rhombus_shape_with_side_length`:
<img width="478" alt="image" src="https://github.com/user-attachments/assets/5b59aa5b-807c-4ced-b3d7-2b3b54f96dd7">

**Frozen** `create_a_circle_size` and `create_snowflake_dropdown`:
![image](https://github.com/user-attachments/assets/e2834863-05dc-4e45-980d-3ff2e1b20fb6)



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
