### PR TITLE
Remove logic restricting LTI cards in section create modal

### DIFF
--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -106,7 +106,6 @@ class LoginTypePicker extends Component {
       providers && providers.includes(OAuthSectionTypes.microsoft_classroom);
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
-    const withLti = providers && providers.includes(SectionLoginType.lti_v1);
     const withAllLmsProviders =
       providers &&
       [
@@ -262,20 +261,16 @@ class LoginTypePicker extends Component {
                     }
                   />
                 )}
-                {!withLti && (
-                  <>
-                    <LmsInformationalCard
-                      lmsName={LmsLoginTypeNames.canvas}
-                      lmsLogo={canvasLogo}
-                      lmsInformationalUrl={LmsLoginInstructionUrls.canvas}
-                    />
-                    <LmsInformationalCard
-                      lmsName={LmsLoginTypeNames.schoology}
-                      lmsLogo={schoologyLogo}
-                      lmsInformationalUrl={LmsLoginInstructionUrls.schoology}
-                    />
-                  </>
-                )}
+                <LmsInformationalCard
+                  lmsName={LmsLoginTypeNames.canvas}
+                  lmsLogo={canvasLogo}
+                  lmsInformationalUrl={LmsLoginInstructionUrls.canvas}
+                />
+                <LmsInformationalCard
+                  lmsName={LmsLoginTypeNames.schoology}
+                  lmsLogo={schoologyLogo}
+                  lmsInformationalUrl={LmsLoginInstructionUrls.schoology}
+                />
               </div>
             </>
           )}

--- a/apps/test/unit/templates/teacherDashboard/LoginTypePickerTest.jsx
+++ b/apps/test/unit/templates/teacherDashboard/LoginTypePickerTest.jsx
@@ -72,7 +72,7 @@ describe('LoginTypePicker', () => {
     expect(lmsCards.children).toHaveLength(4);
   });
 
-  it('does not show LTI-based LMS info cards for LTI users', () => {
+  it('shows all cards for LTI users', () => {
     render(
       <LoginTypePicker
         title="title"
@@ -88,11 +88,7 @@ describe('LoginTypePicker', () => {
     );
 
     const lmsCards = screen.getByTestId('lms-info-cards-container');
-    expect(lmsCards.children).toHaveLength(2);
-    expect(within(lmsCards).queryByText(LmsLoginTypeNames.canvas)).toBeNull();
-    expect(
-      within(lmsCards).queryByText(LmsLoginTypeNames.schoology)
-    ).toBeNull();
+    expect(lmsCards.children).toHaveLength(4);
   });
 
   it('does not show the Google LMS info card for Google users', () => {


### PR DESCRIPTION
[This PR](https://github.com/code-dot-org/code-dot-org/pull/60410) added new informational cards for the various LMS/oauth providers. Originally, the cards were only supposed to show up for providers that the user didn't have connected. This changed, and product thinks it would be better to show the Canvas and Schoology cards for all users.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1103)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
