### PR TITLE
Add error messages for new teacher sign-up page

### DIFF
--- a/apps/i18n/signup/en_us.json
+++ b/apps/i18n/signup/en_us.json
@@ -56,5 +56,6 @@
   "msCoder": "Ms. Coder",
   "coder": "Coder",
   "female": "Female",
-  "parentEmailPlaceholder": "parentemail@email.com"
+  "parentEmailPlaceholder": "parentemail@email.com",
+  "display_name_error_message": "Please enter your display name"
 }

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -22,12 +22,19 @@ const FinishTeacherAccount: React.FunctionComponent<{
   usIp: boolean;
 }> = ({usIp}) => {
   const [name, setName] = useState('');
+  const [showNameError, setShowNameError] = useState(false);
   const [emailOptInChecked, setEmailOptInChecked] = useState(false);
 
   const onNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const newName = e.target.value;
     setName(newName);
     sessionStorage.setItem(DISPLAY_NAME_SESSION_KEY, newName);
+
+    if (newName === '') {
+      setShowNameError(true);
+    } else {
+      setShowNameError(false);
+    }
   };
 
   const onEmailOptInChange = (): void => {
@@ -55,9 +62,14 @@ const FinishTeacherAccount: React.FunctionComponent<{
             placeholder={locale.msCoder()}
             onChange={onNameChange}
           />
-          <BodyThreeText>
+          <BodyThreeText className={style.displayNameSubtext}>
             {locale.this_is_what_your_students_will_see()}
           </BodyThreeText>
+          {showNameError && (
+            <BodyThreeText className={style.errorMessage}>
+              {locale.display_name_error_message()}
+            </BodyThreeText>
+          )}
         </div>
         <SchoolDataInputs usIp={usIp} includeHeaders={false} />
         <div>
@@ -88,6 +100,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
             iconStyle: 'solid',
             title: 'arrow-right',
           }}
+          disabled={name === ''}
         />
       </div>
     </div>

--- a/apps/src/signUpFlow/signUpFlowStyles.module.scss
+++ b/apps/src/signUpFlow/signUpFlowStyles.module.scss
@@ -51,6 +51,11 @@ span {
   }
 }
 
+.errorMessage {
+  margin-top: 0.4375rem;
+  color: $light_negative_500;
+}
+
 
 // Login Type Selection page
 
@@ -373,6 +378,10 @@ span {
 
 .teacherKeepMeUpdated {
   margin-bottom: 0.375rem !important;
+}
+
+.displayNameSubtext {
+  margin-top: 0.125rem;
 }
 
 .emailOptInFootnote {

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -116,4 +116,48 @@ describe('FinishTeacherAccount', () => {
     fireEvent.click(emailOptInCheckbox);
     expect(sessionStorage.getItem(EMAIL_OPT_IN_SESSION_KEY)).toBe('false');
   });
+
+  it('finish teacher signup button starts disabled', () => {
+    renderDefault();
+
+    // Link will show as "null" for React Testing Library since the component is disabled
+    expect(
+      screen.queryByRole('link', {
+        name: locale.go_to_my_account(),
+      })
+    ).toBe(null);
+  });
+
+  it('leaving the displayName field empty shows error message and disabled button until display name is entered', () => {
+    renderDefault();
+    const displayNameInput = screen.getAllByDisplayValue('')[0];
+
+    // Error message doesn't show and button is disabled by default
+    expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
+    expect(
+      screen.queryByRole('link', {
+        name: locale.go_to_my_account(),
+      })
+    ).toBe(null);
+
+    // Enter display name
+    fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
+
+    // Error does not show and button is enabled when display name is entered
+    expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
+    screen.getByRole('link', {
+      name: locale.go_to_my_account(),
+    });
+
+    // Clear display name
+    fireEvent.change(displayNameInput, {target: {value: ''}});
+
+    // Error shows and button is disabled with empty display name
+    screen.getByText(locale.display_name_error_message());
+    expect(
+      screen.queryByRole('link', {
+        name: locale.go_to_my_account(),
+      })
+    ).toBe(null);
+  });
 });

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -120,44 +120,35 @@ describe('FinishTeacherAccount', () => {
   it('finish teacher signup button starts disabled', () => {
     renderDefault();
 
-    // Link will show as "null" for React Testing Library since the component is disabled
-    expect(
-      screen.queryByRole('link', {
-        name: locale.go_to_my_account(),
-      })
-    ).toBe(null);
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
   });
 
   it('leaving the displayName field empty shows error message and disabled button until display name is entered', () => {
     renderDefault();
     const displayNameInput = screen.getAllByDisplayValue('')[0];
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
 
     // Error message doesn't show and button is disabled by default
     expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
-    expect(
-      screen.queryByRole('link', {
-        name: locale.go_to_my_account(),
-      })
-    ).toBe(null);
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
 
     // Enter display name
     fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
 
     // Error does not show and button is enabled when display name is entered
     expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
-    screen.getByRole('link', {
-      name: locale.go_to_my_account(),
-    });
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
 
     // Clear display name
     fireEvent.change(displayNameInput, {target: {value: ''}});
 
     // Error shows and button is disabled with empty display name
     screen.getByText(locale.display_name_error_message());
-    expect(
-      screen.queryByRole('link', {
-        name: locale.go_to_my_account(),
-      })
-    ).toBe(null);
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
   });
 });


### PR DESCRIPTION
Adds error messaging for the `displayName` field on the new teacher sign-up page.

### Submit button defaults to grayed out
![starts greyed out](https://github.com/user-attachments/assets/a7ebce84-3700-49f4-8aef-9c6f3614fc80)

### Once user enters a name, button is enabled
![Button is enabled with name](https://github.com/user-attachments/assets/3a012fdf-ecc6-49af-b1e8-e3c8b37c4267)

### If name is then backspaced, button is disabled and error message shows
![Error shows if name is empty](https://github.com/user-attachments/assets/ee509766-19bb-4ee5-8ee8-9f8baabaaa25)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1988)

## Testing story
Local testing and adding unit tests.
