### PR TITLE
Job which emails warnings to teachers about their CAP affected sections

### DIFF
--- a/dashboard/app/jobs/cap/sections_warning_email_sender.rb
+++ b/dashboard/app/jobs/cap/sections_warning_email_sender.rb
@@ -1,0 +1,56 @@
+require 'metrics/events'
+require 'services/child_account'
+
+module CAP
+  # Sends an email to a teacher warning them about which sections have students
+  # currently being affected by our Child Account Policy(CAP).
+  class SectionsWarningEmailSender < ApplicationJob
+    rescue_from StandardError, with: :report_exception
+
+    def perform(teacher_id:, section_ids:)
+      return unless teacher_id
+      teacher = User.find_by_id(teacher_id)
+      return unless teacher
+
+      return if section_ids.nil_or_empty?
+      sections = Section.where(id: section_ids)
+      return if sections.nil_or_empty?
+
+      send_warning_email(teacher, sections)
+      log_metrics(teacher)
+    end
+
+    private def log_metrics(teacher)
+      Services::ChildAccount::EventLogger.log_sections_warning_email_sent(teacher)
+      Metrics::Events.log_event(
+        user: teacher,
+        event_name: 'CAP Sections Warning Email Sent',
+        metadata: {
+          'template' => :cap_section_warning.to_s,
+        }
+      )
+    end
+    private def send_warning_email(teacher, sections)
+      template_variables = {}
+      template_variables[:sections] = sections.map do |section|
+        {
+          Name: section.name,
+          Link: section.manage_students_url,
+        }
+      end
+      MailJet.send_teacher_cap_section_warning(teacher, template_variables)
+    end
+
+    private def report_exception(exception)
+      Honeybadger.notify(
+        exception,
+        error_message: '[CAP::SectionsWarningEmailSender] Runtime error',
+        context: {
+          job: as_json,
+        }
+      )
+    ensure
+      raise exception
+    end
+  end
+end

--- a/dashboard/app/models/cap/user_event.rb
+++ b/dashboard/app/models/cap/user_event.rb
@@ -29,6 +29,7 @@ module CAP
       ACCOUNT_LOCKING = 'account_locking'.freeze,
       ACCOUNT_PURGING = 'account_purging'.freeze,
       COMPLIANCE_REMOVING = 'compliance_removing'.freeze,
+      SECTIONS_WARNING_EMAIL_SENT = 'sections_warning_email_sent'.freeze
     ].freeze
 
     enum policy: POLICIES.index_by(&:underscore), _suffix: true

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -494,7 +494,7 @@ class Section < ApplicationRecord
         linkToCurrentUnit: link_to_current_unit,
         courseVersionName: course_version_name,
         numberOfStudents: num_students,
-        linkToStudents: "#{base_url}#{id}/manage_students",
+        linkToStudents: manage_students_url,
         code: code,
         lesson_extras: lesson_extras,
         pairing_allowed: pairing_allowed,
@@ -527,6 +527,10 @@ class Section < ApplicationRecord
         ai_tutor_enabled: ai_tutor_enabled,
       }
     end
+  end
+
+  def manage_students_url
+    CDO.studio_url("/teacher_dashboard/sections/#{id}/manage_students")
   end
 
   def provider_managed?

--- a/dashboard/lib/services/child_account/event_logger.rb
+++ b/dashboard/lib/services/child_account/event_logger.rb
@@ -8,6 +8,7 @@ module Services
       # def self.log_account_locking(user)
       # def self.log_account_purging(user)
       # def self.log_compliance_removing(user)
+      # def self.log_sections_warning_email_sent(user)
       CAP::UserEvent.names.each_key do |event_name|
         define_singleton_method("log_#{event_name}") do |user|
           call(user: user, event_name: event_name)

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -274,6 +274,30 @@ FactoryBot.define do
           user.save validate: false
         end
       end
