### PR TITLE
[Aichat] Teacher view of student chat history - UI updates

### DIFF
--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -35,31 +35,24 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
   const hasWarningStyle = status === Status.PII_VIOLATION;
 
   const getDisplayText: string = useMemo(() => {
-    if (status === Status.OK || status === Status.UNKNOWN) {
-      return chatMessageText;
-    }
-
-    if (status === Status.PROFANITY_VIOLATION) {
-      if (
-        role === Role.USER &&
-        profaneMessageViewToggle === ProfaneMessageViewToggle.HIDE
-      ) {
+    switch (status) {
+      case Status.OK:
+      case Status.UNKNOWN:
         return chatMessageText;
-      }
-      return commonI18n.aiChatInappropriateUserMessage();
+      case Status.PROFANITY_VIOLATION:
+        return role === Role.USER &&
+          profaneMessageViewToggle === ProfaneMessageViewToggle.HIDE
+          ? chatMessageText
+          : commonI18n.aiChatInappropriateUserMessage();
+      case Status.PII_VIOLATION:
+        return commonI18n.aiChatTooPersonalUserMessage();
+      case Status.ERROR:
+        return role === Role.ASSISTANT
+          ? commonI18n.aiChatResponseError()
+          : chatMessageText;
+      default:
+        return '';
     }
-
-    if (status === Status.PII_VIOLATION) {
-      return commonI18n.aiChatTooPersonalUserMessage();
-    }
-
-    if (status === Status.ERROR) {
-      return role === Role.ASSISTANT
-        ? commonI18n.aiChatResponseError()
-        : chatMessageText;
-    }
-
-    return '';
   }, [chatMessageText, role, status, profaneMessageViewToggle]);
 
   return (

--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -7,7 +7,7 @@ import {commonI18n} from '@cdo/apps/types/locale';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 import aiBotIcon from '@cdo/static/aichat/ai-bot-icon.svg';
 
-import {Role, ProfaneMessageViewToggle} from './types';
+import {Role} from './types';
 
 import moduleStyles from './chat-message.module.scss';
 
@@ -15,18 +15,16 @@ interface ChatMessageProps {
   chatMessageText: string;
   role: Role;
   status: string;
-  isTeacherView?: boolean;
+  showProfaneUserMessageToggle?: boolean;
 }
 
 const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
   chatMessageText,
   role,
   status,
-  isTeacherView,
+  showProfaneUserMessageToggle,
 }) => {
-  const [profaneMessageViewToggle, setProfaneMessageViewToggle] = useState(
-    ProfaneMessageViewToggle.VIEW
-  );
+  const [showProfaneUserMessage, setShowProfaneUserMessage] = useState(false);
 
   const hasDangerStyle =
     status === Status.PROFANITY_VIOLATION ||
@@ -40,8 +38,7 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
       case Status.UNKNOWN:
         return chatMessageText;
       case Status.PROFANITY_VIOLATION:
-        return role === Role.USER &&
-          profaneMessageViewToggle === ProfaneMessageViewToggle.HIDE
+        return role === Role.USER && showProfaneUserMessage
           ? chatMessageText
           : commonI18n.aiChatInappropriateUserMessage();
       case Status.PII_VIOLATION:
@@ -53,7 +50,7 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
       default:
         return '';
     }
