### PR TITLE
Fix two word states so they pdf works on promote

### DIFF
--- a/pegasus/sites.v3/code.org/views/promote_state.haml
+++ b/pegasus/sites.v3/code.org/views/promote_state.haml
@@ -2,6 +2,7 @@
 -data = DB[:cdo_state_promote].where(state_code_s:state).first
 -pass if data.nil?
 -statename = get_us_state_from_abbr(state)
+-statename_no_space = statename.gsub(/\s+/, "")
 -petition_url = data[:petition_url_t]
 %script{type: "text/javascript", src: "/shared/js/helpers.js"}
 %script{type: "text/javascript", src: "/js/promote.js"}
@@ -109,7 +110,7 @@
 .state-buttons
   -if ! state.nil_or_empty?
     .state-button.download-fact-sheet
-      %a{href: "https://code.org/assets/advocacy/stateofcs/2023/#{statename}.pdf", target: '_blank'}
+      %a{href: "https://code.org/assets/advocacy/stateofcs/2023/#{statename_no_space}.pdf", target: '_blank'}
         %button<
           View state fact-sheet
 


### PR DESCRIPTION
I noticed that states with two word names on code.org/promote were not getting the to the state PDF with the new changes made (https://github.com/code-dot-org/code-dot-org/pull/60112). The space in the name such as "North Dakota" was causing them to fail. I stripped the space out and now the PDFs are getting found locally.