### PR TITLE
AI Component Library: update chat message colors

### DIFF
--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -2,10 +2,8 @@
 @import '@cdo/apps/componentLibrary/typography/typography.module';
 
 $message-border-radius: 8px;
-
-// TODO: Swap these colors after Gen AI Pilot v2
-$user-color: $brand_primary_light;
-$assistant-color: $light_gray_100;
+$user-color: $light_gray_100;
+$assistant-color: $brand_primary_light;
 
 %message {
   @extend %markdown-styles;


### PR DESCRIPTION
Swap the user and assistant chat message colors as per design mocks. These were previously flipped to match existing curriculum materials in the Gen AI pilots, but we can now restore them as we head into launch.

FYI @etaderhold @cearachew @Erin007 as this will affect AI Tutor and AI Teaching Assistant too.

Before (currently on production):
<img width="584" alt="Screenshot 2024-08-20 at 4 18 45 PM" src="https://github.com/user-attachments/assets/9b78972f-19ec-4383-8cb8-6a2ea01a9273">

After:
<img width="583" alt="Screenshot 2024-08-20 at 4 20 16 PM" src="https://github.com/user-attachments/assets/df951e3d-0f93-47a9-abbf-f47e66e9c672">

## Links

https://codedotorg.atlassian.net/browse/LABS-984

## Testing story

Tested locally