### PR TITLE
P20 1001/confirmation banner after account linking

### DIFF
--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -50,6 +50,7 @@ module Lti
             metadata: metadata,
           )
           target_url = session[:user_return_to] || home_path
+          flash[:notice] = I18n.t('lti.account_linking.successfully_linked')
           redirect_to target_url
         else
           flash.alert = I18n.t('lti.account_linking.invalid_credentials')

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -362,6 +362,8 @@ class LtiV1Controller < ApplicationController
     respond_to do |format|
       format.html do
         if had_changes || params[:force]
+          session[:keep_flashes] = true
+          flash.keep
           render lti_v1_sync_course_path
         else
           redirect_to home_path

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -593,6 +593,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         event_name: 'lti_user_signin',
         metadata: metadata,
       )
+      flash[:notice] = I18n.t('lti.account_linking.successfully_linked')
       sign_in_and_redirect user and return
     end
 

--- a/dashboard/app/helpers/application_helper.rb
+++ b/dashboard/app/helpers/application_helper.rb
@@ -80,17 +80,29 @@ module ApplicationHelper
     ret = ''
     if notice.present?
       ret += content_tag(:div, flash.notice, {class: 'alert alert-success'})
-      flash.notice = nil
+      if session[:keep_flashes]
+        session[:keep_flashes] = false
+      else
+        flash.notice = nil
+      end
     end
 
     if flash[:info].present?
       ret += content_tag(:div, flash[:info], {class: 'alert alert-info'})
-      flash[:info] = nil
+      if session[:keep_flashes]
+        session[:keep_flashes] = false
+      else
+        flash[:info] = nil
+      end
     end
 
     if alert.present?
       ret += content_tag(:div, flash.alert, {class: 'alert alert-danger'})
-      flash.alert = nil
+      if session[:keep_flashes]
+        session[:keep_flashes] = false
+      else
+        flash.alert = nil
+      end
     end
 
     ret

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1454,6 +1454,7 @@ en:
       linking_page_header: "Link your %{provider} account to your existing Code.org account"
       linking_page_description: "Choose the sign-in method you normally use to access Code.org"
       sign_in_and_connect: "Sign in and connect"
+      successfully_linked: "You have successfully linked your Code.org account!"
     create_integration_success: "Successfully created your LTI integration"
     dynamic_registration_title: "Code.org Dynamic Registration"
     error:

--- a/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
@@ -37,6 +37,7 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
       )
     )
     post :link_email, params: {email: @user.email, password: 'password'}
+    assert_equal "You have successfully linked your Code.org account!", flash[:notice]
     assert_redirected_to target_url
     assert Policies::Lti.lti?(@user)
   end

--- a/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/account_linking_controller_test.rb
@@ -37,7 +37,7 @@ class Lti::V1::AccountLinkingControllerTest < ActionController::TestCase
       )
     )
     post :link_email, params: {email: @user.email, password: 'password'}
-    assert_equal "You have successfully linked your Code.org account!", flash[:notice]
+    assert_equal I18n.t('lti.account_linking.successfully_linked'), flash[:notice]
     assert_redirected_to target_url
     assert Policies::Lti.lti?(@user)
   end

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1798,7 +1798,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
           # so this includes 1 email, 1 SSO, and 1 LTI auth option
           _(user.authentication_options.count).must_equal 3
           _(user.authentication_options).must_include lti_auth_option
-          assert_equal "You have successfully linked your Code.org account!", flash[:notice]
+          assert_equal I18n.t('lti.account_linking.successfully_linked'), flash[:notice]
         end
 
         context 'if account linking is locked for user' do

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1798,6 +1798,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
           # so this includes 1 email, 1 SSO, and 1 LTI auth option
           _(user.authentication_options.count).must_equal 3
           _(user.authentication_options).must_include lti_auth_option
+          assert_equal "You have successfully linked your Code.org account!", flash[:notice]
         end
 
         context 'if account linking is locked for user' do

--- a/i18n/locales/source/dashboard/base.yml
+++ b/i18n/locales/source/dashboard/base.yml
@@ -1454,7 +1454,6 @@ en:
       linking_page_header: "Link your %{provider} account to your existing Code.org account"
       linking_page_description: "Choose the sign-in method you normally use to access Code.org"
       sign_in_and_connect: "Sign in and connect"
-      successfully_linked: "You have successfully linked your Code.org account!"
     create_integration_success: "Successfully created your LTI integration"
     dynamic_registration_title: "Code.org Dynamic Registration"
     error:

--- a/i18n/locales/source/dashboard/base.yml
+++ b/i18n/locales/source/dashboard/base.yml
@@ -1454,6 +1454,7 @@ en:
       linking_page_header: "Link your %{provider} account to your existing Code.org account"
       linking_page_description: "Choose the sign-in method you normally use to access Code.org"
       sign_in_and_connect: "Sign in and connect"
+      successfully_linked: "You have successfully linked your Code.org account!"
     create_integration_success: "Successfully created your LTI integration"
     dynamic_registration_title: "Code.org Dynamic Registration"
     error:


### PR DESCRIPTION
Adds a confirmation banner after linking an existing account to an LMS account. This banner will only appear when the LMS target_link_uri is set to certain pages. There are more details in the [Jira ticket](https://codedotorg.atlassian.net/browse/P20-1001). 

![image](https://github.com/user-attachments/assets/df5713c2-5305-4b79-92f9-29db6c6f4d13)

## Links

- Jira Ticket: [P20-1001](https://codedotorg.atlassian.net/browse/P20-1001)