### PR TITLE
Update flaky applab_project and gamelab_project UI tests

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature
@@ -89,7 +89,7 @@ Scenario: Save Project After Signing Out
   And I click selector "#runButton" once I see it
   Then I get redirected to "/users/sign_in" via "dashboard"
 
-  When I sign in as "Sally Student" from the sign in page
+  When I sign in as "Sally Student"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
   And I wait for the lab page to fully load
   And I ensure droplet is in text mode
@@ -115,7 +115,7 @@ Scenario: Save Script Level After Signing Out
   And I click selector "#runButton" once I see it
   Then I get redirected to "/users/sign_in" via "dashboard"
 
-  When I sign in as "Sally Student" from the sign in page
+  When I sign in as "Sally Student"
   And I get redirected to "/s/csp3-2017/lessons/5/levels/3" via "dashboard"
   And I wait for the lab page to fully load
   And I ensure droplet is in text mode

--- a/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature
@@ -37,7 +37,7 @@ Scenario: Applab Flow
   And selector "#codeWorkspace" doesn't have class "readonly"
   And I should see title includes "Code Ninja - App Lab - Code.org"
 
-  Then I am on "http://studio.code.org/users/sign_out"
+  And I sign out
   And I navigate to the last shared URL
   And I wait to see "#footerDiv"
   And element "#codeWorkspace" is hidden
@@ -62,7 +62,7 @@ Scenario: Applab Flow
   And I wait to see "#codeWorkspace"
   And selector "#codeWorkspace" has class "readonly"
 
-  Then I am on "http://studio.code.org/users/sign_out"
+  And I sign out
   And I am on "http://studio.code.org/"
   # TODO - maybe we do a remix and/or create new as well
 
@@ -82,7 +82,7 @@ Scenario: Save Project After Signing Out
   And I press "runButton"
   And element ".project_updated_at" eventually contains text "Saved"
 
-  When I sign out using jquery
+  And I sign out
   And I add code "// comment 2" to ace editor
   And ace editor code is equal to "// comment 1// comment 2"
   And I press "resetButton"
@@ -108,7 +108,7 @@ Scenario: Save Script Level After Signing Out
   And I press "runButton"
   And element ".project_updated_at" eventually contains text "Saved"
 
-  When I sign out using jquery
+  And I sign out
   And I add code "// turtle 2" to ace editor
   And ace editor code is equal to "// turtle 1// turtle 2"
   And I press "resetButton"

--- a/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature
@@ -89,7 +89,7 @@ Scenario: Save Project After Signing Out
   And I click selector "#runButton" once I see it
   Then I get redirected to "/users/sign_in" via "dashboard"
 
-  When I sign in as "Sally Student"
+  When I sign in as "Sally Student" from the sign in page
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
   And I wait for the lab page to fully load
   And I ensure droplet is in text mode
@@ -115,7 +115,7 @@ Scenario: Save Script Level After Signing Out
   And I click selector "#runButton" once I see it
   Then I get redirected to "/users/sign_in" via "dashboard"
 
-  When I sign in as "Sally Student"
+  When I sign in as "Sally Student" from the sign in page
   And I get redirected to "/s/csp3-2017/lessons/5/levels/3" via "dashboard"
   And I wait for the lab page to fully load
   And I ensure droplet is in text mode

--- a/dashboard/test/ui/features/teacher_tools/projects/gamelab_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/gamelab_project.feature
@@ -69,8 +69,7 @@ Scenario: Gamelab Flow
 
   # Test navigating to /edit as a non-owner user redirects to /view
   Given I am on "http://studio.code.org/"
-  And I create a teacher named "Non-Owner"
-  When I sign in as "Non-Owner" from the sign in page
+  And I create a teacher named "Non-Owner" and go home
   And I navigate to the last shared URL
   And I append "/edit" to the URL
   Then I get redirected to "/projects/gamelab/([^\/]*?)/view" via "pushState"

--- a/dashboard/test/ui/features/teacher_tools/projects/gamelab_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/gamelab_project.feature
@@ -44,7 +44,7 @@ Scenario: Gamelab Flow
   And selector "#codeWorkspace" doesn't have class "readonly"
 
   # Test the "View code" button, as an anonymous user goes to /view
