### PR TITLE
Deprecate custom workshops from CSD course in workshop dashboard

### DIFF
--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -112,8 +112,7 @@ module Pd
         SUBJECT_CSD_WORKSHOP_1_2 = SUBJECT_WORKSHOP_1_2,
         SUBJECT_CSD_WORKSHOP_3_4 = SUBJECT_WORKSHOP_3_4,
         SUBJECT_CSD_TEACHER_CON = SUBJECT_TEACHER_CON,
-        SUBJECT_CSD_FIT = SUBJECT_FIT,
-        SUBJECT_CSD_CUSTOM_WORKSHOP = SUBJECT_CUSTOM_WORKSHOP
+        SUBJECT_CSD_FIT = SUBJECT_FIT
       ],
       COURSE_CSF => [
         SUBJECT_CSF_101,
@@ -242,7 +241,8 @@ module Pd
         LEGACY_SUBJECT_CSD_VIRTUAL_5 = 'Virtual Workshop 5'.freeze,
         LEGACY_SUBJECT_CSD_VIRTUAL_6 = 'Virtual Workshop 6'.freeze,
         LEGACY_SUBJECT_CSD_VIRTUAL_7 = 'Virtual Workshop 7'.freeze,
-        LEGACY_SUBJECT_CSD_VIRTUAL_8 = 'Virtual Workshop 8'.freeze
+        LEGACY_SUBJECT_CSD_VIRTUAL_8 = 'Virtual Workshop 8'.freeze,
+        SUBJECT_CSD_CUSTOM_WORKSHOP = SUBJECT_CUSTOM_WORKSHOP
       ]
     }.freeze
 


### PR DESCRIPTION
I tried to deprecate more subjects in https://github.com/code-dot-org/code-dot-org/pull/60522 but other subjects have a bunch of other debt we need to remove so just reducing to removing custom workshops subject for now.
