### PR TITLE
Show header for enrolled workshops

### DIFF
--- a/apps/src/code-studio/pd/professional_learning_landing/EnrolledWorkshops.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/EnrolledWorkshops.jsx
@@ -23,7 +23,7 @@ class EnrolledWorkshops extends React.Component {
         hideNoWorkshopsMessage={true}
         tableHeader={i18n.myWorkshops()}
       >
-        <WorkshopsTable />
+        <WorkshopsTable tableHeader={i18n.myWorkshops()} />
       </WorkshopTableLoader>
     );
   }


### PR DESCRIPTION
I broke this when I restricted the workshops shown for facilitators, program managers, workshop organizers, and workshop admins to only the workshops that hadn't been completed. 😅 

Before:

![Screenshot 2024-08-09 at 11 58 04 AM](https://github.com/user-attachments/assets/ca33b087-86cc-4c24-9a63-414097a867b9)

After:

![Screenshot 2024-08-09 at 12 15 43 PM](https://github.com/user-attachments/assets/8f5d0f3a-40ae-427a-914a-47f975856d00)



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
