### PR TITLE
prevent adding unit to multiple courses during course edit

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -89,7 +89,7 @@ class CoursesController < ApplicationController
     raise ActiveRecord::ReadOnlyRecord if @unit_group.try(:plc_course)
     @unit_group_data = {
       course_summary: @unit_group.summarize(@current_user, for_edit: true),
-      script_names: Unit.all.select {|unit| unit.is_course? == false}.map(&:name),
+      script_names: Unit.all.select {|unit| unit.is_course? == false && !unit.unit_groups.any?}.map(&:name),
       course_families: UnitGroup.family_names,
       version_year_options: UnitGroup.get_version_year_options,
       missing_required_device_compatibilities: @unit_group&.course_version&.course_offering&.missing_required_device_compatibility?

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -228,6 +228,45 @@ class UnitGroup < ApplicationRecord
     end.map(&:name)
     raise "Cannot add units that have resources or vocabulary: #{unaddable_unit_names}" if unaddable_unit_names.any?
 
+    # make sure a unit cannot be in multiple unit groups.
+    #
+    # update_scripts gets called either when a course is edited via
+    # levelbuilder, or during seeding. we already take steps to prevent
+    # levelbuilders from adding units that are in other courses in the
+    # levelbuilder UI. So, if we hit the following error case, it's likely
+    # during the seed process.
+
+    # one way this can happen is if a unit was moved between unit groups via the
+    # levelbuilder UI, by first removing the unit from the old location before
+    # adding it to the new location. If those two changes reached the current
+    # environment during a single deploy, then the unit may not have been
+    # removed from the old unit group by the time we are adding it to the new
+    # unit group, in particular because the old unit group comes later in
+    # alphabetical order.
+    #
+    # in this case, we make sure the deploy doesn't fail, and also that
+    # the new data is _eventually_ seeded properly, similar to how we do it here
+    # for seeding resources and vocab:
+    # https://github.com/code-dot-org/code-dot-org/blob/7e67fddbad1c77aae37858f2350774c58e864c1e/dashboard/lib/services/script_seed.rb#L432-L445
+    #
+    # what we want to happen here is:
+    # 1. levelbuilder removes unit_1 from z_old_unit_group
+    # 2. levelbuilder adds unit_1 to a_new_unit_group
+    # 3. levelbuilder scoop + deploy to staging
+    # 4. during the first staging deploy
+    #    a. we try to add unit_1 to a_new_unit_group, but it's still in z_old_unit_group, so we can't add it yet. just print a warning for now.
+    #    b. we try to remove unit_1 from z_old_unit_group, and succeed
+    # 5. during the next staging deploy, we try to add unit_1 to a_new_unit_group again, and succeed
+    taken_units = new_units_objects.select do |u|
+      u.unit_groups.any? {|ug| ug != self}
+    end
+    if taken_units.any?
+      puts "WARNING: Cannot add units that are already in another unit group: #{taken_units.map(&:name)}. " \
+             "This is only to be expected if the unit was recently moved between unit groups. " \
+             "In that case, the issue will be resolved on the next deploy."
+      new_units_objects -= taken_units
+    end
+
     new_units_objects.each_with_index do |unit, index|
       unit_group_unit = UnitGroupUnit.find_or_create_by!(unit_group: self, script: unit) do |ugu|
         ugu.position = index + 1

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -445,6 +445,30 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_equal 1, unit_group1.default_unit_group_units.length
     end
 
+    test 'cannot add UnitGroupUnits that are in another unit group' do
+      old_unit_group = create :unit_group
+      new_unit_group = create :unit_group
+
+      create :script, name: 'unit1'
+      create :script, name: 'unit2'
+
+      # add unit2 to old_unit_group
+      old_unit_group.update_scripts(['unit2'])
+
+      # cannot add unit 2 to new_unit_group, and doesn't raise
+      new_unit_group.update_scripts(['unit1', 'unit2'])
+      new_unit_group.reload
+      assert_equal ['unit1'], new_unit_group.default_units.map(&:name)
+
+      # remove unit 2 from old_unit_group
+      old_unit_group.update_scripts([])
+
+      # can add unit 2 to new_unit_group
+      new_unit_group.update_scripts(['unit1', 'unit2'])
+      new_unit_group.reload
+      assert_equal ['unit1', 'unit2'], new_unit_group.default_units.map(&:name)
+    end
+
     test "remove UnitGroupUnits" do
       unit_group = create(
         :unit_group,

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -445,30 +445,6 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_equal 1, unit_group1.default_unit_group_units.length
     end
 
-    test 'cannot add UnitGroupUnits that are in another unit group' do
-      old_unit_group = create :unit_group
-      new_unit_group = create :unit_group
-
-      create :script, name: 'unit1'
-      create :script, name: 'unit2'
-
-      # add unit2 to old_unit_group
-      old_unit_group.update_scripts(['unit2'])
-
-      # cannot add unit 2 to new_unit_group, and doesn't raise
-      new_unit_group.update_scripts(['unit1', 'unit2'])
-      new_unit_group.reload
-      assert_equal ['unit1'], new_unit_group.default_units.map(&:name)
-
-      # remove unit 2 from old_unit_group
-      old_unit_group.update_scripts([])
-
-      # can add unit 2 to new_unit_group
-      new_unit_group.update_scripts(['unit1', 'unit2'])
-      new_unit_group.reload
-      assert_equal ['unit1', 'unit2'], new_unit_group.default_units.map(&:name)
-    end
-
     test "remove UnitGroupUnits" do
       unit_group = create(
         :unit_group,


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-761 . From the slack thread, the specific problem was that units like `k5-maker-pilot-2024-1` were able to be added to a pl sandbox course even though they were already part of  https://levelbuilder-studio.code.org/courses/microbitmakermodule-2024/edit

done in this PR:
* update course edit UI to not show units which are already in other courses

alternative:

if you look at the commit history you can see that I originally thought about adding logic that would prevent this problem from occurring during the seed process. However, that solution was starting to look tricky, and since we're about to change these codepaths to actually allow units to be shared between courses as part of modularity early next year, the smaller change seems more appropriate for now.

### screenshots

the screenshots show how we prevent the problem from recurring, by removing the option to add a unit to a unit group if it is already part of another unit group:

#### before 

https://github.com/user-attachments/assets/efda3454-e455-4b8f-a3ee-0bc5680bc21e

#### after

https://github.com/user-attachments/assets/77cc9370-6425-4b3c-b8eb-86fdf775259c

## Testing story

manual testing show in screenshots

## Deployment strategy

Squash-and-merge