### PR TITLE
Add New "Ethics Opportunity" Tooltip for Lesson Plans

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1182,6 +1182,7 @@
   "errorSubmittingFeedback": "Error submitting feedback to student.",
   "errorUnusedFunction": "You created a function, but never used it on your workspace! Click on \"Functions\" in the toolbox and make sure you use it in your program.",
   "errorUnusedParam": "You added a parameter block, but didn't use it in the definition. Make sure to use your parameter by clicking \"edit\" and placing the parameter block inside the green block.",
+  "ethicsOpportunity": "Ethics Opportunity",
   "evaluate": "Evaluate",
   "exactNumberOfBlocks": "Only {numBlocks, plural, one {1 block} other {# blocks}} used!",
   "exampleErrorMessage": "The function {functionName} has one or more examples that need adjusting. Make sure they match your definition and answer the question.",

--- a/apps/src/templates/lessonOverview/activities/LessonTip.jsx
+++ b/apps/src/templates/lessonOverview/activities/LessonTip.jsx
@@ -32,6 +32,12 @@ export const tipTypes = {
     color: color.purple,
     backgroundColor: color.lightest_purple,
   },
+  ethicsOpportunity: {
+    displayName: i18n.ethicsOpportunity(),
+    icon: 'head-side-heart',
+    color: color.green,
+    backgroundColor: color.lighter_green,
+  },
 };
 
 class LessonTip extends Component {

--- a/dashboard/config/scripts_json/allthemigratedthings.script_json
+++ b/dashboard/config/scripts_json/allthemigratedthings.script_json
@@ -14,7 +14,7 @@
     },
     "new_name": null,
     "family_name": "ui-test-versioned-script",
-    "serialized_at": "2021-11-22 19:57:34 UTC",
+    "serialized_at": "2024-08-15 18:37:53 UTC",
     "published_state": "beta",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -360,7 +360,13 @@
       "position": 2,
       "properties": {
         "name": "Standalone Video",
-        "progression_name": "Standalone Video"
+        "progression_name": "Standalone Video",
+        "tips": [
+          {
+            "type": "ethicsOpportunity",
+            "markdown": "This is a great time to talk about ethics."
+          }
+        ]
       },
       "seeding_key": {
         "activity_section.key": "d0e7256a-9dbf-4850-8386-31aca733070a",
@@ -625,6 +631,15 @@
 
   ],
   "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+
+  ],
+  "learning_goals": [
+
+  ],
+  "learning_goal_evidence_levels": [
 
   ]
 }


### PR DESCRIPTION
This adds a new callout for lesson plans called "Ethics Opportunity" to support our new AI curricula. Ideally, this will create a new callout in the lesson editor like this:

![image](https://github.com/user-attachments/assets/dc6cd93e-d580-4687-b1f3-5ba8abae41c7)

I followed the pattern of the other teaching tips and re-used colors already defined in `/shared/css/color.scss`, which is why the green one is used. I would've preferred to have maybe a more reddish color (or something less puke-green), but I didn't want to rock the boat too much.

I haven't done any testing - this is just a proof of concept that hopefully an engineer can help me get across the finish line!