### PR TITLE
Support other environments testing contact lists

### DIFF
--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -44,7 +44,9 @@ module MailJet
 
     contact = find_or_create_contact(user.email, user.name)
     update_contact_field(contact, 'sign_up_date', user.created_at.to_datetime.rfc3339)
-    contact_list_id = CONTACT_LISTS[:welcome_series][locale.to_sym] || CONTACT_LISTS[:welcome_series][:default]
+
+    subaccount_contact_list_config = CONTACT_LISTS[:welcome_series][subaccount.to_sym]
+    contact_list_id = subaccount_contact_list_config[locale.to_sym] || subaccount_contact_list_config[:default]
     add_to_contact_list(contact, contact_list_id)
   end
 

--- a/lib/cdo/shared_constants/mailjet_constants.rb
+++ b/lib/cdo/shared_constants/mailjet_constants.rb
@@ -22,9 +22,18 @@ module MailJetConstants
 
   CONTACT_LISTS = {
     welcome_series: {
-      default: 10_353_815,
-      'es-MX': 10_353_822,
-      'es-ES': 10_353_822,
+      production: {
+        default: 10_353_815,
+        'es-MX': 10_353_822,
+        'es-ES': 10_353_822,
+      },
+      staging: {
+        default: 407_739,
+      },
+      development: {
+        default: 10_443_291,
+        'es-MX': 10_443_295,
+      },
     }
   }
 end

--- a/lib/test/cdo/test_mailjet.rb
+++ b/lib/test/cdo/test_mailjet.rb
@@ -149,7 +149,8 @@ class MailJetTest < Minitest::Test
 
     MailJet.expects(:update_contact_field).with(mock_contactdata, 'sign_up_date', sign_up_time.rfc3339)
 
-    MailJet.expects(:add_to_contact_list).with(mock_contactdata, MailJet::CONTACT_LISTS[:welcome_series][:default])
+    MailJet.stubs(:subaccount).returns('development')
+    MailJet.expects(:add_to_contact_list).with(mock_contactdata, MailJet::CONTACT_LISTS[:welcome_series][:development][:default])
 
     MailJet.create_contact_and_add_to_welcome_series(user)
   end
@@ -170,7 +171,8 @@ class MailJetTest < Minitest::Test
 
     MailJet.expects(:update_contact_field).with(mock_contactdata, 'sign_up_date', sign_up_time.rfc3339)
 
-    MailJet.expects(:add_to_contact_list).with(mock_contactdata, MailJet::CONTACT_LISTS[:welcome_series][:'es-MX'])
+    MailJet.stubs(:subaccount).returns('development')
+    MailJet.expects(:add_to_contact_list).with(mock_contactdata, MailJet::CONTACT_LISTS[:welcome_series][:development][:'es-MX'])
 
     MailJet.create_contact_and_add_to_welcome_series(user, 'es-MX')
   end


### PR DESCRIPTION
Implements a similar pattern as I did with emails to allow testing contact lists of other environments (I used the production environment to test the welcome series, but that was partly to test the actual functionality). The lists in other environments do not have a series associated with them and could be used as a catch-all. 

This will also resolve a [Honeybadger error](https://app.honeybadger.io/projects/3240/faults/110493849) in staging.

I have a [task](https://codedotorg.atlassian.net/browse/ACQ-2268) in next sprint to update the documentation for this new feature.

