### PR TITLE
NAV-Remove underline from option

### DIFF
--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -63,6 +63,7 @@
 
   &:hover {
     background-color: $neutral_gray10;
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
Removes underline from option when user is hovering over it.

Old:
<img width="258" alt="image" src="https://github.com/user-attachments/assets/479467dc-5c5d-45d7-ac9e-ab8ce5c29e9f">



New:
<img width="247" alt="image" src="https://github.com/user-attachments/assets/782ed333-4392-451f-a86d-321540bf3b58">
