### PR TITLE
[Google Blockly] controls_for_counter generator

### DIFF
--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -738,8 +738,9 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setTitleValue(counter, 'VAR');
     },
   };
-
-  generator.controls_for_counter = generator.controls_for;
+  // Google Blockly uses forBlock, CDO Blockly does not.
+  generator.controls_for_counter =
+    generator.controls_for || generator.forBlock.controls_for;
 
   // Delete these standard blocks.
   delete blockly.Blocks.procedures_defreturn;


### PR DESCRIPTION
During the Artist bug bash, @molly-moen identified a block that was causing an error due to a missing generator function:

<img width="575" alt="image" src="https://github.com/user-attachments/assets/865948a5-1356-4374-a550-0df8e9f9fac9">

With Blockly v10, these generator functions have been moved to `generator.forBlock`. The `controls_for` block and generator are provided with core Blockly, so we do not ever have them defined on the generator object itself. If the function isn't there, we can find it on `forBlock`. 

Now the block can be used and generates code correctly.

<img width="537" alt="image" src="https://github.com/user-attachments/assets/4d58ba94-034a-41df-89ef-8fda7b0e8f7c">



## Links

Bug bash doc: https://docs.google.com/document/d/14nGoZMVSptvDnRt1He0t6JQBRf-Em3ZcSIMUoEPYMq0/edit

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
