### PR TITLE
Disable Safari_hour_of_code_hour_of_code_finish

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -1,3 +1,4 @@
+@no_safari
 Feature: After completing the Hour of Code, the player is directed to a congratulations page
 
 Scenario: Completing Minecraft HoC should go to certificate page and generate a certificate


### PR DESCRIPTION
Test is flakey > 0.33 on Safari and has broken a few test builds over the past few days.

Flaky test ticket: https://codedotorg.atlassian.net/issues/LABS-928

FYI @wilkie 