### PR TITLE
P20-1073: Implement warning sender for teachers regarding sections with CAP-affected students

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ group :development, :test do
   # For unit testing.
   gem 'webmock', '~> 3.8', require: false
 
+  gem 'faker', '~> 3.4', require: false
   gem 'fakeredis', require: false
   gem 'mocha', require: false
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,6 +371,8 @@ GEM
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
     fakefs (2.5.0)
+    faker (3.4.2)
+      i18n (>= 1.8.11, < 2)
     fakeredis (0.9.2)
       redis (~> 4.8)
     faraday (1.10.3)
@@ -979,6 +981,7 @@ DEPENDENCIES
   eyes_selenium (= 3.18.4)
   factory_bot_rails (~> 6.2)
   fakefs (~> 2.5.0)
+  faker (~> 3.4)
   fakeredis
   full-name-splitter!
   gemoji

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -646,6 +646,7 @@ mailgun_api_key:
 active_job_queues:
   :default: :default
   :mailers: :mailers
+  :mailjet: :mailjet
 
 # ActiveJob Queue Adapter
 active_job_queue_adapter: :delayed_job

--- a/dashboard/app/jobs/application_job.rb
+++ b/dashboard/app/jobs/application_job.rb
@@ -1,5 +1,7 @@
 class ApplicationJob < ActiveJob::Base
   include ActiveJobMetrics
+  include ActiveJobReporting
+
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked
 

--- a/dashboard/app/jobs/cap/lockout_job.rb
+++ b/dashboard/app/jobs/cap/lockout_job.rb
@@ -32,17 +32,5 @@ module CAP
       # in case the reason is a re-estimation of the user's lockout date.
       self.class.schedule_for(user, reschedules: reschedules.pred) unless user_is_locked_out || reschedules <= 0
     end
-
-    private def report_exception(exception)
-      Honeybadger.notify(
-        exception,
-        error_message: '[CAP::LockoutJob] Runtime error',
-        context: {
-          job: as_json,
-        }
-      )
-    ensure
-      raise exception
-    end
   end
 end

--- a/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
+++ b/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module CAP
+  class TeacherSectionsWarningJob < ApplicationJob
+    rescue_from StandardError, with: :report_exception
+
+    def perform
+      teachers.find_each do |teacher|
+        teacher_cap_affected_sections = cap_affected_sections.where(user: teacher)
+
+        email_template_vars = {
+          capSections: teacher_cap_affected_sections.find_each.map do |section|
+            {
+              Name: section.name,
+              Link: section.manage_students_url,
+            }
+          end
+        }
+
+        MailjetDeliveryJob.perform_later(
+          :cap_section_warning,
+          teacher.email,
+          teacher.name,
+          vars: email_template_vars
+        )
+      end
+    end
+
+    private def cap_affected_sections
+      @cap_affected_sections ||= Queries::Section.cap_affected(
+        period: Policies::ChildAccount::MAX_AGE_GATE_DURATION_TO_STOP_TEACHER_SECTIONS_WARNING.ago..
+      )
+    end
+
+    private def teachers
+      return @teachers if defined? @teachers
+
+      available_emails = DCDO.get('cap_teacher_section_warning_emails', [])
+      return @teachers = User.none if available_emails.blank?
+
+      @teachers = User.where(id: cap_affected_sections.select(:user_id))
+      return @teachers if available_emails.include?('all')
+
+      @teachers = @teachers.where(email: available_emails)
+    end
+  end
+end

--- a/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
+++ b/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
@@ -40,7 +40,7 @@ module CAP
 
     private def cap_affected_sections
       @cap_affected_sections ||= Queries::Section.cap_affected(
-        period: Policies::ChildAccount::MAX_AGE_GATE_DURATION_TO_STOP_TEACHER_SECTIONS_WARNING.ago..
+        period: Policies::ChildAccount::TEACHER_WARNING_PERIOD.ago..
       )
     end
 

