### PR TITLE
[Google Blockly] Maze/Star Wars: Remove DCDO and URL params

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -104,7 +104,7 @@ class Blockly < Level
 
   def uses_google_blockly?
     skin = properties['skin']
-    self.class.migrated_skins.include?(skin) && DCDO.get('maze_sw_google_blockly', true)
+    self.class.migrated_skins.include?(skin)
   end
 
   def summarize_for_lab2_properties(script, script_level = nil, current_user = nil)

--- a/dashboard/app/models/levels/maze.rb
+++ b/dashboard/app/models/levels/maze.rb
@@ -30,9 +30,9 @@ class Maze < Grid
     step_mode
     shape_shift
   )
-  # Use a DCDO flag here so we can revert back to CDO Blockly without a deploy
+
   def uses_google_blockly?
-    DCDO.get('maze_sw_google_blockly', true)
+    true
   end
 
   # List of possible skins, the first is used as a default.

--- a/dashboard/app/models/levels/star_wars_grid.rb
+++ b/dashboard/app/models/levels/star_wars_grid.rb
@@ -44,7 +44,7 @@ class StarWarsGrid < Studio
   end
 
   def uses_google_blockly?
-    DCDO.get('maze_sw_google_blockly', true)
+    true
   end
 
   def common_blocks(_)

--- a/dashboard/test/models/levels/karel_test.rb
+++ b/dashboard/test/models/levels/karel_test.rb
@@ -5,13 +5,7 @@ class KarelTest < ActiveSupport::TestCase
     @karel = Karel.new
   end
 
-  test 'uses_google_blockly? returns true when DCDO flag is true' do
-    DCDO.stubs(:get).with('maze_sw_google_blockly', true).returns(true)
+  test 'uses_google_blockly? returns true' do
     assert @karel.uses_google_blockly?
-  end
-
-  test 'uses_google_blockly? returns false when DCDO flag is false' do
-    DCDO.stubs(:get).with('maze_sw_google_blockly', true).returns(false)
-    refute @karel.uses_google_blockly?
   end
 end

--- a/dashboard/test/models/levels/maze_test.rb
+++ b/dashboard/test/models/levels/maze_test.rb
@@ -5,13 +5,7 @@ class MazeTest < ActiveSupport::TestCase
     @maze = Maze.new
   end
 
-  test 'uses_google_blockly? returns true when DCDO flag is true' do
-    DCDO.stubs(:get).with('maze_sw_google_blockly', true).returns(true)
+  test 'uses_google_blockly? returns true' do
     assert @maze.uses_google_blockly?
-  end
-
-  test 'uses_google_blockly? returns false when DCDO flag is false' do
-    DCDO.stubs(:get).with('maze_sw_google_blockly', true).returns(false)
-    refute @maze.uses_google_blockly?
   end
 end

--- a/dashboard/test/models/levels/star_wars_grid_test.rb
+++ b/dashboard/test/models/levels/star_wars_grid_test.rb
@@ -5,13 +5,7 @@ class StarWarsGridTest < ActiveSupport::TestCase
     @star_wars_grid = StarWarsGrid.new
   end
 
-  test 'uses_google_blockly? returns true when DCDO flag is true' do
-    DCDO.stubs(:get).with('maze_sw_google_blockly', true).returns(true)
+  test 'uses_google_blockly? returns true' do
     assert @star_wars_grid.uses_google_blockly?
-  end
-
-  test 'uses_google_blockly? returns false when DCDO flag is false' do
-    DCDO.stubs(:get).with('maze_sw_google_blockly', true).returns(false)
-    refute @star_wars_grid.uses_google_blockly?
   end
 end

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
@@ -4,7 +4,7 @@ Background:
   Given I am on "http://studio.code.org/hoc/reset"
 
 Scenario: Solving puzzle 1, proceeding to puzzle 2, verifying that puzzle 1 appears as solved
