### PR TITLE
Set up homepage banner for Best of STEM

### DIFF
--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -57,6 +57,7 @@ class DCDOBase < DynamicConfigBase
       'show-age-gated-students-banner': DCDO.get('show-age-gated-students-banner', true),
       'cfu-pin-hide-enabled': DCDO.get('cfu-pin-hide-enabled', false),
       'teacher-local-nav-v2': DCDO.get('teacher-local-nav-v2', false),
+      'best-of-stem-2024': DCDO.get('best-of-stem-2024', false),
     }
   end
 end

--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -129,7 +129,7 @@
           "type": "best-of-stem-2024",
           "text_h1": "best_of_stem_heading",
           "external_link": true,
-          "button_link": "#",
+          "button_link": "https://medium.com/@codeorg/code-org-wins-two-best-of-stem-2024-awards-155e55bde866",
           "button_text": "call_to_action_learn_more"
         }
       ]

--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -129,7 +129,7 @@
           "type": "best-of-stem-2024",
           "text_h1": "best_of_stem_heading",
           "external_link": true,
-          "button_link": "/test",
+          "button_link": "#",
           "button_text": "call_to_action_learn_more"
         }
       ]

--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -4,7 +4,8 @@
       "hoc2023-soon-hoc",
       "hoc2023-actual-hoc",
       "pl-launch-superhero",
-      "curriculum-launch-2024"
+      "curriculum-launch-2024",
+      "best-of-stem-2024"
     ]
   },
 
@@ -116,6 +117,20 @@
           "button_link": "https://codeorg.medium.com/ai-game-design-and-more-in-code-orgs-2024-25-curriculum-updates-caff691935ad",
           "button_text": "curriculum_launch_2024.banner.button_learn_more_here",
           "img_src": "/images/banners/banner-curriculum-catalog-illustration-black.png"
+        }
+      ]
+    },
+    "best-of-stem-2024": {
+      "dcdo": "best-of-stem-2024",
+      "class": "best-of-stem-2024",
+      "desktopImage": "/images/banners/banner-bg-best-of-stem-confetti.png",
+      "actions": [
+        {
+          "type": "best-of-stem-2024",
+          "text_h1": "best_of_stem_heading",
+          "external_link": true,
+          "button_link": "/test",
+          "button_text": "call_to_action_learn_more"
         }
       ]
     }

--- a/pegasus/sites.v3/code.org/public/images/banners/banner-bg-best-of-stem-confetti.png
+++ b/pegasus/sites.v3/code.org/public/images/banners/banner-bg-best-of-stem-confetti.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8def6e633c5663488737a3b7bdd33d1d46a9bf6e228a1e82be9a894a12c94ff
+size 141455

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -22,9 +22,6 @@ style_min: true
 -# Apply this stylesheet when 'curriculum-launch-2024' is set to 'true'
 - if !!DCDO.get('curriculum-launch-2024', false)
   =inline_css '/generated/banners-curriculum-launch.css'
--# TODO: Remove this after Best of STEM 2024 is over
-- if !!DCDO.get('best-of-stem-2024', false)
-  =inline_css '/generated/best-of-stem-hero-banner.css'
 
 - cookie_key = environment_specific_cookie_name '_user_type'
 - user_type = request.cookies[cookie_key]

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -22,6 +22,9 @@ style_min: true
 -# Apply this stylesheet when 'curriculum-launch-2024' is set to 'true'
 - if !!DCDO.get('curriculum-launch-2024', false)
   =inline_css '/generated/banners-curriculum-launch.css'
+-# TODO: Remove this after Best of STEM 2024 is over
+- if !!DCDO.get('best-of-stem-2024', false)
+  =inline_css '/generated/best-of-stem-hero-banner.css'
 
 - cookie_key = environment_specific_cookie_name '_user_type'
 - user_type = request.cookies[cookie_key]

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -69,6 +69,14 @@
               = I18n.t(entry[:button_text])
           %figure
             %img{src: entry[:img_src], alt: ""}
+      - elsif entry[:type] == "best-of-stem-2024"
+        %div
+          %i{class: "fa-solid fa-award", style: "font-size: 4rem; color: #F9CB28; margin-block: 1rem;"}
+          %h1.white{style: "margin-top: 0"}
+            = I18n.t(entry[:text_h1])
+          .button-wrapper
+            %a.link-button.white.has-external-link{href: entry[:button_link], target: (entry[:external_link] ? "_blank" : nil), rel: (entry[:external_link] ? "noopener noreferrer" : nil)}
+              = I18n.t(entry[:button_text])
   .clear{style: "clear: both"}
 
 #hero{style: "position: relative"}

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -175,6 +175,8 @@
   explore_our_curriculum: "Explore Our Curriculum"
   start_professional_learning: "Start Professional Learning"
 
+  best_of_stem_heading: "Code.org wins Best of STEM 2024"
+
   how_ai_works_video_series: "How AI Works Video Series"
   learn_how_ai_works: "Learn How AI Works"
   ai_101_for_educators: "AI 101 for Educators"


### PR DESCRIPTION
Adds a Best of Stem homepage hero banner on the code.org homepage in case we win this year's award. This is controlled by the `best-of-stem-2024` DCDO flag and we'll flip this if we win. 

## Links
Jira ticket: [ACQ-2199](https://codedotorg.atlassian.net/browse/ACQ-2199)

## Testing story
Tested locally that DCDO flag works

----

## Desktop
![localhost code org_3000_(Code org - 1366x768)](https://github.com/user-attachments/assets/63cc4b2e-107b-4cc0-b069-e54f887f4759)

| Tablet | Mobile |
| ---- | ---- |
| ![localhost code org_3000_(Code org - 810x1080)](https://github.com/user-attachments/assets/3b7b88e0-c9e7-4f9c-8d27-71aa9b10c875) | ![localhost code org_3000_(Code org - 390x844)](https://github.com/user-attachments/assets/2682a04a-cb61-4dd1-a6ee-db057b043eec) |

