### PR TITLE
AI Tutor: primm_progression_type method for script_level

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -744,6 +744,25 @@ class ScriptLevel < ApplicationRecord
     level&.deprecated?
   end
 
+  # WARNING: Do NOT reuse this trashy little method. It is fragile English-only string comparison
+  # written for a very specific use case - logging analytics for the CSA '24-'25 AI Tutor pilot,
+  # in which the level progression naming conventions follow a very specific pattern aligned
+  # with the PRIMM pedagogical approach.
+  #
+  # If the concept of a "progression type" becomes more general, or you're tempted to use this method,
+  # consider a more robust solution such as creating a new property that can be designated by a
+  # Levelbuilder, similar to how we designate assessment levels.
+  def primm_progression_type
+    progression_name = properties["progression"]
+    substring = progression_name.split(":").first if progression_name
+    return "predict_and_run" if substring&.include?("Predict and Run")
+    return "investigate_and_modify" if substring&.include?("Investigate and Modify")
+    return "practice" if substring&.include?("Practice")
+    return "project" if substring&.include?("Project")
+    return "assessment" if substring&.include?("Check for Understanding")
+    return "other"
+  end
+
   private def kind
     if level.unplugged?
       LEVEL_KIND.unplugged


### PR DESCRIPTION
[CT-750](https://codedotorg.atlassian.net/browse/CT-750) partial

One of the [AI Tutor Metrics](https://docs.google.com/document/d/1EoeR4VhVjjuquh1DSVlrpyVJFiD_pCUmppRlQz7HeYA/edit) we want to log for the upcoming CSA pilot is what AI Tutor usage looks like for different phases of the [PRIMM](https://static.teachcomputing.org/pedagogy/QR11-PRIMM.pdf?ref=blog.teachcomputing.org&_ga=2.195915116.1302635284.1724718594-39175919.1724718594) learning progression. For example, are students engaging more with the Tutor on "Predict and Run" levels or on "Investigate and Modify" levels?

This concept of something like a "progression type" is not standardized in the database models of our curriculum hierarchy; however the progression names for the CSA '24-'25 course follow specific conventions established by the Teaching & Learning team that, with a little gymnastics, we can leverage to get the information we need for each level. 

In this PR I set up a helper method to determine which PRIMM category applies to a given script level, which I will then pass along in follow up work to the AI Tutor code so we can log it as an event field for metrics. 

I tested this change by finding the CSA '24-'25 Unit 1 levels and comparing the progression to the primm_progression_type to spot check that primm_progression_type is as expected. Locally, it's unit 215 in my database, so `Unit.find(215).script_levels.map(&:primm_progression_type)` gave me the [output](https://docs.google.com/spreadsheets/d/1biRPsmECLuqDcTz0HxGbcGagzp0QT9d9Zad8v03SQ60/edit?gid=0#gid=0) I was looking for. 