### PR TITLE
Add new logos to the in partnership section at the bottom of code.org/ai

### DIFF
--- a/pegasus/sites.v3/code.org/public/ai/index.haml
+++ b/pegasus/sites.v3/code.org/public/ai/index.haml
@@ -131,7 +131,8 @@ theme: responsive_full_width
       %img{src: "/images/avatars/microsoft.png", alt: "Microsoft logo", style: "max-width: 150px"}
       %img{src: "/images/avatars/infosys_foundation_usa.png", alt: "Infosys logo", style: "max-width: 50px"}
       %img{src: "/images/avatars/schmidt-futures.png", alt: "Schmidt Futures logo", style: "max-width: 340px"}
-
+      %img{src: "/images/avatars/fortive.png", alt: "Fortive logo", style: "max-width: 160px"}
+      %img{src: "/images/avatars/amd.png", alt: "AMD logo", style: "max-width: 100px"}
 
 = view :swiper_page_ai
 

--- a/pegasus/sites.v3/code.org/public/images/avatars/amd.png
+++ b/pegasus/sites.v3/code.org/public/images/avatars/amd.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:702c22fea6cd79498a3673873875f3abb48204aa0e903a4b5e1080fbeaad2fde
+size 16903

--- a/pegasus/sites.v3/code.org/public/images/avatars/fortive.png
+++ b/pegasus/sites.v3/code.org/public/images/avatars/fortive.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddd2f636f9be6549643f7911adcf08479fc116aafadd43a2953b9f3c929965e2
+size 69828


### PR DESCRIPTION
Adds two new partner logos to https://code.org/ai: Fortive and AMD

<img width="1186" alt="Screenshot 2024-08-01 at 12 56 48 PM" src="https://github.com/user-attachments/assets/d6d23c90-da91-4a1e-8744-bddf3b559ef1">


## Links
Jira ticket: [ACQ-2133](https://codedotorg.atlassian.net/browse/ACQ-2133)