### PR TITLE
[Google Blockly] Blockly.showUnusedBlocks and block.isUserVisible

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -443,8 +443,12 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   };
 
   extendedBlockSvg.isUserVisible = function () {
-    // TODO - used for EXTRA_TOP_BLOCKS_FAIL feedback
-    return false;
+    // Used for EXTRA_TOP_BLOCKS_FAIL feedback
+    // Mainline Blockly doesn't support invisible blocks. If a block should be
+    // invisible, we instead load it to the hidden workspace. We use custom
+    // serialization hooks to manage this block state.
+    // Any block on the main workspace is visible.
+    return this.workspace === Blockly.getMainWorkspace();
   };
 
   // Labs like Maze and Artist turn undeletable blocks gray.
@@ -769,6 +773,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.isToolboxMode =
       optOptionsExtended.editBlocks === 'toolbox_blocks';
     blocklyWrapper.toolboxBlocks = options.toolbox;
+    blocklyWrapper.showUnusedBlocks = options.showUnusedBlocks;
     blocklyWrapper.blockLimitMap = cdoUtils.createBlockLimitMap();
     const workspace = blocklyWrapper.blockly_.inject(
       container,

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -85,6 +85,7 @@ type GoogleBlocklyType = typeof GoogleBlockly;
 
 // Type for the Blockly instance created and modified by googleBlocklyWrapper.
 export interface BlocklyWrapperType extends GoogleBlocklyType {
+  showUnusedBlocks: boolean | undefined;
   BlockFieldHelper: {[fieldHelper: string]: string};
   enableParamEditing: boolean;
   selected: BlockSvg;
@@ -281,6 +282,7 @@ export interface ExtendedBlocklyOptions extends BlocklyOptions {
   useBlocklyDynamicCategories: boolean;
   grayOutUndeletableBlocks: boolean | undefined;
   disableParamEditing: boolean;
+  showUnusedBlocks: boolean | undefined;
 }
 
 export interface ExtendedWorkspace extends Workspace {


### PR DESCRIPTION
This migrates one block method and a wrapper property that originated with CDO Blockly. These are used together to give students feedback about "unused" blocks. 

On production with Artist and Google Blockly, we can see that students can get bad feedback (and sad bee noises) immediately upon dragging a block out of the toolbox. Shown below at `s/csc-starquilts-2023/lessons/2/levels/2?blocklyVersion=google`:

![2024-08-08 13-11-55 2024-08-08 13_12_46](https://github.com/user-attachments/assets/fae1b36c-7369-4645-ac50-1a988c0ca27b)

The issue is two-fold: The feedback string is the wrong one. The feedback also shouldn't be given here at all. 

If a student is failing due to unused blocks (extra top blocks), and there is a `when run` block, we show more specific feedback: "You have unattached blocks. Did you mean to attach these to the \"when run\" block?"

https://github.com/code-dot-org/code-dot-org/blob/826c81f94a4531a28852a0773481b7a3b910cc6c/apps/src/feedback.js#L738-L749

We are currently seeing a less specific feedback message because we're not detecting the visible `when run` block on the main workspace. Because mainline Blockly doesn't support invisible blocks, we move them to the hidden workspace. Therefore, all blocks on the main workspace are (and should be) visible. Providing a working definition for `extendedBlockSvg.isUserVisible` gets us using the correct string. However, in this case, the string shouldn't be there at all.

We enter this failure state based on few separate checks, including whether `Blockly.showUnusedBlocks` is falsy:

https://github.com/code-dot-org/code-dot-org/blob/826c81f94a4531a28852a0773481b7a3b910cc6c/apps/src/feedback.js#L1685-L1691

Studio App calls inject with an `options.showUnusedBlocks` value that is true unless explicitly set in the config:

https://github.com/code-dot-org/code-dot-org/blob/826c81f94a4531a28852a0773481b7a3b910cc6c/apps/src/StudioApp.js#L2983


CDO Blockly reads and sets this value during `inject` but Google Blockly does not. By adding this to the wrapper, we ensure it gets set correctly, which results in the above feedback no longer being shown erroneously.

By fixing both issues, the level can now be completed without an interruption of bad feedback:
![2024-08-08 13-31-06 2024-08-08 13_31_38](https://github.com/user-attachments/assets/fbbe990a-310d-411b-a69e-4f59abc52fe7)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
