### PR TITLE
Music: make SoundCache a singleton

### DIFF
--- a/apps/src/music/player/SamplePlayer.ts
+++ b/apps/src/music/player/SamplePlayer.ts
@@ -43,7 +43,7 @@ export default class SamplePlayer {
 
   constructor(
     metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter(),
-    soundCache: SoundCache = new SoundCache(),
+    soundCache: SoundCache = SoundCache.getInstance(),
     soundPlayer: SoundPlayer = new SoundPlayer()
   ) {
     this.metricsReporter = metricsReporter;

--- a/apps/src/music/player/SoundCache.ts
+++ b/apps/src/music/player/SoundCache.ts
@@ -6,12 +6,21 @@ import {baseAssetUrlRestricted} from '../constants';
 import {LoadFinishedCallback} from '../types';
 
 class SoundCache {
+  private static instance: SoundCache;
+
+  public static getInstance() {
+    if (!SoundCache.instance) {
+      SoundCache.instance = new SoundCache();
+    }
+    return SoundCache.instance;
+  }
+
   private readonly audioContext: AudioContext;
   private readonly metricsReporter: LabMetricsReporter;
   private audioBuffers: {[id: string]: AudioBuffer};
   private hasLoadedSignedCookies: boolean;
 
-  constructor(
+  private constructor(
     audioContext: AudioContext = new AudioContext(),
     metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter()
   ) {

--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -54,7 +54,7 @@ class ToneJSPlayer implements AudioPlayer {
 
   constructor(
     bpm = DEFAULT_BPM,
-    private readonly soundCache: SoundCache = new SoundCache(),
+    private readonly soundCache: SoundCache = SoundCache.getInstance(),
     private readonly metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter()
   ) {
     Transport.bpm.value = bpm;


### PR DESCRIPTION
Make SoundCache a singleton, so that it can persist between level changes even if Music Lab is unmounted. Currently Music Lab is always rendered in the background if present in a lab2 progression, partially because we wanted the cache to persist between levels. Now the sounds will still stay cached even if we don't always have Music Lab rendered in the background. 

Note that Music Lab will still stay rendered in the background as of this PR - there is one more necessary change related to analytics lifecycle management before we can flip the flag to not have Music Lab render in the background.

Example: (I manually set Music Lab to not render in the background (`backgroundMode: false`) locally only)

https://github.com/user-attachments/assets/b62a5f11-f592-4f22-aeb5-e660bc106889

## Links

https://codedotorg.atlassian.net/browse/LABS-925

## Testing story

Tested on the intro progression and verified sounds are not reloaded once cached even when switching to a panels level and back.