--- a/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
+++ b/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
@@ -2,26 +2,38 @@
 
 module CAP
   class TeacherSectionsWarningJob < ApplicationJob
+    EVENT_NAME = 'cap_teacher_sections_warning'
+
     rescue_from StandardError, with: :report_exception
 
     def perform
       teachers.find_each do |teacher|
-        teacher_cap_affected_sections = cap_affected_sections.where(user: teacher)
+        cap_section_ids = []
+        email_cap_sections = []
 
-        email_template_vars = {
-          capSections: teacher_cap_affected_sections.find_each.map do |section|
-            {
-              Name: section.name,
-              Link: section.manage_students_url,
-            }
-          end
-        }
+        cap_affected_sections.where(user: teacher).find_each do |section|
+          cap_section_ids << section.id
+          email_cap_sections << {
+            Name: section.name,
+            Link: section.manage_students_url,
+          }
+        end
 
         MailjetDeliveryJob.perform_later(
           :cap_section_warning,
           teacher.email,
           teacher.name,
-          vars: email_template_vars
+          vars: {
+            capSections: email_cap_sections,
+          }
+        )
+
+        Metrics::Events.log_event(
+          event_name: EVENT_NAME,
+          metadata: {
+            teacher_id: teacher.id,
+            cap_section_ids: cap_section_ids,
+          }
         )
       end
     end

--- a/dashboard/app/jobs/concerns/active_job_reporting.rb
+++ b/dashboard/app/jobs/concerns/active_job_reporting.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'cdo/honeybadger'
+
+module ActiveJobReporting
+  extend ActiveSupport::Concern
+
+  protected def report_exception(exception)
+    Honeybadger.notify(
+      exception,
+      error_message: "[#{self.class}] Runtime error",
+      context: {
+        job: as_json,
+      }
+    )
+  ensure
+    raise exception
+  end
+end

--- a/dashboard/app/jobs/mail_delivery_job.rb
+++ b/dashboard/app/jobs/mail_delivery_job.rb
@@ -10,18 +10,7 @@ require 'cdo/honeybadger'
 # @see https://apidock.com/rails/v6.1.7.7/ActionMailer/MessageDelivery/deliver_later
 class MailDeliveryJob < ActionMailer::MailDeliveryJob
   include ActiveJobMetrics
+  include ActiveJobReporting
 
   rescue_from StandardError, with: :report_exception
-
-  private def report_exception(exception)
-    Honeybadger.notify(
-      exception,
-      error_message: '[MailDeliveryJob] Runtime error',
-      context: {
-        job: as_json,
-      }
-    )
-  ensure
-    raise exception
-  end
 end

--- a/dashboard/app/jobs/mailjet_delivery_job.rb
+++ b/dashboard/app/jobs/mailjet_delivery_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'cdo/mailjet'
+
+# This class is an ActiveJob wrapper for scheduling MailJet email sending.
+class MailjetDeliveryJob < ApplicationJob
+  queue_as CDO.active_job_queues[:mailjet]
+
+  rescue_from StandardError, with: :report_exception
+
+  # @see MailJet.send_email
+  def perform(...)
+    MailJet.send_email(...)
+  end
+end

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -494,7 +494,7 @@ class Section < ApplicationRecord
         linkToCurrentUnit: link_to_current_unit,
         courseVersionName: course_version_name,
         numberOfStudents: num_students,
-        linkToStudents: "#{base_url}#{id}/manage_students",
+        linkToStudents: manage_students_url,
         code: code,
         lesson_extras: lesson_extras,
         pairing_allowed: pairing_allowed,
@@ -527,6 +527,10 @@ class Section < ApplicationRecord
         ai_tutor_enabled: ai_tutor_enabled,
       }
     end
