### PR TITLE
Remove /volunteer references from hourofcode.com

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
+++ b/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
@@ -93,24 +93,6 @@ Get started at http://hourofcode.com/{{ country_language }}
 <br>
 
 ***
-<a id="help-schools"></a>
-### Volunteer at a school:
-#### [Find more resources and information about volunteering in schools here]({{ how_to_volunteers_url }}).
-
-**Subject line:** Can we help you host an Hour of Code?
-
-Between {{ campaign_date/short }}, ten percent of students around the world will celebrate Computer Science Education Week by doing an Hour of Code at their school. It’s an opportunity for every child to learn how the technology around us works.
-
-[Our organization/My name] would love to help [school name] run an Hour of Code event. We can help teachers host an Hour of Code in their classrooms (we don’t even need computers!) or if you would like to host a school assembly, we can arrange for a speaker to talk about how technology works and what it’s like to be a software engineer.
-
-The students will create their own apps or games they can show their parents, and we’ll also print Hour of Code certificates they can bring home. And, it’s fun! With interactive, hands-on activities, students will learn computational thinking skills in an approachable way.
-
-Computers are everywhere, changing every industry on the planet. But only 51% of all high schools offer computer science. The good news is, we’re on our way to change this! If you've heard about the Hour of Code before, you might know it made history - more than 100 million students around the world have tried an Hour of Code. Even leaders like President Obama and Canadian Prime Minister Justin Trudeau wrote their first lines of code as part of the campaign.
-
-You can read more about the event at http://hourofcode.com. Or, let us know if you’d like to schedule some time to talk about how [school name] can participate.
-<br>
-
-***
 <a id="parents"></a>
 ### Tell parents about your school's event:
 

--- a/pegasus/sites.v3/hourofcode.com/public/thanks.md.partial
+++ b/pegasus/sites.v3/hourofcode.com/public/thanks.md.partial
@@ -17,20 +17,17 @@ social:
 Begin by exploring our library of [Hour of Code activities](/learn) and review this [how-to guide](/how-to) for helpful tips on how to find an activity, inspire students, and determine your technology needs. Try [diving into the world of artificial intelligence](/ai) - an exciting area of technology that’s shaping our future. There are various approaches to AI: empower your students to learn how AI works and your teachers to learn with AI 101 for teachers.
 
 ## 2. Spread the word
