### PR TITLE
P20-1104: Update `omniauth-clever` to version 2.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -163,8 +163,7 @@ gem 'cancancan', '~> 3.5.0'
 gem 'devise', '~> 4.9.0'
 gem 'devise_invitable', '~> 2.0.2'
 
-# Ref: https://github.com/daynew/omniauth-clever/pull/1
-gem 'omniauth-clever', '~> 2.0.0', github: 'code-dot-org/omniauth-clever'
+gem 'omniauth-clever', '~> 2.0.1', github: 'code-dot-org/omniauth-clever', tag: 'v2.0.1'
 gem 'omniauth-facebook', '~> 4.0.0'
 gem 'omniauth-google-oauth2', '~> 0.6.0'
 gem 'omniauth-microsoft_v2_auth', github: 'dooly-ai/omniauth-microsoft_v2_auth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,10 +32,11 @@ GIT
 
 GIT
   remote: https://github.com/code-dot-org/omniauth-clever.git
-  revision: d71f68e78592d3d291995a0a313f4900e7853ded
+  revision: 995409e9be86a9864e344e360869ca982c834845
+  tag: v2.0.1
   specs:
-    omniauth-clever (2.0.0)
-      omniauth-oauth2 (>= 1.1, <= 1.5)
+    omniauth-clever (2.0.1)
+      omniauth-oauth2 (>= 1.1, <= 1.8)
 
 GIT
   remote: https://github.com/code-dot-org/omniauth-windowslive.git
@@ -393,7 +394,7 @@ GEM
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
-    faraday-net_http (1.0.1)
+    faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
@@ -559,7 +560,7 @@ GEM
     multi_json (1.15.0)
     multi_test (0.1.2)
     multi_xml (0.6.0)
-    multipart-post (2.2.3)
+    multipart-post (2.4.1)
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.5)
@@ -585,12 +586,13 @@ GEM
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    oauth2 (1.4.11)
+    oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
-      multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
     octokit (6.0.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -606,9 +608,9 @@ GEM
       jwt (>= 2.0)
       omniauth (>= 1.1.1)
       omniauth-oauth2 (>= 1.5)
-    omniauth-oauth2 (1.5.0)
-      oauth2 (~> 1.1)
-      omniauth (~> 1.2)
+    omniauth-oauth2 (1.7.3)
+      oauth2 (>= 1.4, < 3)
+      omniauth (>= 1.9, < 3)
     omniauth-openid (1.0.1)
       omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
@@ -831,6 +833,9 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.2.3)
       tilt (~> 2.0)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -891,6 +896,7 @@ GEM
     validates_email_format_of (1.6.3)
       i18n
     vcr (3.0.3)
+    version_gem (1.1.4)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -1022,7 +1028,7 @@ DEPENDENCIES
   nokogiri (>= 1.10.0)
   octokit
   oj (~> 3.10)
-  omniauth-clever (~> 2.0.0)!
+  omniauth-clever (~> 2.0.1)!
   omniauth-facebook (~> 4.0.0)
   omniauth-google-oauth2 (~> 0.6.0)
   omniauth-microsoft_v2_auth!


### PR DESCRIPTION
The [omniauth-clever](https://github.com/code-dot-org/omniauth-clever) gem currently supports only `omniauth-oauth2` version 1.5. However, the latest `omniauth-oauth2` version 1.8 is required to ensure compatibility with `omniauth` version 2, which includes a fix for the vulnerability [CVE-2015-9284](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284).

1. Updated `omniauth-clever` to support `omniauth-oauth2` version 1.8.
2. Updated `omniauth-oauth2` to version 1.7.3, the latest release that supports the current version of `omniauth` (1.9.2)

![clever-login](https://github.com/user-attachments/assets/c43cc82c-6bb9-4669-9c41-0f0530dd522e)

## Links
- JIRA task: [P20-1104](https://codedotorg.atlassian.net/browse/P20-1104)
- `omniauth-clever` v2.0.1 changelog: https://github.com/code-dot-org/omniauth-clever/compare/master...code-dot-org:omniauth-clever:omniauth-oauth2-v1.8