### PR TITLE
Codebridge/Lab2 version history polish

### DIFF
--- a/apps/i18n/lab2/en_us.json
+++ b/apps/i18n/lab2/en_us.json
@@ -1,2 +1,4 @@
 {
+  "versionHistoryLoadFailure": "Sorry, we couldn't load your version history. Please try again.",
+  "versionHistoryLoading": "Loading version history..."
 }

--- a/apps/i18n/lab2/en_us.json
+++ b/apps/i18n/lab2/en_us.json
@@ -1,4 +1,5 @@
 {
   "versionHistoryLoadFailure": "Sorry, we couldn't load your version history. Please try again.",
-  "versionHistoryLoading": "Loading version history..."
+  "versionHistoryLoading": "Loading version history...",
+  "versionLoadFailure": "Sorry, we couldn't load that version. Please try again."
 }

--- a/apps/src/lab2/locale-do-not-import.js
+++ b/apps/src/lab2/locale-do-not-import.js
@@ -1,0 +1,15 @@
+/**
+ * DO NOT IMPORT THIS DIRECTLY. Instead do:
+ *   ```
+ *   import msg from '@cdo/apps/lab2/locale'.
+ *   ```
+ * This allows the webpack config to determine how locales should be loaded,
+ * which is important for making locale setup work seamlessly in tests.
+ */
+
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+
+let locale = safeLoadLocale('lab2_locale');
+locale = localeWithI18nStringTracker(locale, 'lab2');
+module.exports = locale;

--- a/apps/src/lab2/locale.ts
+++ b/apps/src/lab2/locale.ts
@@ -1,0 +1,9 @@
+/**
+ * A TypeScript wrapper for the Lab2 Locale object which casts
+ * it to the {@link Locale} type.
+ */
+import {Locale} from '@cdo/apps/types/locale';
+
+export default require('@cdo/lab2/locale') as Locale<
+  typeof import('@cdo/i18n/lab2/en_us.json')
+>;

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -247,7 +247,6 @@ export default class ProjectManager {
   }
 
   async getVersionList() {
-    // TODO: Error handling
     return await this.sourcesStore.getVersionList(this.channelId);
   }
 

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, {useState} from 'react';
 
 import {Button} from '@cdo/apps/componentLibrary/button';
