### PR TITLE
Add ChatEventLogger unit tests

### DIFF
--- a/apps/src/aichat/chatEventLogger.ts
+++ b/apps/src/aichat/chatEventLogger.ts
@@ -25,18 +25,24 @@ export default class ChatEventLogger {
     return ChatEventLogger.instance;
   }
 
-  public static create() {
+  public static create(): void {
     ChatEventLogger.instance = new ChatEventLogger();
   }
 
-  logChatEvent(chatEvent: ChatEvent, aichatContext: AichatContext) {
+  // For testing purposes.
+  public setSendingInProgress(sendingInProgress: boolean): void {
+    this.sendingInProgress = sendingInProgress;
+  }
+
+  public logChatEvent(chatEvent: ChatEvent, aichatContext: AichatContext) {
     this.queue.push({chatEvent, aichatContext});
     if (!this.sendingInProgress) {
       this.sendChatEvent();
     }
   }
 
-  private async sendChatEvent() {
+  // Not private for testing purposes.
+  async sendChatEvent() {
     // Send aichat events to the server to be logged.
     while (this.queue.length > 0) {
       const loggerPayload = this.queue.shift(); // Remove the first element from the queue.
@@ -52,7 +58,6 @@ export default class ChatEventLogger {
           Lab2Registry.getInstance()
             .getMetricsReporter()
             .logError('Error in aichat event logging request', error as Error);
-          return;
         }
       }
     }

--- a/apps/src/aichat/chatEventLogger.ts
+++ b/apps/src/aichat/chatEventLogger.ts
@@ -29,11 +29,6 @@ export default class ChatEventLogger {
     ChatEventLogger.instance = new ChatEventLogger();
   }
 
-  // For testing purposes only.
-  setSendingInProgress(sendingInProgress: boolean): void {
-    this.sendingInProgress = sendingInProgress;
-  }
-
   public logChatEvent(chatEvent: ChatEvent, aichatContext: AichatContext) {
     this.queue.push({chatEvent, aichatContext});
     if (!this.sendingInProgress) {

--- a/apps/src/aichat/chatEventLogger.ts
+++ b/apps/src/aichat/chatEventLogger.ts
@@ -47,11 +47,9 @@ export default class ChatEventLogger {
       const loggerPayload = this.queue.shift(); // Remove the first element from the queue.
       if (loggerPayload) {
         const {chatEvent, aichatContext} = loggerPayload;
-        let logResponse;
         this.sendingInProgress = true;
         try {
-          logResponse = await postLogChatEvent(chatEvent, aichatContext);
-          console.log('logChatEventResponse', logResponse);
+          await postLogChatEvent(chatEvent, aichatContext);
           this.sendingInProgress = false;
         } catch (error) {
           Lab2Registry.getInstance()

--- a/apps/src/aichat/chatEventLogger.ts
+++ b/apps/src/aichat/chatEventLogger.ts
@@ -29,8 +29,8 @@ export default class ChatEventLogger {
     ChatEventLogger.instance = new ChatEventLogger();
   }
 
-  // For testing purposes.
-  public setSendingInProgress(sendingInProgress: boolean): void {
+  // For testing purposes only.
+  setSendingInProgress(sendingInProgress: boolean): void {
     this.sendingInProgress = sendingInProgress;
   }
 
@@ -41,8 +41,7 @@ export default class ChatEventLogger {
     }
   }
 
-  // Not private for testing purposes.
-  async sendChatEvent() {
+  private async sendChatEvent() {
     // Send aichat events to the server to be logged.
     while (this.queue.length > 0) {
       const loggerPayload = this.queue.shift(); // Remove the first element from the queue.

--- a/apps/test/unit/aichat/ChatEventLoggerTest.ts
+++ b/apps/test/unit/aichat/ChatEventLoggerTest.ts
@@ -22,9 +22,6 @@ describe('ChatEventLogger', () => {
       channelId: 'abc123',
     };
     chatEventLogger = ChatEventLogger.getInstance();
-    postLogChatEventSpy = jest
-      .spyOn(aichatApi, 'postLogChatEvent')
-      .mockResolvedValue({chat_event_id: 1, chat_event: userChatMessage});
   });
 
   afterEach(() => {
@@ -32,24 +29,38 @@ describe('ChatEventLogger', () => {
   });
 
   it('logChatEvent calls on postLogChatEvent', async () => {
-    chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
+    postLogChatEventSpy = jest
+      .spyOn(aichatApi, 'postLogChatEvent')
+      .mockResolvedValue({chat_event_id: 1, chat_event: userChatMessage});
+
+    chatEventLogger.logChatEvent(userChatMessage, aichatContext);
     expect(postLogChatEventSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('postLogChatEvent not called when sendingInProgress is true', async () => {
-    // Simulate a sending in progress state.
-    chatEventLogger.setSendingInProgress(true);
-    chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
-    // If sending in process is true, sendChatEvent should not be called.
-    expect(postLogChatEventSpy).toHaveBeenCalledTimes(0);
-  });
+  it('logChatEvent waits to send second chat event when sending in process - postLogChatEvent eventually called twice', async () => {
+    postLogChatEventSpy = jest
+      .spyOn(aichatApi, 'postLogChatEvent')
+      .mockImplementation(() => {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            resolve({chat_event_id: 1, chat_event: userChatMessage});
+          }, 1000);
+        });
+      });
 
-  it('postLogChatEvent called twice when logChatEvent called twice', async () => {
-    chatEventLogger.setSendingInProgress(false);
-    chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
-    // Simulate that response to first chat event has been received.
-    chatEventLogger.setSendingInProgress(false);
-    chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
-    expect(postLogChatEventSpy).toHaveBeenCalledTimes(2);
+    chatEventLogger.logChatEvent(userChatMessage, aichatContext);
+    chatEventLogger.logChatEvent(userChatMessage, aichatContext);
+    // Because the first postLogChatEvent call is not yet resolved, the second logChatEvent
+    // does not call on sendChatEvent.
+    expect(postLogChatEventSpy).toHaveBeenCalledTimes(1);
+    return new Promise<void>(resolve => {
+      setTimeout(() => {
+        // After 1 second, the first postLogChatEvent call resolves
+        // so that sending is no longer in process. Since the queue has length of 1,
+        // postLogChatEvent is called again so now it has been called a total of 2 times.
+        expect(postLogChatEventSpy).toHaveBeenCalledTimes(2);
+        resolve();
+      }, 1000);
+    });
   });
 });

--- a/apps/test/unit/aichat/ChatEventLoggerTest.ts
+++ b/apps/test/unit/aichat/ChatEventLoggerTest.ts
@@ -3,17 +3,21 @@ import sinon from 'ts-sinon';
 
 import * as aichatApi from '@cdo/apps/aichat/aichatApi';
 import ChatEventLogger from '@cdo/apps/aichat/chatEventLogger';
-import {ChatMessage} from '@cdo/apps/aichat/types';
+import {AichatContext, ChatMessage} from '@cdo/apps/aichat/types';
+import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 
 describe('ChatEventLogger', () => {
-  it('logChatEvent calls on postLogChatEvent', async () => {
-    const userChatMessage = {
-      role: 'user',
+  let userChatMessage: ChatMessage;
+  let aichatContext: AichatContext;
+
+  beforeEach(() => {
+    userChatMessage = {
+      role: Role.USER,
       chatMessageText: 'hello',
       status: 'OK',
       timestamp: Date.now(),
     };
-    const aichatContext = {
+    aichatContext = {
       currentLevelId: 123,
       scriptId: 321,
       channelId: 'abc123',
@@ -23,6 +27,13 @@ describe('ChatEventLogger', () => {
       chat_event_id: 1,
       chat_event: userChatMessage as ChatMessage,
     });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('logChatEvent calls on postLogChatEvent', async () => {
     const chatEventLogger = ChatEventLogger.getInstance();
     expect(chatEventLogger).to.not.be.undefined;
     chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
@@ -31,23 +42,6 @@ describe('ChatEventLogger', () => {
   });
 
   it('sendChatEvent not called when sendingInProgress is true', async () => {
-    const userChatMessage = {
-      role: 'user',
-      chatMessageText: 'hello',
-      status: 'OK',
-      timestamp: Date.now(),
-    };
-    const aichatContext = {
-      currentLevelId: 123,
-      scriptId: 321,
-      channelId: 'abc123',
-    };
-
-    sinon.stub(aichatApi, 'postLogChatEvent').resolves({
-      chat_event_id: 2,
-      chat_event: userChatMessage as ChatMessage,
-    });
-
     const chatEventLogger = ChatEventLogger.getInstance();
     chatEventLogger.setSendingInProgress(true);
     chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
@@ -56,36 +50,9 @@ describe('ChatEventLogger', () => {
   });
 
   it('postLogChatEvent called twice when logChatEvent called twice', async () => {
-    const userChatMessage = {
-      role: 'user',
-      chatMessageText: 'hello',
-      status: 'OK',
-      timestamp: Date.now(),
-    };
-    const assistantChatMessage = {
-      role: 'assistant',
-      chatMessageText: 'How can I assist you?',
-      status: 'OK',
-      timestamp: Date.now(),
-    };
-    const aichatContext = {
-      currentLevelId: 123,
-      scriptId: 321,
-      channelId: 'abc123',
-    };
-
-    sinon.stub(aichatApi, 'postLogChatEvent').resolves({
-      chat_event_id: 3,
-      chat_event: userChatMessage as ChatMessage,
-    });
-
     const chatEventLogger = ChatEventLogger.getInstance();
     chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
-    chatEventLogger.logChatEvent(
-      assistantChatMessage as ChatMessage,
-      aichatContext
-    );
+    chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
     expect(aichatApi.postLogChatEvent).to.have.been.calledTwice;
-    sinon.restore();
   });
 });

--- a/apps/test/unit/aichat/ChatEventLoggerTest.ts
+++ b/apps/test/unit/aichat/ChatEventLoggerTest.ts
@@ -22,7 +22,6 @@ describe('ChatEventLogger', () => {
       scriptId: 321,
       channelId: 'abc123',
     };
-
     sinon.stub(aichatApi, 'postLogChatEvent').resolves({
       chat_event_id: 1,
       chat_event: userChatMessage as ChatMessage,
@@ -38,7 +37,6 @@ describe('ChatEventLogger', () => {
     expect(chatEventLogger).to.not.be.undefined;
     chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
     expect(aichatApi.postLogChatEvent).to.have.been.calledOnce;
-    sinon.restore();
   });
 
   it('sendChatEvent not called when sendingInProgress is true', async () => {
@@ -48,7 +46,6 @@ describe('ChatEventLogger', () => {
     chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
     // If sending in process is true, sendChatEvent should not be called.
     expect(aichatApi.postLogChatEvent).to.not.have.been.calledOnce;
-    sinon.restore();
   });
 
   it('postLogChatEvent called twice when logChatEvent called twice', async () => {

--- a/apps/test/unit/aichat/ChatEventLoggerTest.ts
+++ b/apps/test/unit/aichat/ChatEventLoggerTest.ts
@@ -43,8 +43,10 @@ describe('ChatEventLogger', () => {
 
   it('sendChatEvent not called when sendingInProgress is true', async () => {
     const chatEventLogger = ChatEventLogger.getInstance();
+    // Simulate a sending in progress state.
     chatEventLogger.setSendingInProgress(true);
     chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
+    // If sending in process is true, sendChatEvent should not be called.
     expect(aichatApi.postLogChatEvent).to.not.have.been.calledOnce;
     sinon.restore();
   });

--- a/apps/test/unit/aichat/ChatEventLoggerTest.ts
+++ b/apps/test/unit/aichat/ChatEventLoggerTest.ts
@@ -1,0 +1,91 @@
+import {expect} from 'chai'; // eslint-disable-line no-restricted-imports
+import sinon from 'ts-sinon';
+
+import * as aichatApi from '@cdo/apps/aichat/aichatApi';
+import ChatEventLogger from '@cdo/apps/aichat/chatEventLogger';
+import {ChatMessage} from '@cdo/apps/aichat/types';
+
+describe('ChatEventLogger', () => {
+  it('logChatEvent calls on postLogChatEvent', async () => {
+    const userChatMessage = {
+      role: 'user',
+      chatMessageText: 'hello',
+      status: 'OK',
+      timestamp: Date.now(),
+    };
+    const aichatContext = {
+      currentLevelId: 123,
+      scriptId: 321,
+      channelId: 'abc123',
+    };
+
+    sinon.stub(aichatApi, 'postLogChatEvent').resolves({
+      chat_event_id: 1,
+      chat_event: userChatMessage as ChatMessage,
+    });
+    const chatEventLogger = ChatEventLogger.getInstance();
+    expect(chatEventLogger).to.not.be.undefined;
+    chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
+    expect(aichatApi.postLogChatEvent).to.have.been.calledOnce;
+    sinon.restore();
+  });
+
+  it('sendChatEvent not called when sendingInProgress is true', async () => {
+    const userChatMessage = {
+      role: 'user',
+      chatMessageText: 'hello',
+      status: 'OK',
+      timestamp: Date.now(),
+    };
+    const aichatContext = {
+      currentLevelId: 123,
+      scriptId: 321,
+      channelId: 'abc123',
+    };
+
+    sinon.stub(aichatApi, 'postLogChatEvent').resolves({
+      chat_event_id: 2,
+      chat_event: userChatMessage as ChatMessage,
+    });
+
+    const chatEventLogger = ChatEventLogger.getInstance();
+    chatEventLogger.setSendingInProgress(true);
+    chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
+    expect(aichatApi.postLogChatEvent).to.not.have.been.calledOnce;
+    sinon.restore();
+  });
+
+  it('postLogChatEvent called twice when logChatEvent called twice', async () => {
+    const userChatMessage = {
+      role: 'user',
+      chatMessageText: 'hello',
+      status: 'OK',
+      timestamp: Date.now(),
+    };
+    const assistantChatMessage = {
+      role: 'assistant',
+      chatMessageText: 'How can I assist you?',
+      status: 'OK',
+      timestamp: Date.now(),
+    };
+    const aichatContext = {
+      currentLevelId: 123,
+      scriptId: 321,
+      channelId: 'abc123',
+    };
+
+    sinon.stub(aichatApi, 'postLogChatEvent').resolves({
+      chat_event_id: 3,
+      chat_event: userChatMessage as ChatMessage,
+    });
+
+    const chatEventLogger = ChatEventLogger.getInstance();
+    chatEventLogger.logChatEvent(userChatMessage as ChatMessage, aichatContext);
+    chatEventLogger.logChatEvent(
+      assistantChatMessage as ChatMessage,
+      aichatContext
+    );
+    expect(aichatApi.postLogChatEvent).to.have.been.calledTwice;
+    sinon.restore();
+  });
+});


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/60110 which added `ChatEventLogger`.
This PR adds 2 unit tests for the `ChatEventLogger`.

I haven't added apps unit tests recently so initially used chai, but then used jest since I saw the 'eslint-disable-line no-restricted-imports' exception. Reference: https://github.com/code-dot-org/code-dot-org/pull/59565.

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-958)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
