### PR TITLE
Create getFullName for students in util file

### DIFF
--- a/apps/src/templates/levelSummary/FreeResponseResponses.jsx
+++ b/apps/src/templates/levelSummary/FreeResponseResponses.jsx
@@ -9,6 +9,7 @@ import {Heading3} from '@cdo/apps/componentLibrary/typography';
 import DCDO from '@cdo/apps/dcdo';
 import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {getFullName} from '@cdo/apps/templates/manageStudents/utils.ts';
 import i18n from '@cdo/locale';
 
 import ResponseMenuDropdown from './ResponseMenuDropdown';
@@ -17,9 +18,7 @@ import styles from './summary.module.scss';
 
 const FreeResponseResponses = ({responses, showStudentNames, eventData}) => {
   const constructStudentName = response =>
-    response.student_family_name
-      ? response.student_display_name + ' ' + response.student_family_name
-      : response.student_display_name;
+    getFullName(response.student_display_name, response.student_family_name);
 
   const [hiddenResponses, setHiddenResponses] = React.useState([]);
   const [pinnedResponseIds, setPinnedResponseIds] = React.useState([]);

--- a/apps/src/templates/manageStudents/utils.ts
+++ b/apps/src/templates/manageStudents/utils.ts
@@ -1,11 +1,11 @@
 export function getFullName(student: {
   name: string;
-  familyName?: string;
+  familyName: string | null;
 }): string;
 export function getFullName(name: string, familyName?: string): string;
 
 export function getFullName(
-  studentOrName: {name: string; familyName: string} | string,
+  studentOrName: {name: string; familyName: string | null} | string,
   familyName?: string
 ): string {
   if (typeof studentOrName === 'string') {

--- a/apps/src/templates/manageStudents/utils.ts
+++ b/apps/src/templates/manageStudents/utils.ts
@@ -1,11 +1,9 @@
-// Function Overload Signatures
 export function getFullName(student: {
   name: string;
   familyName: string;
 }): string;
 export function getFullName(name: string, familyName?: string): string;
 
-// Function Implementation
 export function getFullName(
   studentOrName: {name: string; familyName: string} | string,
   familyName?: string

--- a/apps/src/templates/manageStudents/utils.ts
+++ b/apps/src/templates/manageStudents/utils.ts
@@ -1,6 +1,6 @@
 export function getFullName(student: {
   name: string;
-  familyName: string;
+  familyName?: string;
 }): string;
 export function getFullName(name: string, familyName?: string): string;
 

--- a/apps/src/templates/manageStudents/utils.ts
+++ b/apps/src/templates/manageStudents/utils.ts
@@ -1,0 +1,22 @@
+// Function Overload Signatures
+export function getFullName(student: {
+  name: string;
+  familyName: string;
+}): string;
+export function getFullName(name: string, familyName?: string): string;
+
+// Function Implementation
+export function getFullName(
+  studentOrName: {name: string; familyName: string} | string,
+  familyName?: string
+): string {
+  if (typeof studentOrName === 'string') {
+    // If the first argument is a string, assume it's the name and the second argument is the familyName
+    return familyName ? `${studentOrName} ${familyName}` : studentOrName;
+  } else {
+    // If the first argument is an object, extract the name and familyName from the object
+    return studentOrName.familyName
+      ? `${studentOrName.name} ${studentOrName.familyName}`
+      : studentOrName.name;
+  }
+}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
@@ -4,6 +4,7 @@ import * as Sticky from 'reactabular-sticky';
 import * as Table from 'reactabular-table';
 import * as Virtualized from 'reactabular-virtualized';
 
+import {getFullName} from '@cdo/apps/templates/manageStudents/utils.ts';
 import {scriptUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import i18n from '@cdo/locale';
 
@@ -62,12 +63,12 @@ export default class ProgressTableStudentList extends React.Component {
       scriptData.name,
       rowData.student.id
     );
-    const fullName = rowData.student.familyName
-      ? `${rowData.student.name} ${rowData.student.familyName}`
-      : rowData.student.name;
+    // const fullName = rowData.student.familyName
+    //   ? `${rowData.student.name} ${rowData.student.familyName}`
+    //   : rowData.student.name;
     return (
       <ProgressTableStudentName
-        name={fullName}
+        name={getFullName(rowData.student)}
         studentId={rowData.student.id}
         sectionId={sectionId}
         scriptId={scriptData.id}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
@@ -63,9 +63,6 @@ export default class ProgressTableStudentList extends React.Component {
       scriptData.name,
       rowData.student.id
     );
-    // const fullName = rowData.student.familyName
-    //   ? `${rowData.student.name} ${rowData.student.familyName}`
-    //   : rowData.student.name;
     return (
       <ProgressTableStudentName
         name={getFullName(rowData.student)}

--- a/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/ExpandedProgressDataColumn.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
+import {getFullName} from '@cdo/apps/templates/manageStudents/utils.ts';
 import i18n from '@cdo/locale';
 
 import {studentLevelProgressType} from '../progress/progressTypes';
@@ -12,9 +13,6 @@ import ExpandedProgressColumnHeader from './ExpandedProgressColumnHeader.jsx';
 import LevelDataCell, {getStudentRowHeaderId} from './LevelDataCell';
 
 import styles from './progress-table-v2.module.scss';
-
-const getFullName = student =>
-  student.familyName ? `${student.name} ${student.familyName}` : student.name;
 
 function ExpandedProgressDataColumn({
   lesson,

--- a/apps/src/templates/sectionProgressV2/StudentColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/StudentColumn.jsx
@@ -6,6 +6,7 @@ import {connect} from 'react-redux';
 
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {getFullName} from '@cdo/apps/templates/manageStudents/utils.ts';
 import i18n from '@cdo/locale';
 
 import FontAwesome from '../../legacySharedComponents/FontAwesome';
@@ -42,9 +43,6 @@ function StudentColumn({
   expandMetadataForStudents,
   collapseMetadataForStudents,
 }) {
-  const getFullName = student =>
-    student.familyName ? `${student.name} ${student.familyName}` : student.name;
-
   const collapseRow = studentId => {
     analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_ONE_ROW_COLLAPSED, {
       sectionId: sectionId,

--- a/apps/test/unit/templates/manageStudents/utilsTest.ts
+++ b/apps/test/unit/templates/manageStudents/utilsTest.ts
@@ -1,0 +1,10 @@
+import {getFullName} from '@cdo/apps/templates/manageStudents/utils';
+
+describe('getFullName', function () {
+  it('returns accurate name given inputs', function () {
+    const student = {id: 1, name: 'Student 1', familyName: 'FamNameB'};
+    expect(getFullName(student)).toBe('Student 1 FamNameB');
+    expect(getFullName('Ada', 'Lovelace')).toBe('Ada Lovelace');
+    expect(getFullName('Sza')).toBe('Sza');
+  });
+});

--- a/apps/test/unit/templates/manageStudents/utilsTest.ts
+++ b/apps/test/unit/templates/manageStudents/utilsTest.ts
@@ -2,8 +2,10 @@ import {getFullName} from '@cdo/apps/templates/manageStudents/utils';
 
 describe('getFullName', function () {
   it('returns accurate name given inputs', function () {
-    const student = {id: 1, name: 'Student 1', familyName: 'FamNameB'};
-    expect(getFullName(student)).toBe('Student 1 FamNameB');
+    const student1 = {id: 1, name: 'Student 1', familyName: 'FamNameB'};
+    const student2 = {id: 2, name: 'Student 1'};
+    expect(getFullName(student1)).toBe('Student 1 FamNameB');
+    expect(getFullName(student2)).toBe('Student 1');
     expect(getFullName('Ada', 'Lovelace')).toBe('Ada Lovelace');
     expect(getFullName('Sza')).toBe('Sza');
   });

--- a/apps/test/unit/templates/manageStudents/utilsTest.ts
+++ b/apps/test/unit/templates/manageStudents/utilsTest.ts
@@ -3,7 +3,7 @@ import {getFullName} from '@cdo/apps/templates/manageStudents/utils';
 describe('getFullName', function () {
   it('returns accurate name given inputs', function () {
     const student1 = {id: 1, name: 'Student 1', familyName: 'FamNameB'};
-    const student2 = {id: 2, name: 'Student 1'};
+    const student2 = {id: 2, name: 'Student 1', familyName: null};
     expect(getFullName(student1)).toBe('Student 1 FamNameB');
     expect(getFullName(student2)).toBe('Student 1');
     expect(getFullName('Ada', 'Lovelace')).toBe('Ada Lovelace');


### PR DESCRIPTION
Based on feedback, I added a function to `getFullName` of a student.  This is used in the dashboard and in the CFUs.  I used these functions in each of the locations I found where we were separately defining `getFullName` functions

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1204)