### PR TITLE
Removing the CPA exceptions added by p20-937

### DIFF
--- a/dashboard/lib/cpa.rb
+++ b/dashboard/lib/cpa.rb
@@ -11,11 +11,6 @@ module Cpa
   NEW_USER_LOCKOUT_DATE = DateTime.parse('2023-07-01T00:00:00MDT').freeze
   ALL_USER_LOCKOUT_DATE = DateTime.parse('2024-07-01T00:00:00MDT').freeze
 
-  # P20-937 - We had a regression which we have chosen to mitigate by allowing
-  # accounts created before the below date to have their lock-out delayed until
-  # the CAP policy is set to lockout all users.
-  CREATED_AT_EXCEPTION_DATE = DateTime.parse('2024-05-26T00:00:00MDT')
-
   # There are four phases for the Colorado Privacy Act:
   # 1. Nothing - nil
   # 2. New User Accounts must be compliant - 'cpa_new_user_lockout'

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -436,15 +436,7 @@ FactoryBot.define do
         child_account_compliance_state_last_updated {DateTime.now}
       end
 
-      trait :before_p20_937_exception_date do
-        created_at {Cpa::CREATED_AT_EXCEPTION_DATE.ago(1.second)}
-      end
-
-      trait :p20_937_exception_date do
-        created_at {Cpa::CREATED_AT_EXCEPTION_DATE}
-      end
-
-      factory :cpa_non_compliant_student, traits: [:U13, :in_colorado, :p20_937_exception_date], aliases: %i[non_compliant_child] do
+      factory :cpa_non_compliant_student, traits: [:U13, :in_colorado], aliases: %i[non_compliant_child] do
         trait :predates_policy do
           created_at {Policies::ChildAccount.state_policies.dig('CO', :start_date).ago(1.second)}
         end

--- a/dashboard/test/integration/cap/cpa/lockout_test.rb
+++ b/dashboard/test/integration/cap/cpa/lockout_test.rb
@@ -59,18 +59,6 @@ module CAP
             end
           end
 
-          context 'when student was create before P20-937-exception-date' do
-            let(:student) {create(:cpa_non_compliant_student, :before_p20_937_exception_date)}
-
-            it 'student should not be locked out yet' do
-              assert_student_is_not_locked_out
-            end
-
-            it 'student should be redirected away from the lockout page' do
-              assert_student_is_redirected_away_from_lockout
-            end
-          end
-
           context 'when student provider is Google' do
             before do
               create(:google_authentication_option, user: student)
@@ -163,18 +151,6 @@ module CAP
               it 'student should be redirected away from the lockout page' do
                 assert_student_is_redirected_away_from_lockout
               end
-            end
-          end
-
-          context 'when student was create before P20-937-exception-date' do
-            let(:student) {create(:cpa_non_compliant_student, :before_p20_937_exception_date)}
-
-            it 'student should be transited to grace period state' do
-              assert_student_in_grace_period
-            end
-
-            it 'student should be redirected away from the lockout page' do
-              assert_student_is_redirected_away_from_lockout
             end
           end
 

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -88,13 +88,6 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2024-07-01T00:00:00MDT'}], false],
       [[:non_compliant_child, :with_google_authentication_option, {created_at: '2024-06-29T23:59:59MDT'}], true],
       [[:non_compliant_child, :with_google_authentication_option, {created_at: '2024-07-01T00:00:00MDT'}], false],
-      # The following test cases address P20-937
-      [[:non_compliant_child, :before_p20_937_exception_date], true],
-      [[:non_compliant_child, :microsoft_v2_sso_provider, :before_p20_937_exception_date], true],
-      [[:non_compliant_child, :facebook_sso_provider, :before_p20_937_exception_date], true],
-      [[:non_compliant_child, :p20_937_exception_date], false],
-      [[:non_compliant_child, :microsoft_v2_sso_provider, :p20_937_exception_date], false],
-      [[:non_compliant_child, :facebook_sso_provider, :p20_937_exception_date], false],
     ]
     failures = []
     test_matrix.each do |traits, compliance|

--- a/dashboard/test/ui/features/platform/policy_compliance.feature
+++ b/dashboard/test/ui/features/platform/policy_compliance.feature
@@ -2,10 +2,9 @@
 Feature: Policy Compliance and Parental Permission
   Scenario: New under 13 account should be able to send a parental request.
     Given I am on "http://studio.code.org"
