### PR TITLE
Move Blockly setup into MusicView, remove setupFunction

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -230,11 +230,6 @@ export interface Lab2EntryPoint {
    * to the default theme if not specified.
    */
   theme?: Theme;
-  /**
-   * Optional function to run when the lab is first mounted. This is useful
-   * for any one-time setup actions such as setting up Blockly.
-   */
-  setupFunction?: () => void;
 }
 
 export type LevelData = ProjectLevelData | VideoLevelData;

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -39,8 +39,6 @@ const LabViewsRenderer: React.FunctionComponent = () => {
   // When navigating to a new app type, add it to the list of apps to render.
   useEffect(() => {
     if (currentAppName && !appsToRender.includes(currentAppName)) {
-      // Run the setup function for the Lab if it has one.
-      lab2EntryPoints[currentAppName]?.setupFunction?.();
       setAppsToRender([...appsToRender, currentAppName]);
     }
   }, [currentAppName, appsToRender]);

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -17,6 +17,7 @@ import {
   TriggerStart,
   TRIGGER_FIELD,
 } from './constants';
+import {setUpBlocklyForMusicLab} from './setup';
 import {getToolbox} from './toolbox';
 
 const experiments = require('@cdo/apps/util/experiments');
@@ -30,6 +31,19 @@ type CompiledEvents = {[key: string]: {code: string; args?: string[]}};
  * workspace view, execute code, and save/load projects.
  */
 export default class MusicBlocklyWorkspace {
+  private static isBlocklyEnvironmentSetup = false;
+
+  // Setup the global Blockly environment for Music Lab.
+  // This should only happen once per page load.
+  public static setupBlocklyEnvironment() {
+    if (this.isBlocklyEnvironmentSetup) {
+      return;
+    }
+
+    setUpBlocklyForMusicLab();
+    this.isBlocklyEnvironmentSetup = true;
+  }
+
   private workspace: WorkspaceSvg | Workspace | null;
   private container: HTMLElement | null;
   private codeHooks: {[key: string]: (...args: unknown[]) => void};

--- a/apps/src/music/entrypoint.ts
+++ b/apps/src/music/entrypoint.ts
@@ -1,11 +1,9 @@
 import {OptionsToAvoid, Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
-import {setUpBlocklyForMusicLab} from '@cdo/apps/music/blockly/setup'; // avoid hardcoding imports like this in an entrypoint.tsx
 import MusicView from '@cdo/apps/music/views/MusicView'; // avoid hardcoding imports like this in an entrypoint.tsx
 
 export const MusicEntryPoint: Lab2EntryPoint = {
   backgroundMode: true,
   theme: Theme.DARK,
-  setupFunction: setUpBlocklyForMusicLab,
   view: OptionsToAvoid.UseHardcodedView_WARNING_Bloats_Lab2_Bundle,
   hardcodedView: MusicView,
 };

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -144,6 +144,8 @@ class UnconnectedMusicView extends React.Component {
       loadedLibrary: false,
       hasLoadedInitialSounds: false,
     };
+
+    MusicBlocklyWorkspace.setupBlocklyEnvironment();
   }
 
   componentDidMount() {


### PR DESCRIPTION
Move the calling of the one-time Blockly setup out of the `setupFunction` call in lab2 and into `MusicView` directly. This allows us to fully remove the `setupFunction` hook from lab2 entrypoints since Music Lab was the only user of this feature. This gets us closer to being able to lazy-load Music Lab.

## Links

https://codedotorg.atlassian.net/browse/LABS-926

## Testing story

Tested with the music lab intro script + allthethings. Blockly setup only happens once per page load.