### PR TITLE
AI Chat UI tweaks

### DIFF
--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -168,22 +168,24 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
         />
       )}
 
-      {canChatWithModel && (
-        <UserChatMessageEditor
-          editorContainerClassName={moduleStyles.messageEditorContainer}
-        />
-      )}
-      <div className={moduleStyles.buttonRow}>
-        <Button
-          text="Clear chat"
-          disabled={!canChatWithModel}
-          iconLeft={{iconName: 'eraser'}}
-          size="s"
-          type="secondary"
-          color="gray"
-          onClick={onClear}
-        />
-        <CopyButton />
+      <div className={moduleStyles.footer}>
+        {canChatWithModel && (
+          <UserChatMessageEditor
+            editorContainerClassName={moduleStyles.messageEditorContainer}
+          />
+        )}
+        <div className={moduleStyles.buttonRow}>
+          <Button
+            text="Clear chat"
+            disabled={!canChatWithModel}
+            iconLeft={{iconName: 'eraser'}}
+            size="s"
+            type="secondary"
+            color="gray"
+            onClick={onClear}
+          />
+          <CopyButton />
+        </div>
       </div>
     </div>
   );

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -36,6 +36,10 @@ enum WorkspaceTeacherViewTab {
   TEST_STUDENT_MODEL = 'testStudentModel',
 }
 
+const eraserIcon: FontAwesomeV6IconProps = {
+  iconName: 'eraser',
+};
+
 /**
  * Renders the AI Chat Lab main chat workspace component.
  */
@@ -178,7 +182,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
           <Button
             text="Clear chat"
             disabled={!canChatWithModel}
-            iconLeft={{iconName: 'eraser'}}
+            iconLeft={eraserIcon}
             size="s"
             type="secondary"
             color="gray"

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -35,13 +35,16 @@ $default-spacing: 16px;
   width: 50px;
 }
 
-.messageEditorContainer {
-  padding-left: 20px;
-  padding-right: 20px;
-}
-
 .buttonRow {
   display: flex;
   gap: 8px;
-  padding: 0 20px 20px 20px;
+  padding: 0 10px;
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 16px 6px;
+  border-top: 1px solid $light_gray_200;
 }

--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -20,7 +20,7 @@ $default-spacing: 4px;
 
   .tabsContainer {
     background-color: #eaebeb;
-    padding-top: $default-spacing;
+    padding: $default-spacing $default-spacing 0 $default-spacing;
   }
 
   .tabPanels {


### PR DESCRIPTION
- Fix the user message editor alignment and add a top border to the footer area as per mocks
- Add left padding to the model customization tabs

Message editor before:
<img width="586" alt="Screenshot 2024-08-20 at 5 09 58 PM" src="https://github.com/user-attachments/assets/65b58d0c-59e9-4bc8-a1ab-5758093886ef">

Message editor after:
<img width="588" alt="Screenshot 2024-08-20 at 5 09 42 PM" src="https://github.com/user-attachments/assets/3fbe8407-a41d-4ffa-95d1-a4e5690b981c">

Tabs before:
<img width="246" alt="Screenshot 2024-08-20 at 4 41 29 PM" src="https://github.com/user-attachments/assets/eabe9d0d-a1b9-47aa-812d-8e886a1e5378">

Tabs after:
<img width="256" alt="Screenshot 2024-08-20 at 4 41 18 PM" src="https://github.com/user-attachments/assets/bfd57fdb-ee38-4c33-8573-01f80e9c9133">


## Links

https://codedotorg.atlassian.net/browse/LABS-980
https://codedotorg.atlassian.net/browse/LABS-935

## Testing story

Tested locally on Gen AI pilot & allthethings