### PR TITLE
fix(RosterDialog): dispatch import failure when redirect ajax fails

### DIFF
--- a/apps/src/templates/teacherDashboard/RosterDialog.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.jsx
@@ -16,6 +16,7 @@ import {
   cancelImportRosterFlow,
   importOrUpdateRoster,
   isRosterDialogOpen,
+  rosterImportFailed,
 } from './teacherSectionsRedux';
 
 const COMPLETED_EVENT = 'Section Setup Completed';
@@ -151,6 +152,7 @@ class RosterDialog extends React.Component {
     // Provided by Redux
     handleImport: PropTypes.func,
     handleCancel: PropTypes.func,
+    handleImportFailure: PropTypes.func,
     isOpen: PropTypes.bool,
     classrooms: PropTypes.arrayOf(classroomShape),
     loadError: loadErrorShape,
@@ -199,7 +201,8 @@ class RosterDialog extends React.Component {
         courseName,
       })
         .done(resolve)
-        .fail(jqxhr =>
+        .fail(jqxhr => {
+          this.props.handleImportFailure(jqxhr);
           reject(
             new Error(`
             url: ${importSectionUrl}
@@ -207,8 +210,8 @@ class RosterDialog extends React.Component {
             statusText: ${jqxhr.statusText}
             responseText: ${jqxhr.responseText}
           `)
-          )
-        );
+          );
+        });
     }).then(newSection => this.redirectToEditSectionPage(newSection.id));
   };
 
@@ -353,5 +356,6 @@ export default connect(
   {
     handleImport: importOrUpdateRoster,
     handleCancel: cancelImportRosterFlow,
+    handleImportFailure: rosterImportFailed,
   }
 )(RosterDialog);

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -587,6 +587,11 @@ export const beginGoogleImportRosterFlow = () => dispatch => {
   dispatch(beginImportRosterFlow());
 };
 
+export const rosterImportFailed = result => ({
+  type: IMPORT_ROSTER_FLOW_LIST_LOAD_FAILED,
+  status: result.status,
+});
+
 /**
  * Import the course with the given courseId from a third-party provider
  * (like Google Classroom or Clever), creating a new section. If the course

--- a/apps/test/unit/templates/teacherDashboard/RosterDialogTest.js
+++ b/apps/test/unit/templates/teacherDashboard/RosterDialogTest.js
@@ -118,4 +118,33 @@ describe('RosterDialog', () => {
     );
     expect(wrapper.find('#import-button-and-redirect')).to.have.lengthOf(1);
   });
+
+  it('should dispatch handleImportFailure when the redirect ajax fails', async () => {
+    const handleImportFailureMock = jest.fn();
+
+    const rosterDialog = shallow(
+      <RosterDialog
+        handleImport={() => {}}
+        handleCancel={() => {}}
+        handleImportFailure={handleImportFailureMock}
+        isOpen={true}
+        classrooms={[
+          {
+            id: '2',
+            name: 'Test',
+          },
+        ]}
+        loadError={failedLoadError}
+        rosterProvider={OAuthSectionTypes.google_classroom}
+      />
+    );
+
+    rosterDialog.instance().setState({selectedId: '2'});
+    await rosterDialog
+      .instance()
+      .handleRedirect()
+      .catch(error => {
+        expect(handleImportFailureMock.mock.calls.length).to.equal(1);
+      });
+  });
 });


### PR DESCRIPTION
When importing from Google Classrooms, if the list courses succeeds but course roster sync fails, the roster dialog remains in the list of courses state providing the user with no feedback that something went wrong. Instead, dispatch the failure notification to prompt the user to reauthorize their token.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-1115)

## Testing story

1. Logged into Code.org via Google
2. Authorized Google Classroom for teacher section
3. Rejected the scope "View your Google Classroom class rosters"
4. Attempted to create section

Expected: Reauthorization screen presented to re-request the missing scope.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
