### PR TITLE
District and administrator page updates

### DIFF
--- a/i18n/locales/source/hourofcode/en.yml
+++ b/i18n/locales/source/hourofcode/en.yml
@@ -437,7 +437,7 @@
   call_to_action_explore_learning_ages_11_plus: "Explore learning for ages 11+"
   call_to_action_get_started: "Get started"
   call_to_action_discover_district_program: "Discover our District Program"
-  call_to_action_see_district_partners: "See our District Partners"
+  call_to_action_see_district_partners: "See our Code.org Districts"
   call_to_action_read_full_story: "Read the full story"
   call_to_action_learn_about_pl: "Learn about Professional Learning"
   call_to_action_pilot_web_dev_unit: "Pilot our newly updated Web Development unit!"
@@ -1265,7 +1265,7 @@
   ai_vid_ethics1_caption: "Ethics & AI: Equal Access and Algorithmic Bias"
   ai_vid_ethics2_caption: "Ethics & AI: Privacy and the Future of Work"
 
-  admins_page_top_heading: "Expand computer science in your school or district"
+  admins_page_top_heading: "Expand computer science in your district"
   admins_page_top_subhead: "Unlock the future of education with Code.org's comprehensive computer science (CS) programs."
   admins_page_top_desc: "Join a visionary network of over 2 million educators dedicated to shaping innovative leaders, critical thinkers, and engaged digital citizens. Code.org partners with administrators to seamlessly integrate CS into schools, offering extensive resources, tailored professional development, and continual support for systemic success."
   admins_page_elevate_heading: "Elevate computer science education at your school"
@@ -1303,7 +1303,7 @@
   admins_page_resources_desc_unplugged: "Now you can teach the fundamentals of computer science to your students, whether you have computers in your classroom or not!"
 
   districts_page_top_heading: "Districts in the Code.org District Program"
-  districts_page_top_desc: "We're actively expanding our network of district partners across the US. Explore this list of districts currently enrolled in our District Partner program."
+  districts_page_top_desc: "We're actively expanding our network of Code.org Districts across the US. Explore this list of districts currently enrolled in our District Partner program."
   districts_page_join_heading: "Join our District Partner Program"
   districts_page_join_desc: "District leaders around the United States have partnered with Code.org directly, at no cost to bring computer science to their district, and teach students the skills of the future."
 

--- a/i18n/locales/source/hourofcode/en.yml
+++ b/i18n/locales/source/hourofcode/en.yml
@@ -437,7 +437,7 @@
   call_to_action_explore_learning_ages_11_plus: "Explore learning for ages 11+"
   call_to_action_get_started: "Get started"
   call_to_action_discover_district_program: "Discover our District Program"
-  call_to_action_see_district_partners: "See our Code.org Districts"
+  call_to_action_see_district_partners: "See our District Partners"
   call_to_action_read_full_story: "Read the full story"
   call_to_action_learn_about_pl: "Learn about Professional Learning"
   call_to_action_pilot_web_dev_unit: "Pilot our newly updated Web Development unit!"
@@ -1265,7 +1265,7 @@
   ai_vid_ethics1_caption: "Ethics & AI: Equal Access and Algorithmic Bias"
   ai_vid_ethics2_caption: "Ethics & AI: Privacy and the Future of Work"
 
-  admins_page_top_heading: "Expand computer science in your district"
+  admins_page_top_heading: "Expand computer science in your school or district"
   admins_page_top_subhead: "Unlock the future of education with Code.org's comprehensive computer science (CS) programs."
   admins_page_top_desc: "Join a visionary network of over 2 million educators dedicated to shaping innovative leaders, critical thinkers, and engaged digital citizens. Code.org partners with administrators to seamlessly integrate CS into schools, offering extensive resources, tailored professional development, and continual support for systemic success."
   admins_page_elevate_heading: "Elevate computer science education at your school"
@@ -1303,7 +1303,7 @@
   admins_page_resources_desc_unplugged: "Now you can teach the fundamentals of computer science to your students, whether you have computers in your classroom or not!"
 
   districts_page_top_heading: "Districts in the Code.org District Program"
-  districts_page_top_desc: "We're actively expanding our network of Code.org Districts across the US. Explore this list of districts currently enrolled in our District Partner program."
+  districts_page_top_desc: "We're actively expanding our network of district partners across the US. Explore this list of districts currently enrolled in our District Partner program."
   districts_page_join_heading: "Join our District Partner Program"
   districts_page_join_desc: "District leaders around the United States have partnered with Code.org directly, at no cost to bring computer science to their district, and teach students the skills of the future."
 

