### PR TITLE
Fixes flaky remix test for Safari_teacher_tools_projects_personal_project_gallery

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/projects/personal_project_gallery.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/personal_project_gallery.feature
@@ -38,7 +38,7 @@ Scenario: Can Remix a Project
   And the first project in the table is named "Remix Template"
   Then I scroll the ".ui-projects-table-dropdown" element into view
   Then I click selector ".ui-projects-table-dropdown"
-  And I press the child number 1 of class ".pop-up-menu-item"
+  And I press the child number 1 of class ".pop-up-menu-item" to load a new page
   And I wait until current URL contains "/edit"
 
 Scenario: Can Delete a Project

--- a/dashboard/test/ui/features/teacher_tools/projects/personal_project_gallery.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/personal_project_gallery.feature
@@ -28,7 +28,6 @@ Scenario: Can Rename a Project
   And I wait until element "#ui-projects-rename-save" is not visible
   And the first project in the table is named "New Name"
 
-@no_safari
 Scenario: Can Remix a Project
   Given I make a "playlab" project named "Remix Template"
   Given I am on "http://studio.code.org/projects"


### PR DESCRIPTION
The flaky test was a result of the "signing out" action racing the loading of the project page. We need to wait for the page load that is the result of clicking on the "Remix" button in the dropdown.

## Testing story

Before this change, `test` would not pass this test at all during the DTT, which is what prompted the merge of the skip for Safari (which this reverts.)

This change was tested on the `test` server itself and was seen to pass on the first try.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
