### PR TITLE
[JIMT][LABS-990] - disable safari and mobile test for scenario

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -40,6 +40,8 @@ Feature: BubbleChoice
     And I wait for 4 seconds
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
+  # this scenario is currently breaking on ipad and safari
+  @no_mobile @no_safari
   Scenario: Lab2 BubbleChoice progress
     Given I create a teacher-associated student named "Alice"
 
@@ -86,11 +88,11 @@ Feature: BubbleChoice
 
     # View progress from BubbleChoice sublevel activity page
     Given I am on "http://studio.code.org/s/allthethings/lessons/52/levels/8/sublevel/1"
-    
+
     # Dismiss the dialog
     And I click selector "#ui-close-dialog" once I see it
     And I wait until element "#ui-close-dialog" is not visible
-    
+
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".teacher-panel .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it
@@ -99,14 +101,14 @@ Feature: BubbleChoice
 
   Scenario: Navigating between a Lab2 sublevel and another Lab2 level
     Given I create a teacher-associated student named "Alice"
-    
+
     # Go to Lab2 BubbleChoice sublevel
     Given I am on "http://studio.code.org/s/allthethings/lessons/52/levels/8/sublevel/1"
-    
+
     # Dismiss the dialog
     And I click selector "#ui-close-dialog" once I see it
     And I wait until element "#ui-close-dialog" is not visible
-    
+
     # Go to another Lab2 level (panels)
     And I click selector ".progress-bubble:nth(5)"
     And I wait until element "#lab2-panels" is visible

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -99,6 +99,8 @@ Feature: BubbleChoice
     And I wait until element "#lab2-aichat" is visible
     Then I verify progress for the sublevel with selector ".teacher-panel .progress-bubble:first" is "perfect"
 
+  # this scenario is currently breaking on ipad and safari
+  @no_mobile @no_safari
   Scenario: Navigating between a Lab2 sublevel and another Lab2 level
     Given I create a teacher-associated student named "Alice"
 


### PR DESCRIPTION
As per thread @ https://codedotorg.slack.com/archives/C03DBDN67B7/p1724696888754679

disables safari and ipad tests for the lab2 scenario.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LABS-990](https://codedotorg.atlassian.net/browse/LABS-990)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
