### PR TITLE
Delete MySQL 5.7 ParameterGroups

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -114,53 +114,6 @@
 # We don't yet provision the production database cluster/instances via CloudFormation, but we're incrementally
 # working towards that. Start with provisioning the DB Instance and Cluster ParameterGroups via this template.
 
-  # Aurora Engine 2.x (MySQL 5.x) ParameterGroups
-  AuroraClusterDBParameters:
-    Type: AWS::RDS::DBClusterParameterGroup
-    Properties:
-      Description: !Sub "Aurora Cluster DB Parameters for ${AWS::StackName}."
-      Family: aurora-mysql5.7
-      Parameters:
-        # BEGIN: Static configuration settings.
-        # WARNING - Changing these settings triggers restart of each database instance in the cluster during Stack Update.
-
-        binlog_format: 'ROW'
-        gtid-mode: 'ON'
-        enforce_gtid_consistency: 'ON'
-
-        innodb_autoinc_lock_mode: 2
-        #END: Static configuration settings.
-
-        # BEGIN: Dynamic configuration settings. Changing these settings does NOT require nor trigger restart of instances.
-        slow_query_log: 1
-        innodb_monitor_enable: all
-        tx_isolation: READ-COMMITTED
-
-        # Prevent a slow query from degrading instance or cluster performance.
-        # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_execution_time
-        max_execution_time: 30000
-
-        # Favor write performance over durability. In the event of a database server crash
-        # we could lose roughly 1 second of transactions.
-        # https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_flush_log_at_trx_commit
-        innodb_flush_log_at_trx_commit: 1
-        # END: Dynamic configuration settings.
-  AuroraWriterDBParameters:
-    Type: AWS::RDS::DBParameterGroup
-    Properties:
-      Description: !Sub "Aurora Writer DB Parameters for ${AWS::StackName}."
-      Family: aurora-mysql5.7
-      Parameters:
-        # BEGIN: Static configuration settings. Changing these settings will trigger a restart of each database instance.
-
-        # END: Static configuration settings.
-
-        # BEGIN: Dynamic configuration settings. Changing these settings does NOT require nor trigger restart of instances.
-
-        # Prevent a slow query from degrading instance or cluster performance.
-        # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_execution_time
-        max_execution_time: 30000
-        # END: Dynamic configuration settings.
   Aurora3ClusterDBParameters:
     Type: AWS::RDS::DBClusterParameterGroup
     Properties:


### PR DESCRIPTION
Now that we've deleted the old production MySQL 5.7 Aurora 2.x cluster, we can delete the Aurora 2.x / MySQL 5.7 cluster and instance ParameterGroups.

https://codedotorg.atlassian.net/browse/INF-1394

## Testing story

This adhoc provisioned successfully:

`bundle exec rake adhoc:start RAILS_ENV=adhoc DATABASE=yupMakeAnAuroraCluster STACK_NAME=adhoc-delete-mysql57-configuration`

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
