### PR TITLE
Incorporate Custom Workshop surveys

### DIFF
--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -64,7 +64,7 @@ module Pd
     end
 
     def new_facilitator_post_foorm(workshop)
-      survey_name = FACILITATOR_POST_SURVEY_CONFIG_PATH
+      survey_name = workshop.subject == SUBJECT_CUSTOM_WORKSHOP ? FACILITATOR_CUSTOM_WORKSHOP_POST_SURVEY_CONFIG_PATH : FACILITATOR_POST_SURVEY_CONFIG_PATH
 
       agenda = params[:agenda] || nil
       # remove / from agenda url so module/1 => module1

--- a/dashboard/lib/pd/workshop_survey_foorm_constants.rb
+++ b/dashboard/lib/pd/workshop_survey_foorm_constants.rb
@@ -20,7 +20,8 @@ module Pd
       SUBJECT_WORKSHOP_4 => 'surveys/pd/ayw_workshop_post_survey',
       SUBJECT_WORKSHOP_1_2 => 'surveys/pd/ayw_workshop_post_survey',
       SUBJECT_WORKSHOP_3_4 => 'surveys/pd/ayw_workshop_post_survey',
-      SUBJECT_VIRTUAL_KICKOFF => 'surveys/pd/ayw_kickoff_call'
+      SUBJECT_VIRTUAL_KICKOFF => 'surveys/pd/ayw_kickoff_call',
+      SUBJECT_CUSTOM_WORKSHOP => 'surveys/pd/custom_workshop_post_teachers'
     }
 
     PRE_SURVEY_CONFIG_PATHS = {
@@ -47,6 +48,7 @@ module Pd
     ].map(&:values).flatten.concat(TEST_PARTICIPANT_SURVEY_CONFIG_PATHS)
 
     FACILITATOR_POST_SURVEY_CONFIG_PATH = 'surveys/pd/csd_csp_facilitator_post_survey'
+    FACILITATOR_CUSTOM_WORKSHOP_POST_SURVEY_CONFIG_PATH = 'surveys/pd/custom_workshop_post_facilitators'
 
     FOORM_SUBMIT_API = '/api/v1/pd/foorm/workshop_survey_submission'
 


### PR DESCRIPTION
As discussed [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1722548735081799), custom workshop surveys currently don't work.

When a new workshop survey Foorm [is generated](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb#L109), it uses `POST_SURVEY_CONFIG_PATHS` to get which survey to use [based on the subject](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb#L95). Looking into `POST_SURVEY_CONFIG_PATHS`, it [did not have an entry for custom workshops](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/pd/workshop_survey_foorm_constants.rb#L11-L24) despite us already having a [teacher](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/config/foorm/forms/surveys/pd/custom_workshop_post_teachers.0.json) and [facilitator](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/config/foorm/forms/surveys/pd/custom_workshop_post_facilitators.0.json) survey config set up.

This PR adds the teacher config into `POST_SURVEY_CONFIG_PATHS` to ensure the teacher custom workshop survey shows up. It does the same for facilitators but in-line rather than in a constant since it looks like facilitators are always shown `FACILITATOR_POST_SURVEY_CONFIG_PATH`.

### Old view when a user tried to view a custom workshop survey
![sad bee](https://github.com/user-attachments/assets/349a48df-40d4-4639-84ca-bf2d56fcf94a)

### Now teachers will see a custom workshop survey
(shows "There is no visible page or question in the survey" message, but Foorm doesn't work locally so this view means Foorm will show up on production)
![teacher survey success](https://github.com/user-attachments/assets/9261e337-3e80-4884-ae6d-ac33d8b70d88)

### Now facilitators will see a custom workshop survey
(shows "There is no visible page or question in the survey" message, but Foorm doesn't work locally so this view means Foorm will show up on production)
![facilitator](https://github.com/user-attachments/assets/ce82c313-bccb-4fab-ace4-1bed204b16c7)

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1722548735081799)

## Testing story
Local testing.
