### PR TITLE
AI Release Path Update for Claude 3.5

### DIFF
--- a/dashboard/app/jobs/concerns/ai_rubric_config.rb
+++ b/dashboard/app/jobs/concerns/ai_rubric_config.rb
@@ -6,7 +6,7 @@ class AiRubricConfig
   #
   # Basic validation of the new AI config is done by UI tests, or can be done locally
   # by running `AiRubricConfig.validate_ai_config` from the rails console.
-  S3_AI_RELEASE_PATH = 'teaching_assistant/releases/2024-04-30-confidence-autogen-turbo/'.freeze
+  S3_AI_RELEASE_PATH = 'teaching_assistant/releases/2024-08-12-claude-3-release/'.freeze
 
   # 2D Map from unit name and level name, to the name of the lesson files within
   # the release dir in S3 which will be used for AI evaluation.


### PR DESCRIPTION
Updates S3_AI_RELEASE_PATH in ai_rubric_config.py to point to the new Claude release in AWS S3. Final step for transition to AWS bedrock Claude models. Includes the following PRs:
https://github.com/code-dot-org/code-dot-org/pull/60063
https://github.com/code-dot-org/aitt_release_data/pull/1
https://github.com/code-dot-org/aiproxy/pull/87

## Links
[AITT-730](https://codedotorg.atlassian.net/browse/AITT-730)

## Testing story
Tested manually in local development environment.
![image](https://github.com/user-attachments/assets/153b45cc-8f45-48e4-844f-096bf3e92299)
## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
