### PR TITLE
be more careful locating teacher before deleting progress

### DIFF
--- a/bin/oneoff/reset_student_progress_in_bulk/delete_user_progress_by_unit.rb
+++ b/bin/oneoff/reset_student_progress_in_bulk/delete_user_progress_by_unit.rb
@@ -17,7 +17,14 @@ require 'csv'
 csv_file_path = ARGV[1]
 
 teacher_id = ARGV[0]
-teacher_user = User.find_by(id: teacher_id) || User.find_by_email(teacher_id)
+teacher_user = nil
+if teacher_id.include?('@')
+  teacher_user = User.find_by_email(teacher_id)
+elsif teacher_id.to_i.to_s == teacher_id
+  teacher_user = User.find_by_id(teacher_id)
+else
+  raise "teacher id must be an id or email: #{teacher_id.inspect}"
+end
 raise "Teacher with id or email " + teacher_id.to_s.dump + " not found" if teacher_user.nil?
 
 rows = CSV.read(csv_file_path, headers: true)

--- a/bin/oneoff/reset_student_progress_in_bulk/delete_user_progress_by_unit.rb
+++ b/bin/oneoff/reset_student_progress_in_bulk/delete_user_progress_by_unit.rb
@@ -17,7 +17,7 @@ require 'csv'
 csv_file_path = ARGV[1]
 
 teacher_id = ARGV[0]
-teacher_user = User.find_by(id: teacher_id) || User.find_by(email: teacher_id)
+teacher_user = User.find_by(id: teacher_id) || User.find_by_email(teacher_id)
 raise "Teacher with id or email " + teacher_id.to_s.dump + " not found" if teacher_user.nil?
 
 rows = CSV.read(csv_file_path, headers: true)


### PR DESCRIPTION
When I went to run the deletion script from https://github.com/code-dot-org/code-dot-org/pull/60292 in production using the email address from the zendesk ticket, I got a lot of "Student with id X is not in teacher Y section" errors when I did a dry run. but when I look up the user by zendesk email, I see it is linked to another email:
```
[production] dashboard > User.find_by_email('1234567890@k12.xx.us').email
=> "firstname.lastname@k12.xx.us"
```
then when I use the resulting email, the script seems to work fine.

This led me to notice 2 problems with the current code:
* behind the scenes, `User.find_by_email` is doing something non-obvious to find accounts which `User.find_by(email: ...)` might not find: https://github.com/code-dot-org/code-dot-org/blob/8c08486a20fd7e232ee664a6425a3d98f5037cb9/dashboard/app/models/user.rb#L742-L746
*`User.find_by(id: '1234567890@k12.xx.us')` will find the user with id `1234567890`, which won't cause anything bad to happen to user data since they are likely not teachers of the specified students, but it is enough to prevent us from finding the right teacher by email and stop the script from working.

This PR fixes those issues so that the script can be run with teacher email like `1234567890@k12.xx.us`. 

## Testing story

* manually tested all of the cases I could think of locally
* manually tested the case for the user in the zendesk ticket on production by pasting in these changes on production-daemon and doing dry runs there
* also manually verified on production that `User.find_by_email(...).id` gives the same user id whether I give it the zendesk email or the other email
