### PR TITLE
Music: fix for levels with no start sources

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -392,15 +392,14 @@ class UnconnectedMusicView extends React.Component {
   };
 
   getStartSources = () => {
-    if (getBlockMode() !== BlockMode.SIMPLE2) {
+    if (
+      getBlockMode() !== BlockMode.SIMPLE2 ||
+      !this.props.levelProperties?.levelData?.startSources
+    ) {
       const startSourcesFilename = 'startSources' + getBlockMode();
       return require(`@cdo/static/music/${startSourcesFilename}.json`);
-    } else if (this.props.levelProperties?.levelData?.startSources) {
-      return this.props.levelProperties?.levelData.startSources;
     } else {
-      this.props.setPageError({
-        errorMessage: 'Error finding start sources',
-      });
+      return this.props.levelProperties?.levelData.startSources;
     }
   };
 


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/60574 which fixes an error in levels that don't provide their own `startSources`. 