### PR TITLE
[Google Blockly] Support custom color palette for Frozen tutorial

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -174,7 +174,6 @@
     "@amplitude/analytics-browser": "^1.5.4",
     "@blockly/block-shareable-procedures": "~4.0.5",
     "@blockly/field-bitmap": "^4.1.0",
-    "@blockly/field-colour": "^4.0.0",
     "@blockly/field-grid-dropdown": "~4.0.9",
     "@blockly/keyboard-navigation": "~0.5.6",
     "@blockly/plugin-cross-tab-copy-paste": "~5.0.4",

--- a/apps/src/blockly/addons/cdoFieldColour.ts
+++ b/apps/src/blockly/addons/cdoFieldColour.ts
@@ -1,0 +1,49 @@
+import {FieldColour, FieldColourConfig, FieldColourValidator} from 'blockly';
+
+export default class CdoFieldColour extends FieldColour {
+  // The colours and columns properties are both private in the parent class, so we create
+  // additional properties to track the config values.
+  private coloursConfig: string[] | null = null;
+  private columnsConfig: number = 0;
+  static COLOURS: string[] = FieldColour.COLOURS;
+  static TITLES: string[] = [];
+  static COLUMNS: number = 7;
+  /**
+   * @param value The initial value of the field.  Should be in '#rrggbb'
+   *     format.  Defaults to the first value in the default colour array.  Also
+   *     accepts Field.SKIP_SETUP if you wish to skip setup (only used by
+   *     subclasses that want to handle configuration and setting the field
+   *     value after their own constructors have run).
+   * @param validator A function that is called to validate changes to the
+   *     field's value.  Takes in a colour string & returns a validated colour
+   *     string ('#rrggbb' format), or null to abort the change.
+   * @param config A map of options used to configure the field.
+   *     See the [field creation documentation]{@link
+   * https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/colour}
+   * for a list of properties this parameter supports.
+   */
+  constructor(
+    value?: string | typeof Blockly.Field.SKIP_SETUP,
+    validator?: FieldColourValidator,
+    config?: FieldColourConfig
+  ) {
+    super(value, validator, config);
+    // Duplicates this.colours and this.columns, which are both private in the parent class.
+    if (config) {
+      if (config.colourOptions) this.coloursConfig = config.colourOptions;
+      if (config.columns) this.columnsConfig = config.columns;
+    }
+  }
+
+  /**
+   * Create and show the colour field's editor.
+   * Artist modifies blockly.FieldColour.COLOURS and blockly.FieldColour.COLUMNS directly.
+   * Therefore, wait to read these values until we need to create the field dropdown.
+   * @override
+   * */
+  protected override showEditor_() {
+    this.setColours(this.coloursConfig || CdoFieldColour.COLOURS);
+    this.setColumns(this.columnsConfig || CdoFieldColour.COLUMNS);
+    super.showEditor_();
+  }
+}

--- a/apps/src/blockly/addons/extensions/logic_compare.ts
+++ b/apps/src/blockly/addons/extensions/logic_compare.ts
@@ -27,5 +27,9 @@ const LOGIC_COMPARE_EXTENSION = function (this: CompareBlock) {
   // Add onchange handler to ensure types are compatible.
   this.mixin(LOGIC_COMPARE_ONCHANGE_MIXIN);
 };
-GoogleBlockly.Extensions.unregister('logic_compare');
-GoogleBlockly.Extensions.register('logic_compare', LOGIC_COMPARE_EXTENSION);
+export default function registerMutator() {
+  if (GoogleBlockly.Extensions.isRegistered('logic_compare')) {
+    GoogleBlockly.Extensions.unregister('logic_compare');
+  }
+  GoogleBlockly.Extensions.register('logic_compare', LOGIC_COMPARE_EXTENSION);
+}

--- a/apps/src/blockly/addons/plusMinusBlocks/if.js
+++ b/apps/src/blockly/addons/plusMinusBlocks/if.js
@@ -242,11 +242,13 @@ const controlsIfHelper = function () {
   this.getInput('IF0').insertFieldAt(0, createPlusField(), 'PLUS');
 };
 