-  }, [chatMessageText, role, status, profaneMessageViewToggle]);
+  }, [chatMessageText, role, status, showProfaneUserMessage]);
 
   return (
     <>
@@ -77,23 +74,15 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
           <SafeMarkdown markdown={getDisplayText} />
         </div>
       </div>
-      {isTeacherView &&
+      {showProfaneUserMessageToggle &&
         role === Role.USER &&
         status === Status.PROFANITY_VIOLATION && (
           <div className={moduleStyles[`container-user`]}>
             <Button
               onClick={() => {
-                setProfaneMessageViewToggle(
-                  profaneMessageViewToggle === ProfaneMessageViewToggle.VIEW
-                    ? ProfaneMessageViewToggle.HIDE
-                    : ProfaneMessageViewToggle.HIDE
-                );
+                setShowProfaneUserMessage(!showProfaneUserMessage);
               }}
-              text={
-                profaneMessageViewToggle === ProfaneMessageViewToggle.VIEW
-                  ? 'View message'
-                  : 'Hide message'
-              }
+              text={showProfaneUserMessage ? 'Hide message' : 'Show message'}
               size="xs"
               type="tertiary"
               className={moduleStyles.userProfaneMessageButton}

--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -1,75 +1,115 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, {useMemo, useState} from 'react';
 
+import Button from '@cdo/apps/componentLibrary/button/Button';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 import aiBotIcon from '@cdo/static/aichat/ai-bot-icon.svg';
 
-import {Role} from './types';
+import {Role, ProfaneMessageViewToggle} from './types';
 
 import moduleStyles from './chat-message.module.scss';
-
-function getDisplayText(chatMessageText: string, status: string, role: Role) {
-  if (status === Status.OK || status === Status.UNKNOWN) {
-    return chatMessageText;
-  }
-
-  if (status === Status.PROFANITY_VIOLATION) {
-    return commonI18n.aiChatInappropriateUserMessage();
-  }
-
-  if (status === Status.PII_VIOLATION) {
-    return commonI18n.aiChatTooPersonalUserMessage();
-  }
-
-  if (status === Status.ERROR) {
-    return role === Role.ASSISTANT
-      ? commonI18n.aiChatResponseError()
-      : chatMessageText;
-  }
-}
 
 interface ChatMessageProps {
   chatMessageText: string;
   role: Role;
   status: string;
+  isTeacherView?: boolean;
 }
 
 const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
   chatMessageText,
   role,
   status,
+  isTeacherView,
 }) => {
+  const [profaneMessageViewToggle, setProfaneMessageViewToggle] = useState(
+    ProfaneMessageViewToggle.VIEW
+  );
+
   const hasDangerStyle =
     status === Status.PROFANITY_VIOLATION ||
     (role === Role.ASSISTANT && status === Status.ERROR);
 
   const hasWarningStyle = status === Status.PII_VIOLATION;
 
+  const getDisplayText: string = useMemo(() => {
+    if (status === Status.OK || status === Status.UNKNOWN) {
+      return chatMessageText;
+    }
+
+    if (status === Status.PROFANITY_VIOLATION) {
+      if (
+        role === Role.USER &&
+        profaneMessageViewToggle === ProfaneMessageViewToggle.HIDE
+      ) {
+        return chatMessageText;
+      }
+      return commonI18n.aiChatInappropriateUserMessage();
+    }
+
+    if (status === Status.PII_VIOLATION) {
+      return commonI18n.aiChatTooPersonalUserMessage();
+    }
+
+    if (status === Status.ERROR) {
+      return role === Role.ASSISTANT
+        ? commonI18n.aiChatResponseError()
+        : chatMessageText;
+    }
+
+    return '';
+  }, [chatMessageText, role, status, profaneMessageViewToggle]);
+
   return (
-    <div className={moduleStyles[`container-${role}`]}>
-      {role === Role.ASSISTANT && (
-        <div className={moduleStyles.botIconContainer}>
-          <img
-            src={aiBotIcon}
-            alt={commonI18n.aiChatBotIconAlt()}
-            className={moduleStyles.botIcon}
-          />
-        </div>
-      )}
-      <div
-        className={classNames(
-          moduleStyles[`message-${role}`],
-          hasDangerStyle && moduleStyles.danger,
-          hasWarningStyle && moduleStyles.warning
+    <>
+      <div className={moduleStyles[`container-${role}`]}>
+        {role === Role.ASSISTANT && (
+          <div className={moduleStyles.botIconContainer}>
+            <img
+              src={aiBotIcon}
+              alt={commonI18n.aiChatBotIconAlt()}
+              className={moduleStyles.botIcon}
+            />
+          </div>
         )}
-      >
-        <SafeMarkdown
-          markdown={getDisplayText(chatMessageText, status, role)}
-        />
+        <div
+          className={classNames(
+            moduleStyles[`message-${role}`],
+            hasDangerStyle && moduleStyles.danger,
+            hasWarningStyle && moduleStyles.warning
+          )}
+        >
+          <SafeMarkdown markdown={getDisplayText} />
+        </div>
       </div>
-    </div>
+      {isTeacherView &&
+        role === Role.USER &&
+        status === Status.PROFANITY_VIOLATION && (
+          <div className={moduleStyles[`container-user`]}>
+            <Button
+              onClick={() => {
+                if (
+                  profaneMessageViewToggle === ProfaneMessageViewToggle.VIEW
+                ) {
+                  setProfaneMessageViewToggle(ProfaneMessageViewToggle.HIDE);
+                } else {
+                  setProfaneMessageViewToggle(ProfaneMessageViewToggle.VIEW);
+                }
+              }}
+              text={
+                profaneMessageViewToggle === ProfaneMessageViewToggle.VIEW
+                  ? 'View message'
+                  : 'Hide message'
+              }
+              size="xs"
+              type="tertiary"
+              className={moduleStyles.userProfaneMessageButton}
+            />
+          </div>
+        )}
+    </>
   );
 };
 

--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -83,13 +83,11 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
           <div className={moduleStyles[`container-user`]}>
             <Button
               onClick={() => {
-                if (
+                setProfaneMessageViewToggle(
                   profaneMessageViewToggle === ProfaneMessageViewToggle.VIEW
-                ) {
-                  setProfaneMessageViewToggle(ProfaneMessageViewToggle.HIDE);
-                } else {
-                  setProfaneMessageViewToggle(ProfaneMessageViewToggle.VIEW);
-                }
+                    ? ProfaneMessageViewToggle.HIDE
+                    : ProfaneMessageViewToggle.HIDE
+                );
               }}
               text={
                 profaneMessageViewToggle === ProfaneMessageViewToggle.VIEW

--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -77,6 +77,11 @@ $assistant-color: $light_gray_100;
   justify-content: flex-end;
 }
 
+.userProfaneMessageButton {
+  width: 120px;
+  margin-top: -10px;
+}
+
 .botIconContainer {
   flex: 0 0 32px;
   height: 32px;

--- a/apps/src/aiComponentLibrary/chatMessage/types.ts
+++ b/apps/src/aiComponentLibrary/chatMessage/types.ts
@@ -3,3 +3,8 @@ export enum Role {
   USER = 'user',
   ASSISTANT = 'assistant',
 }
+
+export enum ProfaneMessageViewToggle {
+  VIEW = 'view',
+  HIDE = 'hide',
+}

--- a/apps/src/aiComponentLibrary/chatMessage/types.ts
+++ b/apps/src/aiComponentLibrary/chatMessage/types.ts
@@ -3,8 +3,3 @@ export enum Role {
   USER = 'user',
   ASSISTANT = 'assistant',
 }
-
-export enum ProfaneMessageViewToggle {
-  VIEW = 'view',
-  HIDE = 'hide',
-}

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -3,8 +3,8 @@ import {LevelProperties} from '@cdo/apps/lab2/types';
 import {Role} from '../aiComponentLibrary/chatMessage/types';
 
 export const ChatEventDescriptions = {
-  CLEAR_CHAT: 'The user clears the chat workspace.',
-  LOAD_LEVEL: 'The user loads the aichat level.',
+  CLEAR_CHAT: 'The user cleared the chat workspace.',
+  LOAD_LEVEL: 'The user loaded the aichat level.',
 } as const;
 
 // TODO: Update this once https://codedotorg.atlassian.net/browse/CT-471 is resolved

--- a/apps/src/aichat/views/ChatEventView.tsx
+++ b/apps/src/aichat/views/ChatEventView.tsx
@@ -54,28 +54,23 @@ const ChatEventView: React.FunctionComponent<ChatEventViewProps> = ({
   const dispatch = useAppDispatch();
 
   if (isChatMessage(event)) {
-    const {chatMessageText, role, status} = event;
     return (
-      <ChatMessage
-        chatMessageText={chatMessageText}
-        role={role}
-        status={status}
-        isTeacherView={isTeacherView}
-      />
+      <ChatMessage {...event} showProfaneUserMessageToggle={isTeacherView} />
     );
   }
 
   if (isNotification(event)) {
     const {id, text, notificationType, timestamp} = event;
-    const alertArgs: AlertProps = {
-      text: `${text} ${timestampToLocalTime(timestamp)}`,
-      type: notificationType === 'error' ? 'danger' : 'success',
-      size: 's',
-    };
-    if (!isTeacherView) {
-      alertArgs.onClose = () => dispatch(removeUpdateMessage(id));
-    }
-    return <Alert {...alertArgs} />;
+    return (
+      <Alert
+        text={`${text} ${timestampToLocalTime(timestamp)}`}
+        type={notificationType === 'error' ? 'danger' : 'success'}
+        onClose={
+          isTeacherView ? undefined : () => dispatch(removeUpdateMessage(id))
+        }
+        size="s"
+      />
+    );
   }
 
   if (isModelUpdate(event)) {

--- a/apps/src/aichat/views/ChatEventView.tsx
+++ b/apps/src/aichat/views/ChatEventView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatMessage/ChatMessage';
-import Alert, {AlertProps} from '@cdo/apps/componentLibrary/alert/Alert';
+import Alert from '@cdo/apps/componentLibrary/alert/Alert';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import {modelDescriptions} from '../constants';
@@ -74,15 +74,18 @@ const ChatEventView: React.FunctionComponent<ChatEventViewProps> = ({
   }
 
   if (isModelUpdate(event)) {
-    const alertArgs: AlertProps = {
-      text: formatModelUpdateText(event),
-      type: 'success',
-      size: 's',
-    };
-    if (!isTeacherView) {
-      alertArgs.onClose = () => dispatch(removeUpdateMessage(event.id));
-    }
-    return <Alert {...alertArgs} />;
+    return (
+      <Alert
+        text={formatModelUpdateText(event)}
+        type="success"
+        size="s"
+        onClose={
+          isTeacherView
+            ? undefined
+            : () => dispatch(removeUpdateMessage(event.id))
+        }
+      />
+    );
   }
 
   if (event.descriptionKey) {

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -23,18 +23,6 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   isTeacherView,
 }) => {
   const {isWaitingForChatResponse} = useAppSelector(state => state.aichat);
-
-  const displayWaitingAnimation = useCallback(() => {
-    if (isWaitingForChatResponse) {
-      return (
-        <img
-          src="/blockly/media/aichat/typing-animation.gif"
-          alt={'Waiting for response'}
-          className={moduleStyles.waitingForResponse}
-        />
-      );
-    }
-  }, [isWaitingForChatResponse]);
 
   // Compare the chat events  as a string since the object reference will change on every update.
   // This way we will only scroll when the contents of the events have changed.
@@ -63,9 +51,24 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
           isTeacherView={isTeacherView}
         />
       ))}
-      {isWaitingForChatResponse && displayWaitingAnimation()}
+      <WaitingAnimation shouldDisplay={isWaitingForChatResponse} />
     </div>
   );
+};
+
+const WaitingAnimation: React.FunctionComponent<{shouldDisplay: boolean}> = ({
+  shouldDisplay,
+}) => {
+  if (shouldDisplay) {
+    return (
+      <img
+        src="/blockly/media/aichat/typing-animation.gif"
+        alt={'Waiting for response'}
+        className={moduleStyles.waitingForResponse}
+      />
+    );
+  }
+  return null;
 };
 
 export default ChatEventsList;

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -11,6 +11,7 @@ import moduleStyles from './chatWorkspace.module.scss';
 interface ChatEventsListProps {
   events: ChatEvent[];
   showWaitingAnimation: () => React.ReactNode;
+  isTeacherView?: boolean;
 }
 
 /**
@@ -19,6 +20,7 @@ interface ChatEventsListProps {
 const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   events,
   showWaitingAnimation,
+  isTeacherView,
 }) => {
   const {isWaitingForChatResponse} = useAppSelector(state => state.aichat);
 
@@ -43,7 +45,11 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
       ref={conversationContainerRef}
     >
       {events.map(event => (
-        <ChatEventView event={event} key={event.timestamp} />
+        <ChatEventView
+          event={event}
+          key={event.timestamp}
+          isTeacherView={isTeacherView}
+        />
       ))}
       {showWaitingAnimation()}
     </div>

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
@@ -10,7 +10,7 @@ import moduleStyles from './chatWorkspace.module.scss';
 
 interface ChatEventsListProps {
   events: ChatEvent[];
-  showWaitingAnimation: () => React.ReactNode;
+  showWaitingAnimation: boolean;
   isTeacherView?: boolean;
 }
 
@@ -23,6 +23,18 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   isTeacherView,
 }) => {
   const {isWaitingForChatResponse} = useAppSelector(state => state.aichat);
+
+  const displayWaitingAnimation = useCallback(() => {
+    if (isWaitingForChatResponse) {
+      return (
+        <img
+          src="/blockly/media/aichat/typing-animation.gif"
+          alt={'Waiting for response'}
+          className={moduleStyles.waitingForResponse}
+        />
+      );
+    }
+  }, [isWaitingForChatResponse]);
 
   // Compare the chat events  as a string since the object reference will change on every update.
   // This way we will only scroll when the contents of the events have changed.
@@ -51,7 +63,7 @@ const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
           isTeacherView={isTeacherView}
         />
       ))}
-      {showWaitingAnimation()}
+      {isWaitingForChatResponse && displayWaitingAnimation()}
     </div>
   );
 };

--- a/apps/src/aichat/views/ChatEventsList.tsx
+++ b/apps/src/aichat/views/ChatEventsList.tsx
@@ -10,7 +10,6 @@ import moduleStyles from './chatWorkspace.module.scss';
 
 interface ChatEventsListProps {
   events: ChatEvent[];
-  showWaitingAnimation: boolean;
   isTeacherView?: boolean;
 }
 
@@ -19,7 +18,6 @@ interface ChatEventsListProps {
  */
 const ChatEventsList: React.FunctionComponent<ChatEventsListProps> = ({
   events,
-  showWaitingAnimation,
   isTeacherView,
 }) => {
   const {isWaitingForChatResponse} = useAppSelector(state => state.aichat);

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -104,20 +104,14 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
           : ''),
 
       tabContent: (
-        <ChatEventsList
-          events={studentChatHistory}
-          showWaitingAnimation={false}
-          isTeacherView={true}
-        />
+        <ChatEventsList events={studentChatHistory} isTeacherView={true} />
       ),
       iconLeft: iconValue,
     },
     {
       value: 'testStudentModel',
       text: 'Test student model',
-      tabContent: (
-        <ChatEventsList events={visibleItems} showWaitingAnimation={true} />
-      ),
+      tabContent: <ChatEventsList events={visibleItems} />,
     },
   ];
 
@@ -152,7 +146,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
       {experiments.isEnabled(experiments.VIEW_CHAT_HISTORY) && viewAsUserId ? (
         <Tabs {...tabArgs} />
       ) : (
-        <ChatEventsList events={visibleItems} showWaitingAnimation={true} />
+        <ChatEventsList events={visibleItems} />
       )}
 
       {canChatWithModel && (

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -45,8 +45,9 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   const [selectedTab, setSelectedTab] =
     useState<WorkspaceTeacherViewTab | null>(null);
 
-  const {showWarningModal, isWaitingForChatResponse, studentChatHistory} =
-    useAppSelector(state => state.aichat);
+  const {showWarningModal, studentChatHistory} = useAppSelector(
+    state => state.aichat
+  );
   const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
   const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
   const visibleItems = useSelector(selectAllVisibleMessages);
@@ -88,18 +89,6 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     }
   }, [viewAsUserId, selectedTab]);
 
-  const showWaitingAnimation = () => {
-    if (isWaitingForChatResponse) {
-      return (
-        <img
-          src="/blockly/media/aichat/typing-animation.gif"
-          alt={'Waiting for response'}
-          className={moduleStyles.waitingForResponse}
-        />
-      );
-    }
-  };
-
   const iconValue: FontAwesomeV6IconProps = {
     iconName: 'lock',
     iconStyle: 'solid',
@@ -117,7 +106,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
       tabContent: (
         <ChatEventsList
           events={studentChatHistory}
-          showWaitingAnimation={() => null}
+          showWaitingAnimation={false}
           isTeacherView={true}
         />
       ),
@@ -127,10 +116,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
       value: 'testStudentModel',
       text: 'Test student model',
       tabContent: (
-        <ChatEventsList
-          events={visibleItems}
-          showWaitingAnimation={showWaitingAnimation}
-        />
+        <ChatEventsList events={visibleItems} showWaitingAnimation={true} />
       ),
     },
   ];
