### PR TITLE
PythonLab: update delete button color on predict levels 

### DIFF
--- a/apps/src/lab2/views/components/PredictResetButton.tsx
+++ b/apps/src/lab2/views/components/PredictResetButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Alert from '@cdo/apps/componentLibrary/alert/Alert';
-import {Button} from '@cdo/apps/componentLibrary/button';
+import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import {resetPredictProgress} from '@cdo/apps/lab2/redux/predictLevelRedux';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import {CourseRoles} from '@cdo/apps/templates/currentUserRedux';
@@ -48,7 +48,7 @@ const PredictResetButton: React.FunctionComponent = () => {
         disabled={!hasSubmitted}
         iconLeft={{iconStyle: 'solid', iconName: 'trash'}}
         type={'secondary'}
-        color={'black'}
+        color={buttonColors.destructive}
       />
       <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
       {resetFailed && (

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -58,7 +58,7 @@ export const UnconnectedContainedLevelResetButton = ({
         disabled={!hasLevelResults || !!codeIsRunning}
         color={buttonColors.destructive}
         iconLeft={{iconStyle: 'solid', iconName: 'trash'}}
-        type={'primary'}
+        type={'secondary'}
       />
       <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
       {resetFailed && (

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 
 import {resetContainedLevel} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {queryUserProgress} from '@cdo/apps/code-studio/progressRedux';
-import Button from '@cdo/apps/legacySharedComponents/Button';
+import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {CourseRoles} from '@cdo/apps/templates/currentUserRedux';
@@ -53,8 +53,11 @@ export const UnconnectedContainedLevelResetButton = ({
           );
           logButtonClick();
         }}
-        color={Button.ButtonColor.red}
+        size={'s'}
         disabled={!hasLevelResults || !!codeIsRunning}
+        color={buttonColors.destructive}
+        iconLeft={{iconStyle: 'solid', iconName: 'trash'}}
+        type={'secondary'}
       />
       <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
       {resetFailed && (

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -42,6 +42,7 @@ export const UnconnectedContainedLevelResetButton = ({
   return (
     <div>
       <Button
+        name="containedLevelResetButton"
         text={i18n.deleteAnswer()}
         onClick={() => {
           resetContainedLevel().then(

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -58,7 +58,7 @@ export const UnconnectedContainedLevelResetButton = ({
         disabled={!hasLevelResults || !!codeIsRunning}
         color={buttonColors.destructive}
         iconLeft={{iconStyle: 'solid', iconName: 'trash'}}
-        type={'secondary'}
+        type={'primary'}
       />
       <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
       {resetFailed && (

--- a/apps/test/unit/templates/instructions/ContainedLevelResetButtonTest.jsx
+++ b/apps/test/unit/templates/instructions/ContainedLevelResetButtonTest.jsx
@@ -38,7 +38,7 @@ describe('ContainedLevelResetButton', () => {
         codeIsRunning={false}
       />
     );
-    const button = wrapper.find('Button');
+    const button = wrapper.find({name: 'containedLevelResetButton'});
     expect(button.props().disabled).to.be.true;
   });
 
@@ -52,7 +52,7 @@ describe('ContainedLevelResetButton', () => {
         codeIsRunning={false}
       />
     );
-    const button = wrapper.find('Button');
+    const button = wrapper.find({name: 'containedLevelResetButton'});
     expect(button.props().disabled).to.be.false;
   });
 
@@ -84,7 +84,7 @@ describe('ContainedLevelResetButton', () => {
         codeIsRunning={false}
       />
     );
-    const button = wrapper.find('Button');
+    const button = wrapper.find({name: 'containedLevelResetButton'});
 
     button.simulate('click');
     await setTimeout(() => {}, 50);


### PR DESCRIPTION
[CT-681](https://codedotorg.atlassian.net/browse/CT-681)

**Before `PredictResetButton`** 
![Screenshot 2024-08-01 at 12 17 28 PM](https://github.com/user-attachments/assets/9a8817b0-bbab-4afc-b043-ec9122a80684)

**After `PredictResetButton`** 
![Screenshot 2024-08-01 at 12 18 14 PM](https://github.com/user-attachments/assets/ad3fb585-bc01-47cf-a3ec-8e9ba85673e6)

**Before `ContainedLevelResetButton`**
![Screenshot 2024-08-01 at 2 46 30 PM](https://github.com/user-attachments/assets/8475fe76-24a9-4807-a7ac-d7ad610f7b2f)

**After `ContainedLevelResetButton`**

![Screenshot 2024-08-02 at 12 44 28 PM](https://github.com/user-attachments/assets/617d155e-1902-46dc-8691-b38703600716)

