### PR TITLE
build-cdo: pass HOME to `rake build` so pdm isn't confused

### DIFF
--- a/cookbooks/cdo-apps/metadata.rb
+++ b/cookbooks/cdo-apps/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-apps'
 long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.646'
+version          '0.2.647'
 
 depends 'apt'
 

--- a/cookbooks/cdo-apps/recipes/build.rb
+++ b/cookbooks/cdo-apps/recipes/build.rb
@@ -13,7 +13,7 @@ env = {
 execute 'build-cdo' do
   command 'bundle exec rake build --trace'
   cwd root
-  environment env.merge(node['cdo-apps']['bundle_env'])
+  environment env.merge(node['cdo-apps']['bundle_env'], {HOME: "/home/#{user}"})
   live_stream true
   user user
   group user


### PR DESCRIPTION
PyCall PR resulted in chef build breakage on production-console and frontend instances (probably AMIBuilder). 

This is the same type of error we saw with cdo_apps.rb.

Chef `execute` with `user user` doesn't set the user env vars, so HOME=/root and USER=root. pdm checks for a config file in $HOME, but its running as `ubuntu`, and cannot access /root/.config. It exits, and the build is broken.

See previous parallel fix: c612ac4000411bf9a1d899c3aefabaf9b7ba3eee (actually, that one just reformatted, it was the change before that)

Error looked like:
```
Recipe: cdo-apps::build
  * execute[build-cdo] action run
    [execute] ** Invoke build (first_time)
              ** Execute build
              ** Invoke build:all (first_time)
              ** Invoke build:dashboard (first_time)
              ** Invoke package (first_time)
              ** Invoke package:apps (first_time)
              ** Invoke package:apps:update (first_time)
              ** Execute package:apps:update
              GetSecretValue: production/cdo/slack_token
              GetSecretValue: production/cdo/slack_bot_token
              ** Invoke package:apps:symlink (first_time)
              ** Execute package:apps:symlink
              ** Execute package:apps
              ** Execute package
              ** Execute build:dashboard
              I, [2024-08-09T07:48:02.657099 #2356270]  INFO -- : Package is current: 716e558111056fac64612724702ab0da0ebb0ef5528b991bd1585a9339dd184b
              Finished package:apps:update (less than a minute)
              Finished package:apps:symlink (less than a minute)
              Finished package:apps (less than a minute)
              Finished package (less than a minute)
              sudo bundle config set --local without development adhoc staging test levelbuilder integration
              sudo bundle install --quiet --jobs 4
              pdm install --prod --frozen-lockfile
              Traceback (most recent call last):
                File "/usr/local/bin/pdm", line 8, in <module>
                  sys.exit(main())
                File "/usr/local/lib/python3.8/dist-packages/pdm/core.py", line 344, in main
                  core = Core()
                File "/usr/local/lib/python3.8/dist-packages/pdm/core.py", line 82, in __init__
                  self.load_plugins()
                File "/usr/local/lib/python3.8/dist-packages/pdm/core.py", line 328, in load_plugins
                  self._add_project_plugins_library()
                File "/usr/local/lib/python3.8/dist-packages/pdm/core.py", line 302, in _add_project_plugins_library
                  project = self.create_project(is_global=False)
                File "/usr/local/lib/python3.8/dist-packages/pdm/core.py", line 156, in create_project
                  return self.project_class(self, root_path, is_global, global_config)
                File "/usr/local/lib/python3.8/dist-packages/pdm/project/core.py", line 92, in __init__
                  self.global_config = Config(Path(global_config), is_global=True)
                File "/usr/local/lib/python3.8/dist-packages/pdm/project/config.py", line 266, in __init__
                  self._file_data = load_config(self.config_file)
                File "/usr/local/lib/python3.8/dist-packages/pdm/project/config.py", line 45, in load_config
                  if not file_path.is_file():
                File "/usr/lib/python3.8/pathlib.py", line 1439, in is_file
                  return S_ISREG(self.stat().st_mode)
                File "/usr/lib/python3.8/pathlib.py", line 1198, in stat
                  return self._accessor.stat(self)
              PermissionError: [Errno 13] Permission denied: '/root/.config/pdm/config.toml'
              rake aborted!
              'pdm install --prod --frozen-lockfile' returned 1
              
              Tasks: TOP => build:all => build:dashboard
```
