### PR TITLE
add test env ID to dcdo identifier

### DIFF
--- a/lib/dynamic_config/environment_aware_dynamic_config_helper.rb
+++ b/lib/dynamic_config/environment_aware_dynamic_config_helper.rb
@@ -6,6 +6,8 @@ module EnvironmentAwareDynamicConfigHelper
       # Use the memory adapter if we're running unit tests, but not if we're
       # running the web application server.
       adapter = MemoryAdapter.new
+      # Append the test env number to prevent conflicts between parallel tests
+      identifier = "#{identifier}#{ENV.fetch('TEST_ENV_NUMBER', nil)}"
     elsif rack_or_rails_env == 'production' || managed_test_server?
       # Production and the managed test system web application servers
       # (test.code.org / studio.code.org) use DynamoDB.

--- a/lib/test/dynamic_config/test_environment_aware_dynamic_config_helper.rb
+++ b/lib/test/dynamic_config/test_environment_aware_dynamic_config_helper.rb
@@ -44,10 +44,14 @@ class EnvironmentAwareDynamicConfigHelperTest < Minitest::Test
     assert_equal EnvironmentAwareDynamicConfigHelper.rack_or_rails_env, "development"
   end
 
-  def test_shared_cache_name
-    prefix = SecureRandom.hex
-    expected_cache_key_identifier = "#{prefix}#{ENV.fetch('TEST_ENV_NUMBER', nil)}"
-    assert_equal expected_cache_key_identifier, EnvironmentAwareDynamicConfigHelper.create_datastore_cache(prefix).instance_variable_get(:@identifier)
+  def test_shared_cache_key
+    test_env_num = 'expected_test_env_num'
+    identifier = 'expected_identifier'
+
+    Object.stub_const :ENV, ENV.to_h.merge!('TEST_ENV_NUMBER' => test_env_num) do
+      datastore_cache = EnvironmentAwareDynamicConfigHelper.create_datastore_cache(identifier)
+      assert_equal "DynamicConfigData/#{identifier}#{test_env_num}", datastore_cache.shared_cache_key
+    end
   end
 
   # Simple helper method to DRY up the code

--- a/lib/test/dynamic_config/test_environment_aware_dynamic_config_helper.rb
+++ b/lib/test/dynamic_config/test_environment_aware_dynamic_config_helper.rb
@@ -44,6 +44,12 @@ class EnvironmentAwareDynamicConfigHelperTest < Minitest::Test
     assert_equal EnvironmentAwareDynamicConfigHelper.rack_or_rails_env, "development"
   end
 
+  def test_shared_cache_name
+    prefix = SecureRandom.hex
+    expected_cache_key_identifier = "#{prefix}#{ENV.fetch('TEST_ENV_NUMBER', nil)}"
+    assert_equal expected_cache_key_identifier, EnvironmentAwareDynamicConfigHelper.create_datastore_cache(prefix).instance_variable_get(:@identifier)
+  end
+
   # Simple helper method to DRY up the code
   private def created_datastore_for_current_environment
     return EnvironmentAwareDynamicConfigHelper.


### PR DESCRIPTION
Appends the TEST_ENV_NUMBER environment variable to the shared_cache identifier when creating a new instance of DCDO in test. This ensures each parallel test process has its own instance of DCDO, and won't conflict with other tests when the test helper clears DCDO between tests.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1064)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
