### PR TITLE
Wait for progress to load to fix Age gated banner flakiness

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_students_modal.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/age_gated_students_modal.feature
@@ -37,6 +37,7 @@ Feature: Age Gated Students Modal and Banner
     And I wait until element "a:contains('Untitled Section')" is visible
     And I save the section id from row 0 of the section table
     Then I navigate to teacher dashboard for the section I saved
+    And I wait until element "h3" contains text "It's a bit empty here..."
 
     # Click on Age Gated Banner Learn More button to view Age Gated Students Modal
     And I wait until element "#uitest-age-gated-banner" is visible


### PR DESCRIPTION
Wait for the empty progress to load before beginning eyes test differeneces to fix flakiness.
Previously the progress was not loading in time leading to eyes differences.

## Links

- jira ticket: []()
- slack thread: [here](https://codedotorg.slack.com/archives/C032LKQL53Q/p1723570662811579)

## Testing story
Tested Locally using sauce labs

