### PR TITLE
Add retry and timeout to flaky DCDO test

### DIFF
--- a/dashboard/test/lib/dcdo_test.rb
+++ b/dashboard/test/lib/dcdo_test.rb
@@ -3,10 +3,28 @@ require 'dynamic_config/dcdo'
 require 'timeout'
 
 class DCDOTest < ActiveSupport::TestCase
+  setup do
+    DCDO.unstub(:get)
+  end
+
   test 'basic set and get' do
-    assert_nil DCDO.get('key', nil)
-    DCDO.set('key', 'okay')
-    assert_equal DCDO.get('key', nil), 'okay'
+    key = SecureRandom.hex
+    assert_nil DCDO.get(key, nil)
+    DCDO.set(key, 'okay')
+
+    result = nil
+    Timeout.timeout(10) do
+      loop do
+        result = DCDO.get(key, nil)
+        if result.present?
+          break
+        else
+          sleep 1
+        end
+      end
+    end
+
+    assert_equal result, 'okay'
   end
 
   test 'returns default if key is not stored' do
@@ -18,7 +36,7 @@ class DCDOTest < ActiveSupport::TestCase
       'b' => 'yo dude',
       'c' => [1, 2, 3]
     }
-    key = 'random'
+    key = SecureRandom.hex
     DCDO.set(key, to_store)
 
     result = nil

--- a/dashboard/test/lib/dcdo_test.rb
+++ b/dashboard/test/lib/dcdo_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'dynamic_config/dcdo'
+require 'timeout'
 
 class DCDOTest < ActiveSupport::TestCase
   test 'basic set and get' do
@@ -19,7 +20,20 @@ class DCDOTest < ActiveSupport::TestCase
     }
     key = 'random'
     DCDO.set(key, to_store)
-    assert_equal DCDO.get(key, nil), to_store
+
+    result = nil
+    Timeout.timeout(10) do
+      loop do
+        result = DCDO.get(key, nil)
+        if result.present?
+          break
+        else
+          sleep 1
+        end
+      end
+    end
+
+    assert_equal result, to_store
   end
 
   test 'storing a non-jsonable object fails' do


### PR DESCRIPTION
Adds a 1-second retry and 10-second timeout to a flaky DCDO test. Previously, [I had a PR up](https://github.com/code-dot-org/code-dot-org/pull/60021) to correct this same issue by making the call to DynamoDB strongly consistent, but the majority of reviewers did not like that solution.

This retry loop is a bit more basic of a solution, but carries no risk of affecting other tests or reducing parity with production configuration. Note that this test is only flaky in the test env (which uses DynamoDB to back DCDO), so we won't be able to observe that the test is truly fixed until it's been merged and no longer produces flaky results over time.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1064)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
