### PR TITLE
add warning banner to python lab start mode

### DIFF
--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -3,7 +3,9 @@ import {Editor} from '@codebridge/Editor';
 import {FileTabs} from '@codebridge/FileTabs';
 import React from 'react';
 
+import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {isProjectTemplateLevel} from '@cdo/apps/lab2/lab2Redux';
+import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import ProjectTemplateWorkspaceIcon from '@cdo/apps/templates/ProjectTemplateWorkspaceIcon';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -14,6 +16,7 @@ import HeaderButtons from './HeaderButtons';
 import moduleStyles from './workspace.module.scss';
 const Workspace = () => {
   const {config} = useCodebridgeContext();
+  const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
 
   const headerContent = (
@@ -31,6 +34,16 @@ const Workspace = () => {
       className={moduleStyles.workspace}
     >
       <FileTabs />
+      {isStartMode && (
+        <div
+          id="startSourcesWarningBanner"
+          className={moduleStyles.warningBanner}
+        >
+          {projectTemplateLevel
+            ? 'WARNING: You are editing start sources for a level with a template. Start sources should be defined on the template.'
+            : 'You are editing start sources.'}
+        </div>
+      )}
       <Editor
         langMapping={config.languageMapping}
         editableFileTypes={config.editableFileTypes}

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -6,3 +6,12 @@
   background-color: $darkest_gray;
   color: $white;
 }
+
+.warningBanner {
+  z-index: 99;
+  background-color: $light_yellow;
+  height: 20px;
+  padding: 5px;
+  width: 100%;
+  color: $black;
+}


### PR DESCRIPTION
Similar to:
- https://github.com/code-dot-org/code-dot-org/pull/50082

If a Code Bridge level is in start mode, we will show a yellow warning banner indicating this. If the level has a template, we will show stronger language to encourage editing the template start sources instead. This is similar to other labs, which can be seen in the PR linked above. Note that I used the darker yellow color used by Java Lab.

## New CodeBridge screenshots
**Normal student view (no change)**
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/142f4399-3f15-460f-883e-efcbdf226162">

**Start Mode, normal level**
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/bf01a64e-ffd0-496b-8385-82dfdc544995">

**Start sources with template**
<img width="1139" alt="image" src="https://github.com/user-attachments/assets/6436c690-175f-438c-93a3-07be7656c8d0">## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


Jira - https://codedotorg.atlassian.net/browse/CT-657
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
