### PR TITLE
use separate instance of DCDOBase in dcdo_test

### DIFF
--- a/dashboard/test/lib/dcdo_test.rb
+++ b/dashboard/test/lib/dcdo_test.rb
@@ -13,6 +13,10 @@ class DCDOTest < ActiveSupport::TestCase
     @dcdo.clear
   end
 
+  test 'DCDO and @dcdo are instances of the same class' do
+    assert_instance_of @dcdo.class, DCDO
+  end
+
   test 'basic set and get' do
     assert_nil @dcdo.get('key', nil)
     @dcdo.set('key', 'okay')

--- a/dashboard/test/lib/dcdo_test.rb
+++ b/dashboard/test/lib/dcdo_test.rb
@@ -2,14 +2,25 @@ require 'test_helper'
 require 'dynamic_config/dcdo'
 
 class DCDOTest < ActiveSupport::TestCase
+  setup do
+    # DCDO needs to be created using a unique cache key, so that it doesn't conflict
+    # with the "real" DCDO, which is cleared between tests in the test_helper.
+    @dcdo = DCDOBase.new(EnvironmentAwareDynamicConfigHelper.create_datastore_cache(SecureRandom.hex))
+  end
+
+  teardown do
+    # Since this is a separate instance of DCDOBase, we need to clear it here.
+    @dcdo.clear
+  end
+
   test 'basic set and get' do
-    assert_nil DCDO.get('key', nil)
-    DCDO.set('key', 'okay')
-    assert_equal DCDO.get('key', nil), 'okay'
+    assert_nil @dcdo.get('key', nil)
+    @dcdo.set('key', 'okay')
+    assert_equal @dcdo.get('key', nil), 'okay'
   end
 
   test 'returns default if key is not stored' do
-    assert_equal DCDO.get('UNSET_key', 123), 123
+    assert_equal @dcdo.get('UNSET_key', 123), 123
   end
 
   test 'storing hashes' do
@@ -18,8 +29,8 @@ class DCDOTest < ActiveSupport::TestCase
       'c' => [1, 2, 3]
     }
     key = 'random'
-    DCDO.set(key, to_store)
-    assert_equal DCDO.get(key, nil), to_store
+    @dcdo.set(key, to_store)
+    assert_equal @dcdo.get(key, nil), to_store
   end
 
   test 'storing a non-jsonable object fails' do
@@ -27,11 +38,11 @@ class DCDOTest < ActiveSupport::TestCase
     end
 
     assert_raises do
-      DCDO.set(key, RandomClass.new)
+      @dcdo.set(key, RandomClass.new)
     end
   end
 
   test 'frontend_config should return a hash' do
-    assert_instance_of(Hash, DCDO.frontend_config)
+    assert_instance_of(Hash, @dcdo.frontend_config)
   end
 end


### PR DESCRIPTION
The test helper [clears DCDO on each test run](https://github.com/code-dot-org/code-dot-org/blob/bb519086d25905c10f801ce737629094fa25741d/dashboard/test/test_helper.rb#L84). Since the DCDO tests themselves rely on being able to reliably retrieve data from DCDO, this can, in rare cases, cause the tests to fail if a parallel test clears DCDO at the same time dcdo_test is trying to retrieve a value.

By using a separate instance of `DCDOBase`, with a different value for the shared_cache identifier, the dcdo tests can run without conflicting with other tests clearing the real DCDO cache.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
