### PR TITLE
[Python Lab] Run setup and cleanup code separately from user code

### DIFF
--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -17,5 +17,6 @@
   "newFolderPrompt": "Please name your new folder",
   "noFileExtensionError": "Please include a file extension",
   "renameFile": "Rename file",
-  "renameFolder": "Rename folder"
+  "renameFolder": "Rename folder",
+  "systemCodeError": "We're sorry, we hit an issue running your program. Please refresh the page and try again."
 }

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -3,6 +3,7 @@ import SwapLayoutButton from '@codebridge/SwapLayoutButton';
 import React, {useEffect, useRef, useState} from 'react';
 import {useDispatch} from 'react-redux';
 
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import Button, {buttonColors} from '@cdo/apps/componentLibrary/button';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -101,6 +102,13 @@ const Console: React.FunctionComponent = () => {
             return (
               <div key={index} className={moduleStyles.errorLine}>
                 {outputLine.contents}
+              </div>
+            );
+          } else if (outputLine.type === 'system_error') {
+            return (
+              <div key={index} className={moduleStyles.errorLine}>
+                {systemMessagePrefix}
+                {codebridgeI18n.systemCodeError()}
               </div>
             );
           } else {

--- a/apps/src/codebridge/redux/consoleRedux.ts
+++ b/apps/src/codebridge/redux/consoleRedux.ts
@@ -5,7 +5,13 @@ export interface CodeBridgeConsoleState {
 }
 
 export interface ConsoleLog {
-  type: 'system_out' | 'system_in' | 'img' | 'system_msg' | 'error';
+  type:
+    | 'system_out'
+    | 'system_in'
+    | 'img'
+    | 'system_msg'
+    | 'error'
+    | 'system_error';
   contents: string;
 }
 
@@ -33,6 +39,9 @@ const consoleSlice = createSlice({
     appendErrorMessage(state, action: PayloadAction<string>) {
       state.output.push({type: 'error', contents: action.payload});
     },
+    appendSystemError(state, action: PayloadAction<string>) {
+      state.output.push({type: 'system_error', contents: action.payload});
+    },
     resetOutput(state) {
       state.output = [];
     },
@@ -45,6 +54,7 @@ export const {
   appendOutputImage,
   appendSystemMessage,
   appendErrorMessage,
+  appendSystemError,
   resetOutput,
 } = consoleSlice.actions;
 

--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -80,6 +80,8 @@ self.onmessage = async event => {
   self.postMessage({type: 'run_complete', message: results, id});
 };
 
+// Run code owned by us (not the user). If there is an error, post a
+// system_error message and return false, otherwise return true.
 async function runInternalCode(code, id) {
   try {
     await self.pyodide.runPythonAsync(code);

--- a/apps/src/pythonlab/pyodideWorkerManager.js
+++ b/apps/src/pythonlab/pyodideWorkerManager.js
@@ -5,17 +5,12 @@ import {
   appendErrorMessage,
 } from '@codebridge/redux/consoleRedux';
 
-import {MAIN_PYTHON_FILE} from '@cdo/apps/lab2/constants';
 import {setAndSaveProjectSource} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import MetricsReporter from '@cdo/apps/lib/metrics/MetricsReporter';
 import {getStore} from '@cdo/apps/redux';
 
 import {parseErrorMessage} from './pythonHelpers/messageHelpers';
 import {MATPLOTLIB_IMG_TAG} from './pythonHelpers/patches';
-import {
-  applyPatches,
-  deleteCachedUserModules,
-} from './pythonHelpers/pythonScriptUtils';
 
 // This syntax doesn't work with typescript, so this file is in js.
 const pyodideWorker = new Worker(
@@ -67,11 +62,8 @@ const asyncRun = (() => {
     id = (id + 1) % Number.MAX_SAFE_INTEGER;
     return new Promise(onSuccess => {
       callbacks[id] = onSuccess;
-      let wrappedScript = applyPatches(script);
-      wrappedScript =
-        wrappedScript + deleteCachedUserModules(source, MAIN_PYTHON_FILE);
       const messageData = {
-        python: wrappedScript,
+        python: script,
         id,
         source,
       };

--- a/apps/src/pythonlab/pyodideWorkerManager.js
+++ b/apps/src/pythonlab/pyodideWorkerManager.js
@@ -3,6 +3,7 @@ import {
   appendSystemMessage,
   appendSystemOutMessage,
   appendErrorMessage,
+  appendSystemError,
 } from '@codebridge/redux/consoleRedux';
 
 import {setAndSaveProjectSource} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
@@ -41,6 +42,13 @@ pyodideWorker.onmessage = event => {
   } else if (type === 'internal_error') {
     MetricsReporter.logError({
       type: 'PythonLabInternalError',
+      message,
+    });
+    return;
+  } else if (type === 'system_error') {
+    getStore().dispatch(appendSystemError(message));
+    MetricsReporter.logError({
+      type: 'PythonLabSystemCodeError',
       message,
     });
     return;

--- a/apps/src/pythonlab/pythonHelpers/messageHelpers.ts
+++ b/apps/src/pythonlab/pythonHelpers/messageHelpers.ts
@@ -7,10 +7,7 @@ import {HOME_FOLDER} from './constants';
  * for end users.
  * Pyodide error messages start with an internal stack trace we can ignore.
  * The first useful line is the one that starts with "File "/Files/main.py", line (line number)", which refers to a line number
- * in main.py. We prepend setup code to the user's main.py, so we adjust the line number accordingly.
- * If there is a further stack trace (from other files) we can just send those lines as is.
- * If there is not, we continue to adjust the line numbers in the error message to account for the setup code we prepended,
- * as the error message line numbers will all refer to main.py.
+ * in main.py. If we find this line, we return the error message starting from this line.
  * If we never find the main error, we return the entire message unaltered.
  *
  * There is one exception to this rule: if the error message is a ModuleNotFoundError relating to a module

--- a/apps/src/pythonlab/pythonHelpers/messageHelpers.ts
+++ b/apps/src/pythonlab/pythonHelpers/messageHelpers.ts
@@ -1,7 +1,6 @@
 import {MAIN_PYTHON_FILE} from '@cdo/apps/lab2/constants';
 
 import {HOME_FOLDER} from './constants';
-import {ALL_PATCHES} from './patches';
 
 /**
  * This method parses an error message from pyodide and makes it more readable and useful
@@ -33,7 +32,6 @@ export function parseErrorMessage(errorMessage: string) {
   const mainErrorRegex = new RegExp(
     `File "\/${HOME_FOLDER}\/${MAIN_PYTHON_FILE}", line \\d+.*`
   );
-  const mainErrorLineRegex = /line (\d+)/;
   let mainErrorLine = 0;
   while (
     mainErrorLine < errorLines.length &&
@@ -45,55 +43,6 @@ export function parseErrorMessage(errorMessage: string) {
     // If we never find the main.py error, return the entire message.
     return errorMessage;
   }
-  let parsedError = getCorrectedMainErrorMessage(
-    errorLines[mainErrorLine],
-    mainErrorLineRegex
-  );
-  let currentLine = mainErrorLine + 1;
-  const lineRegex = new RegExp(
-    `File "\/${HOME_FOLDER}\/([^"]+)", line (\\d+).*`
-  );
-  let hasMultiFileStackTrace = false;
-  while (currentLine < errorLines.length) {
-    let newLine = errorLines[currentLine];
-    if (lineRegex.test(errorLines[currentLine])) {
-      // If the error message refers to another file, we know this is a multi-file stack trace.
-      // We need to track if this is a multi-file stack trace because if it's not, we need to adjust
-      // the line number(s) in the error message.
-      hasMultiFileStackTrace = true;
-    } else if (
-      !hasMultiFileStackTrace &&
-      mainErrorLineRegex.test(errorLines[currentLine])
-    ) {
-      // If the error message refers to a line number in main.py, adjust it.
-      newLine = getCorrectedMainErrorMessage(
-        errorLines[currentLine],
-        mainErrorLineRegex
-      );
-    }
-    parsedError += `\n${newLine}`;
-    currentLine++;
-  }
-  return parsedError;
-}
-
-/**
- * @param message Original error message for the main.py file.
- * @param mainErrorLineRegex Regex to pull out the line number from the main error line
- * @returns The error message with an ajusted line number for main.py that ignores any patches
- * prepended to the user's code
- */
-function getCorrectedMainErrorMessage(
-  message: string,
-  mainErrorLineRegex: RegExp
-) {
-  const originalLine = message.match(mainErrorLineRegex)![1];
-  let prependedLines = 0;
-  for (const patch of ALL_PATCHES) {
-    if (patch.shouldPrepend) {
-      prependedLines += patch.contents.split('\n').length;
-    }
-  }
-  const correctedLine = parseInt(originalLine) - prependedLines;
-  return `${message.replace(`line ${originalLine}`, `line ${correctedLine}`)}`;
+  const adjustedErrorLines = errorLines.slice(mainErrorLine, errorLines.length);
+  return adjustedErrorLines.join('\n');
 }

--- a/apps/src/pythonlab/pythonHelpers/patches.ts
+++ b/apps/src/pythonlab/pythonHelpers/patches.ts
@@ -2,7 +2,7 @@ export const MATPLOTLIB_IMG_TAG = 'MATPLOTLIB_SHOW_IMG';
 
 // Ensure stdout is flushed at the end of the user's program
 // so all of their prints show up. This patch is always appended to the end of the user's code.
-const FLUSH_STDOUT = `import sys
+export const FLUSH_STDOUT = `import sys
 import os
 
 sys.stdout.flush()
@@ -12,11 +12,6 @@ os.fsync(sys.stdout.fileno())
 // TODO: Should we always patch matplotlib? Or can we be smarter about when to patch it?
 // (patching it requires importing it, which can be slow).
 // Ticket: https://codedotorg.atlassian.net/browse/CT-475
-const SETUP_CODE = `from pythonlab_setup import setup_pythonlab
+export const SETUP_CODE = `from pythonlab_setup import setup_pythonlab
 setup_pythonlab('${MATPLOTLIB_IMG_TAG}')
 `;
-
-export const ALL_PATCHES = [
-  {contents: SETUP_CODE, shouldPrepend: true},
-  {contents: FLUSH_STDOUT, shouldPrepend: false},
-];

--- a/apps/src/pythonlab/pythonHelpers/pythonScriptUtils.ts
+++ b/apps/src/pythonlab/pythonHelpers/pythonScriptUtils.ts
@@ -6,22 +6,17 @@ import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
 import _ from 'lodash';
 import {PyodideInterface} from 'pyodide';
 
+import {MAIN_PYTHON_FILE} from '@cdo/apps/lab2/constants';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 
 import {PyodideMessage, PyodidePathContent} from '../types';
 
 import {HIDDEN_FOLDERS} from './constants';
-import {ALL_PATCHES} from './patches';
+import {FLUSH_STDOUT} from './patches';
 
-export function applyPatches(originalCode: string) {
-  let finalCode = originalCode;
-
-  for (const patch of ALL_PATCHES) {
-    finalCode = patch.shouldPrepend
-      ? patch.contents + '\n' + finalCode
-      : finalCode + '\n' + patch.contents;
-  }
-  return finalCode;
+export function getCleanupCode(source: MultiFileSource) {
+  const cleanupCode = FLUSH_STDOUT;
+  return cleanupCode + deleteCachedUserModules(source, MAIN_PYTHON_FILE);
 }
 
 // Pyodide uses the same interpreter for the lifetime of the browser tab.

--- a/apps/src/pythonlab/pythonHelpers/pythonScriptUtils.ts
+++ b/apps/src/pythonlab/pythonHelpers/pythonScriptUtils.ts
@@ -14,7 +14,9 @@ import {PyodideMessage, PyodidePathContent} from '../types';
 import {HIDDEN_FOLDERS} from './constants';
 import {FLUSH_STDOUT} from './patches';
 
+// Returns the cleanup code to be run after the user's code.
 export function getCleanupCode(source: MultiFileSource) {
+  // FLUSH_STDOUT imports sys, so we don't need to import it again for deleteCachedUserModules.
   const cleanupCode = FLUSH_STDOUT;
   return cleanupCode + deleteCachedUserModules(source, MAIN_PYTHON_FILE);
 }
@@ -22,6 +24,7 @@ export function getCleanupCode(source: MultiFileSource) {
 // Pyodide uses the same interpreter for the lifetime of the browser tab.
 // In order to ensure we get updated user code for each run, we delete the
 // modules created by the user code from the sys.modules cache.
+// This script should only be run after sys has been imported.
 export function deleteCachedUserModules(
   source: MultiFileSource,
   excludedFileName: string


### PR DESCRIPTION
When running user code in Python Lab, I was appending setup and cleanup code to the beginning and end of their main method. This meant we had to manually adjust line numbers in error messages relating to the main method, which was a fragile operation. @snickell pointed out we could make separate calls to `runPythonAsync` for our code and the student's code, since the environment is shared between runs. This PR makes this change and removes the unnecessary code for fixing the error messages!

In the very rare (perhaps impossible?) case where our setup code hits an error, we tell the user to refresh the page. I could see this potentially happening if the user does some very unexpected messing around with system code/working directory/etc. in their code. I don't think this could occur in expected user behavior. Refreshing the page will ensure a clean environment.

Error message in this case (generated by forcing an error to be thrown):
![Screenshot 2024-08-08 at 9 07 21 AM](https://github.com/user-attachments/assets/301e61a1-433f-4bc6-922a-95f383456df9)

## Links
- jira ticket: [CT-702](https://codedotorg.atlassian.net/browse/CT-702)

## Testing story
Tested locally.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
