### PR TITLE
[Google Blockly] Merge level toolbox xml blocks into auto-populated functions category

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -800,3 +800,22 @@ export function getCodeFromBlockXmlSource(blockXmlString: string) {
   workspace.dispose();
   return result;
 }
+
+// Returns a list of Blockly toolbox blocks in JSON for a given category.
+// This is used in order to merge XML toolbox blocks with the dynamically created
+// blocks in auto-populated categories, such as Behaviors, Functions, and Variables.
+export function getCategoryBlocksJson(category: string) {
+  const levelToolboxBlocks = Blockly.cdoUtils.getLevelToolboxBlocks(category);
+  if (!levelToolboxBlocks?.querySelector('xml')?.hasChildNodes()) {
+    return [];
+  }
+
+  // Blockly supports XML or JSON, but not a combination of both.
+  // We convert to JSON here because the other flyout blocks are JSON.
+  const blocksConvertedJson = convertXmlToJson(
+    levelToolboxBlocks.documentElement
+  );
+  const flyoutJson = getSimplifiedStateForFlyout(blocksConvertedJson);
+
+  return flyoutJson;
+}

--- a/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/behaviorBlocks.ts
@@ -4,7 +4,6 @@ import {BlockChange} from 'blockly/core/events/events_block_change';
 import {FlyoutItemInfoArray} from 'blockly/core/utils/toolbox';
 
 import BlockSvgFrame from '@cdo/apps/blockly/addons/blockSvgFrame';
-import {convertXmlToJson} from '@cdo/apps/blockly/addons/cdoSerializationHelpers';
 import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
 import {ExtendedBlockSvg, ProcedureBlock} from '@cdo/apps/blockly/types';
 import {commonI18n} from '@cdo/apps/types/locale';
@@ -245,19 +244,7 @@ export function flyoutCategory(
   }
 
   // Add blocks from the level toolbox XML, if present.
-  const levelToolboxBlocks = Blockly.cdoUtils.getLevelToolboxBlocks('Behavior');
-  if (!levelToolboxBlocks?.querySelector('xml')?.hasChildNodes()) {
-    return blockList;
-  }
-
-  // Blockly supports XML or JSON, but not a combination of both.
-  // We convert to JSON here because the behavior_get blocks are JSON.
-  const blocksConvertedJson = convertXmlToJson(
-    levelToolboxBlocks.documentElement
-  );
-  const blocksJson =
-    Blockly.cdoUtils.getSimplifiedStateForFlyout(blocksConvertedJson);
-  blockList.push(...blocksJson);
+  blockList.push(...Blockly.cdoUtils.getCategoryBlocksJson('Behavior'));
 
   // Workspaces to populate behaviors flyout category from
   const workspaces = [

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
@@ -398,6 +398,9 @@ export function flyoutCategory(
     blockList.push(functionDefinitionBlock);
   }
 
+  // Add blocks from the level toolbox XML, if present.
+  blockList.push(...Blockly.cdoUtils.getCategoryBlocksJson('PROCEDURE'));
+
   // Workspaces to populate functions flyout category from
   const workspaces = [
     Blockly.getMainWorkspace(),

--- a/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/variableBlocks.ts
@@ -1,7 +1,6 @@
 import {WorkspaceSvg} from 'blockly';
 import {BlockInfo, FlyoutItemInfoArray} from 'blockly/core/utils/toolbox';
 
-import {convertXmlToJson} from '@cdo/apps/blockly/addons/cdoSerializationHelpers';
 import {commonI18n} from '@cdo/apps/types/locale';
 
 /**
@@ -18,20 +17,7 @@ export function flyoutCategory(workspace: WorkspaceSvg) {
   blockList.push(...categoryBlocks);
 
   // Add blocks from the level toolbox XML, if present.
-  const levelToolboxBlocks = Blockly.cdoUtils.getLevelToolboxBlocks('VARIABLE');
-  if (!levelToolboxBlocks?.querySelector('xml')?.hasChildNodes()) {
-    return blockList;
-  }
-
-  // Blockly supports XML or JSON, but not a combination of both.
-  // We convert to JSON here because the behavior_get blocks are JSON.
-  const blocksConvertedJson = convertXmlToJson(
-    levelToolboxBlocks.documentElement
-  );
-  const flyoutJson =
-    Blockly.cdoUtils.getSimplifiedStateForFlyout(blocksConvertedJson);
-
-  blockList.push(...flyoutJson);
+  blockList.push(...Blockly.cdoUtils.getCategoryBlocksJson('VARIABLE'));
 
   // The toolox may include "change [var] by" blocks with custom default values.
   // If any of these blocks are found, we can remove the auto-generated block.


### PR DESCRIPTION
Normally with Google Blockly, the Functions category flyout will contain:
1. Either a "new function" button, or an empty definition block (depending on whether the modal editor is enabled)
2. A call block for each defined function

In the Frozen project level, there are also a couple of additional blocks which are defined in the level toolbox XML.

<img width="518" alt="image" src="https://github.com/user-attachments/assets/470f5441-f345-49f7-b796-5932b1554fd7">
 Both `create_a_circle_size` and `create_snowflake_dropdown` are custom Artist blocks that only look like function call blocks. (`do something` and `do something2` were created as a student, using the button)
<br/>
<img width="383" alt="image" src="https://github.com/user-attachments/assets/3d72c245-9331-40fd-9a36-0a55d4b9235c">

Fortunately, this a problem we already solved in advance of the Sprite Lab migration for variables and behaviors. It was just not known at the time that we also had levels that did this with functions.

When I did this for variables https://github.com/code-dot-org/code-dot-org/pull/54302, I lazily copied some code from behaviors to variables. Now that we have "many" (aka 3) instances that need this logic, I've moved it to a util.


## Links

https://codedotorg.atlassian.net/browse/CT-709
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Manually tested.

![image](https://github.com/user-attachments/assets/8b586e87-5be5-44bc-81c8-cdbd5821d048)

I also manually confirmed that there were no regressions for behaviors or variables in Sprite Lab:

![image](https://github.com/user-attachments/assets/6a04990d-0774-4136-a177-6629f8853042)
![image](https://github.com/user-attachments/assets/98bf95b6-a15f-4516-9f25-4a6ae14fb359)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
