### PR TITLE
Fixing the slack notification for group to use group specific formatting.

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -98,7 +98,6 @@ module Services
               "temporary directory contents: #{Dir.entries(pdfs_dir).inspect}",
               color: 'red'
             )
-            # Group ID: S07FB3XSAR5 - teacher-tools-on-call would be notified
             ChatClient.log(
               "Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
               color: 'red',
@@ -223,9 +222,8 @@ module Services
             color: 'yellow'
           )
 
-          # Group ID: S07FB3XSAR5 - teacher-tools-on-call would be notified
           ChatClient.log(
-            "<!subteam^S07FB3XSAR5> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
+            "Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
             color: 'yellow',
             notify_group: 'teacher-tools-on-call'
           )

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -98,8 +98,9 @@ module Services
               "temporary directory contents: #{Dir.entries(pdfs_dir).inspect}",
               color: 'red'
             )
+            # !subteam^S07FB3XSAR5 - would notify the teacher-tools-on-call group
             ChatClient.log(
-              "<@teacher-tools-on-call> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
+              "<!subteam^S07FB3XSAR5> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
               color: 'red'
             )
             raise exception
@@ -221,8 +222,9 @@ module Services
             color: 'yellow'
           )
 
+          # !subteam^S07FB3XSAR5 - would notify the teacher-tools-on-call group
           ChatClient.log(
-            "<@teacher-tools-on-call> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
+            "<!subteam^S07FB3XSAR5> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
             color: 'yellow'
           )
           return nil

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -98,7 +98,7 @@ module Services
               "temporary directory contents: #{Dir.entries(pdfs_dir).inspect}",
               color: 'red'
             )
-            # !subteam^S07FB3XSAR5 - would notify the teacher-tools-on-call group
+            # Group ID: S07FB3XSAR5 - teacher-tools-on-call would be notified
             ChatClient.log(
               "<!subteam^S07FB3XSAR5> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
               color: 'red'
@@ -222,7 +222,7 @@ module Services
             color: 'yellow'
           )
 
-          # !subteam^S07FB3XSAR5 - would notify the teacher-tools-on-call group
+          # Group ID: S07FB3XSAR5 - teacher-tools-on-call would be notified
           ChatClient.log(
             "<!subteam^S07FB3XSAR5> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
             color: 'yellow'

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -100,8 +100,9 @@ module Services
             )
             # Group ID: S07FB3XSAR5 - teacher-tools-on-call would be notified
             ChatClient.log(
-              "<!subteam^S07FB3XSAR5> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
-              color: 'red'
+              "Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
+              color: 'red',
+              notify_group: 'teacher-tools-on-call'
             )
             raise exception
           end
@@ -225,7 +226,8 @@ module Services
           # Group ID: S07FB3XSAR5 - teacher-tools-on-call would be notified
           ChatClient.log(
             "<!subteam^S07FB3XSAR5> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot",
-            color: 'yellow'
+            color: 'yellow',
+            notify_group: 'teacher-tools-on-call'
           )
           return nil
         end

--- a/lib/cdo/chat_client.rb
+++ b/lib/cdo/chat_client.rb
@@ -9,7 +9,7 @@ require 'cdo/slack'
 # implementation (namely Slack as of February 2017).
 class ChatClient
   USER_GROUP_ID_MAP = {
-    teacher_tools_on_call: 'S07FB3XSAR5'
+    'teacher-tools-on-call': 'S07FB3XSAR5'
   }.freeze
 
   @@name = CDO.name[0..14]
@@ -30,6 +30,8 @@ class ChatClient
   #   color (optional): The color the message should be posted.
   # @return [Boolean] Whether the message was posted successfully.
   def self.message(room, message, options = {})
+    message = "<!subteam^#{USER_GROUP_ID_MAP[options[:notify_group].to_sym]}> #{message}" if options[:notify_group]
+
     unless @@logger
       FileUtils.mkdir_p(deploy_dir('log'))
       @@logger = Logger.new(deploy_dir('log', 'chat_messages.log'))
@@ -39,8 +41,6 @@ class ChatClient
     unless CDO.hip_chat_logging
       return
     end
