### PR TITLE
Do not re-verify verified teachers

### DIFF
--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -17,6 +17,7 @@ class Policies::User
   # - Have a google_oauth2 Authentication Option
   # - Have a non-google/non-gmail email domain attached to that googele_oauth2 authentication option
   def self.verified_teacher_candidate?(user)
+    return false if user.verified_teacher?
     google_ao = user.authentication_options.find_by(credential_type: AuthenticationOption::GOOGLE)
     return false unless google_ao
 

--- a/dashboard/test/lib/policies/user_test.rb
+++ b/dashboard/test/lib/policies/user_test.rb
@@ -47,5 +47,8 @@ class Policies::UserTest < ActiveSupport::TestCase
     # Google Authentication Option has a gmail email, criteria not met
     create :google_authentication_option, user: teacher, email: 'test@gmail.com'
     assert_equal false, Policies::User.verified_teacher_candidate?(teacher)
+    # Teacher already verified, criteria not met
+    teacher.verify_teacher!
+    assert_equal false, Policies::User.verified_teacher_candidate?(teacher)
   end
 end

--- a/dashboard/test/lib/policies/user_test.rb
+++ b/dashboard/test/lib/policies/user_test.rb
@@ -47,8 +47,14 @@ class Policies::UserTest < ActiveSupport::TestCase
     # Google Authentication Option has a gmail email, criteria not met
     create :google_authentication_option, user: teacher, email: 'test@gmail.com'
     assert_equal false, Policies::User.verified_teacher_candidate?(teacher)
-    # Teacher already verified, criteria not met
+  end
+
+  test 'verified_teacher_candidate? should return false when teacher is already verified' do
+    teacher = create :teacher
+    # Change teacher to verified
     teacher.verify_teacher!
+    assert_equal true, teacher.verified_teacher?
+    # Teacher already verified, not eligible for re-verification
     assert_equal false, Policies::User.verified_teacher_candidate?(teacher)
   end
 end

--- a/dashboard/test/lib/policies/user_test.rb
+++ b/dashboard/test/lib/policies/user_test.rb
@@ -50,11 +50,9 @@ class Policies::UserTest < ActiveSupport::TestCase
   end
 
   test 'verified_teacher_candidate? should return false when teacher is already verified' do
-    teacher = create :teacher
-    # Change teacher to verified
-    teacher.verify_teacher!
-    assert_equal true, teacher.verified_teacher?
-    # Teacher already verified, not eligible for re-verification
-    assert_equal false, Policies::User.verified_teacher_candidate?(teacher)
+    teacher = create :teacher, :with_google_authentication_option
+    assert_changes -> {Policies::User.verified_teacher_candidate?(teacher)}, from: true, to: false do
+      teacher.verify_teacher!
+    end
   end
 end


### PR DESCRIPTION
We realized the new functionality to auto-verify eligible teachers would verify teachers who are already verified, which kicks off a generated email. This is obviously undesirable.

This PR adds a check in User::Policies.verified_teacher_candidate? to return false if teacher is already verified

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

```
bundle exec spring testunit ./test/lib/policies/user_test.rb
Running via Spring preloader in process 44067
Started with run options --seed 63269

  7/7: [=====================================================================================================================================================================] 100% Time: 00:00:00, Time: 00:00:00

Finished in 0.89748s
7 tests, 12 assertions, 0 failures, 0 errors, 0 skips
```
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
