### PR TITLE
Add new users to welcome series list

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -140,12 +140,14 @@ class RegistrationsController < Devise::RegistrationsController
         begin
           MailJet.create_contact_and_add_to_welcome_series(current_user, request.locale)
         rescue => exception
-          # If the welcome email fails to send, we don't want to disrupt
+          # If we can't add the user to the welcome series, we don't want to disrupt
           # sign up, but we do want to know about it.
           Honeybadger.notify(
             exception,
-            error_message: 'Failed to send MailJet welcome email',
-            context: {}
+            error_message: 'Failed to add user to welcome series',
+            context: {
+              locale: request.locale,
+            }
           )
         end
       end

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -138,7 +138,7 @@ class RegistrationsController < Devise::RegistrationsController
     if current_user && current_user.errors.blank?
       if current_user.teacher?
         begin
-          MailJet.create_contact_and_send_welcome_email(current_user, request.locale)
+          MailJet.create_contact_and_add_to_welcome_series(current_user, request.locale)
         rescue => exception
           # If the welcome email fails to send, we don't want to disrupt
           # sign up, but we do want to know about it.

--- a/dashboard/app/views/layouts/_implicit_new_user_terms_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_implicit_new_user_terms_interstitial.html.haml
@@ -1,7 +1,7 @@
 #implicit-terms-modal.modal{'data-backdrop' => 'static', 'data-keyboard' => 'false', style: 'display: none;'}
   %row
     .span#implicit_accept_terms_message