-
-    message = "<!subteam^#{USER_GROUP_ID_MAP[group_name.to_sym]}> #{message}" if options[:notify_group]
 
     Slack.message(
       message.to_s,

--- a/lib/cdo/chat_client.rb
+++ b/lib/cdo/chat_client.rb
@@ -8,6 +8,10 @@ require 'cdo/slack'
 # This class is intended to be a thin wrapper around our chat client
 # implementation (namely Slack as of February 2017).
 class ChatClient
+  USER_GROUP_ID_MAP = {
+    teacher_tools_on_call: 'S07FB3XSAR5'
+  }.freeze
+
   @@name = CDO.name[0..14]
   @@logger = nil
 
@@ -35,6 +39,8 @@ class ChatClient
     unless CDO.hip_chat_logging
       return
     end
+
+    message = "<!subteam^#{USER_GROUP_ID_MAP[group_name.to_sym]}> #{message}" if options[:notify_group]
 
     Slack.message(
       message.to_s,

--- a/lib/cdo/chat_client.rb
+++ b/lib/cdo/chat_client.rb
@@ -8,10 +8,6 @@ require 'cdo/slack'
 # This class is intended to be a thin wrapper around our chat client
 # implementation (namely Slack as of February 2017).
 class ChatClient
-  USER_GROUP_ID_MAP = {
-    'teacher-tools-on-call': 'S07FB3XSAR5'
-  }.freeze
-
   @@name = CDO.name[0..14]
   @@logger = nil
 
@@ -30,7 +26,7 @@ class ChatClient
   #   color (optional): The color the message should be posted.
   # @return [Boolean] Whether the message was posted successfully.
   def self.message(room, message, options = {})
-    message = "<!subteam^#{USER_GROUP_ID_MAP[options[:notify_group].to_sym]}> #{message}" if options[:notify_group]
+    message = Slack.tag_user_group(message, options[:notify_group]) if options[:notify_group]
 
     unless @@logger
       FileUtils.mkdir_p(deploy_dir('log'))

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -187,7 +187,7 @@ class Slack
   # @param message [String] the message to update to tag the user_group
   # @param user_group [String] slack user group to be tagged for notification
   def self.tag_user_group(message, user_group)
-    "<!subteam^#{USER_GROUP_ID_MAP[user_group.to_sym]}> #{message}"
+    "<!subteam^#{USER_GROUP_ID_MAP[user_group&.to_sym]}> #{message}"
   end
 
   # Returns the channel ID for the channel with the requested channel_name.

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -33,6 +33,10 @@ class Slack
     'server-operations' => 'C0CCSS3PX'
   }.freeze
 
+  USER_GROUP_ID_MAP = {
+    'teacher-tools-on-call': 'S07FB3XSAR5'
+  }.freeze
+
   SLACK_TOKEN = CDO.methods.include?(:slack_token) ? CDO.slack_token.freeze : nil
   SLACK_BOT_TOKEN = CDO.methods.include?(:slack_bot_token) ? CDO.slack_bot_token.freeze : nil
 
@@ -178,6 +182,12 @@ class Slack
     return false unless channel
     result = post_to_slack("https://slack.com/api/conversations.join", {"channel" => channel})
     return !!result
+  end
+
+  # @param message [String] the message to update to tag the user_group
+  # @param user_group [String] slack user group to be tagged for notification
+  def self.tag_user_group(message, user_group)
+    "<!subteam^#{USER_GROUP_ID_MAP[user_group.to_sym]}> #{message}"
   end
 
   # Returns the channel ID for the channel with the requested channel_name.

--- a/lib/test/cdo/test_chat_client.rb
+++ b/lib/test/cdo/test_chat_client.rb
@@ -23,4 +23,14 @@ class ChatClientTest < Minitest::Test
     Logger.any_instance.expects(:info)
     ChatClient.log(FAKE_MESSAGE)
   end
+
+  def test_log_with_notify_group
+    Slack.expects(:tag_user_group).with do |_message, group|
+      group == "teacher-tools-on-call"
+    end.returns(FAKE_MESSAGE)
+    Slack.expects(:message).with do |_text, params|
+      params[:channel] == CDO.slack_log_room
+    end.returns(false)
+    ChatClient.log(FAKE_MESSAGE, notify_group: 'teacher-tools-on-call')
+  end
 end

--- a/lib/test/cdo/test_chat_client.rb
+++ b/lib/test/cdo/test_chat_client.rb
@@ -25,6 +25,7 @@ class ChatClientTest < Minitest::Test
   end
 
   def test_log_with_notify_group
+    ENV.expects(:[]).returns(false)
     Slack.expects(:tag_user_group).with do |_message, group|
       group == "teacher-tools-on-call"
     end.returns(FAKE_MESSAGE)

--- a/lib/test/cdo/test_slack.rb
+++ b/lib/test/cdo/test_slack.rb
@@ -123,4 +123,9 @@ class SlackTest < Minitest::Test
     user_group = "invalid-group"
     assert_equal "<!subteam^> test message", Slack.tag_user_group(message, user_group)
   end
+
+  def test_tag_user_group_with_null_group
+    message = "test message"
+    assert_equal "<!subteam^> test message", Slack.tag_user_group(message, nil)
+  end
 end

--- a/lib/test/cdo/test_slack.rb
+++ b/lib/test/cdo/test_slack.rb
@@ -111,4 +111,16 @@ class SlackTest < Minitest::Test
     Net::HTTP.expects(:post_form).returns(stub(code: 400))
     refute Slack.message(FAKE_MESSAGE, channel: FAKE_CHANNEL)
   end
+
+  def test_tag_user_group_with_valid_group
+    message = "test message"
+    user_group = "teacher-tools-on-call"
+    assert_equal "<!subteam^S07FB3XSAR5> test message", Slack.tag_user_group(message, user_group)
+  end
+
+  def test_tag_user_group_with_invalid_group
+    message = "test message"
+    user_group = "invalid-group"
+    assert_equal "<!subteam^> test message", Slack.tag_user_group(message, user_group)
+  end
 end


### PR DESCRIPTION
Context: Currently any file that fails PDF generation (intermittent google API failures, sharing settings are incorrect, size too large) goes unnoticed until reported by a teacher. The goal of this task is to tag teacher tools on call whenever PDF generation fails, so it can be investigated in a proactive manner.

Issue: The original approach for this was to include <@teacher-tools-on-call> to tag the group, but it was not resulting in a notification from slack. 

Upon investigating further, found that the notification format for groups is different from users when sending messages programmatically. 

Fix: This change implements tagging user groups in slack following this documentation https://api.slack.com/reference/surfaces/formatting#mentioning-groups 

Logs from local validation
`I, [2024-08-06T15:33:22.069814 #646726]  INFO -- : [development] <!subteam^S07FB3XSAR5> Please follow instructions in https://docs.google.com/document/d/1mBY56DeAzrwTM3CVIOFho3azTi9mudE37ZQrVZXxaMA/edit#heading=h.axfu5or8cueg to troubleshoot`

Snippet from API documentation
![image](https://github.com/user-attachments/assets/7a940895-ce59-4f50-be3e-483d35cd6cea)

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1178

## Testing story

Local validation could only confirm the expected message was getting written. Need to further validate in staging once this change is merged.

## Deployment strategy

Regular deploy pipeline

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
