### PR TITLE
Adds ability to set remote location and uses it to refactor and fix flaky GDPR tests.

### DIFF
--- a/apps/src/templates/GDPRDialog.jsx
+++ b/apps/src/templates/GDPRDialog.jsx
@@ -22,8 +22,13 @@ export default class GDPRDialog extends Component {
 
   handleYesClick = () => {
     this.setState({isDialogOpen: false});
-    $.post(`/dashboardapi/v1/users/accept_data_transfer_agreement`, {
+    $.post('/dashboardapi/v1/users/accept_data_transfer_agreement', {
       user_id: this.props.currentUserId,
+    }).then(() => {
+      const gdprDataScript = document.querySelector('script[data-gdpr]');
+      const gdprData = JSON.parse(gdprDataScript.dataset['gdpr']);
+      gdprData.show_gdpr_dialog = false;
+      gdprDataScript.dataset['gdpr'] = JSON.stringify(gdprData);
     });
   };
 

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -320,6 +320,11 @@ gatekeeper_table_name: gatekeeper_<%=env%>
 # Allows DCDO settings via cookies. See: `Rack::CookieDCDO`
 use_cookie_dcdo: false
 
+# Allows Geolocation to be altered via cookies.
+# See: 'lib/cdo/rack/geolocation_override.rb'
+# and: 'dashboard/test/ui/features/xteam/gdpr_dialog.feature'
+use_geolocation_override: false
+
 # Poste (internal transactional email processing framework)
 poste_host: '<%= code_org_url.sub('//', '') %>'
 poste_attachment_dir:

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -71,6 +71,9 @@ mapbox_upload_tileset:    'censustiles-dev'
 # Enables DCDO settings via cookies
 use_cookie_dcdo: true
 
+# Allows Geolocation to be altered via cookies.
+use_geolocation_override: true
+
 # ActiveJob Queue Adapter, default to async which doesn't require manually
 # starting the worker processes. See locals.yml.default for more discussion.
 active_job_queue_adapter: :async

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -65,3 +65,6 @@ statsig_api_client_key: 'client-fake-key'
 
 # Enables DCDO settings via cookies
 use_cookie_dcdo: true
+
+# Allows Geolocation to be altered via cookies.
+use_geolocation_override: true

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -98,6 +98,12 @@ module Dashboard
       config.middleware.insert_after ActionDispatch::RequestId, Rack::CookieDCDO
     end
 
+    if CDO.use_geolocation_override
+      # Apply the remote_addr middleware to allow pretending to be at a particular IP
+      require 'cdo/rack/geolocation_override'
+      config.middleware.insert_after ActionDispatch::RequestId, Rack::GeolocationOverride
+    end
+
     config.encoding = 'utf-8'
 
     Rails.application.routes.default_url_options[:host] = CDO.canonical_hostname('studio.code.org')

--- a/dashboard/test/ui/features/step_definitions/geolocation_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/geolocation_steps.rb
@@ -1,0 +1,13 @@
+require 'cdo/rack/geolocation_override'
+
+Given "I am in Europe" do
+  # Make sure we navigate to the domain we want to set the cookie for
+  url = @browser.current_url
+  unless url.include?('code.org')
+    navigate_to replace_hostname('http://studio.code.org')
+  end
+
+  # Get an appropriately european IP address
+  location_cookie = '102.177.191.255' # Spain
+  @browser.manage.add_cookie(name: Rack::GeolocationOverride::KEY, value: location_cookie)
+end

--- a/dashboard/test/ui/features/step_definitions/script_data_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/script_data_steps.rb
@@ -1,0 +1,5 @@
+Then "it is eventually observed that the {string} script data field {string} is {string}" do |dataset, key, value|
+  wait_until do
+    @browser.execute_script("return JSON.parse(document.querySelector('script[data-#{dataset}]')?.dataset['#{dataset}'] || '{}')['#{key}']").to_s == value
+  end
+end

--- a/dashboard/test/ui/features/xteam/gdpr_dialog.feature
+++ b/dashboard/test/ui/features/xteam/gdpr_dialog.feature
@@ -1,45 +1,51 @@
 @no_mobile
-
 Feature: GDPR Dialog - data transfer agreement
 
   Scenario: EU user sees the GDPR Dialog on dashboard, opt out
-    Given I am a teacher
-    Given I am on "http://studio.code.org/home?force_in_eu=1"
-    Then element ".ui-test-gdpr-dialog" is visible
+    Given I am in Europe
+    And I am a teacher
+    And I am on "http://studio.code.org/home"
+    When element ".ui-test-gdpr-dialog" is visible
     Then I click selector ".ui-test-gdpr-dialog-logout"
     Then I wait until I am on "http://code.org/"
-    Then I wait to see ".header_user"
+    And I wait to see ".header_user"
     Then element ".ui-test-gdpr-dialog" is not visible
 
   Scenario: EU user sees the GDPR Dialog on dashboard, opt in, don't show again
-    Given I create a teacher named "Madame Maxime"
-    Given I am on "http://studio.code.org/home?force_in_eu=1"
-    Then element ".ui-test-gdpr-dialog" is visible
+    Given I am in Europe
+    And I create a teacher named "Madame Maxime"
+    And I am on "http://studio.code.org/home"
+    When element ".ui-test-gdpr-dialog" is visible
     Then I click selector ".ui-test-gdpr-dialog-accept"
     Then element ".ui-test-gdpr-dialog" is not visible
-    Given I am on "http://studio.code.org/home?force_in_eu=1"
+    And it is eventually observed that the "gdpr" script data field "show_gdpr_dialog" is "false"
+    Given I am on "http://studio.code.org/home"
     Then I wait to see ".header_user"
     Then element ".ui-test-gdpr-dialog" is not visible
 
   Scenario: EU student who accepted on sign up doesn't see the GDPR Dialog
-    Given I create a student in the eu named "Viktor Krum"
-    Given I am on "http://studio.code.org/home?force_in_eu=1"
+    Given I am in Europe
+    And I create a student in the eu named "Viktor Krum"
+    And I am on "http://studio.code.org/home"
     Then element ".ui-test-gdpr-dialog" is not visible
 
   Scenario: GDPR Dialog privacy link works from dashboard
-    Given I am a teacher
-    Given I am on "http://studio.code.org/home?force_in_eu=1"
-    Then element ".ui-test-gdpr-dialog" is visible
+    Given I am in Europe
+    And I am a teacher
+    And I am on "http://studio.code.org/home"
+    When element ".ui-test-gdpr-dialog" is visible
     Then I press the first ".ui-test-gdpr-dialog-privacy-link" element to load a new tab
     Then check that I am on "http://code.org/privacy"
 
   Scenario: Accept, sign out, sign in again, no dialog
-    Given I create a teacher named "Madame Maxime"
-    Given I am on "http://studio.code.org/home?force_in_eu=1"
+    Given I am in Europe
+    And I create a teacher named "Madame Maxime"
+    When I am on "http://studio.code.org/home"
     Then element ".ui-test-gdpr-dialog" is visible
-    Then I click selector ".ui-test-gdpr-dialog-accept"
+    When I click selector ".ui-test-gdpr-dialog-accept"
     Then element ".ui-test-gdpr-dialog" is not visible
+    And it is eventually observed that the "gdpr" script data field "show_gdpr_dialog" is "false"
     Then I sign out
     Given I sign in as "Madame Maxime" and go home
     Then I wait to see ".header_user"
-    Then element ".ui-test-gdpr-dialog" is not visible
+    And element ".ui-test-gdpr-dialog" is not visible

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -143,6 +143,12 @@ class HttpCache
       default_cookies << Rack::CookieDCDO::KEY
     end
 
+    # Allows Geolocation to be altered via cookies. See: Rack::GeolocationOverride
+    if CDO.use_geolocation_override
+      require 'cdo/rack/geolocation_override'
+      default_cookies << Rack::GeolocationOverride::KEY
+    end
+
     # These cookies are allowlisted on all session-specific (not cached) pages.
     allowlisted_cookies = [
       'hour_of_code',

--- a/lib/cdo/rack/geolocation_override.rb
+++ b/lib/cdo/rack/geolocation_override.rb
@@ -1,0 +1,24 @@
+module Rack
+  class GeolocationOverride
+    KEY = 'GeolocationOverride'.freeze
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      # Forcibly update the REMOTE_ADDR to any given by the X_REMOTE_ADDR header
+      override = Rack::Request.new(env).cookies[KEY]
+      env['REMOTE_ADDR'] = override if override
+
+      # Coerce Geocoder to turn an internal ip to localhost so it will consider
+      # it a locale with a 'RD' country code.
+      if Geocoder.search(env['REMOTE_ADDR']).try(:first)&.data&.[]('bogon')
+        env['REMOTE_ADDR'] = '127.0.0.1'
+      end
+
+      # Call the application as normal
+      @app.call(env)
+    end
+  end
+end

--- a/lib/cdo/rack/geolocation_override.rb
+++ b/lib/cdo/rack/geolocation_override.rb
@@ -28,7 +28,7 @@ module Rack
 
       # Also override the data cloudfront is providing
       # See: RequestExtension.country in lib/cdo/rack/request.rb
-      location = Geocoder.search(request.ip).try(:first)
+      location = Geocoder.search(env['REMOTE_ADDR']).try(:first)
       country_code = location&.country_code.to_s.upcase
       env['HTTP_CLOUDFRONT_VIEWER_COUNTRY'] = country_code if country_code
 

--- a/lib/cdo/rack/geolocation_override.rb
+++ b/lib/cdo/rack/geolocation_override.rb
@@ -16,7 +16,7 @@ module Rack
     end
 
     def call(env)
-      # Forcibly update the REMOTE_ADDR to any given by the X_REMOTE_ADDR header
+      # Forcibly update the REMOTE_ADDR to the value given by the cookie
       override = Rack::Request.new(env).cookies[KEY]
       env['REMOTE_ADDR'] = override if override
 


### PR DESCRIPTION
Reverts (the revert) via code-dot-org/code-dot-org#60468

I refer to the original PR for the full context: https://github.com/code-dot-org/code-dot-org/pull/59605

This is a second attempt to cover the flaky test but also add the ability to have a UI test reflect a user in a geographic region by overriding the request IP in-flight.

The prior implementation caused a problem on a production-like system since that, interestingly, uses CloudFront to determine the requester location instead of the remote IP passed through the proxy. This adds an override for that specific header as well. This should get us through the staging and test woes.

Production remains completely unaffected by this update.