### PR TITLE
Add missing lti_user_created metrics

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -153,6 +153,7 @@ class RegistrationsController < Devise::RegistrationsController
         metadata = {
           'user_type' => current_user.user_type,
           'lms_name' => lms_name,
+          'context' => 'registration_controller'
         }
         Metrics::Events.log_event(
           user: current_user,

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -200,6 +200,7 @@ module Services
             event_name: 'lti_user_created',
             metadata: {
               lms_name: lti_integration[:platform_name],
+              context: 'roster_sync'
             }
           )
         end

--- a/dashboard/lib/services/lti/account_linker.rb
+++ b/dashboard/lib/services/lti/account_linker.rb
@@ -27,7 +27,6 @@ module Services
               user: user,
               event_name: 'lti_user_created',
               metadata: {
-                'user_type' => user.user_type,
                 'lms_name' => @lti_integration[:platform_name],
                 'context' => 'account_linking',
               }

--- a/dashboard/lib/services/lti/account_linker.rb
+++ b/dashboard/lib/services/lti/account_linker.rb
@@ -14,17 +14,30 @@ module Services
         ActiveRecord::Base.transaction do
           user.authentication_options << rehydrated_user.authentication_options.first
           Services::Lti.create_lti_user_identity(user)
+          @lti_integration = user.lti_user_identities.first.lti_integration
           handle_sections(rehydrated_user, user)
           user.lti_roster_sync_enabled = true if user.teacher?
           user.lms_landing_opted_out = true
           PartialRegistration.delete(session)
+          unless rehydrated_user.id
+            # For fresh LTI users who are linking their account, we want to count
+            # them as "new" users for metrics, since they won't hit the registration
+            # controller like they would if they chose to create a new account.
+            Metrics::Events.log_event(
+              user: user,
+              event_name: 'lti_user_created',
+              metadata: {
+                'user_type' => user.user_type,
+                'lms_name' => @lti_integration[:platform_name],
+              }
+            )
+          end
           rehydrated_user.destroy if rehydrated_user.id
         end
 
-        lti_integration = user.lti_user_identities.first.lti_integration
         metadata = {
-          'lms_name' => lti_integration[:platform_name],
-          'lms_client_id' => lti_integration[:client_id],
+          'lms_name' => @lti_integration[:platform_name],
+          'lms_client_id' => @lti_integration[:client_id],
           'login_type' => user.primary_contact_info&.credential_type,
         }
         Metrics::Events.log_event(

--- a/dashboard/lib/services/lti/account_linker.rb
+++ b/dashboard/lib/services/lti/account_linker.rb
@@ -29,6 +29,7 @@ module Services
               metadata: {
                 'user_type' => user.user_type,
                 'lms_name' => @lti_integration[:platform_name],
+                'context' => 'account_linking',
               }
             )
           end


### PR DESCRIPTION
Product noticed a gap in metrics for new LTI users. This adds events to the spots where they were missing: when users are created during a roster sync, and when a new LTI user launches and links a previous account. Also added a metadata property to distinguish between the types of user creation.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1083)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

We have enough LTI metrics being published in multiple spots that it might be good to create a new LTI metrics service with reusable functions and constants for the event names.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
