### PR TITLE
[Google Blockly] Fix custom getVars implementations

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -618,11 +618,7 @@ const STANDARD_INPUT_TYPES = {
     addInput(blockly, block, inputConfig, currentInputRow) {
       // Make sure the variable name gets declared at the top of the program
       block.getVars = function () {
-        return {
-          [Blockly.Variables.DEFAULT_CATEGORY]: [
-            block.getFieldValue(inputConfig.name),
-          ],
-        };
+        return [block.getFieldValue(inputConfig.name)];
       };
 
       // Add the variable field to the block

--- a/apps/src/blockly/addons/cdoVariables.ts
+++ b/apps/src/blockly/addons/cdoVariables.ts
@@ -9,7 +9,6 @@ export default function initializeVariables(
   // Re-use the variable getter block's generator function for paramters.
   blocklyWrapper.JavaScript.forBlock.parameters_get =
     blocklyWrapper.JavaScript.forBlock.variables_get;
-  blocklyWrapper.Variables.DEFAULT_CATEGORY = 'Default';
 
   // TODO: Removing support for sprite variables as a separate variable type is
   // captured in https://codedotorg.atlassian.net/browse/CT-213
@@ -30,14 +29,10 @@ export default function initializeVariables(
   };
 
   /**
-   * Standard implementation of getVars for blocks with a single 'VAR' title
-   * @param {string=} opt_category Variable category, defaults to 'Default'
+   * Standard implementation of getVars for blocks with a single 'VAR' field
    */
-  blocklyWrapper.Variables.getVars = function (this: Block, opt_category) {
-    const category = opt_category || blocklyWrapper.Variables.DEFAULT_CATEGORY;
-    const vars: {[key: string]: string[]} = {};
-    vars[category] = [this.getFieldValue('VAR')];
-    return vars;
+  blocklyWrapper.Variables.getVars = function (this: Block) {
+    return [this.getFieldValue('VAR')];
   };
 
   // Add serialization hooks to allow these blocks to be hidden on the

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -355,7 +355,7 @@ export interface ExtendedVariables extends VariablesType {
   getters: {[key: string]: string};
   registerGetter: (category: string, blockName: string) => void;
   allVariablesFromBlock: (block: Block) => string[];
-  getVars: (opt_category?: string) => {[key: string]: string[]};
+  getVars: (opt_category?: string) => string[];
 }
 
 export interface ProcedureBlock extends ExtendedBlockSvg, IProcedureBlock {

--- a/apps/src/dance/blockly/blocks.js
+++ b/apps/src/dance/blockly/blocks.js
@@ -27,11 +27,7 @@ const customInputTypes = {
   spritePicker: {
     addInput(blockly, block, inputConfig, currentInputRow) {
       block.getVars = function () {
-        return {
-          [Blockly.BlockValueType.SPRITE]: [
-            block.getFieldValue(inputConfig.name),
-          ],
-        };
+        return [block.getFieldValue(inputConfig.name)];
       };
 
       currentInputRow

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -107,49 +107,6 @@ const customInputTypes = {
       return `(${block.getFieldValue(arg.name)})`;
     },
   },
-  locationVariableDropdown: {
-    addInput(blockly, block, inputConfig, currentInputRow) {
-      block.getVars = function () {
-        return {
-          [Blockly.BlockValueType.LOCATION]: [
-            block.getFieldValue(inputConfig.name),
-          ],
-        };
-      };
-      block.renameVar = function (oldName, newName) {
-        if (
-          Blockly.Names.equals(oldName, block.getFieldValue(inputConfig.name))
-        ) {
-          block.setTitleValue(newName, inputConfig.name);
-        }
-      };
-      block.removeVar = function (oldName) {
-        if (
-          Blockly.Names.equals(oldName, block.getFieldValue(inputConfig.name))
-        ) {
-          block.dispose(true, true);
-        }
-      };
-
-      currentInputRow
-        .appendField(inputConfig.label)
-        .appendField(Blockly.Msg.VARIABLES_GET_TITLE)
-        .appendField(
-          new Blockly.FieldVariable(
-            Blockly.Msg.VARIABLES_SET_ITEM,
-            null,
-            null,
-            Blockly.BlockValueType.LOCATION,
-            null
-          ),
-          inputConfig.name
-        )
-        .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
-    },
-    generateCode(block, arg) {
-      return Blockly.JavaScript.translateVarName(block.getFieldValue(arg.name));
-    },
-  },
   soundPicker: {
     addInput(blockly, block, inputConfig, currentInputRow) {
       const icon = document.createElementNS(SVG_NS, 'tspan');
@@ -306,11 +263,7 @@ const customInputTypes = {
   spritePicker: {
     addInput(blockly, block, inputConfig, currentInputRow) {
       block.getVars = function () {
-        return {
-          [Blockly.BlockValueType.SPRITE]: [
-            block.getFieldValue(inputConfig.name),
-          ],
-        };
+        return [block.getFieldValue(inputConfig.name)];
       };
 
       currentInputRow

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -738,8 +738,9 @@ exports.install = function (blockly, blockInstallOptions) {
       this.setTitleValue(counter, 'VAR');
     },
   };
-
-  generator.controls_for_counter = generator.controls_for;
+  // Google Blockly uses forBlock, CDO Blockly does not.
+  generator.controls_for_counter =
+    generator.controls_for || generator.forBlock.controls_for;
 
   // Delete these standard blocks.
   delete blockly.Blocks.procedures_defreturn;


### PR DESCRIPTION
A couple issues came up during the Artist bug bash that shared a root cause related to the `block.getVars` method.

At the Artist Binary level `/s/course4/lessons/18/levels/9?blocklyVersion=google`, an error is displayed saying that we can't run the code:
![image](https://github.com/user-attachments/assets/69eab790-40ac-4ee6-94ac-beee6cb9aac6)

![image](https://github.com/user-attachments/assets/c8101459-ec85-4607-a405-095dfa169b52)

This happens as part of a check to make sure nested for loops don't use the same variable.

This branch is based on https://github.com/code-dot-org/code-dot-org/pull/60448 because I also noticed that the `controls_for_counter` block was affected. 

## Explanation

Google Blockly has a standard implementation of `block.getVars()` that returns a list of variable names:
https://github.com/google/blockly/blob/17e4f1c96665dd56ff33f5a45db809f7e2805e82/core/block.ts#L1118-L1134

In CDO Blockly however, the same function returned an object with keys (representing variable types) and values (list of variable names of the given type). This explains the previous version of each version of `getVars()` that was modified in this branch. Most of these are old. In the case of migrated labs like Sprite Lab and Dance, we don't see to ever actually _need_ or call these functions.

The outlier here is the implementation for `Blockly.Variables.getVars` which was added before Sprite Lab was migrated here:
https://github.com/code-dot-org/code-dot-org/pull/55276/files#diff-ff941d5d2ca36511c7401a50c5160671b0bba06e9bbd8f0d34ef21128e8a4f0bR22-R31

This was part of an effort to pre-emptively import missing variable methods from CDO Blockly. Unfortunately, that version wouldn't have worked as expected because it had the wrong return type for Google Blockly. Several functions in that PR (https://github.com/code-dot-org/code-dot-org/pull/55276) weren't able to be manually tested; we were just hoping that importing the CDO definitions would be helpful down the road.

After uncovering this descrepency, I was able to rework `Blockly.Variables.getVars` to just return a simple list of variable names. This function is assigned to several Artist blocks as `block.getVars`: `variables_get_counter`, `variables_get_length`, `variables_get_sides`, and `controls_for_counter`, all of which should now be working.

I did the same for several other custom `getVars` implementations, namely those used by blocks defined in our pools. These blocks are just found in Sprite Lab and Dance. Again, there doesn't seem to be any evidence that we've actually needed the block method in these labs which is why it hasn't been a problem. However, it makes sense to make them work correctly, should we need them in the future.

As a similar point of clean up, I noticed we also provided a custom `getVars` as part of the `locationVariableDropdown` custom input type. This was an experimental idea for a type of Sprite Lab block that would have worked with location variables (think `var top = {x: 200, y: 400};`. The idea was never fully implemented. In fact, there is no other reference to `locationVariableDropdown` in our entire main repo. Therefore, instead of updating this instance of `getVar` I instead deleted the entire custom input type.

## Links

Bug Bash: https://docs.google.com/document/d/14nGoZMVSptvDnRt1He0t6JQBRf-Em3ZcSIMUoEPYMq0/edit
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I manually tested that previously-broken levels were now working.
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/543fd8e1-569e-4c44-ad6d-4d9787aa279f">

It's also possible to get feedback about using nested loops with the same variable:

<img width="639" alt="image" src="https://github.com/user-attachments/assets/809b8b18-1f91-4666-a787-ce5794e26ae2">

I confirmed that there were no regressions with blocks using the custom variable input or sprite picker in both Sprite Lab (shown) and Dance:
<img width="727" alt="image" src="https://github.com/user-attachments/assets/4f66519d-2f7f-49d6-98d2-a2f49a34dac1">

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
