### PR TITLE
Align text & icons centered vertically in codebridge fileTab

### DIFF
--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -25,6 +25,11 @@
   background-color: $dark_charcoal;
 }
 
+.fileTab > span {
+  display: flex;
+  align-items: center;
+}
+
 .inlineButton {
   border: none;
   background: none;


### PR DESCRIPTION
The text and icon in file tabs in Python Lab were smooshed into the top of the tab and slightly cut off.  This aligns the span within the fileTab to be centered vertically so they aren't cut off at the top.

## Testing story

Tested manually in Python Lab
Before change:
![image](https://github.com/user-attachments/assets/51b22117-5a32-4316-9be1-b18ae11bbdbe)

After change:
![image](https://github.com/user-attachments/assets/6fe86795-6708-4b02-9161-c1e9a8056ffa)

