### PR TITLE
Revert "[JIMT][LABS-990] - disable safari and mobile test for scenario"

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -40,8 +40,6 @@ Feature: BubbleChoice
     And I wait for 4 seconds
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"
 
-  # this scenario is currently breaking on ipad and safari
-  @no_mobile @no_safari
   Scenario: Lab2 BubbleChoice progress
     Given I create a teacher-associated student named "Alice"
 
@@ -88,29 +86,27 @@ Feature: BubbleChoice
 
     # View progress from BubbleChoice sublevel activity page
     Given I am on "http://studio.code.org/s/allthethings/lessons/52/levels/8/sublevel/1"
-
+    
     # Dismiss the dialog
     And I click selector "#ui-close-dialog" once I see it
     And I wait until element "#ui-close-dialog" is not visible
-
+    
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".teacher-panel .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it
     And I wait until element "#lab2-aichat" is visible
     Then I verify progress for the sublevel with selector ".teacher-panel .progress-bubble:first" is "perfect"
 
-  # this scenario is currently breaking on ipad and safari
-  @no_mobile @no_safari
   Scenario: Navigating between a Lab2 sublevel and another Lab2 level
     Given I create a teacher-associated student named "Alice"
-
+    
     # Go to Lab2 BubbleChoice sublevel
     Given I am on "http://studio.code.org/s/allthethings/lessons/52/levels/8/sublevel/1"
-
+    
     # Dismiss the dialog
     And I click selector "#ui-close-dialog" once I see it
     And I wait until element "#ui-close-dialog" is not visible
-
+    
     # Go to another Lab2 level (panels)
     And I click selector ".progress-bubble:nth(5)"
     And I wait until element "#lab2-panels" is visible

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -86,11 +86,11 @@ Feature: BubbleChoice
 
     # View progress from BubbleChoice sublevel activity page
     Given I am on "http://studio.code.org/s/allthethings/lessons/52/levels/8/sublevel/1"
-    
+
     # Dismiss the dialog
     And I click selector "#ui-close-dialog" once I see it
     And I wait until element "#ui-close-dialog" is not visible
-    
+
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".teacher-panel .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it
@@ -99,14 +99,14 @@ Feature: BubbleChoice
 
   Scenario: Navigating between a Lab2 sublevel and another Lab2 level
     Given I create a teacher-associated student named "Alice"
-    
+
     # Go to Lab2 BubbleChoice sublevel
     Given I am on "http://studio.code.org/s/allthethings/lessons/52/levels/8/sublevel/1"
-    
+
     # Dismiss the dialog
     And I click selector "#ui-close-dialog" once I see it
     And I wait until element "#ui-close-dialog" is not visible
-    
+
     # Go to another Lab2 level (panels)
     And I click selector ".progress-bubble:nth(5)"
     And I wait until element "#lab2-panels" is visible

--- a/lib/cdo/rack/upgrade_insecure_requests.rb
+++ b/lib/cdo/rack/upgrade_insecure_requests.rb
@@ -46,7 +46,7 @@ module Rack
             "default-src 'self' https:",
             "frame-src 'self' https: blob:",
             "worker-src 'self' blob: ",
-            "child-src blob: ",
+            "child-src 'self' blob: ",
             "script-src 'self' https: 'unsafe-inline' https://vaas.acapela-group.com 'unsafe-eval'",
             "style-src 'self' https: 'unsafe-inline'",
             "img-src 'self' https: data: blob: https://*.code.org",


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#60657

We skipped a couple of UI tests that started failing with [this DTT](https://github.com/code-dot-org/code-dot-org/pull/60646) yesterday. Stephen helpfully showed me the "Live" feature in Saucelabs, where you can specify a browser/device version and use an actual browser. Using this, I was able to repro the issue and see console errors, which showed:

![image](https://github.com/user-attachments/assets/7c995120-c1a8-47e9-b28a-1a600bd43746)

This is the offending line:

https://github.com/code-dot-org/code-dot-org/blob/d0f99054046f94b69cf9f0fe30b8c842ddde45eb/apps/src/music/ai/patternAi.ts#L4

This appears to be a real issue in older versions of Safari (which we use in UI tests), which doesn't support the `worker-src` Content Security Policy header until Safari 15.5 (we use 14 in UI tests).

I believe the fallback is the `child-src` Content Security Policy header, so I've updated that to allow same origin.

## Links

- [Slack discussion](https://codedotorg.slack.com/archives/C046G4TRLEN/p1724716680607349)
- [child-src docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/child-src)
- [caniuse for worker-src](https://caniuse.com/?search=worker-src)
- [Stack Overflow discussing similar issue](https://stackoverflow.com/questions/67095697/safari-unable-to-create-worker-from-blob-due-to-content-security-policy-issue)

## Testing story

This issue doesn't repro when running tests using localhost/Saucelabs so I can't really verify that it will definitely work, so I'll try and merge it one day after we've DTP'd in case it causes issues.