### PR TITLE
[Google Blockly] Normalize angle helper endAngle

### DIFF
--- a/apps/src/blockly/addons/cdoAngleHelper.ts
+++ b/apps/src/blockly/addons/cdoAngleHelper.ts
@@ -466,8 +466,11 @@ class CdoAngleHelper {
     startAngle: number,
     endAngle: number
   ): string {
-    startAngle %= 360;
-    endAngle %= 360;
+    // Normalize endAngle to ensure it's within 360º of startAngle, to prevent visual glitches.
+    // Examples:
+    // - If startAngle = 0 and endAngle = 450, the result will be startAngle = 0 and endAngle = 90.
+    // - If startAngle = 270 and endAngle = 360, the result will be unchanged (startAngle = 270 and endAngle = 360).
+    endAngle = ((endAngle - startAngle) % 360) + startAngle;
     const vector = center.clone().add(new Vector(radius, 0));
     const start = Vector.rotateAroundPoint(vector, center, startAngle);
     const end = Vector.rotateAroundPoint(vector, center, endAngle);


### PR DESCRIPTION
During the Artist bug bash yesterday, we learned that the Angle Picker can actually be rotated by dragging the black dot:

**CDO Blockly**
![cdo](https://github.com/user-attachments/assets/ff296749-e19f-4e96-ae2b-45a0ecc55194)

This prompted me to poke at the new implementation and sure enough I found one small glitch with Google Blockly. If this 90 degree angle is rotated such that the start angle is between 270-359, the arc that gets drawn is inverted:

**Google Blockly**
![google blockly broken](https://github.com/user-attachments/assets/e2d21363-0505-40f3-8ae0-de3e9be66115)

This is because we are normally both the start angle (e.g. 270) and the end angle (360) to be between 0-359. In this case, the end angle ends up being less than the start angle (270 and 0) and so the arc is drawn in the negative direction. This normalization was a new intentional change to fix a bug present in both version of Google Blockly. Without normalization, angles > 360 were drawn totally incorrectly. https://github.com/code-dot-org/code-dot-org/pull/59789/commits/95b166419a462dd2b5357e58bceb8126fdaca346
**Previously fixed bug, still present on CDO Blockly**
![image](https://github.com/user-attachments/assets/312cbbd3-7169-412e-86fa-dc5fa7195e13)![image](https://github.com/user-attachments/assets/c1e00e2c-b7a9-42f3-8b31-2e9cd157b56b)

This branch tweaks the math performed in order to maintain the fix for that issue while also preventing the arc from being inverted:

**Google Blockly, this branch**
![google blockly fixed](https://github.com/user-attachments/assets/9e684ff6-a4cd-48a5-9341-1d498b3558a4)



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
