### PR TITLE
AITT-698 move ai evaluation status from banner to tooltip

### DIFF
--- a/apps/src/templates/rubrics/RubricTabButtons.jsx
+++ b/apps/src/templates/rubrics/RubricTabButtons.jsx
@@ -97,9 +97,7 @@ export default function RubricTabButtons({
                 effect="solid"
                 place="bottom"
               >
-                <div style={{maxWidth: 400}}>
-                  <p>{statusText()}</p>
-                </div>
+                {statusText()}
               </ReactTooltip>
             )}
           </div>

--- a/apps/src/templates/rubrics/RubricTabButtons.jsx
+++ b/apps/src/templates/rubrics/RubricTabButtons.jsx
@@ -61,10 +61,9 @@ export default function RubricTabButtons({
   const runButtonTooltipId = _.uniqueId();
 
   return (
-    <div>
+    <div className="uitest-rubric-tab-buttons">
       <div className={style.rubricTabGroup}>
         <SegmentedButtons
-          className="uitest-rubric-tab-buttons"
           selectedButtonValue={selectedTab}
           size="s"
           buttons={[

--- a/apps/src/templates/rubrics/RubricTabButtons.jsx
+++ b/apps/src/templates/rubrics/RubricTabButtons.jsx
@@ -1,11 +1,12 @@
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
+import ReactTooltip from 'react-tooltip';
 
 import SegmentedButtons from '@cdo/apps/componentLibrary/segmentedButtons/SegmentedButtons';
 import {RubricAiEvaluationLimits} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
-import {InfoAlert} from './RubricContent';
 import {TAB_NAMES} from './rubricHelpers';
 import {reportingDataShape, rubricShape} from './rubricShapes';
 import RunAIAssessmentButton, {STATUS} from './RunAIAssessmentButton';
@@ -57,6 +58,8 @@ export default function RubricTabButtons({
     }
   };
 
+  const runButtonTooltipId = _.uniqueId();
+
   return (
     <div>
       <div className={style.rubricTabGroup}>
@@ -75,7 +78,7 @@ export default function RubricTabButtons({
           onChange={value => tabSelectCallback(value)}
         />
         {selectedTab === TAB_NAMES.RUBRIC && teacherHasEnabledAi && (
-          <div>
+          <div data-tip data-for={runButtonTooltipId}>
             <RunAIAssessmentButton
               canProvideFeedback={canProvideFeedback}
               teacherHasEnabledAi={teacherHasEnabledAi}
@@ -87,19 +90,21 @@ export default function RubricTabButtons({
               setStatus={setStatus}
               reportingData={reportingData}
             />
+            {!!statusText() && (
+              <ReactTooltip
+                id={runButtonTooltipId}
+                role="tooltip"
+                effect="solid"
+                place="bottom"
+              >
+                <div style={{maxWidth: 400}}>
+                  <p>{statusText()}</p>
+                </div>
+              </ReactTooltip>
+            )}
           </div>
         )}
       </div>
-      {selectedTab === TAB_NAMES.RUBRIC &&
-        canProvideFeedback &&
-        teacherHasEnabledAi &&
-        !!statusText() && (
-          <InfoAlert
-            className={'uitest-eval-status-text'}
-            text={statusText() || ''}
-            dismissable={true}
-          />
-        )}
     </div>
   );
 }

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -710,9 +710,6 @@ describe('RubricContainer', () => {
     wrapper.update();
     expect(userFetchStub).to.have.been.called;
     expect(allFetchStub).to.have.been.called;
-    expect(wrapper.find('[title="info circle icon"]').length).to.be.greaterThan(
-      0
-    );
     expect(wrapper.text()).to.include(
       i18n.aiEvaluationStatus_request_too_large()
     );
@@ -798,7 +795,6 @@ describe('RubricContainer', () => {
 
     expect(userFetchStub).to.have.been.called;
     expect(allFetchStub).to.have.been.called;
-    expect(screen.queryByTestId('info-alert')).to.exist;
     screen.getByText(
       i18n.aiEvaluationStatus_teacher_limit_exceeded({
         limit: RubricAiEvaluationLimits.TEACHER_LIMIT,

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -47,8 +47,7 @@ Feature: Evaluate student code against rubrics using AI
     When I click selector "#ui-floatingActionButton"
     And I wait until element "#uitest-rubric-content" is visible
     And element ".uitest-run-ai-assessment" is disabled
-    And element ".uitest-info-alert" is visible
-    Then I wait until element ".uitest-info-alert" contains text "AI analysis already completed for this project."
+    Then I wait until element ".uitest-rubric-tab-buttons .__react_component_tooltip" contains text "AI analysis already completed for this project."
 
     # Teacher views AI evaluation results in rubric
     And I wait until element "#uitest-next-goal" is visible
@@ -99,8 +98,7 @@ Feature: Evaluate student code against rubrics using AI
 
     # Teacher runs AI evaluation
     When I click selector ".uitest-run-ai-assessment"
-    Then I wait until element ".uitest-info-alert" is visible
-    And I wait until element ".uitest-info-alert" contains text "AI analysis complete."
+    Then I wait until element ".uitest-rubric-tab-buttons .__react_component_tooltip" contains text "AI analysis complete."
 
     # Teacher views AI evaluation results in rubric tab
     And I wait until element "#uitest-next-goal" is visible

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -162,7 +162,6 @@ Scenario: Teacher views Rubric and Settings tabs
   And I wait until element "h5:contains(Code Quality)" is visible
   Then I see no difference for "rubric tab, Code Quality learning goal"
   And element ".uitest-run-ai-assessment" is disabled
-  And element ".uitest-info-alert" is visible
 
   When I click selector "#uitest-next-goal"
   And I wait until element "h5:contains(Sprites)" is visible


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-698

## Screenshots

when AI evaluation is run by the teacher:
https://github.com/user-attachments/assets/60d25345-b187-4e9a-b763-9062c792ce5f

when AI has already run:
![already-complete](https://github.com/user-attachments/assets/9f4763fc-8213-4e30-b2eb-d346870be9b6)

when there is an error:
![teacher-limit](https://github.com/user-attachments/assets/7f6cb0d1-ff05-4e9d-b1aa-9be9e4acb7f6)


## Testing story
