### PR TITLE
Flaky eyes test manage_students_tab_views_eyes

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -17,6 +17,7 @@ Feature: Using the manage students tab of the teacher dashboard
     # Add a family name for Sally
     And I click selector ".ui-test-section-dropdown" once I see it
     And I press the child number 0 of class ".pop-up-menu-item"
+    And I wait until element "input[name='uitest-family-name']" is visible
     And I press keys "SallyAlsoHasAVeryVeryLongLastName" for element "input[name='uitest-family-name']"
     And I click selector "button:contains(Save)"
     And I see no difference for "manage students tab"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -2,7 +2,6 @@
 @eyes
 Feature: Using the manage students tab of the teacher dashboard
 
-  @skip
   Scenario: Viewing the manage students tab in normal and edit mode
     When I open my eyes to test "manage students tab"
     Given I create an authorized teacher-associated student named "SallyHasAVeryVeryLongFirstName"


### PR DESCRIPTION
Issue: When trying to edit the student first name/family name, there is a timing issue between clicking on the edit button and for the input field to become editable. The test fails in these cases unable to find the required input element

![image](https://github.com/user-attachments/assets/67ef21dc-c5db-43bd-93f4-aed80f32c5c7)

Sauce labs link with failure https://app.saucelabs.com/tests/838fc43488694f9c92c21d62fc9b31c5#73

Fix: Including a step to wait for the element to be visible before filling in the element.
Sample sauce labs run with fix https://app.saucelabs.com/tests/e5f2ffda69d74185af650533cb3a196f#62

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1262

## Testing story

Validated the change by running the test 4 times in drone and was successful

## Deployment strategy

Regular DTP

## Follow-up work

Monitor dashboard to ensure fix is working

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
