### PR TITLE
P20-1101: Remove unsupported School Project OpenID integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -365,4 +365,5 @@ gem 'statsig', '~> 1.33'
 gem 'mailgun-ruby', '~>1.2.14'
 gem 'mailjet', '~> 1.7.3'
 
+gem 'json-jwt', '~> 1.15'
 gem "json-schema", "~> 4.3"

--- a/Gemfile
+++ b/Gemfile
@@ -299,7 +299,6 @@ gem 'full-name-splitter', github: 'pahanix/full-name-splitter'
 gem 'rambling-trie', '>= 2.1.1'
 
 gem 'omniauth-openid'
-gem 'omniauth-openid-connect', github: 'code-dot-org/omniauth-openid-connect', ref: 'cdo'
 
 # Ref: https://github.com/toy/image_optim/pull/145
 # Also include sRGB color profile conversion.

--- a/Gemfile
+++ b/Gemfile
@@ -287,6 +287,7 @@ gem 'addressable'
 gem 'bcrypt', '3.1.13'
 gem 'sshkit'
 gem 'validates_email_format_of'
+gem 'validate_url', '~> 1.0.15'
 
 gem 'composite_primary_keys', '~> 13.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,7 @@ GEM
       activerecord (>= 4.2)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    aes_key_wrap (1.1.0)
     afm (0.2.2)
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
@@ -263,6 +264,7 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
+    bindata (2.5.0)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -489,6 +491,11 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.6.2)
+    json-jwt (1.15.3.1)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
+      httpclient
     json-schema (4.3.1)
       addressable (>= 2.8)
     jsonapi-renderer (0.2.2)
@@ -988,6 +995,7 @@ DEPENDENCIES
   image_size
   jquery-rails
   jquery-ui-rails (~> 6.0.1)
