### PR TITLE
P20/1082 - Adds fallback video player event

### DIFF
--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -89,6 +89,10 @@ window.onYouTubeIframeAPIReady = function () {
       },
       onError: function (error) {
         if (currentVideoOptions) {
+          analyticsReporter.sendEvent(EVENTS.VIDEO_FALLBACK_LOADED, {
+            url: location.href,
+            video: player.getVideoUrl(),
+          });
           var size = error.target.f.getBoundingClientRect();
           addFallbackVideoPlayer(currentVideoOptions, size.width, size.height);
         }

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -267,6 +267,7 @@ const EVENTS = {
 
   // videos
   VIDEO_LOADED: 'Video Loaded',
+  VIDEO_FALLBACK_LOADED: 'Video Fallback Loaded',
   VIDEO_STARTED: 'Video Started',
   VIDEO_PAUSED: 'Video Paused',
   VIDEO_ENDED: 'Video Played To Completion',


### PR DESCRIPTION
Adds the `VIDEO_FALLBACK_LOADED` event alongside the existing video events to track when the youtube player fails and fallsback to the embedded video player.

We want to track the usage of the fallback player to encourage / support accessibility updates to the fallback video player.

## Links

- jira ticket: [P20-1082](https://codedotorg.atlassian.net/browse/P20-1082)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
