### PR TITLE
Change the colors in the panelContainer headers to meet light mode standards / match the figma design.

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -158,7 +158,7 @@ const AichatView: React.FunctionComponent = () => {
   const chatWorkspaceHeader = (
     <div>
       {projectTemplateLevel && (
-        <ProjectTemplateWorkspaceIcon tooltipPlace="bottom" dark /> // todo: dark should be conditional based on the theme (light/dark)
+        <ProjectTemplateWorkspaceIcon tooltipPlace="bottom" dark />
       )}
       {viewMode === ViewMode.EDIT
         ? aichatI18n.aichatWorkspaceHeader()
@@ -285,7 +285,7 @@ const renderModelCustomizationHeaderRight = (onStartOver: () => void) => {
       <Button
         icon={{iconStyle: 'solid', iconName: 'refresh'}}
         isIconOnly={true}
-        color={'black'} // todo: This should be conditional based on the theme (light/dark)
+        color={'black'}
         onClick={onStartOver}
         ariaLabel={'Start Over'}
         size={'xs'}

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -158,7 +158,7 @@ const AichatView: React.FunctionComponent = () => {
   const chatWorkspaceHeader = (
     <div>
       {projectTemplateLevel && (
-        <ProjectTemplateWorkspaceIcon tooltipPlace="bottom" />
+        <ProjectTemplateWorkspaceIcon tooltipPlace="bottom" dark /> // todo: dark should be conditional based on the theme (light/dark)
       )}
       {viewMode === ViewMode.EDIT
         ? aichatI18n.aichatWorkspaceHeader()
@@ -285,7 +285,7 @@ const renderModelCustomizationHeaderRight = (onStartOver: () => void) => {
       <Button
         icon={{iconStyle: 'solid', iconName: 'refresh'}}
         isIconOnly={true}
-        color={'white'}
+        color={'black'} // todo: This should be conditional based on the theme (light/dark)
         onClick={onStartOver}
         ariaLabel={'Start Over'}
         size={'xs'}

--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -2,6 +2,9 @@
 @import '../../mixins.scss';
 @import './aichat-common.module.scss';
 
+// Constants
+$default-spacing: 4px;
+
 %full-width {
   width: 100%;
   box-sizing: border-box;
@@ -17,6 +20,7 @@
 
   .tabsContainer {
     background-color: #eaebeb;
+    padding-top: $default-spacing;
   }
 
   .tabPanels {

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -1,8 +1,5 @@
 @import 'color.scss';
 
-// Constants
-$default-spacing: 2px;
-
 .panelContainer {
   width: 100%;
   height: 100%;
@@ -13,19 +10,21 @@ $default-spacing: 2px;
 
 %panel-container-header {
   min-height: 30px;
-  margin-bottom: $default-spacing;
   position: relative;
   z-index: 1;
+  border-bottom: 1px $light_gray_200 solid;
 }
 
 .panelContainerHeader-dark {
   @extend %panel-container-header;
   background-color: $neutral_dark80;
+  color: $neutral_light;
 }
 
 .panelContainerHeader-light {
   @extend %panel-container-header;
-  background-color: $neutral_dark;
+  background-color: $neutral_gray10;
+  color: $neutral_dark;
 }
 
 .panelContainerHeaderItem {
@@ -34,16 +33,17 @@ $default-spacing: 2px;
   transform: translateY(-50%);
 
   &Text {
-    color: $neutral_light;
     width: 100%;
     text-align: center;
   }
 
-  [dir="ltr"] &Right, [dir="rtl"] &Left {
+  [dir='ltr'] &Right,
+  [dir='rtl'] &Left {
     right: 4px;
   }
 
-  [dir="ltr"] &Left, [dir="rtl"] &Right {
+  [dir='ltr'] &Left,
+  [dir='rtl'] &Right {
     left: 4px;
   }
 }

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -1,5 +1,8 @@
 @import 'color.scss';
 
+// Constants
+$default-spacing: 2px;
+
 .panelContainer {
   width: 100%;
   height: 100%;
@@ -12,19 +15,20 @@
   min-height: 30px;
   position: relative;
   z-index: 1;
-  border-bottom: 1px $light_gray_200 solid;
 }
 
 .panelContainerHeader-dark {
   @extend %panel-container-header;
   background-color: $neutral_dark80;
   color: $neutral_light;
+  margin-bottom: $default-spacing;
 }
 
 .panelContainerHeader-light {
   @extend %panel-container-header;
   background-color: $neutral_gray10;
   color: $neutral_dark;
+  border-bottom: 1px $light_gray_200 solid;
 }
 
 .panelContainerHeaderItem {

--- a/apps/src/templates/ProjectTemplateWorkspaceIcon.jsx
+++ b/apps/src/templates/ProjectTemplateWorkspaceIcon.jsx
@@ -13,6 +13,7 @@ const IMAGE_BASE_URL = '/blockly/media/';
 export default class ProjectTemplateWorkspaceIcon extends React.Component {
   static propTypes = {
     tooltipPlace: PropTypes.string,
+    dark: PropTypes.bool,
   };
 
   constructor(props) {
@@ -36,7 +37,10 @@ export default class ProjectTemplateWorkspaceIcon extends React.Component {
               'projectTemplateWorkspaceIcon',
               moduleStyles.projectTemplateIcon
             )}
-            src={IMAGE_BASE_URL + 'connect.svg'}
+            src={
+              IMAGE_BASE_URL +
+              (this.props.dark ? 'connect-dark.svg' : 'connect.svg')
+            }
             alt={msg.workspaceProjectTemplateLevel()}
           />
         </button>

--- a/apps/static/connect-dark.svg
+++ b/apps/static/connect-dark.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4ef66bc5fab5781433efe1eda1d091bc6d0b1c31fb7ae9a74424aa96d4af7a8
+size 1761


### PR DESCRIPTION
This change does the following: 
- Updates the panel header colors to match the standards of light mode and the figma design here:
![image](https://github.com/user-attachments/assets/1b713c49-2f66-4e3d-a089-b32051c52250)

 - Adds a new dark version of the svg for the `ProjectTemplateWorkspaceIcon`
 - Adds 2px more padding between the header and top of the tabs in the center panel to match the figma design. 
 - Some css refactor to keep dark mode the same given the changes to light mode.

## Links

- jira ticket: [Changing the colors of the header to meet light mode standards](https://codedotorg.atlassian.net/browse/LABS-878)


## Testing story

Visual inspection of the new colors and layout for ai chat, and the other labs that share the changed component (Music Lab, Python Lab)

Here is a video comparing the new implementation with the old on an ai chat level. Note that the colors of the panel containers changed from light to dark. The icons changed from being white to dark, and I also slightly changed the padding between the header and the tabs in the middle pane to match the figma design.

https://github.com/user-attachments/assets/a69afeb5-3ec4-4148-b445-e2dfc2c7447a

Since the PanelContainer is a shared component, changing it could affect a few other labs. I tested to make sure that these changes do not change how Music Lab looks:

https://github.com/user-attachments/assets/ba6bd64d-f31b-4eeb-84fa-8531b58ea87e

There is a slight change in padding that is visible in Python lab but I think it's acceptable:

https://github.com/user-attachments/assets/f514fcb0-e481-4c07-bb92-62fbb4647edf