-    # CPA new user lockout phase starts 1 month before CPA exception
-    Given CPA new user lockout phase starts at "2024-04-26T00:00:00MDT"
+    Given CPA new user lockout phase starts at "2023-07-01T00:00:00MDT"
 
-    When I create a young student in Colorado who has never signed in named "Sally Student" after CPA exception and go home
+    When I create a young student in Colorado who has never signed in named "Sally Student" after CAP start and go home
     Then I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request
@@ -28,10 +27,9 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: New under 13 account should be able to provide state and see lockout page to send parental request.
     Given I am on "http://studio.code.org"
-    # CPA new user lockout phase starts 1 month before CPA exception
-    Given CPA new user lockout phase starts at "2024-04-26T00:00:00MDT"
+    Given CPA new user lockout phase starts at "2023-07-01T00:00:00MDT"
 
-    When I create a young student who has never signed in named "Sally Student" after CPA exception
+    When I create a young student who has never signed in named "Sally Student" after CAP start
     Then I am on "http://studio.code.org/home?forceStudentInterstitial=true"
 
     Then I wait to see "#student-information-modal"
@@ -55,10 +53,9 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: New under 13 account should be able to elect to sign out at the lockout.
     Given I am on "http://studio.code.org"
-    # CPA new user lockout phase starts 1 month before CPA exception
-    Given CPA new user lockout phase starts at "2024-04-26T00:00:00MDT"
+    Given CPA new user lockout phase starts at "2023-07-01T00:00:00MDT"
 
-    When I create a young student in Colorado who has never signed in named "Sally Student" after CPA exception and go home
+    When I create a young student in Colorado who has never signed in named "Sally Student" after CAP start and go home
     Then I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request
@@ -71,10 +68,9 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: New under 13 account should be able to resend the email
     Given I am on "http://studio.code.org"
-    # CPA new user lockout phase starts 1 month before CPA exception
-    Given CPA new user lockout phase starts at "2024-04-26T00:00:00MDT"
+    Given CPA new user lockout phase starts at "2023-07-01T00:00:00MDT"
 
-    When I create a young student in Colorado who has never signed in named "Sally Student" after CPA exception and go home
+    When I create a young student in Colorado who has never signed in named "Sally Student" after CAP start and go home
     Then I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request
@@ -95,10 +91,9 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: New under 13 account should be able to send a different email
     Given I am on "http://studio.code.org"
-    # CPA new user lockout phase starts 1 month before CPA exception
-    Given CPA new user lockout phase starts at "2024-04-26T00:00:00MDT"
+    Given CPA new user lockout phase starts at "2023-07-01T00:00:00MDT"
 
-    When I create a young student in Colorado who has never signed in named "Sally Student" after CPA exception and go home
+    When I create a young student in Colorado who has never signed in named "Sally Student" after CAP start and go home
     Then I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request
@@ -126,10 +121,9 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: Student should not be able to enter their own email as their parent's email
     Given I am on "http://studio.code.org"
-    # CPA new user lockout phase starts 1 month before CPA exception
-    Given CPA new user lockout phase starts at "2024-04-26T00:00:00MDT"
+    Given CPA new user lockout phase starts at "2023-07-01T00:00:00MDT"
 
-    When I create a young student in Colorado who has never signed in named "Sally Student" after CPA exception and go home
+    When I create a young student in Colorado who has never signed in named "Sally Student" after CAP start and go home
     Then I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request
@@ -142,10 +136,9 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: Student should be able to enter their parent's email if their parent created their account
     Given I am on "http://studio.code.org"
-    # CPA new user lockout phase starts 1 month before CPA exception
-    Given CPA new user lockout phase starts at "2024-04-26T00:00:00MDT"
+    Given CPA new user lockout phase starts at "2023-07-01T00:00:00MDT"
 
-    When I create as a parent a young student in Colorado who has never signed in named "Sally Student" after CPA exception and go home
+    When I create as a parent a young student in Colorado who has never signed in named "Sally Student" after CAP start and go home
     Then I am on "http://studio.code.org/lockout"
 
     # It should not be a pending request
@@ -158,14 +151,13 @@ Feature: Policy Compliance and Parental Permission
 
   Scenario: Existing under 13 account in Colorado should not be locked out.
     Given I am on "http://studio.code.org"
-    # CPA new user lockout phase starts 1 month before CPA exception
-    Given CPA new user lockout phase starts at "2024-04-26T00:00:00MDT"
+    Given CPA new user lockout phase starts at "2023-07-01T00:00:00MDT"
 
