### PR TITLE
Adding more logging and notifying teacher tools team in case of failure exporting files from google drive as PDF

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -83,7 +83,7 @@ module Services
             PDF.merge_local_pdfs(destination, *pdfs)
           rescue Exception => exception
             ChatClient.log(
-              "Error when trying to merge resource PDFs for #{script.name}: #{exception}",
+              "@teacher-tools-team Error when trying to merge resource PDFs for #{script.name}: #{exception}",
               color: 'red'
             )
             ChatClient.log(
@@ -211,15 +211,14 @@ module Services
               return path
             end
           end
-        rescue Google::Apis::ClientError, Google::Apis::ServerError, GoogleDrive::Error => exception
+        rescue Google::Apis::ClientError, Google::Apis::ServerError, GoogleDrive::Error, URI::InvalidURIError, OpenURI::HTTPError => exception
           ChatClient.log(
-            "Google error when trying to fetch PDF from #{url.inspect} to #{path.inspect}: #{exception}",
+            "Error when trying to fetch PDF from #{url.inspect} to #{path.inspect}: #{exception.inspect}",
             color: 'yellow'
           )
-          return nil
-        rescue URI::InvalidURIError, OpenURI::HTTPError => exception
+
           ChatClient.log(
-            "URI error when trying to fetch PDF from #{url.inspect} to #{path.inspect}: #{exception}",
+            "@teacher-tools-team Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
             color: 'yellow'
           )
           return nil


### PR DESCRIPTION
This change does two updates during the step where files stored in google drive are exported as a PDF

1. Tags teacher tools team when an error is hit, so the team can proactively fix the issue for intermittent failures
2. Include more details from the exception, which is helpful to get more info about the HTTP response status and also get the URI to replay in google API explorer

## Slack logs before the change for two different types of exceptions
I, [2024-08-01T15:04:15.146723 #2194]  INFO -- : [development] `URI error when trying to fetch PDF from "https://docs.google.com/document/d/15ho43\\-c0njEcIEIr-RmHcUjZfIJPFdVZvQdpH6GC4B4/edit?usp=sharing" to "/tmp/generate_script_resources_pdf20240801-2194-pi947d/resource.resource_packet.pdf": bad URI(is not URI?): "https://docs.google.com/document/d/15ho43\\-c0njEcIEIr-RmHcUjZfIJPFdVZvQdpH6GC4B4/edit?usp=sharing"`

I, [2024-08-01T15:04:19.999054 #2194]  INFO -- : [development] `Google error when trying to fetch PDF from "https://docs.google.com/document/d/15gERZooKYoMlBjeHTEb63zlkG9oaCayUUblHzaSW9VE/edit?usp=sharing" to "/tmp/generate_script_resources_pdf20240801-2194-pi947d/resource.activity_packet_1.pdf": Invalid request`


## Slack logs after the change for the same two exceptions

I, [2024-08-01T14:38:40.370287 #186703]  INFO -- : [development] `Error when trying to fetch PDF from "https://docs.google.com/document/d/15ho43\\-c0njEcIEIr-RmHcUjZfIJPFdVZvQdpH6GC4B4/edit?usp=sharing" to "/tmp/generate_script_resources_pdf20240801-186703-s3w4gz/resource.resource_packet.pdf": #<URI::InvalidURIError: bad URI(is not URI?): "https://docs.google.com/document/d/15ho43\\-c0njEcIEIr-RmHcUjZfIJPFdVZvQdpH6GC4B4/edit?usp=sharing">`
I, [2024-08-01T14:38:40.370348 #186703]  INFO -- : [development] `@teacher-tools-team Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot`

I, [2024-08-01T14:38:43.814887 #186703]  INFO -- : [development] `Error when trying to fetch PDF from "https://docs.google.com/document/d/15gERZooKYoMlBjeHTEb63zlkG9oaCayUUblHzaSW9VE/edit?usp=sharing" to "/tmp/generate_script_resources_pdf20240801-186703-s3w4gz/resource.activity_packet_1.pdf": #<Google::Apis::ClientError: Invalid request status_code: 403 header: #<HTTP::Message::Headers:0x00005557490339a0 @http_version="1.1", @body_size=0, @chunked=false, @request_method="GET", @request_uri=#<Addressable::URI:0x23690 URI:https://www.googleapis.com/drive/v3/files/15gERZooKYoMlBjeHTEb63zlkG9oaCayUUblHzaSW9VE/export?alt=media&mimeType=application%2Fpdf>, @request_query={"alt"=>"media", "mimeType"=>"application/pdf"}, @request_absolute_uri=nil, @status_code=403, @reason_phrase="Forbidden", @body_type=nil, @body_charset=nil, @body_date=nil, @body_encoding=#<Encoding:UTF-8>, @is_request=false, @header_item=[["Cache-Control", "private, max-age=0"], ["Content-Type", "application/json; charset=UTF-8"], ["Date", "Thu, 01 Aug 2024 21:38:44 GMT"], ["Expires", "Thu, 01 Aug 2024 21:38:44 GMT"], ["Server", "ESF"], ["Vary", "Origin, X-Origin"], ["X-Content-Type-Options", "nosniff"], ["X-Frame-Options", "SAMEORIGIN"], ["X-XSS-Protection", "0"], ["X-GUploader-UploadID", "AHxI1nNCpLuXD8qN0wvte0Vt1-N2NBtwizyTst0KiyUzX7T8Tt3Sgz2lTmVcw149fqbpIuEYMZON5wNinA"], ["Content-Length", "266"], ["Alt-Svc", "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"]], @dumped=false>>`
I, [2024-08-01T14:38:43.815055 #186703]  INFO -- : [development] `@teacher-tools-team Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot`


## Links

JIRA https://codedotorg.atlassian.net/browse/TEACH-1178

## Testing story

- Validated locally by enabling chat logs and used the log output to file 
- Drone

## Deployment strategy
- Merge the change right after a DTP
- Closely monitor the change once it hits staging by trying to generate a PDF that is known to fail

## Follow-up work

None

## Privacy

Given the exception info should contain links URLs only for our curriculum content, there shouldn't be any privacy concerns here

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
