### PR TITLE
[Google Blockly] support draw_colour_simple block

### DIFF
--- a/apps/src/blockly/addons/cdoCss.ts
+++ b/apps/src/blockly/addons/cdoCss.ts
@@ -60,7 +60,7 @@ export default function initializeCss(blocklyWrapper: BlocklyWrapperType) {
     }
     .fieldAngleDropDownContainer .blocklyMenu{
       float: left;
-    }    
+    }
     .fieldAngleDropDownContainer .blocklyMenu::after {
       content: '';
       border-left: 1px solid #949ca2;
@@ -71,7 +71,11 @@ export default function initializeCss(blocklyWrapper: BlocklyWrapperType) {
     }
     .fieldAngleDropDownContainer .blocklyMenuItem{
       min-width: 0em;
-    }    
+    }
+    .k1ColourDropdown>tr>td {
+      height: 35px;
+      width: 45px;
+    }
     `
   );
 }

--- a/apps/src/blockly/addons/cdoFieldColour.ts
+++ b/apps/src/blockly/addons/cdoFieldColour.ts
@@ -8,6 +8,8 @@ export default class CdoFieldColour extends FieldColour {
   static COLOURS: string[] = FieldColour.COLOURS;
   static TITLES: string[] = [];
   static COLUMNS: number = 7;
+  static K1_FIELD_SIZE = {height: 35, width: 45};
+  private isK1: boolean;
   /**
    * @param value The initial value of the field.  Should be in '#rrggbb'
    *     format.  Defaults to the first value in the default colour array.  Also
@@ -25,7 +27,8 @@ export default class CdoFieldColour extends FieldColour {
   constructor(
     value?: string | typeof Blockly.Field.SKIP_SETUP,
     validator?: FieldColourValidator,
-    config?: FieldColourConfig
+    config?: FieldColourConfig,
+    isK1?: boolean
   ) {
     super(value, validator, config);
     // Duplicates this.colours and this.columns, which are both private in the parent class.
@@ -33,17 +36,42 @@ export default class CdoFieldColour extends FieldColour {
       if (config.colourOptions) this.coloursConfig = config.colourOptions;
       if (config.columns) this.columnsConfig = config.columns;
     }
+    this.isK1 = !!isK1;
   }
 
   /**
    * Create and show the colour field's editor.
    * Artist modifies blockly.FieldColour.COLOURS and blockly.FieldColour.COLUMNS directly.
    * Therefore, wait to read these values until we need to create the field dropdown.
+   * For pre-reader blocks (CSF Course A-B, Course 1 and Pre-Reader Express), we add a
+   * class to manually increase the size of the field.
    * @override
    * */
   protected override showEditor_() {
     this.setColours(this.coloursConfig || CdoFieldColour.COLOURS);
     this.setColumns(this.columnsConfig || CdoFieldColour.COLUMNS);
     super.showEditor_();
+    if (this.isK1) {
+      // @ts-expect-error: Accessing private member 'picker'
+      Blockly.utils.dom.addClass(this.picker, 'k1ColourDropdown');
+    }
+  }
+
+  /**
+   * This override allows resizing of the colour options to align with conventions used
+   * in our pre-reader blocks.
+   * The base class version updates the size of the field based on whether it is a full
+   * block fieldor not.
+   *
+   * @param margin margin to use when positioning the field.
+   */
+  protected updateSize_(margin?: number) {
+    super.updateSize_(margin);
+
+    if (this.isK1) {
+      this.size_ = CdoFieldColour.K1_FIELD_SIZE;
+    }
+
+    this.positionBorderRect_();
   }
 }

--- a/apps/src/blockly/addons/cdoFieldColour.ts
+++ b/apps/src/blockly/addons/cdoFieldColour.ts
@@ -8,7 +8,8 @@ export default class CdoFieldColour extends FieldColour {
   static COLOURS: string[] = FieldColour.COLOURS;
   static TITLES: string[] = [];
   static COLUMNS: number = 7;
-  static K1_FIELD_SIZE = {height: 35, width: 45};
+  static K1_HEIGHT: number = 35;
+  static K1_WIDTH: number = 45;
   private isK1: boolean;
   /**
    * @param value The initial value of the field.  Should be in '#rrggbb'
@@ -69,7 +70,10 @@ export default class CdoFieldColour extends FieldColour {
     super.updateSize_(margin);
 
     if (this.isK1) {
-      this.size_ = CdoFieldColour.K1_FIELD_SIZE;
+      this.size_ = {
+        width: CdoFieldColour.K1_WIDTH,
+        height: CdoFieldColour.K1_HEIGHT,
+      };
     }
 
     this.positionBorderRect_();

--- a/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
+++ b/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
@@ -116,4 +116,7 @@ export const blocks = {
   },
   addSerializationHooksToBlock() {},
   mathRandomIntGenerator: blockly.JavaScript.math_random_int,
+  getColourDropdownField(colours) {
+    return new Blockly.FieldColourDropdown(colours, 45, 35);
+  },
 };

--- a/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
@@ -129,4 +129,21 @@ export const blocks = {
     const code = `${functionName}(${argument0}, ${argument1})`;
     return [code, generator.ORDER_FUNCTION_CALL];
   },
+  // Creates and returns a 3-column colour field with an increased height/width
+  // for menu options and the field itself. Used for the K1 Artist colour picker block.
+  getColourDropdownField(colours: string[]) {
+    const configOptions = {
+      colourOptions: colours,
+      columns: 3,
+    };
+    const defaultColour = colours[0];
+    const optionalValidator = undefined;
+    const isK1 = true;
+    return new Blockly.FieldColour(
+      defaultColour,
+      optionalValidator,
+      configOptions,
+      isK1
+    );
+  },
 };

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -1433,7 +1433,7 @@ exports.install = function (blockly, blockInstallOptions) {
   blockly.Blocks.draw_colour_simple = {
     // Simplified dropdown block for setting the colour.
     init: function () {
-      var colours = [
+      const colours = [
         Colours.RED,
         Colours.BLACK,
         Colours.PINK,
@@ -1449,7 +1449,7 @@ exports.install = function (blockly, blockInstallOptions) {
         BlockColors.LOGIC,
         BlockStyles.LOGIC
       );
-      var colourField = new Blockly.FieldColourDropdown(colours, 45, 35);
+      const colourField = Blockly.customBlocks.getColourDropdownField(colours);
       this.appendDummyInput()
         .appendField(msg.setColour())
         .appendField(colourField, 'COLOUR');


### PR DESCRIPTION
The pre-reader Artist lessons use a color picker block which features larger-than-normal menu options and a larger field:
<img width="296" alt="image" src="https://github.com/user-attachments/assets/ff67048a-4722-44e2-8151-3929740c5370">

This field hasn't been migrated, so it was causing a page crash on levels that used the block.

```
TypeError: Blockly.FieldColourDropdown is not a constructor
```

In CDO Blockly, `FieldColourDropdown` extends `FieldRectangularDropdown`, neither of which exist in our Google Blockly implementation. The colour dropdown field is only used for this one block, and rectangular dropdown isn't used directly anywhere in the main repo. Rather than migrate both of these classes, I opted to instead make a small tweak to the existing `CdoFieldColour`, shown here in Dance:

<img width="184" alt="image" src="https://github.com/user-attachments/assets/9938b965-6ab9-4142-bc71-886c19891610">

There are two specific changes required for this one block.
1. When a value is selected, we should increase the size of the field itself (the color on the block, not the dropdown editor).
2. When the dropdown editor is shown, we should create the menu options with a larger size.

For the first fix, we can update the field class instance's `size_` property during `updateSize_`. For the second fix, we want to override some existing CSS rules, so a new class is added. This is all controlled by a new `isK1` property that can now optionally be provided to the constructor.

Because this approach uses a different Blockly field class name (`FieldColour` instead of `FieldColourDropdown`) and different properties, I opted to move the logic for creating this field out to our `/customBlocks/` folders.

The result a working color picker with larger boxes:
<img width="191" alt="image" src="https://github.com/user-attachments/assets/48dc5aec-8c89-4107-8da9-f0528a3cc7c8">

The color options will also now be keyboard navigable once we are using Google Blockly.

You may notice that the first screenshot (CDO Blockly) shows four columns instead of three. I believe this was actually a regression in CDO Blockly and not something we should strive to reproduce exactly.


## Links

Bug bash doc: https://docs.google.com/document/d/14nGoZMVSptvDnRt1He0t6JQBRf-Em3ZcSIMUoEPYMq0/edit
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
