### PR TITLE
Fix signed out header statsig events

### DIFF
--- a/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
+++ b/apps/src/userHeaderEventLogger/userHeaderEventLogger.js
@@ -36,13 +36,16 @@ function addClickEventToLinks(selector, eventName, additionalProperties = {}) {
 const addCreateMenuMetrics = (
   headerCreateMenu,
   platforms,
+  isSignedIn,
   additionalOptions = {}
 ) => {
   if (headerCreateMenu) {
     // Log if a signed-out user clicks the "Create" menu dropdown
     headerCreateMenu.addEventListener('click', () => {
       analyticsReporter.sendEvent(
-        EVENTS.SIGNED_IN_USER_CLICKS_CREATE_DROPDOWN,
+        isSignedIn
+          ? EVENTS.SIGNED_IN_USER_CLICKS_CREATE_DROPDOWN
+          : EVENTS.SIGNED_OUT_USER_CLICKS_CREATE_DROPDOWN,
         additionalOptions,
         platforms
       );
@@ -55,7 +58,9 @@ const addCreateMenuMetrics = (
         .getElementById(`create_menu_option_${option}`)
         .addEventListener('click', () => {
           analyticsReporter.sendEvent(
-            EVENTS.SIGNED_IN_USER_SELECTS_CREATE_DROPDOWN_OPTION,
+            isSignedIn
+              ? EVENTS.SIGNED_IN_USER_SELECTS_CREATE_DROPDOWN_OPTION
+              : EVENTS.SIGNED_OUT_USER_SELECTS_CREATE_DROPDOWN_OPTION,
             {
               option: option,
               ...additionalOptions,
@@ -136,7 +141,7 @@ const addSignedOutMetrics = (pageUrl, headerCreateMenu) => {
     );
   });
 
-  addCreateMenuMetrics(headerCreateMenu, PLATFORMS.BOTH);
+  addCreateMenuMetrics(headerCreateMenu, PLATFORMS.BOTH, false);
 };
 
 const addSignedInMetrics = (pageUrl, headerCreateMenu) => {
@@ -181,7 +186,12 @@ const addSignedInMetrics = (pageUrl, headerCreateMenu) => {
     additionalOptions
   );
 
-  addCreateMenuMetrics(headerCreateMenu, PLATFORMS.STATSIG, additionalOptions);
+  addCreateMenuMetrics(
+    headerCreateMenu,
+    PLATFORMS.STATSIG,
+    true,
+    additionalOptions
+  );
 };
 
 $(document).ready(function () {


### PR DESCRIPTION
[A previous PR ](https://github.com/code-dot-org/code-dot-org/commit/dbe637adb34634b62b3dbf1f57abdc934e5c7120#diff-57b281b44ecccd1c062c71cb895f24dc331f62c4c961319b599ae8666b0bbb24L96-L98)combined signed-in and signed-out metrics for the create menu. This PR fixes it by splitting it back into signed in and signed out metrics

## Links
https://codedotorg.atlassian.net/browse/TEACH-1273
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
