### PR TITLE
Remove call out to map on https://code.org/international/apply

### DIFF
--- a/pegasus/sites.v3/code.org/public/international/apply.md
+++ b/pegasus/sites.v3/code.org/public/international/apply.md
@@ -32,7 +32,7 @@ If you have plans to promote the Hour of Code campaign across your whole country
 - You’ll receive the latest updates on exciting news, special events, program updates, useful resources, and more.
 - You’ll be given access to an invite-only online community of global experts, including Code.org employees and fellow Code.org International Partners, who share the goal of expanding computer science education worldwide.
 
-Please note that this partnership opportunity is for organizations with broad reach. If you are an individual teacher, or your organization’s plans span a school, city, or a smaller scale, we welcome you to organize your Hour of Code and record it [on our global map](https://hourofcode.com/) (sign-ups to open by October).
+Please note that this partnership opportunity is for organizations with broad reach.
 
 ***
 


### PR DESCRIPTION
Removes call out to register an event for Hour of Code on https://code.org/international/apply.

## Links
[ACQ-2218](https://codedotorg.atlassian.net/browse/ACQ-2218)

----

| Before | After |
| ---- | ---- |
| <img width="1041" alt="Before" src="https://github.com/user-attachments/assets/60652442-1592-441b-b824-5b476681f59d"> | <img width="1041" alt="After" src="https://github.com/user-attachments/assets/e85deee1-709e-4b16-9bff-c963e75647a3"> |
