### PR TITLE
 `HintPrompt` modernization

### DIFF
--- a/apps/src/templates/instructions/HintPrompt.jsx
+++ b/apps/src/templates/instructions/HintPrompt.jsx
@@ -1,12 +1,13 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
+import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import msg from '@cdo/locale';
 
-import LegacyButton from '../../legacySharedComponents/LegacyButton';
-
 import ChatBubble from './ChatBubble';
+
+import styles from './hint-prompt.module.scss';
 
 const HintPrompt = ({
   onConfirm,
@@ -29,22 +30,26 @@ const HintPrompt = ({
       textToSpeechEnabled={textToSpeechEnabled}
     >
       <p id={'hint-prompt-message'}>{message}</p>
-      <LegacyButton
+      <Button
         id="hint-prompt-yes-button"
-        type="cancel"
+        type="primary"
+        text={msg.yes()}
+        color={buttonColors.white}
         onClick={onConfirm}
-        style={{marginRight: 5}}
-        aria-labelledby="hint-prompt-message"
-      >
-        {msg.yes()}
-      </LegacyButton>
-      <LegacyButton
-        type="cancel"
+        className={classNames(styles.button, styles.buttonYes)}
+        size="m"
+        ariaLabel={msg.yes()}
+      />
+      <Button
+        id="hint-prompt-no-button"
+        type="primary"
+        text={msg.no()}
+        color={buttonColors.white}
         onClick={onDismiss}
-        aria-labelledby="hint-prompt-message"
-      >
-        {msg.no()}
-      </LegacyButton>
+        className={classNames(styles.button)}
+        size="m"
+        ariaLabel={msg.no()}
+      />
     </ChatBubble>
   );
 };
@@ -59,4 +64,4 @@ HintPrompt.propTypes = {
   textToSpeechEnabled: PropTypes.bool,
 };
 
-export default Radium(HintPrompt);
+export default HintPrompt;

--- a/apps/src/templates/instructions/hint-prompt.module.scss
+++ b/apps/src/templates/instructions/hint-prompt.module.scss
@@ -1,6 +1,6 @@
 .button {
   border: 2px solid black;
   &Yes {
-    margin-right: 5px;
+    margin-inline-end: 8px;
   }
 }

--- a/apps/src/templates/instructions/hint-prompt.module.scss
+++ b/apps/src/templates/instructions/hint-prompt.module.scss
@@ -1,0 +1,6 @@
+.button {
+  border: 2px solid black;
+  &Yes {
+    margin-right: 5px;
+  }
+}


### PR DESCRIPTION
`HintPrompt` is an old component used in CSF courses to allow students to confirm or cancel a hint request. I made a few code tidying updates to incrementally work towards our [goals of modernizing the frontend](https://docs.google.com/document/d/1Yxek5dqYKLJUraB17yCdEFLlJvlOiB1zhSWZAuu3zPU/edit#heading=h.18w2m61099gz):
- removed the usage of Radium (it's deprecated!) which wasn't actually adding any value to this component any way. Partial for [XTEAM-204](https://codedotorg.atlassian.net/browse/XTEAM-204)
- extracted a couple of inline styles to a SCSS module 
- swapped `LegacyButton` for the DSCO `Button` component. Partial for [XTEAM-430](https://codedotorg.atlassian.net/browse/XTEAM-430)

There are slight visual changes, but no functional differences. 

BEFORE 
![hint_prompt_before](https://github.com/user-attachments/assets/df40d621-66cc-4a3d-baef-4a20f7b600e7)

AFTER 
![hint_prompt_after](https://github.com/user-attachments/assets/5a3d4493-f762-491e-a02b-a0ededb7a094)