@@ -163,10 +149,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
       {experiments.isEnabled(experiments.VIEW_CHAT_HISTORY) && viewAsUserId ? (
         <Tabs {...tabArgs} />
       ) : (
-        <ChatEventsList
-          events={visibleItems}
-          showWaitingAnimation={showWaitingAnimation}
-        />
+        <ChatEventsList events={visibleItems} showWaitingAnimation={true} />
       )}
 
       {canChatWithModel && (

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -135,7 +135,10 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     onChange: handleOnChange,
     type: 'secondary',
     tabsContainerClassName: moduleStyles.tabsContainer,
-    tabPanelsContainerClassName: moduleStyles.tabPanels,
+    tabPanelsContainerClassName:
+      selectedTab === WorkspaceTeacherViewTab.STUDENT_CHAT_HISTORY
+        ? moduleStyles.tabPanelsStudentChatHistoryActive
+        : moduleStyles.tabPanelsChatWithModelActive,
   };
 
   const onCloseWarningModal = useCallback(

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -118,6 +118,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
         <ChatEventsList
           events={studentChatHistory}
           showWaitingAnimation={() => null}
+          isTeacherView={true}
         />
       ),
       iconLeft: iconValue,

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -129,10 +129,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     onChange: handleOnChange,
     type: 'secondary',
     tabsContainerClassName: moduleStyles.tabsContainer,
-    tabPanelsContainerClassName:
-      selectedTab === WorkspaceTeacherViewTab.STUDENT_CHAT_HISTORY
-        ? moduleStyles.tabPanelsStudentChatHistoryActive
-        : moduleStyles.tabPanelsChatWithModelActive,
+    tabPanelsContainerClassName: moduleStyles.tabPanelsContainer,
   };
 
   const onCloseWarningModal = useCallback(

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -27,8 +27,16 @@ $default-spacing: 16px;
   background-color: #eaebeb;
 }
 
