### PR TITLE
[Google Blockly] remove unwanted function blocks from toolboxes

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.ts
+++ b/apps/src/blockly/addons/cdoUtils.ts
@@ -645,7 +645,7 @@ function updateVariableFields(
   const fields = block.fields;
   for (const key in fields) {
     const field = fields[key];
-    if (field.id && serializedVariableMap.has(field.id)) {
+    if (field?.id && serializedVariableMap.has(field.id)) {
       field.name = serializedVariableMap.get(field.id)!;
       delete field.id;
     }

--- a/apps/src/blockly/addons/cdoXml.ts
+++ b/apps/src/blockly/addons/cdoXml.ts
@@ -455,19 +455,50 @@ export function getBlockElements(xml: Element) {
   return Array.from(xml.querySelectorAll('xml > block'));
 }
 
+/**
+ * Removes all top-level invisible blocks from a Blockly xml element. "Top-level" blocks
+ * in this case also includes blocks that nested directly within a category element.
+ * Used to (unsupported) invisible blocks from a toolbox definition
+ */
 export function removeInvisibleBlocks(xml: Element) {
-  // Get all top-level blocks
-  const topLevelBlocks = xml.getElementsByTagName('block');
+  const categories = xml.getElementsByTagName('category');
+  const blocks = xml.getElementsByTagName('block');
+
   // Convert HTMLCollection to an array to iterate safely
-  const blocksArray = Array.from(topLevelBlocks);
+  const blocksArray = Array.from(blocks);
+  const categoriesArray = Array.from(categories);
 
   blocksArray.forEach(block => {
     if (
-      block.parentElement === xml &&
+      (block.parentElement === xml ||
+        categoriesArray.includes(block.parentElement as Element)) &&
       block.getAttribute('uservisible') === 'false'
     ) {
       block.remove();
     }
   });
+  return xml;
+}
+
+/**
+ * Removes statically-defined procedure call blocks from the auto-populated
+ * Functions toolbox category. Call blocks are automatically supplied by the
+ * flyout category callback.
+ */
+export function removeStaticCallBlocks(xml: Element) {
+  // Find the auto-populated Functions category, if it exists.
+  const procedureCategory = Array.from(
+    xml.getElementsByTagName('category')
+  ).find(category => category.getAttribute('custom') === 'PROCEDURE');
+
+  if (procedureCategory) {
+    // Find any procedure call blocks defined within the XML for this category
+    const procedureCallBlocks = Array.from(
+      procedureCategory.getElementsByTagName('block')
+    ).filter(block => block.getAttribute('type') === BLOCK_TYPES.procedureCall);
+
+    // Remove each of the filtered blocks
+    procedureCallBlocks.forEach(block => block.remove());
+  }
   return xml;
 }

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -60,7 +60,10 @@ import CdoTrashcan from './addons/cdoTrashcan';
 import * as cdoUtils from './addons/cdoUtils';
 import initializeVariables from './addons/cdoVariables';
 import CdoVerticalFlyout from './addons/cdoVerticalFlyout';
-import initializeBlocklyXml, {removeInvisibleBlocks} from './addons/cdoXml';
+import initializeBlocklyXml, {
+  removeInvisibleBlocks,
+  removeStaticCallBlocks,
+} from './addons/cdoXml';
 import {registerAllContextMenuItems} from './addons/contextMenu';
 import registerLogicCompareMutator from './addons/extensions/logic_compare';
 import FunctionEditor from './addons/functionEditor';
@@ -741,12 +744,14 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       media: '/blockly/media/google_blockly',
       modalInputs: false, // Prevents pop-up editor on mobile
     };
-    // Google Blockly doesn't support invisible blocks, so we want to prevent
-    // them from showing up in the toolbox.
+    // For old levels, we remove statically-defined procedure call blocks from the
+    // auto-populated Functions category. We also remove any invisible blocks because
+    // Google Blockly doesn't support them.
     if (typeof options.toolbox === 'string') {
-      options.toolbox = Blockly.Xml.domToText(
-        removeInvisibleBlocks(Blockly.Xml.textToDom(options.toolbox))
-      );
+      const toolboxDom = Blockly.Xml.textToDom(options.toolbox);
+      const visibleBlocksDom = removeInvisibleBlocks(toolboxDom);
+      const finalToolboxDom = removeStaticCallBlocks(visibleBlocksDom);
+      options.toolbox = Blockly.Xml.domToText(finalToolboxDom);
     }
     // CDO Blockly takes assetUrl as an inject option, and it's used throughout
     // apps, so we should also set it here.


### PR DESCRIPTION
During yesterday's Artist bug bash @molly-moen found some levels where unwanted function blocks were showing up in categorized toolboxes. These levels all happen to use the modal function editor and the auto-populated functions category.

_An "invisible" definition block showing up below the new function button:_
<img width="377" alt="image" src="https://github.com/user-attachments/assets/d1678bc0-f795-47b6-81ce-61f3ea05e9a2">
_Another definition block showing up in the math category:_
<img width="694" alt="image" src="https://github.com/user-attachments/assets/149719b3-d6bb-4e92-886b-30ffda85e69a">
_A definition block and a second copy of a call block:_
<img width="762" alt="image" src="https://github.com/user-attachments/assets/c37861dd-dce7-47f9-a0b1-fdebf98d0824">
_A second copy of a call block, with incorrect parameters:_
<img width="564" alt="image" src="https://github.com/user-attachments/assets/f4082720-978d-48be-a224-f64bd065c41d">

In each case, the unwanted blocks can be explained by the toolbox XML.
 
In the case of all definition blocks, these were set to `uservisible="false"` which CDO Blockly handles by hiding them. Google Blockly doesn't support invisible blocks, so we should remove them. This is most easily done before we call inject, by modifying the XML string directly. This fix was started recently here https://github.com/code-dot-org/code-dot-org/pull/59991, but that attempt didn't account for categorized toolboxes.

The extra call blocks are also defined in the toolbox XML. It should be noted that both versions of Blockly auto-populate the functions flyout with a call block for each defined function. CDO Blockly must be ignoring the redundant/statically-defined call blocks from the XML, because they are _not_ marked as invisible.
In any case, it makes sense to remove these blocks too as Blockly automatically provides them with the 'PROCEDURES' category callback.

With these changes, the Google Blockly toolbox now contains only the blocks that are seen with CDO Blockly.
|Google Blockly|CDO Blockly|
|<img width="327" alt="image" src="https://github.com/user-attachments/assets/67ae786c-a1c3-4821-98b1-64c2d4951e45">|<img width="296" alt="image" src="https://github.com/user-attachments/assets/5f322de0-cccf-46f1-8a71-c16891a35f35">|
|<img width="320" alt="image" src="https://github.com/user-attachments/assets/3b759c44-e03e-4d78-9dec-d1201d54ab05">|<img width="402" alt="image" src="https://github.com/user-attachments/assets/5ee902ba-95d4-431f-9973-307423a1b758">|
|<img width="313" alt="image" src="https://github.com/user-attachments/assets/904df10d-2f5b-416d-825d-91ad547210df">|<img width="322" alt="image" src="https://github.com/user-attachments/assets/daa2c33e-d71a-4cc5-8953-fbb46d61726f">|
|<img width="297" alt="image" src="https://github.com/user-attachments/assets/3f92a436-6849-48e8-b91c-cfae4097848a">|<img width="325" alt="image" src="https://github.com/user-attachments/assets/f60a6cad-d9f2-43a5-b4d0-726af7bc70e2">|


@molly-moen also noticed that the Functions category could not be opened at `/s/course4/lessons/14/levels/10?blocklyVersion=google`
<img width="433" alt="image" src="https://github.com/user-attachments/assets/bb65724e-260b-4a1b-a4d6-e9414a67c4e6">
Removing the offending block from the toolbox prevents the error entirely. However, the root cause of the error is actually a missing null check that was added with the second commit on this branch. With just the null-check and none of the other changes on this branch, we're able to load the (unwanted) block without errors:
<img width="413" alt="image" src="https://github.com/user-attachments/assets/cdd82563-2ee5-44df-9098-87e09054b89d">

With both changes, the flyout just contains the button.

## Links
 
Bug Bash doc: https://docs.google.com/document/d/14nGoZMVSptvDnRt1He0t6JQBRf-Em3ZcSIMUoEPYMq0/edit
Jira: https://codedotorg.atlassian.net/browse/CT-745
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
