### PR TITLE
ChatClient: print messages in dev too

### DIFF
--- a/lib/cdo/chat_client.rb
+++ b/lib/cdo/chat_client.rb
@@ -19,6 +19,10 @@ class ChatClient
     end
   end
 
+  def self.bold_tags_to_terminal_escapes(input)
+    input.gsub(/<b>(.*?)<\/b>/, "\e[1m\\1\e[22m")
+  end
+
   # @param room [String] The room to post to which message should be posted.
   # @param message [String] The message to post. Can also be anything that
   #   responds to the method to_s.
@@ -33,6 +37,7 @@ class ChatClient
       @@logger = Logger.new(deploy_dir('log', 'chat_messages.log'))
     end
     @@logger.info("[#{room}] #{message}")
+    puts bold_tags_to_terminal_escapes message
 
     unless CDO.hip_chat_logging
       return


### PR DESCRIPTION
This PR will make `rake build` and other rake output look the same as it does in #infra-staging and #infra-test.

Currently the messages in #infra-staging, #infra-test etc don't align with local build messages. This lowers the opportunity to passively learn the relationship between the two ("oh, when it prints such and such a message remotely, that correlates with this point locally"), which makes the remote build more of a mystery.

This PR puts CatClient messages to stdout as well. Because we use the <b> tag, it converts <b> tags to bold terminal escape codes.