### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -206,4 +206,4 @@ updates:
   - package-ecosystem: 'pip'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -203,3 +203,7 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 0
 
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
~Dependabot could be enabled for this repository. Please enable it by merging this pull request so that we can keep our dependencies up to date and secure.~

Dependabot is already enabled on this repository. This PR adds coverage for Python packages.