### PR TITLE
Remove old .md files from i18n sync

### DIFF
--- a/bin/i18n/resources/pegasus/markdown/sync_in.rb
+++ b/bin/i18n/resources/pegasus/markdown/sync_in.rb
@@ -12,27 +12,10 @@ module I18n
         class SyncIn < I18n::Utils::SyncInBase
           LOCALIZABLE_FILE_SUBPATHS = %w[
             public/athome.md.partial
-            public/break.md.partial
-            public/coldplay.md.partial
             public/csforgood.md
             public/curriculum/unplugged.md.partial
-            public/educate/csc.md.partial
-            public/educate/curriculum/csf-transition-guide.md
             public/educate/it.md
             public/helloworld.md.partial
-            public/hourofcode/artist.md.partial
-            public/hourofcode/flappy.md.partial
-            public/hourofcode/frozen.md.partial
-            public/hourofcode/hourofcode.md.partial
-            public/hourofcode/infinity.md.partial
-            public/hourofcode/mc.md.partial
-            public/hourofcode/starwars.md.partial
-            public/hourofcode/unplugged-conditionals-with-cards.md.partial
-            public/international/about.md.partial
-            public/poetry.md.partial
-            views/hoc2022_create_activities.md.partial
-            views/hoc2022_play_activities.md.partial
-            views/hoc2022_explore_activities.md.partial
           ].freeze
 
           def process


### PR DESCRIPTION
Removes old .md files from the i18n sync:

- public/break.md.partial
- public/coldplay.md.partial
- public/educate/csc.md.partial
- public/educate/curriculum/csf-transition-guide.md*
- public/hourofcode/artist.md.partial
- public/hourofcode/flappy.md.partial
- public/hourofcode/frozen.md.partial
- public/hourofcode/hourofcode.md.partial
- public/hourofcode/infinity.md.partial
- public/hourofcode/mc.md.partial
- public/hourofcode/playlab.md.partial
- public/hourofcode/starwars.md.partial
- public/hourofcode/unplugged-conditionals-with-cards.md.partial
- public/international/about.md.partial*
- public/poetry.md.partial*
- views/hoc2022_create_activities.md.partial
- views/hoc2022_play_activities.md.partial
- views/hoc2022_explore_activities.md.partial

## Links
Jira ticket: [ACQ-2327](https://codedotorg.atlassian.net/browse/ACQ-2327)
Slack convo: [here](https://codedotorg.slack.com/archives/C0T0UQH0R/p1724793079360759?thread_ts=1724791647.297609&cid=C0T0UQH0R)

## Followup
*We are now able to delete the .md and .md.partial pages related to these deprecated pages. I made a ticket here: [ACQ-2328](https://codedotorg.atlassian.net/browse/ACQ-2328)