### PR TITLE
GenAi: Only render retrieval input area when not read-only.

### DIFF
--- a/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
@@ -61,30 +61,33 @@ const RetrievalCustomization: React.FunctionComponent = () => {
   return (
     <div className={modelCustomizationStyles.verticalFlexContainer}>
       <div className={modelCustomizationStyles.customizationContainer}>
-        <div className={modelCustomizationStyles.inputContainer}>
-          <FieldLabel
-            label="Retrieval"
-            id="retrieval-input"
-            tooltipText="Retrieval lets you add new information for a chatbot to reference. Type in each retrieval statement into the text box, then click “Add” for each one."
-          />
-          <textarea
-            id="retrieval-input"
-            onChange={event => setNewRetrievalContext(event.target.value)}
-            value={newRetrievalContext}
-            disabled={isReadOnly}
-          />
-        </div>
-        <div className={styles.addItemContainer}>
-          <Button
-            text="Add"
-            type="secondary"
-            color="gray"
-            size="s"
-            onClick={onAdd}
-            iconLeft={{iconName: 'plus'}}
-            disabled={!newRetrievalContext || isReadOnly}
-          />
-        </div>
+        {!isReadOnly && (
+          <>
+            <div className={modelCustomizationStyles.inputContainer}>
+              <FieldLabel
+                label="Retrieval"
+                id="retrieval-input"
+                tooltipText="Retrieval lets you add new information for a chatbot to reference. Type in each retrieval statement into the text box, then click “Add” for each one."
+              />
+              <textarea
+                id="retrieval-input"
+                onChange={event => setNewRetrievalContext(event.target.value)}
+                value={newRetrievalContext}
+              />
+            </div>
+            <div className={styles.addItemContainer}>
+              <Button
+                text="Add"
+                type="secondary"
+                color="gray"
+                size="s"
+                onClick={onAdd}
+                iconLeft={{iconName: 'plus'}}
+                disabled={!newRetrievalContext}
+              />
+            </div>
+          </>
+        )}
         <div className={styles.addedItemsHeaderContainer}>
           <StrongText>Added</StrongText>
         </div>


### PR DESCRIPTION
This change removes the input area of the Retrieval tab in Gen AI Units when they are read-only.

Before the change (when retrieval is read-only):
![image](https://github.com/user-attachments/assets/99951c09-3a25-409e-8959-d7405667f18b)

After the change:
![image](https://github.com/user-attachments/assets/6d914038-6954-4d94-b660-f664028744ca)

## Links

- jira ticket: [Feature Request: hide text inputs when retrieval is in Read Only](https://codedotorg.atlassian.net/browse/LABS-778)


## Testing story

Checked a level with and without read-only set.
