### PR TITLE
hide product tour immediately when tour is closed

### DIFF
--- a/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
@@ -151,10 +151,10 @@ export default function EvidenceLevelsForTeachersV2({
           <BodyFourText>
             {showDescription !== INVALID_UNDERSTANDING
               ? evidenceLevels.find(e => e.understanding === showDescription)
-                  .teacherDescription
+                  ?.teacherDescription
               : understanding >= 0 &&
                 evidenceLevels.find(e => e.understanding === understanding)
-                  .teacherDescription}
+                  ?.teacherDescription}
           </BodyFourText>
         </div>
       </div>

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -139,15 +139,18 @@ export default function RubricContainer({
   const showSettings = onLevelForEvaluation && teacherHasEnabledAi;
 
   // Update the server to indicate that the product tour has been seen.
-  const updateTourStatus = useCallback(() => {
-    setProductTour(false);
-    const bodyData = JSON.stringify({seen: true});
-    const rubricId = rubric.id;
-    const url = `/rubrics/${rubricId}/update_ai_rubrics_tour_seen`;
-    HttpClient.post(url, bodyData, true, {
-      'Content-Type': 'application/json',
-    });
-  }, [rubric.id]);
+  const updateTourStatus = useCallback(
+    visible => {
+      setProductTour(visible);
+      const bodyData = JSON.stringify({seen: !visible});
+      const rubricId = rubric.id;
+      const url = `/rubrics/${rubricId}/update_ai_rubrics_tour_seen`;
+      HttpClient.post(url, bodyData, true, {
+        'Content-Type': 'application/json',
+      });
+    },
+    [rubric.id]
+  );
 
   const getTourStatus = useCallback(() => {
     const rubricId = rubric.id;
@@ -171,7 +174,7 @@ export default function RubricContainer({
 
   const tourRestartHandler = () => {
     tourRestarted.current = true;
-    updateTourStatus();
+    updateTourStatus(true);
     analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_TOUR_RESTARTED, {
       ...(reportingData || {}),
     });
@@ -189,7 +192,7 @@ export default function RubricContainer({
   };
 
   const onTourExit = stepIndex => {
-    updateTourStatus();
+    updateTourStatus(false);
     analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_TOUR_CLOSED, {
       ...(reportingData || {}),
       step: stepIndex,
@@ -197,7 +200,7 @@ export default function RubricContainer({
   };
 
   const onTourComplete = () => {
-    updateTourStatus();
+    updateTourStatus(false);
     analyticsReporter.sendEvent(EVENTS.TA_RUBRIC_TOUR_COMPLETE, {
       ...(reportingData || {}),
     });

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -138,24 +138,16 @@ export default function RubricContainer({
   // add more functionality to the settings tab.
   const showSettings = onLevelForEvaluation && teacherHasEnabledAi;
 
+  // Update the server to indicate that the product tour has been seen.
   const updateTourStatus = useCallback(() => {
-    const bodyData = JSON.stringify({seen: productTour});
+    setProductTour(false);
+    const bodyData = JSON.stringify({seen: true});
     const rubricId = rubric.id;
     const url = `/rubrics/${rubricId}/update_ai_rubrics_tour_seen`;
     HttpClient.post(url, bodyData, true, {
       'Content-Type': 'application/json',
-    })
-      .then(response => {
-        return response.json();
-      })
-      .then(json => {
-        if (json['seen']) {
-          setProductTour(false);
-        } else {
-          setProductTour(true);
-        }
-      });
-  }, [rubric.id, productTour]);
+    });
+  }, [rubric.id]);
 
   const getTourStatus = useCallback(() => {
     const rubricId = rubric.id;


### PR DESCRIPTION
Speculative fix for https://codedotorg.atlassian.net/browse/AITT-719. Previous attempt was not successful: https://github.com/code-dot-org/code-dot-org/pull/60365

the saucelabs links in the Jira ticket above was captured during a test failure during a DTT. in that video, you can see that the product tour is closed via the `x` button, then opens again a few seconds later. 

I was not able to repro locally. To better simulate the DTT environment, I created an adhoc and added an artificial delay of 5 seconds to the `update_ai_rubrics_tour_seen` route on the server. In those conditions, the problem reproduces reliably:

https://github.com/user-attachments/assets/00e58e95-0fc0-4cd3-ad4f-a826af893b54

There are two problems that can be seen in the video:
1. the product tour is not hidden in the UI until the ajax request to `update_ai_rubrics_tour_seen` is complete
2. for some reason, the product tour fires onTourExit a second time. when it does, this toggles the visibility of the tour (rather than setting it to hidden), causing it to become visible again

The fix addresses these two issues:
1. when the tour exits or completes, always set the tour to hidden, rather than toggling it
2. hide the tour immediately upon tour exit / completion, rather than waiting for the server round trip to complete

## Testing story

I was able to verify the issue is resolved by pushing my fix to the adhoc branch:


https://github.com/user-attachments/assets/96e457d5-1374-4dc8-bb9c-8ec1b69feb1a

