### PR TITLE
make isCurrentLevelLab2 optional

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -81,7 +81,7 @@ class TeacherPanel extends React.Component {
     setSectionLockStatus: PropTypes.func.isRequired,
     selectSection: PropTypes.func.isRequired,
     setViewType: PropTypes.func.isRequired,
-    isCurrentLevelLab2: PropTypes.bool.isRequired,
+    isCurrentLevelLab2: PropTypes.bool,
     lab2ExampleSolutions: PropTypes.array,
   };
 


### PR DESCRIPTION
Script overview pages are showing the following error in the console:

![image (214)](https://github.com/user-attachments/assets/ce5316a6-4cef-43a3-a980-058f1129359f)

This is because the Teacher Panel expects the `isCurrentLevelLab2` property to be required. However, there's no level when we're on a script overview page. The solution is to not make this property required.

Slack thread: https://codedotorg.slack.com/archives/C044AGTKW3D/p1723133710098249
