### PR TITLE
Fix age popup loop

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -296,7 +296,7 @@ class RegistrationsController < Devise::RegistrationsController
 
     student_information[:age] = params[:user][:age] if current_user.age.blank?
     us_state_param = params[:user][:us_state]
-    student_information[:us_state] = us_state_param if us_state_param && !current_user.user_provided_us_state
+    student_information[:us_state] = us_state_param if us_state_param.present? && !current_user.user_provided_us_state
     student_information[:user_provided_us_state] = params[:user][:us_state].present? unless current_user.user_provided_us_state
     student_information[:gender_student_input] = params[:user][:gender_student_input] if current_user.gender.blank?
     student_information[:country_code] = params[:user][:country_code] if current_user.country_code.blank?

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -295,11 +295,11 @@ class RegistrationsController < Devise::RegistrationsController
     student_information = {}
 
     student_information[:age] = params[:user][:age] if current_user.age.blank?
-    student_information[:us_state] = params[:user][:us_state] unless current_user.user_provided_us_state
+    us_state_param = params[:user][:us_state]
+    student_information[:us_state] = us_state_param if us_state_param && !current_user.user_provided_us_state
     student_information[:user_provided_us_state] = params[:user][:us_state].present? unless current_user.user_provided_us_state
     student_information[:gender_student_input] = params[:user][:gender_student_input] if current_user.gender.blank?
     student_information[:country_code] = params[:user][:country_code] if current_user.country_code.blank?
-
     current_user.update(student_information) unless student_information.empty?
   end
 

--- a/dashboard/test/integration/registration/set_student_information_test.rb
+++ b/dashboard/test/integration/registration/set_student_information_test.rb
@@ -76,5 +76,16 @@ module RegistrationsControllerTests
       assert_equal 'm', student.gender
       assert_equal 'US', student.country_code
     end
+
+    test "set_student_information sets age if user has user_provided_us_state set to false" do
+      student = create :student
+      student.update!(birthday: nil, age: nil, country_code: 'RD')
+      sign_in student
+
+      patch '/users/set_student_information', params: {user: {age: '10'}}
+      assert_response :success
+
+      assert_equal 10, student.reload.age
+    end
   end
 end


### PR DESCRIPTION
Some users are experiencing a loop where the age popup will return every time they visit a new page. This appears to happen when the `set_student_information` route tries to update the user record with a nil value for `us_state`, but with other conditions met for the user model to validate the presence of `us_state`. In these cases, the update fails, but since we are using `update` instead of `update!`, the error is swallowed. This PR changes the function to only set us_state in the update params if the us_state param is present. I decided not to change to `update!`, to avoid users getting stuck on the popup if another similar case exists that we haven't encountered yet. Open to feedback here if folks would rather change to throwing an error if the validation fails.

Here's an example of calling `update!` with a set of properties that passes without error if a normal `update` is called:
```
[development] dashboard > u.update!({:age=>"10", :us_state=>nil, :user_provided_us_state=>false, :gender_student_input=>nil})
  TRANSACTION (0.4ms)  BEGIN
  AuthenticationOption Exists? (0.9ms)  SELECT 1 AS one FROM `authentication_options` WHERE `authentication_options`.`authentication_id` = BINARY '985ecfa311c95bc3c76ccc19a70d38c2' AND `authentication_options`.`deleted_at` IS NULL AND `authentication_options`.`id` != 388 AND `authentication_options`.`credential_type` = 'email' AND `authentication_options`.`deleted_at` IS NULL LIMIT 1
  AuthenticationOption Exists? (0.5ms)  SELECT 1 AS one FROM `authentication_options` WHERE `authentication_options`.`authentication_id` = BINARY '985ecfa311c95bc3c76ccc19a70d38c2' AND `authentication_options`.`deleted_at` IS NULL AND `authentication_options`.`id` != 388 AND `authentication_options`.`credential_type` = 'email' AND `authentication_options`.`deleted_at` IS NULL LIMIT 1
  TRANSACTION (1.4ms)  ROLLBACK
/Users/creiner/.asdf/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/activerecord-6.1.7.7/lib/active_record/validations.rb:80:in `raise_validation_error': Validation failed: State is required (ActiveRecord::RecordInvalid)
```

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1102)
Various zendesk tickets

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
