### PR TITLE
pycall 1.5.1 => pycall 1.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -349,7 +349,7 @@ gem 'cld'
 
 gem 'crowdin-api', '~> 1.10.0'
 
-gem "pycall", "~> 1.5"
+gem "pycall", ">= 1.5.2"
 
 gem "delayed_job_active_record", "~> 4.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -673,7 +673,7 @@ GEM
       multi_json (~> 1.0)
       pusher-signature (~> 0.1.8)
     pusher-signature (0.1.8)
-    pycall (1.5.1)
+    pycall (1.5.2)
     racc (1.6.2)
     rack (2.2.6.4)
     rack-cache (1.13.0)


### PR DESCRIPTION
I've been reading a lot of pycall source code, and `pycall 1.5.2` has a fix I'd like to pull in, without it there's a potential segfault on ruby exit.

The change I want in particular is: https://github.com/mrkn/pycall.rb/commit/9a40e6b9c01ec904837a902fb323978ebebf596c