--- a/pegasus/sites.v3/code.org/public/districts.haml
+++ b/pegasus/sites.v3/code.org/public/districts.haml
@@ -21,8 +21,6 @@ theme: responsive_full_width
 - icon_chart_pie = "fa-solid fa-chart-pie"
 - icon_badge_check = "fa-solid fa-badge-check"
 - icon_folder_open = "fa-solid fa-folder-open"
-- icon_smile = "fa-solid fa-smile"
-- icon_money_check_dollar_pen = "fa-solid fa-money-check-dollar-pen"
 
 = view :top_skinny_banner, banner_id: "banner-districts", banner_url: nil, banner_icon: "fa-solid fa-megaphone", banner_text: hoc_s("districts_skinny_banner_title", markdown: :inline, locals: {district_partners_url: district_partners_url}), external_link: false, light_theme: true
 

--- a/pegasus/sites.v3/code.org/public/districts.haml
+++ b/pegasus/sites.v3/code.org/public/districts.haml
@@ -97,18 +97,6 @@ theme: responsive_full_width
         .text-wrapper
           %h3 National visibility and recognition
           %p We'll spotlight your district on the Code.org website alongside partners including Amazon, The College Board, Google, and Microsoft.
-      %li
-        %div
-          %i{class: "#{icon_smile}"}
-        .text-wrapper
-          %h3 Amazon Future Engineer Benefits
-          %p Eligible schools can receive paid 1-year CSTA membership for teachers, Amazon classroom resources, first access to career exploration offerings, awards, scholarships, and more.
-      %li
-        %div
-          %i{class: "#{icon_money_check_dollar_pen}"}
-        .text-wrapper
-          %h3 Scholarships for schools serving underserved students
-          %p Access to $1.5M in Professional Learning scholarships for teachers serving students traditionally underrepresented in CS.
     .button-wrapper.centered
       %a.link-button{href: url_learn_more} Learn more
       %a.link-button.secondary{href: url_enroll_now, target: "_blank", rel: "noopener noreferrer"} Enroll now

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -437,7 +437,7 @@
   call_to_action_explore_learning_ages_11_plus: "Explore learning for ages 11+"
   call_to_action_get_started: "Get started"
   call_to_action_discover_district_program: "Discover our District Program"
-  call_to_action_see_district_partners: "See our District Partners"
+  call_to_action_see_district_partners: "See our Code.org Districts"
   call_to_action_read_full_story: "Read the full story"
   call_to_action_learn_about_pl: "Learn about Professional Learning"
   call_to_action_pilot_web_dev_unit: "Pilot our newly updated Web Development unit!"
@@ -1265,7 +1265,7 @@
   ai_vid_ethics1_caption: "Ethics & AI: Equal Access and Algorithmic Bias"
   ai_vid_ethics2_caption: "Ethics & AI: Privacy and the Future of Work"
 
-  admins_page_top_heading: "Expand computer science in your school or district"
+  admins_page_top_heading: "Expand computer science in your district"
   admins_page_top_subhead: "Unlock the future of education with Code.org's comprehensive computer science (CS) programs."
   admins_page_top_desc: "Join a visionary network of over 2 million educators dedicated to shaping innovative leaders, critical thinkers, and engaged digital citizens. Code.org partners with administrators to seamlessly integrate CS into schools, offering extensive resources, tailored professional development, and continual support for systemic success."
   admins_page_elevate_heading: "Elevate computer science education at your school"
@@ -1303,7 +1303,7 @@
   admins_page_resources_desc_unplugged: "Now you can teach the fundamentals of computer science to your students, whether you have computers in your classroom or not!"
 
   districts_page_top_heading: "Districts in the Code.org District Program"
-  districts_page_top_desc: "We're actively expanding our network of district partners across the US. Explore this list of districts currently enrolled in our District Partner program."
+  districts_page_top_desc: "We're actively expanding our network of Code.org Districts across the US. Explore this list of districts currently enrolled in our District Partner program."
   districts_page_join_heading: "Join our District Partner Program"
   districts_page_join_desc: "District leaders around the United States have partnered with Code.org directly, at no cost to bring computer science to their district, and teach students the skills of the future."
 


### PR DESCRIPTION
Banks asked for some updates to the text and content of the code.org/administrators page and the code.org/districts page.  This updates copy in a couple places as well as removing two of the benefits for the district program. Requests are in this doc: https://docs.google.com/document/d/1xWBHNDHaDToHwiUHTLM-Lzj7NjpPkKMHAlyyPQmTaBo/edit