### PR TITLE
Fix translation issue in hamburger menu on studio

### DIFF
--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -1,5 +1,7 @@
 :ruby
   options = { level: level, script_level: script_level, language: language, user_type: user_type, loc_prefix: loc_prefix, request: request }
+  user_header_options = { loc_prefix: loc_prefix }
+  dashboard ||= false
   contents = Hamburger.get_hamburger_contents(options)
 
 #hamburger{class: contents[:visibility], tabindex: "0", 'aria-label': I18n.t('header_screen_reader_hamburger')}
@@ -10,12 +12,12 @@
         .button-wrapper
           %a.linktag{href: CDO.studio_url('users/sign_in'), class: 'button-signin', id: 'signin_button'}
             .header_button.header_user#header_user_signin
-              %span= I18n.t("user_header_signin")
+              %span= I18n.t(dashboard ? "#{user_header_options[:loc_prefix]}signin" : "user_header_signin")
               .signin_callout_wrapper
           -# Create Acount button for the A/B test
           %a.linktag{href: CDO.studio_url('users/sign_up'), class: 'button-create-account', id: 'create_account_button'}
             .header_button.header_user#header_user_create_account
-              %span= I18n.t("user_header_create_account_low_cap")
+              %span= I18n.t(dashboard ? "#{user_header_options[:loc_prefix]}create_account_low_cap" : "user_header_create_account_low_cap")
         .divider
     - contents[:entries].each do |entry|
       - if entry[:type] == "divider"


### PR DESCRIPTION
Fixes broken translations for the new `Sign in` and `Create account` buttons in the hamburger when in the Test bucket for the Create Account Button experiment. This adds logic to display the correct string prefix for studio.code.org. Dashboard strings come from the [en.yml](https://github.com/code-dot-org/code-dot-org/blob/7f29fda5a11c2b4ab9760e802b1bce0b356f3e42/dashboard/config/locales/en.yml#L439-L442) file, whereas code.org strings come from the [i18n](https://docs.google.com/spreadsheets/d/1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU/edit?gid=0#gid=0&range=1554:1556) gsheet that has a different prefix.

## Links
Jira ticket: [ACQ-2184](https://codedotorg.atlassian.net/browse/ACQ-2184)
Slack convo: [here](https://codedotorg.slack.com/archives/C0453TUMLE7/p1722635379775619)

## Testing story
Tested locally

----

| Before on studio | After code.org | After studio.code.org |
| ---- | ---- | ---- |
| ![studio code org_incubator(Code org - 390x844)](https://github.com/user-attachments/assets/3939668b-ddb8-4326-b63b-e34bc7906823) | ![localhost code org_3000_students(Code org - 390x844)](https://github.com/user-attachments/assets/d0af94c4-7d47-4048-95a9-811fea593eab) | ![localhost-studio code org_3000_incubator(Code org - 390x844)](https://github.com/user-attachments/assets/764ef059-638c-40f6-9a0f-04ecb235d183) |

## Spanish

| code.org | studio.code.org |
| ---- | ---- |
| ![localhost code org_3000_students(Code org - 390x844)](https://github.com/user-attachments/assets/89c8e835-c79b-466e-8ed5-732cdc0a7d6b) | ![localhost-studio code org_3000_incubator(Code org - 390x844)](https://github.com/user-attachments/assets/f1dc6e82-46ba-4359-82e2-328b800b3b0a) |

