### PR TITLE
Add controller actions for AI Chat ActiveJob request

### DIFF
--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -1,4 +1,6 @@
 ROLES_FOR_MODEL = %w(assistant user).freeze
+DEFAULT_POLLING_INTERVAL_MS = 1000
+DEFAULT_POLLING_BACKOFF_RATE = 1.2
 
 class AichatController < ApplicationController
   include AichatSagemakerHelper
@@ -18,6 +20,66 @@ class AichatController < ApplicationController
 
     response_body = get_response_body
 
+    render(status: :ok, json: response_body)
+  end
+
+  # POST /aichat/start_chat_completion
+  # Initiate a chat completion request, which is performed asynchronously as an ActiveJob.
+  # Returns the ID of the request and a base polling interval + backoff rate.
+  def start_chat_completion
+    return render status: :forbidden, json: {} unless AichatSagemakerHelper.can_request_aichat_chat_completion?
+    unless chat_completion_has_required_params?
+      return render status: :bad_request, json: {}
+    end
+
+    # Filter out non-OK messages (e.g. errors)
+    messages_for_model = params[:storedMessages].select {|message| message[:status] == SharedConstants::AI_INTERACTION_STATUS[:OK]}
+    context = params[:aichatContext]
+
+    # Create the request object
+    begin
+      request = AichatRequest.create!(
+        user_id: current_user.id,
+        model_customizations: params[:aichatModelCustomizations].to_json,
+        stored_messages: messages_for_model.to_json,
+        new_message: params[:newMessage].to_json,
+        level_id: context[:currentLevelId],
+        script_id: context[:scriptId],
+        project_id: get_project_id(context)
+      )
+    rescue StandardError => exception
+      return render status: :bad_request, json: {error: exception.message}
+    end
+
+    # Start the job
+    locale = params[:locale] || "en"
+    AichatRequestChatCompletionJob.perform_later(request: request, locale: locale)
+
+    # Return the request ID, polling interval, and backoff rate
+    response_body = {
+      requestId: request.id,
+      pollingIntervalMs: get_polling_interval_ms,
+      backoffRate: get_backoff_rate
+    }
+    render(status: :ok, json: response_body)
+  end
+
+  # GET /aichat/chat_request/:id
+  # Get the chat completion request status and response for the given ID.
+  def chat_request
+    begin
+      request = AichatRequest.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      return render status: :not_found, json: {}
+    end
+
+    # Only the user who initiated the request can view the response and status
+    return render status: :forbidden, json: {} if request.user_id != current_user.id
+
+    response_body = {
+      executionStatus: request.execution_status,
+      response: request.response
+    }
     render(status: :ok, json: response_body)
   end
 
@@ -171,5 +233,20 @@ class AichatController < ApplicationController
 
   private def get_user_message(status)
     params[:newMessage].merge({status: status})
+  end
+
+  private def get_polling_interval_ms
+    DCDO.get("aichat_polling_interval_ms", DEFAULT_POLLING_INTERVAL_MS)
+  end
+
+  private def get_backoff_rate
+    DCDO.get("aichat_polling_backoff_rate", DEFAULT_POLLING_BACKOFF_RATE)
+  end
+
+  private def get_project_id(context)
+    if context[:channelId]
+      _, project_id = storage_decrypt_channel_id(context[:channelId])
+      project_id
+    end
   end
 end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -486,6 +486,8 @@ class Ability
           user.teachers.any? {|teacher| teacher.has_pilot_experiment?(GENAI_PILOT)})
         can :chat_completion, :aichat
         can :log_chat_event, :aichat
+        can :start_chat_completion, :aichat
+        can :chat_request, :aichat
       end
       # Only teachers can view student chat history.
       if user.has_pilot_experiment?(GENAI_PILOT)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1171,6 +1171,8 @@ Dashboard::Application.routes.draw do
     post '/aichat/log_chat_event', to: 'aichat#log_chat_event'
     get '/aichat/student_chat_history', to: 'aichat#student_chat_history'
     post '/aichat/check_message_safety', to: 'aichat#check_message_safety'
+    post '/aichat/start_chat_completion', to: 'aichat#start_chat_completion'
+    get '/aichat/chat_request/:id', to: 'aichat#chat_request'
 
     resources :ai_tutor_interactions, only: [:create, :index] do
       resources :feedbacks, controller: 'ai_tutor_interaction_feedbacks', only: [:create]


### PR DESCRIPTION
Adds actions to the `aichat_controller` for kicking off the AichatRequest ActiveJob and querying its status and response. I added these as separate from the existing `chat_completion` action that they will eventually replace, to avoid breaking the existing implementation.

- `POST /aichat/start_chat_completion` creates a new `AichatRequest` from the given parameters and kicks off the job. It returns the request's ID, a polling interval in ms, and a backoff rate to the client (the latter two are configurable via DCDO).
- `GET /aichat/chat_request/:id` returns the current status of the given request ID and the response if present. This is the endpoint that client will poll while waiting for a response from the model.

## Links

https://codedotorg.atlassian.net/browse/LABS-959

## Testing story

Tested with front-end changes (upcoming) and unit tests