### PR TITLE
Create Account Button A/B Test - Remove high-traffic events 

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -16,8 +16,6 @@ import {addCallouts} from '@cdo/apps/code-studio/callouts';
 import {createLibraryClosure} from '@cdo/apps/code-studio/components/libraries/libraryParser';
 import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
 import {queryParams} from '@cdo/apps/code-studio/utils';
-import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants.js';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
 import {
@@ -2156,9 +2154,6 @@ StudioApp.prototype.configureDom = function (config) {
   var container = document.getElementById(config.containerId);
   var codeWorkspace = container.querySelector('#codeWorkspace');
 
-  const isSignedOut = !config.isSignedIn;
-  const isStandaloneProject = config.level.isProjectLevel;
-
   var runButton = container.querySelector('#runButton');
   var resetButton = container.querySelector('#resetButton');
   var runClick = this.runButtonClick.bind(this);
@@ -2168,22 +2163,8 @@ StudioApp.prototype.configureDom = function (config) {
     trailing: false,
   });
 
-  function handleRunButtonClick() {
-    throttledRunClick.call(this);
-    // Sends a Statsig event when the Run button is pressed by a signed out user
-    // This is related to the Create Account Button A/B Test; see Jira ticket:
-    // https://codedotorg.atlassian.net/browse/ACQ-1938
-    if (isSignedOut && isStandaloneProject) {
-      analyticsReporter.sendEvent(
-        EVENTS.RUN_BUTTON_PRESSED_SIGNED_OUT,
-        {},
-        PLATFORMS.STATSIG
-      );
-    }
-  }
-
   if (runButton && resetButton) {
-    dom.addClickTouchEvent(runButton, _.bind(handleRunButtonClick, this));
+    dom.addClickTouchEvent(runButton, _.bind(throttledRunClick, this));
     dom.addClickTouchEvent(resetButton, _.bind(this.resetButtonClick, this));
     this.keyHandler.registerEvent(['Control', 'Enter'], () => {
       if (this.isRunning()) {

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -288,11 +288,9 @@ const EVENTS = {
   MY_PL_PAGE_VISITED: 'My Professional Learning Page Visited',
 
   // Header navigation - signed out
-  SIGNED_OUT_USER_SEES_HEADER: 'Signed Out Navigation Header Shown',
   SIGNED_OUT_USER_CLICKS_HEADER_LINK: 'Signed Out User Clicks Header Link',
   SIGNED_OUT_USER_CLICKS_HAMBURGER_LINK:
     'Signed Out User Clicks Hamburger Link',
-  SIGNED_OUT_USER_CLICKS_SIGN_IN: 'Signed Out User Clicks Sign In Button',
   SIGNED_OUT_USER_CLICKS_HELP_MENU: 'Signed Out User Clicks Help Menu',
   CREATE_ACCOUNT_BUTTON_CLICKED: 'Create Account Button Clicked',
 
@@ -319,10 +317,6 @@ const EVENTS = {
     'Signed In User Clicks Create Dropdown',
   SIGNED_IN_USER_SELECTS_CREATE_DROPDOWN_OPTION:
     'Signed In User Selects Create Dropdown Option',
-
-  // Projects
-  RUN_BUTTON_PRESSED_SIGNED_OUT:
-    'Signed Out User Presses Run Button on Standalone Project',
 
   // Project sharing via 'Share' button
   SHARING_DIALOG_OPEN: 'User Opens Project Share Dialog',

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -11,10 +11,6 @@ import {
   setPageError,
 } from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants.js';
-// This is the utils AnalyticsReporter
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-// This is the Music Lab specific AnalyticsReporter
 import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 
@@ -467,16 +463,6 @@ class UnconnectedMusicView extends React.Component {
     if (play) {
       this.playSong();
       this.analyticsReporter.onButtonClicked('play');
-      // Sends a Statsig event when the Run button is pressed by a signed out user
-      // This is related to the Create Account Button A/B Test; see Jira ticket:
-      // https://codedotorg.atlassian.net/browse/ACQ-1938
-      if (this.props.signInState === SignInState.SignedOut) {
-        analyticsReporter.sendEvent(
-          EVENTS.RUN_BUTTON_PRESSED_SIGNED_OUT,
-          {},
-          PLATFORMS.STATSIG
-        );
-      }
     } else {
       this.stopSong();
     }

--- a/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
+++ b/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
@@ -33,13 +33,6 @@ function addClickEventToLinks(selector, eventName, additionalProperties = {}) {
   });
 }
 
-function getHeaderType(screenWidth) {
-  if (screenWidth < 425) return 'mobile';
-  if (screenWidth < 1024) return 'tablet';
-  if (screenWidth <= 1268) return 'small desktop';
-  return 'large desktop';
-}
-
 const addCreateMenuMetrics = (
   headerCreateMenu,
   platforms,
@@ -112,16 +105,6 @@ const addMenuMetrics = (
 };
 
 const addSignedOutMetrics = (pageUrl, headerCreateMenu) => {
-  const screenWidth = window.innerWidth;
-  analyticsReporter.sendEvent(
-    EVENTS.SIGNED_OUT_USER_SEES_HEADER,
-    {
-      pageUrl: pageUrl,
-      headerType: getHeaderType(screenWidth),
-    },
-    PLATFORMS.STATSIG
-  );
-
   // Log if a header link is clicked
   addClickEventToLinks('headerlink', EVENTS.SIGNED_OUT_USER_CLICKS_HEADER_LINK);
 
@@ -139,18 +122,6 @@ const addSignedOutMetrics = (pageUrl, headerCreateMenu) => {
         EVENTS.CREATE_ACCOUNT_BUTTON_CLICKED,
         {pageUrl: pageUrl},
         PLATFORMS.BOTH
-      );
-    });
-  }
-
-  const signInButton = document.getElementById('signin_button');
-  // Log if the Sign in button is clicked
-  if (signInButton) {
-    signInButton.addEventListener('click', () => {
-      analyticsReporter.sendEvent(
-        EVENTS.SIGNED_OUT_USER_CLICKS_SIGN_IN,
-        {pageUrl: pageUrl},
-        PLATFORMS.STATSIG
       );
     });
   }


### PR DESCRIPTION
Removes the following high-traffic events put in place for the Create Account button Statsig experiment:
- [Signed Out User Presses Run Button on Standalone Project](https://console.statsig.com/6uqJc02CIZP7hHowwYO7AS/metrics/events/Signed%20Out%20User%20Presses%20Run%20Button%20on%20Standalone%20Project)
- [Signed Out Navigation Header Shown](https://console.statsig.com/6uqJc02CIZP7hHowwYO7AS/metrics/events/Signed%20Out%20Navigation%20Header%20Shown)
- [Signed Out User Clicks Sign In Button](https://console.statsig.com/6uqJc02CIZP7hHowwYO7AS/metrics/events/Signed%20Out%20User%20Clicks%20Sign%20In%20Button)

## Links
Jira ticket: [ACQ-1902](https://codedotorg.atlassian.net/browse/ACQ-1902)
Tech spec: [here](https://docs.google.com/document/d/1RDQv2IAjkdJvxfxWFgisRNM9GuJInfqwf7v4Muifgt8/edit#heading=h.4schd43y1qoc)
PRs where these events were added: 
- https://github.com/code-dot-org/code-dot-org/pull/59125 
- https://github.com/code-dot-org/code-dot-org/pull/59656

## Testing story
Tested locally to see that the experiment related events weren't showing up anymore for Music Lab; I think the other events stopped showing up in the console once we made the test live.