### PR TITLE
Fix editing courses with unit_groups instead of units

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -462,6 +462,10 @@ class UnitGroup < ApplicationRecord
 
   # @param user [User]
   # @return [Boolean] Whether the user can view the course.
+
+  # locale_code is added so that it matches the signature of `unit.can_view_version?`.
+  # This is necessary because course_version.content_root is either a unit or a unit_group
+  # and script.summarize_for_unit_edit calls `can_view_version?` on the content_root with two arguments.
   def can_view_version?(user = nil, locale_code = 'en-us')
     return false unless Ability.new(user).can?(:read, self)
 

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -462,7 +462,7 @@ class UnitGroup < ApplicationRecord
 
   # @param user [User]
   # @return [Boolean] Whether the user can view the course.
-  def can_view_version?(user = nil)
+  def can_view_version?(user = nil, locale_code = 'en-us')
     return false unless Ability.new(user).can?(:read, self)
 
     latest_course_version = UnitGroup.latest_stable_version(family_name)


### PR DESCRIPTION
Editing courses that use unit_groups instead of units throws the following error:
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/cc59cade-ab53-4f45-a7de-4b9ada3de477">

This is because course_version.content_root is either a unit or a unit_group and script.summarize_for_unit_edit calls `can_view_version?` on the content_root with two arguments.

This PR adds a second argument (that isn't used and has a default value) to `unit_group.can_view_version?`

## Links
[Slack discussion](https://codedotorg.slack.com/archives/C036XVC3CBF/p1724266383134409)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
