### PR TITLE
AI Tutor: Statsig logging for teacher toggles to en/disable AI Tutor 

### DIFF
--- a/apps/src/aiTutor/views/teacherDashboard/SectionAccessToggle.tsx
+++ b/apps/src/aiTutor/views/teacherDashboard/SectionAccessToggle.tsx
@@ -3,6 +3,8 @@ import {useSelector} from 'react-redux';
 
 import {handleUpdateSectionAITutorEnabled} from '@cdo/apps/aiTutor/accessControlsApi';
 import Toggle from '@cdo/apps/componentLibrary/toggle/Toggle';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import InfoHelpTip from '@cdo/apps/sharedComponents/InfoHelpTip';
 import {updateSectionAiTutorEnabled} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
@@ -38,6 +40,13 @@ const SectionAccessToggle: React.FC<SectionAccessToggleProps> = ({
     const newValue = !aiTutorEnabled;
     handleUpdateSectionAITutorEnabled(sectionId, newValue);
     setAiTutorEnabled(newValue);
+    const event = aiTutorEnabled
+      ? EVENTS.AI_TUTOR_DISABLED
+      : EVENTS.AI_TUTOR_ENABLED;
+    analyticsReporter.sendEvent(event, {
+      sectionId: sectionId,
+      uiLocation: 'aiTutorTeacherDashboardTab',
+    });
     dispatch(updateSectionAiTutorEnabled(sectionId, newValue));
   };
 

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -244,6 +244,8 @@ const EVENTS = {
   AI_TUTOR_ASK_ABOUT_COMPILATION: 'AI Tutor was asked about compilation',
   AI_TUTOR_ASK_ABOUT_VALIDATION: 'AI Tutor was asked about validation',
   AI_TUTOR_ASK_GENERAL_CHAT: 'AI Tutor was asked a question in general chat',
+  AI_TUTOR_DISABLED: 'Teacher disabled AI Tutor for a section',
+  AI_TUTOR_ENABLED: 'Teacher enabled AI Tutor for a section',
 
   // Hour of Code
   AGE_21_SELECTED_EVENT: 'Age 21+ Selected',

--- a/apps/src/templates/sectionsRefresh/AdvancedSettingToggles.jsx
+++ b/apps/src/templates/sectionsRefresh/AdvancedSettingToggles.jsx
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Toggle from '@cdo/apps/componentLibrary/toggle/Toggle';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import InfoHelpTip from '@cdo/apps/sharedComponents/InfoHelpTip';
 import i18n from '@cdo/locale';
 
@@ -38,6 +40,13 @@ export default function AdvancedSettingToggles({
 
   const handleAITutorEnabledToggle = e => {
     const updatedValue = !section.aiTutorEnabled;
+    const event = section.aiTutorEnabled
+      ? EVENTS.AI_TUTOR_DISABLED
+      : EVENTS.AI_TUTOR_ENABLED;
+    analyticsReporter.sendEvent(event, {
+      sectionId: section.id,
+      uiLocation: 'sectionEditAdvancedSettings',
+    });
     updateSection('aiTutorEnabled', updatedValue);
   };
 


### PR DESCRIPTION
In preparation for piloting AI Tutor this fall, we are adding in [additional product analytic logging](https://docs.google.com/document/d/1EoeR4VhVjjuquh1DSVlrpyVJFiD_pCUmppRlQz7HeYA/edit) to get a better sense for how students and teachers are interacting with the tools. One interaction we want to track is when teachers toggle AI Tutor on/off for a section. 

There are currently two places that teachers can do this: 

1.) In the Advanced Settings area of the section edit page 
![Screenshot 2024-08-27 at 8 47 30 PM](https://github.com/user-attachments/assets/50c1d7b1-61b6-44e7-b32d-ead5e7eb054b)

2.) The AI Tutor tab on the Teacher Dashboard 
![Screenshot 2024-08-27 at 8 47 00 PM](https://github.com/user-attachments/assets/a440ba92-8797-4b20-b38b-8e19ca99dd9f)

I set up logging to Statsig for enabling and disabling from each UI location and included where from the site the user is taking the action. 

<img width="418" alt="Screenshot 2024-08-27 at 8 38 38 PM" src="https://github.com/user-attachments/assets/8e7ccc1a-5799-4b01-bbe6-fa0143f63c8a">

<img width="404" alt="Screenshot 2024-08-27 at 8 38 43 PM" src="https://github.com/user-attachments/assets/4e1b0c92-0a32-4888-ab48-a9445ac5677a">

![Screenshot 2024-08-27 at 8 44 37 PM](https://github.com/user-attachments/assets/e04ec266-fb33-4c95-acca-98822b1c652f)

![Screenshot 2024-08-27 at 8 44 49 PM](https://github.com/user-attachments/assets/c71c931a-eb70-4f64-ab20-0ab65bbdd993)

I also logged a post-pilot clean up [ticket](https://codedotorg.atlassian.net/browse/CT-755) to analyze the toggle usage in both places and then either consolidate the code to share across both or eliminate one. 



