### PR TITLE
Music Lab: consume library translations in experiment

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -1,3 +1,5 @@
+import cloneDeep from 'lodash/cloneDeep';
+
 import currentLocale from '@cdo/apps/util/currentLocale';
 import experiments from '@cdo/apps/util/experiments';
 import HttpClient, {
@@ -62,7 +64,7 @@ async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
     }
 
     // Early return with no translations unless experiment is enabled for now.
-    if (!experiments.isEnabled('libraryLocalization')) {
+    if (!experiments.isEnabledAllowingQueryString('libraryLocalization')) {
       return new MusicLibrary(libraryName, libraryJson);
     }
 
@@ -341,9 +343,7 @@ const localizeLibrary = (
   library: LibraryJson,
   translations: Translations
 ): LibraryJson => {
-  const libraryJsonLocalized = JSON.parse(
-    JSON.stringify(library)
-  ) as LibraryJson;
+  const libraryJsonLocalized = cloneDeep(library);
   libraryJsonLocalized.instruments.forEach(
     instrument =>
       (instrument.name = translations[instrument.id] || instrument.name)

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -51,7 +51,7 @@ async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
       promises.push(translationPromise);
     }
 
-    // translations may be undefined if locale is en_us.
+    // translations will be undefined if locale is en_us.
     const [libraryJsonResponse, translations] = await Promise.allSettled(
       promises
     );

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -37,6 +37,7 @@ async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
       LibraryValidator
     );
 
+    // skip if english
     const translationsPromise = loadTranslations(
       libraryFilename,
       currentLocale().toLowerCase().replace('-', '_')
@@ -57,16 +58,14 @@ async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
       return new MusicLibrary(libraryName, libraryJson);
     }
 
-    let libraryJsonLocalized = {} as LibraryJson;
     if (translations.status === 'fulfilled') {
-      libraryJsonLocalized = localizeLibrary(
+      libraryJson = localizeLibrary(
         libraryJson,
         translations.value.value as Translations
       );
     }
 
-    // should first arg be libraryFilename?
-    return new MusicLibrary(libraryName, libraryJsonLocalized);
+    return new MusicLibrary(libraryName, libraryJson);
   }
 }
 

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -36,43 +36,32 @@ async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
     );
 
     // To do: load locale from browser.
-    // To do: handle missing translation file.
     // To do: wrap this (getting translations, localizing library)
     //   in an experiment so we can ship it without any user-facing impact?
     //   Or can just wait to merge it until we have real translations.
-    const translationsPromise = loadTranslations(libraryFilename, 'fr_fr');
+    const translationsPromise = loadTranslations(libraryFilename, 'gagaga');
 
-    // if translation rejects, just send library json
-    //
-    const [libraryJsonResponse, translations] = await Promise.all([
+    const [libraryJsonResponse, translations] = await Promise.allSettled([
       libraryJsonResponsePromise,
       translationsPromise,
     ]);
 
-    // const libraryJsonResponse = results[0].value;
-    // const translations = results[1].value;
+    let libraryJsonLocalized = {} as LibraryJson;
+    if (libraryJsonResponse.status === 'fulfilled') {
+      libraryJsonLocalized = libraryJsonResponse.value.value as LibraryJson;
+    }
 
-    // const [libraryJsonResponse, translations] = results
-    //   .filter(isFulfilled)
-    //   .map(item => item?.value);
-
-    const libraryJsonLocalized = localizeLibrary(
-      libraryJsonResponse.value as LibraryJson,
-      translations as Translations
-    );
+    if (translations.status === 'fulfilled') {
+      libraryJsonLocalized = localizeLibrary(
+        libraryJsonLocalized,
+        translations.value as Translations
+      );
+    }
 
     // should first arg be libraryFilename?
     return new MusicLibrary(libraryName, libraryJsonLocalized);
   }
 }
-
-// const isRejected = (
-//   input: PromiseSettledResult<unknown>
-// ): input is PromiseRejectedResult => input.status === 'rejected';
-//
-// const isFulfilled = <T>(
-//   input: PromiseSettledResult<T>
-// ): input is PromiseFulfilledResult<T> => input.status === 'fulfilled';
 
 type Translations = {[key: string]: string};
 

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -1,3 +1,4 @@
+import currentLocale from '@cdo/apps/util/currentLocale';
 import HttpClient, {ResponseValidator} from '@cdo/apps/util/HttpClient';
 
 import AppConfig, {getBaseAssetUrl} from '../appConfig';
@@ -39,7 +40,10 @@ async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
     // To do: wrap this (getting translations, localizing library)
     //   in an experiment so we can ship it without any user-facing impact?
     //   Or can just wait to merge it until we have real translations.
