### PR TITLE
AI Tutor: change chat deletion window from 30 -> 90 days

### DIFF
--- a/bin/cron/cleanup_mvp_ai_tutor_interactions
+++ b/bin/cron/cleanup_mvp_ai_tutor_interactions
@@ -11,8 +11,8 @@ require_relative '../../dashboard/config/environment'
 # and we have an approved long-term deletion/obfuscation policy we will
 # disable this cron job. See: https://codedotorg.atlassian.net/browse/CT-372.
 def main
-  thirty_days_ago = Time.now - 30.days
-  AiTutorInteraction.where('created_at < ?', thirty_days_ago).destroy_all
+  ninety_days_ago = Time.now - 90.days
+  AiTutorInteraction.where('created_at < ?', ninety_days_ago).destroy_all
 end
 
 main


### PR DESCRIPTION
[CT-751](https://codedotorg.atlassian.net/browse/CT-751)

To give us a little more time to run analysis and gather insights as we pilot we're keeping the chat history around for 90 days rather than 30 days. This is consistent with the GenAI student chat pilot deletion plan as well. 