### PR TITLE
Add farsi to CSF language list

### DIFF
--- a/pegasus/sites.v3/code.org/public/curriculum/csf.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/csf.haml
@@ -37,7 +37,7 @@ theme: responsive_full_width
     .clear
 
 %section.bg-neutral-light
-  - languages = "العربية, Bahasa Indonesia, Català, 简体字, 繁體字, Čeština, Français, Deutsch, हिन्दी, Italiano, 日本語, 한국어, ಕನ್ನಡ, بهاس ملايو, Монгол хэл, Polski, Português (Brasil), Română, Русский, Slovenčina, Filipino, தமிழ், ภาษาไทย, Türkçe, Українська, Español (España), Español (LATAM), اردو, O'zbekcha, Tiếng Việt"
+  - languages = "فارسی ,العربية , Bahasa Indonesia, Català, 简体字, 繁體字, Čeština, Français, Deutsch, हिन्दी, Italiano, 日本語, 한국어, ಕನ್ನಡ, بهاس ملايو, Монгол хэл, Polski, Português (Brasil), Română, Русский, Slovenčina, Filipino, தமிழ், ภาษาไทย, Türkçe, Українська, Español (España), Español (LATAM), اردو, O'zbekcha, Tiếng Việt"
   .wrapper
     = view :curriculum_glance_section, heading: hoc_s(:heading_curricula_at_a_glance), grades: hoc_s(:module_grade_k_5), duration: hoc_s(:module_duration_month_quarter), level: hoc_s(:module_level_beginner), tools: hoc_s(:csf_page_curriculum_glance_tools), devices: hoc_s(:csf_page_curriculum_glance_devices), professional_learning: hoc_s(:csf_page_curriculum_glance_professional_learning), topics: hoc_s(:csf_page_curriculum_glance_topics), accessibility_features: hoc_s(:csf_page_curriculum_glance_accessibility_features), languages: languages
 

--- a/pegasus/sites.v3/code.org/public/curriculum/csf.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/csf.haml
@@ -37,7 +37,7 @@ theme: responsive_full_width
     .clear
 
 %section.bg-neutral-light
-  - languages = "فارسی ,العربية , Bahasa Indonesia, Català, 简体字, 繁體字, Čeština, Français, Deutsch, हिन्दी, Italiano, 日本語, 한국어, ಕನ್ನಡ, بهاس ملايو, Монгол хэл, Polski, Português (Brasil), Română, Русский, Slovenčina, Filipino, தமிழ், ภาษาไทย, Türkçe, Українська, Español (España), Español (LATAM), اردو, O'zbekcha, Tiếng Việt"
+  - languages = "فارسی ,العربية , Bahasa Indonesia, Català, 简体字, 繁體字, Čeština, Français, Deutsch, हिन्दी, Italiano, 日本語, 한국어, ಕನ್ನಡ, بهاس ملايو, Монгол хэл, English, Polski, Português (Brasil), Română, Русский, Slovenčina, Filipino, தமிழ், ภาษาไทย, Türkçe, Українська, Español (España), Español (LATAM), اردو, O'zbekcha, Tiếng Việt"
   .wrapper
     = view :curriculum_glance_section, heading: hoc_s(:heading_curricula_at_a_glance), grades: hoc_s(:module_grade_k_5), duration: hoc_s(:module_duration_month_quarter), level: hoc_s(:module_level_beginner), tools: hoc_s(:csf_page_curriculum_glance_tools), devices: hoc_s(:csf_page_curriculum_glance_devices), professional_learning: hoc_s(:csf_page_curriculum_glance_professional_learning), topics: hoc_s(:csf_page_curriculum_glance_topics), accessibility_features: hoc_s(:csf_page_curriculum_glance_accessibility_features), languages: languages
 


### PR DESCRIPTION
Melika asked that farsi be added to the list of supported languages on code.org/csf. I also noticed that English seemed to be missing from the list