### PR TITLE
Disable Javalab Code Review flakey tests

### DIFF
--- a/dashboard/test/ui/features/javalab/code_review_finish_button.feature
+++ b/dashboard/test/ui/features/javalab/code_review_finish_button.feature
@@ -34,6 +34,7 @@ Feature: Code review Finish Button
     And I wait until element ".javalab-console" contains text "[JAVALAB] Program completed."
     Then element "#finishButton" is disabled
 
+  @skip
   Scenario: Running code in your peer's code review does not enable the finish button
     Given I sign in as "student_1"
     And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/2?noautoplay=true"

--- a/dashboard/test/ui/features/javalab/code_review_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_scenarios.feature
@@ -1,5 +1,6 @@
 @no_mobile
 @eyes
+@skip
 Feature: Code review V2
 
   # Note: this test does not cover adding comments to the review because the slate text editor


### PR DESCRIPTION
Disables two flaky tests (over 0.5 flaky):
1. Chrome_javalab_code_review_finish_button scenario Scenario: Running code in your peer's code review does not enable the finish button
2. Chrome_javalab_code_review_scenarios_eyes whole test

Flaky test tickets:
1. https://codedotorg.atlassian.net/browse/LABS-954
3. https://codedotorg.atlassian.net/issues/LABS-955