### PR TITLE
Update flaky sharepage_logo UI test

### DIFF
--- a/dashboard/test/ui/features/star_labs/sharepage_logo.feature
+++ b/dashboard/test/ui/features/star_labs/sharepage_logo.feature
@@ -58,7 +58,7 @@ Feature: Lab share page logo
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
-    And I am on "http://studio.code.org/users/sign_out"
+    And I sign out using jquery
     And I navigate to the last shared URL
     And element "div:contains('STUDIO')" does not exist
     And I press the first "#logo-img img" element to load a new page
@@ -72,7 +72,7 @@ Feature: Lab share page logo
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
-    And I am on "http://studio.code.org/users/sign_out"
+    And I sign out using jquery
     And I navigate to the last shared URL
     And element "div:contains('STUDIO')" does not exist
     And I press the first "#logo-img img" element to load a new page

--- a/dashboard/test/ui/features/star_labs/sharepage_logo.feature
+++ b/dashboard/test/ui/features/star_labs/sharepage_logo.feature
@@ -58,7 +58,7 @@ Feature: Lab share page logo
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
-    And I sign out using jquery
+    And I sign out
     And I navigate to the last shared URL
     And element "div:contains('STUDIO')" does not exist
     And I press the first "#logo-img img" element to load a new page
@@ -72,7 +72,7 @@ Feature: Lab share page logo
     And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
-    And I sign out using jquery
+    And I sign out
     And I navigate to the last shared URL
     And element "div:contains('STUDIO')" does not exist
     And I press the first "#logo-img img" element to load a new page

--- a/dashboard/test/ui/features/star_labs/sharepage_logo.feature
+++ b/dashboard/test/ui/features/star_labs/sharepage_logo.feature
@@ -59,7 +59,6 @@ Feature: Lab share page logo
     And I navigate to the share URL
     And I wait to see "#runButton"
     And I am on "http://studio.code.org/users/sign_out"
-    And I reload the page
     And I navigate to the last shared URL
     And element "div:contains('STUDIO')" does not exist
     And I press the first "#logo-img img" element to load a new page
@@ -74,7 +73,6 @@ Feature: Lab share page logo
     And I navigate to the share URL
     And I wait to see "#runButton"
     And I am on "http://studio.code.org/users/sign_out"
-    And I reload the page
     And I navigate to the last shared URL
     And element "div:contains('STUDIO')" does not exist
     And I press the first "#logo-img img" element to load a new page

--- a/dashboard/test/ui/features/star_labs/sharepage_logo.feature
+++ b/dashboard/test/ui/features/star_labs/sharepage_logo.feature
@@ -81,7 +81,7 @@ Feature: Lab share page logo
     And check that I am on "http://code.org/"
 
   @only_mobile
-  Scenario: Select the logo on a playlab share page while logged out and visit the homepage
+  Scenario: When on an applab share page while logged out on mobile, there is no logo.
     Given I am on "http://studio.code.org/projects/applab"
     And I wait for the lab page to fully load
     Then I click selector ".project_share"
@@ -91,7 +91,7 @@ Feature: Lab share page logo
     And element "#main_logo" does not exist
 
   @only_mobile
-  Scenario: Select the logo on a playlab share page while logged out and visit the homepage
+  Scenario: When on a gamelab share page while logged out on mobile, there is no logo.
     Given I am on "http://studio.code.org/projects/gamelab"
     And I wait for the lab page to fully load
     Then I click selector ".project_share"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
The `sharepage_logo` UI test has been quite flaky recently. See [Flaky test Cloudwatch dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/DoTD_Health).


![Screenshot 2024-08-14 at 5 02 20 PM](https://github.com/user-attachments/assets/e18b2a41-ddcc-4fde-8119-620b2fdf6f77)

I observed out of the 8 scenarios, this test failed due to the 'Select the logo on a playlab share page while logged out and visit the homepage' scenario. [Example failure](https://app.saucelabs.com/tests/16addab25cc6472e9dab47e1fc04d937#46)

In [this scenario](https://github.com/code-dot-org/code-dot-org/blob/58fcc9e1e9a97c78f09cedbee6a05f88ce98baba/dashboard/test/ui/features/star_labs/sharepage_logo.feature#L54-L66), the user creates a Playlab project, gets the share link, then signs out. Then the user navigates to last share URL logged out and clicks on the Code.org logo. The user should end up at code.org, but instead goes to studio.code.org as a sign-in user.

I noticed in the Cloudwatch dashboard that `applab_project` and `gamelab_project` were also in the top 10 UI test failures. 

It appears that these 3 UI tests have failed for the same reason after the step: `And I am on "http://studio.code.org/users/sign_out"`. They are expected to be signed out, but end up still being logged in.

- `applab_project.feature`: [Step that is failing](https://github.com/code-dot-org/code-dot-org/blob/58fcc9e1e9a97c78f09cedbee6a05f88ce98baba/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature#L51) - Recent failure example -   https://app.saucelabs.com/tests/40409a4cd15143a69fff88746778edf7
- `gamelab_project.feature`: [Step that is failing](https://github.com/code-dot-org/code-dot-org/blob/58fcc9e1e9a97c78f09cedbee6a05f88ce98baba/dashboard/test/ui/features/teacher_tools/projects/gamelab_project.feature#L57) - Recent failure example - https://app.saucelabs.com/tests/ef46c55c2519439eb5a624f403212262 

Thus, I am replacing this step in this UI test with `And I sign out using jquery` which is used in several other UI tests.

Recently, a 3-second wait time was added to this step `And I sign out using jquery` by https://github.com/code-dot-org/code-dot-org/pull/60376 as this behavior has been a wider issue causing several other UI tests to be flaky. See [very involved Slack discussion](https://codedotorg.slack.com/archives/C0T0PNR0D/p1722444400850089). The root cause seems to be a race condition 'where an asynchronous API call is resetting the learn session to an old value if the fetch is completed after a new session was instantiated (via sign in, log out, etc).' (from [write-up](https://docs.google.com/document/d/1_H7SDk1vPnUr5N7I14FPSoYs2bPPBGUz7KUAIE8X_A0/edit) by @stephenliang .

Long term fix logged at  https://codedotorg.atlassian.net/browse/P20-1080.


## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-972)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Will continue to monitor this test in the [Flaky test Cloudwatch dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/DoTD_Health) - in particular, curious about `applab_projects.feature` and `gamelab_projects.feature`.

Not necessarily related to this test failure, I also observe the following error that is not causing a failure, but does have to do with loading the page:
```
HTTP Status: 404
{
	"message": "stale element reference: element is not attached to the page document\n  (Session info: chrome=105.0.5195.54)",
	"error": "stale element reference"
}
```

The error is following the `I press the <element> to load a new page` step - see [test example](https://app.saucelabs.com/tests/51e8e497db6d44ae8af9d65a6d56a076#42) (run locally from this PR).

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
