### PR TITLE
Document [test eyes] to make drone run eyes tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -96,7 +96,7 @@ You can get a local coverage report with
 
 
 ### UI Tests and Eyes Tests
-We have a set of integration tests, divided into "UI tests" (Selenium+Cucumber) and "Eyes tests" (Selenium+Cucumber+Applitools).  These tests live in [dashboard/test/ui](dashboard/test/ui) - for information on setting up and running these tests, see [the README in that directory](dashboard/test/ui) and our [guide to adding an eyes test](docs/testing-with-applitools-eyes.md).
+We have a set of integration tests, divided into "UI tests" (Selenium+Cucumber) and "Eyes tests" (Selenium+Cucumber+Applitools).  These tests live in [dashboard/test/ui](dashboard/test/ui) - for information on setting up and running these tests, see [the README in that directory](dashboard/test/ui/README.md) and our [guide to adding an eyes test](docs/testing-with-applitools-eyes.md).
 Or you can just use this shortcut (after you've installed chromedriver):
 
 `bundle exec rake test:ui feature=dashboard/test/ui/features/sometest.feature`

--- a/TESTING.md
+++ b/TESTING.md
@@ -101,6 +101,10 @@ Or you can just use this shortcut (after you've installed chromedriver):
 
 `bundle exec rake test:ui feature=dashboard/test/ui/features/sometest.feature`
 
+#### Running eyes tests from Drone CI
+
+If you'd like our CI to run all eyes tests on your PR using Saucelabs, include the string "[test eyes]" in your commit message.
+
 ### Shared and Lib Tests
 Tests in the `shared/` and `lib/` directories need to be run slightly differently since they are outside of our Rails environment.
 

--- a/dashboard/test/ui/README.md
+++ b/dashboard/test/ui/README.md
@@ -115,6 +115,7 @@ Run **eyes tests** on one feature in one saucelabs browser against your local ma
 - If you're new to [Cucumber](https://cucumber.io), read about [Cucumber scenarios](https://cucumber.io/docs/guides/overview/), especially the keywords [Given When Then](https://cucumber.io/docs/gherkin/reference/).
 - When debugging test scripts, it can be helpful to add pauses, such as: `And I wait for 5 seconds`.
 - If you're missing data locally, try running `bundle exec rake seed:ui_test` from the dashboard directory
+- If you'd like eyes tests to run from Drone CI, include the string `[test eyes]` in your commit message.
 
 ## See Also
 


### PR DESCRIPTION
If you push a commit to a PR that includes the string `[test eyes]` in the commit message, drone will run eyes tests. This feature is underdocumented and hard to discover.