-We need your help to inspire volunteers and organizers from across the globe. Tell your friends about your #HourOfCode and [use these helpful resources](/resources) to promote your event. 
+We need your help to inspire organizers from across the globe. Tell your friends about your #HourOfCode and [use these helpful resources](/resources) to promote your event.
 <br>
 
 You can also help engage more people from your school and community by [sending our sample emails](/promote/resources#sample-emails) to your principal, a local group, or even some friends.
 
 {{ social_media_hoc }}
 
-## 3. Find a local volunteer to help you with your event.
-[Search our volunteer map](https://code.org/volunteer/local) to find volunteers who can visit your classroom or video chat remotely to inspire your students about the breadth of possibilities with computer science.
-
-## 4. Check out Hour of Code swag
+## 3. Check out Hour of Code swag
 Swag is a great way to get students excited about the Hour of Code and reward them for completing their activity. If you are hosting an event for your entire school, consider [sharing your Hour of Code plan](https://docs.google.com/forms/d/e/1FAIpQLSdD90kD2nkNZqTUMcAb2cQdOhUv99Q5XDQmkLDec25yZJHYhw/viewform) to receive a special engagement kit with t-shirts, posters, laptop stickers, and more. [At the Code.org store](https://store.code.org/), you can order Hour of Code swag kits, fun stickers, buttons, temporary tattoos, and more. But hurry, supplies are limited.
 
-## 5. Encourage kids to continue learning
+## 4. Encourage kids to continue learning
 An Hour of Code is just the beginning! We hear over and over again how much students love the Hour of Code and discover a newfound interest in computer science. Encourage them to continue learning. Whether you're an administrator, teacher, or advocate, we have professional learning, free classroom curriculum and lesson plans, and resources to help you [bring computer science classes to your school](https://code.org/teach) or expand your offerings.
 
 Many of the organizations offering activities on HourofCode.com also have curriculum and professional learning available as well. We've highlighted curriculum providers that can help you or your students [go beyond an hour](/beyond).

--- a/pegasus/sites.v3/hourofcode.com/public/thanks.md.partial
+++ b/pegasus/sites.v3/hourofcode.com/public/thanks.md.partial
@@ -17,17 +17,20 @@ social:
 Begin by exploring our library of [Hour of Code activities](/learn) and review this [how-to guide](/how-to) for helpful tips on how to find an activity, inspire students, and determine your technology needs. Try [diving into the world of artificial intelligence](/ai) - an exciting area of technology that’s shaping our future. There are various approaches to AI: empower your students to learn how AI works and your teachers to learn with AI 101 for teachers.
 
 ## 2. Spread the word
-We need your help to inspire organizers from across the globe. Tell your friends about your #HourOfCode and [use these helpful resources](/resources) to promote your event.
+We need your help to inspire volunteers and organizers from across the globe. Tell your friends about your #HourOfCode and [use these helpful resources](/resources) to promote your event. 
 <br>
 
 You can also help engage more people from your school and community by [sending our sample emails](/promote/resources#sample-emails) to your principal, a local group, or even some friends.
 
 {{ social_media_hoc }}
 
-## 3. Check out Hour of Code swag
+## 3. Find a local volunteer to help you with your event.
+[Search our volunteer map](https://code.org/volunteer/local) to find volunteers who can visit your classroom or video chat remotely to inspire your students about the breadth of possibilities with computer science.
+
+## 4. Check out Hour of Code swag
 Swag is a great way to get students excited about the Hour of Code and reward them for completing their activity. If you are hosting an event for your entire school, consider [sharing your Hour of Code plan](https://docs.google.com/forms/d/e/1FAIpQLSdD90kD2nkNZqTUMcAb2cQdOhUv99Q5XDQmkLDec25yZJHYhw/viewform) to receive a special engagement kit with t-shirts, posters, laptop stickers, and more. [At the Code.org store](https://store.code.org/), you can order Hour of Code swag kits, fun stickers, buttons, temporary tattoos, and more. But hurry, supplies are limited.
 
-## 4. Encourage kids to continue learning
+## 5. Encourage kids to continue learning
 An Hour of Code is just the beginning! We hear over and over again how much students love the Hour of Code and discover a newfound interest in computer science. Encourage them to continue learning. Whether you're an administrator, teacher, or advocate, we have professional learning, free classroom curriculum and lesson plans, and resources to help you [bring computer science classes to your school](https://code.org/teach) or expand your offerings.
 
 Many of the organizations offering activities on HourofCode.com also have curriculum and professional learning available as well. We've highlighted curriculum providers that can help you or your students [go beyond an hour](/beyond).

--- a/pegasus/sites.v3/hourofcode.com/views/how-to/faq/faq_educators.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/how-to/faq/faq_educators.haml
@@ -29,6 +29,3 @@
               =hoc_s(:device_mobile_device)
           %p
             =hoc_s(:hoc_how_to_faq_answer_devices_02, markdown: :inline, locals: {pair_url: "https://www.youtube.com/watch?v=q7d_JtyCq1A", unplugged_url: "/learn?platform=no-computers"})
-        - if index === 2
-          %a{href: resolve_url("/how-to/volunteers")}
-            =hoc_s(:call_to_action_become_a_volunteer)

--- a/pegasus/sites.v3/hourofcode.com/views/how_to_nav.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/how_to_nav.haml
@@ -20,9 +20,6 @@
     %a.nav-link{href: resolve_url('/how-to/public-officials')}
       = hoc_s(:how_to_nav_public_officials)
   %div.nav-item
-    %a.nav-link{href: resolve_url('/how-to/volunteers')}
-      = hoc_s(:how_to_nav_volunteers)
-  %div.nav-item
     %a.nav-link{href: resolve_url('/how-to/virtual')}
       = hoc_s(:how_to_nav_virtual)
 = view :resources_nav

--- a/pegasus/sites.v3/hourofcode.com/views/how_to_volunteers_url.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/how_to_volunteers_url.erb
@@ -1,1 +1,0 @@
-<%= resolve_url('/how-to/volunteers') %>

--- a/pegasus/sites.v3/hourofcode.com/views/urls/volunteer.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/urls/volunteer.erb
@@ -1,1 +1,0 @@
-<%= codeorg_url('/volunteer') %>

--- a/pegasus/sites.v3/hourofcode.com/views/urls/volunteer_engineer.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/urls/volunteer_engineer.erb
@@ -1,1 +1,0 @@
-<%= codeorg_url('/volunteer/engineer') %>

--- a/pegasus/sites.v3/hourofcode.com/views/urls/volunteer_local.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/urls/volunteer_local.erb
@@ -1,1 +1,0 @@
-<%= codeorg_url('/volunteer/local') %>


### PR DESCRIPTION
Removes references to the volunteer pages on hourofcode.com on the following pages:
- https://hourofcode.com/promote/resources
- https://hourofcode.com/how-to (Educators guide)

Also removes volunteer page link views that are used on pages that will be deprecated.

## Links
Jira ticket: [ACQ-2258](https://codedotorg.atlassian.net/browse/ACQ-2258)