-  When I am on "http://studio.code.org/users/sign_out"
+  And I sign out
   And I navigate to the last shared URL
   And I wait to see "#footerDiv"
   Then I should see title includes "Code Ninja II: Uncaught Exception - Game Lab - Code.org"
@@ -70,9 +70,8 @@ Scenario: Gamelab Flow
   # Test navigating to /edit as a non-owner user redirects to /view
   Given I am on "http://studio.code.org/"
   And I create a teacher named "Non-Owner"
-  And I am on "http://studio.code.org/users/sign_in"
-  And I reload the page
-  When I navigate to the last shared URL
+  When I sign in as "Non-Owner" from the sign in page
+  And I navigate to the last shared URL
   And I append "/edit" to the URL
   Then I get redirected to "/projects/gamelab/([^\/]*?)/view" via "pushState"
   And I wait to see "#codeWorkspace"

--- a/dashboard/test/ui/features/teacher_tools/projects/gamelab_project.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/gamelab_project.feature
@@ -69,7 +69,7 @@ Scenario: Gamelab Flow
 
   # Test navigating to /edit as a non-owner user redirects to /view
   Given I am on "http://studio.code.org/"
-  And I create a teacher named "Non-Owner" and go home
+  And I create a teacher named "Non-Owner"
   And I navigate to the last shared URL
   And I append "/edit" to the URL
   Then I get redirected to "/projects/gamelab/([^\/]*?)/view" via "pushState"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is following up https://github.com/code-dot-org/code-dot-org/pull/60428 which updates the flaky `sharepage_logo` UI test. 
This PR updates `gamelab_project` and `applab_project` UI tests. It appears that these 3 UI tests were failing for the same reason after the step: `And I am on "http://studio.code.org/users/sign_out"`. They are expected to be signed out, but end up still being logged in.

- `applab_project.feature`: [Step that is failing](https://github.com/code-dot-org/code-dot-org/blob/58fcc9e1e9a97c78f09cedbee6a05f88ce98baba/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature#L51) - Recent failure example -   https://app.saucelabs.com/tests/40409a4cd15143a69fff88746778edf7
- `gamelab_project.feature`: [Step that is failing](https://github.com/code-dot-org/code-dot-org/blob/58fcc9e1e9a97c78f09cedbee6a05f88ce98baba/dashboard/test/ui/features/teacher_tools/projects/gamelab_project.feature#L57) - Recent failure example - https://app.saucelabs.com/tests/ef46c55c2519439eb5a624f403212262 

See [Flaky test Cloudwatch dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/DoTD_Health).

![Screenshot 2024-08-19 at 11 46 12 AM](https://github.com/user-attachments/assets/8897a1eb-9116-4b4b-ab33-337b20804680)

I updated the 
```
And I am on "http://studio.code.org/users/sign_out"
And I reload the page
```
steps to `And I sign out` recently modified by https://github.com/code-dot-org/code-dot-org/pull/60376. This behavior has been a wider issue causing several other UI tests to be flaky. See [very involved Slack discussion](https://codedotorg.slack.com/archives/C0T0PNR0D/p1722444400850089). The root cause seems to be a race condition 'where an asynchronous API call is resetting the learn session to an old value if the fetch is completed after a new session was instantiated (via sign in, log out, etc).' (from [write-up](https://docs.google.com/document/d/1_H7SDk1vPnUr5N7I14FPSoYs2bPPBGUz7KUAIE8X_A0/edit) by @stephenliang .


I also updated the step `And I create a teacher named "Non-Owner"` in `gamelab_project` removing the following unnecessary steps:
```
And I am on "http://studio.code.org/users/sign_in"
And I reload the page
```


Note that `applab_project` also exhibits flakiness on signing in. Example at 
 https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_teacher_tools_projects_applab_project_output.html?versionId=5O9tzcytpzmzeZdSLsU3J_QyQgw5TC.m.
But this PR does NOT address this flakiness.


## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-978)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally and confirmed in SauceLabs and tests passed on Drone.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
