### PR TITLE
Add old Facilitator post-workshop survey route back in

### DIFF
--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -805,6 +805,7 @@ Dashboard::Application.routes.draw do
       post 'workshop_survey/submit', to: 'workshop_daily_survey#submit_general'
       get 'workshop_post_survey', to: 'workshop_daily_survey#new_post'
       get 'workshop_survey/post/:enrollment_code', to: 'workshop_daily_survey#new_post', as: 'new_workshop_survey'
+      get 'workshop_survey/facilitator_post_foorm', to: 'workshop_daily_survey#new_facilitator_post'
       get 'workshop_survey/new_facilitator_post', to: 'workshop_daily_survey#new_facilitator_post'
       get 'workshop_survey/csf/post101(/:enrollment_code)', to: 'workshop_daily_survey#new_csf_post101'
       get 'workshop_survey/csf/pre201', to: 'workshop_daily_survey#new_csf_pre201'


### PR DESCRIPTION
As part of [this PR](https://github.com/code-dot-org/code-dot-org/pull/59875/files), the workshop survey controller route that sent facilitators to their post-workshop survey was updated to not include the word "foorm" since the new Build Your Own workshop surveys don't use Foorm. However, this meant that all facilitator post-workshop emails sent out with survey links before [this change](https://github.com/code-dot-org/code-dot-org/pull/59875/files#diff-3fffe83c5f87f14c4c59c00fc3556305f7d4a28ee7748b688700228b3c64e70dR806) was merged would have broken URLs (as seen in [this Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/502281)).

Following a [similar fix](https://github.com/code-dot-org/code-dot-org/pull/60057/files#diff-3fffe83c5f87f14c4c59c00fc3556305f7d4a28ee7748b688700228b3c64e70dR806) for participant post-survey links, this PR temporarily adds that old route back in but points it to the new method `new_facilitator_post` instead. This will allow both the old and new URLs to work. I've created a followup ticket [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64/backlog?selectedIssue=ACQ-2176) to remove this and the particpant's old post-workshop survey route after all workshops that started before the [original PR](https://github.com/code-dot-org/code-dot-org/pull/59875/files#diff-3fffe83c5f87f14c4c59c00fc3556305f7d4a28ee7748b688700228b3c64e70dR806) was merged have finsihed.

### Shows working survey with old `facilitator_post_foorm` route
![foorm](https://github.com/user-attachments/assets/a4c1485f-9555-4760-953c-2ba792fbd21f)

### Shows working survey with new `new_facilitator_post` route
![newFacilitatorPost](https://github.com/user-attachments/assets/31ee363c-9304-40e0-aa05-32f8b6fda71b)

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1722445180806989)
Main PR that originally updated post-workshop methods: [here](https://github.com/code-dot-org/code-dot-org/pull/59875/files#diff-3fffe83c5f87f14c4c59c00fc3556305f7d4a28ee7748b688700228b3c64e70dR806)
Similar fix for participant post-workshop surveys: [here](https://github.com/code-dot-org/code-dot-org/pull/60057/files#diff-3fffe83c5f87f14c4c59c00fc3556305f7d4a28ee7748b688700228b3c64e70dR806)

## Testing story
Local testing.
