### PR TITLE
Remove activity submission link on hourofcode.com/learn

### DIFF
--- a/apps/src/tutorialExplorer/tutorialExplorer.js
+++ b/apps/src/tutorialExplorer/tutorialExplorer.js
@@ -639,14 +639,6 @@ export default class TutorialExplorer extends React.Component {
               </div>
 
               <div style={bottomLinksContainerStyle}>
-                <div style={styles.bottomLinksLinkFirst}>
-                  <a
-                    style={styles.bottomLinksLink}
-                    href="https://hourofcode.com/activity-guidelines"
-                  >
-                    {i18n.bottomGuidelinesLink()}
-                  </a>
-                </div>
                 <div>
                   <a
                     style={styles.bottomLinksLink}


### PR DESCRIPTION
Removes the `Click here to see our criteria and submission guidelines for Hour of Code tutorials.` link at the bottom of https://hourofcode.com/learn.

## Links
Jira ticket: [ACQ-2226](https://codedotorg.atlassian.net/browse/ACQ-2226)

## Followup
The page this links to will be deprecated here: [ACQ-2225](https://codedotorg.atlassian.net/browse/ACQ-2225)

----

| Before | After |
| ---- | ---- |
| <img width="1041" alt="Before" src="https://github.com/user-attachments/assets/00953579-7af8-4e0a-9c83-f02df4c70577"> | <img width="1041" alt="After" src="https://github.com/user-attachments/assets/ead99605-3a1c-48d1-b03c-9453cac52ef8"> |

