### PR TITLE
Update aichat_controller tests / remove logging to AichatSessions

### DIFF
--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -17,12 +17,7 @@ class AichatController < ApplicationController
     end
 
     response_body = get_response_body
-    response_body[:session_id] = log_chat_session(response_body[:messages])
 
-    # Rails controller tests reuse the same controller instance across requests within a test,
-    # which causes tests to fail. Nulling out the session ID before responding fixes this issue.
-    # More detail/other confused developers here: https://github.com/rails/rails/issues/24566
-    @session_id = nil
     render(status: :ok, json: response_body)
   end
 
@@ -101,7 +96,6 @@ class AichatController < ApplicationController
         context: {
           model_response: latest_assistant_response_from_sagemaker,
           flagged_content: filter_result.content,
-          aichat_session_id: log_chat_session(messages)
         }
       )
 
@@ -131,81 +125,6 @@ class AichatController < ApplicationController
     # If so, the above require check will not pass.
     # Check storedMessages param separately.
     params[:storedMessages].is_a?(Array)
-  end
-
-  private def log_chat_session(new_messages)
-    # Allows us to create/update a new session when we log to Honeybadger
-    # and reuse it when we respond to the client.
-    return @session_id if @session_id
-
-    if params[:sessionId].present?
-      session_id = params[:sessionId]
-      session = AichatSession.find_by(id: session_id)
-      if session && matches_existing_session?(session)
-        @session_id = update_session(session, new_messages)
-        return @session_id
-      end
-    end
-
-    @session_id = create_session(new_messages)
-  end
-
-  private def matches_existing_session?(session)
-    context = params[:aichatContext]
-    if session.level_id != context[:currentLevelId] ||
-        session.script_id != context[:scriptId] ||
-        current_user.id != session.user_id
-      return false
-    end
-
-    if context[:channelId]
-      _, project_id = storage_decrypt_channel_id(context[:channelId])
-      if session.project_id != project_id
-        return false
-      end
-    end
-
-    if params[:aichatModelCustomizations] != JSON.parse(session.model_customizations)
-      return false
-    end
-
-    # Compare stored messages in sessions table with stored message from front-end
-    # for the following fields only: chatMessageText, role, and status.
-    sessions_stored_messages = JSON.parse(session.messages).map {|message| message.slice('chatMessageText', 'role', 'status')}
-    frontend_stored_messages = params[:storedMessages].map {|message| message.slice('chatMessageText', 'role', 'status')}
-    if sessions_stored_messages != frontend_stored_messages
-      return false
-    end
-
-    true
-  end
-
-  private def update_session(session, new_messages)
-    session.messages = updated_message_list(new_messages).to_json
-    session.save
-    session.id
-  end
-
-  private def create_session(new_messages)
-    context = params[:aichatContext]
-
-    project_id = nil
-    if context[:channelId]
-      _, project_id = storage_decrypt_channel_id(context[:channelId])
-    end
-
-    AichatSession.create(
-      user_id: current_user.id,
-      level_id: context[:currentLevelId],
-      script_id: context[:scriptId],
-      project_id: project_id,
-      model_customizations: params[:aichatModelCustomizations].to_json,
-      messages: updated_message_list(new_messages).to_json
-    ).id
-  end
-
-  private def updated_message_list(new_messages)
-    params[:storedMessages] + new_messages
   end
 
   private def get_user_message(status)

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -481,7 +481,7 @@ class Ability
           (!user.teachers.empty? &&
           user.teachers.any? {|teacher| teacher.has_pilot_experiment?(GENAI_PILOT)})
         can :chat_completion, :aichat
