### PR TITLE
Serializing course json on unit_group_unit entry deletion with additional warnings during deletion.

### DIFF
--- a/dashboard/app/models/unit_group_unit.rb
+++ b/dashboard/app/models/unit_group_unit.rb
@@ -26,9 +26,15 @@ class UnitGroupUnit < ApplicationRecord
   # the experiment_name enabled.
   belongs_to :default_script, class_name: 'Unit', optional: true
 
+  after_destroy_commit :update_course_json
+
   def self.experiments
     Rails.cache.fetch("course_script_experiments") do
       UnitGroupUnit.where.not(experiment_name: nil).map(&:experiment_name)
     end
+  end
+
+  def update_course_json
+    UnitGroup.find_by(id: course_id)&.write_serialization
   end
 end

--- a/dashboard/app/views/scripts/index.html.haml
+++ b/dashboard/app/views/scripts/index.html.haml
@@ -18,4 +18,4 @@
           - if script_level
             %td= link_to 'Play', script_next_path(script)
           %td= link_to(t('crud.edit'), edit_script_path(script))
-          %td= link_to t('crud.destroy'), script_path(script), method: :delete, data: { confirm: "Deleting [#{script.name}], #{t('crud.confirm')}" }
+          %td= link_to t('crud.destroy'), script_path(script), method: :delete, data: { confirm: "Deleting [#{script.name}], #{t('crud.confirm')} \n\nIf the unit is part of an unit group, delete the unit in staging and production environments before the content is seeded." }

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -2520,16 +2520,41 @@ class UnitTest < ActiveSupport::TestCase
   test 'deleting unit in unit group updates course json' do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     unit_in_course = create :script, is_migrated: true, name: 'coursename1-2021'
-    unit_group = create(:unit_group)
-    unit_gp_unit = create :unit_group_unit, unit_group: @unit_group, script: unit_in_course, position: 1
-    CourseOffering.add_course_offering(unit_group)
+    course_unit_group = create(:unit_group)
+    unit_gp_unit = create :unit_group_unit, unit_group: course_unit_group, script: unit_in_course, position: 1
+    CourseOffering.add_course_offering(course_unit_group)
 
     File.stubs(:write)
     UnitGroup.any_instance.expects(:write_serialization).once
 
-    unit_group.reload
+    course_unit_group.reload
     unit_in_course.reload
     assert UnitGroupUnit.find_by(id: unit_gp_unit.id)
+
+    # delete unit in unit group
+    unit_id = unit_in_course.id
+    unit_in_course.destroy
+
+    assert Unit.find_by(id: unit_id).nil?
+    assert UnitGroupUnit.find_by(id: unit_gp_unit.id).nil?
+  end
+
+  test 'deleting unit after unit group deletion' do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    unit_in_course = create :script, is_migrated: true, name: 'coursename1-2021'
+    course_unit_group = create(:unit_group)
+    unit_gp_unit = create :unit_group_unit, unit_group: course_unit_group, script: unit_in_course, position: 1
+    CourseOffering.add_course_offering(course_unit_group)
+
+    UnitGroup.any_instance.expects(:write_serialization).never
+
+    course_unit_group.reload
+    unit_in_course.reload
+    assert UnitGroupUnit.find_by(id: unit_gp_unit.id)
+
+    # delete unit group
+    course_unit_group.destroy
+    assert UnitGroupUnit.find_by(id: unit_gp_unit.course_id).nil?
 
     # delete unit in unit group
     unit_id = unit_in_course.id


### PR DESCRIPTION
Issue: As part of this change, [UnitGroupUnit table entries must be deleted when unit is deleted by vijayamanohararaj · Pull Request #59518 · code-dot-org/code-dot-org](https://github.com/code-dot-org/code-dot-org/pull/59518)  when an unit is deleted from the levelbuilder UI, the corresponding unit_group_unit entry in the DB is deleted. But the entry from the course json was not deleted. As a result, anytime levelbuilder environment was built after a unit (which is part of unit group) deletion, it failed due to references to deleted unit from the course JSON.

Fix: The changes in this PR implement an active record call back on deletion to update the course JSON to remove the entry.

When the course json change is seeded in other environments, it will try to delete the unit, which might fail in some cases if it has references. So, there is an updated warning during deletion to correctly orchestrate the unit deletion across all environments to ensure the unit is deleted before the content update gets deployed there.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1200

## Testing story

- Drone
- Manual validation to ensure course JSON is updated

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