+  end
+
+  def manage_students_url
+    CDO.studio_url("/teacher_dashboard/sections/#{id}/manage_students")
   end
 
   def provider_managed?

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -36,7 +36,7 @@ class Policies::ChildAccount
 
   # The maximum number of days a student should be age-gated before
   # a teacher stops receiving warnings about the sections the student is following.
-  MAX_AGE_GATE_DURATION_TO_STOP_TEACHER_SECTIONS_WARNING = 30.days
+  TEACHER_WARNING_PERIOD = 30.days
 
   # Is this user compliant with our Child Account Policy(cap)?
   # For students under-13, in Colorado, with a personal email login: we require

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -34,6 +34,10 @@ class Policies::ChildAccount
   # The maximum number of times a student can resend a request to a parent.
   MAX_PARENT_PERMISSION_RESENDS = 3
 
+  # The maximum number of days a student should be age-gated before
+  # a teacher stops receiving warnings about the sections the student is following.
+  MAX_AGE_GATE_DURATION_TO_STOP_TEACHER_SECTIONS_WARNING = 30.days
+
   # Is this user compliant with our Child Account Policy(cap)?
   # For students under-13, in Colorado, with a personal email login: we require
   # parent permission before the student can start using their account.

--- a/dashboard/lib/queries/child_account.rb
+++ b/dashboard/lib/queries/child_account.rb
@@ -15,4 +15,13 @@ class Queries::ChildAccount
       cap_status_date: ..expiration_date
     )
   end
+
+  # Selects users who are currently non-compliant with the Child Account Policy.
+  # @param scope {User::ActiveRecord_Relation} The range of users to query.
+  # @return {User::ActiveRecord_Relation} The CAP non-compliant users.
+  def self.cap_affected(scope: User.all)
+    scope.where.not(
+      cap_status: [Policies::ChildAccount::ComplianceState::PERMISSION_GRANTED, nil],
+    )
+  end
 end

--- a/dashboard/lib/queries/section.rb
+++ b/dashboard/lib/queries/section.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Queries
+  module Section
+    # Selects sections with followers affected by the Child Account Policy.
+    #
+    # @param scope [Section::ActiveRecord_Relation] The range of sections to query.
+    # @param period [Date, Range<Date>] The period to query for CAP affected followers.
+    #
+    # @return [Section::ActiveRecord_Relation] The sections with CAP affected followers.
+    def self.cap_affected(scope: ::Section.all, period: nil)
+      cap_affected_students = Queries::ChildAccount.cap_affected
+      cap_affected_students = cap_affected_students.where(cap_status_date: period) if period
+
+      cap_affected_followers = Follower.where(
+        student_user_id: cap_affected_students.select(:id),
+      )
+
+      scope.where(
+        id: cap_affected_followers.select(:section_id),
+      )
+    end
+  end
+end

--- a/dashboard/test/jobs/application_job_test.rb
+++ b/dashboard/test/jobs/application_job_test.rb
@@ -11,6 +11,14 @@ class ApplicationJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'includes ActiveJobMetrics' do
+    assert_includes ApplicationJob.ancestors, ActiveJobMetrics
+  end
+
+  test 'includes ActiveJobReporting' do
+    assert_includes ApplicationJob.ancestors, ActiveJobReporting
+  end
+
   test 'enqueued jobs log PendingJobCount FailedJobCount WaitTime ExecutionTime and TotalTime' do
     expected_failed_count = 5
     expected_pending_count = 3

--- a/dashboard/test/jobs/cap/lockout_job_test.rb
+++ b/dashboard/test/jobs/cap/lockout_job_test.rb
@@ -4,6 +4,10 @@ class CAP::LockoutJobTest < ActiveJob::TestCase
   let(:described_class) {CAP::LockoutJob}
   let(:described_instance) {described_class.new}
 
+  it 'inherits from ApplicationJob' do
+    _(described_class.superclass).must_equal ::ApplicationJob
+  end
+
   describe '.schedule_for' do
     let(:schedule_lockout_for_user) {described_class.schedule_for(user)}
 

