### PR TITLE
Only Log Effective Lock and Unlock Events

### DIFF
--- a/dashboard/lib/devise/models/custom_lockable.rb
+++ b/dashboard/lib/devise/models/custom_lockable.rb
@@ -32,46 +32,54 @@ module Devise
         reload
       end
 
-      # Record lock and unlock events.
+      # Record lock and unlock events. Make sure to only log method invocations
+      # that will actually result in a state change, to avoid logging no-op
+      # invocations such as from the password reset workflow.
       #
       # As a core system event related to the user model, we want to log these
-      # in CloudWatch in order to preverse metrics for the long term. And as a
+      # in CloudWatch in order to preserve metrics for the long term. And as a
       # newly-enabled feature, we want to also log them in Statsig to make the
       # metric available on the product team's dashboards in the short term.
 
       # @override https://github.com/heartcombo/devise/blob/v4.9.3/lib/devise/models/lockable.rb#L42-L50
       def lock_access!
-        # CloudWatch
-        Cdo::Metrics.put(
-          'User', 'DeviseLockableAccessLocked', 1, {
-            Environment: CDO.rack_env,
-            UserType: user_type
-          }
-        )
+        unless access_locked?
+          # CloudWatch
+          Cdo::Metrics.put(
+            'User', 'DeviseLockableAccessLocked', 1, {
+              Environment: CDO.rack_env,
+              UserType: user_type
+            }
+          )
 
-        # Statsig
-        Metrics::Events.log_event(
-          user: current_user,
-          event_name: 'devise-lockable-user-access-locked',
-        )
+          # Statsig
+          Metrics::Events.log_event(
+            user: current_user,
+            event_name: 'devise-lockable-user-access-locked',
+          )
+        end
+
         super
       end
 
       # @override https://github.com/heartcombo/devise/blob/v4.9.3/lib/devise/models/lockable.rb#L53-L58
       def unlock_access!
-        # CloudWatch
-        Cdo::Metrics.put(
-          'User', 'DeviseLockableAccessUnlocked', 1, {
-            Environment: CDO.rack_env,
-            UserType: user_type
-          }
-        )
+        if access_locked?
+          # CloudWatch
+          Cdo::Metrics.put(
+            'User', 'DeviseLockableAccessUnlocked', 1, {
+              Environment: CDO.rack_env,
+              UserType: user_type
+            }
+          )
 
-        # Statsig
-        Metrics::Events.log_event(
-          user: current_user,
-          event_name: 'devise-lockable-user-access-unlocked',
-        )
+          # Statsig
+          Metrics::Events.log_event(
+            user: current_user,
+            event_name: 'devise-lockable-user-access-unlocked',
+          )
+        end
+
         super
       end
 


### PR DESCRIPTION
With [the recently-enabled user account lockout functionality](https://github.com/code-dot-org/code-dot-org/pull/57515), we also added some tracking to the `lock_access!` and `unlock_access!` method with the goal of generating metrics reflecting actual usage of this functionality.

Unfortunately, we're seeing in the logs [a number of "unlock" events that don't appear to be associated with any "lock" events](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~'User~'DeviseLockableAccessUnlocked~'Environment~'production~'UserType~'teacher)~(~'.~'DeviseLockableAccessLocked~'.~'.~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-1~start~'-PT72H~end~'P0D~stat~'Sum~period~300)&query=~'*7bUser*2cEnvironment*2cUserType*7d), including [some unlocks associated with student accounts](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(view~'timeSeries~stacked~false~region~'us-east-1~start~'-PT72H~end~'P0D~stat~'Sum~period~300~metrics~(~(~'User~'DeviseLockableAccessUnlocked~'Environment~'production~'UserType~'student)))&query=~'*7bUser*2cEnvironment*2cUserType*7d), which aren't even able to get locked in the first place.

Fortunately, [I had actually already done the investigation](https://github.com/code-dot-org/code-dot-org/pull/57515#issuecomment-2174472787) that revealed the underlying reason, I just forgot about it by the time I got around to adding metrics: [Devise's built-in password reset workflow explicitly calls `unlock_access!`](https://github.com/heartcombo/devise/blob/1d6658097e364d45b5e059976f1e822eee7d67da/app/controllers/devise/passwords_controller.rb#L38)

To prevent logging these no-op calls to the method, we add some logic to only log invocations of the method when the invocation will result in an actual state change; ie, only log calls to lock when we're unlocked and only log calls to unlock when we're locked.

I recommend reviewing [with whitespace changes disabled](https://github.com/code-dot-org/code-dot-org/pull/60124/files?w=1)

## Links

- https://github.com/code-dot-org/code-dot-org/pull/57515
- [teacher lock and "unlock" events](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~'User~'DeviseLockableAccessUnlocked~'Environment~'production~'UserType~'teacher)~(~'.~'DeviseLockableAccessLocked~'.~'.~'.~'.))~view~'timeSeries~stacked~false~region~'us-east-1~start~'-PT72H~end~'P0D~stat~'Sum~period~300)&query=~'*7bUser*2cEnvironment*2cUserType*7d)
- [student "unlock" events](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(view~'timeSeries~stacked~false~region~'us-east-1~start~'-PT72H~end~'P0D~stat~'Sum~period~300~metrics~(~(~'User~'DeviseLockableAccessUnlocked~'Environment~'production~'UserType~'student)))&query=~'*7bUser*2cEnvironment*2cUserType*7d)
- [`Devise::PasswordsController#update`](https://github.com/heartcombo/devise/blob/1d6658097e364d45b5e059976f1e822eee7d67da/app/controllers/devise/passwords_controller.rb#L38)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
