### PR TITLE
Add wait before reset_session to fix flaky ui tests

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -104,7 +104,6 @@ Scenario: Oceans uncustomized dashboard certificate pages
 
 Scenario: Course A 2017 uncustomized dashboard certificate pages
   Given I create a student named "Student1"
-  And I sign in as "Student1"
   And I complete unit coursea-2017
   And I am on "http://studio.code.org/congrats"
   Then I wait until element "#uitest-certificate" is visible
@@ -204,7 +203,6 @@ Scenario: congrats certificate pages
   And I see no difference for "customized 20-hour certificate"
 
   Given I create a student named "Student1"
-  And I sign in as "Student1"
   And I complete unit coursea-2017
   When I am on "http://code.org/congrats/coursea-2017"
   And I wait until current URL contains "http://studio.code.org/congrats"

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -104,6 +104,7 @@ Scenario: Oceans uncustomized dashboard certificate pages
 
 Scenario: Course A 2017 uncustomized dashboard certificate pages
   Given I create a student named "Student1"
+  And I sign in as "Student1"
   And I complete unit coursea-2017
   And I am on "http://studio.code.org/congrats"
   Then I wait until element "#uitest-certificate" is visible
@@ -203,6 +204,7 @@ Scenario: congrats certificate pages
   And I see no difference for "customized 20-hour certificate"
 
   Given I create a student named "Student1"
+  And I sign in as "Student1"
   And I complete unit coursea-2017
   When I am on "http://code.org/congrats/coursea-2017"
   And I wait until current URL contains "http://studio.code.org/congrats"

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -17,6 +17,7 @@ Then /^I sign out using jquery$/ do
 end
 
 Given(/^I sign in as "([^"]*)"( and go home)?$/) do |name, home|
+  steps "And I wait for 3 seconds"
   navigate_to replace_hostname('http://studio.code.org/reset_session')
   sign_in name
   redirect = 'http://studio.code.org/home'
@@ -97,6 +98,7 @@ end
 
 # Creates the user and signs them in.
 def create_user(name, url: '/api/test/create_user', **user_opts)
+  steps "And I wait for 3 seconds"
   navigate_to replace_hostname('http://studio.code.org/reset_session')
   Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, tries: 3) do
     # Generate the user
@@ -278,6 +280,7 @@ When(/^I sign out$/) do
     browser_request(url: replace_hostname('/users/sign_out.json'), code: 204)
     @browser.execute_script("sessionStorage.clear(); localStorage.clear();")
   else
+    steps "And I wait for 3 seconds"
     navigate_to replace_hostname('http://studio.code.org/reset_session')
   end
 end

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -17,8 +17,7 @@ Then /^I sign out using jquery$/ do
 end
 
 Given(/^I sign in as "([^"]*)"( and go home)?$/) do |name, home|
-  steps "And I wait for 3 seconds"
-  navigate_to replace_hostname('http://studio.code.org/reset_session')
+  reset_session
   sign_in name
   redirect = 'http://studio.code.org/home'
   navigate_to replace_hostname(redirect) if home
@@ -98,8 +97,7 @@ end
 
 # Creates the user and signs them in.
 def create_user(name, url: '/api/test/create_user', **user_opts)
-  steps "And I wait for 3 seconds"
-  navigate_to replace_hostname('http://studio.code.org/reset_session')
+  reset_session
   Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, tries: 3) do
     # Generate the user
     email, password = generate_user(name)
@@ -280,8 +278,7 @@ When(/^I sign out$/) do
     browser_request(url: replace_hostname('/users/sign_out.json'), code: 204)
     @browser.execute_script("sessionStorage.clear(); localStorage.clear();")
   else
-    steps "And I wait for 3 seconds"
-    navigate_to replace_hostname('http://studio.code.org/reset_session')
+    reset_session
   end
 end
 
@@ -323,4 +320,15 @@ end
 
 And(/^I get debug info for the current user$/) do
   puts browser_request(url: '/api/v1/users/current', method: 'GET')
+end
+
+# reset_session flakes by not signing out the user.
+# This is because an in flight request to the server may still return and set the session to the user
+# after reset_session should have reset the user.
+# To counteract this, we wait for 3 seconds before calling reset_session to ensure all in flight requests have finished.
+# See this PR for more info: https://github.com/code-dot-org/code-dot-org/pull/60376
+# We are tracking a long-term fix here: https://codedotorg.atlassian.net/browse/P20-1080
+def reset_session
+  steps "And I wait for 3 seconds"
+  navigate_to replace_hostname('http://studio.code.org/reset_session')
 end

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1484,7 +1484,6 @@ When /^I set up code review for teacher "([^"]*)" with (\d+(?:\.\d*)?) students 
   student_count.to_i.times do |i|
     add_student_step_list.push("Given I create a student named \"student_#{i}\"")
     add_student_step_list.push("And I join the section")