--- a/dashboard/test/jobs/cap/teacher_sections_warning_job_test.rb
+++ b/dashboard/test/jobs/cap/teacher_sections_warning_job_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CAP::TeacherSectionsWarningJobTest < ActiveJob::TestCase
+  describe '.perform_later' do
+    subject(:perform_later) {described_class.perform_later}
+
+    let(:cap_teacher_section_warning_emails) {['all']}
+
+    let(:student_aga_gate_start_date) {30.days.ago}
+    let(:teacher_email) {Faker::Internet.unique.email}
+    let(:teacher_name) {Faker::Name.unique.name}
+    let(:section_name) {Faker::Educator.unique.course_name}
+
+    let(:teacher) {create(:teacher, email: teacher_email, name: teacher_name)}
+    let(:section) {create(:section, user: teacher, name: section_name)}
+    let(:student) {create(:cpa_non_compliant_student, :in_grace_period, cap_status_date: student_aga_gate_start_date)}
+
+    let(:expect_teacher_warning_to_be_sent) do
+      MailjetDeliveryJob.expects(:perform_later).with(
+        :cap_section_warning,
+        teacher_email,
+        teacher_name,
+        vars: {
+          capSections: [
+            Name: section_name,
+            Link: "//test-studio.code.org/teacher_dashboard/sections/#{section.id}/manage_students"
+          ],
+        },
+      )
+    end
+
+    around do |test|
+      Timecop.freeze {test.call}
+    end
+
+    before do
+      create(:follower, section: section, student_user: student)
+    end
+
+    before do
+      MailjetDeliveryJob.stubs(:perform_later)
+      DCDO.stubs(:get).with('cap_teacher_section_warning_emails', []).returns(cap_teacher_section_warning_emails)
+    end
+
+    it 'enqueues job to "default" queue' do
+      assert_enqueued_with(job: described_class, queue: 'default') do
+        perform_later
+      end
+    end
+
+    it 'schedules warning email via MailjetDeliveryJob with expected arguments' do
+      expect_teacher_warning_to_be_sent.once
+      perform_enqueued_jobs {perform_later}
+      assert_performed_jobs 1
+    end
+
+    context 'when StandardError is raised' do
+      let(:exception) {StandardError.new('expected_exception')}
+
+      before do
+        expect_teacher_warning_to_be_sent.raises(exception)
+      end
+
+      it 'rescues from exception with #report_exception' do
+        described_class.any_instance.expects(:report_exception).with(exception).once
+        perform_enqueued_jobs {perform_later}
+        assert_performed_jobs 1
+      end
+    end
+
+    context 'when student is age-gated for more than 30 days' do
+      let(:student_aga_gate_start_date) {30.days.ago - 1.second}
+
+      it 'does not warn teacher' do
+        expect_teacher_warning_to_be_sent.never
+        perform_enqueued_jobs {perform_later}
+        assert_performed_jobs 1
+      end
+    end
+
+    context 'when student has parental permission' do
+      let(:student) {create(:student, :with_parent_permission, cap_status_date: student_aga_gate_start_date)}
+
+      it 'does not warn teacher' do
+        expect_teacher_warning_to_be_sent.never
+        perform_enqueued_jobs {perform_later}
+        assert_performed_jobs 1
+      end
+    end
+
+    context 'when emails whitelist is empty' do
+      let(:cap_teacher_section_warning_emails) {[]}
+
+      it 'does not warn teacher' do
+        expect_teacher_warning_to_be_sent.never
+        perform_enqueued_jobs {perform_later}
+        assert_performed_jobs 1
+      end
+    end
+
+    context 'when teacher email is in whitelist' do
+      let(:cap_teacher_section_warning_emails) {[teacher_email]}
+
+      it 'schedules teacher warning email' do
+        expect_teacher_warning_to_be_sent.once
+        perform_enqueued_jobs {perform_later}
+        assert_performed_jobs 1
+      end
+    end
+  end
+end

