### PR TITLE
Adds basic docker-compose.yml for development environment.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -200,6 +200,7 @@ updates:
     directories:
     - "/aws/offsite/aurora-snapshots-fargate"
     - "/docker/dockerfiles"
+    - "/docker/developers"
     schedule:
       interval: "weekly"
       day: "sunday"

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -41,7 +41,7 @@ brew services start colima
 
 1. Verify that Docker works
 ```shell
-docker run hello-world
+docker run --rm hello-world
 ```
 
 ### Ubuntu

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,123 @@
+# Development with Docker
+
+## Features
+
+* Run development server requirements such as MySQL and Redis in containers.
+
+## Installing Docker
+
+Our Docker development environment requires at least Docker Compose version 2.23 or higher.
+These instructions will walk you through installing a compatible version.
+
+To install Docker, see the appropriate section below:
+[macOS](#macos), [Ubuntu](#ubuntu), [Windows](#windows)
+or consult your package management for your OS.
+
+### macOS
+
+1. Install Docker itself:
+```shell
+brew install docker
+```
+
+1. Install Docker Compose:
+    1. ```shell
+       export DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+       mkdir -p $DOCKER_CONFIG/cli-plugins
+       curl -SL https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-darwin-$(uname -m) -o $DOCKER_CONFIG/cli-plugins/docker-compose
+       chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+       ```
+    1. You can inspect that the version is appropriate by running `docker compose version` and inspecting the result.
+
+1. Install Colima as a container runtime:
+```shell
+brew install colima
+```
+
+1. Start the Colima service (and have it start on login)
+```shell
+brew services start colima
+```
+
+1. Verify that Docker works
+```shell
+docker run hello-world
+```
+
+### Ubuntu
+
+1. Open a terminal.
+
+1. Install Docker via `apt`:
+
+```shell
+sudo apt update && sudo apt install docker.io
+```
+
+1. Enable and start the Docker service
+```shell
+sudo systemctl enable docker
+sudo systemctl start docker
+```
+
+1. Give your account privileges to run Docker
+```shell
+sudo usermod -aG docker ${USER}
+```
+
+1. Verify that Docker works without root (You may need to restart your terminal session.)
+```shell
+docker run hello-world
+```
+
+1. Install Docker Compose:
+    1. ```shell
+       export DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+       mkdir -p $DOCKER_CONFIG/cli-plugins
+       curl -SL https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-linux-$(uname -m) -o $DOCKER_CONFIG/cli-plugins/docker-compose
+       chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+       ```
+    1. You can inspect that the version is appropriate by running `docker compose version` and inspecting the result.
+
+### Windows
+
+Docker on Windows is facilitated with the Docker Desktop application which you can find [here](https://www.docker.com/products/docker-desktop/).
+
+When you install that, you will need to follow the instructions in that app to enable Docker, which may require updating some system settings. There are other instructions found [here](https://docs.docker.com/desktop/install/windows-install/) that may help.
+
+1. Install Docker Desktop from [here](https://www.docker.com/products/docker-desktop/). Using instructions found [here](https://docs.docker.com/desktop/install/windows-install/).
+
+1. Start Docker Desktop. It will say "Engine running" in the lower-left corner of the Docker Desktop window.
+
+1. Start your WSL Ubuntu session.
+
+1. Verify Docker works:
+```shell
+docker run hello-world
+```
+
+1. Verify Docker Compose version is at least 2.23.
+```shell
+docker compose version
+```
+
+## Running a Native Dashboard Server
+
+If you want to run the server code natively, but leverage Docker to run the dependent services, you can follow these instructions.
+
+First, you want to follow the normal [SETUP.md](SETUP.md) instructions for your platform.
+You can skip over many steps that are related to running mysql and redis.
+
+Instead, once you have a working Ruby and Node environment, you can then use this command to spin up the database and redis servers:
+
+```shell
+docker compose run dashboard-services
+```
+
+This will tell you which items you will need to place in your `locals.yml` file for the server to connect to the contained database.
+
+Just copy those lines into your `locals.yml` and start your Dashboard server via:
+
+```shell
+./bin/dashboard-server
+```

--- a/bin/mysql-client-admin
+++ b/bin/mysql-client-admin
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_credential_admin' unless CDO.db_credential_admin
 credentials = CDO.db_credential_admin
+host = CDO.db_endpoint_writer.split(':')[0]
+port = CDO.db_endpoint_writer.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_writer,
-  port: 3306,
+  host: host,
+  port: port,
   path: '/'
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-dashboard-reader
+++ b/bin/mysql-client-dashboard-reader
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_proxy_reader' unless CDO.db_endpoint_proxy_reader
 credentials = CDO.db_credential_reader
+host = CDO.db_endpoint_proxy_reader.split(':')[0]
+port = CDO.db_endpoint_proxy_reader.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_proxy_reader,
-  port: 3306,
+  host: host,
+  port: port,
   path: '/' + CDO.dashboard_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-dashboard-reporting
+++ b/bin/mysql-client-dashboard-reporting
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please set CDO.db_endpoint_proxy_reporting' unless CDO.db_endpoint_proxy_reporting
 credentials = CDO.db_credential_reader
+host = CDO.db_endpoint_proxy_reporting.split(':')[0]
+port = CDO.db_endpoint_proxy_reporting.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_proxy_reporting,
-  port: 3306,
+  host: host,
+  port: port,
   path: '/' + CDO.dashboard_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-dashboard-writer
+++ b/bin/mysql-client-dashboard-writer
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_writer' unless CDO.db_endpoint_writer
 credentials = CDO.db_credential_writer
+host = CDO.db_endpoint_proxy_writer.split(':')[0]
+port = CDO.db_endpoint_proxy_writer.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_writer,
-  port: 3306,
+  host: host,
+  port: port,
   path: '/' + CDO.dashboard_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-pegasus-reader
+++ b/bin/mysql-client-pegasus-reader
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_proxy_reader' unless CDO.db_endpoint_proxy_reader
 credentials = CDO.db_credential_reader
+host = CDO.db_endpoint_proxy_reader.split(':')[0]
+port = CDO.db_endpoint_proxy_reader.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_proxy_reader,
-  port: 3306,
+  host: host,
+  port: port,
   path: '/' + CDO.pegasus_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-pegasus-reporting
+++ b/bin/mysql-client-pegasus-reporting
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_proxy_reporting' unless CDO.db_endpoint_proxy_reporting
 credentials = CDO.db_credential_reader
+host = CDO.db_endpoint_proxy_reporting.split(':')[0]
+port = CDO.db_endpoint_proxy_reporting.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_proxy_reporting,
-  port: 3306,
+  host: host,
+  port: port,
   path: '/' + CDO.pegasus_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-pegasus-writer
+++ b/bin/mysql-client-pegasus-writer
@@ -5,11 +5,13 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_writer' unless CDO.db_endpoint_writer
 credentials = CDO.db_credential_writer
+host = CDO.db_endpoint_proxy_writer.split(':')[0]
+port = CDO.db_endpoint_proxy_writer.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_writer,
-  port: 3306,
+  host: host,
+  port: port,
   path: '/' + CDO.pegasus_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+# Our entry into our docker development environment is described here.
+
+# For an overview of how to use the Docker Development Environment see `DOCKER.md`
+
+# It is split among a few different files that are then merged together via
+# the following `include` section.
+
+include:
+  # Services the dashboard server depends on
+  - path: ./docker/developers/docker-compose.mysql.yml
+  - path: ./docker/developers/docker-compose.redis.yml
+
+  # The dashboard server
+  - path: ./docker/developers/docker-compose.dashboard.yml

--- a/docker/developers/.env
+++ b/docker/developers/.env
@@ -1,0 +1,3 @@
+# The port to spin up a mysql server that is visible to the system (the default is 3306)
+# (This does not affect the port for the fully dockerized mysql container, that is always 3306)
+MYSQL_NATIVE_PORT: 3307

--- a/docker/developers/.env
+++ b/docker/developers/.env
@@ -1,3 +1,6 @@
 # The port to spin up a mysql server that is visible to the system (the default is 3306)
 # (This does not affect the port for the fully dockerized mysql container, that is always 3306)
 MYSQL_NATIVE_PORT: 3306
+
+# Similarly, the native port for redis
+REDIS_NATIVE_PORT: 6379

--- a/docker/developers/.env
+++ b/docker/developers/.env
@@ -1,3 +1,3 @@
 # The port to spin up a mysql server that is visible to the system (the default is 3306)
 # (This does not affect the port for the fully dockerized mysql container, that is always 3306)
-MYSQL_NATIVE_PORT: 3307
+MYSQL_NATIVE_PORT: 3306

--- a/docker/developers/docker-compose.dashboard.yml
+++ b/docker/developers/docker-compose.dashboard.yml
@@ -1,0 +1,32 @@
+include:
+  - path: ./docker-compose.mysql.yml
+  - path: ./docker-compose.redis.yml
+  - path: ./docker-compose.networks.yml
+
+services:
+  # Runs all the dependent services when the dashboard server is running natively
+  dashboard-services:
+    image: alpine
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    command: >
+      /bin/sh -c "
+        echo 'Dashboard services running.' &&
+        echo &&
+        echo 'To shut down all containers:' &&
+        echo 'docker compose stop' &&
+        echo &&
+        echo 'To run the native dashboard server:' &&
+        echo './bin/dashboard-server' &&
+        echo &&
+        echo 'Be sure to have the following in your locals.yml to link to the contained services:' &&
+        echo &&
+        echo 'db_writer: mysql://root:password@127.0.0.1/' &&
+        echo 'db_endpoint_writer: 127.0.0.1' &&
+        echo 'db_credential_admin:' &&
+        echo '  username: user' &&
+        echo '  password: password'
+      "

--- a/docker/developers/docker-compose.dashboard.yml
+++ b/docker/developers/docker-compose.dashboard.yml
@@ -23,10 +23,20 @@ services:
         echo './bin/dashboard-server' &&
         echo &&
         echo 'Be sure to have the following in your locals.yml to link to the contained services:' &&
+        echo 'These will allow you to connect to the database with: ./bin/mysql-client-admin' &&
         echo &&
-        echo 'db_writer: mysql://root:password@127.0.0.1/' &&
-        echo 'db_endpoint_writer: 127.0.0.1' &&
+        echo 'db_writer: mysql://root:password@127.0.0.1:${MYSQL_NATIVE_PORT:-3306}/' &&
+        echo 'db_endpoint_writer: 127.0.0.1:${MYSQL_NATIVE_PORT:-3306}' &&
         echo 'db_credential_admin:' &&
-        echo '  username: user' &&
+        echo '  username: root' &&
+        echo '  password: password' &&
+        echo 'db_endpoint_proxy_reporting: 127.0.0.1:${MYSQL_NATIVE_PORT:-3306}' &&
+        echo 'db_endpoint_proxy_reader: 127.0.0.1:${MYSQL_NATIVE_PORT:-3306}' &&
+        echo 'db_credential_reader:' &&
+        echo '  username: root' &&
+        echo '  password: password' &&
+        echo 'db_endpoint_proxy_writer: 127.0.0.1:${MYSQL_NATIVE_PORT:-3306}' &&
+        echo 'db_credential_writer:' &&
+        echo '  username: root' &&
         echo '  password: password'
       "

--- a/docker/developers/docker-compose.dashboard.yml
+++ b/docker/developers/docker-compose.dashboard.yml
@@ -25,6 +25,11 @@ services:
         echo 'Be sure to have the following in your locals.yml to link to the contained services:' &&
         echo 'These will allow you to connect to the database with: ./bin/mysql-client-admin' &&
         echo &&
+        echo '# Redis connections' &&
+        echo 'geocoder_redis_url: redis://localhost:${REDIS_NATIVE_PORT}/0/geocoder' &&
+        echo 'session_store_server: redis://localhost:${REDIS_NATIVE_PORT}/0/session' &&
+        echo &&
+        echo '# MySQL connections' &&
         echo 'db_writer: mysql://root:password@127.0.0.1:${MYSQL_NATIVE_PORT:-3306}/' &&
         echo 'db_endpoint_writer: 127.0.0.1:${MYSQL_NATIVE_PORT:-3306}' &&
         echo 'db_credential_admin:' &&

--- a/docker/developers/docker-compose.mysql.yml
+++ b/docker/developers/docker-compose.mysql.yml
@@ -1,0 +1,41 @@
+include:
+  - path: ./docker-compose.networks.yml
+
+services:
+  # Docker-managed database
+  mysql-base: &mysql-base
+    hostname: db
+    image: mysql/mysql-server:8.0
+    # You can add default options via the 'command':
+    #command:
+    # - '--log-error-verbosity=3'
+    environment:
+      MYSQL_DATABASE: 'db'
+      MYSQL_USER: 'user'
+      MYSQL_PASSWORD: 'password'
+      MYSQL_ROOT_PASSWORD: 'password'
+      MYSQL_ROOT_HOST: '%'
+    volumes:
+      - mysql_data:/var/lib/mysql
+    # Many default ulimits are just too high
+    # And, so, it will consume way too much memory (16GB+)
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+
+  mysql-contained:
+    <<: *mysql-base
+    expose:
+      - "3306"
+    networks:
+      cdo_network_test:
+      cdo_network:
+
+  mysql:
+    <<: *mysql-base
+    ports:
+      - "3306:3306"
+
+volumes:
+  mysql_data:

--- a/docker/developers/docker-compose.mysql.yml
+++ b/docker/developers/docker-compose.mysql.yml
@@ -24,6 +24,7 @@ services:
         soft: 65536
         hard: 65536
 
+  # Supports a Dockerized Dashboard server
   mysql-contained:
     <<: *mysql-base
     expose:
@@ -32,10 +33,11 @@ services:
       cdo_network_test:
       cdo_network:
 
+  # Runs a database visible to the native machine
   mysql:
     <<: *mysql-base
     ports:
-      - "3306:3306"
+      - "${MYSQL_NATIVE_PORT:-3306}:3306"
 
 volumes:
   mysql_data:

--- a/docker/developers/docker-compose.networks.yml
+++ b/docker/developers/docker-compose.networks.yml
@@ -1,0 +1,5 @@
+networks:
+  cdo_network:
+    driver: bridge
+  cdo_network_test:
+    driver: bridge

--- a/docker/developers/docker-compose.redis.yml
+++ b/docker/developers/docker-compose.redis.yml
@@ -1,0 +1,21 @@
+include:
+  - path: ./docker-compose.networks.yml
+
+services:
+  # Docker-managed redis server
+  redis-base: &redis-base
+    hostname: redis
+    image: redis:latest
+
+  redis-contained: 
+    <<: *redis-base
+    expose:
+      - "6379"
+    networks:
+      cdo_network_test:
+      cdo_network:
+
+  redis:
+    <<: *redis-base
+    ports:
+      - "6379:6379"

--- a/docker/developers/docker-compose.redis.yml
+++ b/docker/developers/docker-compose.redis.yml
@@ -10,7 +10,7 @@ services:
   redis-contained: 
     <<: *redis-base
     expose:
-      - "6379"
+      - "${REDIS_NATIVE_PORT}"
     networks:
       cdo_network_test:
       cdo_network:
@@ -18,4 +18,4 @@ services:
   redis:
     <<: *redis-base
     ports:
-      - "6379:6379"
+      - "${REDIS_NATIVE_PORT:-6379}:6379"


### PR DESCRIPTION
This adds Docker Compose support for third-party services directly depended upon by our Dashboard and Pegasus servers to run a local version of the site.

This adds:
* `docker-compose.yml` to the project root
* Some Docker specific instructions in `DOCKER.md`
* Docker compose service files that are split up by major services and placed in `docker/developers`
* Introduces the conventions for compose services and where those go
* Adds, just as a matter of convenience, references to such services in their "contained" varieties. These are for later on when such services are used with our code-dot-org applications being run, themselves, within the container network.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
