### PR TITLE
NAV - Blank Page component for Teacher Navigation

### DIFF
--- a/apps/src/templates/teacherDashboard/teacherNavigation/TemporaryBlankPage.tsx
+++ b/apps/src/templates/teacherDashboard/teacherNavigation/TemporaryBlankPage.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import comingSoonGraphic from '@cdo/apps/templates/teacherDashboard/teacherNavigation/comingSoonGraphic.png';
+
+const TemporaryBlankPage: React.FC = () => {
+  return (
+    <img
+      src={comingSoonGraphic}
+      alt="Cat loving Code.org"
+      style={{position: 'absolute', left: '45%'}}
+    />
+  );
+};
+
+export default TemporaryBlankPage;

--- a/apps/src/templates/teacherDashboard/teacherNavigation/comingSoonGraphic.png
+++ b/apps/src/templates/teacherDashboard/teacherNavigation/comingSoonGraphic.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb74f56aa38856e70f8c84825f78cbe9764872b30c0055592c85119450020069
+size 441657


### PR DESCRIPTION
This page is intended to be a place holder for pages we have not yet created for the V2 of Teacher Navigation.  

When in place, this component will include the image Molly created.  This is not expected to be externally facing at all but rather in place for play testing with product folks.

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/a14c4967-fd98-4104-a1f6-3eb3c249dece">

Note: I didn't do any tests for this since it is a very temporary component.

## Links
[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1241)