### PR TITLE
Document Some Unexpected Chef Behavior on Adhocs

### DIFF
--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -78,6 +78,6 @@ When we [render the template that defines the bootstrap
 script](https://github.com/code-dot-org/code-dot-org/blob/bb519086d25905c10f801ce737629094fa25741d/aws/cloudformation/bootstrap_chef_stack.sh.erb#L152),
 it [uploads the output of `berks package` to S3 as a side
 effect](https://github.com/code-dot-org/code-dot-org/blob/bb519086d25905c10f801ce737629094fa25741d/lib/cdo/cloud_formation/cdo_app.rb#L163-L182).
-That artifact is then [downloaded to `/var/chef/cookbooks` as part of
-initial
-bootstrapping](https://github.com/code-dot-org/code-dot-org/blob/bb519086d25905c10f801ce737629094fa25741d/aws/chef-bootstrap.sh#L133-L135).
+That artifact is then [downloaded to `/var/chef/cookbooks` as part of initial
+bootstrapping](https://github.com/code-dot-org/code-dot-org/blob/bb519086d25905c10f801ce737629094fa25741d/aws/chef-bootstrap.sh#L133-L135),
+but will not thereafter be automatically updated.

--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -61,3 +61,23 @@ KITCHEN_LOCAL_YAML=../.kitchen.ec2.yml bundle exec kitchen [create|converge|veri
 
 Note that the live EC2 instance will continue consuming resources until `destroy` is called,
 so make sure to do this at the end of your testing!
+
+## Adding a New Dependency
+
+When adding a new dependency to an individual cookbook, there are three places you need to declare the dependency:
+
+1. The cookbook-specific Berksfile; ie, `cookbook 'pyenv'` in `cookbooks/cdo-python/Berksfile`
+2. The cookbook-specific metadata.rb; ie, `depends 'pyenv'` in `cookbooks/cdo-python/metadata.rb`
+3. The top-level Berksfile; ie, `cookbook 'pyenv'` in `cookbooks/Berksfile`
+
+## Deploying Cookbooks to Adhocs
+
+Note that adhocs will not automatically pick up updates to cookbook code.
+
+When we [render the template that defines the bootstrap
+script](https://github.com/code-dot-org/code-dot-org/blob/bb519086d25905c10f801ce737629094fa25741d/aws/cloudformation/bootstrap_chef_stack.sh.erb#L152),
+it [uploads the output of `berks package` to S3 as a side
+effect](https://github.com/code-dot-org/code-dot-org/blob/bb519086d25905c10f801ce737629094fa25741d/lib/cdo/cloud_formation/cdo_app.rb#L163-L182).
+That artifact is then [downloaded to `/var/chef/cookbooks` as part of
+initial
+bootstrapping](https://github.com/code-dot-org/code-dot-org/blob/bb519086d25905c10f801ce737629094fa25741d/aws/chef-bootstrap.sh#L133-L135).


### PR DESCRIPTION
Specifically: it's often surprising to find out that adhocs don't automatically pick up changes to Chef cookbooks, and the process for adding a new dependency to a cookbook is a bit more convoluted than it should be.

I recommend reviewing [the rich text diff](https://github.com/code-dot-org/code-dot-org/pull/60181/files?short_path=cce89eb#diff-cce89eb8537756dd5be89ad0f03055f85fc9ff1f1bd64077c4eeb1020f4536da) in addition to the source text diff.

## Links

Inspired by some debugging we had to do for https://github.com/code-dot-org/code-dot-org/pull/60048

## Follow-up work

Currently, cookbooks get uploaded to S3 as a side effect of calling `cookbooks_path`, which gets called as a side effect of rendering `bootstrap_chef_stack.sh.erb`. I'd argue we should revisit that workflow.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
