### PR TITLE
Use DSCO Button in Copyright Footer

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -572,6 +572,7 @@
   "copySectionCodeTooltip": "Click here to copy the link students need to join the section",
   "copyStudentsConfirm": "Yes, I want to copy student(s) to be in this current section AND the new section.",
   "copyright": "Copyright",
+  "copyrightInfoButton": "View copyright information",
   "correct": "Correct",
   "correctAnswer": "That is the correct answer.",
   "costume": "costume",

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -310,15 +310,16 @@ export default class SmallFooter extends React.Component {
         <span className="copyright-button">
           <Button
             aria-label="Copyright Button"
-            size="xs"
+            className="copyright-link no-mc"
             color={buttonColors.gray}
-            type="secondary"
-            onClick={this.clickBaseCopyright}
-            isIconOnly
             icon={{
               iconName: 'copyright',
               iconStyle: 'light',
             }}
+            isIconOnly
+            onClick={this.clickBaseCopyright}
+            size="xs"
+            type="secondary"
           />
         </span>
       );

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -309,7 +309,7 @@ export default class SmallFooter extends React.Component {
       return (
         <span className="copyright-button">
           <Button
-            aria-label="Copyright Button"
+            aria-label={i18n.copyrightInfoButton()}
             className="copyright-link no-mc"
             color={buttonColors.gray}
             icon={{

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -12,7 +12,7 @@ import debounce from 'lodash/debounce';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
+import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import i18n from '@cdo/locale';
@@ -190,7 +190,6 @@ export default class SmallFooter extends React.Component {
         color: color.neutral_dark30,
         backgroundColor: color.background_gray,
         cursor: 'pointer',
-        fontSize: 24,
         border: 'none',
       },
       copyrightScrollArea: {
@@ -269,11 +268,17 @@ export default class SmallFooter extends React.Component {
               )}
             />
             <Button
-              id="x-close-copyright"
-              onClick={() => this.setState({menuState: MenuState.MINIMIZED})}
-              icon="fa-solid fa-xmark"
-              style={styles.copyrightXClose}
               aria-label={i18n.closeDialog()}
+              icon={{
+                iconName: 'xmark',
+                iconStyle: 'light',
+              }}
+              id="x-close-copyright"
+              isIconOnly
+              onClick={() => this.setState({menuState: MenuState.MINIMIZED})}
+              size="l"
+              style={styles.copyrightXClose}
+              type="primary"
             />
           </div>
         </div>
@@ -303,13 +308,18 @@ export default class SmallFooter extends React.Component {
     if (this.props.copyrightInBase) {
       return (
         <span className="copyright-button">
-          <button
-            className="copyright-link no-mc"
-            type="button"
+          <Button
+            aria-label="Copyright Button"
+            size="xs"
+            color={buttonColors.gray}
+            type="secondary"
             onClick={this.clickBaseCopyright}
-          >
-            &copy;
-          </button>
+            isIconOnly
+            icon={{
+              iconName: 'copyright',
+              iconStyle: 'light',
+            }}
+          />
         </span>
       );
     }


### PR DESCRIPTION
This PR updates the Copyright button to use our new design system(DSCO) Button component.
NOTE: This Pr just updates the Copyright button in the footer. The other components will be updated in different PRs

Why:
These are legacy buttons that have not been updated in a long time. As we begin to build new labs, we need to consider more than we did at the time these buttons were made. Light/dark, the possibility of floating action buttons to call AI, and custom layouts per lab type, are all reasons we need to begin using DSCO components (wherever possible) and adding the capability to adjust styling and layout easily.

## Links
- spec: [P20-1036](https://codedotorg.atlassian.net/browse/P20-1036)
<img width="1158" alt="Screenshot 2024-08-15 at 10 33 13" src="https://github.com/user-attachments/assets/b7bc3042-3bd7-4d9e-9d01-c36f0a2e1242">

- jira ticket: [P20-1038](https://codedotorg.atlassian.net/browse/P20-1038)

## Testing story

<img width="1710" alt="Screenshot 2024-08-15 at 10 12 10" src="https://github.com/user-attachments/assets/a28cac9a-2abe-44fa-bc0b-a772b2edfc47">

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