-.tabPanels {
+.tabPanelsChatWithModelActive {
   @extend %conversation-area;
+}
+
+.tabPanelsStudentChatHistoryActive {
+  @extend %conversation-area;
+  > div {
+    display: flex;
+    height: 100%;
+  }
 }
 
 .waitingForResponse {

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -27,15 +27,14 @@ $default-spacing: 16px;
   background-color: #eaebeb;
 }
 
-.tabPanelsChatWithModelActive {
-  @extend %conversation-area;
-}
-
-.tabPanelsStudentChatHistoryActive {
+.tabPanelsContainer {
   @extend %conversation-area;
   > div {
     display: flex;
     height: 100%;
+  }
+  > div[hidden] {
+    display: none;
   }
 }
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR makes UI updates to the teacher view of student chat history in aichat levels which includes:
-ability to view/hide user messages marked as profane
- removes x (delete button) from notifications and model updates
- Adds auto-scrolling to the most recent message when in teacher view of student chat history
- Notifications such as 'The user cleared the chat workspace.' and 'The user loaded the aichat level.' use `Alert` information UI (blue)

Note that I checked with @markabarrett about these UI updates in [this Slack thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1723840207395219).

I also included updating the prop `showWaitingAnimation` to be a `boolean` to address https://github.com/code-dot-org/code-dot-org/pull/60322#discussion_r1715971768.

The auto-scrolling to the most recent chat event was quite tricky. Thanks to @sanchitmalhotra126 for helping me figure out that the parent of the student chat history div (`_TabPanel` `div`) requires `display: flex` and `height: 100%` in order for the computed scroll height to have effect. Without `height: 100%`, the parent `div` was set to the height of the entire chat history. ~~I don't think I fully understand why `display: flex` is necessary - I welcome thoughts on this. 😄~~
`display: flex` is needed since the child component (scrollable container) has `flex-grow:  1` but this doesn't have any effect unless the parent (tab panel) has `display: flex`. (Thanks Sanchit!)

~~The other update I needed to include was a condition on which tab was active. If I didn't include the condition that the style above was only when the student chat history tab was active, then the chat history was in view even when 'Test student model' tab was active. Initially, I thought I needed to add additional `classNames` for the `Tabs` component for the active/hidden tabs, but thankfully can just update style according to which tab is active.~~
Based on https://github.com/code-dot-org/code-dot-org/pull/60483#discussion_r1723804788 - updated style for the tab panels container so that for the active panel, display is set to `flex` and for the hidden panel, display is set to `none`. 

Screencast video:

https://github.com/user-attachments/assets/f912b421-c718-4976-b92b-ea7fd8cb01cc







## Links
[jra](https://codedotorg.atlassian.net/browse/LABS-968)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally in aichat levels in /allthethings with a teacher account that has a section with 3 students.


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Remove experiment flag after testing on production.


<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