-      = t('terms_interstitial.accept_tos', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy'), markdown: :inline).html_safe
+      = t('terms_interstitial.accept_new_tos', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy'), markdown: :inline).html_safe
   %row
     %button#close_btn_go_to_account{type: 'button'}
       = t('signup_form.go_to_account')

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -972,7 +972,7 @@ en:
     privacy_notice: "Privacy Notice"
     accept_label: 'I agree to the <a href="%{tos_url}" target="_blank">Terms of Service</a> and <a href="%{privacy_url}" target="_blank">Privacy Policy</a>.'
     accept_label_markdown: I agree to the [Terms of Service](%{tos_url}) and [Privacy Policy](%{privacy_url}).
-    accept_tos: By signing up for Code.org, you agree to our [Terms of Service](%{tos_url}) and [Privacy Policy](%{privacy_url}), and acknowledge that you will receive a series of 6 onboarding emails over 2 weeks.
+    accept_tos: By signing up for Code.org, you agree to our [Terms of Service](%{tos_url}) and [Privacy Policy](%{privacy_url}), and acknowledge that you will receive a series of onboarding emails over the next few weeks.
     accept_new_tos: By signing up for Code.org, you agree to our [Terms of Service](%{tos_url}) and [Privacy Policy](%{privacy_url}).
     accept: "Accept"
     print: "Print"

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -972,7 +972,8 @@ en:
     privacy_notice: "Privacy Notice"
     accept_label: 'I agree to the <a href="%{tos_url}" target="_blank">Terms of Service</a> and <a href="%{privacy_url}" target="_blank">Privacy Policy</a>.'
     accept_label_markdown: I agree to the [Terms of Service](%{tos_url}) and [Privacy Policy](%{privacy_url}).
-    accept_tos: By signing up for Code.org, you agree to our [Terms of Service](%{tos_url}) and [Privacy Policy](%{privacy_url}).
+    accept_tos: By signing up for Code.org, you agree to our [Terms of Service](%{tos_url}) and [Privacy Policy](%{privacy_url}), and acknowledge that you will receive a series of 6 onboarding emails over 2 weeks.
+    accept_new_tos: By signing up for Code.org, you agree to our [Terms of Service](%{tos_url}) and [Privacy Policy](%{privacy_url}).
     accept: "Accept"
     print: "Print"
     reminder_desc: 'We have updated our <a href="%{tos_url}" target="_blank">Terms of Service</a> and <a href="%{privacy_url}" target="_blank">Privacy Policy</a>. Please read these carefully before accepting them. Note that our tools teaching JavaScript may be unavailable to your students before explicitly accepting the updated terms.'

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -348,7 +348,7 @@ class RegistrationsControllerTest < ActionController::TestCase
     teacher_params = @default_params.update(user_type: 'teacher', email_preference_opt_in: 'yes')
     Geocoder.stubs(:search).returns([OpenStruct.new(country_code: 'CA')])
     MailJet.stubs(:enabled?).returns(true)
-    MailJet.expects(:create_contact_and_send_welcome_email).once
+    MailJet.expects(:create_contact_and_add_to_welcome_series).once
     assert_creates(User) do
       post :create, params: {user: teacher_params}
     end

--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -52,17 +52,13 @@ module MailJet
     return nil unless enabled?
     return nil unless valid_email?(email)
 
-    Mailjet.configure do |config|
-      config.api_key = API_KEY
-      config.secret_key = SECRET_KEY
-      config.api_version = "v3"
-    end
+    configure_api_v3
 
     contact = Mailjet::Contact.find(email)
     return contact if contact&.id.present?
 
     Mailjet::Contact.create(
-      is_excluded_from_campaigns: "false",
+      is_excluded_from_campaigns: false,
       email: email,
       name: name
     )
@@ -87,11 +83,7 @@ module MailJet
   def self.delete_contact(email)
     return unless enabled?
 
-    Mailjet.configure do |config|
-      config.api_key = API_KEY
-      config.secret_key = SECRET_KEY
-      config.api_version = "v3"
-    end
+    configure_api_v3
 
     contact = Mailjet::Contact.find(email)
     return unless contact
@@ -109,11 +101,7 @@ module MailJet
     return unless enabled?
     return if contact.nil?
 
-    Mailjet.configure do |config|
-      config.api_key = API_KEY
-      config.secret_key = SECRET_KEY
-      config.api_version = "v3"
-    end
+    configure_api_v3
 
     # This will raise an exception if the contact is already on the list
     Mailjet::Listrecipient.create(
@@ -126,11 +114,7 @@ module MailJet
     return unless enabled?
     return unless contact&.email.present?
 
-    Mailjet.configure do |config|
-      config.api_key = API_KEY
-      config.secret_key = SECRET_KEY
-      config.api_version = "v3.1"
-    end
+    configure_api_v3dot1
 
     from_address = email_config[:from_address]
     from_name = email_config[:from_name]
@@ -165,5 +149,22 @@ module MailJet
     # Description of values in the result field described here: https://documentation.mailgun.com/docs/inboxready/mailgun-validate/single-valid-ir/#result-types
     return false if %w(do_not_send undeliverable).include?(validation_response['result'])
     return true
+  end
+
+  # The send API has an option of v3 or v3.1. We've been using v3.1.
+  def self.configure_api_v3dot1
+    Mailjet.configure do |config|
+      config.api_key = API_KEY
+      config.secret_key = SECRET_KEY
+      config.api_version = "v3.1"
+    end
+  end
+
+  def self.configure_api_v3
+    Mailjet.configure do |config|
+      config.api_key = API_KEY
+      config.secret_key = SECRET_KEY
+      config.api_version = "v3"
+    end
   end
 end

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -24,6 +24,7 @@ module MailJetConstants
     welcome_series: {
       default: 10_353_815,
       'es-MX': 10_353_822,
+      'es-ES': 10_353_822,
     }
   }
 end

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -19,4 +19,11 @@ module MailJetConstants
       from_name: 'Hadi Partovi',
     }
   }.freeze
+
+  CONTACT_LISTS = {
+    welcome_series: {
+      default: 10_353_815,
+      'es-MX': 10_353_822,
+    }
+  }
 end

--- a/lib/test/cdo/test_mailjet.rb
+++ b/lib/test/cdo/test_mailjet.rb
@@ -10,7 +10,7 @@ class MailJetTest < Minitest::Test
     email = 'fake.email@test.xx'
     name = 'Fake Name'
 
