### PR TITLE
[Google Blockly] custom random color block

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -501,6 +501,7 @@
   "codeToEmbed": "Code that will be embedded.",
   "codeTooltip": "See generated JavaScript code.",
   "collapseAll": "Collapse all student rows",
+  "colourRandom": "random color",
   "commentPrefix": "comment:",
   "commentTooltip": "Leave a message for yourself, or anyone else reading your code.",
   "committedVersionLabel": "Commit from {timestamp}",

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -117,6 +117,7 @@ export function stripUserCreated(xmlString: string) {
 export enum BLOCK_TYPES {
   behaviorDefinition = 'behavior_definition',
   behaviorGet = 'gamelab_behavior_get',
+  colourRandom = 'colour_random',
   danceWhenSetup = 'Dancelab_whenSetup',
   parametersGet = 'parameters_get',
   procedureDefinition = 'procedures_defnoreturn',

--- a/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
+++ b/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
@@ -108,6 +108,7 @@ export const blocks = {
       return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
     };
   },
+  installCustomColourRandomBlock() {},
   copyBlockGenerator(generator, type1, type2) {
     generator[type1] = generator[type2];
   },

--- a/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
@@ -10,7 +10,9 @@ import {
   BlocklyWrapperType,
   JavascriptGeneratorType,
 } from '@cdo/apps/blockly/types';
+import i18n from '@cdo/locale';
 
+import {BLOCK_TYPES} from '../../constants';
 import {readBooleanAttribute} from '../../utils';
 
 const mutatorProperties: string[] = [];
@@ -22,6 +24,19 @@ export const blocks = {
     blockly.Blocks.text_join_simple = blockly.Blocks.text_join;
     blockly.JavaScript.forBlock.text_join_simple =
       blockly.JavaScript.forBlock.text_join;
+  },
+  installCustomColourRandomBlock(blockly: BlocklyWrapperType) {
+    delete blockly.Blocks['colour_random'];
+    blockly.common.defineBlocks(
+      blockly.common.createBlockDefinitionsFromJsonArray([
+        {
+          type: BLOCK_TYPES.colourRandom,
+          message0: i18n.colourRandom(),
+          output: 'Colour',
+          style: 'colour_blocks',
+        },
+      ])
+    );
   },
   copyBlockGenerator(
     generator: JavascriptGeneratorType,

--- a/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
@@ -25,6 +25,7 @@ export const blocks = {
     blockly.JavaScript.forBlock.text_join_simple =
       blockly.JavaScript.forBlock.text_join;
   },
+  // We need to use a custom block so that English users will see "random color".
   installCustomColourRandomBlock(blockly: BlocklyWrapperType) {
     delete blockly.Blocks['colour_random'];
     blockly.common.defineBlocks(

--- a/apps/src/blocksCommon.js
+++ b/apps/src/blocksCommon.js
@@ -22,6 +22,7 @@ exports.install = function (blockly, blockInstallOptions) {
   installWhenRun(blockly, skin, isK1);
   installJoinBlock(blockly);
   installCommentBlock(blockly);
+  installCustomColourRandomBlock(blockly);
 };
 
 function installControlsRepeatSimplified(blockly, skin) {
@@ -275,6 +276,9 @@ function installWhenRun(blockly, skin, isK1) {
 
 function installJoinBlock(blockly) {
   Blockly.customBlocks.installJoinBlock(blockly);
+}
+function installCustomColourRandomBlock(blockly) {
+  Blockly.customBlocks.installCustomColourRandomBlock(blockly);
 }
 
 function installCommentBlock(blockly) {

--- a/apps/src/blocksCommon.js
+++ b/apps/src/blocksCommon.js
@@ -22,6 +22,7 @@ exports.install = function (blockly, blockInstallOptions) {
   installWhenRun(blockly, skin, isK1);
   installJoinBlock(blockly);
   installCommentBlock(blockly);
+  // The custom block supports the US English spelling of "color"
   installCustomColourRandomBlock(blockly);
 };
 


### PR DESCRIPTION
During the Artist bug bash yesterday, @onlinecsteacher noticed an inconsistency in the spelling of the word color/colour:
<img width="330" alt="image" src="https://github.com/user-attachments/assets/ef511355-727a-4f99-a2cd-125ea52b8a36">

The reason for this is that the `set color` block is a custom CDO block whereas `random colour` comes from Core Blockly (up to v10) or the Field Colour plugin (v11+). In CDO Blockly, we own the translations and use the American "color". However, mainline Google Blockly use "colour" exclusively.

To work around this, we need to delete the standard block and re-install it with our block definition. This way, we can use our own translations. This will make the block appear as expected in standard US English.

There was no need to touch or replace the existing generator function. The block still works as expected in Artist:
<img width="962" alt="image" src="https://github.com/user-attachments/assets/85076c81-4c8f-4ad4-ace8-3ef4415d544c">


## Links

Jira: https://codedotorg.atlassian.net/browse/CT-744
Bug bash doc: https://docs.google.com/document/d/14nGoZMVSptvDnRt1He0t6JQBRf-Em3ZcSIMUoEPYMq0/edit

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
