### PR TITLE
Remove feedback banner for teachers who create accounts after V2 launch

### DIFF
--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -24,6 +24,7 @@ const SET_DATE_PROGRESS_TABLE_INVITATION_LAST_DELAYED =
   'currentUser/SET_DATE_PROGRESS_TABLE_INVITATION_LAST_DELAYED';
 const SET_SEEN_PROGRESS_TABLE_INVITATION =
   'currentUser/SET_SEEN_PROGRESS_TABLE_INVITATION';
+const SET_USER_CREATED_AT = 'currentUser/SET_USER_CREATED_AT';
 
 export const SignInState = makeEnum('Unknown', 'SignedIn', 'SignedOut');
 
@@ -97,6 +98,10 @@ export const setAiRubricsDisabled = aiRubricsDisabled => ({
   type: SET_AI_RUBRICS_DISABLED,
   aiRubricsDisabled,
 });
+export const setUserCreatedAt = userCreatedAt => ({
+  type: SET_USER_CREATED_AT,
+  userCreatedAt,
+});
 
 const initialState = {
   userId: null,
@@ -117,6 +122,7 @@ const initialState = {
   countryCode: null,
   usStateCode: null,
   inSection: null,
+  userCreatedAt: null,
 };
 
 export default function currentUser(state = initialState, action) {
@@ -215,6 +221,12 @@ export default function currentUser(state = initialState, action) {
       aiRubricsDisabled: action.aiRubricsDisabled,
     };
   }
+  if (action.type === SET_USER_CREATED_AT) {
+    return {
+      ...state,
+      userCreatedAt: action.userCreatedAt,
+    };
+  }
 
   if (action.type === SET_INITIAL_DATA) {
     const {
@@ -236,6 +248,7 @@ export default function currentUser(state = initialState, action) {
       country_code,
       us_state_code,
       in_section,
+      created_at,
     } = action.serverUser;
     analyticsReport.setUserProperties(
       id,
@@ -271,6 +284,7 @@ export default function currentUser(state = initialState, action) {
       countryCode: country_code,
       usStateCode: us_state_code,
       inSection: in_section,
+      userCreatedAt: created_at,
     };
   }
 

--- a/apps/src/templates/sectionProgressV2/ProgressBanners.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressBanners.jsx
@@ -1,18 +1,33 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import {connect} from 'react-redux';
 
 import ProgressFeedbackBanner from './ProgressFeedbackBanner';
 
-export default function ProgressBanners({hasJustSwitchedToV2}) {
+function ProgressBanners({hasJustSwitchedToV2, userCreatedAt}) {
   // Only show the feedback banner if we are on the v2 table AND
-  // the toggle between v1 and v2 has not been used.
+  // the toggle between v1 and v2 has not been used AND the user
+  // was created before the automatic enrollment started for new users
+
+  const userAutomaticallyEnrolledInV2 =
+    new Date(userCreatedAt) > new Date('2024-08-02');
+
   return (
     <>
-      <ProgressFeedbackBanner canShow={!hasJustSwitchedToV2} />
+      <ProgressFeedbackBanner
+        canShow={!hasJustSwitchedToV2 && !userAutomaticallyEnrolledInV2}
+      />
     </>
   );
 }
 
 ProgressBanners.propTypes = {
   hasJustSwitchedToV2: PropTypes.bool,
+  userCreatedAt: PropTypes.string,
 };
+
+export const UnconnectedProgressBanners = ProgressBanners;
+
+export default connect(state => ({
+  userCreatedAt: state.currentUser.userCreatedAt,
+}))(ProgressBanners);

--- a/apps/src/templates/sectionProgressV2/ProgressBanners.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressBanners.jsx
@@ -1,33 +1,18 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {connect} from 'react-redux';
 
 import ProgressFeedbackBanner from './ProgressFeedbackBanner';
 
-function ProgressBanners({hasJustSwitchedToV2, userCreatedAt}) {
+export default function ProgressBanners({hasJustSwitchedToV2}) {
   // Only show the feedback banner if we are on the v2 table AND
-  // the toggle between v1 and v2 has not been used AND the user
-  // was created before the automatic enrollment started for new users
-
-  const userAutomaticallyEnrolledInV2 =
-    new Date(userCreatedAt) > new Date('2024-08-02');
-
+  // the toggle between v1 and v2 has not been used.
   return (
     <>
-      <ProgressFeedbackBanner
-        canShow={!hasJustSwitchedToV2 && !userAutomaticallyEnrolledInV2}
-      />
+      <ProgressFeedbackBanner canShow={!hasJustSwitchedToV2} />
     </>
   );
 }
 
 ProgressBanners.propTypes = {
   hasJustSwitchedToV2: PropTypes.bool,
-  userCreatedAt: PropTypes.string,
 };
-
-export const UnconnectedProgressBanners = ProgressBanners;
-
-export default connect(state => ({
-  userCreatedAt: state.currentUser.userCreatedAt,
-}))(ProgressBanners);

--- a/apps/src/templates/sectionProgressV2/ProgressFeedbackBanner.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressFeedbackBanner.jsx
@@ -21,6 +21,7 @@ const ProgressFeedbackBanner = ({
   fetchProgressV2Feedback,
   createProgressV2Feedback,
   errorWhenCreatingOrLoading,
+  userCreatedAt,
 }) => {
   const [bannerStatus, setBannerStatus] = React.useState(BANNER_STATUS.UNSET);
 
@@ -46,7 +47,10 @@ const ProgressFeedbackBanner = ({
       bannerStatus === BANNER_STATUS.UNSET &&
       progressV2Feedback
     ) {
-      if (progressV2Feedback.empty) {
+      if (
+        progressV2Feedback.empty &&
+        new Date(userCreatedAt) < new Date('2024-08-02')
+      ) {
         setBannerStatus(BANNER_STATUS.UNANSWERED);
       } else {
         setBannerStatus(BANNER_STATUS.PREVIOUSLY_ANSWERED);
@@ -54,6 +58,7 @@ const ProgressFeedbackBanner = ({
     }
   }, [
     progressV2Feedback,
+    userCreatedAt,
     bannerStatus,
     canShow,
     isLoading,
@@ -100,7 +105,7 @@ const ProgressFeedbackBanner = ({
 };
 
 ProgressFeedbackBanner.propTypes = {
-  currentUser: PropTypes.object.isRequired,
+  userCreatedAt: PropTypes.string,
   canShow: PropTypes.bool,
   isLoading: PropTypes.bool.isRequired,
   progressV2Feedback: PropTypes.object,
@@ -113,7 +118,7 @@ export const UnconnectedProgressFeedbackBanner = ProgressFeedbackBanner;
 
 export default connect(
   state => ({
-    currentUser: state.currentUser,
+    userCreatedAt: state.currentUser.userCreatedAt,
     isLoading: state.progressV2Feedback.isLoading,
     progressV2Feedback: state.progressV2Feedback.progressV2Feedback,
     errorWhenCreatingOrLoading: state.progressV2Feedback.error,

--- a/apps/src/templates/sectionProgressV2/ProgressFeedbackBanner.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressFeedbackBanner.jsx
@@ -40,6 +40,11 @@ const ProgressFeedbackBanner = ({
       return;
     }
 
+    // V2 was launched on 2024-08-02. If the user was created before that date,
+    // we want them to see the feedback banner.
+    const userCreatedBeforeV2Released =
+      new Date(userCreatedAt) < new Date('2024-08-02');
+
     // If feedback has been loaded and empty and the user hasn't answered, it is unanswered.
     // If we have feedback and the user did not just submit feedback, set to previously-answered.
     if (
@@ -47,10 +52,7 @@ const ProgressFeedbackBanner = ({
       bannerStatus === BANNER_STATUS.UNSET &&
       progressV2Feedback
     ) {
-      if (
-        progressV2Feedback.empty &&
-        new Date(userCreatedAt) < new Date('2024-08-02')
-      ) {
+      if (progressV2Feedback.empty && userCreatedBeforeV2Released) {
         setBannerStatus(BANNER_STATUS.UNANSWERED);
       } else {
         setBannerStatus(BANNER_STATUS.PREVIOUSLY_ANSWERED);

--- a/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressFeedbackBannerTest.jsx
@@ -11,7 +11,7 @@ describe('ProgressFeedbackBanner', () => {
   const fakeFetch = sinon.spy();
   const fakeCreate = sinon.spy();
   const defaultProps = {
-    currentUser: {isAdmin: false},
+    userCreatedAt: '2024-07-01',
     canShow: true,
     isLoading: false,
     progressV2Feedback: {empty: true},
@@ -30,6 +30,26 @@ describe('ProgressFeedbackBanner', () => {
       <UnconnectedProgressFeedbackBanner
         {...defaultProps}
         canShow={false}
+        fetchProgressV2Feedback={fakeFetch}
+      />
+    );
+    expect(fakeFetch).to.have.been.calledOnce;
+    const questionText = screen.queryByText(
+      i18n.progressV2_feedback_question()
+    );
+    const shareMoreText = screen.queryByText(
+      i18n.progressV2_feedback_shareMore()
+    );
+    expect(questionText).to.not.exist;
+    expect(shareMoreText).to.not.exist;
+  });
+
+  it('renders empty if the user was created after roll out date', () => {
+    render(
+      <UnconnectedProgressFeedbackBanner
+        {...defaultProps}
+        userCreatedAt={'2024-08-03'}
+        canShow={true}
         fetchProgressV2Feedback={fakeFetch}
       />
     );

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -41,6 +41,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         country_code: helpers.country_code(current_user, request),
         us_state_code: current_user.us_state_code,
         in_section: current_user.student? ? current_user.sections_as_student.present? : nil,
+        created_at: current_user.created_at,
       }
     else
       render json: {


### PR DESCRIPTION
Currently, when a new user signs up, they immediately see a feedback banner in the V2 view.  We don't want them to see that banner.  This PR removes that banner for those users.  All other users should see no change in behavior. 


## Links

[Slack convo](https://codedotorg.slack.com/archives/C06ERUABG01/p1722952839776999)
[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1231)

## Testing story

- Modified unit test
- Tested locally
- Expecting to have eyes tests fail when merged in - will accept new baselines at that point and let DOTD know
