### PR TITLE
Report eyes diff as a different metric to the cloudwatch dashboard.

### DIFF
--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -343,10 +343,7 @@ def run_tests(env, feature, target_platform, arguments, log_prefix)
                         feature_name: feature.include?(".feature") ? feature.split(".feature")[0] : feature,
                         target_browser: target_platform}
     # Metrics for individual feature runs. They will be flushed once all of them run
-    unless eyes_succeeded
-      Infrastructure::Logger.put("runner_feature_eyes_diff", 1, extra_dimensions)
-    end
-
+    Infrastructure::Logger.put("runner_feature_eyes_diff", 1, extra_dimensions) unless eyes_succeeded
     Infrastructure::Logger.put("runner_feature_success", cucumber_succeeded ? 1 : 0, extra_dimensions)
     Infrastructure::Logger.put("runner_feature_failure", cucumber_succeeded ? 0 : 1, extra_dimensions)
     Infrastructure::Logger.put("runner_feature_execution_time", duration, extra_dimensions)

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -343,6 +343,10 @@ def run_tests(env, feature, target_platform, arguments, log_prefix)
                         feature_name: feature.include?(".feature") ? feature.split(".feature")[0] : feature,
                         target_browser: target_platform}
     # Metrics for individual feature runs. They will be flushed once all of them run
+    unless eyes_succeeded
+      Infrastructure::Logger.put("runner_feature_eyes_diff", 1, extra_dimensions)
+    end
+
     Infrastructure::Logger.put("runner_feature_success", cucumber_succeeded ? 1 : 0, extra_dimensions)
     Infrastructure::Logger.put("runner_feature_failure", cucumber_succeeded ? 0 : 1, extra_dimensions)
     Infrastructure::Logger.put("runner_feature_execution_time", duration, extra_dimensions)

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -344,8 +344,8 @@ def run_tests(env, feature, target_platform, arguments, log_prefix)
                         target_browser: target_platform}
     # Metrics for individual feature runs. They will be flushed once all of them run
     Infrastructure::Logger.put("runner_feature_eyes_diff", 1, extra_dimensions) unless eyes_succeeded
-    Infrastructure::Logger.put("runner_feature_success", cucumber_succeeded ? 1 : 0, extra_dimensions)
-    Infrastructure::Logger.put("runner_feature_failure", cucumber_succeeded ? 0 : 1, extra_dimensions)
+    Infrastructure::Logger.put("runner_feature_success", 1, extra_dimensions) if cucumber_succeeded
+    Infrastructure::Logger.put("runner_feature_failure", 1, extra_dimensions) unless cucumber_succeeded
     Infrastructure::Logger.put("runner_feature_execution_time", duration, extra_dimensions)
     return cucumber_succeeded, eyes_succeeded, stdout, stderr, duration
   end


### PR DESCRIPTION
Eyes diffs are not considered as errors and hence not reported as runner failures to cloud watch metrics. Although this is true in the ideal case, we have many instances where eyes diffs tend to be flaky and needs to be surfaced for appropriate prioritization.

Fix: When UI tests fail due to eyes diffs, emit that as a different metric for seeing trends in the dashboard. This would contain valid/expected diffs to start with, but once we do the work to ensure eyes diffs are accepted as part of the PRs, this would only report on flaky issues.

## Links

JIRA https://codedotorg.atlassian.net/browse/TEACH-1227

## Testing story

Validated the change by running eyes test locally and seeing metrics show up for an intentionally introduced diff
- [Cloudwatch dashboard with metrics emitted in local testing](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~'Infrastructure~'runner_feature_eyes_diff~'environment~'development~'feature_name~'features*2feyes~'target_browser~'LocalBrowser~'test_type~'Eyes~'is_continuous_integration_run~'false))~sparkline~false~view~'table~stacked~false~region~'us-east-1~stat~'Average~period~300)&query=~'*7bInfrastructure*2cenvironment*2cfeature_name*2cis_continuous_integration_run*2ctarget_browser*2ctest_type*7d*20runner_feature_eyes_diff)
- [Diffs in applit tools](https://eyes.applitools.com/app/test-results/00000251679409808080/?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
