### PR TITLE
Create AichatRequest model for ActiveJob

### DIFF
--- a/dashboard/app/models/aichat_request.rb
+++ b/dashboard/app/models/aichat_request.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: aichat_requests
+#
+#  id                   :bigint           not null, primary key
+#  user_id              :integer          not null
+#  model_customizations :json             not null
+#  stored_messages      :json
+#  new_message          :text(65535)      not null
+#  status               :integer
+#  response             :text(65535)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+class AichatRequest < ApplicationRecord
+  belongs_to :user
+end

--- a/dashboard/app/models/aichat_request.rb
+++ b/dashboard/app/models/aichat_request.rb
@@ -6,7 +6,7 @@
 #  user_id              :integer          not null
 #  model_customizations :json             not null
 #  stored_messages      :json
-#  new_message          :text(65535)      not null
+#  new_message          :json             not null
 #  status               :integer
 #  response             :text(65535)
 #  created_at           :datetime         not null

--- a/dashboard/app/models/aichat_request.rb
+++ b/dashboard/app/models/aichat_request.rb
@@ -4,10 +4,13 @@
 #
 #  id                   :bigint           not null, primary key
 #  user_id              :integer          not null
+#  level_id             :integer
+#  script_id            :integer
+#  project_id           :integer
 #  model_customizations :json             not null
-#  stored_messages      :json
+#  stored_messages      :json             not null
 #  new_message          :json             not null
-#  status               :integer
+#  execution_status     :integer          not null
 #  response             :text(65535)
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null

--- a/dashboard/db/migrate/20240807174943_create_aichat_requests.rb
+++ b/dashboard/db/migrate/20240807174943_create_aichat_requests.rb
@@ -1,0 +1,15 @@
+class CreateAichatRequests < ActiveRecord::Migration[6.1]
+  def change
+    # use utf8mb4 to support emoji
+    create_table :aichat_requests, charset: 'utf8mb4', collation: 'utf8mb4_bin' do |t|
+      t.integer :user_id, null: false
+      t.json :model_customizations, null: false
+      t.json :stored_messages
+      t.text :new_message, null: false
+      t.integer :status
+      t.text :response
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/migrate/20240807174943_create_aichat_requests.rb
+++ b/dashboard/db/migrate/20240807174943_create_aichat_requests.rb
@@ -3,10 +3,13 @@ class CreateAichatRequests < ActiveRecord::Migration[6.1]
     # use utf8mb4 to support emoji
     create_table :aichat_requests, charset: 'utf8mb4', collation: 'utf8mb4_bin' do |t|
       t.integer :user_id, null: false
+      t.integer :level_id
+      t.integer :script_id
+      t.integer :project_id
       t.json :model_customizations, null: false
-      t.json :stored_messages
+      t.json :stored_messages, null: false
       t.json :new_message, null: false
-      t.integer :status
+      t.integer :execution_status, null: false
       t.text :response
 
       t.timestamps

--- a/dashboard/db/migrate/20240807174943_create_aichat_requests.rb
+++ b/dashboard/db/migrate/20240807174943_create_aichat_requests.rb
@@ -5,7 +5,7 @@ class CreateAichatRequests < ActiveRecord::Migration[6.1]
       t.integer :user_id, null: false
       t.json :model_customizations, null: false
       t.json :stored_messages
-      t.text :new_message, null: false
+      t.json :new_message, null: false
       t.integer :status
       t.text :response
 

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_26_205216) do
+ActiveRecord::Schema.define(version: 2024_08_07_174943) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -79,6 +79,17 @@ ActiveRecord::Schema.define(version: 2024_07_26_205216) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id", "level_id", "script_id"], name: "index_ace_user_level_script"
+  end
+
+  create_table "aichat_requests", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.json "model_customizations", null: false
+    t.json "stored_messages"
+    t.text "new_message", null: false
+    t.integer "status"
+    t.text "response"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "aichat_sessions", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 2024_08_07_174943) do
     t.integer "user_id", null: false
     t.json "model_customizations", null: false
     t.json "stored_messages"
-    t.text "new_message", null: false
+    t.json "new_message", null: false
     t.integer "status"
     t.text "response"
     t.datetime "created_at", precision: 6, null: false

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -83,10 +83,13 @@ ActiveRecord::Schema.define(version: 2024_08_07_174943) do
 
   create_table "aichat_requests", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "user_id", null: false
+    t.integer "level_id"
+    t.integer "script_id"
+    t.integer "project_id"
     t.json "model_customizations", null: false
-    t.json "stored_messages"
+    t.json "stored_messages", null: false
     t.json "new_message", null: false
-    t.integer "status"
+    t.integer "execution_status", null: false
     t.text "response"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -743,4 +743,25 @@ module SharedConstants
     STUDENT: 'student',
     TEACHER: 'teacher',
   ).freeze
+
+  AI_REQUEST_EXECUTION_STATUS = {
+    # The request has been created but has not yet been processed.
+    NOT_STARTED: 0,
+    # The request has been queued for processing.
+    QUEUED: 1,
+    # The request is currently being processed.
+    RUNNING: 2,
+    # The request was successfully processed.
+    SUCCESS: 3,
+    # The request failed to process for an unexpected reason.
+    FAILURE: 1000,
+    # Profanity detected in the user's input.
+    USER_PROFANITY: 1001,
+    # PII detected in the user's input.
+    USER_PII: 1002,
+    # Profanity detected in the model's output.
+    MODEL_PROFANITY: 1003,
+    # PII detected in the model's output.
+    MODEL_PII: 1004
+  }
 end


### PR DESCRIPTION
Part 1 of moving the aichat chat completion request to an Active Job. This model will be used to store the inputs for the sagemaker request, the status of the job, and the output when completed (or appropriate failure status). 

I've also included a list of execution status codes I'm thinking of using in `shared_constants`. These aren't directly used in this PR, but will be in the job processing and front end request/polling implementation. Included here for reference on how the "status" column would be used. These are modeled after the `RUBRIC_AI_EVALUATION_STATUS` codes that are similarly used to track job status.

Also note that because this model stores the user ID of the requestor, this table can also serve as a record of requests and responses from SageMaker (instead of storing this information in Cloudwatch). I also considered storing additional metadata like level ID, channel ID, etc, but opted to keep this table focused on the specific information necessary for the task. I figured if we wanted to look up a specific user, we could look up their full event history in the AichatEvents table.

## Links

https://codedotorg.atlassian.net/browse/LABS-959

## Testing story

Tested by creating models in the console and in ActiveJob code.