-    const translationsPromise = loadTranslations(libraryFilename, 'gagaga');
+    const translationsPromise = loadTranslations(
+      libraryFilename,
+      currentLocale().toLowerCase().replace('-', '_')
+    );
 
     const [libraryJsonResponse, translations] = await Promise.allSettled([
       libraryJsonResponsePromise,
@@ -65,14 +69,13 @@ async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
 
 type Translations = {[key: string]: string};
 
-// To do: specify values that libraryFilename can be?
 const loadTranslations = async (
   libraryName: string,
   locale: string
 ): Promise<Translations> => {
   // To do: change musiclab-test/ to musiclab/ once we have real translations.
   const translations = await HttpClient.fetchJson<Translations>(
-    `https://curriculum.code.org/media/musiclab-test/${libraryName}-loc/${locale}.json`
+    `https://curriculum.code.org/media/musiclab/${libraryName}-loc/${locale}.json`
   );
   return translations.value;
 };

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -77,43 +77,6 @@ async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
   }
 }
 
-const localizeLibrary = (
-  library: LibraryJson,
-  translations: Translations
-): LibraryJson => {
-  const libraryJsonLocalized = JSON.parse(
-    JSON.stringify(library)
-  ) as LibraryJson;
-  libraryJsonLocalized.instruments.forEach(
-    instrument =>
-      (instrument.name = translations[instrument.id] || instrument.name)
-  );
-
-  libraryJsonLocalized.kits.forEach(kit => {
-    const kitId = kit.id;
-    kit.name = translations[kitId] || kit.name;
-    kit.sounds.forEach(sound => {
-      const soundId = `${kitId}/${sound.src}`;
-      sound.name = translations[soundId] || sound.name;
-    });
-  });
-
-  libraryJsonLocalized.packs.forEach(pack => {
-    const packId = pack.id;
-    if (!pack.skipLocalization) {
-      pack.name = translations[packId] || pack.name;
-    }
-    pack.sounds.forEach(sound => {
-      if (!sound.skipLocalization) {
-        const soundId = `${packId}/${sound.src}`;
-        sound.name = translations[soundId] || sound.name;
-      }
-    });
-  });
-
-  return libraryJsonLocalized;
-};
-
 export default class MusicLibrary {
   private static instance: MusicLibrary | undefined;
 
@@ -372,6 +335,43 @@ export const LibraryValidator: ResponseValidator<LibraryJson> = response => {
     throw new Error(`Invalid library JSON: ${response}`);
   }
   return libraryJson;
+};
+
+const localizeLibrary = (
+  library: LibraryJson,
+  translations: Translations
+): LibraryJson => {
+  const libraryJsonLocalized = JSON.parse(
+    JSON.stringify(library)
+  ) as LibraryJson;
+  libraryJsonLocalized.instruments.forEach(
+    instrument =>
+      (instrument.name = translations[instrument.id] || instrument.name)
+  );
+
+  libraryJsonLocalized.kits.forEach(kit => {
+    const kitId = kit.id;
+    kit.name = translations[kitId] || kit.name;
+    kit.sounds.forEach(sound => {
+      const soundId = `${kitId}/${sound.src}`;
+      sound.name = translations[soundId] || sound.name;
+    });
+  });
+
+  libraryJsonLocalized.packs.forEach(pack => {
+    const packId = pack.id;
+    if (!pack.skipLocalization) {
+      pack.name = translations[packId] || pack.name;
+    }
+    pack.sounds.forEach(sound => {
+      if (!sound.skipLocalization) {
+        const soundId = `${packId}/${sound.src}`;
+        sound.name = translations[soundId] || sound.name;
+      }
+    });
+  });
+
+  return libraryJsonLocalized;
 };
 
 export type SoundType = 'beat' | 'bass' | 'lead' | 'fx' | 'vocal' | 'preview';


### PR DESCRIPTION
Now that we are getting strings from Music Lab libraries translated via CrowdIn and putting the resulting translations in S3, we can consume those translations in front end Music Lab code. This change requests a translation file, and, if it exists, replaces the default English library with any strings that are available in the 

Currently gated behind a flag`?enableExperiments=libraryLocalization` just for safety/initial testing, but I think the flag could be removed without issue.

## Links

- [Localizing Music Lab Libraries dev doc](https://docs.google.com/document/d/1nXTflYDo-VMca0PF0osKNvzjO4BB1-y-TE9VpgwxN3g/edit#heading=h.1xqo1c3r7xss)
- [Add Music Lab Libraries to translation pipeline PR](https://github.com/code-dot-org/code-dot-org/pull/59898)

## Testing story

Music Lab library strings were just added to CrowdIn, so most strings have not been translated yet. We have a handful of translations that are in our S3 bucket currently (ie, for common words like "Feedback" and "Effects" that are translated elsewhere on our site), so I was able to test with those. I tested manually in Spanish and saw translations happening for the intro and launch libraries. I also saw no changes with the experiment flag disabled, and the request being skipped when the locale was set to English.

![intro pack i18n](https://github.com/user-attachments/assets/b5ecce72-41fb-41c6-9b99-d76cec2b7c3c)
![will-i-am-i18n](https://github.com/user-attachments/assets/00ca6953-70dc-4c17-9631-290fbcfdfdea)
