### PR TITLE
ActiveJob - Log workable jobs

### DIFF
--- a/bin/cron/report_activejob_metrics
+++ b/bin/cron/report_activejob_metrics
@@ -29,6 +29,15 @@ def push_queue_length_metrics
         dimensions: [
           {name: 'Environment', value: CDO.rack_env},
         ],
+      },
+      {
+        metric_name: 'WorkableJobCount',
+        value: Delayed::Job.where(failed_at: nil, locked_at: nil).where('run_at <= ?', Time.now).count,
+        unit: 'Count',
+        timestamp: Time.now,
+        dimensions: [
+          {name: 'Environment', value: CDO.rack_env},
+        ],
       }
     ]
   )


### PR DESCRIPTION
Add a 'WorkableJobCount' metric, for jobs that are available to be worked. This is useful because 'PendingJobCount' includes jobs that have a future run_at date.

An increase in WorkableJobCount, or any count above zero, means our workers are not able to keep up with the load.

## Links

Jira: AITT-740

## Testing story

## Deployment strategy

## Follow-up work

I see two valuable improvements here:

* _additionally_ log these counts with a dimension for JobName
* Eliminate the duplication between the cron job and the before_enqueue function.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
