### PR TITLE
Throttle AI Chat endpoints

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -157,6 +157,7 @@
   "aiChatInappropriateUserMessage": "This message has been flagged as inappropriate.",
   "aiChatTooPersonalUserMessage": "This message has been flagged as too personal.",
   "aiChatResponseError": "There was an error getting a response. Please try again.",
+  "aiChatRateLimitError": "You've sent too many messages in the last minute. Please wait a moment before sending another message.",
   "all": "All",
   "allHandouts": "All Handouts",
   "allowEditing": "Allow editing",

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -16,6 +16,7 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {registerReducers} from '@cdo/apps/redux';
+import {commonI18n} from '@cdo/apps/types/locale';
 import {RootState} from '@cdo/apps/types/redux';
 import experiments from '@cdo/apps/util/experiments';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
@@ -404,20 +405,7 @@ export const submitChatContents = createAsyncThunk(
         experiments.isEnabled(experiments.AICHAT_POLLING)
       );
     } catch (error) {
-      Lab2Registry.getInstance()
-        .getMetricsReporter()
-        .logError('Error in aichat completion request', error as Error);
-
-      thunkAPI.dispatch(clearChatMessagePending());
-      dispatch(addChatEvent({...newUserMessage, status: Status.ERROR}));
-      dispatch(
-        addChatEvent({
-          role: Role.ASSISTANT,
-          status: Status.ERROR,
-          chatMessageText: 'error',
-          timestamp: Date.now(),
-        })
-      );
+      handleChatCompletionError(error as Error, newUserMessage, dispatch);
       return;
     }
 
@@ -442,6 +430,41 @@ export const submitChatContents = createAsyncThunk(
     });
   }
 );
+
+function handleChatCompletionError(
+  error: Error,
+  newUserMessage: ChatMessage,
+  dispatch: AppDispatch
+) {
+  Lab2Registry.getInstance()
+    .getMetricsReporter()
+    .logError('Error in aichat completion request', error as Error);
+
+  dispatch(clearChatMessagePending());
+  dispatch(addChatEvent({...newUserMessage, status: Status.ERROR}));
+
+  // Display a specific error notification if the user was rate limited (HTTP 429).
+  // Otherwise, display a generic error assistant response.
+  if (error instanceof NetworkError && error.response.status === 429) {
+    dispatch(
+      addChatEvent({
+        id: getNewMessageId(),
+        text: commonI18n.aiChatRateLimitError(),
+        notificationType: 'error',
+        timestamp: Date.now(),
+      })
+    );
+  } else {
+    dispatch(
+      addChatEvent({
+        role: Role.ASSISTANT,
+        status: Status.ERROR,
+        chatMessageText: 'error',
+        timestamp: Date.now(),
+      })
+    );
+  }
+}
 
 // This thunk's callback function submits a teacher's student's id along with the level/script id
 // (and the scriptLevelId if the level is a sublevel) to the student chat history endpoint,

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -1,3 +1,7 @@
+require 'cdo/throttle'
+
+AICHAT_PREFIX = "aichat/".freeze
+DEFAULT_REQUEST_LIMIT_PER_MIN = 50
 ROLES_FOR_MODEL = %w(assistant user).freeze
 DEFAULT_POLLING_INTERVAL_MS = 1000
 DEFAULT_POLLING_BACKOFF_RATE = 1.2
@@ -13,6 +17,7 @@ class AichatController < ApplicationController
   # aichatContext: {currentLevelId: number; scriptId: number; channelId: string;}
   # POST /aichat/chat_completion
   def chat_completion
+    return head :too_many_requests if should_throttle?
     return render status: :forbidden, json: {} unless AichatSagemakerHelper.can_request_aichat_chat_completion?
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}
@@ -27,6 +32,7 @@ class AichatController < ApplicationController
   # Initiate a chat completion request, which is performed asynchronously as an ActiveJob.
   # Returns the ID of the request and a base polling interval + backoff rate.
   def start_chat_completion
+    return head :too_many_requests if should_throttle?
     return render status: :forbidden, json: {} unless AichatSagemakerHelper.can_request_aichat_chat_completion?
     unless chat_completion_has_required_params?
       return render status: :bad_request, json: {}
@@ -250,5 +256,11 @@ class AichatController < ApplicationController
       _, project_id = storage_decrypt_channel_id(context[:channelId])
       project_id
     end
+  end
+
+  private def should_throttle?
+    id = current_user&.id || session.id
+    limit = DCDO.get('aichat_request_limit_per_min', DEFAULT_REQUEST_LIMIT_PER_MIN)
+    Cdo::Throttle.throttle(AICHAT_PREFIX + id.to_s, limit, 60)
   end
 end


### PR DESCRIPTION
Adds per-user throttling to AI Chat chat completion endpoints.

<img width="585" alt="Screenshot 2024-08-19 at 2 50 14 PM" src="https://github.com/user-attachments/assets/78ee25a9-a751-4c23-8cc4-77524168e061">

## Links

https://codedotorg.atlassian.net/browse/LABS-944

## Testing story

Tested locally (using a low throttling limit with DCDO) + unit.