### PR TITLE
Fix highlight color in dark mode for codemirror

### DIFF
--- a/apps/src/lab2/views/components/editor/editorThemes.ts
+++ b/apps/src/lab2/views/components/editor/editorThemes.ts
@@ -19,8 +19,8 @@ const chalky = '#e5c07b',
   whiskey = '#d19a66',
   violet = '#c678dd',
   darkBackground = '#21252b',
-  highlightBackground = '#484D57',
-  selection = '#3E4451',
+  highlightBackground = '#2c313a',
+  selection = '#484D57',
   cursor = '#528bff';
 
 /**

--- a/apps/src/lab2/views/components/editor/editorThemes.ts
+++ b/apps/src/lab2/views/components/editor/editorThemes.ts
@@ -19,7 +19,7 @@ const chalky = '#e5c07b',
   whiskey = '#d19a66',
   violet = '#c678dd',
   darkBackground = '#21252b',
-  highlightBackground = '#2c313a',
+  highlightBackground = '#484D57',
   selection = '#3E4451',
   cursor = '#528bff';
 
@@ -36,10 +36,9 @@ export const darkTheme = EditorView.theme(
       caretColor: cursor,
     },
     '&.cm-focused .cm-cursor': {borderLeftColor: cursor},
-    '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, ::selection':
-      {
-        backgroundColor: selection,
-      },
+
+    '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection':
+      {backgroundColor: selection},
     '.cm-panels': {backgroundColor: darkBackground, color: color.lighter_gray},
     '.cm-panels button': {color: color.lightest_gray},
     '.cm-panels.cm-panels-top': {borderBottom: '2px solid black'},
@@ -51,7 +50,7 @@ export const darkTheme = EditorView.theme(
     '.cm-searchMatch.cm-searchMatch-selected': {
       backgroundColor: '#6199ff2f',
     },
-    '.cm-activeLine': {backgroundColor: color.dark_gray},
+    '.cm-activeLine': {backgroundColor: '#6699ff0b'},
     '.cm-selectionMatch': {backgroundColor: '#aafe661a'},
     '.cm-matchingBracket, .cm-nonmatchingBracket': {
       backgroundColor: '#bad0f847',


### PR DESCRIPTION
While working on Python Lab, @mikeharv pointed out that the highlight color was barely perceptible. We also recently got a ticket to the same effect about Java Lab, which uses the same theme.

I think this used to work, but at some point the styling broke. I looked at codemirror's theme-one-dark (which we copied and adjusted) and noticed our selector for `highlightBackground` was significantly different than the one in [theme-one-dark](https://github.com/codemirror/theme-one-dark/blob/834068627f48715d413bbebbe1af9498647d7b74/src/one-dark.ts#L57). I updated that selector and things started working better, although the active line was messing with the highlight still (the active line wouldn't look the same color as the rest of the selected text). I also updated our active line color to match theme-one-dark, and now things work much better. The big difference is the active line color is partially transparent, so the highlight color shows through.

While working on this Mark gave me a hex code for the selection color, which is very similar to the old one, but I updated to use the new color to get more in line with desired designs.

## Before
### All text selected
![Screenshot 2024-08-19 at 4 05 42 PM](https://github.com/user-attachments/assets/0bf704bc-774e-4c1e-8701-a3cdfa726ba5)
You can see both issues in this screenshot if you look closely; all the text is highlighted here, but the first line is a different color than the other lines.

### Just active line styling
![Screenshot 2024-08-19 at 5 04 08 PM](https://github.com/user-attachments/assets/010346ff-659b-4351-90a4-4f1c35167c16)
This is the styling when you click on line 3.

## After
### All text selected
![Screenshot 2024-08-19 at 5 01 14 PM](https://github.com/user-attachments/assets/85840d6b-a046-4812-99ee-5b59bb42c8fb)
Now all the highlighted text is obvious! The first line is a slightly different color now but it all still looks uniform

### Just active line styling
![Screenshot 2024-08-19 at 5 04 13 PM](https://github.com/user-attachments/assets/ac31c840-752f-4b08-87d9-655f79f1ccf8)
This is also clicking on line 3. It's a little less obvious now because of the transparency.

## Links
- jira ticket: [CT-719](https://codedotorg.atlassian.net/browse/CT-719)


## Testing story
Tested locally in both Java Lab and Python Lab.


## Follow-up work
There's still some bug going on on iPads with our codemirror themes. That has been tracked in [CT-219](https://codedotorg.atlassian.net/browse/CT-219) for a while. I looked at it a little while working on this, and it's still there, and I still have no idea what's causing it.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
