### PR TITLE
Add metrics for signed in users to header

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -287,7 +287,7 @@ const EVENTS = {
   // PL Landing Page
   MY_PL_PAGE_VISITED: 'My Professional Learning Page Visited',
 
-  // Header navigation
+  // Header navigation - signed out
   SIGNED_OUT_USER_SEES_HEADER: 'Signed Out Navigation Header Shown',
   SIGNED_OUT_USER_CLICKS_HEADER_LINK: 'Signed Out User Clicks Header Link',
   SIGNED_OUT_USER_CLICKS_HAMBURGER_LINK:
@@ -296,11 +296,29 @@ const EVENTS = {
   SIGNED_OUT_USER_CLICKS_HELP_MENU: 'Signed Out User Clicks Help Menu',
   CREATE_ACCOUNT_BUTTON_CLICKED: 'Create Account Button Clicked',
 
-  // Header Create menu
+  // Header Create menu - signed out
   SIGNED_OUT_USER_CLICKS_CREATE_DROPDOWN:
     'Signed Out User Clicks Create Dropdown',
   SIGNED_OUT_USER_SELECTS_CREATE_DROPDOWN_OPTION:
     'Signed Out User Selects Create Dropdown Option',
+
+  // Header navigation - signed in
+  SIGNED_IN_USER_CLICKS_HEADER_LINK: 'Signed In User Clicks Header Link',
+  SIGNED_IN_USER_CLICKS_HAMBURGER_LINK: 'Signed In User Clicks Hamburger Link',
+  SIGNED_IN_USER_CLICKS_HAMBURGER_OPTION:
+    'Signed In User Clicks Hamburger Dropdown Option',
+  SIGNED_IN_USER_CLICKS_HELP_MENU: 'Signed In User Clicks Help Menu',
+  SIGNED_IN_USER_CLICKS_HELP_MENU_OPTION:
+    'Signed In User Clicks Help Menu Option',
+  SIGNED_IN_USER_CLICKS_USER_MENU: 'Signed In User Clicks User Menu',
+  SIGNED_IN_USER_CLICKS_USER_MENU_OPTION:
+    'Signed In User Clicks User Menu Option',
+
+  // Header Create menu - signed in
+  SIGNED_IN_USER_CLICKS_CREATE_DROPDOWN:
+    'Signed In User Clicks Create Dropdown',
+  SIGNED_IN_USER_SELECTS_CREATE_DROPDOWN_OPTION:
+    'Signed In Signed In User Selects Create Dropdown Option',
 
   // Projects
   RUN_BUTTON_PRESSED_SIGNED_OUT:

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -318,7 +318,7 @@ const EVENTS = {
   SIGNED_IN_USER_CLICKS_CREATE_DROPDOWN:
     'Signed In User Clicks Create Dropdown',
   SIGNED_IN_USER_SELECTS_CREATE_DROPDOWN_OPTION:
-    'Signed In Signed In User Selects Create Dropdown Option',
+    'Signed In User Selects Create Dropdown Option',
 
   // Projects
   RUN_BUTTON_PRESSED_SIGNED_OUT:

--- a/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
+++ b/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
@@ -179,13 +179,6 @@ const addSignedInMetrics = (pageUrl, headerCreateMenu) => {
     additionalOptions
   );
 
-  // Log if a hamburger link is clicked
-  addClickEventToLinks(
-    'hamburgerlink',
-    EVENTS.SIGNED_IN_USER_CLICKS_HAMBURGER_LINK,
-    additionalOptions
-  );
-
   addMenuMetrics(
     'header_user_menu',
     USER_MENU_OPTION_IDS,

--- a/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
+++ b/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
@@ -4,8 +4,10 @@ import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
+const USER_MENU_OPTION_IDS = ['my-projects', 'user-edit', 'user-signout'];
+
 // Adds an event to each header or hamburger link
-function addClickEventToLinks(selector, eventName) {
+function addClickEventToLinks(selector, eventName, additionalProperties = {}) {
   const links = document.querySelectorAll(`.${selector}`);
   links.forEach(link => {
     link.addEventListener('click', () => {
@@ -13,6 +15,7 @@ function addClickEventToLinks(selector, eventName) {
         eventName,
         {
           [selector]: link.href,
+          ...additionalProperties,
         },
         PLATFORMS.STATSIG
       );
@@ -20,76 +23,67 @@ function addClickEventToLinks(selector, eventName) {
   });
 }
 
-$(document).ready(function () {
-  const signInButton = document.getElementById('signin_button');
-  const headerCreateMenu = document.getElementById('header_create_menu');
-  const pageUrl = window.location.href;
-  const helpIcon = document.querySelector('#help-icon');
-  const createAccountButton = document.querySelector('#create_account_button');
-  const screenWidth = window.innerWidth;
+function getHeaderType(screenWidth) {
+  if (screenWidth < 425) return 'mobile';
+  if (screenWidth < 1024) return 'tablet';
+  if (screenWidth <= 1268) return 'small desktop';
+  return 'large desktop';
+}
 
-  function getHeaderType(screenWidth) {
-    if (screenWidth < 425) return 'mobile';
-    if (screenWidth < 1024) return 'tablet';
-    if (screenWidth <= 1268) return 'small desktop';
-    return 'large desktop';
+const addSignedOutMetrics = (pageUrl, helpIcon, headerCreateMenu) => {
+  const screenWidth = window.innerWidth;
+  analyticsReporter.sendEvent(
+    EVENTS.SIGNED_OUT_USER_SEES_HEADER,
+    {
+      pageUrl: pageUrl,
+      headerType: getHeaderType(screenWidth),
+    },
+    PLATFORMS.STATSIG
+  );
+
+  // Log if a header link is clicked
+  addClickEventToLinks('headerlink', EVENTS.SIGNED_OUT_USER_CLICKS_HEADER_LINK);
+
+  // Log if a hamburger link is clicked
+  addClickEventToLinks(
+    'hamburgerlink',
+    EVENTS.SIGNED_OUT_USER_CLICKS_HAMBURGER_LINK
+  );
+
+  const createAccountButton = document.querySelector('#create_account_button');
+  // Log if the Create Account button is clicked
+  if (createAccountButton) {
+    createAccountButton.addEventListener('click', () => {
+      analyticsReporter.sendEvent(
+        EVENTS.CREATE_ACCOUNT_BUTTON_CLICKED,
+        {pageUrl: pageUrl},
+        PLATFORMS.BOTH
+      );
+    });
   }
 
-  if (getScriptData('isSignedOut')) {
-    analyticsReporter.sendEvent(
-      EVENTS.SIGNED_OUT_USER_SEES_HEADER,
-      {
-        pageUrl: pageUrl,
-        headerType: getHeaderType(screenWidth),
-      },
-      PLATFORMS.STATSIG
-    );
-
-    // Log if a header link is clicked
-    addClickEventToLinks(
-      'headerlink',
-      EVENTS.SIGNED_OUT_USER_CLICKS_HEADER_LINK
-    );
-
-    // Log if a hamburger link is clicked
-    addClickEventToLinks(
-      'hamburgerlink',
-      EVENTS.SIGNED_OUT_USER_CLICKS_HAMBURGER_LINK
-    );
-
-    // Log if the Create Account button is clicked
-    if (createAccountButton) {
-      createAccountButton.addEventListener('click', () => {
-        analyticsReporter.sendEvent(
-          EVENTS.CREATE_ACCOUNT_BUTTON_CLICKED,
-          {pageUrl: pageUrl},
-          PLATFORMS.BOTH
-        );
-      });
-    }
-
-    // Log if the Sign in button is clicked
-    if (signInButton) {
-      signInButton.addEventListener('click', () => {
-        analyticsReporter.sendEvent(
-          EVENTS.SIGNED_OUT_USER_CLICKS_SIGN_IN,
-          {pageUrl: pageUrl},
-          PLATFORMS.STATSIG
-        );
-      });
-    }
-
-    // Log if the Help icon menu is clicked
-    helpIcon.addEventListener('click', () => {
+  const signInButton = document.getElementById('signin_button');
+  // Log if the Sign in button is clicked
+  if (signInButton) {
+    signInButton.addEventListener('click', () => {
       analyticsReporter.sendEvent(
-        EVENTS.SIGNED_OUT_USER_CLICKS_HELP_MENU,
-        {},
+        EVENTS.SIGNED_OUT_USER_CLICKS_SIGN_IN,
+        {pageUrl: pageUrl},
         PLATFORMS.STATSIG
       );
     });
   }
 
-  if (getScriptData('isSignedOut') && headerCreateMenu) {
+  // Log if the Help icon menu is clicked
+  helpIcon.addEventListener('click', () => {
+    analyticsReporter.sendEvent(
+      EVENTS.SIGNED_OUT_USER_CLICKS_HELP_MENU,
+      {},
+      PLATFORMS.STATSIG
+    );
+  });
+
+  if (headerCreateMenu) {
     // Log if a signed-out user clicks the "Create" menu dropdown
     headerCreateMenu.addEventListener('click', () => {
       analyticsReporter.sendEvent(
@@ -114,5 +108,111 @@ $(document).ready(function () {
           );
         });
     });
+  }
+};
+
+const addSignedInMetrics = (pageUrl, helpIcon, headerCreateMenu) => {
+  const userType = getScriptData('userType');
+
+  // Log if a header link is clicked
+  addClickEventToLinks('headerlink', EVENTS.SIGNED_IN_USER_CLICKS_HEADER_LINK, {
+    userType: userType,
+    pageUrl: pageUrl,
+  });
+
+  // Log if a hamburger link is clicked
+  addClickEventToLinks(
+    'hamburgerlink',
+    EVENTS.SIGNED_IN_USER_CLICKS_HAMBURGER_LINK,
+    {
+      userType: userType,
+      pageUrl: pageUrl,
+    }
+  );
+
+  // Log if the Help icon menu is clicked
+  helpIcon.addEventListener('click', () => {
+    analyticsReporter.sendEvent(
+      EVENTS.SIGNED_IN_USER_CLICKS_HELP_MENU,
+      {
+        userType: userType,
+        pageUrl: pageUrl,
+      },
+      PLATFORMS.STATSIG
+    );
+  });
+
+  const headerUserMenu = document.getElementById('header_user_menu');
+  if (headerUserMenu) {
+    // Log if a signed-out user clicks the "Create" menu dropdown
+    headerUserMenu.addEventListener('click', () => {
+      analyticsReporter.sendEvent(
+        EVENTS.SIGNED_IN_USER_CLICKS_USER_MENU,
+        {
+          userType: userType,
+          pageUrl: pageUrl,
+        },
+        PLATFORMS.STATSIG
+      );
+    });
+
+    // Log if a signed-out user clicks an option in the "Create" menu dropdown
+    USER_MENU_OPTION_IDS.forEach(option => {
+      document.getElementById(option).addEventListener('click', () => {
+        analyticsReporter.sendEvent(
+          EVENTS.SIGNED_IN_USER_CLICKS_USER_MENU_OPTION,
+          {
+            option: option,
+            userType: userType,
+            pageUrl: pageUrl,
+          },
+          PLATFORMS.STATSIG
+        );
+      });
+    });
+  }
+
+  if (headerCreateMenu) {
+    // Log if a signed-out user clicks the "Create" menu dropdown
+    headerCreateMenu.addEventListener('click', () => {
+      analyticsReporter.sendEvent(
+        EVENTS.SIGNED_IN_USER_CLICKS_CREATE_DROPDOWN,
+        {
+          userType: userType,
+          pageUrl: pageUrl,
+        },
+        PLATFORMS.STATSIG
+      );
+    });
+
+    // Log if a signed-out user clicks an option in the "Create" menu dropdown
+    const createMenuOptions = getScriptData('createMenuOptions');
+    createMenuOptions.forEach(option => {
+      document
+        .getElementById(`create_menu_option_${option}`)
+        .addEventListener('click', () => {
+          analyticsReporter.sendEvent(
+            EVENTS.SIGNED_IN_USER_SELECTS_CREATE_DROPDOWN_OPTION,
+            {
+              option: option,
+              userType: userType,
+              pageUrl: pageUrl,
+            },
+            PLATFORMS.STATSIG
+          );
+        });
+    });
+  }
+};
+
+$(document).ready(function () {
+  const headerCreateMenu = document.getElementById('header_create_menu');
+  const pageUrl = window.location.href;
+  const helpIcon = document.querySelector('#help-icon');
+
+  if (getScriptData('isSignedOut')) {
+    addSignedOutMetrics(pageUrl, helpIcon, headerCreateMenu);
+  } else {
+    addSignedInMetrics(pageUrl, helpIcon, headerCreateMenu);
   }
 });

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -98,7 +98,7 @@
     .header_button.header_user#header_user_create_account
       %span= I18n.t("#{loc_prefix}create_account_low_cap")
 
-= render inline: File.read(shared_dir('haml/user_header_event_logger.haml')), type: :haml, locals: {is_signed_out: user_type.nil?, create_menu_options: create_drop_down_items&.map{|entry| entry[:title]}&.append("view_all")}
+= render inline: File.read(shared_dir('haml/user_header_event_logger.haml')), type: :haml, locals: {is_signed_out: user_type.nil?, user_type: user_type, create_menu_options: create_drop_down_items&.map{|entry| entry[:title]}&.append("view_all")}
 
 :javascript
   window.cookieEnvSuffix = '#{rack_env?(:production) ? '' : "_#{rack_env}"}';

--- a/shared/haml/user_header_event_logger.haml
+++ b/shared/haml/user_header_event_logger.haml
@@ -1,1 +1,1 @@
-%script{src: webpack_asset_path('js/userHeaderEventLogger.js'), data: {isSignedOut: is_signed_out.to_json, createMenuOptions: create_menu_options&.to_json}}
+%script{src: webpack_asset_path('js/userHeaderEventLogger.js'), data: {isSignedOut: is_signed_out.to_json, userType: user_type.to_json, createMenuOptions: create_menu_options&.to_json}}


### PR DESCRIPTION
* Adds metrics for all existing signed out metrics for signed in users
* Adds metrics for the user menu and each option
* Adds metrics for the help menu and each option
* Adds metrics for the hamburger menu and each option
* Adds 'userType' to each signed in header user metric
* Adds 'pageURL' to each signed in header user metric

## Links
[TEACH-1203](https://codedotorg.atlassian.net/browse/TEACH-1203)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested each option and button manually that a STATSIG event is emitted in console.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