-    add_student_step_list.push("And I wait for 3 seconds")
   end
 
   add_students_to_group_step_list = []
@@ -1502,7 +1501,6 @@ When /^I set up code review for teacher "([^"]*)" with (\d+(?:\.\d*)?) students 
     #{add_student_step_list.join("\n")}
     And I wait to see ".alert-success"
     And I sign out using jquery
-    And I wait for 3 seconds
     Given I sign in as "#{teacher_name}" and go home
     And I create a new code review group for the section I saved
     #{add_students_to_group_step_list.join("\n")}


### PR DESCRIPTION
There is a race condition in each ui test step that calls reset_session based on when the response for in-flight API calls is returned and when the reset_session call is made. This has made some tests that use the following three steps flaky: 
`I sign in as ""` ([code](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/ui/features/step_definitions/account_steps.rb#L20))
`I create a student named ""` or any step that goes through `create_user()`: ([code](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/ui/features/step_definitions/account_steps.rb#L100))
`I sign out` ([code](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/ui/features/step_definitions/account_steps.rb#L281))

Workaround: wait 3 seconds before navigating to reset_session

Long term fix: https://codedotorg.atlassian.net/browse/P20-1080

This adds a wait for 3 seconds to each step named above.

This should fix multiple flaky test failures including:
* features/teacher_tools/teacher_dashboard/teacher_dashboard_assessments2
* features/teacher_tools/rubrics/teacher_view_of_rubric
* features/javalab/code_review_finish_button.feature
* features/javalab/code_review_scenarios.feature
However many other tests could flake from the scenario if they use any of the above steps and then try to confirm behavior on a new user or signed out state.

## Expected test slowdowns

Because this adds a wait to frequently used steps, there is an expected slowdown from this PR change for all drone runs and test runs. Some quick math shows:

I sign in as: ~106 count
I sign out: ~54 count
create_user : ~186 count

Total: ~346 uses of these steps. 

With 3 seconds added gives 1048 seconds

[Drone parallelization](https://github.com/code-dot-org/code-dot-org/blob/41c593d6e51553d067cf90e24796945283de036c/lib/rake/circle.rake#L112): 16
[Test server parallelization](https://github.com/code-dot-org/code-dot-org/blob/2e116dfe2ed3e35e37bdb99c814ca9e47286652a/lib/rake/test.rake#L33): 120
[Number of browsers](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/ui/browsers.json) (test server only): 5

Drone run addition: `~65 seconds (346 tests* 3 seconds / 16 threads)`
Test server run addition `~43 seconds (346 tests * 3 seconds * 5 browsers / 120 threads)`

Note: rough numbers only. Some tests may not run on all browsers, may not have been found from my rough searches or parallelization may not be optimized.

## Links
[Slack thread](https://codedotorg.slack.com/archives/C0T0PNR0D/p1722444400850089)
Flaky test 1 ticket: [TEACH-1235](https://codedotorg.atlassian.net/browse/TEACH-1235)
Flaky test 2 ticket: [TEACH-1191](https://codedotorg.atlassian.net/browse/TEACH-1191)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Alternatives considered

### Only add wait statements manually to tests that we see flake

Pros:
* Does not add extra wait time to each drone/test server run

Cons:
* Requires group knowledge about these common ui test issues and the fix
* Requires tests flaking and wasting team member time rerunning and investigating before they are fixed

### Close the browser and reopen ([slack suggestion](https://codedotorg.slack.com/archives/C0T0PNR0D/p1722980761932299?thread_ts=1722444400.850089&cid=C0T0PNR0D))
General thought: personally don't think there is enough evidence to show this would be an improvement to spend the time working on it.
Pros:
* May provide more resilience and prevent further flakes
* Does not rely on an arbitrary wait
* Might be faster (would need exploration)

Cons:
* Might be slower especially on ios (would need exploration)
* More time for initial implementation

### Go through manually now and add wait to each test that might flake
Pros:
* Less time added to tests

Cons:
* Most tests will need the wait anyways
* Significantly more time for initial implementation (Manually go through ~350 tests)
* Large PR
* Might miss tests cases that will flake without the 3 seconds and then it will be harder to debug
