### PR TITLE
Automatically mark users as attended upon enrolling for a Build Your Own workshop

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -61,6 +61,14 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
 
         if @workshop.course == COURSE_BUILD_YOUR_OWN
           enrollment.update!(enrollment_params)
+
+          # Mark attendance for all sessions in Build Your Own workshops (we are not tracking attendance in
+          # this way for Build Your Own workshops, but we want to ensure that functionality for emails,
+          # certificates, etc. remains the same).
+          @workshop.sessions.each do |session|
+            attendance = Pd::Attendance.find_restore_or_create_by! session: session, teacher: user, enrollment: enrollment
+            attendance.update! marked_by_user: user
+          end
         else
           enrollment.update!(enrollment_params.merge(school_info_attributes: school_info_params))
           user&.update_school_info(enrollment.school_info)


### PR DESCRIPTION
Automatically marks users as attended upon enrolling for a Build Your Own workshop. This will allow users to see their workshop certificate and receive the post-workshop survey email when the Build Your Own workshop has ended without having to mark attendance.

### After enrolling, the attendance was automatically marked
![attendance auto_created](https://github.com/user-attachments/assets/9dfed74a-d18a-447b-bec7-d674a5814a82)

Also shows up in the db:
![in db](https://github.com/user-attachments/assets/47b62875-3a92-4cb5-a81c-7d1e5be67001)

Works with multiple sessions too:
![1](https://github.com/user-attachments/assets/c4b88789-ef58-45b2-8968-454aed0fc342)
![2](https://github.com/user-attachments/assets/65a46305-07ac-4c71-b75c-11f8f9b2d874)
![3](https://github.com/user-attachments/assets/aac6fe65-a973-4dd2-bab1-68d014ce1eb8)

### Shows certificate button
![print certificate works](https://github.com/user-attachments/assets/8f730296-1ea2-4b13-bed4-f72dd0f61ed4)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2164)

## Testing story
Local testing and updating unit tests.
