### PR TITLE
AITT - move ai assessment arrow to follow suggested level

### DIFF
--- a/apps/src/EditorAnnotator.js
+++ b/apps/src/EditorAnnotator.js
@@ -830,10 +830,10 @@ export default class EditorAnnotator {
       return EditorAnnotator.code_;
     }
 
-    let code = EditorAnnotator.annotator().getCode();
+    let code = EditorAnnotator.annotator()?.getCode();
     EditorAnnotator.code_ = code;
 
-    if (options.stripComments) {
+    if (options.stripComments && code) {
       code = EditorAnnotator.anonymizeCode_(code);
       EditorAnnotator.strippedCode_ = code;
     }

--- a/apps/src/templates/rubrics/EvidenceLevels.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevels.jsx
@@ -21,6 +21,7 @@ export default function EvidenceLevels({
   isAutosaving,
   isAiAssessed,
   aiEvalInfo,
+  arrowPositionCallback,
 }) {
   const sortedEvidenceLevels = () => {
     const newArray = [...evidenceLevels];
@@ -45,6 +46,7 @@ export default function EvidenceLevels({
         radioButtonCallback={radioButtonCallback}
         canProvideFeedback={canProvideFeedback}
         isAutosaving={isAutosaving}
+        arrowPositionCallback={arrowPositionCallback}
       />
     );
   }
@@ -62,4 +64,5 @@ EvidenceLevels.propTypes = {
   isAutosaving: PropTypes.bool,
   isAiAssessed: PropTypes.bool.isRequired,
   aiEvalInfo: aiEvaluationShape,
+  arrowPositionCallback: PropTypes.func,
 };

--- a/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
@@ -100,7 +100,6 @@ export default function EvidenceLevelsForTeachersV2({
       const nextDim = nodes[1].getBoundingClientRect();
       left = (nextDim.left - dim.right) / 2 + dim.right - edge;
     }
-    console.log(left);
     arrowPositionCallback(left);
   }, [arrowPositionCallback, suggestedEvidenceLevels]);
 

--- a/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
@@ -85,6 +85,10 @@ export default function EvidenceLevelsForTeachersV2({
   }, [productTour]);
 
   useLayoutEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
     // Get the position of the suggested buttons and determine the position of the arrow
     const edge = ref.current.getBoundingClientRect().left;
     const nodes = ref.current.querySelectorAll('button[data-ai-suggested]');
@@ -101,7 +105,7 @@ export default function EvidenceLevelsForTeachersV2({
       left = (nextDim.left - dim.right) / 2 + dim.right - edge;
     }
     arrowPositionCallback(left);
-  }, [arrowPositionCallback, suggestedEvidenceLevels]);
+  }, [ref, arrowPositionCallback, suggestedEvidenceLevels]);
 
   if (canProvideFeedback) {
     return (

--- a/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
@@ -1,6 +1,12 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {useMemo, useState, useEffect} from 'react';
+import React, {
+  useMemo,
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from 'react';
 
 import {
   BodyThreeText,
@@ -29,7 +35,10 @@ export default function EvidenceLevelsForTeachersV2({
   isAutosaving,
   isAiAssessed,
   aiEvalInfo,
+  arrowPositionCallback,
 }) {
+  const ref = useRef(null);
+
   // Generates a list of evidence levels to highlight, indicating the AI
   // recommendation. Using the precomputed value showExactMatch, decides whether
   // to highlight a single evidence level (exact match) or a range of two
@@ -75,15 +84,40 @@ export default function EvidenceLevelsForTeachersV2({
     }
   }, [productTour]);
 
+  useLayoutEffect(() => {
+    // Get the position of the suggested buttons and determine the position of the arrow
+    const edge = ref.current.getBoundingClientRect().left;
+    const nodes = ref.current.querySelectorAll('button[data-ai-suggested]');
+    const node = nodes[0];
+    const dim = node?.getBoundingClientRect();
+
+    let left = 0;
+    if (nodes.length === 1) {
+      // If there is just one node, we center it on that suggested level
+      left = (dim.right - dim.left) / 2 + dim.left - edge;
+    } else if (nodes.length === 2) {
+      // If there are two nodes, we place it between the two
+      const nextDim = nodes[1].getBoundingClientRect();
+      left = (nextDim.left - dim.right) / 2 + dim.right - edge;
+    }
+    console.log(left);
+    arrowPositionCallback(left);
+  }, [arrowPositionCallback, suggestedEvidenceLevels]);
+
   if (canProvideFeedback) {
     return (
       <div id="tour-evidence-levels">
         <BodyThreeText className={style.evidenceLevelHeaderText}>
           <StrongText>{i18n.assignARubricScore()}</StrongText>
         </BodyThreeText>
-        <div className={style.evidenceLevelSetHorizontal}>
+        <div className={style.evidenceLevelSetHorizontal} ref={ref}>
           {evidenceLevels.map(evidenceLevel => (
             <button
+              data-ai-suggested={
+                suggestedEvidenceLevels.includes(evidenceLevel.understanding)
+                  ? ''
+                  : null
+              }
               disabled={isAutosaving}
               type="button"
               key={evidenceLevel.id}
@@ -154,4 +188,5 @@ EvidenceLevelsForTeachersV2.propTypes = {
   isAutosaving: PropTypes.bool,
   isAiAssessed: PropTypes.bool.isRequired,
   aiEvalInfo: aiEvaluationShape,
+  arrowPositionCallback: PropTypes.func,
 };

--- a/apps/src/templates/rubrics/LearningGoal.jsx
+++ b/apps/src/templates/rubrics/LearningGoal.jsx
@@ -298,6 +298,7 @@ export default function LearningGoal({
             submittedEvaluation={submittedEvaluation}
             isStudent={isStudent}
             isAutosaving={autosaveStatus === STATUS.IN_PROGRESS}
+            arrowPositionCallback={_ => {}}
           />
           {learningGoal.tips && !isStudent && (
             <div>

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -303,6 +303,11 @@ export default function LearningGoals({
   const [aiFeedback, setAiFeedback] = useState(-1);
   const [doneLoading, setDoneLoading] = useState(false);
 
+  // The position of the 'arrow' that points up from the AiAssessment region
+  // to the EvidenceLevels component. When this value is 0, there is no
+  // specific left and the arrow is centered.
+  const [arrowLeft, setArrowLeft] = useState(10);
+
   // The ref version of this state is used when updating the information based
   // on saved info retrieved by network requests so as not to race them.
   const [currentLearningGoal, setCurrentLearningGoal] = useState(0);
@@ -728,6 +733,7 @@ export default function LearningGoals({
                   submittedEvaluation={submittedEvaluation}
                   isStudent={isStudent}
                   isAutosaving={autosaveStatus === STATUS.IN_PROGRESS}
+                  arrowPositionCallback={setArrowLeft}
                 />
                 {teacherHasEnabledAi &&
                   !!studentLevelInfo &&
@@ -737,6 +743,14 @@ export default function LearningGoals({
                       id="tour-ai-assessment"
                       className={style.aiAssessmentOuterBlock}
                     >
+                      {/* Draw the arrow pointing at the AI suggested buttons.
+                          EvidenceLevels sets the arrowLeft parameter to reflect the
+                          position of the buttons. And we subtract some to center it.*/}
+                      <div
+                        id="ai-assessment-arrow"
+                        className={style.aiAssessmentArrow}
+                        style={arrowLeft === 0 ? {} : {left: arrowLeft - 10}}
+                      />
                       <AiAssessment
                         isAiAssessed={
                           learningGoals[currentLearningGoal].aiEnabled

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -1091,7 +1091,6 @@ p.evidenceLevelHeaderText {
   border: 1px solid $light_black;
   background: $neutral_white;
   gap: 10px;
-  padding: 3px 16px 0;
   font-size: 0.875rem;
   height: 32px;
   box-shadow: 0 0 0 0.125rem $ai_rubric_cyan;

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -571,19 +571,18 @@ p.errorMessage {
   border: 1px solid $neutral_dark20;
   background: $neutral_white;
   position: relative;
+}
 
-  &::after {
-    content: '';
-    position: absolute;
-    top: calc(-0.5rem * sqrt(2) + 0.125rem);
-    left: calc(50% - 0.5rem);
-    width: 1rem;
-    height: 1rem;
-    background: $neutral_white;
-    transform: rotate(45deg);
-    border-top: 1px solid $neutral_dark20;
-    border-left: 1px solid $neutral_dark20;
-  }
+.aiAssessmentArrow {
+  position: absolute;
+  top: calc(-0.5rem * sqrt(2) + 0.125rem);
+  left: calc(50% - 0.5rem);
+  width: 1rem;
+  height: 1rem;
+  background: $neutral_white;
+  transform: rotate(45deg);
+  border-top: 1px solid $neutral_dark20;
+  border-left: 1px solid $neutral_dark20;
 }
 
 .aiAssessmentBlock {

--- a/apps/test/unit/templates/rubrics/EvidenceLevelsForTeachersV2Test.jsx
+++ b/apps/test/unit/templates/rubrics/EvidenceLevelsForTeachersV2Test.jsx
@@ -19,6 +19,7 @@ const DEFAULT_PROPS = {
     {id: 4, understanding: 3, teacherDescription: 'test4'},
   ],
   learningGoalKey: 'key-1',
+  arrowPositionCallback: _ => {},
 };
 
 describe('EvidenceLevelsForTeachersV2', () => {


### PR DESCRIPTION
This moves the arrow in the area separating the rest of the AI assessment box with the evidence level buttons such that the arrow lines up with the suggested level.

## Screenshots

Without the AI box details:

![image](https://github.com/user-attachments/assets/8e571c16-4dd1-40f3-a9a8-944b13e5bc49)

With two buttons:

![image](https://github.com/user-attachments/assets/5927c96b-7344-4cb7-b19c-e6ec3e20d6f3)

With one button:

![image](https://github.com/user-attachments/assets/224cc982-6de9-4964-ac89-2140496c6aba)

When teacher selects an option, it resets to center (since this is not the AI suggestion anymore)

![image](https://github.com/user-attachments/assets/c9d1149e-e8c8-4c0b-a0b4-ca9311448270)

Video in the Jira link.

## Links

- jira ticket: [AITT-513](https://codedotorg.atlassian.net/browse/AITT-513)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
