### PR TITLE
Add Workshops heading to My PL page

### DIFF
--- a/apps/src/code-studio/pd/professional_learning_landing/EnrolledWorkshops.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/EnrolledWorkshops.jsx
@@ -158,19 +158,22 @@ class WorkshopsTable extends React.Component {
     });
 
     return (
-      <Table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Date</th>
-            <th>Time</th>
-            <th>Location</th>
-            {this.props.forMyPlPage && <th>Status</th>}
-            <th style={{width: '20%'}} />
-          </tr>
-        </thead>
-        <tbody>{rows}</tbody>
-      </Table>
+      <>
+        <Heading2>Workshops</Heading2>
+        <Table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Date</th>
+              <th>Time</th>
+              <th>Location</th>
+              {this.props.forMyPlPage && <th>Status</th>}
+              <th style={{width: '20%'}} />
+            </tr>
+          </thead>
+          <tbody>{rows}</tbody>
+        </Table>
+      </>
     );
   }
 


### PR DESCRIPTION
Adds the "Workshops" header back to the https://studio.code.org/my-professional-learning above the workshops table. The headings in the table aren't translated so I didn't translate this. 

_Note for reviewer:_ Hide whitespace when reviewing.

## Links
Jira ticket: [ACQ-2193](https://codedotorg.atlassian.net/browse/ACQ-2193)
Slack convo: [here](https://codedotorg.slack.com/archives/C0453TUMLE7/p1722969883706959)

## Testing story
Tested locally

----

| Before | After |
| ---- | ---- |
| <img width="916" alt="Screenshot 2024-08-06 at 1 57 45 PM" src="https://github.com/user-attachments/assets/8d22c264-b68d-43a8-acb7-a9a1facbaaf1"> | <img width="916" alt="Screenshot 2024-08-06 at 1 55 22 PM" src="https://github.com/user-attachments/assets/74955ea4-282d-4ef8-b88c-d3015921aee9"> |

