### PR TITLE
Update Session Store Evictions Alarm

### DIFF
--- a/aws/cloudformation/components/session_store.yml.erb
+++ b/aws/cloudformation/components/session_store.yml.erb
@@ -35,7 +35,6 @@
   # https://aws.amazon.com/blogs/database/monitoring-best-practices-with-amazon-elasticache-for-redis-using-amazon-cloudwatch/
   SessionStoreCPUUsageAlarm:
     Type: AWS::CloudWatch::Alarm
-    DependsOn: SessionStoreGroup
     Properties:
       AlarmName: <%="Redis Session Store CPU Usage Too High (#{stack_name})" %>
       AlarmDescription: AWS Documentation recommends maintaining
@@ -70,45 +69,6 @@
 <% end -%>
   SessionStoreEvictionsAlarm:
     Type: AWS::CloudWatch::Alarm
-    DependsOn: SessionStoreGroup
-    Properties:
-      AlarmName: <%="Redis Session Store High Eviction Rate (#{stack_name})" %>
-      AlarmDescription: We're seeing a lot of evictions from the Redis session store.
-        A steady amount of evictions is not a bad thing, but a rapid increase in
-        eviction rate could be a sign of other instability. Note that the
-        current limit is aribtrary and speculative; we should adjust it once we
-        have enough data to understand our normal operating eviction rate.
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref InfraLowPriority
-      EvaluationPeriods: 5
-      DatapointsToAlarm: 3
-      # TODO infra: update this threshold and upgrade the alarm to Urgent once
-      # we've collected enough data to make a reasonable estimate of this.
-      Threshold: 5000
-      ComparisonOperator: GreaterThanThreshold
-      TreatMissingData: missing
-      Metrics:
-        - Id: max_evictions
-          Label: Maximum Evictions Among Redis Session Store NOdes
-          ReturnData: true
-          Expression: MAX(METRICS())
-<% (1..num_cache_clusters).each do |cluster_id| -%>
-        - Id: <%= "evictions_#{cluster_id}" %>
-          ReturnData: false
-          MetricStat:
-            Metric:
-              Namespace: AWS/ElastiCache
-              MetricName: Evictions
-              Dimensions:
-                - Name: CacheClusterId
-                  Value: !Sub "${SessionStoreGroup}-<%= cluster_id.to_s.rjust(3, '0') %>"
-            Period: 60
-            Stat: Maximum
-<% end -%>
-  SessionStoreNetworkBytesInAlarm:
-    Type: AWS::CloudWatch::Alarm
-    DependsOn: SessionStoreGroup
     Properties:
       AlarmName: <%="Redis Session Store Incoming Network Traffic Too High (#{stack_name})" %>
       AlarmDescription:
@@ -144,7 +104,6 @@
 <% end -%>
   SessionStoreNetworkBytesOutAlarm:
     Type: AWS::CloudWatch::Alarm
-    DependsOn: SessionStoreGroup
     Properties:
       AlarmName: <%="Redis Session Store Outgoing Network Traffic Too High (#{stack_name})" %>
       AlarmDescription:

--- a/aws/cloudformation/components/session_store.yml.erb
+++ b/aws/cloudformation/components/session_store.yml.erb
@@ -70,6 +70,30 @@
   SessionStoreEvictionsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: <%="Redis Session Store High Eviction Rate (#{stack_name})" %>
+      AlarmDescription: We're seeing a lot of evictions from the Redis session store.
+        A steady amount of evictions is not a bad thing, but a rapid increase in
+        eviction rate could be a sign of other instability.
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref InfraLowPriority
+      MetricName: Evictions
+      Namespace: AWS/ElastiCache
+      Statistic: Maximum
+      Dimensions:
+        - Name: CacheClusterId
+          Value: !Sub "${SessionStoreGroup}-001"
+      Period: 300
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 3
+      # TODO infra: update this threshold and upgrade the alarm to Urgent once
+      # we've confirmed that this threshold and implementation are practical.
+      Threshold: 10000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: missing
+  SessionStoreNetworkBytesInAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
       AlarmName: <%="Redis Session Store Incoming Network Traffic Too High (#{stack_name})" %>
       AlarmDescription:
         The cache.r7g.xlarge nodes we use have a guaranteed performance of "Up


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/60236

After a couple weeks of regular evictions, we have a bit of data on which to base our actual alarm threshold. Unfortunately, the data we have is also pretty spiky so it's going to be a balancing act.

[Looking at the past two weeks of data](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~'AWS*2fElastiCache~'Evictions~'CacheClusterId~'ausxf3ubdbzebgu-001~'CacheNodeId~'0001)~(~'...~'ausxf3ubdbzebgu-002~'.~'.)~(~'...~'ausxf3ubdbzebgu-003~'.~'.))~region~'us-east-1~title~'Evictions~stat~'Maximum~view~'timeSeries~start~'2024-08-07T22*3a40*3a00.000Z~end~'2024-08-21T22*3a41*3a00.000Z~period~300)), I propose we increase the time window to 5 minutes and the threshold to 10k; I believe that should be sufficient to avoid false positives while still allowing us to be notified promptly if something does go wrong.

![image](https://github.com/user-attachments/assets/4f427e91-35c2-478d-9269-867b1636aa72)

I also simplified this metric to only look at the one node in the cluster that actually performs evictions, and removed some unnecessary `DependsOn` directives (according to `cfn-lint`, these alarms' `SessionStoreGroup` dependency is already enforced by the `Ref`s they use).

## Testing story

Tested with `bundle exec rake stack:lint` and `bundle exec rake stack:validate`

## Deployment strategy

This changeset should get deployed automatically by our standard DTP process

## Follow-up work

Once we're confident this isn't going to generate any more false positives, we can update it from `InfraLowPriority` to `InfraUrgent`

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
