### PR TITLE
Music: remove analytics listeners on unmount

### DIFF
--- a/apps/src/lab2/utils/LifecycleNotifier.tsx
+++ b/apps/src/lab2/utils/LifecycleNotifier.tsx
@@ -6,7 +6,7 @@ export enum LifecycleEvent {
   LevelLoadCompleted,
 }
 
-type callbackArgs = {
+type CallbackArgs = {
   [LifecycleEvent.LevelChangeRequested]: [
     previousLevelId: string | null,
     nextLevelId: string
@@ -19,29 +19,35 @@ type callbackArgs = {
   ];
 };
 
+type Callback<T extends LifecycleEvent> = (...args: CallbackArgs[T]) => void;
+
 /**
  * Notifies listeners of lifecycle events in the Lab2 system, which doesn't reload the page between levels.
  */
 class LifecycleNotifier {
-  private listeners: {
-    [event in LifecycleEvent]?: ((...args: callbackArgs[event]) => void)[];
-  };
+  private listeners: {[T in LifecycleEvent]?: Callback<T>[]};
 
   constructor() {
     this.listeners = {};
   }
 
-  addListener<T extends LifecycleEvent>(
-    event: T,
-    callback: (...args: callbackArgs[T]) => void
-  ) {
+  addListener<T extends LifecycleEvent>(event: T, callback: Callback<T>) {
     if (!this.listeners[event]) {
       this.listeners[event] = [];
     }
     this.listeners[event]?.push(callback);
   }
 
-  notify<T extends LifecycleEvent>(event: T, ...args: callbackArgs[T]) {
+  removeListener<T extends LifecycleEvent>(event: T, callback: Callback<T>) {
+    if (this.listeners[event]) {
+      const index = this.listeners[event].indexOf(callback);
+      if (index !== -1) {
+        this.listeners[event].splice(index, 1);
+      }
+    }
+  }
+
+  notify<T extends LifecycleEvent>(event: T, ...args: CallbackArgs[T]) {
     this.listeners[event]?.forEach(callback => callback(...args));
   }
 }


### PR DESCRIPTION
Minor update to remove the analytics listeners whenever Music Lab unmounts. Currently this doesn't happen because Music Lab is always rendered in the background, but if we were to switch to unmounting when Music Lab is not on the page, we'd need to remove these listeners so they don't get added twice when Music Lab gets mounted again.

## Testing story

Tested by locally setting backgroundMode to false. Confirmed that listeners are only called once per event.