-  Given I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/hoc/1?noautoplay=true"
   And I wait for the lab page to fully load
   And I drag block "moveForward" to block "startBlock"
   And I press "runButton"
@@ -12,7 +12,7 @@ Scenario: Solving puzzle 1, proceeding to puzzle 2, verifying that puzzle 1 appe
   And element ".modal .congrats" contains text "You completed Puzzle 1."
   And I close the dialog
   ## Verify that closing doesn't redirect to the next level
-  Then check that I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
+  Then check that I am on "http://studio.code.org/hoc/1?noautoplay=true"
   Then I am on "http://studio.code.org/hoc/2?noautoplay=true"
   And I wait for the lab page to fully load
   And I verify progress in the header of the current page is "perfect" for level 1
@@ -24,14 +24,14 @@ Scenario: Solving puzzle 1, proceeding to puzzle 2, verifying that puzzle 1 appe
   Then I wait until I am on "http://studio.code.org/s/20-hour/lessons/2/levels/2?noautoplay=true"
   And I verify progress in the header of the current page is "not_tried" for level 1
   # Level source is saved
-  Then I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
-  Then I wait until I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
+  Then I am on "http://studio.code.org/hoc/1?noautoplay=true"
+  Then I wait until I am on "http://studio.code.org/hoc/1?noautoplay=true"
   And I wait for the lab page to fully load
   And block "moveForward" is child of block "startBlock"
   # Level source is reset
   Then I am on "http://studio.code.org/hoc/reset"
-  Then I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
-  Then I wait until I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
+  Then I am on "http://studio.code.org/hoc/1?noautoplay=true"
+  Then I wait until I am on "http://studio.code.org/hoc/1?noautoplay=true"
   And I wait for the lab page to fully load
   And element "g[data-id=\'startBlock\'] g[data-id=\'moveForward\']" does not exist
 

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
@@ -2,7 +2,7 @@
 Feature: Hour of Code tests for users that are signed in
 
 Scenario:
-  Given I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/hoc/1?noautoplay=true"
   And I wait for the lab page to fully load
   And I drag block "moveForward" to block "startBlock"
   And I press "runButton"
@@ -19,12 +19,12 @@ Scenario:
   Then I am on "http://studio.code.org/s/20-hour/lessons/2/levels/2?noautoplay=true"
   And I verify progress in the header of the current page is "not_tried" for level 1
   # Level source is saved
-  Then I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
+  Then I am on "http://studio.code.org/hoc/1?noautoplay=true"
   And I wait for the lab page to fully load
   And block "moveForward" is child of block "startBlock"
   # Level source is reset
   Then I am on "http://studio.code.org/hoc/reset"
-  Then I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
+  Then I am on "http://studio.code.org/hoc/1?noautoplay=true"
   And I wait for the lab page to fully load
   And block "moveForward" is child of block "startBlock"
 

--- a/dashboard/test/ui/features/star_labs/bee.feature
+++ b/dashboard/test/ui/features/star_labs/bee.feature
@@ -1,7 +1,7 @@
 Feature: Complete a bee level
 
 Scenario: Complete Bee Conditions 4-5 Level 3
-  Given I am on "http://studio.code.org/s/course3/lessons/7/levels/3?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/course3/lessons/7/levels/3?noautoplay=true"
   And I wait for the lab page to fully load
   When I dismiss the login reminder
   # repeat to when run

--- a/dashboard/test/ui/features/star_labs/clearpuzzle.feature
+++ b/dashboard/test/ui/features/star_labs/clearpuzzle.feature
@@ -1,7 +1,7 @@
 Feature: Clear Puzzle
 
 Background:
-  Given I am on "http://studio.code.org/hoc/1?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/hoc/1?noautoplay=true"
   And I wait for the lab page to fully load
   Then element "#runButton" is visible
   And element "#resetButton" is hidden

