### PR TITLE
Remove Stray Temporary Comment

### DIFF
--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -25,8 +25,6 @@ namespace :ci do
         end
       end
     elsif CDO.daemon && CDO.chef_managed
-
-      # Temporarily disable automatic chef cookbook updates for Ubuntu upgrade except for envs undergoing upgrade
       ChatClient.log('Updating Chef cookbooks...')
       RakeUtils.with_bundle_dir(cookbooks_dir) do
         # Automatically update Chef cookbook versions in staging environment.


### PR DESCRIPTION
This comment was added in reference to some temporary changes we made several years ago: https://github.com/code-dot-org/code-dot-org/pull/30881. The temporary changes themselves [were cleaned up not long after](https://github.com/code-dot-org/code-dot-org/commit/b815299ddb72bb917d13c3a0e48729b6f7e5ce1e), but the comment lingered.
