### PR TITLE
Music: revive the revived advanced model

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -392,11 +392,15 @@ class UnconnectedMusicView extends React.Component {
   };
 
   getStartSources = () => {
-    if (this.props.levelProperties?.levelData?.startSources) {
-      return this.props.levelProperties?.levelData.startSources;
-    } else {
+    if (getBlockMode() !== BlockMode.SIMPLE2) {
       const startSourcesFilename = 'startSources' + getBlockMode();
       return require(`@cdo/static/music/${startSourcesFilename}.json`);
+    } else if (this.props.levelProperties?.levelData?.startSources) {
+      return this.props.levelProperties?.levelData.startSources;
+    } else {
+      this.props.setPageError({
+        errorMessage: 'Error finding start sources',
+      });
     }
   };
 


### PR DESCRIPTION
This revives the advanced programming model which was last revived in https://github.com/code-dot-org/code-dot-org/pull/57166.  

With this change, when a non-simple2 model is specified, it loads the appropriate start sources for that model.  

This most likely regressed in https://github.com/code-dot-org/code-dot-org/pull/58623 when support for `/projectbeats` was removed.  Until then, the appropriate start sources were being loaded for the specified model when visiting `/projectbeats`.
