### PR TITLE
Music: image attribution

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -337,6 +337,12 @@ export interface SoundData {
   key?: Key;
 }
 
+export interface ImageAttribution {
+  author: string;
+  color?: string;
+  position?: 'left' | 'right';
+}
+
 export type SoundFolderType = 'sound' | 'kit' | 'instrument';
 
 export interface SoundFolder {
@@ -351,6 +357,7 @@ export interface SoundFolder {
   sounds: SoundData[];
   bpm?: number;
   key?: Key;
+  imageAttribution?: ImageAttribution;
 }
 
 export type LibraryJson = {

--- a/apps/src/music/views/PackDialog.module.scss
+++ b/apps/src/music/views/PackDialog.module.scss
@@ -77,15 +77,34 @@
             border-radius: 5px;
           }
 
-          &Image {
+          &ImageContainer {
             width: 100%;
             transform: scale(1, 1);
             transition: 0.1s ease-in-out;
-            border-radius: 5px;
 
             &:hover, &Selected {
               transform: scale(1.03, 1.03);
               transition: 0.1s ease-in-out;
+            }
+          }
+
+          &Image {
+            border-radius: 5px;
+
+            &Attribution {
+              transform: rotate(270deg) translate(0, 0);
+              position: absolute;
+              top: 6px;
+              right: 18px;
+              transform-origin: top right;
+              font-size: 8px;
+              opacity: 0.3;
+
+              &Left {
+                top: -10px;
+                right: initial;
+                transform: translate(-100%, 100%) rotate(270deg);
+              }
             }
           }
 

--- a/apps/src/music/views/PackDialog.tsx
+++ b/apps/src/music/views/PackDialog.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import React, {useCallback, useState, useRef, useContext} from 'react';
 import FocusLock from 'react-focus-lock';
 
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import Typography from '@cdo/apps/componentLibrary/typography';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -37,6 +38,9 @@ const PackEntry: React.FunctionComponent<PackEntryProps> = ({
   const soundPath = previewSound && folder.id + '/' + previewSound.src;
   const isPlayingPreview = previewSound && playingPreview === soundPath;
   const imageSrc = library?.getPackImageUrl(folder.id);
+  const imageAttributionAuthor = folder.imageAttribution?.author;
+  const imageAttributionColor = folder.imageAttribution?.color;
+  const packImageAttributionLeft = folder.imageAttribution?.position === 'left';
 
   const onEntryClick = useCallback(() => {
     onSelect(folder);
@@ -61,15 +65,42 @@ const PackEntry: React.FunctionComponent<PackEntryProps> = ({
     >
       <div className={styles.packImageContainer}>
         {imageSrc && (
-          <img
-            src={imageSrc}
+          <div
             className={classNames(
-              styles.packImage,
-              isSelected && styles.packImageSelected
+              styles.packImageContainer,
+              isSelected && styles.packImageContainerSelected
             )}
-            alt=""
-            draggable={false}
-          />
+          >
+            <img
+              className={styles.packImage}
+              src={imageSrc}
+              alt=""
+              draggable={false}
+            />
+            {imageAttributionAuthor && (
+              <div
+                className={classNames(
+                  styles.packImageAttribution,
+                  packImageAttributionLeft && styles.packImageAttributionLeft
+                )}
+                style={{color: imageAttributionColor}}
+              >
+                <FontAwesomeV6Icon
+                  iconName={'brands fa-creative-commons'}
+                  iconStyle="solid"
+                  className={styles.icon}
+                />
+                &nbsp;
+                <FontAwesomeV6Icon
+                  iconName={'brands fa-creative-commons-by'}
+                  iconStyle="solid"
+                  className={styles.icon}
+                />
+                &nbsp;
+                {imageAttributionAuthor}
+              </div>
+            )}
+          </div>
         )}
       </div>
       <div className={styles.packFooter}>


### PR DESCRIPTION
This adds an optional image attribution property to the music library and renders it in the pack selection dialog.  This is an attempt to reproduce what was apparently already being applied to some images directly.

### Examples

```
      "imageAttribution": {
        "author": "author1"
      },
```
```
      "imageAttribution": {
        "author": "author2",
        "position": "left"
      },
```
```
      "imageAttribution": {
        "author": "author3",
        "color": "#000"
      },
```
```
      "imageAttribution": {
        "author": "author3",
        "color": "#000",
        "position": "left"
      },
```