### PR TITLE
P20-1055: Add migration for new CAP columns

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -50,10 +50,13 @@
 #  races                    :string(255)
 #  primary_contact_info_id  :integer
 #  unlock_token             :string(255)
+#  cap_state                :string(1)
+#  cap_state_date           :datetime
 #
 # Indexes
 #
 #  index_users_on_birthday                             (birthday)
+#  index_users_on_cap_state_and_cap_state_date         (cap_state,cap_state_date)
 #  index_users_on_current_sign_in_at                   (current_sign_in_at)
 #  index_users_on_deleted_at                           (deleted_at)
 #  index_users_on_email_and_deleted_at                 (email,deleted_at)

--- a/dashboard/app/serializers/user_serializer.rb
+++ b/dashboard/app/serializers/user_serializer.rb
@@ -50,10 +50,13 @@
 #  races                    :string(255)
 #  primary_contact_info_id  :integer
 #  unlock_token             :string(255)
+#  cap_state                :string(1)
+#  cap_state_date           :datetime
 #
 # Indexes
 #
 #  index_users_on_birthday                             (birthday)
+#  index_users_on_cap_state_and_cap_state_date         (cap_state,cap_state_date)
 #  index_users_on_current_sign_in_at                   (current_sign_in_at)
 #  index_users_on_deleted_at                           (deleted_at)
 #  index_users_on_email_and_deleted_at                 (email,deleted_at)

--- a/dashboard/db/migrate/20240723202827_add_cap_state_and_cap_state_date_to_users.rb
+++ b/dashboard/db/migrate/20240723202827_add_cap_state_and_cap_state_date_to_users.rb
@@ -1,0 +1,29 @@
+class AddCAPStateAndCAPStateDateToUsers < ActiveRecord::Migration[6.1]
+  def up
+    add_column :users, :cap_state, :string, limit: 1
+    add_column :users, :cap_state_date, :datetime
+
+    # Attempting to create this index via a migration will fail on a table as
+    # large as the one we have in production. To avoid that, we plan to execute
+    # the index creation query manually after the rest of this migration has
+    # completed.
+    #
+    # Specifically: on MySQL 8.0, adding an index does not lock the table but
+    # it does still take quite a while to apply successfully (see
+    # https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-column-syntax-notes).
+    # When tested against a clone of our production database, this operation
+    # took approximately 35 minutes, much longer than the 30 seconds migrations
+    # will wait before erroring out. To create the index without the time limit
+    # enforced by migrations, we should run this command from a bash shell on
+    # production-console:
+    #
+    #     nohup mysql-client-dashboard-writer "CREATE INDEX index_users_on_cap_state_and_cap_state_date ON users (cap_state, cap_state_date)" &
+    add_index :users, %i[cap_state cap_state_date] unless Rails.env.production?
+  end
+
+  def down
+    remove_index :users, %i[cap_state cap_state_date], if_exists: true
+    remove_column :users, :cap_state, :string
+    remove_column :users, :cap_state_date, :datetime
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -2399,7 +2399,10 @@ ActiveRecord::Schema.define(version: 2024_07_26_205216) do
     t.string "races"
     t.integer "primary_contact_info_id"
     t.string "unlock_token"
+    t.string "cap_state", limit: 1
+    t.datetime "cap_state_date"
     t.index ["birthday"], name: "index_users_on_birthday"
+    t.index ["cap_state", "cap_state_date"], name: "index_users_on_cap_state_and_cap_state_date"
     t.index ["current_sign_in_at"], name: "index_users_on_current_sign_in_at"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email", "deleted_at"], name: "index_users_on_email_and_deleted_at"


### PR DESCRIPTION
Added user columns `cap_state` and `cap_state_date`, along with the corresponding index for efficient querying.

`CAP` - Child Account Policy
https://github.com/code-dot-org/code-dot-org/blob/180cf779efa5c7bc0918ca17ca0a3dd0e4933fb6/dashboard/config/initializers/inflections.rb#L22

Index creation script:
```bash
nohup mysql-client-dashboard-writer "CREATE INDEX index_users_on_cap_state_and_cap_state_date ON users (cap_state, cap_state_date)" &
```

## Links
- JIRA task: [P20-1055](https://codedotorg.atlassian.net/browse/P20-1055)
- Phase 1 PR: https://github.com/code-dot-org/code-dot-org/pull/59962
- Phase 2 PR: https://github.com/code-dot-org/code-dot-org/pull/59963