--- a/dashboard/test/jobs/concerns/active_job_reporting_test.rb
+++ b/dashboard/test/jobs/concerns/active_job_reporting_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActiveJobReportingTest < ActiveJob::TestCase
+  class TestableJob < ::ActiveJob::Base
+    include ActiveJobReporting
+
+    rescue_from StandardError, with: :report_exception
+
+    def perform(...)
+    end
+  end
+
+  subject(:described_class) {ActiveJobReportingTest::TestableJob}
+  subject(:decribed_instance) {described_class.new(*job_args)}
+
+  let(:job_args) {[]}
+
+  before do
+    Honeybadger.stubs(:notify)
+  end
+
+  describe '#report_exception' do
+    subject(:report_exception) {decribed_instance.send(:report_exception, exception)}
+
+    let(:exception) {StandardError.new('expected_error')}
+
+    let(:job_arg1) {'expected_arg1'}
+    let(:job_arg2) {{'expected_arg2' => 'key_arg'}}
+    let(:job_args) {[job_arg1, job_arg2]}
+
+    it 'reports exception to Honeybadger' do
+      Honeybadger.expects(:notify).with(
+        exception,
+        has_entries(
+          error_message: '[ActiveJobReportingTest::TestableJob] Runtime error',
+          context: has_entries(
+            job: has_entries(
+              'arguments' => job_args,
+              'exception_executions' => anything,
+              'executions' => anything,
+              'job_id' => anything,
+              'priority' => anything,
+              'queue_name' => anything,
+              'timezone' => anything
+            )
+          )
+        )
+      ).once
+
+      _ {report_exception}.must_raise
+    end
+
+    it 're-raises exception' do
+      actual_exception = _ {report_exception}.must_raise exception.class
+      _(actual_exception).must_equal exception
+    end
+  end
+
+  describe '.perform_later' do
+    subject(:perform_later) {described_class.perform_later(*job_args)}
+
+    context 'when StandardError' do
+      let(:exception) {StandardError.new('expected_error')}
+
+      before do
+        described_class.any_instance.stubs(:perform).raises(exception)
+      end
+
+      it 'rescues from exception with #report_exception' do
+        perform_enqueued_jobs do
+          described_class.any_instance.expects(:report_exception).with(exception).once
+
+          perform_later
+
+          assert_performed_jobs 1
+        end
+      end
+    end
+  end
+end

--- a/dashboard/test/jobs/mailjet_delivery_job_test.rb
+++ b/dashboard/test/jobs/mailjet_delivery_job_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MailjetDeliveryJobTest < ActiveJob::TestCase
+  setup do
+    MailJet.stubs(:send_email)
+  end
+
+  it 'inherits from ApplicationJob' do
+    _(MailjetDeliveryJob.superclass).must_equal ::ApplicationJob
+  end
+
+  describe '.perform_later' do
+    subject(:perform_later) {described_class.perform_later(template_name, contact_email, contact_name, vars: vars, locale: locale)}
+
+    let(:template_name) {:expected_template_name}
+    let(:contact_email) {'expected_contact_email'}
+    let(:contact_name) {'expected_contact_name'}
+    let(:vars) {{expected: 'vars'}}
+    let(:locale) {'expected_locale'}
+
+    it 'enqueues job to "mailjet" queue' do
+      assert_enqueued_with(job: described_class, queue: 'mailjet') do
+        perform_later
+      end
+    end
+
+    it 'sends email via MailJet with expected arguments' do
+      MailJet.
+        expects(:send_email).
+        with(template_name, contact_email, contact_name, vars: vars, locale: locale).
+        once
+
+      perform_enqueued_jobs {perform_later}
+
+      assert_performed_jobs 1
+    end
+
+    context 'when StandardError is raised' do
+      let(:exception) {StandardError.new('expected_exception')}
+
+      before do
+        MailJet.stubs(:send_email).raises(exception)
+      end
+
+      it 'rescues from exception with #report_exception' do
+        described_class.any_instance.expects(:report_exception).with(exception).once
+
+        perform_enqueued_jobs {perform_later}
+
+        assert_performed_jobs 1
+      end
+    end
+  end
+end

