### PR TITLE
AI Chat: fix collapsible section jumping on open

### DIFF
--- a/apps/src/aichat/views/presentation/ModelCardRow.tsx
+++ b/apps/src/aichat/views/presentation/ModelCardRow.tsx
@@ -45,8 +45,6 @@ const ModelCardRow: React.FunctionComponent<ModelCardRowProps> = ({
     <>
       <div className={moduleStyles.modelCardAttributes}>
         <CollapsibleSection
-          collapsedIcon="caret-right"
-          expandedIcon="caret-down"
           headerContent={
             <div className={moduleStyles.sectionHeader}>
               {titleIcon && (

--- a/apps/src/templates/CollapsibleSection.tsx
+++ b/apps/src/templates/CollapsibleSection.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, {useState, useCallback} from 'react';
 
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
@@ -8,6 +9,10 @@ interface CollapsibleSectionProps {
   children: React.ReactNode;
   headerContent: React.ReactNode;
   initiallyCollapsed?: boolean;
+  // If a single iconName is provided, it will be used for both collapsed and expanded states.
+  // When expanded, the icon will be rotated 90 degrees.
+  iconName?: string;
+  // If separate collapsed and expanded icons are provided, each will be used in its respective state.
   collapsedIcon?: string;
   expandedIcon?: string;
 }
@@ -16,8 +21,9 @@ const CollapsibleSection: React.FunctionComponent<CollapsibleSectionProps> = ({
   children,
   headerContent,
   initiallyCollapsed = true,
-  collapsedIcon = 'chevron-down',
-  expandedIcon = 'chevron-up',
+  iconName = 'caret-right',
+  collapsedIcon = 'caret-right',
+  expandedIcon = 'caret-down',
 }) => {
   const [collapsed, setCollapsed] = useState(initiallyCollapsed);
   const toggleCollapsed = useCallback(() => {
@@ -32,8 +38,12 @@ const CollapsibleSection: React.FunctionComponent<CollapsibleSectionProps> = ({
         className={moduleStyles.expandCollapseButton}
       >
         <FontAwesomeV6Icon
-          iconName={collapsed ? collapsedIcon : expandedIcon}
+          iconName={iconName || (collapsed ? collapsedIcon : expandedIcon)}
           iconStyle="solid"
+          className={classNames(
+            moduleStyles.icon,
+            iconName && !collapsed && moduleStyles.iconExpanded
+          )}
         />
         {headerContent}
       </button>

--- a/apps/src/templates/collapsible-section.module.scss
+++ b/apps/src/templates/collapsible-section.module.scss
@@ -10,3 +10,10 @@
   gap: 10px;
   width: 100%;
 }
+
+.icon {
+  transition: transform 0.2s ease;
+  &Expanded {
+    transform: rotate(90deg);
+  }
+}


### PR DESCRIPTION
Minor tweaks to the collapsible section icon used in AI Chat. The original issue was that there was a slight jump whenever opening/closing the section, which was due to slight size differences between the collapsed and expanded icons. As a fix, I added an option to use the same icon for both expanded and collapsed states, with a CSS rotate when expanded so the width is preserved, plus a transition so it looks a bit nicer. I also updated the default icon to the caret we use in AI Chat since I thought it just looked better 🙂

With updates (AI Chat):

https://github.com/user-attachments/assets/c2567de6-baf9-4eac-be9a-f003fb41dda9

With updates (level edit page):

https://github.com/user-attachments/assets/bb7f4363-f0a0-4326-b36a-e7ca54a4a9de

## Links

https://codedotorg.atlassian.net/browse/LABS-936

## Testing story

Tested locally on allthethings and level edit page