### PR TITLE
Update BaseDialog to use component library button

### DIFF
--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -1,11 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
+import Button, {buttonColors} from '@cdo/apps/componentLibrary/button';
 import i18n from '@cdo/locale';
 
 import {BASE_DIALOG_WIDTH} from '../constants';
-import color from '../util/color';
 
 /**
  * BaseDialog
@@ -157,9 +156,7 @@ export default class BaseDialog extends React.Component {
       top: 0,
       right: 0,
       padding: 0,
-      color: color.neutral_dark30,
       cursor: 'pointer',
-      fontSize: 24,
       border: 'none',
     };
 
@@ -183,10 +180,16 @@ export default class BaseDialog extends React.Component {
           {!this.props.uncloseable && !this.props.hideCloseButton && (
             <Button
               id="x-close"
+              color={buttonColors.gray}
+              icon={{
+                iconName: 'xmark',
+                iconStyle: 'solid',
+              }}
+              isIconOnly
               onClick={this.closeDialog}
-              icon="fa-solid fa-xmark"
+              size="l"
               style={xCloseStyle}
-              color="white"
+              type="secondary"
               aria-label={i18n.closeDialog()}
             />
           )}

--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -153,9 +153,9 @@ export default class BaseDialog extends React.Component {
     };
     xCloseStyle = {
       position: 'absolute',
-      top: 0,
-      right: 0,
-      padding: 0,
+      top: 5,
+      right: 5,
+      padding: 5,
       cursor: 'pointer',
       border: 'none',
     };


### PR DESCRIPTION
Update BaseDialog.jsx to use the component library (DSCO) Button instead of the legacy Button.

## Testing story
### Before:
<img width="1052" alt="Screenshot 2024-08-19 at 16 10 51" src="https://github.com/user-attachments/assets/d5969bbc-71ff-4eff-b8c8-e82d8bfd0512">

### After:
<img width="1052" alt="Screenshot 2024-08-19 at 18 01 22" src="https://github.com/user-attachments/assets/75f232e8-6893-45ee-8b6b-fcb87deaa91d">

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
