### PR TITLE
Speculative fix for the Create Account button experiment loading issue

### DIFF
--- a/apps/src/userHeaderStatsigReporter/userHeaderStatsigReporter.js
+++ b/apps/src/userHeaderStatsigReporter/userHeaderStatsigReporter.js
@@ -6,6 +6,7 @@ if (document.readyState !== 'loading') {
 } else {
   document.addEventListener('DOMContentLoaded', function () {
     console.log('Document is loading');
+    console.log(`Document ready state: ${document.readyState}`);
     runStatsigReporter();
   });
 }

--- a/apps/src/userHeaderStatsigReporter/userHeaderStatsigReporter.js
+++ b/apps/src/userHeaderStatsigReporter/userHeaderStatsigReporter.js
@@ -5,7 +5,7 @@ if (document.readyState !== 'loading') {
   runStatsigReporter();
 } else {
   document.addEventListener('DOMContentLoaded', function () {
-    console.log('Document is loading');
+    console.log('DOM content has loaded');
     console.log(`Document ready state: ${document.readyState}`);
     runStatsigReporter();
   });

--- a/apps/src/userHeaderStatsigReporter/userHeaderStatsigReporter.js
+++ b/apps/src/userHeaderStatsigReporter/userHeaderStatsigReporter.js
@@ -1,6 +1,17 @@
 import statsigReporter from '../lib/util/StatsigReporter';
 
-document.addEventListener('DOMContentLoaded', function () {
+if (document.readyState !== 'loading') {
+  console.log('Document is ready');
+  runStatsigReporter();
+} else {
+  document.addEventListener('DOMContentLoaded', function () {
+    console.log('Document is loading');
+    runStatsigReporter();
+  });
+}
+
+function runStatsigReporter() {
+  console.log('Running Statsig Reporter');
   const createAccountButton = document.querySelector('#create_account_button');
   const createAccountButtonDesktop = document.querySelector(
     '#create_account_button.desktop'
@@ -49,4 +60,4 @@ document.addEventListener('DOMContentLoaded', function () {
     // Hide the Sign in and Create account buttons in the hamburger
     hamburgerButtons ? (hamburgerButtons.style.display = 'none') : null;
   }
-});
+}


### PR DESCRIPTION
Adds logic to run the Statsig Reporter event listener once the document is ready. I based this off of what @breville suggested [here](https://codedotorg.slack.com/archives/C046G4TRLEN/p1722373489753019?thread_ts=1722290836.545479&cid=C046G4TRLEN). 

Hopefully this will fix the issue on production where the Create Account button isn't showing up unless another page is visited first. I added console log statements so we can check this on production since we're unable to add breakpoints.

**Making sure the function runs after the document has loaded:** 

https://github.com/user-attachments/assets/9c2cc017-aa3b-4693-9acc-7b540d003d7b


## Links
Jira ticket: [ACQ-2173](https://codedotorg.atlassian.net/browse/ACQ-2173)
Slack convo: [here](https://codedotorg.slack.com/archives/C046G4TRLEN/p1722373489753019?thread_ts=1722290836.545479&cid=C046G4TRLEN)

## Testing story
Tested locally to see the console.log statements and checked to make sure the experiment was still working in Statsig:
<img width="1137" alt="Screenshot 2024-07-31 at 4 06 49 PM" src="https://github.com/user-attachments/assets/2ba98a99-f32c-47cb-9204-386a07af4c5d">