+      # Gives teacher ownership of a section which has CAP grace_period student.
+      trait :with_cap_grace_period_section do
+        after(:create) do |teacher|
+          student = create(:cpa_non_compliant_student, :in_grace_period)
+          section = create(:section, user: teacher)
+          section.add_student(student)
+        end
+      end
+      # Gives teacher ownership of a section which has CAP locked_out student.
+      trait :with_cap_locked_out_section do
+        after(:create) do |teacher|
+          student = create(:locked_out_child)
+          section = create(:section, user: teacher)
+          section.add_student(student)
+        end
+      end
+      # Gives teacher ownership of a section which has a CAP compliant student.
+      trait :with_cap_compliant_section do
+        after(:create) do |teacher|
+          student = create(:cpa_non_compliant_student, :with_parent_permission)
+          section = create(:section, user: teacher)
+          section.add_student(student)
+        end
+      end
     end
 
     factory :student do

--- a/dashboard/test/jobs/cap/sections_warning_email_sender_test.rb
+++ b/dashboard/test/jobs/cap/sections_warning_email_sender_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+class CAP::SectionsWarningEmailSenderTest < ActiveJob::TestCase
+  let(:described_class) {CAP::SectionsWarningEmailSender}
+
+  describe '#perform_later' do
+    let(:teacher) {create(:teacher, :with_cap_grace_period_section, :with_cap_locked_out_section, :with_cap_compliant_section)}
+    let(:sections) {teacher.sections[..1]}
+    let(:schedule_job) {described_class.perform_later(teacher_id: teacher.id, section_ids: sections.map(&:id))}
+
+    it 'schedules the job on the queue' do
+      assert_enqueued_with(job: described_class) do
+        schedule_job
+      end
+    end
+
+    it 'sends the email only to the CAP gated sections' do
+      described_class.any_instance.expects(:send_warning_email).with(teacher, sections).once
+      perform_enqueued_jobs do
+        schedule_job
+      end
+    end
+
+    it 'logs a CAP::UserEvent' do
+      Services::ChildAccount::EventLogger.expects(:log_sections_warning_email_sent).with(teacher).once
+      perform_enqueued_jobs do
+        schedule_job
+      end
+    end
+
+    it 'logs an event to Metrics::Events' do
+      event_data = {
+        user: teacher,
+        event_name: 'CAP Sections Warning Email Sent',
+        metadata: {
+          'template' => :cap_section_warning.to_s,
+        }
+      }
+      Metrics::Events.expects(:log_event).with(event_data).once
+      perform_enqueued_jobs do
+        schedule_job
+      end
+    end
+    context 'when the teacher_id is nil' do
+      let(:schedule_job) {described_class.perform_later(teacher_id: nil, section_ids: sections.map(&:id))}
+
+      it 'does not send an email' do
+        described_class.any_instance.expects(:send_warning_email).never
+        perform_enqueued_jobs do
+          schedule_job
+        end
+      end
+    end
+
+    context 'when section_ids is nil' do
+      let(:schedule_job) {described_class.perform_later(teacher_id: teacher.id, section_ids: nil)}
+
+      it 'does not send an email' do
+        described_class.any_instance.expects(:send_warning_email).never
+        perform_enqueued_jobs do
+          schedule_job
+        end
+      end
+    end
+
+    context 'when the teacher_id is deleted' do
+      let(:teacher) {create(:teacher, :deleted)}
+
+      it 'does not send an email' do
+        described_class.any_instance.expects(:send_warning_email).never
+        perform_enqueued_jobs do
+          schedule_job
+        end
+      end
+    end
+
+    context 'exception thrown' do
+      let(:exception) {StandardError.new('expected_exception')}
+
+      it 'reports exception to Honeybadger' do
+        described_class.any_instance.stubs(:send_warning_email).with(teacher, sections).raises(exception)
+        Honeybadger.expects(:notify).with(exception, anything).once
+        perform_enqueued_jobs do
+          assert_raises(exception.class) do
+            schedule_job
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creating an ActiveJob wrapper for queuing up warning emails to be sent to teachers who have CAP gated students.

* Creates an ActiveJob which takes a Teacher.id and an array of Section.id's and sends a templated warning email using Mailjet.
* Logs a CAP::UserEvent when the email is sent for the teacher.
* Logs a Statsig & Amplitude event when the email is sent for the teacher.
## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1074)


## Testing story
* Unit tests

## Follow-up work
* There is a separate follow up task to actually query for the teachers and queue these jobs.