--- a/dashboard/test/lib/queries/section_test.rb
+++ b/dashboard/test/lib/queries/section_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+class Queries::SectionTest < ActiveSupport::TestCase
+  describe '.cap_affected' do
+    subject(:cap_affected_sections) {described_class.cap_affected}
+
+    let(:section) {create(:section)}
+    let(:section_student) {create(:cpa_non_compliant_student, :in_grace_period)}
+
+    before do
+      create(:follower, section: section, student_user: section_student)
+    end
+
+    it 'returns sections with CAP affected students' do
+      _cap_affected_sections.must_include section
+    end
+
+    context 'when section has no CAP affected followers' do
+      let!(:section_student) {create(:student, :with_parent_permission)}
+
+      it 'does not return section' do
+        _cap_affected_sections.wont_include section
+      end
+    end
+
+    describe 'with scope' do
+      subject(:cap_affected_sections) {described_class.cap_affected(scope: scope)}
+
+      context 'when section is within provided scope' do
+        let(:scope) {Section.where(id: section.id)}
+
+        it 'returns section' do
+          _cap_affected_sections.must_include section
+        end
+      end
+
+      context 'when section is outside provided scope' do
+        let(:scope) {Section.where.not(id: section.id)}
+
+        it 'does not return section' do
+          _cap_affected_sections.wont_include section
+        end
+      end
+    end
+
+    describe 'with period' do
+      subject(:cap_affected_sections) {described_class.cap_affected(period: period)}
+
+      context 'when follower where age gated during provided period' do
+        let(:period) {section_student.cap_status_date..}
+
+        it 'returns section' do
+          _cap_affected_sections.must_include section
+        end
+      end
+
+      context 'when follower where age-gated outside provided period' do
+        let(:period) {section_student.cap_status_date.since(1.second)..}
+
+        it 'does not return section' do
+          _cap_affected_sections.wont_include section
+        end
+      end
+    end
+  end
+end

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'test_reporter'
+require 'faker'
 
 if defined? ActiveRecord
   ActiveRecord::Migration&.check_pending!

--- a/dashboard/test/testing/spec_syntax.rb
+++ b/dashboard/test/testing/spec_syntax.rb
@@ -42,6 +42,26 @@ module ActiveSupport
 
           name
         end
+
+        def subject(name = :subject, &block)
+          already_initialized = respond_to?(name)
+
+          let name, &block
+
+          let("_#{name}") {_ public_send(name)} unless already_initialized
+        end
+
+        def let!(name, &block)
+          already_initialized = respond_to?(name)
+
+          let name, &block
+
+          before {public_send(name)} unless already_initialized
+        end
+      end
+
+      def described_class
+        @described_class ||= class_name[/^(.*)Test::/, 1]&.constantize
       end
     end
   end

--- a/dashboard/test/testing/spec_syntax.rb
+++ b/dashboard/test/testing/spec_syntax.rb
@@ -43,6 +43,23 @@ module ActiveSupport
           name
         end
 
+        # This method is used to define a memoized assertion helper method for the test subject within the example scope.
+        #
+        # @see https://rspec.info/features/3-13/rspec-core/subject/explicit-subject
+        # @example Defining the subject of the test
+        #   class FooTest < ActiveSupport::TestCase
+        #     describe '.bar' do
+        #       subject(:bar) { Foo.bar }
+        #
+        #       it 'returns bar' do
+        #         _bar.must_equal 'bar'
+        #       end
+        #     end
+        #   end
+        #
+        # @param name [Symbol] The name of the tested subject
+        # @param block [Proc] The block that defines the subject
+        # @return [void]
         def subject(name = :subject, &block)
           already_initialized = respond_to?(name)
 