--- a/dashboard/test/ui/features/star_labs/farmer.feature
+++ b/dashboard/test/ui/features/star_labs/farmer.feature
@@ -1,7 +1,7 @@
 Feature: Playing the Farmer Game
 
 Background:
-  Given I am on "http://studio.code.org/s/20-hour/lessons/9/levels/1?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/20-hour/lessons/9/levels/1?noautoplay=true"
   And I wait for the lab page to fully load
   And I dismiss the login reminder
   And element ".instructions-markdown p" has text "Hi, I'm a farmer. I need your help to flatten the field on my farm so it's ready for planting. Move me to the pile of dirt and use the \"remove\" block to remove it."

--- a/dashboard/test/ui/features/star_labs/maze.feature
+++ b/dashboard/test/ui/features/star_labs/maze.feature
@@ -2,7 +2,7 @@ Feature: Complete a complicated maze level
 
 Background:
   Given I am on "http://studio.code.org/reset_session"
-  Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/15?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/15?noautoplay=true"
   And I wait for the lab page to fully load
   And I dismiss the login reminder
   And element ".csf-top-instructions p" has text "Ok, this is just like the last puzzle, but you need to remember how you used the \"if\" block and the \"repeat\" block together."

--- a/dashboard/test/ui/features/star_labs/maze2.feature
+++ b/dashboard/test/ui/features/star_labs/maze2.feature
@@ -2,7 +2,7 @@ Feature: Complete a simple maze level
 
   Background:
     Given I am on "http://studio.code.org/reset_session"
-    Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/11?noautoplay=true&blocklyVersion=google"
+    Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/11?noautoplay=true"
     And I wait for the lab page to fully load
     And I dismiss the login reminder
     Then element ".csf-top-instructions p" has text "Ok, one last time for practice - can you solve this one using only 4 blocks?"

--- a/dashboard/test/ui/features/star_labs/simpledrag.feature
+++ b/dashboard/test/ui/features/star_labs/simpledrag.feature
@@ -1,7 +1,7 @@
 Feature: Blocks can be dragged
 
 Scenario: Connect two blocks from toolbox
-  Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/5?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/20-hour/lessons/2/levels/5?noautoplay=true"
   When I wait for the lab page to fully load
   And I dismiss the login reminder
   And I wait to see ".blocklySvg"

--- a/dashboard/test/ui/features/star_labs/step_mode.feature
+++ b/dashboard/test/ui/features/star_labs/step_mode.feature
@@ -2,7 +2,7 @@
 Feature: Step Mode
 
 Scenario: Step Only - Failure
-  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1?blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1"
     And I wait for the lab page to fully load
   Then element "#runButton" is hidden
     And element "#resetButton" is hidden
@@ -35,7 +35,7 @@ Scenario: Step Only - Failure
     And element "#stepButton" is not disabled
 
 Scenario: Step Only - Success
-  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1?blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1"
     And I wait for the lab page to fully load
   Then element "#runButton" is hidden
     And element "#resetButton" is hidden
@@ -55,7 +55,7 @@ Scenario: Step Only - Success
   Then element ".congrats" has text "Congratulations! You completed Puzzle 1."
 
 Scenario: Step Only - Reset while stepping
-  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1?blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/step/lessons/1/levels/1"
     And I wait for the lab page to fully load
   Then element "#runButton" is hidden
     And element "#resetButton" is hidden
@@ -78,7 +78,7 @@ Scenario: Step Only - Reset while stepping
     And element "#stepButton" is not disabled
 
 Scenario: Step and Run - Stepping
-  Given I am on "http://studio.code.org/s/step/lessons/1/levels/2?blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/step/lessons/1/levels/2"
     And I wait for the lab page to fully load
   Then element "#runButton" is visible
     And element "#resetButton" is hidden
@@ -103,7 +103,7 @@ Scenario: Step and Run - Stepping
     And element "#stepButton" is not disabled
 
 Scenario: Step and Run - Running
