### PR TITLE
Make New SessionStoreEvictionsAlarm Quieter

### DIFF
--- a/aws/cloudformation/components/session_store.yml.erb
+++ b/aws/cloudformation/components/session_store.yml.erb
@@ -85,7 +85,7 @@
       DatapointsToAlarm: 3
       # TODO infra: update this threshold and upgrade the alarm to Urgent once
       # we've collected enough data to make a reasonable estimate of this.
-      Threshold: 500
+      Threshold: 5000
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: missing
       Metrics:


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/58409

Our new SessionStoreEvictionsAlarm has fulfilled its initial goal of notifying us when our new Redis session store database has filled up and begun evicting old sessions, as designed: we hit capacity and started seeing our first evictions [at approximately 9:30am Pacific](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~'AWS*2fElastiCache~'DatabaseCapacityUsagePercentage~'CacheClusterId~'ausxf3ubdbzebgu-001~'CacheNodeId~'0001)~(~'...~'ausxf3ubdbzebgu-002~'.~'.)~(~'...~'ausxf3ubdbzebgu-003~'.~'.))~region~'us-east-1~title~'Database*20Capacity*20Usage*20Percentage~stat~'Average~view~'timeSeries~start~'2024-08-06T12*3a30*3a00.000Z~end~'2024-08-06T20*3a00*3a00.000Z)), and got an alarm shortly thereafter:

![image](https://github.com/user-attachments/assets/918858f3-277c-4d2a-9399-5cbc73117dfe)

Our next goal with this alarm is to figure out what threshold we actually want to alarm on, for which we'll want to monitor regular usage for at least a few days if not a few weeks. In order to be less irritated by this alarm while we do that, I propose we temporarily increase the current threshold by a single order of magnitude, which should hopefully reduce the rate at which the wheel squeaks while still being noisy enough to ensure it will get greased in a timely fashion.

## Follow-up work

I've left the TODO in place and the urgency of this alarm set to LowPriority because this is just another temporary adjustment; we still need to gather some more data to be able to settle on a long-term value for an urgent notification.

## Links

- [Evictions](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~'AWS*2fElastiCache~'Evictions~'CacheClusterId~'ausxf3ubdbzebgu-001~'CacheNodeId~'0001)~(~'...~'ausxf3ubdbzebgu-002~'.~'.)~(~'...~'ausxf3ubdbzebgu-003~'.~'.))~region~'us-east-1~title~'Evictions~stat~'Maximum~view~'timeSeries~start~'2024-08-06T09*3a34*3a00.612Z~end~'2024-08-06T21*3a02*3a00.995Z~period~60))
- [Session Store Replication Group dashboard](https://us-east-1.console.aws.amazon.com/elasticache/home?region=us-east-1#/redis/ausxf3ubdbzebgu)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
