### PR TITLE
Code bridge: auto-scroll console to bottom

### DIFF
--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -18,6 +18,7 @@ const Console: React.FunctionComponent = () => {
   const levelId = useAppSelector(state => state.lab.levelProperties?.id);
   const previousLevelId = useRef(levelId);
   const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const consoleRef = useRef<HTMLDivElement>(null);
 
   const [graphModalOpen, setGraphModalOpen] = useState(false);
   const [activeGraphIndex, setActiveGraphIndex] = useState(0);
@@ -32,6 +33,12 @@ const Console: React.FunctionComponent = () => {
       previousLevelId.current = levelId;
     }
   }, [dispatch, levelId]);
+
+  useEffect(() => {
+    if (consoleRef.current) {
+      consoleRef.current.scrollTop = consoleRef.current.scrollHeight;
+    }
+  }, [consoleRef, codeOutput]);
 
   const clearOutput = () => {
     dispatch(resetOutput());
@@ -66,7 +73,7 @@ const Console: React.FunctionComponent = () => {
       headerContent={'Console'}
       rightHeaderContent={headerButton()}
     >
-      <div className={moduleStyles.console}>
+      <div className={moduleStyles.console} ref={consoleRef}>
         {codeOutput.map((outputLine, index) => {
           if (outputLine.type === 'img') {
             return (

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -18,7 +18,7 @@ const Console: React.FunctionComponent = () => {
   const levelId = useAppSelector(state => state.lab.levelProperties?.id);
   const previousLevelId = useRef(levelId);
   const appName = useAppSelector(state => state.lab.levelProperties?.appName);
-  const consoleRef = useRef<HTMLDivElement>(null);
+  const scrollAnchorRef = useRef<HTMLDivElement>(null);
 
   const [graphModalOpen, setGraphModalOpen] = useState(false);
   const [activeGraphIndex, setActiveGraphIndex] = useState(0);
@@ -35,11 +35,10 @@ const Console: React.FunctionComponent = () => {
   }, [dispatch, levelId]);
 
   useEffect(() => {
-    consoleRef.current?.scrollIntoView({
+    scrollAnchorRef.current?.scrollIntoView({
       behavior: 'smooth',
-      block: 'end',
     });
-  }, [consoleRef, codeOutput]);
+  }, [codeOutput]);
 
   const clearOutput = () => {
     dispatch(resetOutput());
@@ -75,64 +74,63 @@ const Console: React.FunctionComponent = () => {
       rightHeaderContent={headerButton()}
     >
       <div className={moduleStyles.console}>
-        <div ref={consoleRef}>
-          {codeOutput.map((outputLine, index) => {
-            if (outputLine.type === 'img') {
-              return (
-                <div key={index}>
-                  <img
+        {codeOutput.map((outputLine, index) => {
+          if (outputLine.type === 'img') {
+            return (
+              <div key={index}>
+                <img
+                  src={`data:image/png;base64,${outputLine.contents}`}
+                  alt="matplotlib_image"
+                />
+                <Button
+                  color={buttonColors.black}
+                  disabled={false}
+                  icon={{
+                    iconName: 'up-right-from-square',
+                    iconStyle: 'solid',
+                  }}
+                  isIconOnly={true}
+                  onClick={() => popOutGraph(index)}
+                  size="xs"
+                  type="primary"
+                  aria-label="open matplotlib_image in pop-up"
+                />
+                {activeGraphIndex === index && graphModalOpen && (
+                  <GraphModal
                     src={`data:image/png;base64,${outputLine.contents}`}
-                    alt="matplotlib_image"
+                    onClose={() => setGraphModalOpen(false)}
                   />
-                  <Button
-                    color={buttonColors.black}
-                    disabled={false}
-                    icon={{
-                      iconName: 'up-right-from-square',
-                      iconStyle: 'solid',
-                    }}
-                    isIconOnly={true}
-                    onClick={() => popOutGraph(index)}
-                    size="xs"
-                    type="primary"
-                    aria-label="open matplotlib_image in pop-up"
-                  />
-                  {activeGraphIndex === index && graphModalOpen && (
-                    <GraphModal
-                      src={`data:image/png;base64,${outputLine.contents}`}
-                      onClose={() => setGraphModalOpen(false)}
-                    />
-                  )}
-                </div>
-              );
-            } else if (
-              outputLine.type === 'system_out' ||
-              outputLine.type === 'system_in'
-            ) {
-              return <div key={index}>{outputLine.contents}</div>;
-            } else if (outputLine.type === 'error') {
-              return (
-                <div key={index} className={moduleStyles.errorLine}>
-                  {outputLine.contents}
-                </div>
-              );
-            } else if (outputLine.type === 'system_error') {
-              return (
-                <div key={index} className={moduleStyles.errorLine}>
-                  {systemMessagePrefix}
-                  {codebridgeI18n.systemCodeError()}
-                </div>
-              );
-            } else {
-              return (
-                <div key={index}>
-                  {systemMessagePrefix}
-                  {outputLine.contents}
-                </div>
-              );
-            }
-          })}
-        </div>
+                )}
+              </div>
+            );
+          } else if (
+            outputLine.type === 'system_out' ||
+            outputLine.type === 'system_in'
+          ) {
+            return <div key={index}>{outputLine.contents}</div>;
+          } else if (outputLine.type === 'error') {
+            return (
+              <div key={index} className={moduleStyles.errorLine}>
+                {outputLine.contents}
+              </div>
+            );
+          } else if (outputLine.type === 'system_error') {
+            return (
+              <div key={index} className={moduleStyles.errorLine}>
+                {systemMessagePrefix}
+                {codebridgeI18n.systemCodeError()}
+              </div>
+            );
+          } else {
+            return (
+              <div key={index}>
+                {systemMessagePrefix}
+                {outputLine.contents}
+              </div>
+            );
+          }
+        })}
+        <div ref={scrollAnchorRef} />
       </div>
     </PanelContainer>
   );

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -35,9 +35,10 @@ const Console: React.FunctionComponent = () => {
   }, [dispatch, levelId]);
 
   useEffect(() => {
-    if (consoleRef.current) {
-      consoleRef.current.scrollTop = consoleRef.current.scrollHeight;
-    }
+    consoleRef.current?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'end',
+    });
   }, [consoleRef, codeOutput]);
 
   const clearOutput = () => {
@@ -73,60 +74,65 @@ const Console: React.FunctionComponent = () => {
       headerContent={'Console'}
       rightHeaderContent={headerButton()}
     >
-      <div className={moduleStyles.console} ref={consoleRef}>
-        {codeOutput.map((outputLine, index) => {
-          if (outputLine.type === 'img') {
-            return (
-              <div key={index}>
-                <img
-                  src={`data:image/png;base64,${outputLine.contents}`}
-                  alt="matplotlib_image"
-                />
-                <Button
-                  color={buttonColors.black}
-                  disabled={false}
-                  icon={{iconName: 'up-right-from-square', iconStyle: 'solid'}}
-                  isIconOnly={true}
-                  onClick={() => popOutGraph(index)}
-                  size="xs"
-                  type="primary"
-                  aria-label="open matplotlib_image in pop-up"
-                />
-                {activeGraphIndex === index && graphModalOpen && (
-                  <GraphModal
+      <div className={moduleStyles.console}>
+        <div ref={consoleRef}>
+          {codeOutput.map((outputLine, index) => {
+            if (outputLine.type === 'img') {
+              return (
+                <div key={index}>
+                  <img
                     src={`data:image/png;base64,${outputLine.contents}`}
-                    onClose={() => setGraphModalOpen(false)}
+                    alt="matplotlib_image"
                   />
-                )}
-              </div>
-            );
-          } else if (
-            outputLine.type === 'system_out' ||
-            outputLine.type === 'system_in'
-          ) {
-            return <div key={index}>{outputLine.contents}</div>;
-          } else if (outputLine.type === 'error') {
-            return (
-              <div key={index} className={moduleStyles.errorLine}>
-                {outputLine.contents}
-              </div>
-            );
-          } else if (outputLine.type === 'system_error') {
-            return (
-              <div key={index} className={moduleStyles.errorLine}>
-                {systemMessagePrefix}
-                {codebridgeI18n.systemCodeError()}
-              </div>
-            );
-          } else {
-            return (
-              <div key={index}>
-                {systemMessagePrefix}
-                {outputLine.contents}
-              </div>
-            );
-          }
-        })}
+                  <Button
+                    color={buttonColors.black}
+                    disabled={false}
+                    icon={{
+                      iconName: 'up-right-from-square',
+                      iconStyle: 'solid',
+                    }}
+                    isIconOnly={true}
+                    onClick={() => popOutGraph(index)}
+                    size="xs"
+                    type="primary"
+                    aria-label="open matplotlib_image in pop-up"
+                  />
+                  {activeGraphIndex === index && graphModalOpen && (
+                    <GraphModal
+                      src={`data:image/png;base64,${outputLine.contents}`}
+                      onClose={() => setGraphModalOpen(false)}
+                    />
+                  )}
+                </div>
+              );
+            } else if (
+              outputLine.type === 'system_out' ||
+              outputLine.type === 'system_in'
+            ) {
+              return <div key={index}>{outputLine.contents}</div>;
+            } else if (outputLine.type === 'error') {
+              return (
+                <div key={index} className={moduleStyles.errorLine}>
+                  {outputLine.contents}
+                </div>
+              );
+            } else if (outputLine.type === 'system_error') {
+              return (
+                <div key={index} className={moduleStyles.errorLine}>
+                  {systemMessagePrefix}
+                  {codebridgeI18n.systemCodeError()}
+                </div>
+              );
+            } else {
+              return (
+                <div key={index}>
+                  {systemMessagePrefix}
+                  {outputLine.contents}
+                </div>
+              );
+            }
+          })}
+        </div>
       </div>
     </PanelContainer>
   );


### PR DESCRIPTION
Auto scroll the code bridge console (only used in Python Lab right now) to the bottom of the content. Previously we would not do any auto-scrolling, so new content in the console that went past the current visible area would not be obvious to users unless the manually scrolled.

## Screen recording

https://github.com/user-attachments/assets/245c473e-8cf0-4d66-ae4c-6c8947830730


## Links

- jira ticket: [CT-724](https://codedotorg.atlassian.net/browse/CT-724)

## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