-    When I create a young student in Colorado who has never signed in named "Sally Student" before CPA exception and go home
+    When I create a young student in Colorado who has never signed in named "Sally Student" before CAP start and go home
     Then I am on "http://studio.code.org/home"
 
   Scenario: Teacher should be able to connect a third-party account even without a state specified
-    Given I create a teacher who has never signed in named "Amstrad Teacher" after CPA exception and go home
+    Given I create a teacher who has never signed in named "Amstrad Teacher" after CAP start and go home
 
     # Find the unlocked buttons to connect an account
     Given I am on "http://studio.code.org/users/edit?cpa-partial-lockout=1"
@@ -173,7 +165,7 @@ Feature: Policy Compliance and Parental Permission
     Then I wait until "form[action=\'/users/auth/google_oauth2?action=connect\'] button" is not disabled
 
   Scenario: Student should not be able to connect a third-party account until their account is unlocked
-    Given I create a young student in Colorado who has never signed in named "Coco Student" after CPA exception and go home
+    Given I create a young student in Colorado who has never signed in named "Coco Student" after CAP start and go home
 
     # Find the locked buttons to connect an account
     Given I am on "http://studio.code.org/users/edit?cpa-partial-lockout=1"
@@ -199,7 +191,7 @@ Feature: Policy Compliance and Parental Permission
     Then I wait until "form[action=\'/users/auth/google_oauth2?action=connect\'] button" is not disabled
 
   Scenario: Sponsored student should not be able to add a personal email on an account until providing a state
-    Given I create an authorized teacher-associated under-13 sponsored student named "Tandy" after CPA exception
+    Given I create an authorized teacher-associated under-13 sponsored student named "Tandy" after CAP start
 
     # Find the disabled region to provide a personal login
     Given I am on "http://studio.code.org/users/edit?cpa-partial-lockout=1"
@@ -222,7 +214,7 @@ Feature: Policy Compliance and Parental Permission
     Then element "#edit_user_create_personal_account input[type=\'password\']" is enabled
 
   Scenario: Sponsored student should not be able to add a personal email when they supply a policy state
-    Given I create an authorized teacher-associated under-13 sponsored student named "Tandy" after CPA exception
+    Given I create an authorized teacher-associated under-13 sponsored student named "Tandy" after CAP start
 
     # Find the disabled region to provide a personal login
     Given I am on "http://studio.code.org/users/edit?cpa-partial-lockout=1"
@@ -248,7 +240,7 @@ Feature: Policy Compliance and Parental Permission
     Then element "#edit_user_create_personal_account_description" has "en-US" text from key "user.create_personal_login_parental_permission_required"
 
   Scenario: Sponsored student is able to add a personal email on an unlocked account
-    Given I create an authorized teacher-associated under-13 sponsored student in Colorado named "Tandy" after CPA exception
+    Given I create an authorized teacher-associated under-13 sponsored student in Colorado named "Tandy" after CAP start
 
     # Find the disabled region to provide a personal login
     Given I am on "http://studio.code.org/users/edit?cpa-partial-lockout=1"
@@ -274,8 +266,8 @@ Feature: Policy Compliance and Parental Permission
     # And it should tell me that the request was granted
     And element "#permission-status" contains text "Granted"
 
-  Scenario: Student account Under-13 in Colorado created before CPA exception cannot change age and state
-    Given I create a young student in Colorado named "Tandy" before CPA exception
+  Scenario: Student account Under-13 in Colorado created before CAP start cannot change age and state
+    Given I create a young student in Colorado named "Tandy" before CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -284,8 +276,8 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is disabled
     Then element "#user_age" is disabled
 
-  Scenario: Student account Under-13 in Colorado created after CPA exception cannot change age and state
-    Given I create a young student in Colorado named "Tandy" after CPA exception
+  Scenario: Student account Under-13 in Colorado created after CAP start cannot change age and state
+    Given I create a young student in Colorado named "Tandy" after CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -294,8 +286,8 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is disabled
     Then element "#user_age" is disabled
 
-  Scenario: Student account Under-13 not in Colorado created after CPA exception can change their age and state
-    Given I create a young student named "Tandy" after CPA exception
+  Scenario: Student account Under-13 not in Colorado created after CAP start can change their age and state
+    Given I create a young student named "Tandy" after CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -304,8 +296,8 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is enabled
     Then element "#user_age" is enabled
 
-  Scenario: Student account Under-13 not in Colorado created before CPA exception can change their age and state
-    Given I create a young student named "Tandy" before CPA exception
+  Scenario: Student account Under-13 not in Colorado created before CAP start can change their age and state
+    Given I create a young student named "Tandy" before CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -314,8 +306,8 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is enabled
     Then element "#user_age" is enabled
 
