### PR TITLE
Fix teacher_dashboard test

### DIFF
--- a/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
+++ b/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
@@ -15,6 +15,7 @@ const BorderedCallToAction = ({
   buttonUrl,
   buttonClass,
   buttonColor,
+  buttonDisabled = false,
   onClick,
   solidBorder,
 }) => {
@@ -39,6 +40,7 @@ const BorderedCallToAction = ({
         text={buttonText}
         href={buttonUrl}
         useAsLink={!!buttonUrl}
+        disabled={buttonDisabled}
       />
     </div>
   );
@@ -55,6 +57,7 @@ BorderedCallToAction.propTypes = {
   buttonColor: PropTypes.string,
   onClick: PropTypes.func,
   solidBorder: PropTypes.bool,
+  buttonDisabled: PropTypes.bool,
 };
 
 export default BorderedCallToAction;

--- a/apps/src/templates/studioHomepages/SetUpSections.jsx
+++ b/apps/src/templates/studioHomepages/SetUpSections.jsx
@@ -19,6 +19,7 @@ class SetUpSections extends Component {
     headingText: PropTypes.string,
     descriptionText: PropTypes.string,
     solidBorder: PropTypes.bool,
+    asyncLoadComplete: PropTypes.bool,
   };
 
   // Wrapped to avoid passing event args
@@ -42,6 +43,7 @@ class SetUpSections extends Component {
         buttonText={i18n.createSection()}
         className="uitest-set-up-sections"
         buttonClass="uitest-newsection"
+        buttonDisabled={!this.props.asyncLoadComplete}
         onClick={this.beginEditingSection}
         solidBorder={this.props.solidBorder || false}
       />
@@ -49,6 +51,11 @@ class SetUpSections extends Component {
   }
 }
 export const UnconnectedSetUpSections = SetUpSections;
-export default connect(undefined, {
-  beginEditingSection,
-})(SetUpSections);
+export default connect(
+  state => ({
+    asyncLoadComplete: state.teacherSections.asyncLoadComplete,
+  }),
+  {
+    beginEditingSection,
+  }
+)(SetUpSections);

--- a/apps/src/templates/studioHomepages/SetUpSections.story.jsx
+++ b/apps/src/templates/studioHomepages/SetUpSections.story.jsx
@@ -4,7 +4,7 @@ import {Provider} from 'react-redux';
 
 import {reduxStore} from '@cdo/storybook/decorators';
 
-import SetUpSections from './SetUpSections';
+import SetUpSections, {UnconnectedSetUpSections} from './SetUpSections';
 
 export default {
   component: SetUpSections,
@@ -12,7 +12,7 @@ export default {
 
 const Template = args => (
   <Provider store={reduxStore()}>
-    <SetUpSections
+    <UnconnectedSetUpSections
       beginEditingSection={action('beginEditingSection')}
       asyncLoadComplete={true}
       {...args}

--- a/apps/src/templates/studioHomepages/SetUpSections.story.jsx
+++ b/apps/src/templates/studioHomepages/SetUpSections.story.jsx
@@ -14,6 +14,7 @@ const Template = args => (
   <Provider store={reduxStore()}>
     <SetUpSections
       beginEditingSection={action('beginEditingSection')}
+      asyncLoadComplete={true}
       {...args}
     />
   </Provider>

--- a/apps/test/unit/templates/studioHomepages/SetUpSectionsTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpSectionsTest.jsx
@@ -1,44 +1,45 @@
-import {shallow, mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {fireEvent, render, screen} from '@testing-library/react';
 import React from 'react';
 
 import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import BorderedCallToAction from '@cdo/apps/templates/studioHomepages/BorderedCallToAction';
 import {UnconnectedSetUpSections as SetUpSections} from '@cdo/apps/templates/studioHomepages/SetUpSections';
 
 describe('SetUpSections', () => {
   it('renders as expected', () => {
-    const wrapper = shallow(<SetUpSections beginEditingSection={() => {}} />);
-    const instance = wrapper.instance();
-
-    expect(
-      wrapper.containsMatchingElement(
-        <BorderedCallToAction
-          type="sections"
-          headingText="Set up your classroom"
-          descriptionText="Create a new classroom section to start assigning courses and seeing your student progress."
-          buttonText="Create a section"
-          onClick={instance.beginEditingSection}
-        />
-      )
+    render(
+      <SetUpSections beginEditingSection={() => {}} asyncLoadComplete={true} />
     );
+
+    screen.getByText('Add a new classroom section');
+    screen.getByText(
+      'Create a new classroom section to start assigning courses and seeing your student progress.'
+    );
+    screen.getByRole('button', {name: 'Create a section'});
   });
 
   it('calls beginEditingSection with no arguments when button is clicked', () => {
     const spy = jest.fn();
-    const wrapper = mount(<SetUpSections beginEditingSection={spy} />);
+    render(
+      <SetUpSections beginEditingSection={spy} asyncLoadComplete={true} />
+    );
     expect(spy).not.toHaveBeenCalled();
 
-    wrapper.find('button').simulate('click', {fake: 'event'});
+    const button = screen.getByRole('button', {name: 'Create a section'});
+    fireEvent.click(button);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy.mock.calls[0]).toHaveLength(0);
   });
 
   it('sends start event when button is clicked', () => {
-    const wrapper = mount(<SetUpSections beginEditingSection={() => {}} />);
+    render(
+      <SetUpSections beginEditingSection={() => {}} asyncLoadComplete={true} />
+    );
     const analyticsSpy = jest.spyOn(analyticsReporter, 'sendEvent').mockClear();
 
-    wrapper.find('button').simulate('click', {fake: 'event'});
+    const button = screen.getByRole('button', {name: 'Create a section'});
+    fireEvent.click(button);
+
     expect(analyticsSpy).toHaveBeenCalledTimes(1);
     expect(analyticsSpy.mock.calls[0]).toEqual([
       'Section Setup Started',
@@ -47,5 +48,14 @@ describe('SetUpSections', () => {
     ]);
 
     analyticsSpy.mockRestore();
+  });
+
+  it('has disabled button if asyncLoadComplete is false', () => {
+    render(
+      <SetUpSections beginEditingSection={() => {}} asyncLoadComplete={false} />
+    );
+    expect(
+      screen.getByRole('button', {name: 'Create a section'})
+    ).toBeDisabled();
   });
 });

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -203,6 +203,7 @@ end
 When /^I press the new section button$/ do
   steps <<-GHERKIN
     Given I scroll the ".uitest-newsection" element into view
+    Then I wait until ".uitest-newsection" is not disabled
     When I press the first ".uitest-newsection" element
   GHERKIN
 end

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
@@ -293,7 +293,6 @@ Feature: Using the teacher dashboard
     And I wait until element "#uitest-course-dropdown" is visible
     And I select the "All the Things! *" option in dropdown "uitest-course-dropdown"
 
-  @skip
   @eyes
   Scenario: Teacher can view more tiles when clicking on view more button
     When I open my eyes to test "teacher dashboard"


### PR DESCRIPTION
teacher_dashboard UI test was very flaky and was disabled. This PR tries to fix the flakiness.

The flakiness was happening because:
* The test clicks `Create a section` as soon as the teacher homepage is loaded
* IF this happens before all sections are done loaded, the dialog opens up with a spinner
* When sections are done loading, it displays the normal dialog to create a section, BUT it does not populate necessary information from the loaded sections because that is done on dialog open
* This means that it shows the participant type question instead of skipping it if there is only one available participant type
* The test fails because it doesn't know it needs to click the participant type

With participant type question:
![image](https://github.com/user-attachments/assets/031f9372-42e4-4fbf-bb84-46401b640de2)


Without participant type question (or after clicking the only option:
![image](https://github.com/user-attachments/assets/354cbc33-9daa-4a9d-85fd-14ceef54a700)

Fix:
* Disable the button while sections are loading. There is no reason to be able to click the `create a section button` while sections are loading as it will just show a spinner.

Alternative considered:
* Set the necessary state when load is done if the dialog is open. I found this to be more cumbersome and a worse user experience than just disabling the button.

## Links
Slack thread disabling test: https://codedotorg.slack.com/archives/C045UAX4WKH/p1724435656116079
https://codedotorg.atlassian.net/browse/TEACH-1260
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Manual testing:
* Button is disabled on load
* Button is not disabled when loaded
* Button is not disabled for new teachers with no sections
