### PR TITLE
Update action block background color on code.org/lms

### DIFF
--- a/pegasus/sites.v3/code.org/views/lms/lms_get_started.haml
+++ b/pegasus/sites.v3/code.org/views/lms/lms_get_started.haml
@@ -1,4 +1,4 @@
-.action-block.action-block--two-col
+.action-block.action-block--two-col.white
   .media-wrapper.col-50
     %img{src: "/images/lms/getStarted.png", alt: ""}
   .text-wrapper.col-50


### PR DESCRIPTION
Make the Getting Started action block background color white on https://code.org/lms.

## Links
Slack convo: [here](https://codedotorg.slack.com/archives/C0453TUMLE7/p1724183744666099)

----

| Before | After |
| ---- | ---- |
| <img width="1041" alt="Before" src="https://github.com/user-attachments/assets/7677d3a3-8e13-4cd8-99a6-750f9e4cd6d5"> | <img width="1041" alt="After" src="https://github.com/user-attachments/assets/246f90a8-2e8a-4751-b2da-385ec4d8f405"> |

