### PR TITLE
Music: report pack ID selection to Amplitude

### DIFF
--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -50,20 +50,21 @@ interface BlockStats {
   maxTriggerBlocksWithCode: number;
 }
 
-interface Session {
-  startTime: number;
-  soundsUsed: Set<string>;
-  soundsPlayed: {[id: string]: number};
+interface CommonSessionFields {
   blockStats: BlockStats;
   featuresUsed: {[feature: string]: boolean};
+  soundsPlayed: {[id: string]: number};
+  selectedPack?: string;
 }
 
-interface SessionEndPayload {
+interface Session extends CommonSessionFields {
+  startTime: number;
+  soundsUsed: Set<string>;
+}
+
+interface SessionEndPayload extends CommonSessionFields {
   durationSeconds: number;
   soundsUsed: string[];
-  blockStats: BlockStats;
-  featuresUsed: {[feature: string]: boolean};
-  soundsPlayed: {[id: string]: number};
 }
 
 const trackedProjectProperties = [
@@ -181,6 +182,18 @@ export default class AnalyticsReporter {
     this.log(`Project property: ${property}: ${value}`);
   }
 
+  setSelectedPack(packId: string | undefined) {
+    if (!this.session) {
+      this.log('No session in progress');
+      return;
+    }
+    this.session.selectedPack = packId;
+  }
+
+  onPackSelected(packId: string) {
+    this.onButtonClicked('select-pack', {packId});
+  }
+
   onButtonClicked(buttonName: string, properties?: object) {
     this.trackUIEvent('Button clicked', {
       buttonName,
@@ -278,11 +291,9 @@ export default class AnalyticsReporter {
     const duration = Date.now() - this.session.startTime;
 
     const payload: SessionEndPayload = {
+      ...this.session,
       durationSeconds: duration / 1000,
       soundsUsed: Array.from(this.session.soundsUsed),
-      blockStats: this.session.blockStats,
-      featuresUsed: this.session.featuresUsed,
-      soundsPlayed: this.session.soundsPlayed,
     };
 
     this.session = undefined;

--- a/apps/src/music/views/hooks/useUpdateAnalytics.ts
+++ b/apps/src/music/views/hooks/useUpdateAnalytics.ts
@@ -109,6 +109,11 @@ function useUpdateAnalytics(analyticsReporter: AnalyticsReporter) {
     sessionInProgress &&
       analyticsReporter.setProjectProperty('scriptName', scriptName);
   }, [sessionInProgress, scriptName, analyticsReporter]);
+
+  const packId = useAppSelector(state => state.music.packId || undefined);
+  useEffect(() => {
+    sessionInProgress && analyticsReporter.setSelectedPack(packId);
+  }, [sessionInProgress, packId, analyticsReporter]);
 }
 
 export default useUpdateAnalytics;


### PR DESCRIPTION
Records analytics when a user chooses a pack in the pack dialog, as well as storing the currently selected pack whenever it changes. This also includes the situation where the user is opening a project that already has a pack selected, so we can track what pack they used for that session.

The pack selection is reported as a 'button click' event, and the final chosen pack is also reported as part of the session end payload in amplitude.

**Button click event:**
<img width="656" alt="Screenshot 2024-08-02 at 2 01 12 PM" src="https://github.com/user-attachments/assets/cfd1a705-bb67-435a-8495-eaf90f35f3c5">

**Additional metadata in the session end event:**
<img width="423" alt="Screenshot 2024-08-02 at 2 01 46 PM" src="https://github.com/user-attachments/assets/ee876469-c453-4ac9-a8f4-5dd1e83278d4">

## Links

https://codedotorg.atlassian.net/browse/LABS-901

## Testing story

Tested with standalone music projects, as well as script levels. For script levels (like the onboarding progression) where no pack ID is specified, no pack ID is reported with the final payload.