### PR TITLE
DSCO swap: replace `ToggleSwitch` with DSCO `Toggle` in `CodeReviewGroupsStatusToggle`

### DIFF
--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
@@ -52,6 +52,7 @@ function CodeReviewGroupsStatusToggle({
     <div>
       <div style={styles.toggleAndError}>
         <Toggle
+          id="uitest-code-review-groups-toggle"
           name="enableCodeReviewToggle"
           checked={isToggledOn}
           onChange={toggleEnableCodeReview}

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {connect} from 'react-redux';
 
-import ToggleSwitch from '@cdo/apps/code-studio/components/ToggleSwitch';
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
+import Toggle from '@cdo/apps/componentLibrary/toggle/Toggle';
 import {
   setSectionCodeReviewExpiresAt,
   selectedSection,
@@ -51,9 +51,10 @@ function CodeReviewGroupsStatusToggle({
   return (
     <div>
       <div style={styles.toggleAndError}>
-        <ToggleSwitch
-          isToggledOn={isToggledOn}
-          onToggle={toggleEnableCodeReview}
+        <Toggle
+          name="enableCodeReviewToggle"
+          checked={isToggledOn}
+          onChange={toggleEnableCodeReview}
           label={i18n.enableCodeReview()}
         />
         {saveInProgress && <Spinner style={styles.spinner} size="medium" />}

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
@@ -70,6 +70,7 @@ function CodeReviewGroupsStatusToggle({
       {isToggledOn && (
         <p
           style={styles.enabledMessage}
+          name="enabledCodeReviewMessage"
           id="uitest-code-review-groups-status-message"
         >
           {i18n.codeReviewAutoDisableMessage({daysLeft})}

--- a/apps/test/unit/templates/codeReviewGroups/CodeReviewGroupsStatusToggleTest.jsx
+++ b/apps/test/unit/templates/codeReviewGroups/CodeReviewGroupsStatusToggleTest.jsx
@@ -18,10 +18,11 @@ describe('Code Review Groups Status Toggle', () => {
         setCodeReviewExpiration={setCodeReviewExpiration}
       />
     );
-    const toggle = wrapper.find('ToggleSwitch');
-    expect(toggle.prop('isToggledOn')).toBe(false);
+    const toggle = wrapper.find('input');
+    expect(toggle.prop('checked')).toBe(false);
     // expect to not find the enabled message
-    expect(wrapper.find('p')).toHaveLength(0);
+    const enabledMsg = wrapper.find({name: 'enabledCodeReviewMessage'});
+    expect(enabledMsg).toHaveLength(0);
   });
 
   it('renders enable toggle if code review expiration date is before today', () => {
@@ -33,8 +34,8 @@ describe('Code Review Groups Status Toggle', () => {
         setCodeReviewExpiration={setCodeReviewExpiration}
       />
     );
-    const toggle = wrapper.find('ToggleSwitch');
-    expect(toggle.prop('isToggledOn')).toBe(false);
+    const toggle = wrapper.find('input');
+    expect(toggle.prop('checked')).toBe(false);
   });
 
   it('renders disable toggle if code review expiration date is after today', () => {
@@ -46,12 +47,12 @@ describe('Code Review Groups Status Toggle', () => {
         setCodeReviewExpiration={setCodeReviewExpiration}
       />
     );
-    const toggle = wrapper.find('ToggleSwitch');
-    expect(toggle.prop('isToggledOn')).toBe(true);
+    const toggle = wrapper.find('input');
+    expect(toggle.prop('checked')).toBe(true);
     // expect to see enabled message
-    const enabledMessage = wrapper.find('p').at(0).text();
+    const enabledMessage = wrapper.find({name: 'enabledCodeReviewMessage'});
     const expectedEnabledMessage =
       'Code review will be automatically disabled in 1 days. To reset this time, disable and re-enable code review.';
-    expect(enabledMessage).toBe(expectedEnabledMessage);
+    expect(enabledMessage.text()).toBe(expectedEnabledMessage);
   });
 });

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_code_review_groups.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_code_review_groups.feature
@@ -28,6 +28,6 @@ Background:
 
   Scenario: Enable code review for a section
     Given I open the code review groups management dialog
-    When I click selector ".toggle-input"
+    When I click selector "#uitest-code-review-groups-toggle"
     # We display a message with the number of days until code review groups expire when code review is enabled
     Then element "#uitest-code-review-groups-status-message" eventually contains text "Code review will be automatically disabled"


### PR DESCRIPTION
### Description 

Similar to https://github.com/code-dot-org/code-dot-org/pull/60062 and https://github.com/code-dot-org/code-dot-org/pull/60086

**Before** 
![Screenshot 2024-07-30 at 4 03 10 PM](https://github.com/user-attachments/assets/92316406-c5d3-4658-a03f-d5ba286eedc0)

**After** 
![Screenshot 2024-07-30 at 4 05 59 PM](https://github.com/user-attachments/assets/e6d9840a-0515-4d0b-b768-9c1a7ad5ca3f)


### Follow up

Up next is deleting `ToggleSwitch`. 