-    Mailjet::Contact.expects(:create).with(is_excluded_from_campaigns: 'false', email: email, name: name)
+    Mailjet::Contact.expects(:create).with(is_excluded_from_campaigns: false, email: email, name: name)
 
     mock_contact = mock('Mailjet::Contact')
     Mailjet::Contact.stubs(:find).with(email).returns(nil).then.returns(mock_contact)

--- a/lib/test/cdo/test_mailjet.rb
+++ b/lib/test/cdo/test_mailjet.rb
@@ -10,7 +10,7 @@ class MailJetTest < Minitest::Test
     email = 'fake.email@test.xx'
     name = 'Fake Name'
 
-    Mailjet::Contact.expects(:create).with(is_excluded_from_campaigns: true, email: email, name: name)
+    Mailjet::Contact.expects(:create).with(is_excluded_from_campaigns: 'false', email: email, name: name)
 
     mock_contact = mock('Mailjet::Contact')
     Mailjet::Contact.stubs(:find).with(email).returns(nil).then.returns(mock_contact)
@@ -133,7 +133,7 @@ class MailJetTest < Minitest::Test
     MailJet.send_template_email(mock_contact, email_config, 'es-MX')
   end
 
-  def test_create_contact_and_send_welcome_email
+  def test_create_contact_and_add_to_welcome_series
     email = 'fake.email@test.xx'
     sign_up_time = Time.now.to_datetime
 
@@ -149,9 +149,30 @@ class MailJetTest < Minitest::Test
 
     MailJet.expects(:update_contact_field).with(mock_contactdata, 'sign_up_date', sign_up_time.rfc3339)
 
-    MailJet.expects(:send_template_email).with(mock_contactdata, MailJet::EMAILS[:welcome], 'en-US')
+    MailJet.expects(:add_to_contact_list).with(mock_contactdata, MailJet::CONTACT_LISTS[:welcome_series][:default])
 
-    MailJet.create_contact_and_send_welcome_email(user)
+    MailJet.create_contact_and_add_to_welcome_series(user)
+  end
+
+  def test_create_contact_and_add_to_welcome_series_non_en
+    email = 'fake.email@test.xx'
+    sign_up_time = Time.now.to_datetime
+
+    user = mock
+    user.stubs(:id).returns(1)
+    user.stubs(:email).returns(email)
+    user.stubs(:name).returns('Fake Name')
+    user.stubs(:teacher?).returns(true)
+    user.stubs(:created_at).returns(sign_up_time)
+
+    mock_contactdata = mock('Mailjet::Contactdata')
+    MailJet.expects(:find_or_create_contact).with(email, user.name).returns(mock_contactdata)
+
+    MailJet.expects(:update_contact_field).with(mock_contactdata, 'sign_up_date', sign_up_time.rfc3339)
+
+    MailJet.expects(:add_to_contact_list).with(mock_contactdata, MailJet::CONTACT_LISTS[:welcome_series][:'es-MX'])
+
+    MailJet.create_contact_and_add_to_welcome_series(user, 'es-MX')
   end
 
   def test_valid_email_deliverable
@@ -194,5 +215,16 @@ class MailJetTest < Minitest::Test
     Net::HTTP.any_instance.expects(:request).never
 
     MailJet.delete_contact(email)
+  end
+
+  def test_add_to_contact_list
+    contact = mock('Mailjet::Contact')
+    contact.stubs(:id).returns(123)
+
+    list_id = 456
+
+    Mailjet::Listrecipient.expects(:create).with(list_id: list_id, contact_id: 123)
+
+    MailJet.add_to_contact_list(contact, list_id)
   end
 end


### PR DESCRIPTION
Instead of sending a welcome email when teachers sign up for our site, we're going to instead add them a "contact list", which will be configured to send the user a series of welcome emails.

I left the previous methods around as we'll need them for other scenarios.

See the [product spec](https://docs.google.com/document/d/11ZhI9YvbJwMICH4St9TJSHoIY-BLluJxt30YJsw0hHk/edit?usp=gmail_thread#heading=h.qi8xxyq72bct) for more details!

