### PR TITLE
ci.rake: `pdm install` before `rake lint` is run

### DIFF
--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -48,6 +48,7 @@ namespace :ci do
   # Additionally run the lint task if specified for the environment.
   timed_task_with_logging build: [:chef_update] do
     Dir.chdir(deploy_dir) do
+      RakeUtils.python_venv_install # we need python for linting python
       ChatClient.wrap('rake lint') {Rake::Task['lint'].invoke} if CDO.lint
       ChatClient.wrap('rake build') {Rake::Task['build'].invoke}
     end


### PR DESCRIPTION
When doing the chef rollout for the PyCall PR #60048, we discovered that staging calls `rake lint` from `rake ci` from `aws/ci_build`. Its called before `rake install` is run, which means that the Python linter `pdm run ruff check` has not been installed, and thus the build fails ([build log](https://cdo-build-logs.s3.amazonaws.com/staging/20240809T042706%2B0000?versionId=m4AapBMMnA.0HDNjtdODf.0jhmBps0ca&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAW5P5EEELCL6R7IXI%2F20240809%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240809T043420Z&X-Amz-Expires=21233&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEEUaCXVzLWVhc3QtMSJHMEUCIQD14pa0F4aYinpdLINtxnHTmlMFsgu%2FOLr9VMoKqMuQpwIgJjarPLVk2331Y0fGWPzeaXiZiVun2B%2BIWMOLTzs5OxwqswUIPhAAGgw0NzU2NjE2MDcxOTAiDDCCAz7QNZfWhbcpiCqQBacCIvwb9yJcSnNZk3dPSFpUm75DuAycpIx9B1P%2B94Oy6b4LXf%2Fsi8TyRxWfypU%2BDiFffUaoEtVhFZTrAi81pQvYRcUZLGWyMrKb3T%2FMi0gcKIvW8qadYar%2Fhs9R81RMYxLCBRetV2Xox8KUEwsIirXASwwrAD6L1q88SpUev82wmLQWAKes2bShq64AV2qzCIIT%2FQQzz93mi%2BlgCDATOlY1PpGztzNv%2FlsF6CuVvzsJjsgd89snpaZOKuPf4XOn2TynAvV%2BnqdlVz7JhVx1jOSH2TwRLi5q3JafvhlFDmMlCC9%2FKCX7LGQq%2BWgUBiN6VbMYMv3P1M%2BBtsei%2BEueF7e5lzhxaDbAzJ86kBOOhFbNM1NVo8h0dkMRmMGCxfZUcb8%2BQKg1d6j%2BE9mTVYZhCTzBfgksR5vSq32FADLZ0JVIf6Ej5fgVEfXrRvAl2jyZPsICe9lgjjN9WVTJ3YF33DtAvDi2W6OFO0HD5lWkBRGvpcBzUbLFfZsiEFbFj85Y8b9xiO0Tp%2FGOBjH2XyQn0v6bkr7%2FouI8ROTBs2x4BKZiK4cygmhFnj9ZefXhHhPyHdlzVGwnvuL5uQ5%2FPAkQPgG9jsDZTfPjk0kpL%2FxBz3gAtKd4YRtSPvGOjriNeNgdDDJ3gX5IFnBPVQ5E%2Biqw%2BgNBZjs3K%2FBh5X%2FmeAZfXiXaY2StGlj47aw5QznQlIHCNlMGKqMm3Q3348xhXfjuyHm7LJokJxo6GAf%2FbRGFUv%2B7m6TA72Nu3ZJKXL3K8ufsQCsx3VWWewItjITcFmCSTPn0mIp13gsO4fYSxB7A8WLmERC9pv%2F74WzeUJLgjrpGD4e%2BoFBjGpLm9YGA9ZlFYXehO1WVyy5V2WNtUUYfvgMPMOmz1rUGOrEBGloVQAuYZUC2Y7rSx4UTsMVjQvkq0sATVkr9rjIKGyHNEwQGqxhAUgOhm5DfzJkq2W2SjgSpA6KkCW1NVMnQGtUm6rXkKDpXGnZRCuYtowKkNGTidzeRw%2BLmYVLl1izFWBeEyxTFlRIPu21P3XRxcRyEt8vYfafJywLm6p47fN2bdN6x2pG0wvAeHkSBk%2BpIbZmJRpaxkkhN05uf0JF4YdNZTOf3xK4qiPkveH0IQ3kN&X-Amz-SignedHeaders=host&X-Amz-Signature=edbe6a29fe3fc74cca1d9748b0f37b198ef4463130e358ee6b95a8aa0c8680e8)).

This PR:
- Manually calls `pdm install` from `rake ci:build` just after running `rake ci:chef_update` and just prior to running `rake lint`.

I did not make it conditional on `CDO.lint`, because it felt better to have the install done at a relatively predictable/stable point as this step can involved installing a new python interpreter when version change, etc.