### PR TITLE
Fixes the issue for historic evaluations that do not have evidence.

### DIFF
--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -545,8 +545,9 @@ export default function LearningGoals({
     clearAnnotations();
 
     if (!!aiEvalInfo && !productTour) {
+      const evidence = aiEvalInfo.evidence || '';
       const annotations = annotateLines(
-        aiEvalInfo.evidence,
+        evidence,
         aiEvalInfo.observations,
         onEvidenceTooltipOpened
       );

--- a/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
@@ -211,6 +211,35 @@ describe('LearningGoals - React Testing Library', () => {
     sinon.assert.notCalled(scrollToLineStub);
   });
 
+  it('does not fail to render when the evidence is null', async () => {
+    const myAiEvaluations = [
+      {
+        ...aiEvaluations[0],
+        evidence: null,
+      },
+      {
+        ...aiEvaluations[1],
+        evidence: null,
+      },
+    ];
+
+    render(
+      <LearningGoals
+        learningGoals={learningGoals}
+        teacherHasEnabledAi={true}
+        aiUnderstanding={3}
+        studentLevelInfo={studentLevelInfo}
+        aiEvaluations={myAiEvaluations}
+      />
+    );
+
+    const user = userEvent.setup();
+    const button = screen.getByRole('button', {
+      name: i18n.rubricNextLearningGoal(),
+    });
+    await user.click(button);
+  });
+
   describe('when aiConfidenceExactMatch is high', () => {
     const myAiEvaluations = [
       {


### PR DESCRIPTION
Fixes a simple issue where the `evidence` field is `NULL`.

The backend job always records at least an empty string, so this issue did not present itself until looking at historic evaluations that were done before evidence existed. The most recent evaluation record with a null evidence was in March. Regardless, this fix will ensure that the front-end also coerces the evidence field to an empty string before parsing it.

## Links

- jira ticket: [AITT-723](https://codedotorg.atlassian.net/browse/AITT-723)

## Testing story

Created the test, ran it and saw it so red:

![image](https://github.com/user-attachments/assets/2fc7e8e4-c96c-4652-8619-f94ce2285ac9)

Then, with proposed changes, green:

![image](https://github.com/user-attachments/assets/5c3d730f-ddf9-4962-b58e-5745d12dcc29)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