-  Given I am on "http://studio.code.org/s/step/lessons/1/levels/2?blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/step/lessons/1/levels/2"
     And I wait for the lab page to fully load
   Then element "#runButton" is visible
     And element "#resetButton" is hidden

--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -1,9 +1,9 @@
 PUZZLE_SOLUTIONS = {
-  "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google" => %{
+  "http://studio.code.org/s/allthethings/lessons/2/levels/1" => %{
     And I drag block "moveWest" to block "whenRun"
     And I drag block "moveWest" to block "moveWest"
   },
-  "http://studio.code.org/s/allthethings/lessons/29/levels/1?blocklyVersion=google&level_name=2-3 Maze 1" => %{
+  "http://studio.code.org/s/allthethings/lessons/29/levels/1?level_name=2-3 Maze 1" => %{
     And I drag block "moveForward" to block "whenRun"
     And I drag block "moveForward" to block "moveForward"
   },

--- a/dashboard/test/ui/features/teacher_tools/challenge_level.feature
+++ b/dashboard/test/ui/features/teacher_tools/challenge_level.feature
@@ -2,7 +2,7 @@ Feature: Challenge level shows different dialogs
 
 Background:
   Given I am on "http://studio.code.org/reset_session"
-  Given I am on "http://studio.code.org/s/allthethings/lessons/2/levels/6?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/2/levels/6?noautoplay=true"
   And I wait for the lab page to fully load
 
 Scenario: Submit passing and perfect solutions

--- a/dashboard/test/ui/features/teacher_tools/feedback.feature
+++ b/dashboard/test/ui/features/teacher_tools/feedback.feature
@@ -2,7 +2,7 @@
 Feature: Recommended/Required Blocks Feedback
 
 Scenario: Solve without recommended blocks
-  Given I am on "http://studio.code.org/s/allthethings/lessons/4/levels/5?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/4/levels/5?noautoplay=true"
   And I wait for the lab page to fully load
 
   When I press "runButton"

--- a/dashboard/test/ui/features/teacher_tools/fun_o_meter.feature
+++ b/dashboard/test/ui/features/teacher_tools/fun_o_meter.feature
@@ -2,7 +2,7 @@
 Feature: Fun-O-Meter
 
 Scenario: Rate a Puzzle
-  Given I am on "http://studio.code.org/s/allthethings/lessons/4/levels/4?noautoplay=true&blocklyVersion=google"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/4/levels/4?noautoplay=true"
   And I wait for the lab page to fully load
 
   When I drag block "getNectar" to block "ifNectar" plus offset 35, 30

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_swap.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_swap.feature
@@ -19,7 +19,7 @@ Feature: Swapped levels
   @as_student
   @no_mobile
   Scenario: Student with progress sees old version
-    Given I complete the level on "http://studio.code.org/s/allthethings/lessons/29/levels/1?blocklyVersion=google&level_name=2-3 Maze 1"
+    Given I complete the level on "http://studio.code.org/s/allthethings/lessons/29/levels/1?level_name=2-3 Maze 1"
     And I complete the level on "http://studio.code.org/s/allthethings/lessons/29/levels/4?level_name=2-3 Artist 1 new"
     And I am on "http://studio.code.org/s/allthethings/lessons/29/levels/5?level_name=ramp_video_loopsArtist&noautoplay=true"
     And I wait until element ".submitButton" is visible

--- a/dashboard/test/ui/features/teacher_tools/progress.feature
+++ b/dashboard/test/ui/features/teacher_tools/progress.feature
@@ -3,7 +3,7 @@ Feature: Level Progress
   Scenario: Progress is saved for signed-in student
     Given I am a student
 
-    When I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+    When I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
     Then I verify progress in the header of the current page is "perfect" for level 1
     And I verify progress in the header of the current page is "not_tried" for level 2
 
@@ -20,7 +20,7 @@ Feature: Level Progress
   Scenario: Progress is saved for signed-out student
     Given I am not signed in
 
-    When I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+    When I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
     Then I verify progress in the header of the current page is "perfect" for level 1
     And I verify progress in the header of the current page is "not_tried" for level 2
 

--- a/dashboard/test/ui/features/teacher_tools/script_overview.feature
+++ b/dashboard/test/ui/features/teacher_tools/script_overview.feature
@@ -8,7 +8,7 @@ Feature: Unit overview page
     Given I create an authorized teacher-associated student named "Sally"
 
     # Make progress as student
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
 
     # Verify progress as student on script overview page
     And I am on "http://studio.code.org/s/allthethings"

--- a/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
@@ -4,7 +4,7 @@ Feature: Using the SectionActionDropdown
   # * Check that we get redirected to the right page
   Scenario: Viewing progress from SectionActionDropdown
     Given I create a teacher-associated student named "Sally"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
     And I complete the free response on "http://studio.code.org/s/allthethings/lessons/27/levels/1"
     And I submit the assessment on "http://studio.code.org/s/allthethings/lessons/33/levels/1"
     And I sign out

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/progress_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/progress_tab_views_eyes.feature
@@ -10,7 +10,7 @@ Feature: Using the progress tab of the teacher dashboard
     Given I am assigned to unit "coursea-2019"
     Given I am assigned to unit "allthethings"
 
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
     And I complete the free response on "http://studio.code.org/s/allthethings/lessons/27/levels/1"
     And I submit the assessment on "http://studio.code.org/s/allthethings/lessons/33/levels/1"
 

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
@@ -3,7 +3,7 @@ Feature: Using the teacher dashboard
 
   Scenario: Visiting student name URLs in teacher dashboard
     Given I create an authorized teacher-associated student named "Sally"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
 
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
@@ -21,7 +21,7 @@ Feature: Using the teacher dashboard
   Scenario: Viewing a student
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
     And I complete the free response on "http://studio.code.org/s/allthethings/lessons/27/levels/1"
     And I submit the assessment on "http://studio.code.org/s/allthethings/lessons/33/levels/1"
 
@@ -107,7 +107,7 @@ Feature: Using the teacher dashboard
 
   Scenario: Toggling student progress
     Given I create an authorized teacher-associated student named "Sally"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
     And I complete the free response on "http://studio.code.org/s/allthethings/lessons/27/levels/1"
     And I submit the assessment on "http://studio.code.org/s/allthethings/lessons/33/levels/1"
 
@@ -239,7 +239,7 @@ Feature: Using the teacher dashboard
   Scenario: Decline invitation to new progress view
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
 
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
@@ -254,7 +254,7 @@ Feature: Using the teacher dashboard
   Scenario: Accept invitation to new progress view and see new view immediately. 
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
 
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
@@ -269,7 +269,7 @@ Feature: Using the teacher dashboard
   Scenario: Delay responding to invitation to new progress view and see old view immediately. 
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
 
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
@@ -4,7 +4,7 @@ Feature: Using the V2 teacher dashboard
 Scenario: Teacher can open and close Icon Key and details
   Given I create an authorized teacher-associated student named "Sally"
   Given I am assigned to unit "allthethings"
-  And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+  And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
 
   When I sign in as "Teacher_Sally" and go home
   And I get levelbuilder access
@@ -132,7 +132,7 @@ Scenario: Teacher can view lesson progress for when students have completed a le
   Given I create an authorized teacher-associated student named "Sally"
   Given I am assigned to unit "allthethings"
   # Student completes one of many levels in lesson 2
-  And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1?blocklyVersion=google"
+  And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
 
   # Student completes all the levels in lesson 10 (there is only one level)
   Given I am on "http://studio.code.org/s/allthethings/lessons/10/levels/1?noautoplay=true"


### PR DESCRIPTION
We have been running all Maze and Star Wars levels on Google Blockly for several weeks without any reported issues. If an issue came up at this point, we would prefer to fix forwards than revert, and unlikely to need to revert with the urgency a DCDO flag provides.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
