### PR TITLE
[Aichat] aichat workspace and model customizations panels are screen reader-accessible/keyboard-navigable

### DIFF
--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -70,6 +70,9 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
             hasDangerStyle && moduleStyles.danger,
             hasWarningStyle && moduleStyles.warning
           )}
+          aria-label={
+            role === Role.ASSISTANT ? 'AI bot' : 'User' + ' chat message'
+          }
         >
           <SafeMarkdown markdown={getDisplayText} />
         </div>


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds an aria label to `ChatMessage` to help screen reader-users between chat messages from the user and from the AI chatbot. I also document the process to test that the `aichat` workspace and model customization panels are screen reader-accessible and keyboard-navigable.

I learned that elements that are not actionable should NOT be tab-navigable. Using the [Chrome screenreader extension](https://chromewebstore.google.com/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn), I confirmed that chat events in the `aichat` workspace are keyboard-navigable (with up/down arrow buttons).

See screencast video below (Macbook on Chrome using Chrome Vox screen reader extension - uses command-ctrl-up/down keys):

https://github.com/user-attachments/assets/ae5a7b80-ab27-4e91-bdae-20d8df577e7c

Note that I also tested on a Windows pc on Chrome using the same extension, and unsure why but the arrow navigation did not work. So I downloaded the free NVDA screen reader (NVDA can only be used on Windows) and confirmed that the chat messages were keyboard-navigable with arrows and screen reader accessible on a Windows PC. I was able to update the NVDA settings to visually highlight the focused chat event.

See screencast video below (Windows on Chrome using NVDA screen reader):


https://github.com/user-attachments/assets/10a81785-3da8-4a9f-965c-a26313467bba



I tested that the model customization panels are keyboard-navigable and screenreader-accessible.
Screencast video (Macbook on Chrome using Chrome Vox screen reader extension):



https://github.com/user-attachments/assets/3c8cf354-17bb-4d7e-b9ee-6d6aa01d16dc



Screencast video (Windows on Chrome using NVDA screen reader):


https://github.com/user-attachments/assets/2ea0a847-6b4e-47cd-af7e-31e0c297538d




I also ran the [axe DevTools scan](https://docs.google.com/document/d/12PA_NSapLo7y8Ks_tx3SsiAdJVpfJegdhzfZ9iwX0Lg/edit) on an`aichat` level. Focusing on elements specific to `aichat` lab levels, these were the listed issues:

- Buttons must have discernible text -> These were the tooltip buttons which include only the 'info' icon.
- Form elements must have labels -> temperature input has customized field label.

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-790) - chat workspace
[jira](https://codedotorg.atlassian.net/browse/LABS-793) - customization panel

[Slack thread](https://codedotorg.slack.com/archives/C9MB4CL07/p1724277725763929) in which I learned that read-only elements should not be tab-navigable.

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
