### PR TITLE
Fix label for teach resources in accordion mode

### DIFF
--- a/pegasus/sites.v3/code.org/views/tabs_section/resources/resources_tabs.haml
+++ b/pegasus/sites.v3/code.org/views/tabs_section/resources/resources_tabs.haml
@@ -48,7 +48,7 @@
     %summary=hoc_s(:resources_tabs_tab_label_assessments)
     = view :"tabs_section/resources/resources_tabs_content_assessments"
   %details.tools
-    %summary=hoc_s(:resources_tabs_tab_label_tools)
+    %summary=hoc_s(:"resources_tabs.progress.tab_label")
     = view :"tabs_section/resources/resources_tabs_content_progress"
 
 %script{src: '../js/tabs-section.js'}


### PR DESCRIPTION
Fixes a small issue where the title of the "Progress" section is still "Programming Tools" in accordion mode. This will cause a small eyes diff.

With this change:

![Screenshot 2024-07-31 at 3 47 13 PM](https://github.com/user-attachments/assets/e2d9add8-476d-4b3a-ac85-44bae1760e2b)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