@@ -84,8 +85,13 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
       {(isVersionHistoryOpen || loading || loadError) && (
         <div className={moduleStyles.versionHistoryDropdown} ref={menuRef}>
           {loading && (
-            <div className={moduleStyles.versionHistoryMessage}>
-              {lab2I18n.versionHistoryLoading()}
+            <div
+              className={classNames(
+                moduleStyles.versionHistoryMessage,
+                moduleStyles.loadingVersionSpinner
+              )}
+            >
+              <i className="fa fa-spinner fa-spin" />
             </div>
           )}
           {loadError && (

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, {useState} from 'react';
 
+import Alert from '@cdo/apps/componentLibrary/alert';
 import {Button} from '@cdo/apps/componentLibrary/button';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
@@ -96,7 +97,11 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
           )}
           {loadError && (
             <div className={moduleStyles.versionHistoryMessage}>
-              {lab2I18n.versionHistoryLoadFailure()}
+              <Alert
+                type="danger"
+                text={lab2I18n.versionHistoryLoadFailure()}
+                size="s"
+              />
             </div>
           )}
           {isVersionHistoryOpen && (

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
@@ -29,12 +29,12 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
   const [isVersionHistoryOpen, setIsVersionHistoryOpen] = useState(false);
   const menuRef = useOutsideClick<HTMLDivElement>(() => {
     setIsVersionHistoryOpen(false);
-    setLoadError(null);
+    setLoadError(false);
   });
 
   const [versionList, setVersionList] = useState<ProjectVersion[]>([]);
   const [loading, setLoading] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState(false);
 
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
   const toggleVersionHistory = (
@@ -45,12 +45,12 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
       return;
     }
     if (loadError) {
-      setLoadError(null);
+      setLoadError(false);
       return;
     }
     const projectManager = Lab2Registry.getInstance().getProjectManager();
     if (!projectManager) {
-      setLoadError(lab2I18n.versionHistoryLoadFailure());
+      setLoadError(true);
       return;
     }
     if (!isVersionHistoryOpen) {
@@ -63,7 +63,7 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
           setLoading(false);
         })
         .catch(() => {
-          setLoadError(lab2I18n.versionHistoryLoadFailure());
+          setLoadError(true);
           setLoading(false);
         });
     } else {
@@ -96,7 +96,7 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
           )}
           {loadError && (
             <div className={moduleStyles.versionHistoryMessage}>
-              {loadError}
+              {lab2I18n.versionHistoryLoadFailure()}
             </div>
           )}
           {isVersionHistoryOpen && (

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, {useCallback, useState} from 'react';
 
+import Alert from '@cdo/apps/componentLibrary/alert/Alert';
 import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import lab2I18n from '@cdo/apps/lab2/locale';
@@ -139,7 +140,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
             moduleStyles.versionDropdownFooter
           )}
         >
-          {lab2I18n.versionLoadFailure()}
+          <Alert type="danger" text={lab2I18n.versionLoadFailure()} size="s" />
         </div>
       )}
     </div>

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -1,7 +1,9 @@
-import React, {useCallback} from 'react';
+import classNames from 'classnames';
+import React, {useCallback, useState} from 'react';
 
 import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import lab2I18n from '@cdo/apps/lab2/locale';
 import {
   setProjectSource,
   setAndSaveProjectSource,
@@ -27,23 +29,34 @@ interface VersionHistoryDropdownProps {
 const VersionHistoryDropdown: React.FunctionComponent<
   VersionHistoryDropdownProps
 > = ({versionList, updatedSourceCallback, startSource, closeDropdown}) => {
+  const [loadError, setLoadError] = useState(false);
+  const [loading, setLoading] = useState(false);
+
   const dispatch = useAppDispatch();
   const restoreVersion = useCallback(
     (version: ProjectVersion) => {
       const projectManager = Lab2Registry.getInstance().getProjectManager();
       if (projectManager) {
-        projectManager.restoreSources(version.versionId).then(sources => {
-          if (sources) {
-            dispatch(setProjectSource(sources));
-            if (updatedSourceCallback) {
-              updatedSourceCallback(sources);
+        setLoading(true);
+        setLoadError(false);
+        projectManager
+          .restoreSources(version.versionId)
+          .then(sources => {
+            if (sources) {
+              dispatch(setProjectSource(sources));
+              if (updatedSourceCallback) {
+                updatedSourceCallback(sources);
+              }
+            } else {
+              setLoadError(true);
             }
-          } else {
-            // TODO: handle no source
-            console.error('no source found!');
-          }
-          closeDropdown();
-        });
+            setLoading(false);
+            closeDropdown();
+          })
+          .catch(() => {
+            setLoadError(true);
+            setLoading(false);
+          });
       }
     },
     [dispatch, updatedSourceCallback, closeDropdown]
@@ -85,25 +98,50 @@ const VersionHistoryDropdown: React.FunctionComponent<
   };
 
   return (
-    <div className={moduleStyles.versionHistoryList}>
-      {versionList.map(version => (
-        <div key={version.versionId} className={moduleStyles.versionHistoryRow}>
-          <div>{parseDate(version.lastModified)}</div>
-          <div className={moduleStyles.versionOptions}>
-            {renderVersionOptions(version)}
+    <div>
+      <div className={moduleStyles.versionHistoryList}>
+        {versionList.map(version => (
+          <div
+            key={version.versionId}
+            className={moduleStyles.versionHistoryRow}
+          >
+            <div>{parseDate(version.lastModified)}</div>
+            <div className={moduleStyles.versionOptions}>
+              {renderVersionOptions(version)}
+            </div>
           </div>
+        ))}
+        <div className={moduleStyles.versionHistoryRow}>
+          <Button
+            text={commonI18n.startOver()}
+            size={'s'}
+            onClick={startOver}
+            color={buttonColors.destructive}
+            className={moduleStyles.startOverButton}
+            iconLeft={{iconStyle: 'solid', iconName: 'trash-undo'}}
+          />
         </div>
-      ))}
-      <div className={moduleStyles.versionHistoryRow}>
-        <Button
-          text={commonI18n.startOver()}
-          size={'s'}
-          onClick={startOver}
-          color={buttonColors.destructive}
-          className={moduleStyles.startOverButton}
-          iconLeft={{iconStyle: 'solid', iconName: 'trash-undo'}}
-        />
       </div>
+      {loading && (
+        <div
+          className={classNames(
+            moduleStyles.loadingVersionSpinner,
+            moduleStyles.versionDropdownFooter
+          )}
+        >
+          <i className="fa fa-spinner fa-spin" />
+        </div>
+      )}
+      {loadError && (
+        <div
+          className={classNames(
+            moduleStyles.versionLoadError,
+            moduleStyles.versionDropdownFooter
+          )}
+        >
+          {lab2I18n.versionLoadFailure()}
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -13,6 +13,14 @@
   right: 0;
 }
 
+.versionHistoryMessage {
+  margin-top: 50px;
+  height: 100px;
+  text-align: center;
+  vertical-align: middle;
+  font-size: 16px;
+}
+
 .versionHistoryList {
   max-height: 300px;
   overflow-y: scroll;

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -41,7 +41,6 @@
 }
 
 .versionDropdownFooter {
-  border-top: 1px solid;
   margin-top: 8px;
   padding: 8px;
 }

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -14,10 +14,7 @@
 }
 
 .versionHistoryMessage {
-  margin-top: 50px;
-  height: 100px;
-  text-align: center;
-  vertical-align: middle;
+  margin: 20px;
   font-size: 16px;
 }
 
@@ -41,4 +38,19 @@
 
 .startOverButton {
   width: 100%;
+}
+
+.versionDropdownFooter {
+  border-top: 1px solid;
+  margin-top: 8px;
+  padding: 8px;
+}
+
+.loadingVersionSpinner {
+  font-size: 32px;
+  text-align: center;
+}
+
+.versionLoadError {
+  font-size: 14px;
 }

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -198,6 +198,7 @@ const LOCALE_ALIASES = {
     localeDoNotImport('@cdo/applab/locale'),
     localeDoNotImport('@cdo/codebridge/locale'),
     localeDoNotImport('@cdo/javalab/locale'),
+    localeDoNotImport('@cdo/lab2/locale'),
     localeDoNotImport('@cdo/music/locale'),
     localeDoNotImport('@cdo/netsim/locale'),
     localeDoNotImport('@cdo/regionalPartnerMiniContact/locale'),

--- a/dashboard/app/views/levels/_lab2.html.haml
+++ b/dashboard/app/views/levels/_lab2.html.haml
@@ -5,6 +5,7 @@
   %script{src: webpack_asset_path("js/#{js_locale}/standaloneVideo_locale.js")}
   %script{src: webpack_asset_path("js/#{js_locale}/aichat_locale.js")}
   %script{src: webpack_asset_path("js/#{js_locale}/codebridge_locale.js")}
+  %script{src: webpack_asset_path("js/#{js_locale}/lab2_locale.js")}
   %script{src: webpack_asset_path('js/googleblockly.js')}
   -# To use css linting in Web Lab 2, uncomment this line. This is commented out because this is a prototype
   -# feature and we aren't ready to have it imported for every lab2 lab yet.

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -672,6 +672,7 @@ class FilesApi < Sinatra::Base
   get %r{/v3/(animations|sources|files|libraries)/([^/]+)/([^/]+)/versions$} do |endpoint, encrypted_channel_id, filename|
     dont_cache
     content_type :json
+    return bad_request
 
     filename.downcase! if endpoint == 'files'
     begin

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -672,7 +672,6 @@ class FilesApi < Sinatra::Base
   get %r{/v3/(animations|sources|files|libraries)/([^/]+)/([^/]+)/versions$} do |endpoint, encrypted_channel_id, filename|
     dont_cache
     content_type :json
-    return bad_request
 
     filename.downcase! if endpoint == 'files'
     begin


### PR DESCRIPTION
Follow up to #60090. This adds the following:
- When loading the list of version, show a spinner until they have loaded rather than not showing a dropdown until the load completed.
- If the version list request fails, show an error message
- When restoring an old version, keep the dropdown open with a spinner at the bottom until the restore completes. If the restore failed, show an error message.
I kept the styling on the spinner and errors pretty minimal for now. I used the `Alert` design system component for the errors. We are still deciding on the final design for version history.

I opted not to do a fade transition between versions because it was going to be a lot of plumbing to get the workspace aware of a new version coming in, rather than relying on our existing project setup. Now that there's a spinner while the project is loading it seems a bit more clear that we loaded a new version. Let me know if we still think a fade is valuable!

As part of this I also added a lab2 locale.
 
## Screenshots/Screen recordings
### Load error
![Screenshot 2024-08-05 at 4 19 23 PM](https://github.com/user-attachments/assets/e5616a7c-66cd-4bf7-9ca6-ca52c63b7d82)

### Fail to restore
https://github.com/user-attachments/assets/5885ad51-b0f2-4d5e-adb7-3e5417b781be


### Successful restore
https://github.com/user-attachments/assets/cd68e3d8-8171-4e3f-b4f9-41e191082204


## Links
- jira ticket: [CT-712](https://codedotorg.atlassian.net/browse/CT-712)

## Testing story
Tested locally. I faked failures to test the failure cases.

## Follow-up work
There's one more polish item in the original ticket to add a start over confirmation dialog. Jim has a PR up now that refactors the lab2 dialogs pretty heavily, so I'm holding on that until his PR is in. I split it out into a separate task: [CT-720](https://codedotorg.atlassian.net/browse/CT-720)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
