### PR TITLE
Python Lab: allow everyone to run code

### DIFF
--- a/apps/src/codebridge/ControlButtons/index.tsx
+++ b/apps/src/codebridge/ControlButtons/index.tsx
@@ -20,19 +20,13 @@ import {
 } from '@cdo/apps/lab2/views/dialogs/DialogManager';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-import {useFetch} from '@cdo/apps/util/useFetch';
 import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import moduleStyles from './control-buttons.module.scss';
 
-interface PermissionResponse {
-  permissions: string[];
-}
-
 const ControlButtons: React.FunctionComponent = () => {
   const {onRun} = useCodebridgeContext();
   const dialogControl = useContext(DialogContext);
-  const {loading, data} = useFetch('/api/v1/users/current/permissions');
   const [hasRun, setHasRun] = useState(false);
   const dispatch = useAppDispatch();
 
@@ -60,7 +54,7 @@ const ControlButtons: React.FunctionComponent = () => {
   // and the user has not yet written a prediction.
   const awaitingPredictSubmit =
     !isStartMode && isPredictLevel && !hasPredictResponse;
-  const disableRunAndTest = loading || awaitingPredictSubmit;
+  const disableRunAndTest = awaitingPredictSubmit;
 
   const onContinue = () => dispatch(navigateToNextLevel());
   // No-op for now. TODO: figure out what the finish button should do.
@@ -95,10 +89,7 @@ const ControlButtons: React.FunctionComponent = () => {
 
   const handleRun = (runTests: boolean) => {
     if (onRun) {
-      const parsedPermissions = data
-        ? (data as PermissionResponse)
-        : {permissions: []};
-      onRun(runTests, dispatch, parsedPermissions.permissions, source);
+      onRun(runTests, dispatch, source);
       setHasRun(true);
     } else {
       dispatch(appendSystemMessage("We don't know how to run your code."));
@@ -107,8 +98,7 @@ const ControlButtons: React.FunctionComponent = () => {
 
   // We disabled navigation if we are still loading, or if this is a submittable level,
   // the user has not submitted yet, and the user has not run their code during this session.
-  const disableNavigation =
-    loading || (isSubmittable && !hasSubmitted && !hasRun);
+  const disableNavigation = isSubmittable && !hasSubmitted && !hasRun;
   const getNavigationButtonProps = () => {
     if (isSubmittable) {
       return {

--- a/apps/src/codebridge/types.ts
+++ b/apps/src/codebridge/types.ts
@@ -58,7 +58,6 @@ export type ResetProjectFunction = () => void;
 export type OnRunFunction = (
   runTests: boolean,
   dispatch: Dispatch<AnyAction>,
-  permissions: string[],
   source: MultiFileSource | undefined
 ) => void;
 

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -103,10 +103,9 @@ const PythonlabView: React.FunctionComponent = () => {
   const onRun = (
     runTests: boolean,
     dispatch: AppDispatch,
-    permissions: string[],
     source: MultiFileSource | undefined
   ) => {
-    handleRunClick(runTests, dispatch, permissions, source);
+    handleRunClick(runTests, dispatch, source);
     // Only send a predict level report if this is a predict level and the predict
     // answer was not locked.
     if (isPredictLevel && !predictAnswerLocked) {

--- a/apps/src/pythonlab/pyodideRunner.ts
+++ b/apps/src/pythonlab/pyodideRunner.ts
@@ -11,16 +11,8 @@ import {runStudentTests, runValidationTests} from './pythonHelpers/scripts';
 export function handleRunClick(
   runTests: boolean,
   dispatch: Dispatch<AnyAction>,
-  permissions: string[],
   source: MultiFileSource | undefined
 ) {
-  // For now, restrict running python code to levelbuilders.
-  if (!permissions.includes('levelbuilder')) {
-    dispatch(
-      appendSystemMessage('You do not have permission to run python code.')
-    );
-    return;
-  }
   if (!source) {
     dispatch(appendSystemMessage('You have no code to run.'));
     return;


### PR DESCRIPTION
We can now remove the permissions check on Python Lab that only allowed levelbuilders to run Python code!

If we decide in the future that we want to have permissions checks on other labs (i.e. if we migrate Java Lab to Code Bridge) we can add the call back to check permissions, but since it wasn't used it didn't make sense to keep that API call.

## Links

- jira ticket: [CT-513](https://codedotorg.atlassian.net/browse/CT-513)

## Testing story
Tested that any user can now run Python code.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
