### PR TITLE
fix(lti): do not hide the save/cancel button for lti login type

### DIFF
--- a/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
@@ -219,7 +219,7 @@ class ManageStudentsActionsCell extends Component {
 
     return (
       <div>
-        {!isEditing && (
+        {!isEditing && loginType !== SectionLoginType.lti_v1 && (
           <QuickActionsCell>
             {this.props.canEdit && (
               <PopUpMenu.Item onClick={this.onEdit}>

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -74,6 +74,7 @@ const LOGIN_TYPES_WITH_ACTIONS_COLUMN = [
   SectionLoginType.email,
   SectionLoginType.google_classroom,
   SectionLoginType.clever,
+  SectionLoginType.lti_v1,
 ];
 const LOGIN_TYPES_WITH_GENDER_COLUMN = [
   SectionLoginType.word,
@@ -215,10 +216,7 @@ class ManageStudentsTable extends Component {
 
   shouldShowActionColumn() {
     const {loginType} = this.props;
-    return (
-      LOGIN_TYPES_WITH_ACTIONS_COLUMN.includes(loginType) ||
-      (loginType === SectionLoginType.lti_v1 && !this.props.syncEnabled)
-    );
+    return LOGIN_TYPES_WITH_ACTIONS_COLUMN.includes(loginType);
   }
 
   // Cell formatters.

--- a/apps/test/unit/templates/manageStudents/ManageStudentsActionsCellTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsActionsCellTest.js
@@ -4,6 +4,7 @@ import React from 'react';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import {UnconnectedManageStudentsActionsCell as ManageStudentsActionsCell} from '@cdo/apps/templates/manageStudents/ManageStudentsActionsCell';
+import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
 
 import {expect} from '../../../util/deprecatedChai'; // eslint-disable-line no-restricted-imports
 
@@ -64,6 +65,16 @@ describe('ManageStudentsActionsCell', () => {
   it('does not render the edit option when canEdit is false', () => {
     const wrapper = shallow(
       <ManageStudentsActionsCell {...DEFAULT_PROPS} canEdit={false} />
+    );
+    expect(wrapper).not.to.contain('Edit');
+  });
+
+  it('does not render the edit option when loginType is lti', () => {
+    const wrapper = shallow(
+      <ManageStudentsActionsCell
+        {...DEFAULT_PROPS}
+        loginType={SectionLoginType.lti_v1}
+      />
     );
     expect(wrapper).not.to.contain('Edit');
   });

--- a/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
@@ -12,7 +12,6 @@ import {
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import CodeReviewGroupsDialog from '@cdo/apps/templates/manageStudents/CodeReviewGroupsDialog';
 import ManageStudentsActionsCell from '@cdo/apps/templates/manageStudents/ManageStudentsActionsCell';
-import ManageStudentActionsHeaderCell from '@cdo/apps/templates/manageStudents/ManageStudentsActionsHeaderCell';
 import ManageStudentFamilyNameCell from '@cdo/apps/templates/manageStudents/ManageStudentsFamilyNameCell';
 import ManageStudentsGenderCell from '@cdo/apps/templates/manageStudents/ManageStudentsGenderCell';
 import ManageStudentNameCell from '@cdo/apps/templates/manageStudents/ManageStudentsNameCell';
@@ -189,36 +188,6 @@ describe('ManageStudentsTable', () => {
           }
         />
       );
-    });
-
-    describe('LTI section tests', () => {
-      it('does not render the Actions column if loginType is lti_v1 and sync is enabled', () => {
-        const store = getStore();
-        store.dispatch(setLoginType(SectionLoginType.lti_v1));
-        store.dispatch(setSections([{...fakeSection, sync_enabled: true}]));
-        const wrapper = mount(
-          <Provider store={store}>
-            <ManageStudentsTable />
-          </Provider>
-        );
-
-        expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be
-          .false;
-      });
-
-      it('does render the Actions column if loginType is lti_v1 and sync is disabled', () => {
-        const store = getStore();
-        store.dispatch(setLoginType(SectionLoginType.lti_v1));
-        store.dispatch(setSections([{...fakeSection, sync_enabled: false}]));
-        const wrapper = mount(
-          <Provider store={store}>
-            <ManageStudentsTable />
-          </Provider>
-        );
-
-        expect(wrapper.find(ManageStudentActionsHeaderCell).exists()).to.be
-          .true;
-      });
     });
 
     describe('Gender field feature flag', () => {


### PR DESCRIPTION
For LTI managed sections, the intention is to hide the student edit/delete button but not the save/cancel button for sharing. This would cause the save/cancel button to not show up resulting in the inability for users to save their sharing preferences.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [jira](https://codedotorg.atlassian.net/browse/P20-1097)
- [slack thread](https://codedotorg.slack.com/archives/C061VNB3YE9/p1724189294295359)

## Testing story

![image](https://github.com/user-attachments/assets/60559f21-d2a1-4c32-8d36-b990383b8578)

Expected: Can save the sharing settings

![image](https://github.com/user-attachments/assets/6ddae11b-0a5b-4261-aa5d-76a2f7660034)

Expected: Cannot delete or edit students


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
