### PR TITLE
Adds docker compose with selenium

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -121,3 +121,107 @@ Just copy those lines into your `locals.yml` and start your Dashboard server via
 ```shell
 ./bin/dashboard-server
 ```
+
+## Running UI tests with a Native Dashboard Server
+
+When running your dashboard server natively, you may want to run browser-based UI tests against certain versions of browsers. We
+can support this via Docker and a set of Selenium containers.
+
+Essentially, Selenium is a service that opens a few ports that allow remote control of a browser instance. Selenium offers a
+"Grid" service that can manage a variety of device types for you. To start up a prepared set of those browser types, you can
+spin up the service as such:
+
+```shell
+docker compose run selenium-nodes
+```
+
+You will see some messaging about how to witness the running tests if you would like to. For instance, for viewing the Edge
+tests as they run, you can open up a browser tab that will connect via VNC to the running container:
+
+[http://localhost:7912/?autoconnect=1&resize=scale&password=secret](http://localhost:7912/?autoconnect=1&resize=scale&password=secret)
+
+You can refer to the message for ways to connect to the other browser sessions.
+
+To run a test with the containerized Selenium Grid (here we are just running one feature to test things out):
+
+```shell
+rake test:ui browser=edge selenium= feature=dashboard/test/ui/features/platform/signing_in.feature
+```
+
+To stop all Selenium Grid nodes:
+
+```shell
+docker compose stop $(docker compose ps --services | grep selenium | awk \'{print $1}\')'
+```
+
+## Running a Selenium service for a particular specific browser
+
+Sometimes you might care to not start the whole set of Selenium nodes and, instead, can elect to just spin up a particular
+instance.  You can spin up such a service for the particular browser you want.
+
+First, make sure you start your dashboard server:
+
+```shell
+./bin/dashboard-server
+```
+
+Then, you can tell it to start up a Chrome instance (and you can substitute `chrome` with `firefox` or `edge`):
+
+```shell
+docker compose run selenium-chrome
+```
+
+When it runs, it will then tell you how to run a UI test and how to connect to the VNC instance. Each browser runs on a
+different port, so you will need to refer to that message to know how to interact.
+
+The final line in that message is an example of running a particular UI test file against that running browser. It will
+look something like this (for Chrome):
+
+```shell
+rake test:ui browser=chrome selenium=http://localhost:4444/wd/hub feature=dashboard/test/ui/features/platform/signing_in.feature
+```
+
+When you are done, you can spin down the selenium server (Again, substituting `chrome` with `firefox` or `edge` as needed):
+
+```shell
+docker compose stop selenium-chrome-native
+```
+
+## Using a different browser version with Selenium
+
+These commands above will start either a Selenium Grid and a set of "nodes" that isolate each browser into its own container, or
+the browser instance as a standalone Selenium service. Either way, the browsers will have their versions match our CI instance
+(see `dashboard/test/ui/browsers.json`) but you can alter those versions if you would like to target a particular version.
+
+To use a different version, first ensure that you have any running instances shut down:
+
+```shell
+docker compose stop $(docker compose ps --services | grep selenium | awk \'{print $1}\')'
+```
+
+After this, modify `docker/developers/.env` and update the `SELENIUM_CHROME_VERSION` (or `FIREFOX` or `EDGE` as needed) with
+the version you want to target. Then follow the normal instructions again. It will download a new Docker image for that
+browser version as you start it back up again.
+
+The version needs to match those found on the Docker Hub. For instance, for Chrome, one can look at
+[the hub page for standalone-chrome](https://hub.docker.com/r/selenium/standalone-chrome/tags) to find the right version tag.
+Generally, tags in the form of `<major>.<minor>`, such as `105.0`, are available, but there are more specific versions as well.
+
+## Recording a video of a UI test
+
+When using the Selenium services via Docker, you can record a UI test by using the selenium-video service.
+
+To use this, you need to spin up the video recording service:
+
+```shell
+docker compose run selenium-video
+```
+
+Then, run the ui test with the `record=<filename>` specified. For instance, to record a Chrome test (based on the commands you
+will find above):
+
+```shell
+rake test:ui browser=chrome record=my-video selenium=http://localhost:4444/wd/hub feature=dashboard/test/ui/features/platform/signing_in.feature
+```
+
+You will then find a `my-video.chrome.mp4` file in your temporary directory (usually `/tmp`).

--- a/SETUP.md
+++ b/SETUP.md
@@ -127,7 +127,11 @@ These steps are for Apple devices running **macOS 14.x**, including those runnin
    ```
    git lfs install --skip-repo
    ```
-1. Start your local **Redis server**
+
+1. **Optional**: Install Docker (this lets you skip installing other services manually):
+   View the [DOCKER.md](DOCKER.md#installing-docker) document to install Docker and Docker Compose on your platform, then return here.
+
+1. Start your local **Redis server** (Skip if using Docker)
    1. Start redis server:
        ```
        brew services start redis
@@ -137,7 +141,8 @@ These steps are for Apple devices running **macOS 14.x**, including those runnin
        ==> Successfully started `redis` (label: homebrew.mxcl.redis)
        ```
    3. macOS will notify you that `redis` has been configured to start automatically upon user login. Confirm this in System Settings --> General --> Login Items --> `redis-server` 
-1. Setup your local **MySQL database server**
+
+1. Setup your local **MySQL database server** (Skip if using Docker)
    1. Link MySQL 8
         ```
         brew link --force --overwrite mysql@8.0
@@ -269,7 +274,7 @@ Windows Subsystem for Linux (WSL) allows you to run a GNU/Linux environment dire
 
 It is worthwhile to make sure that you are using WSL 2. Attempting to use WSL 1 in the past resulted in errors with mysql and pdftk installation. In order to use WSL 2, you must be running Windows 10, updated to version 2004, Build 19041 or higher. If your Windows update service doesn't give you the update automatically, you can download it [from the Windows download page](https://www.microsoft.com/en-us/software-download/windows10).
 
-1. Enable WSL ([unabridged WSL instructions here](https://docs.microsoft.com/en-us/windows/wsl/install-win10)). You should run Powershell as Administrator for the following commands:
+1. Enable WSL ([unabridged WSL instructions here](https://docs.microsoft.com/en-us/windows/wsl/install-win10)). You should run PowerShell as Administrator for the following commands:
     1. `dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart`
     1. `dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart`
     1. Restart your machine. WSL 2 will be the default if your Windows version is sufficiently updated.
@@ -415,7 +420,7 @@ Wondering where to start?  See our [contribution guidelines](CONTRIBUTING.md) fo
 
 #### ImageMagick with Pango
 
-**Note:** Most developers won't need to peronsonalize certificates locally, but some will.  Here are notes on getting this working on macOS.
+**Note:** Most developers won't need to personalize certificates locally, but some will.  Here are notes on getting this working on macOS.
 
 Certificates have been greatly improved with the ability to apply text in many languages.  
 

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -65,7 +65,7 @@ def get_browser(test_run_name)
   browser = nil
   if ENV['TEST_LOCAL'] == 'true'
     headless = ENV['TEST_LOCAL_HEADLESS'] == 'true'
-    browser = SeleniumBrowser.local(browser: ENV.fetch('BROWSER_CONFIG', nil), headless: headless)
+    browser = SeleniumBrowser.local(browser: ENV.fetch('BROWSER_CONFIG', nil), headless: headless, selenium_url: ENV.fetch('SELENIUM_URL', nil))
   else
     browser = Retryable.retryable(tries: MAX_CONNECT_RETRIES) do
       saucelabs_browser(test_run_name)

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -144,6 +144,9 @@ def parse_options
         options.hourofcode_domain = 'localhost.hourofcode.com:3000'
         options.csedweek_domain = 'localhost.csedweek.org:3000'
       end
+      opts.on("-u", "--selenium-hub-url URL", "The Selenium hub URL to use to remotely run tests. Can also be forced via the SELENIUM_URL environment variable.") do |url|
+        options.selenium_hub_url = url
+      end
       opts.on("--headed", "Open visible chrome browser windows. Runs in headless mode without this flag. Only relevant when -l is specified.") do
         options.local_headless = false
       end
@@ -733,6 +736,12 @@ def run_feature(browser, feature, options)
 
   run_environment = {}
   run_environment['BROWSER_CONFIG'] = options.local ? browser['browser'] : browser_name
+
+  # Add a selenium URL, if given, which forces the Selenium browser target to be 'remote'
+  # in the Selenium browser selection.
+  if options.selenium_hub_url
+    run_environment['SELENIUM_URL'] = options.selenium_hub_url
+  end
 
   run_environment['BS_ROTATABLE'] = browser['rotatable'] ? "true" : "false"
   run_environment['PEGASUS_TEST_DOMAIN'] = options.pegasus_domain if options.pegasus_domain

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -2,7 +2,7 @@ require 'selenium/webdriver'
 require 'webdrivers'
 
 module SeleniumBrowser
-  def self.local(browser: :chrome, headless: true)
+  def self.local(browser: :chrome, headless: true, selenium_url: nil)
     browser = browser.to_sym
     options = {}
     case browser
@@ -14,7 +14,17 @@ module SeleniumBrowser
       options[:options] = Selenium::WebDriver::Firefox::Options.new
       options[:options].headless! if headless
       options[:options].add_argument('window-size=1280,1024')
+    when :edge
+      options[:options] = Selenium::WebDriver::Edge::Options.new
+      options[:options].headless! if headless
+      options[:options].add_argument('window-size=1280,1024')
     end
+
+    if selenium_url
+      browser = :remote
+      options[:url] = selenium_url
+    end
+
     Selenium::WebDriver.for browser, options
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,8 @@ include:
   - path: ./docker/developers/docker-compose.mysql.yml
   - path: ./docker/developers/docker-compose.redis.yml
 
+  # Selenium services for UI testing
+  - path: ./docker/developers/docker-compose.selenium.yml
+
   # The dashboard server
   - path: ./docker/developers/docker-compose.dashboard.yml

--- a/docker/developers/.env
+++ b/docker/developers/.env
@@ -4,3 +4,11 @@ MYSQL_NATIVE_PORT: 3306
 
 # Similarly, the native port for redis
 REDIS_NATIVE_PORT: 6379
+
+# Older versions of the browsers require older versions of the selenium hub
+SELENIUM_HUB_VERSION=4.8.2
+
+# This sets common variables used throughout the compose stack
+SELENIUM_FIREFOX_VERSION=112.0
+SELENIUM_CHROME_VERSION=105.0
+SELENIUM_EDGE_VERSION=105.0

--- a/docker/developers/docker-compose.selenium.yml
+++ b/docker/developers/docker-compose.selenium.yml
@@ -43,7 +43,7 @@ services:
       # The Protocol port that our testing infrastructure connects to
       - "4444:4444"  
 
-  selenium-video:
+  selenium-video-base: &selenium-video-base
     hostname: selenium-video
     image: codedotorg/selenium-video
     build:
@@ -51,10 +51,31 @@ services:
       context: ./selenium-video
     environment:
       DISPLAY_CONTAINER_NAME: code-dot-org-selenium-chrome
+    expose:
+      - "9001" # The control server for the video service
     volumes:
       - /tmp:/videos
-    networks:
-      cdo_network_test:
+
+  selenium-video-native:
+    <<: *selenium-video-base
+    network_mode: host
+
+  # Runs selenium grid and spins up all possible browser nodes
+  selenium-video:
+    image: alpine
+    depends_on:
+      selenium-video-native:
+        condition: service_started
+    command: >
+      /bin/sh -c "
+        echo 'Selenium Video Service Started.' &&
+        echo &&
+        echo 'To run a UI test while recording, use the normal command and append \"record=<filename>\" to it:' &&
+        echo '  (you may substitute browser=firefox with chrome or edge as needed)' &&
+        echo 'bundle exec rake test:ui record=my-test-video browser=firefox selenium= feature=dashboard/test/ui/features/platform/signing_in.feature' &&
+        echo &&
+        echo 'Then you will find /tmp/my-test-video.firefox.mp4 afterward.'
+      "
 
   # A Selenium server running Chrome for running UI tests contained in Docker
   selenium-chrome-base: &selenium-chrome-base
@@ -63,6 +84,8 @@ services:
     environment:
       SE_VNC_PORT: 5910
       SE_NO_VNC_PORT: 7910
+      DISPLAY_NUM: 100
+      DISPLAY: ':100.0'
       JAVA_OPTS: -Dwebdriver.chrome.whitelistedIps= -Dwebdriver.chrome.allowedIps=
     shm_size: '2gb'
     expose:
@@ -156,6 +179,8 @@ services:
     environment:
       SE_VNC_PORT: 5911
       SE_NO_VNC_PORT: 7911
+      DISPLAY_NUM: 101
+      DISPLAY: ':101.0'
     ulimits: *selenium-ulimits
 
   # A Selenium server running Firefox for running UI tests locally against a
@@ -173,6 +198,8 @@ services:
       SE_OPTS: "--port 4445"
       SE_VNC_PORT: 5911
       SE_NO_VNC_PORT: 7911
+      DISPLAY_NUM: 101
+      DISPLAY: ':101.0'
     network_mode: host
 
   selenium-firefox:
@@ -238,6 +265,8 @@ services:
     environment:
       SE_VNC_PORT: 5912
       SE_NO_VNC_PORT: 7912
+      DISPLAY_NUM: 102
+      DISPLAY: ':102.0'
     expose:
       - "5912" # The selenium direct VNC port
       - "4444" # The selenium router port
@@ -257,9 +286,11 @@ services:
     <<: *selenium-edge-base
     container_name: code-dot-org-selenium-edge
     environment:
+      DISPLAY_NUM: 102
       SE_VNC_PORT: 5912
       SE_NO_VNC_PORT: 7912
       SE_OPTS: "--port 4446"
+      DISPLAY: ':102.0'
     network_mode: host
 
   selenium-edge:

--- a/docker/developers/docker-compose.selenium.yml
+++ b/docker/developers/docker-compose.selenium.yml
@@ -2,6 +2,24 @@ include:
   - path: ./docker-compose.networks.yml
 
 services:
+  # This is a proxy service to allow our localhost-*.code.org domains to work
+  # when there is no network host.
+  selenium-proxy:
+    image: nginx:1.27.1-alpine3.20-perl
+    volumes:
+      - ./nginx-proxy.conf:/root/nginx-proxy.conf
+      - ./nginx-startup.sh:/docker-entrypoint.d/nginx-startup.sh
+    networks:
+      cdo_network_test:
+        aliases:
+          # The test aliases to map to host
+          - localhost-studio.code.org
+          - localhost.code.org
+          - localhost.hourofcode.com
+          - localhost.codeprojects.org
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
   # A Selenium grid hub that will run *-node services that are described below
   selenium-grid-base: &selenium-grid-base
     image: selenium/hub:${SELENIUM_HUB_VERSION}
@@ -32,7 +50,7 @@ services:
   selenium-grid:
     <<: *selenium-grid-base
     environment: &selenium-grid-environment
-      SE_EVENT_BUS_HOST: localhost
+      SE_EVENT_BUS_HOST: selenium
       SE_EVENT_BUS_PUBLISH_PORT: 4442
       SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
     ports:
@@ -43,28 +61,26 @@ services:
       # The Protocol port that our testing infrastructure connects to
       - "4444:4444"  
 
-  selenium-video-base: &selenium-video-base
+  selenium-video-contained: &selenium-video-base
     hostname: selenium-video
     image: codedotorg/selenium-video
     build:
       dockerfile: ./selenium-video.Dockerfile
       context: ./selenium-video
-    environment:
-      DISPLAY_CONTAINER_NAME: code-dot-org-selenium-chrome
     expose:
       - "9001" # The control server for the video service
+    ports:
+      - "9001:9001"
     volumes:
       - /tmp:/videos
-
-  selenium-video-native:
-    <<: *selenium-video-base
-    network_mode: host
+    networks:
+      cdo_network_test:
 
   # Runs selenium grid and spins up all possible browser nodes
   selenium-video:
     image: alpine
     depends_on:
-      selenium-video-native:
+      selenium-video-contained:
         condition: service_started
     command: >
       /bin/sh -c "
@@ -79,7 +95,7 @@ services:
 
   # A Selenium server running Chrome for running UI tests contained in Docker
   selenium-chrome-base: &selenium-chrome-base
-    hostname: selenium
+    hostname: selenium-chrome
     image: seleniarm/standalone-chromium:${SELENIUM_CHROME_VERSION}
     environment:
       SE_VNC_PORT: 5910
@@ -106,8 +122,18 @@ services:
   # A Selenium server running Chrome for running UI tests locally
   selenium-chrome-native:
     <<: *selenium-chrome-base
-    container_name: code-dot-org-selenium-chrome
-    network_mode: host
+    hostname: selenium-chrome-native
+    ports:
+      - "5910:5910" # The selenium direct VNC port
+      - "4444:4444" # The selenium router port
+      - "7910:7910" # The selenium NoVNC service port
+    depends_on:
+      selenium-proxy:
+        condition: service_started
+    networks:
+      cdo_network_test:
+        aliases:
+          - selenium.chrome
 
   selenium-chrome:
     image: alpine
@@ -131,7 +157,6 @@ services:
   # A Selenium server that connects through the selenium grid
   selenium-chrome-node-base: &selenium-chrome-node-base
     # We need an explicit container name for the target of the video service
-    container_name: code-dot-org-selenium-chrome
     hostname: chrome
     image: selenium/node-chrome:${SELENIUM_CHROME_VERSION}
     shm_size: 2gb
@@ -154,6 +179,7 @@ services:
   # Runs the selenium Chrome as a node on our hosted selenium-grid
   selenium-chrome-node:
     <<: *selenium-chrome-node-base
+    container_name: code-dot-org-selenium-chrome-node
     environment:
       <<: *selenium-grid-environment
       SE_NODE_PORT: 5555
@@ -162,14 +188,24 @@ services:
       DISPLAY_NUM: 100
       DISPLAY: ':100.0'
       JAVA_OPTS: -Dwebdriver.chrome.whitelistedIps= -Dwebdriver.chrome.allowedIps=
+    expose:
+      - "5555" # Selenium Grid Port
+    ports:
+      - "7910:7910" # The selenium NoVNC service port
+      - "5910:5910" # The selenium direct VNC port
     depends_on:
       selenium-grid:
         condition: service_started
-    network_mode: host
+      selenium-proxy:
+        condition: service_started
+    networks:
+      cdo_network_test:
+        aliases:
+          - selenium.chrome
 
   # A Selenium server running Firefox for running UI tests contained in Docker
   selenium-firefox-base: &selenium-firefox-base
-    hostname: selenium
+    hostname: selenium-firefox
     image: seleniarm/standalone-firefox:${SELENIUM_FIREFOX_VERSION}
     shm_size: '2gb'
     expose:
@@ -193,14 +229,22 @@ services:
   # A Selenium server running Firefox for running UI tests locally
   selenium-firefox-native:
     <<: *selenium-firefox-base
-    container_name: code-dot-org-selenium-firefox
+    hostname: selenium-firefox-native
     environment:
       SE_OPTS: "--port 4445"
       SE_VNC_PORT: 5911
       SE_NO_VNC_PORT: 7911
       DISPLAY_NUM: 101
       DISPLAY: ':101.0'
-    network_mode: host
+    ports:
+      - "5911:5911" # The selenium direct VNC port
+      - "4445:4445" # The selenium router port
+      - "7911:7911" # The selenium NoVNC service port
+    depends_on:
+      selenium-proxy:
+        condition: service_started
+    networks:
+      cdo_network_test:
 
   selenium-firefox:
     image: alpine
@@ -246,6 +290,7 @@ services:
   # Runs the selenium Firefox as a node on our hosted selenium-grid
   selenium-firefox-node:
     <<: *selenium-firefox-node-base
+    container_name: code-dot-org-selenium-firefox-node
     environment:
       <<: *selenium-grid-environment
       SE_NODE_PORT: 5556
@@ -253,14 +298,22 @@ services:
       SE_NO_VNC_PORT: 7911
       DISPLAY_NUM: 101
       DISPLAY: ':101.0'
+    expose:
+      - "5556" # Selenium Grid Port
+    ports:
+      - "7911:7911" # The selenium NoVNC service port
+      - "5911:5911" # The selenium direct VNC port
     depends_on:
       selenium-grid:
         condition: service_started
-    network_mode: host
+      selenium-proxy:
+        condition: service_started
+    networks:
+      cdo_network_test:
 
   # A Selenium server running Edge for running UI tests contained in Docker
   selenium-edge-base: &selenium-edge-base
-    hostname: selenium
+    hostname: selenium-edge
     image: selenium/standalone-edge:${SELENIUM_EDGE_VERSION}
     environment:
       SE_VNC_PORT: 5912
@@ -284,14 +337,22 @@ services:
   # A Selenium server running Firefox for running UI tests locally
   selenium-edge-native:
     <<: *selenium-edge-base
-    container_name: code-dot-org-selenium-edge
+    hostname: selenium-edge-native
     environment:
       DISPLAY_NUM: 102
       SE_VNC_PORT: 5912
       SE_NO_VNC_PORT: 7912
       SE_OPTS: "--port 4446"
       DISPLAY: ':102.0'
-    network_mode: host
+    ports:
+      - "5912:5912" # The selenium direct VNC port
+      - "4446:4446" # The selenium router port
+      - "7912:7912" # The selenium NoVNC service port
+    depends_on:
+      selenium-proxy:
+        condition: service_started
+    networks:
+      cdo_network_test:
 
   selenium-edge:
     image: alpine
@@ -337,6 +398,7 @@ services:
   # Runs the selenium edge as a node on our hosted selenium-grid
   selenium-edge-node:
     <<: *selenium-edge-node-base
+    container_name: code-dot-org-selenium-edge-node
     environment:
       <<: *selenium-grid-environment
       SE_NODE_PORT: 5557
@@ -344,10 +406,18 @@ services:
       SE_NO_VNC_PORT: 7912
       DISPLAY_NUM: 102
       DISPLAY: ':102.0'
+    expose:
+      - "5557" # Selenium Grid Port
+    ports:
+      - "7912:7912" # The selenium NoVNC service port
+      - "5912:5912" # The selenium direct VNC port
     depends_on:
       selenium-grid:
         condition: service_started
-    network_mode: host
+      selenium-proxy:
+        condition: service_started
+    networks:
+      cdo_network_test:
 
   # Runs selenium grid and spins up all possible browser nodes
   selenium-nodes:

--- a/docker/developers/docker-compose.selenium.yml
+++ b/docker/developers/docker-compose.selenium.yml
@@ -1,0 +1,347 @@
+include:
+  - path: ./docker-compose.networks.yml
+
+services:
+  # A Selenium grid hub that will run *-node services that are described below
+  selenium-grid-base: &selenium-grid-base
+    image: selenium/hub:${SELENIUM_HUB_VERSION}
+    hostname: selenium
+    expose:
+      # The Selenium 'Publish' port
+      - "4442:4442"
+      # The Selenium 'Subscribe' port
+      - "4443:4443"
+      # The Protocol port that our testing infrastructure connects to
+      - "4444:4444"  
+    ulimits: &selenium-ulimits
+      nofile:
+        soft: 32768
+        hard: 32768
+    networks:
+      cdo_network_test:
+
+  # This just runs selenium-grid within the isolated container network
+  selenium-grid-contained:
+    environment: &selenium-grid-contained-environment
+      SE_EVENT_BUS_HOST: selenium
+      SE_EVENT_BUS_PUBLISH_PORT: 4442
+      SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
+    <<: *selenium-grid-base
+
+  # This runs selenium-grid such that it is visible to the host machine
+  selenium-grid:
+    <<: *selenium-grid-base
+    environment: &selenium-grid-environment
+      SE_EVENT_BUS_HOST: localhost
+      SE_EVENT_BUS_PUBLISH_PORT: 4442
+      SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
+    ports:
+      # The Selenium 'Publish' port
+      - "4442:4442"
+      # The Selenium 'Subscribe' port
+      - "4443:4443"
+      # The Protocol port that our testing infrastructure connects to
+      - "4444:4444"  
+
+  selenium-video:
+    hostname: selenium-video
+    image: codedotorg/selenium-video
+    build:
+      dockerfile: ./selenium-video.Dockerfile
+      context: ./selenium-video
+    environment:
+      DISPLAY_CONTAINER_NAME: code-dot-org-selenium-chrome
+    volumes:
+      - /tmp:/videos
+    networks:
+      cdo_network_test:
+
+  # A Selenium server running Chrome for running UI tests contained in Docker
+  selenium-chrome-base: &selenium-chrome-base
+    hostname: selenium
+    image: seleniarm/standalone-chromium:${SELENIUM_CHROME_VERSION}
+    environment:
+      SE_VNC_PORT: 5910
+      SE_NO_VNC_PORT: 7910
+      JAVA_OPTS: -Dwebdriver.chrome.whitelistedIps= -Dwebdriver.chrome.allowedIps=
+    shm_size: '2gb'
+    expose:
+      - "5910" # The selenium direct VNC port
+      - "4444" # The selenium router port
+      - "7910" # The selenium NoVNC service port
+    # Many default ulimits are just too high
+    # And, so, it will consume way too much memory (16GB+)
+    ulimits: *selenium-ulimits
+
+  # A Selenium server running Chrome for running UI tests locally against a
+  # containerized dashboard server.
+  selenium-chrome-contained:
+    <<: *selenium-chrome-base
+    networks:
+      cdo_network_test:
+
+  # A Selenium server running Chrome for running UI tests locally
+  selenium-chrome-native:
+    <<: *selenium-chrome-base
+    container_name: code-dot-org-selenium-chrome
+    network_mode: host
+
+  selenium-chrome:
+    image: alpine
+    depends_on:
+      selenium-chrome-native:
+        condition: service_started
+    command: >
+      /bin/sh -c "
+        echo 'Selenium Chrome Started.' &&
+        echo &&
+        echo 'To see and interact with this browser session:' &&
+        echo '- http://localhost:7910/?autoconnect=1&resize=scale&password=secret (VNC port 5910)' &&
+        echo &&
+        echo 'To shut down all selenium nodes, use:' &&
+        echo 'docker compose down selenium-chrome-native' &&
+        echo &&
+        echo 'To run a UI test with a locally running dashboard server:' &&
+        echo 'bundle exec rake test:ui browser=chrome selenium=http://localhost:4444/wd/hub feature=dashboard/test/ui/features/platform/signing_in.feature'
+      "
+
+  # A Selenium server that connects through the selenium grid
+  selenium-chrome-node-base: &selenium-chrome-node-base
+    # We need an explicit container name for the target of the video service
+    container_name: code-dot-org-selenium-chrome
+    hostname: chrome
+    image: selenium/node-chrome:${SELENIUM_CHROME_VERSION}
+    shm_size: 2gb
+    ulimits: *selenium-ulimits
+
+  # Runs the selenium Chrome as a node in our fully dockerized environment
+  selenium-chrome-node-contained:
+    <<: *selenium-chrome-node-base
+    environment:
+      <<: *selenium-grid-contained-environment
+      SE_VNC_PORT: 5910
+      SE_NO_VNC_PORT: 7910
+      JAVA_OPTS: -Dwebdriver.chrome.whitelistedIps= -Dwebdriver.chrome.allowedIps=
+    depends_on:
+      selenium-grid-contained:
+        condition: service_started
+    networks:
+      cdo_network_test:
+
+  # Runs the selenium Chrome as a node on our hosted selenium-grid
+  selenium-chrome-node:
+    <<: *selenium-chrome-node-base
+    environment:
+      <<: *selenium-grid-environment
+      SE_NODE_PORT: 5555
+      SE_VNC_PORT: 5910
+      SE_NO_VNC_PORT: 7910
+      DISPLAY_NUM: 100
+      DISPLAY: ':100.0'
+      JAVA_OPTS: -Dwebdriver.chrome.whitelistedIps= -Dwebdriver.chrome.allowedIps=
+    depends_on:
+      selenium-grid:
+        condition: service_started
+    network_mode: host
+
+  # A Selenium server running Firefox for running UI tests contained in Docker
+  selenium-firefox-base: &selenium-firefox-base
+    hostname: selenium
+    image: seleniarm/standalone-firefox:${SELENIUM_FIREFOX_VERSION}
+    shm_size: '2gb'
+    expose:
+      - "5911" # The selenium direct VNC port
+      - "4444" # The selenium router port
+      - "7911" # The selenium NoVNC service port
+    environment:
+      SE_VNC_PORT: 5911
+      SE_NO_VNC_PORT: 7911
+    ulimits: *selenium-ulimits
+
+  # A Selenium server running Firefox for running UI tests locally against a
+  # containerized dashboard server.
+  selenium-firefox-contained:
+    <<: *selenium-firefox-base
+    networks:
+      cdo_network_test:
+
+  # A Selenium server running Firefox for running UI tests locally
+  selenium-firefox-native:
+    <<: *selenium-firefox-base
+    container_name: code-dot-org-selenium-firefox
+    environment:
+      SE_OPTS: "--port 4445"
+      SE_VNC_PORT: 5911
+      SE_NO_VNC_PORT: 7911
+    network_mode: host
+
+  selenium-firefox:
+    image: alpine
+    depends_on:
+      selenium-firefox-native:
+        condition: service_started
+    command: >
+      /bin/sh -c "
+        echo 'Selenium Firefox Started.' &&
+        echo &&
+        echo 'To see and interact with this browser session:' &&
+        echo '- http://localhost:7911/?autoconnect=1&resize=scale&password=secret (VNC port 5911)' &&
+        echo &&
+        echo 'To shut down this selenium service, use:' &&
+        echo 'docker compose down selenium-firefox-native' &&
+        echo &&
+        echo 'To run a UI test with a locally running dashboard server:' &&
+        echo 'bundle exec rake test:ui browser=firefox selenium=http://localhost:4445/wd/hub feature=dashboard/test/ui/features/platform/signing_in.feature'
+      "
+
+  # A Selenium server that connects through the selenium grid
+  selenium-firefox-node-base: &selenium-firefox-node-base
+    # We need an explicit container name for the target of the video service
+    container_name: code-dot-org-selenium-firefox
+    hostname: firefox
+    image: seleniarm/node-firefox:${SELENIUM_FIREFOX_VERSION}
+    shm_size: 2gb
+    ulimits: *selenium-ulimits
+
+  # Runs the selenium Firefox as a node in our fully dockerized environment
+  selenium-firefox-node-contained:
+    <<: *selenium-firefox-node-base
+    environment:
+      <<: *selenium-grid-contained-environment
+      SE_VNC_PORT: 5911
+      SE_NO_VNC_PORT: 7911
+    depends_on:
+      selenium-grid-contained:
+        condition: service_started
+    networks:
+      cdo_network_test:
+
+  # Runs the selenium Firefox as a node on our hosted selenium-grid
+  selenium-firefox-node:
+    <<: *selenium-firefox-node-base
+    environment:
+      <<: *selenium-grid-environment
+      SE_NODE_PORT: 5556
+      SE_VNC_PORT: 5911
+      SE_NO_VNC_PORT: 7911
+      DISPLAY_NUM: 101
+      DISPLAY: ':101.0'
+    depends_on:
+      selenium-grid:
+        condition: service_started
+    network_mode: host
+
+  # A Selenium server running Edge for running UI tests contained in Docker
+  selenium-edge-base: &selenium-edge-base
+    hostname: selenium
+    image: selenium/standalone-edge:${SELENIUM_EDGE_VERSION}
+    environment:
+      SE_VNC_PORT: 5912
+      SE_NO_VNC_PORT: 7912
+    expose:
+      - "5912" # The selenium direct VNC port
+      - "4444" # The selenium router port
+      - "7912" # The selenium NoVNC service port
+    shm_size: '2gb'
+    ulimits: *selenium-ulimits
+
+  # A Selenium server running Edge for running UI tests locally against a
+  # containerized dashboard server.
+  selenium-edge-contained:
+    <<: *selenium-edge-base
+    networks:
+      cdo_network_test:
+
+  # A Selenium server running Firefox for running UI tests locally
+  selenium-edge-native:
+    <<: *selenium-edge-base
+    container_name: code-dot-org-selenium-edge
+    environment:
+      SE_VNC_PORT: 5912
+      SE_NO_VNC_PORT: 7912
+      SE_OPTS: "--port 4446"
+    network_mode: host
+
+  selenium-edge:
+    image: alpine
+    depends_on:
+      selenium-edge-native:
+        condition: service_started
+    command: >
+      /bin/sh -c "
+        echo 'Selenium Edge Started.' &&
+        echo &&
+        echo 'To see and interact with this browser session:' &&
+        echo '- http://localhost:7912/?autoconnect=1&resize=scale&password=secret (VNC port 5912)' &&
+        echo &&
+        echo 'To shut down this selenium service, use:' &&
+        echo 'docker compose down selenium-edge-native' &&
+        echo &&
+        echo 'To run a UI test with a locally running dashboard server:' &&
+        echo 'bundle exec rake test:ui browser=edge selenium=http://localhost:4446/wd/hub feature=dashboard/test/ui/features/platform/signing_in.feature'
+      "
+
+  # A Selenium server that connects through the selenium grid
+  selenium-edge-node-base: &selenium-edge-node-base
+    # We need an explicit container name for the target of the video service
+    container_name: code-dot-org-selenium-edge
+    hostname: edge
+    image: selenium/node-edge:${SELENIUM_EDGE_VERSION}
+    shm_size: 2gb
+    ulimits: *selenium-ulimits
+
+  # Runs the selenium Edge as a node in our fully dockerized environment
+  selenium-edge-node-contained:
+    <<: *selenium-edge-node-base
+    environment:
+      <<: *selenium-grid-contained-environment
+      SE_VNC_PORT: 5912
+      SE_NO_VNC_PORT: 7912
+    depends_on:
+      selenium-grid-contained:
+        condition: service_started
+    networks:
+      cdo_network_test:
+
+  # Runs the selenium edge as a node on our hosted selenium-grid
+  selenium-edge-node:
+    <<: *selenium-edge-node-base
+    environment:
+      <<: *selenium-grid-environment
+      SE_NODE_PORT: 5557
+      SE_VNC_PORT: 5912
+      SE_NO_VNC_PORT: 7912
+      DISPLAY_NUM: 102
+      DISPLAY: ':102.0'
+    depends_on:
+      selenium-grid:
+        condition: service_started
+    network_mode: host
+
+  # Runs selenium grid and spins up all possible browser nodes
+  selenium-nodes:
+    image: alpine
+    depends_on:
+      selenium-chrome-node:
+        condition: service_started
+      selenium-firefox-node:
+        condition: service_started
+      selenium-edge-node:
+        condition: service_started
+    command: >
+      /bin/sh -c "
+        echo 'Selenium Grid Started.' &&
+        echo &&
+        echo 'To see and interact with the browser sessions:' &&
+        echo 'Chrome: http://localhost:7910/?autoconnect=1&resize=scale&password=secret (VNC port 5910)' &&
+        echo 'Firefox: http://localhost:7911/?autoconnect=1&resize=scale&password=secret (VNC port 5911)' &&
+        echo 'Edge: http://localhost:7912/?autoconnect=1&resize=scale&password=secret (VNC port 5912)' &&
+        echo &&
+        echo 'To shut down all selenium nodes, use:' &&
+        echo 'docker compose stop $(docker compose ps --services | grep selenium | awk \'{print $1}\')' &&
+        echo 'or just \'docker compose stop\'' &&
+        echo &&
+        echo 'To run a UI test with a locally running dashboard server:' &&
+        echo '  (you may substitute browser=firefox with chrome or edge)' &&
+        echo 'bundle exec rake test:ui browser=firefox selenium= feature=dashboard/test/ui/features/platform/signing_in.feature'
+      "

--- a/docker/developers/nginx-proxy.conf
+++ b/docker/developers/nginx-proxy.conf
@@ -1,0 +1,20 @@
+# This maps localhost-*.code.org domains to the host IP
+server {
+  listen 3000;
+  server_name localhost-studio.code.org localhost.code.org localhost.hourofcode.com localhost.codeprojects.org;
+  
+  location / {
+    # Proxy to the default Docker loopback interface
+    # This should be a similar IP to the named host.docker.internal
+    proxy_pass http://172.17.0.1:3000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Protocol $scheme;
+    proxy_set_header X-Forwarded-Host $http_host;
+
+    # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+    proxy_buffering off;
+  }
+}

--- a/docker/developers/nginx-startup.sh
+++ b/docker/developers/nginx-startup.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Copy the configuration over and update the host, if we find a
+# host.docker.internal name
+
+echo 'Looking for host.docker.internal'
+
+cp /root/nginx-proxy.conf /root/cdo.conf
+if getent hosts host.docker.internal; then
+  echo 'Found host.docker.internal'
+  sed s/172.17.0.1/host.docker.internal/g -i /root/cdo.conf
+fi
+cp /root/cdo.conf /etc/nginx/conf.d/cdo.conf

--- a/docker/developers/selenium-video/README.md
+++ b/docker/developers/selenium-video/README.md
@@ -1,0 +1,11 @@
+# Selenium-Video Custom Container
+
+We maintain this very simple augmentation of the `selenium-video` container image
+that allows us to remotely start and stop the video recording.
+
+The `Dockerfile` here in this directory is fairly self-explanatory... it mainly
+adds the `control.py` file to the container (here, it is `selenium-video.control.py`.)
+
+See the `docker-compose.selenium.yml` file in the parent directory to see how the
+container is used and referenced. And, also, the `record-*` container services
+described in `docker-compose.testing.yml`.

--- a/docker/developers/selenium-video/selenium-video.Dockerfile
+++ b/docker/developers/selenium-video/selenium-video.Dockerfile
@@ -1,0 +1,19 @@
+# This augments the selenium-video container to allow for remote start/stop of
+# the video generation.
+
+FROM selenium/video
+
+USER 0
+
+COPY selenium-video.supervisord.conf /etc/codeorg.supervisord.conf
+RUN cat /etc/codeorg.supervisord.conf >> /etc/supervisord.conf
+COPY --chown="${SEL_UID}:${SEL_GID}" selenium-video.control.py /opt/bin/control.py
+
+# Turn off the automatic video.sh service
+RUN cat /etc/supervisord.conf | sed -z 's/opt\/bin\/video.sh\nautostart=true/bin\/true\nautostart=false/g' > /etc/new.supervisord.conf
+RUN cp /etc/new.supervisord.conf /etc/supervisord.conf
+
+USER ${SEL_UID}
+
+# Expose the control server port
+EXPOSE 9001

--- a/docker/developers/selenium-video/selenium-video.control.py
+++ b/docker/developers/selenium-video/selenium-video.control.py
@@ -1,0 +1,64 @@
+from http.server import BaseHTTPRequestHandler,HTTPServer
+from urllib.parse import urlparse
+from urllib.parse import parse_qs
+from os import environ
+from os import system
+import subprocess
+import json
+import psutil
+
+video_ready_port = int(environ.get('VIDEO_CONTROL_PORT', 9001))
+
+class Handler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+        print(parsed)
+        print(params)
+        response_code = 404
+        response_body = b''
+
+        if parsed.path == '/start':
+            print('starting')
+
+            # Build our environment as a copy of our own plus the params
+            env = dict(environ)
+            for k, v in params.items():
+                params[k] = v[0]
+            env = {**env, **params}
+
+            # Run the video.sh script
+            process = subprocess.Popen('/opt/bin/video.sh', env=env)
+
+            # Return the PID as a response
+            response_body = json.dumps({'pid': process.pid}).encode('utf-8')
+        elif parsed.path == '/stop':
+            # Gracefully terminate the video.sh script
+            pid = params.get('pid', [])
+            if len(pid) > 0:
+                print(f'stopping process with pid {pid[0]}')
+
+                try:
+                    p = psutil.Process(int(pid[0]))
+                    p.terminate()
+                except psutil.NoSuchProcess:
+                    print('video process already stopped. ignoring.')
+            else:
+                print('no pid given to /stop. ignoring.')
+        elif parsed.path == '/stopall':
+            # Stops ALL ffmpeg processes
+            system('pkill -INT ffmpeg')
+        elif parsed.path == '/status':
+            # This just notices that SOMEBODY is recording something
+            video_ready = "ffmpeg" in (p.name().lower() for p in psutil.process_iter())
+            response_code = 200 if video_ready else 404
+            response_text = "ready" if video_ready else "not ready"
+            response_body = json.dumps({'status': response_text}).encode('utf-8')
+
+        self.send_response(response_code)
+        self.end_headers()
+        self.wfile.write(response_body)
+
+httpd = HTTPServer( ('0.0.0.0', video_ready_port), Handler )
+httpd.serve_forever()

--- a/docker/developers/selenium-video/selenium-video.supervisord.conf
+++ b/docker/developers/selenium-video/selenium-video.supervisord.conf
@@ -1,0 +1,12 @@
+;This adds the python server that can handle starting and restarting
+[program:video-control]
+priority=5
+command=python3 /opt/bin/control.py
+autostart=true
+autorestart=true
+stopsignal=INT
+
+;Logs (all activity redirected to stdout so it can be seen through "docker logs"
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0

--- a/lib/cdo/test_run_utils.rb
+++ b/lib/cdo/test_run_utils.rb
@@ -20,9 +20,39 @@ module TestRunUtils
   end
 
   def self.run_local_ui_test
-    feature_path = File.expand_path(ENV.fetch('feature', nil))
+    args = [
+      "--verbose",
+      "--pegasus=localhost.code.org:3000",
+      "--dashboard=localhost-studio.code.org:3000",
+      "--local",
+      "--headed",
+    ]
+
+    if ENV.fetch('feature', nil)
+      # Perform one or more specific test files (delimited by commas)
+      features = ENV.fetch('feature', nil).split(',')
+      feature_path = features.map do |feature|
+        File.expand_path(feature)
+      end.join(',')
+      args << "--feature=#{feature_path}"
+    else
+      # Perform all tests
+      args << "--with-status-page"
+    end
+
+    # If 'browser=' specified, we pass along our desired browser (firefox, chrome, etc)
+    if ENV.fetch('browser', nil)
+      args << "--browser=#{ENV.fetch('browser', nil)}"
+    end
+
+    # If 'selenium=' is specified, we point the UI tests to the given selenium URL
+    if ENV.fetch('selenium', nil)
+      url = ENV.fetch('selenium', nil) == "" ? "http://localhost:4444/wd/hub" : ENV.fetch('selenium', nil)
+      args << "--selenium-hub-url=#{url}"
+    end
+
     Dir.chdir(dashboard_dir('test/ui/')) do
-      RakeUtils.system "./runner.rb --verbose --pegasus=localhost.code.org:3000 --dashboard=localhost-studio.code.org:3000 --local --headed --feature=#{feature_path}"
+      RakeUtils.system "./runner.rb #{args.join(' ')}"
     end
   end
 

--- a/lib/cdo/test_run_utils.rb
+++ b/lib/cdo/test_run_utils.rb
@@ -62,7 +62,7 @@ module TestRunUtils
 
     Dir.chdir(dashboard_dir('test/ui/')) do
       selenium_video_host = ENV.fetch('SELENIUM_VIDEO_HOST', 'localhost')
-      display_container_name = ENV.fetch('DISPLAY_CONTAINER_NAME', 'localhost')
+      display_container_name = ENV.fetch('DISPLAY_CONTAINER_NAME', "selenium.#{browser}")
 
       # For native hosted docker, the display num is different based on the browser
       display_num = 99


### PR DESCRIPTION
This adds a set of contained Selenium services that can operate on a natively running dashboard server that provide a means of running UI tests against different browsers locally.

It offers a Selenium Grid and standalone Selenium with Chrome.

Right now, SauceLabs is most people’s option since local UI testing is more or less broken out of the box.

Changelog:
* Docker Compose metadata to start Selenium containers
* Docker Compose command to run a UI test (one command for Chrome, Firefox, Edge each)
* This also offers the ability to record a video locally of any UI test.

### Running Selenium UI Tests

With your running dashboard server (`./bin/dashboard-server`), start selenium. You can start up individual nodes or start up a full grid. To start up a full grid:

```shell
docker compose run selenium-nodes
```

Alternatively, starting up specific standalones:

```shell
docker compose up selenium-chrome
```

And then it will instruct you on how to run a test. For instance:

```shell
rake test:ui browser=chrome selenium=http://localhost:4444/wd/hub feature=dashboard/test/ui/features/platform/signing_in.feature
```

### Interaction

You can interact with the browser by using a VNC client or using the web-based VNC connection via localhost:

`http://localhost:7910/?autoconnect=1&resize=scale&password=secret`

Here is it running such a test:

![image](https://github.com/user-attachments/assets/f116a0a5-c186-4146-a21b-d34e1195bb38)

You can spin up a specific version of a browser by altering the `.env` file in `docker/developers` which we need to maintain against our CI versions in `browsers.json`. Just update that file and restart the selenium-nodes.

### Recording Video of a UI Test

This also enables recording a video of a UI test. For this, spin up the video service:

```shell
docker compose run selenium-video
```

Then, as it will instruct you, you can run a ui-test with a flag to record to a video:

```shell
rake test:ui browser=chrome record=my-video selenium=http://localhost:4444/wd/hub feature=dashboard/test/ui/features/platform/signing_in.feature
```

Which will create `/tmp/my-video.chrome.mp4` containing the video of the test session.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
