### PR TITLE
[JIMT] - fixed the button label on startover dialog

### DIFF
--- a/apps/src/lab2/views/dialogs/StartOverDialog.tsx
+++ b/apps/src/lab2/views/dialogs/StartOverDialog.tsx
@@ -47,7 +47,7 @@ const StartOverDialog: React.FunctionComponent<StartOverDialogProps> = ({
       buttons={{
         confirm: {
           callback: handleConfirm,
-          text: commonI18n.skipToProject(),
+          text: commonI18n.startOver(),
         },
         cancel: {
           callback: handleCancel,


### PR DESCRIPTION
#60192 broke the button label on the startover dialog and accidentally set it to the skip dialog's text. Whoops. Sorry.

This puts the proper string back into place.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
