### PR TITLE
Fixing slack tagging and updating to use the on-call group for PDF failure notifications.

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -83,7 +83,7 @@ module Services
             PDF.merge_local_pdfs(destination, *pdfs)
           rescue Exception => exception
             ChatClient.log(
-              "@teacher-tools-team Error when trying to merge resource PDFs for #{script.name}: #{exception}",
+              "Error when trying to merge resource PDFs for #{script.name}: #{exception}",
               color: 'red'
             )
             ChatClient.log(
@@ -96,6 +96,10 @@ module Services
             )
             ChatClient.log(
               "temporary directory contents: #{Dir.entries(pdfs_dir).inspect}",
+              color: 'red'
+            )
+            ChatClient.log(
+              "<@teacher-tools-on-call> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
               color: 'red'
             )
             raise exception
@@ -218,7 +222,7 @@ module Services
           )
 
           ChatClient.log(
-            "@teacher-tools-team Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
+            "<@teacher-tools-on-call> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
             color: 'yellow'
           )
           return nil


### PR DESCRIPTION
Issue: Notifications to teacher tools team during PDF failures doesn't actually tag the team group in slack.

Root cause: The group alias needs to be enclosed in <> to leverage Slack tagging.

This change includes that and also updates the team group to use teacher-tools-on-call, which is a dynamic group where membership is synced every hour to match the current point person for teacher tools team.

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1178

## Testing story

Validated the messages to Slack through local logging.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Regular deployment pipeline. Will validate after the changes are picked up in staging server.

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
