### PR TITLE
added storybook test for accessible dialog

### DIFF
--- a/apps/src/sharedComponents/AccessibleDialog.jsx
+++ b/apps/src/sharedComponents/AccessibleDialog.jsx
@@ -15,6 +15,7 @@ function AccessibleDialog({
   onDismiss,
   children,
   className,
+  fallbackFocus,
   initialFocus = true,
   closeOnClickBackdrop = false,
 }) {
@@ -36,6 +37,7 @@ function AccessibleDialog({
             initialFocus: initialFocus,
             onDeactivate: onClose,
             clickOutsideDeactivates: closeOnClickBackdrop,
+            fallbackFocus: fallbackFocus,
           }}
         >
           <div
@@ -62,6 +64,7 @@ AccessibleDialog.propTypes = {
   onDismiss: PropTypes.func,
   children: PropTypes.node,
   className: PropTypes.string,
+  fallbackFocus: PropTypes.string,
   initialFocus: PropTypes.bool,
   closeOnClickBackdrop: PropTypes.bool,
 };

--- a/apps/src/sharedComponents/AccessibleDialog.story.jsx
+++ b/apps/src/sharedComponents/AccessibleDialog.story.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import AccessibleDialog from './AccessibleDialog';
+
+import defaultStyle from './accessible-dialogue.module.scss';
+
+export default {
+  component: AccessibleDialog,
+  argTypes: {
+    onClose: {action: 'closed'},
+    onDismiss: {action: 'dismissed'},
+  },
+};
+
+const Template = args => <AccessibleDialog {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  children: <div>Default Accessible Dialog</div>,
+  onClose: () => {},
+};
+
+export const CustomStyles = Template.bind({});
+CustomStyles.args = {
+  styles: {
+    modal: defaultStyle.modal + ' custom-modal-style',
+    modalBackdrop: defaultStyle.modalBackdrop + ' custom-backdrop-style',
+    xCloseButton: defaultStyle.xCloseButton + ' custom-close-icon-style',
+  },
+  children: <div>Custom Styled Accessible Dialog</div>,
+  onClose: () => {},
+};
+
+export const WithOnDismiss = Template.bind({});
+WithOnDismiss.args = {
+  children: <div>Accessible Dialog with onDismiss</div>,
+  onDismiss: () => {},
+};
+
+export const WithoutInitialFocus = Template.bind({});
+WithoutInitialFocus.args = {
+  children: <div>Accessible Dialog without initial focus</div>,
+  onClose: () => {},
+  initialFocus: false,
+};
+
+export const ClickBackdropToClose = Template.bind({});
+ClickBackdropToClose.args = {
+  children: <div>Accessible Dialog with backdrop click to close</div>,
+  onClose: () => {},
+  closeOnClickBackdrop: true,
+};

--- a/apps/src/sharedComponents/AccessibleDialog.story.jsx
+++ b/apps/src/sharedComponents/AccessibleDialog.story.jsx
@@ -47,6 +47,7 @@ const Template = args => <AccessibleDialog {...args} />;
 export const Default = Template.bind({});
 Default.args = {
   children: <div>Default Accessible Dialog</div>,
+  fallbackFocus: 'div',
   onClose: action('closed'),
   onDismiss: undefined,
 };
@@ -58,6 +59,7 @@ CustomStyles.args = {
       <p>Custom Styled Accessible Dialog</p>
     </div>
   ),
+  fallbackFocus: 'div',
   onClose: action('closed'),
   onDismiss: undefined,
   styles: {
@@ -70,6 +72,7 @@ CustomStyles.args = {
 export const WithOnDismiss = Template.bind({});
 WithOnDismiss.args = {
   children: <div>Accessible Dialog with onDismiss</div>,
+  fallbackFocus: 'div',
   onClose: action('closed'),
   onDismiss: action('dismissed'),
 };
@@ -77,6 +80,7 @@ WithOnDismiss.args = {
 export const WithoutInitialFocus = Template.bind({});
 WithoutInitialFocus.args = {
   children: <div>Accessible Dialog without initial focus</div>,
+  fallbackFocus: 'div',
   initialFocus: false,
   onClose: action('closed'),
   onDismiss: undefined,
@@ -86,6 +90,7 @@ export const ClickBackdropToClose = Template.bind({});
 ClickBackdropToClose.args = {
   children: <div>Accessible Dialog with backdrop click to close</div>,
   closeOnClickBackdrop: true,
+  fallbackFocus: 'div',
   onClose: action('closed'),
   onDismiss: undefined,
 };

--- a/apps/src/sharedComponents/AccessibleDialog.story.jsx
+++ b/apps/src/sharedComponents/AccessibleDialog.story.jsx
@@ -1,3 +1,4 @@
+import {action} from '@storybook/addon-actions';
 import React from 'react';
 
 import AccessibleDialog from './AccessibleDialog';
@@ -12,41 +13,79 @@ export default {
   },
 };
 
+// Add custom CSS
+const customStyle = document.createElement('style');
+customStyle.innerHTML = `
+  .custom-modal-style {
+    color: #fff;
+    font-size: 26px;
+    background-color: rgb(86 96 101);
+    border: solid 1px rgb(121 124 128);
+    p {
+      font-size: 30px;
+      font-family: "Barlow Semi Condensed Medium", sans-serif;
+    }
+  }
+
+  .custom-backdrop-style {
+    background-color: #000;
+    opacity: 0.3;
+    z-index: 1250;
+  }
+
+  .custom-close-button-style {
+    background: #fff;
+    i {
+      color: #121212;
+    }
+  }
+`;
+document.head.appendChild(customStyle);
+
 const Template = args => <AccessibleDialog {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
   children: <div>Default Accessible Dialog</div>,
-  onClose: () => {},
+  onClose: action('closed'),
+  onDismiss: undefined,
 };
 
 export const CustomStyles = Template.bind({});
 CustomStyles.args = {
+  children: (
+    <div>
+      <p>Custom Styled Accessible Dialog</p>
+    </div>
+  ),
+  onClose: action('closed'),
+  onDismiss: undefined,
   styles: {
     modal: defaultStyle.modal + ' custom-modal-style',
     modalBackdrop: defaultStyle.modalBackdrop + ' custom-backdrop-style',
-    xCloseButton: defaultStyle.xCloseButton + ' custom-close-icon-style',
+    xCloseButton: defaultStyle.xCloseButton + ' custom-close-button-style',
   },
-  children: <div>Custom Styled Accessible Dialog</div>,
-  onClose: () => {},
 };
 
 export const WithOnDismiss = Template.bind({});
 WithOnDismiss.args = {
   children: <div>Accessible Dialog with onDismiss</div>,
-  onDismiss: () => {},
+  onClose: action('closed'),
+  onDismiss: action('dismissed'),
 };
 
 export const WithoutInitialFocus = Template.bind({});
 WithoutInitialFocus.args = {
   children: <div>Accessible Dialog without initial focus</div>,
-  onClose: () => {},
   initialFocus: false,
+  onClose: action('closed'),
+  onDismiss: undefined,
 };
 
 export const ClickBackdropToClose = Template.bind({});
 ClickBackdropToClose.args = {
   children: <div>Accessible Dialog with backdrop click to close</div>,
-  onClose: () => {},
   closeOnClickBackdrop: true,
+  onClose: action('closed'),
+  onDismiss: undefined,
 };


### PR DESCRIPTION
This PR adds a storybook test for AccessibleDIalog.jsx 
This PR also modifies AccesibleDIalog to accept `fallbackFocus` as a prop to allow Storybook test to find a tabbable element and avoid [ERROR: Your focus-trap must have at least one container with at least one tabbable node in it at all times ](https://github.com/focus-trap/focus-trap?tab=readme-ov-file#error-your-focus-trap-must-have-at-least-one-container-with-at-least-one-tabbable-node-in-it-at-all-times).
![Screenshot 2024-08-23 at 16 14 43](https://github.com/user-attachments/assets/e9b01fe1-5f81-4847-a5d9-c61a77dc1633)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
