### PR TITLE
Logging CAP metrics to default platform

### DIFF
--- a/apps/src/sites/studio/pages/policy_compliance/parental_permission/_modal.js
+++ b/apps/src/sites/studio/pages/policy_compliance/parental_permission/_modal.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider, useSelector} from 'react-redux';
 
-import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {getStore} from '@cdo/apps/redux';
 import ParentalPermissionModal from '@cdo/apps/templates/policy_compliance/ParentalPermissionModal';
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const Modal = ({lockoutDate, inSection}) => {
       const reportEvent = (eventName, payload = {}) => {
         payload.inSection = inSection;
-        analyticsReporter.sendEvent(eventName, payload, PLATFORMS.AMPLITUDE);
+        analyticsReporter.sendEvent(eventName, payload);
       };
 
       const handleClose = parentalPermissionRequest => {

--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsBanner.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsBanner.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 
-import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {RootState} from '@cdo/apps/types/redux';
 import i18n from '@cdo/locale';
@@ -25,7 +25,7 @@ export const AgeGatedStudentsBanner: React.FC<Props> = ({
 }) => {
   const currentUser = useSelector((state: RootState) => state.currentUser);
   const reportEvent = (eventName: string, payload: object = {}) => {
-    analyticsReporter.sendEvent(eventName, payload, PLATFORMS.AMPLITUDE);
+    analyticsReporter.sendEvent(eventName, payload);
   };
 
   useEffect(() => {

--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
@@ -3,7 +3,7 @@ import {connect, useSelector} from 'react-redux';
 
 import Link from '@cdo/apps/componentLibrary/link';
 import Typography from '@cdo/apps/componentLibrary/typography';
-import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import {RootState} from '@cdo/apps/types/redux';
@@ -35,7 +35,7 @@ const AgeGatedStudentsModal: React.FC<Props> = ({
 }) => {
   const currentUser = useSelector((state: RootState) => state.currentUser);
   const reportEvent = (eventName: string, payload: object = {}) => {
-    analyticsReporter.sendEvent(eventName, payload, PLATFORMS.AMPLITUDE);
+    analyticsReporter.sendEvent(eventName, payload);
   };
 
   const helpDocsUrl =

--- a/apps/src/templates/policy_compliance/ChildAccountConsent/index.tsx
+++ b/apps/src/templates/policy_compliance/ChildAccountConsent/index.tsx
@@ -10,13 +10,13 @@ import {
   StrongText,
 } from '@cdo/apps/componentLibrary/typography';
 import Button from '@cdo/apps/legacySharedComponents/Button';
-import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import i18n from '@cdo/locale';
 import './index.scss';
 
 const reportEvent = (eventName: string, payload: object = {}) => {
-  analyticsReporter.sendEvent(eventName, payload, PLATFORMS.AMPLITUDE);
+  analyticsReporter.sendEvent(eventName, payload);
 };
 
 const returnToCdoButton = () => {

--- a/apps/src/templates/policy_compliance/LockoutLinkedAccounts.jsx
+++ b/apps/src/templates/policy_compliance/LockoutLinkedAccounts.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, {useState, useEffect, useReducer} from 'react';
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
-import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import parentalPermissionRequestReducer, {
   REQUEST_PARENTAL_PERMISSION_SUCCESS,
@@ -27,7 +27,7 @@ import {hashString} from '../../utils';
  */
 export default function LockoutLinkedAccounts(props) {
   const reportEvent = (eventName, payload = {}) => {
-    analyticsReporter.sendEvent(eventName, payload, PLATFORMS.AMPLITUDE);
+    analyticsReporter.sendEvent(eventName, payload);
   };
 
   const validateEmail = email => {

--- a/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
+++ b/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
@@ -4,7 +4,7 @@ import React, {useState, useEffect} from 'react';
 import {Fade} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {useSelector} from 'react-redux';
 
-import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {ParentalPermissionRequest} from '@cdo/apps/redux/parentalPermissionRequestReducer';
 import Notification, {
@@ -31,7 +31,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
     .format('ll');
 
   const reportEvent = (eventName: string, payload: object = {}) => {
-    analyticsReporter.sendEvent(eventName, payload, PLATFORMS.AMPLITUDE);
+    analyticsReporter.sendEvent(eventName, payload);
   };
 
   useEffect(() => {

--- a/apps/src/templates/sessions/LockoutPanel.tsx
+++ b/apps/src/templates/sessions/LockoutPanel.tsx
@@ -3,7 +3,7 @@ import React, {CSSProperties, useState, useEffect, useReducer} from 'react';
 import {useSelector} from 'react-redux';
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
-import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import parentalPermissionRequestReducer, {
   REQUEST_PARENTAL_PERMISSION_SUCCESS,
@@ -30,7 +30,7 @@ import {hashString} from '../../utils';
  */
 const LockoutPanel: React.FC<LockoutPanelProps> = props => {
   const reportEvent = (eventName: string, payload: object = {}) => {
-    analyticsReporter.sendEvent(eventName, payload, PLATFORMS.AMPLITUDE);
+    analyticsReporter.sendEvent(eventName, payload);
   };
 
   // Determine if we think the given email matches the child email


### PR DESCRIPTION
For our Child Account Policy (CAP) features, we are logging event metrics to Amplitude. However, our organization looks like it will be transitioning to Statsig instead. This PR changes our CAP metrics to be logged with the [default metrics platform](https://github.com/code-dot-org/code-dot-org/blob/767820502b27d1382bc26968f838354e476363db/apps/src/lib/util/AnalyticsReporter.js#L61) rather than Amplitude.

## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1107)

## Testing story
* Didn't test because the integration with Statsig is already well established.