+  json-jwt (~> 1.15)
   json-schema (~> 4.3)
   jumphash
   jwt (~> 2.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -878,6 +878,9 @@ GEM
     unicode_utils (1.4.0)
     uri (0.13.0)
     user_agent_parser (2.15.0)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     validates_email_format_of (1.6.3)
       i18n
     vcr (3.0.3)
@@ -1086,6 +1089,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unf_ext (= 0.0.7.2)
   user_agent_parser
+  validate_url (~> 1.0.15)
   validates_email_format_of
   vcr
   web-console (~> 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,16 +38,6 @@ GIT
       omniauth-oauth2 (>= 1.1, <= 1.5)
 
 GIT
-  remote: https://github.com/code-dot-org/omniauth-openid-connect.git
-  revision: 2397b1415896e2639a7582a36e26c90b9211f99f
-  ref: cdo
-  specs:
-    omniauth-openid-connect (0.2.2)
-      addressable (~> 2.3)
-      omniauth (~> 1.1)
-      openid_connect (~> 1.0, >= 1.0.3)
-
-GIT
   remote: https://github.com/code-dot-org/omniauth-windowslive.git
   revision: 68ece379fa4d79a49505454c52aaf9142cd2ed74
   ref: cdo
@@ -192,14 +182,12 @@ GEM
       activerecord (>= 4.2)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    aes_key_wrap (1.1.0)
     afm (0.2.2)
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
     ansi (1.5.0)
     ast (2.4.2)
-    attr_required (1.0.2)
     auto_strip_attributes (2.1.0)
       activerecord (>= 3.0)
     aws-eventstream (1.3.0)
@@ -275,7 +263,6 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
-    bindata (2.5.0)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -502,11 +489,6 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.6.2)
-    json-jwt (1.15.3.1)
-      activesupport (>= 4.2)
-      aes_key_wrap
-      bindata
-      httpclient
     json-schema (4.3.1)
       addressable (>= 2.8)
     jsonapi-renderer (0.2.2)
@@ -627,18 +609,10 @@ GEM
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
     open-uri (0.1.0)
+      stringio
+      time
+      uri
     open_uri_redirections (0.2.1)
-    openid_connect (1.4.2)
-      activemodel
-      attr_required (>= 1.0.0)
-      json-jwt (>= 1.15.0)
-      net-smtp
-      rack-oauth2 (~> 1.21)
-      swd (~> 1.3)
-      tzinfo
-      validate_email
-      validate_url
-      webfinger (~> 1.2)
     orm_adapter (0.5.0)
     os (1.1.4)
     parallel (1.23.0)
@@ -681,12 +655,6 @@ GEM
       rack (>= 2.0.0)
     rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
-    rack-oauth2 (1.21.3)
-      activesupport
-      attr_required
-      httpclient
-      json-jwt (>= 1.11.0)
-      rack (>= 2.1.0)
     rack-openid (1.3.1)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
@@ -877,10 +845,7 @@ GEM
       ip3country (~> 0.2.1)
       user_agent_parser (~> 2.15.0)
     stringex (2.5.2)
-    swd (1.3.0)
-      activesupport (>= 3)
-      attr_required (>= 0.0.5)
-      httpclient (>= 2.4)
+    stringio (3.1.1)
     sysexits (1.2.0)
     temple (0.8.2)
     thin (1.8.2)
@@ -891,6 +856,8 @@ GEM
     thwait (0.2.0)
       e2mmap
     tilt (2.0.11)
+    time (0.3.0)
+      date
     timecop (0.8.1)
     timeout (0.3.2)
     trailblazer-option (0.1.2)
@@ -909,13 +876,8 @@ GEM
     unf_ext (0.0.7.2)
     unicode-display_width (2.4.2)
     unicode_utils (1.4.0)
+    uri (0.13.0)
     user_agent_parser (2.15.0)
-    validate_email (0.1.6)
-      activemodel (>= 3.0)
-      mail (>= 2.2.5)
-    validate_url (1.0.15)
-      activemodel (>= 3.0.0)
-      public_suffix
     validates_email_format_of (1.6.3)
       i18n
     vcr (3.0.3)
@@ -930,9 +892,6 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
-    webfinger (1.2.0)
-      activesupport
-      httpclient (>= 2.4)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -1057,7 +1016,6 @@ DEPENDENCIES
   omniauth-google-oauth2 (~> 0.6.0)
   omniauth-microsoft_v2_auth!
   omniauth-openid
-  omniauth-openid-connect!
   omniauth-rails_csrf_protection (~> 0.1)
   omniauth-windowslive (~> 0.0.11)!
   open_uri_redirections

--- a/bin/oneoff/data_fix/birthday_and_created_at
+++ b/bin/oneoff/data_fix/birthday_and_created_at
@@ -10,7 +10,6 @@ OAUTH_PROVIDERS = %w(
   facebook
   google_oauth2
   lti_lti_prod_kids.qwikcamps.com
-  the_school_project
   twitter
   windowslive
 ).freeze

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -31,8 +31,6 @@ dashboard_microsoft_key:        !Secret
 dashboard_microsoft_secret:     !Secret
 dashboard_clever_key:           !Secret
 dashboard_clever_secret:        !Secret
-dashboard_schoolproject_key:    !Secret
-dashboard_schoolproject_secret: !Secret
 
 # Recaptcha
 recaptcha_site_key: !Secret

--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -46,7 +46,6 @@ class AuthenticationOption < ApplicationRecord
     GOOGLE = 'google_oauth2',
     POWERSCHOOL = 'powerschool',
     QWIKLABS = 'lti_lti_prod_kids.qwikcamps.com',
-    THE_SCHOOL_PROJECT = 'the_school_project',
     TWITTER = 'twitter',
     WINDOWS_LIVE = 'windowslive',
     MICROSOFT = 'microsoft_v2_auth',

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -878,13 +878,6 @@ class User < ApplicationRecord
     # we don't trust
     user.email = auth.info.email unless user.user_type == 'student' && AuthenticationOption::UNTRUSTED_EMAIL_CREDENTIAL_TYPES.include?(auth.provider)
 
-    if auth.provider == :the_school_project
-      user.username = auth.extra.raw_info.nickname
-      user.user_type = auth.extra.raw_info.role
-      user.locale = auth.extra.raw_info.locale
-      user.school = auth.extra.raw_info.school.name
-    end
-
     # treat clever admin types as teachers
     if CLEVER_ADMIN_USER_TYPES.include? user.user_type
       user.user_type = User::TYPE_TEACHER

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -302,22 +302,6 @@ Devise.setup do |config|
   # with a log in with facebook button)
   config.omniauth :clever, CDO.dashboard_clever_key, CDO.dashboard_clever_secret, provider_ignores_state: true
 
-  config.omniauth :openid_connect, {
-    name: :the_school_project,
-    scope: [:profile, :email, :school],
-    response_type: :code,
-    issuer: 'https://www.cleio.fr/openid',
-    discovery: true,
-    client_options: {
-      port: 443,
-      scheme: 'https',
-      host: CDO.dashboard_hostname,
-      identifier: CDO.dashboard_schoolproject_key,
-      secret: CDO.dashboard_schoolproject_secret,
-      redirect_uri: CDO.studio_url('/users/auth/the_school_project/callback', 'https:')
-    }
-  }
-
   # Powerschool OpenID config
   config.omniauth :openid, {
     provider_ignores_state: true,

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -525,11 +525,6 @@ FactoryBot.define do
       provider {'powerschool'}
     end
 
-    trait :the_school_project_sso_provider do
-      sso_provider
-      provider {'the_school_project'}
-    end
-
     trait :twitter_sso_provider do
       sso_provider
       provider {'twitter'}

--- a/dashboard/test/lib/user_multi_auth_helper_test.rb
+++ b/dashboard/test/lib/user_multi_auth_helper_test.rb
@@ -244,18 +244,6 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
     }
   end
 
-  # At time of writing we have 6 The School Project students and 3 teachers.
-  # These mostly look like test accounts, but presumably we want to continue
-  # supporting them.
-
-  test 'create migrated The School Project student' do
-    assert_created_sso_user create(:student, :the_school_project_sso_provider)
-  end
-
-  test 'create migrated The School Project teacher' do
-    assert_created_sso_user create(:teacher, :the_school_project_sso_provider)
-  end
-
   # Our Twitter SSO support is very old - we have a few thousand such accounts
   # but less than 10 are still active.
 
@@ -468,14 +456,6 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
           }
         }
     end