-        can :log_aichat_event, :aichat
+        can :log_chat_event, :aichat
       end
     end
 

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -11,22 +11,28 @@ class AichatControllerTest < ActionController::TestCase
     @genai_pilot_student = create(:follower, section: pilot_section).student_user
 
     @default_model_customizations = {temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test"}.stringify_keys
+    @default_aichat_context = {
+      currentLevelId: 3,
+      scriptId: 1,
+      channelId: "test"
+    }
     @common_params = {
       storedMessages: [],
       aichatModelCustomizations: @default_model_customizations,
-      aichatContext: {
-        currentLevelId: 3,
-        scriptId: 1,
-        channelId: "test"
-      }
+      aichatContext: @default_aichat_context
     }
     valid_message = {role: 'user', chatMessageText: 'hello', status: 'unknown', timestamp: Time.now.to_i}
     @profanity_violation_message = {role: 'user', chatMessageText: 'Damn you, robot', status: 'unknown', timestamp: Time.now.to_i}
-    @valid_params = @common_params.merge(newMessage: valid_message)
+    @valid_params_chat_completion = @common_params.merge(newMessage: valid_message)
     @profanity_violation_params = @common_params.merge(
       newMessage: @profanity_violation_message
     )
     @missing_stored_messages_params = @common_params.except(:storedMessages)
+
+    @valid_params_log_chat_event = {
+      newChatEvent: {timestamp: Time.now.to_i},
+      aichatContext: @default_aichat_context
+    }
   end
 
   setup do
@@ -36,36 +42,60 @@ class AichatControllerTest < ActionController::TestCase
   end
 
   test_user_gets_response_for :chat_completion,
-    name: "student_no_access_test",
+    name: "student_no_access_chat_completion_test",
     user: :student,
     method: :post,
     response: :forbidden
 
   test_user_gets_response_for :chat_completion,
-    name: "teacher_no_access_test",
+    name: "teacher_no_access_chat_completion_test",
     user: :teacher,
     method: :post,
     response: :forbidden
 
-  test 'pilot teacher has access test' do
+  test_user_gets_response_for :log_chat_event,
+    name: "student_no_access_log_chat_event_test",
+    user: :student,
+    method: :post,
+    response: :forbidden
+
+  test_user_gets_response_for :log_chat_event,
+    name: "teacher_no_access_log_chat_event_test",
+    user: :teacher,
+    method: :post,
+    response: :forbidden
+
+  test 'pilot teacher has access to chat_completion test' do
     sign_in(@genai_pilot_teacher)
-    post :chat_completion, params: @valid_params, as: :json
+    post :chat_completion, params: @valid_params_chat_completion, as: :json
     assert_response :success
   end
 
-  test 'pilot student has access test' do
+  test 'pilot student has access to chat_completion test' do
     sign_in(@genai_pilot_student)
-    post :chat_completion, params: @valid_params, as: :json
+    post :chat_completion, params: @valid_params_chat_completion, as: :json
     assert_response :success
   end
 
-  test 'Bad request if required params are not included' do
+  test 'pilot teacher has access to log_chat_event test' do
+    sign_in(@genai_pilot_teacher)
+    post :log_chat_event, params: @valid_params_log_chat_event, as: :json
+    assert_response :success
+  end
+
+  test 'pilot student has access to log_chat_event test' do
+    sign_in(@genai_pilot_student)
+    post :log_chat_event, params: @valid_params_log_chat_event, as: :json
+    assert_response :success
+  end
+
+  test 'Bad request if required params are not included for chat_completion' do
     sign_in(@genai_pilot_teacher)
     post :chat_completion, params: {newMessage: "hello"}, as: :json
     assert_response :bad_request
   end
 
-  test 'Bad request if storedMessages param is not included' do
+  test 'Bad request if storedMessages param is not included for chat_completion' do
     sign_in(@genai_pilot_teacher)
     post :chat_completion, params: @missing_stored_messages_params, as: :json
     assert_response :bad_request
@@ -78,36 +108,7 @@ class AichatControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal "damn", json_response["flagged_content"]
-    assert_equal json_response.keys, ['messages', 'flagged_content', 'session_id']
-
-    session = AichatSession.find(json_response['session_id'])
-    stored_message = JSON.parse(session.messages)[0]
-    assert_equal stored_message,
-      @profanity_violation_message.merge(
-        status: SharedConstants::AI_INTERACTION_STATUS[:PROFANITY_VIOLATION]
-      ).stringify_keys
-  end
-
-  test 'filters previous profanity when sending previous messages to Sagemaker but still logs' do
-    ok_message = {status: 'ok', role: 'user', chatMessageText: 'another message'}.stringify_keys
-    params = @valid_params.merge(
-      storedMessages: [
-        {status: 'profanity_violation', role: 'user', chatMessageText: 'damn'},
-        ok_message
-      ]
-    )
-
-    # Note that second expected argument filters out the previous profane message
-    # in what we send to Sagemaker.
-    AichatSagemakerHelper.expects(:get_sagemaker_assistant_response).with(params[:aichatModelCustomizations], [ok_message], params[:newMessage].stringify_keys).once
-
-    sign_in(@genai_pilot_student)
-    post :chat_completion, params: params, as: :json
-    assert_response :success
-
-    session = AichatSession.find(json_response['session_id'])
-    assert_equal 4, JSON.parse(session.messages).length
-    assert_equal 1, (JSON.parse(session.messages).count {|message| message["status"] == 'profanity_violation'})
+    assert_equal json_response.keys, ['messages', 'flagged_content']
   end
 
   test 'returns model profanity status when model response contains profanity' do
@@ -116,24 +117,18 @@ class AichatControllerTest < ActionController::TestCase
       nil,
       ShareFailure.new(ShareFiltering::FailureType::PROFANITY, 'damn')
     )
-    post :chat_completion, params: @valid_params, as: :json
+    post :chat_completion, params: @valid_params_chat_completion, as: :json
 
     assert_response :success