@@ -51,6 +68,13 @@ module ActiveSupport
           let("_#{name}") {_ public_send(name)} unless already_initialized
         end
 
+        # This method is used to define a memoized helper method and ensures its invocation before each example.
+        #
+        # @see https://rspec.info/features/3-13/rspec-core/helper-methods/let/
+        #
+        # @param name [Symbol] The name of the memoized helper method
+        # @param block [Proc] The block that defines the helper method
+        # @return [void]
         def let!(name, &block)
           already_initialized = respond_to?(name)
 

--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -36,6 +36,26 @@ module MailJet
     end
   end
 
+  # Sends an email using a MailJet template
+  #
+  # @param template_name [Symbol] The MailJet template name
+  # @param contact_email [String] The MailJet contact (recipient) email address
+  # @param contact_name [String] The MailJet contact (recipient) full name
+  # @param vars [Hash] Optional variables to be passed to the template
+  # @param locale [String] The locale to use for the email
+  #
+  # @return [Mailjet::Send] The MailJet send response
+  def self.send_email(template_name, contact_email, contact_name, vars: {}, locale: 'en-US')
+    return unless enabled?
+
+    email_config = EMAILS[template_name.to_sym]
+    raise ArgumentError, "Invalid email template: #{template_name}" unless email_config
+
+    contact = find_or_create_contact(contact_email, contact_name)
+
+    send_template_email(contact, email_config, locale, variables: vars)
+  end
+
   def self.create_contact_and_add_to_welcome_series(user, locale = 'en-US')
     return unless enabled?
 
@@ -48,36 +68,6 @@ module MailJet
     subaccount_contact_list_config = CONTACT_LISTS[:welcome_series][subaccount.to_sym]
     contact_list_id = subaccount_contact_list_config[locale.to_sym] || subaccount_contact_list_config[:default]
     add_to_contact_list(contact, contact_list_id)
-  end
-
-  # Sends a warning to a teacher about sections with students affected by the Child Account Policy (CAP).
-  #
-  # @note The function may exit early due to any of the following conditions:
-  #   - the feature is not enabled.
-  #   - the user is nil or does not have a valid ID.
-  #   - the user is not a teacher.
-  #
-  # @param user [User] The teacher to be warned.
-  # @param sections [Array<Hash>] The list of CAP-affected sections.
-  #   Each section is represented as a hash with keys:
-  #   - `:Name` [String] The name of the section.
-  #   - `:Link` [String] The URL link to the section.
-  # @param locale [String] The locale to use for the email. Defaults to 'en-US'.
-  #
-  # @return [void]
-  def self.send_teacher_cap_section_warning(user, sections, locale: 'en-US')
-    return unless enabled?
-
-    raise ArgumentError, 'the user must be persisted' unless user&.persisted?
-    raise ArgumentError, 'the user must be a teacher' unless user.teacher?
-
-    contact = find_or_create_contact(user.email, user.name)
-    send_template_email(
-      contact,
-      EMAILS[:cap_section_warning],
-      locale,
-      variables: {capSections: sections}
-    )
   end
 
   def self.find_or_create_contact(email, name)


### PR DESCRIPTION
1. Replaced the method `MailJet.send_teacher_cap_section_warning` with the generalized method `MailJet.send_email`.
2. Implemented `MailjetDeliveryJob` to enable scheduling of any MailJet email.
3. Implemented `CAP::TeacherSectionsWarningJob` to facilitate sending warnings to teachers about sections with CAP-affected students.
4. Added the [faker](https://github.com/faker-ruby/faker) gem for generating fake data such as names, addresses, and phone numbers.

## Links
- JIRA task: [P20-1073](https://codedotorg.atlassian.net/browse/P20-1073)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/60123