### PR TITLE
[Aichat] Remove session id from frontend

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -24,8 +24,7 @@ export async function postAichatCompletionMessage(
   newMessage: ChatMessage,
   storedMessages: ChatMessage[],
   aiCustomizations: AiCustomizations,
-  aichatContext: AichatContext,
-  sessionId?: number
+  aichatContext: AichatContext
 ): Promise<ChatCompletionApiResponse> {
   const aichatModelCustomizations: AichatModelCustomizations = {
     selectedModelId: aiCustomizations.selectedModelId,
@@ -38,7 +37,6 @@ export async function postAichatCompletionMessage(
     storedMessages,
     aichatModelCustomizations,
     aichatContext,
-    ...(sessionId ? {sessionId} : {}),
   };
   const response = await HttpClient.post(
     CHAT_COMPLETION_URL,

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -78,7 +78,6 @@ export interface AichatState {
   savedAiCustomizations: AiCustomizations;
   fieldVisibilities: FieldVisibilities;
   viewMode: ViewMode;
-  currentSessionId?: number;
   // If a save is currently in progress
   saveInProgress: boolean;
   // The type of save action being performed (customization update, publish, model card save, etc).
@@ -374,11 +373,8 @@ export const submitChatContents = createAsyncThunk(
   async (newUserMessageText: string, thunkAPI) => {
     const dispatch = thunkAPI.dispatch as AppDispatch;
     const state = thunkAPI.getState() as RootState;
-    const {
-      savedAiCustomizations: aiCustomizations,
-      chatEventsCurrent,
-      currentSessionId,
-    } = state.aichat;
+    const {savedAiCustomizations: aiCustomizations, chatEventsCurrent} =
+      state.aichat;
 
     const aichatContext: AichatContext = {
       currentLevelId: parseInt(state.progress.currentLevelId || ''),
@@ -403,8 +399,7 @@ export const submitChatContents = createAsyncThunk(
         newUserMessage,
         chatEventsCurrent.filter(isChatMessage) as ChatMessage[],
         aiCustomizations,
-        aichatContext,
-        currentSessionId
+        aichatContext
       );
     } catch (error) {
       Lab2Registry.getInstance()
@@ -430,10 +425,6 @@ export const submitChatContents = createAsyncThunk(
           value: aiCustomizations.selectedModelId,
         },
       ]);
-
-    if (chatApiResponse.session_id) {
-      thunkAPI.dispatch(setChatSessionId(chatApiResponse.session_id));
-    }
 
     if (chatApiResponse.flagged_content) {
       console.log(
@@ -507,7 +498,6 @@ const aichatSlice = createSlice({
     clearChatMessages: state => {
       state.chatEventsPast = [];
       state.chatEventsCurrent = [];
-      state.currentSessionId = undefined;
     },
     setChatMessagePending: (state, action: PayloadAction<ChatMessage>) => {
       state.chatMessagePending = action.payload;
@@ -516,10 +506,6 @@ const aichatSlice = createSlice({
     setNewChatSession: state => {
       state.chatEventsPast.push(...state.chatEventsCurrent);
       state.chatEventsCurrent = [];
-      state.currentSessionId = undefined;
-    },
-    setChatSessionId: (state, action: PayloadAction<number>) => {
-      state.currentSessionId = action.payload;
     },
     setShowWarningModal: (state, action: PayloadAction<boolean>) => {
       state.showWarningModal = action.payload;
@@ -714,7 +700,6 @@ registerReducers({aichat: aichatSlice.reducer});
 export const {
   removeUpdateMessage,
   setNewChatSession,
-  setChatSessionId,
   clearChatMessages,
   setShowWarningModal,
   resetToDefaultAiCustomizations,

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -54,7 +54,6 @@ export function isNotification(event: ChatEvent): event is Notification {
 
 export interface ChatCompletionApiResponse {
   messages: ChatMessage[];
-  session_id: number;
   flagged_content?: string;
 }
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Now that `AichatSessions` table is deprecated, we can remove session id from the frontend. This follows up https://github.com/code-dot-org/code-dot-org/pull/60132.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[jira](https://codedotorg.atlassian.net/browse/LABS-940)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally to confirm there is no impact on user from this change.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