-    assert_equal json_response.keys, ['messages', 'session_id']
-
-    session = AichatSession.find(json_response['session_id'])
-    assert_equal 2, JSON.parse(session.messages).length
-    assert_equal JSON.parse(session.messages),
-      [
-        @valid_params[:newMessage].merge(
-          status: SharedConstants::AI_INTERACTION_STATUS[:ERROR]
-        ),
-        {
-          role: "assistant",
-          status: SharedConstants::AI_INTERACTION_STATUS[:ERROR],
-          chatMessageText: '[redacted - model generated profanity]',
-        }
-      ].map(&:stringify_keys)
+    assert_equal json_response.keys, ['messages']
+    assert_equal json_response["messages"].length, 2
+    user_message = json_response["messages"].first
+    assert_equal user_message["role"], "user"
+    assert_equal user_message["status"], SharedConstants::AI_INTERACTION_STATUS[:ERROR]
+    assistant_message = json_response["messages"].last
+    assert_equal assistant_message["role"], "assistant"
+    assert_equal assistant_message["status"], SharedConstants::AI_INTERACTION_STATUS[:ERROR]
+    assert_equal assistant_message["chatMessageText"], '[redacted - model generated profanity]'
   end
 
   test 'can_request_aichat_chat_completion returns false when DCDO flag is set to `false`' do
@@ -144,92 +139,7 @@ class AichatControllerTest < ActionController::TestCase
   test 'returns forbidden when DCDO flag is set to `false`' do
     AichatSagemakerHelper.stubs(:can_request_aichat_chat_completion?).returns(false)
     sign_in(@genai_pilot_teacher)
-    post :chat_completion, params: @valid_params, as: :json
+    post :chat_completion, params: @valid_params_chat_completion, as: :json
     assert_response :forbidden
-  end
-
-  test 'creates new chat session when no session id provided' do
-    sign_in(@genai_pilot_teacher)
-
-    post :chat_completion, params: @valid_params, as: :json
-    session = AichatSession.find(json_response['session_id'])
-
-    assert_equal @genai_pilot_teacher.id, session.user_id
-    assert_equal @valid_params[:aichatContext][:currentLevelId], session.level_id
-    assert_equal @valid_params[:aichatContext][:scriptId], session.script_id
-    assert_equal 456, session.project_id
-    assert_equal [
-      @valid_params[:newMessage].merge(status: 'ok').stringify_keys,
-      {role: 'assistant', chatMessageText: @assistant_response, status: 'ok'}.stringify_keys
-    ],
-      JSON.parse(session.messages)
-    assert_equal @valid_params[:aichatModelCustomizations].stringify_keys,
-      JSON.parse(session.model_customizations)
-  end
-
-  test 'updates existing chat session when session id provided' do
-    sign_in(@genai_pilot_teacher)
-
-    post :chat_completion, params: @valid_params, as: :json
-    session = AichatSession.find(json_response['session_id'])
-
-    post :chat_completion, params: @valid_params.merge(
-      {
-        sessionId: session.id,
-        storedMessages: [
-          @valid_params[:newMessage].merge(status: 'ok').stringify_keys,
-          {role: 'assistant', chatMessageText: @assistant_response, status: 'ok'}.stringify_keys
-        ]
-      }
-    ),
-      as: :json
-    assert_equal session.id, json_response['session_id']
-
-    # Check that we added two new messages to the stored messages
-    # (the new user and assistant messages).
-    session.reload
-    assert_equal 4, JSON.parse(session.messages).length
-  end
-
-  test 'creates new chat session when session id provided but session property does not match' do
-    sign_in(@genai_pilot_teacher)
-
-    post :chat_completion, params: @valid_params, as: :json
-    session = AichatSession.find(json_response['session_id'])
-
-    post :chat_completion, params: @valid_params.merge(
-      {
-        sessionId: session.id,
-        storedMessages: [
-          @valid_params[:newMessage].merge(status: 'ok').stringify_keys,
-          {role: 'assistant', chatMessageText: @assistant_response, status: 'ok'}.stringify_keys
-        ],
-        aichatModelCustomizations: @default_model_customizations.merge(
-          retrievalContexts: ["test", "mismatched retrieval context item"],
-        ),
-      }
-    ),
-      as: :json
-    refute_equal session.id, json_response['session_id']
-  end
-
-  test 'updates existing chat session when session id provided and a message field outside of chatMessageText, role, and status do not match' do
-    sign_in(@genai_pilot_teacher)
-
-    post :chat_completion, params: @valid_params, as: :json
-    session = AichatSession.find(json_response['session_id'])
-
-    post :chat_completion, params: @valid_params.merge(
-      {
-        sessionId: session.id,
-        storedMessages: [
-          @valid_params[:newMessage].merge(status: 'ok').stringify_keys,
-          {role: 'assistant', chatMessageText: @assistant_response, status: 'ok', timestamp: Time.now.to_i}.stringify_keys
-        ],
-        aichatModelCustomizations: @default_model_customizations
-      }
-    ),
-      as: :json
-    assert_equal session.id, json_response['session_id']
   end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR removes logging to AichatSessions from the `aichat` controller action `chat_completion`. It also updates the unit tests for `chat_completion` and adds tests for the new `log_chat_event` controller action. There is no impact on the user UI or experience.

Note that this PR will NOT be merged until https://github.com/code-dot-org/code-dot-org/pull/60110 is merged which adds logging to the new 'AichatEvents' table.

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-952)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Ran updated unit tests locally and they passed. Tested a couple aichat levels in /allthethings to confirm no changes to user.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