-  Scenario: Student account Over-13 and in Colorado created after CPA exception can change their age and state
-    Given I create a student in Colorado named "Tandy" after CPA exception
+  Scenario: Student account Over-13 and in Colorado created after CAP start can change their age and state
+    Given I create a student in Colorado named "Tandy" after CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -324,8 +316,8 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is enabled
     Then element "#user_age" is enabled
 
-  Scenario: Student account Over-13 and in Colorado created before CPA exception can change their age and state
-    Given I create a student in Colorado named "Tandy" before CPA exception
+  Scenario: Student account Over-13 and in Colorado created before CAP start can change their age and state
+    Given I create a student in Colorado named "Tandy" before CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -334,8 +326,8 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is enabled
     Then element "#user_age" is enabled
 
-  Scenario: Student account under-13 and in Colorado created after CPA exception using only clever cannot change their age and state
-    Given I create a young student using clever in Colorado named "Tandy" after CPA exception
+  Scenario: Student account under-13 and in Colorado created after CAP start using only clever cannot change their age and state
+    Given I create a young student using clever in Colorado named "Tandy" after CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -344,8 +336,8 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is disabled
     Then element "#user_age" is disabled
 
-   Scenario: Student account under-13 and in Colorado created before CPA exception using only clever cannot change their age and state
-    Given I create a young student using clever in Colorado named "Tandy" before CPA exception
+   Scenario: Student account under-13 and in Colorado created before CAP start using only clever cannot change their age and state
+    Given I create a young student using clever in Colorado named "Tandy" before CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -354,8 +346,8 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is disabled
     Then element "#user_age" is disabled
 
-  Scenario: Student account under-13 and in Colorado created before CPA exception using google cannot change their age and state
-    Given I create a young student using google in Colorado named "Tandy" before CPA exception
+  Scenario: Student account under-13 and in Colorado created before CAP start using google cannot change their age and state
+    Given I create a young student using google in Colorado named "Tandy" before CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -364,8 +356,8 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is disabled
     Then element "#user_age" is disabled
 
-  Scenario: Student account under-13 and in Colorado created after CPA exception using google cannot change their age and state
-    Given I create a young student using google in Colorado named "Tandy" after CPA exception
+  Scenario: Student account under-13 and in Colorado created after CAP start using google cannot change their age and state
+    Given I create a young student using google in Colorado named "Tandy" after CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -374,8 +366,8 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is disabled
     Then element "#user_age" is disabled
 
-   Scenario: Student account under-13 not in Colorado created after CPA exception using clever cannot change their age and state
-    Given I create a young student using clever named "Tandy" after CPA exception
+   Scenario: Student account under-13 not in Colorado created after CAP start using clever cannot change their age and state
+    Given I create a young student using clever named "Tandy" after CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -384,8 +376,8 @@ Feature: Policy Compliance and Parental Permission
     Then element "#user_us_state" is enabled
     Then element "#user_age" is enabled
 
-  Scenario: Student account under-13 not in Colorado created before CPA exception using clever cannot change their age and state
-    Given I create a young student using clever named "Tandy" before CPA exception
+  Scenario: Student account under-13 not in Colorado created before CAP start using clever cannot change their age and state
+    Given I create a young student using clever named "Tandy" before CAP start
 
     Given I am on "http://studio.code.org/users/edit"
 
@@ -393,4 +385,3 @@ Feature: Policy Compliance and Parental Permission
     Then I wait to see "#user_us_state"
     Then element "#user_us_state" is enabled
     Then element "#user_age" is enabled
-  

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -149,7 +149,7 @@ def create_user(name, url: '/api/test/create_user', **user_opts)
   end
 end
 
-And(/^I create( as a parent)? a (young )?student(?: using (clever|google))?( in Colorado)?( who has never signed in)? named "([^"]*)"( after CPA exception)?( before CPA exception)?( and go home)?$/) do |parent_created, young, using_sso, locked, new_account, name, after_cpa_exception, before_cpa_exception, home|
+And(/^I create( as a parent)? a (young )?student(?: using (clever|google))?( in Colorado)?( who has never signed in)? named "([^"]*)"( after CAP start)?( before CAP start)?( and go home)?$/) do |parent_created, young, using_sso, locked, new_account, name, after_cap_start, before_cap_start, home|
   age = young ? '10' : '16'
   sign_in_count = new_account ? 0 : 2
 
