### PR TITLE
Conditionally render dialog on levelgroups

### DIFF
--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -124,6 +124,8 @@
  * @property {boolean} isLastLevelInLesson
  * @property {boolean} isLastLevelInScript
  * @property {boolean} showEndOfLessonMsgs
+ * @property {boolean} anonymous
+ * @property {boolean} activity_guide_level
  */
 
 /**

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -170,7 +170,7 @@ function initLevelGroup(levelCount, currentPage, lastAttempt) {
     }
 
     let confirmationDialog = null;
-    if (isSurvey || isAssessment) {
+    if (!isActivityGuideLevel) {
       confirmationDialog = (
         <LegacySingleLevelGroupDialog id={id} title={title} body={body} />
       );

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -152,9 +152,10 @@ function initLevelGroup(levelCount, currentPage, lastAttempt) {
     const isSurvey =
       appOptions.level.anonymous === true ||
       appOptions.level.anonymous === 'true';
-    const isAssessment =
-      appOptions.level.submittable === true ||
-      appOptions.level.submittable === 'true';
+    const isActivityGuideLevel =
+      appOptions.level.activity_guide_level === true ||
+      appOptions.level.activity_guide_level === 'true';
+    const isAssessment = !isSurvey && !isActivityGuideLevel;
     title = isSurvey ? i18n.submitSurvey() : i18n.submitAssessment();
 
     if (isAssessment && validCount !== requiredCount) {

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -153,8 +153,8 @@ function initLevelGroup(levelCount, currentPage, lastAttempt) {
       appOptions.level.anonymous === true ||
       appOptions.level.anonymous === 'true';
     const isActivityGuideLevel =
-      appOptions.level.activity_guide_level === true ||
-      appOptions.level.activity_guide_level === 'true';
+      appOptions.level.activityGuideLevel === true ||
+      appOptions.level.activityGuideLevel === 'true';
     const isAssessment = !isSurvey && !isActivityGuideLevel;
     title = isSurvey ? i18n.submitSurvey() : i18n.submitAssessment();
 

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -152,9 +152,12 @@ function initLevelGroup(levelCount, currentPage, lastAttempt) {
     const isSurvey =
       appOptions.level.anonymous === true ||
       appOptions.level.anonymous === 'true';
+    const isAssessment =
+      appOptions.level.submittable === true ||
+      appOptions.level.submittable === 'true';
     title = isSurvey ? i18n.submitSurvey() : i18n.submitAssessment();
 
-    if (!isSurvey && validCount !== requiredCount) {
+    if (isAssessment && validCount !== requiredCount) {
       // For assessments, warn if some questions were not completed
       id = 'levelgroup-submit-incomplete-dialogcontent';
       body = i18n.submittableIncomplete();
@@ -165,9 +168,12 @@ function initLevelGroup(levelCount, currentPage, lastAttempt) {
         : i18n.submittableComplete();
     }
 
-    const confirmationDialog = (
-      <LegacySingleLevelGroupDialog id={id} title={title} body={body} />
-    );
+    let confirmationDialog = null;
+    if (isSurvey || isAssessment) {
+      confirmationDialog = (
+        <LegacySingleLevelGroupDialog id={id} title={title} body={body} />
+      );
+    }
 
     return {
       response: encodeURIComponent(JSON.stringify(lastAttempt)),

--- a/dashboard/app/dsl/level_group_dsl.rb
+++ b/dashboard/app/dsl/level_group_dsl.rb
@@ -91,12 +91,17 @@ class LevelGroupDSL < LevelDSL
     @hash[:anonymous] = text
   end
 
+  def activity_guide_level(text)
+    @hash[:activity_guide_level] = text
+  end
+
   def self.serialize(level)
     properties = level.properties
     new_dsl = "name '#{level.name}'"
     new_dsl << "\ntitle '#{properties['title'].gsub("'", %q(\\\'))}'" if properties['title']
     new_dsl << "\nsubmittable '#{properties['submittable']}'" if properties['submittable']
     new_dsl << "\nanonymous '#{properties['anonymous']}'" if properties['anonymous']
+    new_dsl << "\nactivity_guide_level '#{properties['activity_guide_level']}'" if properties['activity_guide_level']
 
     level.pages.each do |page|
       new_dsl << "\n\npage"

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -35,7 +35,7 @@ class LevelGroup < DSLDefined
       title 'title of the assessment here'
       submittable 'true'
       anonymous 'false'
-      isActivityGuideLevel 'false'
+      activity_guide_level 'false'
 
       page
       level 'level1'

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -35,6 +35,7 @@ class LevelGroup < DSLDefined
       title 'title of the assessment here'
       submittable 'true'
       anonymous 'false'
+      isActivityGuideLevel 'false'
 
       page
       level 'level1'

--- a/dashboard/config/levels/custom/free_response/test-free-response-retriable-in-levelgroup.level
+++ b/dashboard/config/levels/custom/free_response/test-free-response-retriable-in-levelgroup.level
@@ -1,0 +1,23 @@
+<FreeResponse>
+  <config><![CDATA[{
+  "published": true,
+  "game_id": 52,
+  "created_at": "2024-08-21T07:32:51.000Z",
+  "level_num": "custom",
+  "user_id": 16889,
+  "properties": {
+    "encrypted": "false",
+    "long_instructions": "What do you think this program does?",
+    "allow_user_uploads": "false",
+    "submittable": "false",
+    "peer_reviewable": "false",
+    "optional": "false",
+    "skip_dialog": true,
+    "skip_sound": true,
+    "allow_multiple_attempts": "true"
+  },
+  "audit_log": "[{\"changed_at\":\"2024-08-20T17:32:50.985-07:00\",\"changed\":[\"cloned from \\\"CSA U1L4-L1 Contained_2022\\\"\"],\"cloned_from\":\"CSA U1L4-L1 Contained_2022\"},{\"changed_at\":\"2024-08-20 17:33:08 -0700\",\"changed\":[\"allow_multiple_attempts\"],\"changed_by_id\":8,\"changed_by_email\":\"ken-levelbuilder@code.org\"}]",
+  "level_concept_difficulty": {
+  }
+}]]></config>
+</FreeResponse>

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -406,6 +406,8 @@ en:
               name: Web Lab 2
             lesson-55:
               name: Lab2 Showcase
+            lesson-56:
+              name: Activity Guide Levelgroup
         algebraPD2b:
           title: Computer Science in Algebra PD
           description: 'Phase 2 Online: Blended Summer Study'

--- a/dashboard/config/scripts/test_levelgroup_activityguide.level_group
+++ b/dashboard/config/scripts/test_levelgroup_activityguide.level_group
@@ -1,0 +1,9 @@
+name 'test-levelgroup-activityguide'
+title 'Activity Guide Levelgroup'
+submittable 'false'
+anonymous 'false'
+activity_guide_level 'true'
+
+page
+level 'test-single-multi-retriable-in-levelgroup'
+level 'test-free-response-retriable-in-levelgroup'

--- a/dashboard/config/scripts/test_single_multi_retriable_in_levelgroup.multi
+++ b/dashboard/config/scripts/test_single_multi_retriable_in_levelgroup.multi
@@ -1,0 +1,9 @@
+name 'test-single-multi-retriable-in-levelgroup'
+question 'Look closely at the code below. What will happen after you click "Run"?'
+wrong 'Nothing will happen.', feedback: 'Incorrect. The tumbleweed will begin tumbling.'
+wrong 'The tumbleweed will float to the top of the screen.', feedback: 'Incorrect. The tumbleweed will begin tumbling.'
+right 'The tumbleweed will begin tumbling.', feedback: 'Correct!'
+wrong 'The tumbleweed will blink on and off.', feedback: 'Incorrect. The tumbleweed will begin tumbling.'
+
+
+allow_multiple_attempts true

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2024-07-09 21:08:11 UTC",
+    "serialized_at": "2024-08-21 19:46:40 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -859,6 +859,21 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
+    },
+    {
+      "key": "lesson-56",
+      "name": "Activity Guide Levelgroup",
+      "absolute_position": 56,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 53,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson-56",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
     }
   ],
   "lesson_activities": [
@@ -1567,6 +1582,18 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
+    },
+    {
+      "key": "e109ba15-02bd-458f-9adf-31f75dc9d531",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_activity.key": "e109ba15-02bd-458f-9adf-31f75dc9d531",
+        "lesson.key": "lesson-56",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
     }
   ],
   "activity_sections": [
@@ -2118,6 +2145,16 @@
       "seeding_key": {
         "activity_section.key": "94cf3670-cb1d-45cc-9491-c754494a2399",
         "lesson_activity.key": "2f85210c-bfe7-4eea-9d53-fe10cdf3b0dc"
+      }
+    },
+    {
+      "key": "781a45ef-23bb-4d6c-905a-a421acc0752b",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "781a45ef-23bb-4d6c-905a-a421acc0752b",
+        "lesson_activity.key": "e109ba15-02bd-458f-9adf-31f75dc9d531"
       }
     }
   ],
@@ -6569,6 +6606,9 @@
       "activity_section_position": 7,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Allthethings Python Lab 7"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6822,6 +6862,27 @@
       },
       "level_keys": [
         "Lab2 BubbleChoice Showcase"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "test-levelgroup-activityguide"
+        ],
+        "lesson.key": "lesson-56",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "781a45ef-23bb-4d6c-905a-a421acc0752b"
+      },
+      "level_keys": [
+        "test-levelgroup-activityguide"
       ]
     }
   ],
@@ -8106,19 +8167,6 @@
     },
     {
       "seeding_key": {
-        "level.key": "ramp_video_artistIntro",
-        "script_level.level_keys": [
-          "2-3 Artist 1 new",
-          "ramp_video_artistIntro"
-        ],
-        "lesson.key": "Swapped Levels",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
-      }
-    },
-    {
-      "seeding_key": {
         "level.key": "2-3 Artist 1 new",
         "script_level.level_keys": [
           "2-3 Artist 1 new",
@@ -8132,7 +8180,20 @@
     },
     {
       "seeding_key": {
-        "level.key": "ramp_video_loopsArtist",
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "2-3 Artist 1 new",
+          "ramp_video_artistIntro"
+        ],
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops 2",
         "script_level.level_keys": [
           "2-3 Artist Loops 2",
           "ramp_video_loopsArtist"
@@ -8145,7 +8206,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Artist Loops 2",
+        "level.key": "ramp_video_loopsArtist",
         "script_level.level_keys": [
           "2-3 Artist Loops 2",
           "ramp_video_loopsArtist"
@@ -9266,6 +9327,18 @@
         "lesson_group.key": "",
         "script.name": "allthethings",
         "activity_section.key": "94cf3670-cb1d-45cc-9491-c754494a2399"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "test-levelgroup-activityguide",
+        "script_level.level_keys": [
+          "test-levelgroup-activityguide"
+        ],
+        "lesson.key": "lesson-56",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "781a45ef-23bb-4d6c-905a-a421acc0752b"
       }
     }
   ],

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2024-08-21 00:56:29 UTC",
+    "serialized_at": "2024-07-09 21:08:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -530,7 +530,7 @@
     },
     {
       "key": "Single page assessment",
-      "name": "Single page assessment and activity guide",
+      "name": "Single page assessment",
       "absolute_position": 34,
       "lockable": false,
       "has_lesson_plan": false,
@@ -4957,27 +4957,6 @@
     },
     {
       "chapter": 116,
-      "position": 2,
-      "activity_section_position": 2,
-      "assessment": false,
-      "properties": {
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "test-levelgroup-activityguide"
-        ],
-        "lesson.key": "Single page assessment",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "a23ecea1-cbbf-40f7-b671-f7fdf630e0de"
-      },
-      "level_keys": [
-        "test-levelgroup-activityguide"
-      ]
-    },
-    {
-      "chapter": 117,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5001,7 +4980,7 @@
       ]
     },
     {
-      "chapter": 118,
+      "chapter": 117,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5025,7 +5004,7 @@
       ]
     },
     {
-      "chapter": 119,
+      "chapter": 118,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5049,7 +5028,7 @@
       ]
     },
     {
-      "chapter": 120,
+      "chapter": 119,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5073,7 +5052,7 @@
       ]
     },
     {
-      "chapter": 121,
+      "chapter": 120,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5097,7 +5076,7 @@
       ]
     },
     {
-      "chapter": 122,
+      "chapter": 121,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5121,7 +5100,7 @@
       ]
     },
     {
-      "chapter": 123,
+      "chapter": 122,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5145,7 +5124,7 @@
       ]
     },
     {
-      "chapter": 124,
+      "chapter": 123,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5169,7 +5148,7 @@
       ]
     },
     {
-      "chapter": 125,
+      "chapter": 124,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5193,7 +5172,7 @@
       ]
     },
     {
-      "chapter": 126,
+      "chapter": 125,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5217,7 +5196,7 @@
       ]
     },
     {
-      "chapter": 127,
+      "chapter": 126,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5241,7 +5220,7 @@
       ]
     },
     {
-      "chapter": 128,
+      "chapter": 127,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5265,7 +5244,7 @@
       ]
     },
     {
-      "chapter": 129,
+      "chapter": 128,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -5289,7 +5268,7 @@
       ]
     },
     {
-      "chapter": 130,
+      "chapter": 129,
       "position": 3,
       "activity_section_position": 3,
       "assessment": true,
@@ -5313,7 +5292,7 @@
       ]
     },
     {
-      "chapter": 131,
+      "chapter": 130,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5337,7 +5316,7 @@
       ]
     },
     {
-      "chapter": 132,
+      "chapter": 131,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5361,7 +5340,7 @@
       ]
     },
     {
-      "chapter": 133,
+      "chapter": 132,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5385,7 +5364,7 @@
       ]
     },
     {
-      "chapter": 134,
+      "chapter": 133,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5409,7 +5388,7 @@
       ]
     },
     {
-      "chapter": 135,
+      "chapter": 134,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5433,7 +5412,7 @@
       ]
     },
     {
-      "chapter": 136,
+      "chapter": 135,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5457,7 +5436,7 @@
       ]
     },
     {
-      "chapter": 137,
+      "chapter": 136,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5481,7 +5460,7 @@
       ]
     },
     {
-      "chapter": 138,
+      "chapter": 137,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5505,7 +5484,7 @@
       ]
     },
     {
-      "chapter": 139,
+      "chapter": 138,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -5529,7 +5508,7 @@
       ]
     },
     {
-      "chapter": 140,
+      "chapter": 139,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -5553,7 +5532,7 @@
       ]
     },
     {
-      "chapter": 141,
+      "chapter": 140,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -5577,7 +5556,7 @@
       ]
     },
     {
-      "chapter": 142,
+      "chapter": 141,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -5601,7 +5580,7 @@
       ]
     },
     {
-      "chapter": 143,
+      "chapter": 142,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -5625,7 +5604,7 @@
       ]
     },
     {
-      "chapter": 144,
+      "chapter": 143,
       "position": 10,
       "activity_section_position": 10,
       "assessment": false,
@@ -5649,7 +5628,7 @@
       ]
     },
     {
-      "chapter": 145,
+      "chapter": 144,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5673,7 +5652,7 @@
       ]
     },
     {
-      "chapter": 146,
+      "chapter": 145,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5697,7 +5676,7 @@
       ]
     },
     {
-      "chapter": 147,
+      "chapter": 146,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5721,7 +5700,7 @@
       ]
     },
     {
-      "chapter": 148,
+      "chapter": 147,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5745,7 +5724,7 @@
       ]
     },
     {
-      "chapter": 149,
+      "chapter": 148,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5769,7 +5748,7 @@
       ]
     },
     {
-      "chapter": 150,
+      "chapter": 149,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5793,7 +5772,7 @@
       ]
     },
     {
-      "chapter": 151,
+      "chapter": 150,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5817,7 +5796,7 @@
       ]
     },
     {
-      "chapter": 152,
+      "chapter": 151,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -5841,7 +5820,7 @@
       ]
     },
     {
-      "chapter": 153,
+      "chapter": 152,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -5865,7 +5844,7 @@
       ]
     },
     {
-      "chapter": 154,
+      "chapter": 153,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -5889,7 +5868,7 @@
       ]
     },
     {
-      "chapter": 155,
+      "chapter": 154,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -5913,7 +5892,7 @@
       ]
     },
     {
-      "chapter": 156,
+      "chapter": 155,
       "position": 9,
       "activity_section_position": 10,
       "assessment": false,
@@ -5937,7 +5916,7 @@
       ]
     },
     {
-      "chapter": 157,
+      "chapter": 156,
       "position": 10,
       "activity_section_position": 11,
       "assessment": false,
@@ -5961,7 +5940,7 @@
       ]
     },
     {
-      "chapter": 158,
+      "chapter": 157,
       "position": 11,
       "activity_section_position": 12,
       "assessment": false,
@@ -5985,7 +5964,7 @@
       ]
     },
     {
-      "chapter": 159,
+      "chapter": 158,
       "position": 12,
       "activity_section_position": 13,
       "assessment": false,
@@ -6009,7 +5988,7 @@
       ]
     },
     {
-      "chapter": 160,
+      "chapter": 159,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -6033,7 +6012,7 @@
       ]
     },
     {
-      "chapter": 161,
+      "chapter": 160,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6057,7 +6036,7 @@
       ]
     },
     {
-      "chapter": 162,
+      "chapter": 161,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6081,7 +6060,7 @@
       ]
     },
     {
-      "chapter": 163,
+      "chapter": 162,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6105,7 +6084,7 @@
       ]
     },
     {
-      "chapter": 164,
+      "chapter": 163,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6129,7 +6108,7 @@
       ]
     },
     {
-      "chapter": 165,
+      "chapter": 164,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6153,7 +6132,7 @@
       ]
     },
     {
-      "chapter": 166,
+      "chapter": 165,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6177,7 +6156,7 @@
       ]
     },
     {
-      "chapter": 167,
+      "chapter": 166,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6201,7 +6180,7 @@
       ]
     },
     {
-      "chapter": 168,
+      "chapter": 167,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6225,7 +6204,7 @@
       ]
     },
     {
-      "chapter": 169,
+      "chapter": 168,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6249,7 +6228,7 @@
       ]
     },
     {
-      "chapter": 170,
+      "chapter": 169,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6273,7 +6252,7 @@
       ]
     },
     {
-      "chapter": 171,
+      "chapter": 170,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6297,7 +6276,7 @@
       ]
     },
     {
-      "chapter": 172,
+      "chapter": 171,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6321,7 +6300,7 @@
       ]
     },
     {
-      "chapter": 173,
+      "chapter": 172,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6345,7 +6324,7 @@
       ]
     },
     {
-      "chapter": 174,
+      "chapter": 173,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6369,7 +6348,7 @@
       ]
     },
     {
-      "chapter": 175,
+      "chapter": 174,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -6393,7 +6372,7 @@
       ]
     },
     {
-      "chapter": 176,
+      "chapter": 175,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6417,7 +6396,7 @@
       ]
     },
     {
-      "chapter": 177,
+      "chapter": 176,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6441,7 +6420,7 @@
       ]
     },
     {
-      "chapter": 178,
+      "chapter": 177,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6465,7 +6444,7 @@
       ]
     },
     {
-      "chapter": 179,
+      "chapter": 178,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6489,7 +6468,7 @@
       ]
     },
     {
-      "chapter": 180,
+      "chapter": 179,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6513,7 +6492,7 @@
       ]
     },
     {
-      "chapter": 181,
+      "chapter": 180,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6537,7 +6516,7 @@
       ]
     },
     {
-      "chapter": 182,
+      "chapter": 181,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6561,7 +6540,7 @@
       ]
     },
     {
-      "chapter": 183,
+      "chapter": 182,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6585,14 +6564,11 @@
       ]
     },
     {
-      "chapter": 184,
+      "chapter": 183,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "Allthethings Python Lab 7"
-        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6609,7 +6585,7 @@
       ]
     },
     {
-      "chapter": 185,
+      "chapter": 184,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6633,7 +6609,7 @@
       ]
     },
     {
-      "chapter": 186,
+      "chapter": 185,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6657,7 +6633,7 @@
       ]
     },
     {
-      "chapter": 187,
+      "chapter": 186,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6681,7 +6657,7 @@
       ]
     },
     {
-      "chapter": 188,
+      "chapter": 187,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6705,7 +6681,7 @@
       ]
     },
     {
-      "chapter": 189,
+      "chapter": 188,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6729,7 +6705,7 @@
       ]
     },
     {
-      "chapter": 190,
+      "chapter": 189,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6753,7 +6729,7 @@
       ]
     },
     {
-      "chapter": 191,
+      "chapter": 190,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6777,7 +6753,7 @@
       ]
     },
     {
-      "chapter": 192,
+      "chapter": 191,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6801,7 +6777,7 @@
       ]
     },
     {
-      "chapter": 193,
+      "chapter": 192,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -6825,7 +6801,7 @@
       ]
     },
     {
-      "chapter": 194,
+      "chapter": 193,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -8130,19 +8106,6 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Artist 1 new",
-        "script_level.level_keys": [
-          "2-3 Artist 1 new",
-          "ramp_video_artistIntro"
-        ],
-        "lesson.key": "Swapped Levels",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
-      }
-    },
-    {
-      "seeding_key": {
         "level.key": "ramp_video_artistIntro",
         "script_level.level_keys": [
           "2-3 Artist 1 new",
@@ -8156,7 +8119,20 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Artist Loops 2",
+        "level.key": "2-3 Artist 1 new",
+        "script_level.level_keys": [
+          "2-3 Artist 1 new",
+          "ramp_video_artistIntro"
+        ],
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
         "script_level.level_keys": [
           "2-3 Artist Loops 2",
           "ramp_video_loopsArtist"
@@ -8169,7 +8145,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "ramp_video_loopsArtist",
+        "level.key": "2-3 Artist Loops 2",
         "script_level.level_keys": [
           "2-3 Artist Loops 2",
           "ramp_video_loopsArtist"
@@ -8349,18 +8325,6 @@
         "level.key": "Test longassessment levelgroup new",
         "script_level.level_keys": [
           "Test longassessment levelgroup new"
-        ],
-        "lesson.key": "Single page assessment",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "a23ecea1-cbbf-40f7-b671-f7fdf630e0de"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "test-levelgroup-activityguide",
-        "script_level.level_keys": [
-          "test-levelgroup-activityguide"
         ],
         "lesson.key": "Single page assessment",
         "lesson_group.key": "",

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2024-07-09 21:08:11 UTC",
+    "serialized_at": "2024-08-21 00:56:29 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -530,7 +530,7 @@
     },
     {
       "key": "Single page assessment",
-      "name": "Single page assessment",
+      "name": "Single page assessment and activity guide",
       "absolute_position": 34,
       "lockable": false,
       "has_lesson_plan": false,
@@ -4957,6 +4957,27 @@
     },
     {
       "chapter": 116,
+      "position": 2,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "test-levelgroup-activityguide"
+        ],
+        "lesson.key": "Single page assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "a23ecea1-cbbf-40f7-b671-f7fdf630e0de"
+      },
+      "level_keys": [
+        "test-levelgroup-activityguide"
+      ]
+    },
+    {
+      "chapter": 117,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4980,7 +5001,7 @@
       ]
     },
     {
-      "chapter": 117,
+      "chapter": 118,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5004,7 +5025,7 @@
       ]
     },
     {
-      "chapter": 118,
+      "chapter": 119,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5028,7 +5049,7 @@
       ]
     },
     {
-      "chapter": 119,
+      "chapter": 120,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5052,7 +5073,7 @@
       ]
     },
     {
-      "chapter": 120,
+      "chapter": 121,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5076,7 +5097,7 @@
       ]
     },
     {
-      "chapter": 121,
+      "chapter": 122,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5100,7 +5121,7 @@
       ]
     },
     {
-      "chapter": 122,
+      "chapter": 123,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5124,7 +5145,7 @@
       ]
     },
     {
-      "chapter": 123,
+      "chapter": 124,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5148,7 +5169,7 @@
       ]
     },
     {
-      "chapter": 124,
+      "chapter": 125,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5172,7 +5193,7 @@
       ]
     },
     {
-      "chapter": 125,
+      "chapter": 126,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5196,7 +5217,7 @@
       ]
     },
     {
-      "chapter": 126,
+      "chapter": 127,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5220,7 +5241,7 @@
       ]
     },
     {
-      "chapter": 127,
+      "chapter": 128,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5244,7 +5265,7 @@
       ]
     },
     {
-      "chapter": 128,
+      "chapter": 129,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -5268,7 +5289,7 @@
       ]
     },
     {
-      "chapter": 129,
+      "chapter": 130,
       "position": 3,
       "activity_section_position": 3,
       "assessment": true,
@@ -5292,7 +5313,7 @@
       ]
     },
     {
-      "chapter": 130,
+      "chapter": 131,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5316,7 +5337,7 @@
       ]
     },
     {
-      "chapter": 131,
+      "chapter": 132,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5340,7 +5361,7 @@
       ]
     },
     {
-      "chapter": 132,
+      "chapter": 133,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5364,7 +5385,7 @@
       ]
     },
     {
-      "chapter": 133,
+      "chapter": 134,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5388,7 +5409,7 @@
       ]
     },
     {
-      "chapter": 134,
+      "chapter": 135,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5412,7 +5433,7 @@
       ]
     },
     {
-      "chapter": 135,
+      "chapter": 136,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5436,7 +5457,7 @@
       ]
     },
     {
-      "chapter": 136,
+      "chapter": 137,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5460,7 +5481,7 @@
       ]
     },
     {
-      "chapter": 137,
+      "chapter": 138,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5484,7 +5505,7 @@
       ]
     },
     {
-      "chapter": 138,
+      "chapter": 139,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -5508,7 +5529,7 @@
       ]
     },
     {
-      "chapter": 139,
+      "chapter": 140,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -5532,7 +5553,7 @@
       ]
     },
     {
-      "chapter": 140,
+      "chapter": 141,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -5556,7 +5577,7 @@
       ]
     },
     {
-      "chapter": 141,
+      "chapter": 142,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -5580,7 +5601,7 @@
       ]
     },
     {
-      "chapter": 142,
+      "chapter": 143,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -5604,7 +5625,7 @@
       ]
     },
     {
-      "chapter": 143,
+      "chapter": 144,
       "position": 10,
       "activity_section_position": 10,
       "assessment": false,
@@ -5628,7 +5649,7 @@
       ]
     },
     {
-      "chapter": 144,
+      "chapter": 145,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5652,7 +5673,7 @@
       ]
     },
     {
-      "chapter": 145,
+      "chapter": 146,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5676,7 +5697,7 @@
       ]
     },
     {
-      "chapter": 146,
+      "chapter": 147,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5700,7 +5721,7 @@
       ]
     },
     {
-      "chapter": 147,
+      "chapter": 148,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5724,7 +5745,7 @@
       ]
     },
     {
-      "chapter": 148,
+      "chapter": 149,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5748,7 +5769,7 @@
       ]
     },
     {
-      "chapter": 149,
+      "chapter": 150,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5772,7 +5793,7 @@
       ]
     },
     {
-      "chapter": 150,
+      "chapter": 151,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5796,7 +5817,7 @@
       ]
     },
     {
-      "chapter": 151,
+      "chapter": 152,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -5820,7 +5841,7 @@
       ]
     },
     {
-      "chapter": 152,
+      "chapter": 153,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -5844,7 +5865,7 @@
       ]
     },
     {
-      "chapter": 153,
+      "chapter": 154,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -5868,7 +5889,7 @@
       ]
     },
     {
-      "chapter": 154,
+      "chapter": 155,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -5892,7 +5913,7 @@
       ]
     },
     {
-      "chapter": 155,
+      "chapter": 156,
       "position": 9,
       "activity_section_position": 10,
       "assessment": false,
@@ -5916,7 +5937,7 @@
       ]
     },
     {
-      "chapter": 156,
+      "chapter": 157,
       "position": 10,
       "activity_section_position": 11,
       "assessment": false,
@@ -5940,7 +5961,7 @@
       ]
     },
     {
-      "chapter": 157,
+      "chapter": 158,
       "position": 11,
       "activity_section_position": 12,
       "assessment": false,
@@ -5964,7 +5985,7 @@
       ]
     },
     {
-      "chapter": 158,
+      "chapter": 159,
       "position": 12,
       "activity_section_position": 13,
       "assessment": false,
@@ -5988,7 +6009,7 @@
       ]
     },
     {
-      "chapter": 159,
+      "chapter": 160,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -6012,7 +6033,7 @@
       ]
     },
     {
-      "chapter": 160,
+      "chapter": 161,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6036,7 +6057,7 @@
       ]
     },
     {
-      "chapter": 161,
+      "chapter": 162,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6060,7 +6081,7 @@
       ]
     },
     {
-      "chapter": 162,
+      "chapter": 163,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6084,7 +6105,7 @@
       ]
     },
     {
-      "chapter": 163,
+      "chapter": 164,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6108,7 +6129,7 @@
       ]
     },
     {
-      "chapter": 164,
+      "chapter": 165,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6132,7 +6153,7 @@
       ]
     },
     {
-      "chapter": 165,
+      "chapter": 166,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6156,7 +6177,7 @@
       ]
     },
     {
-      "chapter": 166,
+      "chapter": 167,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6180,7 +6201,7 @@
       ]
     },
     {
-      "chapter": 167,
+      "chapter": 168,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6204,7 +6225,7 @@
       ]
     },
     {
-      "chapter": 168,
+      "chapter": 169,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6228,7 +6249,7 @@
       ]
     },
     {
-      "chapter": 169,
+      "chapter": 170,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6252,7 +6273,7 @@
       ]
     },
     {
-      "chapter": 170,
+      "chapter": 171,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6276,7 +6297,7 @@
       ]
     },
     {
-      "chapter": 171,
+      "chapter": 172,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6300,7 +6321,7 @@
       ]
     },
     {
-      "chapter": 172,
+      "chapter": 173,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6324,7 +6345,7 @@
       ]
     },
     {
-      "chapter": 173,
+      "chapter": 174,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6348,7 +6369,7 @@
       ]
     },
     {
-      "chapter": 174,
+      "chapter": 175,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -6372,7 +6393,7 @@
       ]
     },
     {
-      "chapter": 175,
+      "chapter": 176,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6396,7 +6417,7 @@
       ]
     },
     {
-      "chapter": 176,
+      "chapter": 177,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6420,7 +6441,7 @@
       ]
     },
     {
-      "chapter": 177,
+      "chapter": 178,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6444,7 +6465,7 @@
       ]
     },
     {
-      "chapter": 178,
+      "chapter": 179,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6468,7 +6489,7 @@
       ]
     },
     {
-      "chapter": 179,
+      "chapter": 180,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6492,7 +6513,7 @@
       ]
     },
     {
-      "chapter": 180,
+      "chapter": 181,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6516,7 +6537,7 @@
       ]
     },
     {
-      "chapter": 181,
+      "chapter": 182,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6540,7 +6561,7 @@
       ]
     },
     {
-      "chapter": 182,
+      "chapter": 183,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6564,11 +6585,14 @@
       ]
     },
     {
-      "chapter": 183,
+      "chapter": 184,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Allthethings Python Lab 7"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6585,7 +6609,7 @@
       ]
     },
     {
-      "chapter": 184,
+      "chapter": 185,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6609,7 +6633,7 @@
       ]
     },
     {
-      "chapter": 185,
+      "chapter": 186,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6633,7 +6657,7 @@
       ]
     },
     {
-      "chapter": 186,
+      "chapter": 187,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6657,7 +6681,7 @@
       ]
     },
     {
-      "chapter": 187,
+      "chapter": 188,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6681,7 +6705,7 @@
       ]
     },
     {
-      "chapter": 188,
+      "chapter": 189,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6705,7 +6729,7 @@
       ]
     },
     {
-      "chapter": 189,
+      "chapter": 190,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6729,7 +6753,7 @@
       ]
     },
     {
-      "chapter": 190,
+      "chapter": 191,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6753,7 +6777,7 @@
       ]
     },
     {
-      "chapter": 191,
+      "chapter": 192,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6777,7 +6801,7 @@
       ]
     },
     {
-      "chapter": 192,
+      "chapter": 193,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -6801,7 +6825,7 @@
       ]
     },
     {
-      "chapter": 193,
+      "chapter": 194,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -8106,19 +8130,6 @@
     },
     {
       "seeding_key": {
-        "level.key": "ramp_video_artistIntro",
-        "script_level.level_keys": [
-          "2-3 Artist 1 new",
-          "ramp_video_artistIntro"
-        ],
-        "lesson.key": "Swapped Levels",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
-      }
-    },
-    {
-      "seeding_key": {
         "level.key": "2-3 Artist 1 new",
         "script_level.level_keys": [
           "2-3 Artist 1 new",
@@ -8132,7 +8143,20 @@
     },
     {
       "seeding_key": {
-        "level.key": "ramp_video_loopsArtist",
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "2-3 Artist 1 new",
+          "ramp_video_artistIntro"
+        ],
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "40e74dbd-d44a-468e-9e17-a710d06bc3d3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops 2",
         "script_level.level_keys": [
           "2-3 Artist Loops 2",
           "ramp_video_loopsArtist"
@@ -8145,7 +8169,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Artist Loops 2",
+        "level.key": "ramp_video_loopsArtist",
         "script_level.level_keys": [
           "2-3 Artist Loops 2",
           "ramp_video_loopsArtist"
@@ -8325,6 +8349,18 @@
         "level.key": "Test longassessment levelgroup new",
         "script_level.level_keys": [
           "Test longassessment levelgroup new"
+        ],
+        "lesson.key": "Single page assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "a23ecea1-cbbf-40f7-b671-f7fdf630e0de"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "test-levelgroup-activityguide",
+        "script_level.level_keys": [
+          "test-levelgroup-activityguide"
         ],
         "lesson.key": "Single page assessment",
         "lesson_group.key": "",

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
@@ -3,9 +3,9 @@ Feature: Level Group Activity Guide
 
 @as_student
 Scenario: Submit activity guide and go to next level.
-  Given I am on "http://studio.code.org/s/allthethings/lessons/33/levels/2"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/53/levels/1"
   And I wait to see ".submitButton"
   And element ".submitButton" is visible
 
   And I press ".submitButton:first" using jQuery
-  And I am on "http://studio.code.org/s/allthethings/lessons/34/levels/1"
+  Then I wait until I am on a different page than I noted before

--- a/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/level_group_activity_guide.feature
@@ -1,0 +1,11 @@
+@no_mobile
+Feature: Level Group Activity Guide
+
+@as_student
+Scenario: Submit activity guide and go to next level.
+  Given I am on "http://studio.code.org/s/allthethings/lessons/33/levels/2"
+  And I wait to see ".submitButton"
+  And element ".submitButton" is visible
+
+  And I press ".submitButton:first" using jQuery
+  And I am on "http://studio.code.org/s/allthethings/lessons/34/levels/1"


### PR DESCRIPTION
This update introduces a new usage for levelgroups: activity guides. There is a new setting for levelbuilders to toggle in the DSL editor `activity_guide_level` and for levels with this marked as true the submission dialog that traditionally has appeared on levelgroups will not render so that it acts more like a typical in-progression level.


https://github.com/user-attachments/assets/d6823741-9812-4a29-adec-3c46543e8bbb



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- jira ticket: [CUR-12](https://codedotorg.atlassian.net/browse/CUR-12?atlOrigin=eyJpIjoiNmY4YzdlMGNmMWJmNDA5Y2FhNzE1NWE2MDhjNzY2NGIiLCJwIjoiaiJ9)


## Testing story

Added a new UI test for this use of a levelgroup. This is also the reason for all the added levels and diffs on script files, adding the new lesson and level to the end of allthethings.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