-  end
-
-  test 'de- and re-migrate The School Project student' do
-    round_trip_sso create(:student, :the_school_project_sso_provider)
-  end
-
-  test 'de- and re-migrate The School Project teacher' do
-    round_trip_sso create(:teacher, :the_school_project_sso_provider)
   end
 
   test 'de- and re-migrate Twitter student' do

--- a/dashboard/test/models/authentication_option_test.rb
+++ b/dashboard/test/models/authentication_option_test.rb
@@ -128,11 +128,6 @@ class AuthenticationOptionTest < ActiveSupport::TestCase
     assert option.oauth?
   end
 
-  test 'oauth? true when credential_type is The School Project' do
-    option = create :authentication_option, credential_type: AuthenticationOption::THE_SCHOOL_PROJECT
-    assert option.oauth?
-  end
-
   test 'oauth? true when credential_type is Twitter' do
     option = create :authentication_option, credential_type: AuthenticationOption::TWITTER
     assert option.oauth?


### PR DESCRIPTION
This cleanup allows us to eliminate the dependency on the `omniauth-openid-connect` gem.

## Links
- JIRA ticket: [P20-1101](https://codedotorg.atlassian.net/browse/P20-1101)
- Original PR: https://github.com/code-dot-org/code-dot-org/pull/13649