### PR TITLE
Music: advanced model gets a number

### DIFF
--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -438,6 +438,7 @@ export function getToolbox(toolbox) {
           Events: [BlockTypes.TRIGGERED_AT],
           Control: [BlockTypes.FOR_LOOP],
           Math: [
+            'math_number',
             'math_round',
             'math_arithmetic',
             'math_random_int',


### PR DESCRIPTION
This adds a number block to the math category in the toolbox in the advanced model in Music Lab.
 