@@ -169,15 +169,14 @@ And(/^I create( as a parent)? a (young )?student(?: using (clever|google))?( in 
     user_opts[:user_provided_us_state] = true
   end
 
-  # See Cpa::CREATED_AT_EXCEPTION_DATE
-  cpa_exception_date = DateTime.parse('2024-05-26T00:00:00MDT')
+  cap_start_date = DateTime.parse('2023-07-01T00:00:00MDT').freeze
 
-  if after_cpa_exception
-    user_opts[:created_at] = cpa_exception_date
+  if after_cap_start
+    user_opts[:created_at] = cap_start_date
   end
 
-  if before_cpa_exception
-    user_opts[:created_at] = cpa_exception_date - 1.second
+  if before_cap_start
+    user_opts[:created_at] = cap_start_date - 1.second
   end
 
   if parent_created
@@ -214,7 +213,7 @@ And(/^I create a student in the eu named "([^"]*)"$/) do |name|
   )
 end
 
-And(/^I create a teacher( who has never signed in)? named "([^"]*)"( after CPA exception)?( before CPA exception)?( and go home)?$/) do |new_account, name, after_cpa_exception, before_cpa_exception, home|
+And(/^I create a teacher( who has never signed in)? named "([^"]*)"( after CAP start)?( before CAP start)?( and go home)?$/) do |new_account, name, after_cap_start, before_cap_start, home|
   sign_in_count = new_account ? 0 : 2
 
   user_opts = {
@@ -225,14 +224,14 @@ And(/^I create a teacher( who has never signed in)? named "([^"]*)"( after CPA e
   }
 
   # See Cpa::CREATED_AT_EXCEPTION_DATE
-  cpa_exception_date = DateTime.parse('2024-05-26T00:00:00MDT')
+  cap_start_date = DateTime.parse('2024-05-26T00:00:00MDT')
 
-  if after_cpa_exception
-    user_opts[:created_at] = cpa_exception_date
+  if after_cap_start
+    user_opts[:created_at] = cap_start_date
   end
 
-  if before_cpa_exception
-    user_opts[:created_at] = cpa_exception_date - 1.second
+  if before_cap_start
+    user_opts[:created_at] = cap_start_date - 1.second
   end
 
   create_user(name, **user_opts)

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -95,7 +95,7 @@ And /^I create a new "([^"]*)" student section with course "([^"]*)", version "(
   GHERKIN
 end
 
-And(/^I create a(n authorized)? teacher-associated( under-13)?( sponsored)? student( in Colorado)? named "([^"]*)"( after CPA exception)?( before CPA exception)?$/) do |authorized, under_13, sponsored, locked, name, after_cpa_exception, before_cpa_exception|
+And(/^I create a(n authorized)? teacher-associated( under-13)?( sponsored)? student( in Colorado)? named "([^"]*)"( after CAP start)?( before CAP start)?$/) do |authorized, under_13, sponsored, locked, name, after_cap_start, before_cap_start|
   steps "Given I create a teacher named \"Teacher_#{name}\""
   # enroll in a plc course as a way of becoming an authorized teacher
   steps 'And I am enrolled in a plc course' if authorized
@@ -121,15 +121,14 @@ And(/^I create a(n authorized)? teacher-associated( under-13)?( sponsored)? stud
     user_opts[:user_provided_us_state] = true
   end
 
-  # See Policies::ChildAccount::CPA_CREATED_AT_EXCEPTION_DATE
-  cpa_exception_date = DateTime.parse('2024-05-26T00:00:00MST')
+  cap_start_date = DateTime.parse('2023-07-01T00:00:00MDT').freeze
 
-  if after_cpa_exception
-    user_opts[:created_at] = cpa_exception_date
+  if after_cap_start
+    user_opts[:created_at] = cap_start_date
   end
 
-  if before_cpa_exception
-    user_opts[:created_at] = cpa_exception_date - 1.second
+  if before_cap_start
+    user_opts[:created_at] = cap_start_date - 1.second
   end
 
   create_user(name, **user_opts)


### PR DESCRIPTION
During the CPA Live Site issue in May 2024 we found that we weren’t requiring new Email, Facebook, and Microsoft accounts to declare their US State. This resulted in users suddenly being locked out when they told us their US State. We added an exception for these users so classrooms would not be interrupted. Now that it is Summer, and most schools are not in session, we are going to remove the exception.

## Links
[Jira](https://codedotorg.atlassian.net/browse/P20-942)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
* Unit tests

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