-if (GoogleBlockly.Extensions.isRegistered('controls_if_mutator')) {
-  GoogleBlockly.Extensions.unregister('controls_if_mutator');
+export default function registerMutator() {
+  if (GoogleBlockly.Extensions.isRegistered('controls_if_mutator')) {
+    GoogleBlockly.Extensions.unregister('controls_if_mutator');
+  }
+  GoogleBlockly.Extensions.registerMutator(
+    'controls_if_mutator',
+    controlsIfMutator,
+    controlsIfHelper
+  );
 }
-GoogleBlockly.Extensions.registerMutator(
-  'controls_if_mutator',
-  controlsIfMutator,
-  controlsIfHelper
-);

--- a/apps/src/blockly/addons/plusMinusBlocks/text_join.js
+++ b/apps/src/blockly/addons/plusMinusBlocks/text_join.js
@@ -190,12 +190,13 @@ const textJoinHelper = function () {
   }
   this.updateShape_(MINIMUM_INPUTS);
 };
-
-if (GoogleBlockly.Extensions.isRegistered('text_join_mutator')) {
-  GoogleBlockly.Extensions.unregister('text_join_mutator');
+export default function registerMutator() {
+  if (GoogleBlockly.Extensions.isRegistered('text_join_mutator')) {
+    GoogleBlockly.Extensions.unregister('text_join_mutator');
+  }
+  GoogleBlockly.Extensions.registerMutator(
+    'text_join_mutator',
+    textJoinMutator,
+    textJoinHelper
+  );
 }
-GoogleBlockly.Extensions.registerMutator(
-  'text_join_mutator',
-  textJoinMutator,
-  textJoinHelper
-);

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -181,7 +181,6 @@ export const READ_ONLY_PROPERTIES = [
   'Extensions',
   'FieldAngle',
   'FieldAngleInput',
-  'FieldColour',
   'FieldColourDropdown',
   'FieldIcon',
   'FieldMultilineInput',

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -6,7 +6,6 @@ import {
   ObservableProcedureModel,
   ObservableParameterModel,
 } from '@blockly/block-shareable-procedures';
-import {installAllBlocks as installColourBlocks} from '@blockly/field-colour';
 import {LineCursor, NavigationController} from '@blockly/keyboard-navigation';
 import {CrossTabCopyPaste} from '@blockly/plugin-cross-tab-copy-paste';
 import {
@@ -400,10 +399,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   // Assign all of the properties of the javascript generator to the forBlock array
   // Prevents deprecation warnings related to https://github.com/google/blockly/pull/7150
   Object.setPrototypeOf(javascriptGenerator.forBlock, javascriptGenerator);
-  // Installs all colour blocks, the colour field, and the JS generator functions.
-  installColourBlocks({
-    javascript: javascriptGenerator,
-  });
+
   blocklyWrapper.JavaScript = javascriptGenerator;
   blocklyWrapper.LineCursor = LineCursor;
   blocklyWrapper.navigationController = new NavigationController();

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -1,7 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import './addons/plusMinusBlocks/if';
-import './addons/plusMinusBlocks/text_join';
-import './addons/extensions/logic_compare';
 import {
   ObservableProcedureModel,
   ObservableParameterModel,
@@ -65,7 +62,10 @@ import initializeVariables from './addons/cdoVariables';
 import CdoVerticalFlyout from './addons/cdoVerticalFlyout';
 import initializeBlocklyXml, {removeInvisibleBlocks} from './addons/cdoXml';
 import {registerAllContextMenuItems} from './addons/contextMenu';
+import registerLogicCompareMutator from './addons/extensions/logic_compare';
 import FunctionEditor from './addons/functionEditor';
+import registerIfMutator from './addons/plusMinusBlocks/if';
+import registerTextJoinMutator from './addons/plusMinusBlocks/text_join';
 import {UNKNOWN_BLOCK} from './addons/unknownBlock';
 import {Themes, Renderers} from './constants';
 import {flyoutCategory as behaviorsFlyoutCategory} from './customBlocks/googleBlockly/behaviorBlocks';
@@ -194,6 +194,9 @@ const BlocklyWrapper = function (
  * Blockly.navigationController.dispose() before calling this function again.
  */
 function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
+  registerIfMutator();
+  registerLogicCompareMutator();
+  registerTextJoinMutator();
   // TODO: can we avoid using any here by converting BlocklyWrapper to a class?
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const blocklyWrapper = new (BlocklyWrapper as any)(

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -41,6 +41,7 @@ import CdoFieldAnimationDropdown from './addons/cdoFieldAnimationDropdown';
 import CdoFieldBehaviorPicker from './addons/cdoFieldBehaviorPicker';
 import {CdoFieldBitmap} from './addons/cdoFieldBitmap';
 import CdoFieldButton from './addons/cdoFieldButton';
+import CdoFieldColour from './addons/cdoFieldColour';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import CdoFieldFlyout from './addons/cdoFieldFlyout';
 import CdoFieldImage from './addons/cdoFieldImage';
@@ -265,6 +266,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   const fieldOverrides: [string, string, FieldProto][] = [
     ['field_variable', 'FieldVariable', CdoFieldVariable],
     ['field_dropdown', 'FieldDropdown', CdoFieldDropdown],
+    ['field_colour', 'FieldColour', CdoFieldColour],
     ['field_number', 'FieldNumber', CdoFieldNumber],
     // CdoFieldBitmap extends from a JavaScript class without typing.
     // We know it's a field, so it's safe to cast as unknown.

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -38,6 +38,7 @@ import CdoFieldAnimationDropdown from './addons/cdoFieldAnimationDropdown';
 import CdoFieldBehaviorPicker from './addons/cdoFieldBehaviorPicker';
 import {CdoFieldBitmap} from './addons/cdoFieldBitmap';
 import CdoFieldButton from './addons/cdoFieldButton';
+import CdoFieldColour from './addons/cdoFieldColour';
 import CdoFieldFlyout from './addons/cdoFieldFlyout';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
 import CdoFieldParameter from './addons/cdoFieldParameter';
@@ -120,6 +121,7 @@ export interface BlocklyWrapperType extends GoogleBlocklyType {
   FieldToggle: typeof CdoFieldToggle;
   FieldFlyout: typeof CdoFieldFlyout;
   FieldBitmap: typeof CdoFieldBitmap;
+  FieldColour: typeof CdoFieldColour;
   FieldVariable: typeof CdoFieldVariable;
   FieldParameter: typeof CdoFieldParameter;
   JavaScript: JavascriptGeneratorType;

--- a/apps/src/turtle/artist.js
+++ b/apps/src/turtle/artist.js
@@ -555,16 +555,20 @@ Artist.prototype.afterInject_ = function (config) {
   visualization.appendChild(this.visualization.displayCanvas);
 
   if (this.studioApp_.isUsingBlockly() && this.isFrozenSkin()) {
+    // Google Blockly uses forBlock, CDO Blockly does not.
+    const blockGeneratorFunctionDictionary =
+      Blockly.JavaScript.forBlock || Blockly.JavaScript;
     // Override colour_random to only generate random colors from within our frozen
     // palette
-    Blockly.JavaScript.colour_random = function () {
+    blockGeneratorFunctionDictionary.colour_random = function () {
       // Generate a random colour.
       if (!Blockly.JavaScript.definitions_.colour_random) {
         var functionName = Blockly.JavaScript.variableDB_.getDistinctName(
           'colour_random',
           Blockly.Generator.NAME_TYPE
         );
-        Blockly.JavaScript.colour_random.functionName = functionName;
+        blockGeneratorFunctionDictionary.colour_random.functionName =
+          functionName;
         var func = [];
         func.push('function ' + functionName + '() {');
         func.push(
@@ -574,7 +578,8 @@ Artist.prototype.afterInject_ = function (config) {
         func.push('}');
         Blockly.JavaScript.definitions_.colour_random = func.join('\n');
       }
-      var code = Blockly.JavaScript.colour_random.functionName + '()';
+      var code =
+        blockGeneratorFunctionDictionary.colour_random.functionName + '()';
       return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
     };
   }

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -2595,15 +2595,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@blockly/field-colour@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@blockly/field-colour@npm:4.0.0"
-  peerDependencies:
-    blockly: ^10.4.3
-  checksum: 206c614cc3b405d18ecf66f47c0cbe1938726f4a99a48806edda4509f6f6721cc63670bd756d85cf1b0820459af43404a7e7bba6424eff27bcaee291f694845b
-  languageName: node
-  linkType: hard
-
 "@blockly/field-grid-dropdown@npm:~4.0.9":
   version: 4.0.10
   resolution: "@blockly/field-grid-dropdown@npm:4.0.10"
@@ -8161,7 +8152,6 @@ __metadata:
     "@babel/preset-react": ^7.24.1
     "@blockly/block-shareable-procedures": ~4.0.5
     "@blockly/field-bitmap": ^4.1.0
-    "@blockly/field-colour": ^4.0.0
     "@blockly/field-grid-dropdown": ~4.0.9
     "@blockly/keyboard-navigation": ~0.5.6
     "@blockly/plugin-cross-tab-copy-paste": ~5.0.4


### PR DESCRIPTION
Includes a manual revert of:
- https://github.com/code-dot-org/code-dot-org/pull/57895

The Frozen skin of our Artist lab uses a separate color palette for drawn lines. This impacts the dropdown options in color picker blocks and the generated code for the "random color" block. 


## Color Fields

The way this has worked is by manually modifying `FieldColour.COLOURS` when we install blocks for Artist:
https://github.com/code-dot-org/code-dot-org/blob/dbe67a6960ebf3968a57b20f9e135e638811ae86/apps/src/turtle/blocks.js#L94-L128

These "static" properties are defined in both CDO Blockly and Google Blockly, but only up until v10, our current version. In fact, the entire field was removed from core in v11 in favor of a separate plugin. We actually did the work to get onto the plugin in advance a few months ago https://github.com/code-dot-org/code-dot-org/pull/57895 but now it's making things harder. 
If we revert to just using the version that exists (for now) in core, we can continue to use the static properties which will allow us to migrate Artist. Once that migration is complete, we should rework the custom color logic so that we provide the skin-specific lists to the field class as a config option at the time of creating the block definition. At that point, we should be able to move back to the plugin, which will be required for bumping to v11.

This whole thing is bit weird since modifying these values violates encapsulation. To handle this in CDO Blockly, we modified the color field directly to access these "static" values at the time we create the dropdown.

https://github.com/code-dot-org/blockly/commit/f68cc050ae7473bd547eb4cb560376cb83e55337

For Google Blockly, we can accomplish the same thing by setting the colours and columns values during `showEditor_` (because `dropdownCreate` is also private).

## Code Generation

Even though the random color block doesn't have a colour field, we still needed to extend the class so that `Blockly.FieldColour.COLOURS` will point to the correct value. See https://github.com/code-dot-org/code-dot-org/blob/dbe67a6960ebf3968a57b20f9e135e638811ae86/apps/src/turtle/artist.js#L575

With the work above completed, we only needed to make one other update to the code generation side to get that block work. Specifically, we need to address that Blocklly moved all generator functions to a new dictionary using a `forBlock` property:
https://github.com/google/blockly/pull/7150
https://developers.google.com/blockly/reference/js/blockly.codegenerator_class.forblock_property

Since this new property doesn't exist on CDO Blockly, it should be safe enough to identify the dictionary based on whether or not `forBlock` exists. If we don't add the function to `forBlock` for Google Blockly, we are effectively failing to override the included generator function, but there are no errors.

## Links

Jira: https://codedotorg.atlassian.net/browse/CT-709
Slack discussion: https://codedotorg.slack.com/archives/C05HZFH7BED/p1722542821339269


<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Manually tested. See screenshots below.

A comparison of the `colour_picker` block between Frozen and standard skins. This is a standard Blockly block where we modify the dropdown options by hijacking `blockly.FieldColour.COLOURS`:
<img width="137" alt="image" src="https://github.com/user-attachments/assets/f4877258-5a6a-4593-b2a4-edb84895f092">
<img width="140" alt="image" src="https://github.com/user-attachments/assets/ea32e15b-43ee-4363-89b6-7bdf8f50af38">

Here is the same `colour_picker` block as it shows up in Dance, without customizing the static properties:
<img width="262" alt="image" src="https://github.com/user-attachments/assets/39699cc8-9b5c-4239-9ab4-57697c662d96">

Here is a Dance block (of type `Dancelab_setTintEachInline`) which used our `limitedColourPicker` custom input type. This block's field is created with a custom config option for its 9 colors and 3 columns. These are prioritized over the static properties. (This should be considered the "correct" way to modiy the dropdown options.
<img width="193" alt="image" src="https://github.com/user-attachments/assets/dbd0451b-c591-4ab8-aa4c-3a98bb4ef2c8">

Before and after fixing the generator function for the random colour block:
<img width="849" alt="image" src="https://github.com/user-attachments/assets/310d5788-c298-40a7-9f32-7b8a04dc6d87">

<img width="860" alt="image" src="https://github.com/user-attachments/assets/4bbdad7b-e9d6-4824-bd2c-824a08f0d9f4">


## Follow-up work

1. After the Artist migration is complete, we should rework the Artist skins so that the custom palettes are provided to Blockly when defining (or re-defining) the `colour_picker` block. https://codedotorg.atlassian.net/browse/CT-715
2. When bumping to v11 (or before), move back to using the colour field from the plugin. Consider whether we can remove our extended class entirely after step 1 is complete. https://codedotorg.atlassian.net/browse/CT-597

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
