### PR TITLE
[Google Blockly] handle variableDB_ rename to nameDB_

### DIFF
--- a/apps/src/blockly/addons/cdoGenerator.ts
+++ b/apps/src/blockly/addons/cdoGenerator.ts
@@ -1,6 +1,10 @@
 import {Block} from 'blockly';
 
-import {BlocklyWrapperType, ExtendedBlock} from '@cdo/apps/blockly/types';
+import {
+  BlocklyWrapperType,
+  ExtendedBlock,
+  ExtendedGenerator,
+} from '@cdo/apps/blockly/types';
 
 export default function initializeGenerator(
   blocklyWrapper: BlocklyWrapperType
@@ -63,9 +67,13 @@ export default function initializeGenerator(
 
   const originalBlockToCode = blocklyWrapper.Generator.prototype.blockToCode;
   blocklyWrapper.Generator.prototype.blockToCode = function (
+    this: ExtendedGenerator,
     block: Block | null,
     opt_thisOnly?: boolean
   ) {
+    if (!this.variableDB_) {
+      this.variableDB_ = this.nameDB_;
+    }
     // Skip disabled block check for non-rendered workspaces. Non-rendered workspaces
     // do not have an unused concept.
     if (block?.workspace?.rendered && !block?.isEnabled()) {

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -17,7 +17,7 @@ import {
   WorkspaceSvg,
   Xml,
 } from 'blockly';
-import GoogleBlockly, {Connection} from 'blockly/core';
+import GoogleBlockly, {Connection, Names} from 'blockly/core';
 import {Abstract} from 'blockly/core/events/events_abstract';
 import {Field, FieldProto} from 'blockly/core/field';
 import {IProcedureBlock, IProcedureModel} from 'blockly/core/procedures';
@@ -291,6 +291,8 @@ export interface ExtendedGenerator extends CodeGeneratorType {
   ) => string;
   blocksToCode: (name: string, blocksToGenerate: Block[]) => string;
   prefixLines: (text: string, prefix: string) => string;
+  nameDB_: Names | undefined;
+  variableDB_: Names | undefined;
 }
 
 type XmlType = typeof Xml;


### PR DESCRIPTION
At some point, the Blockly generator's database for variable names was renamed from `variableDB_` to `nameDB_`. This is a problem when a code generator function for a non-migrated lab needs to access the database, such as for functions with parameters. 

The Frozen skin of the Artist lab has some custom procedure blocks that need this:
![image](https://github.com/user-attachments/assets/a0594714-5a45-40f8-a0cf-031651539529)

We actually already reassign `generator.variableDB_ = generator.nameDB_` on line 58 in cdoGenerator during `blocksToCode` (plural). However, it's possible that a block might skin this function and call `blockToCode` (singular). 

By checking whether we have the old key available, we can now generator code for this custom function block:

![image](https://github.com/user-attachments/assets/7dd2e3ec-f69e-48ac-9f6d-b4cfe1bcefca)

(Note that this block also requires a second change found here: https://github.com/code-dot-org/code-dot-org/pull/60082)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
