### PR TITLE
[Aichat] Update UI of aichat temperature slider

### DIFF
--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -49,6 +49,31 @@ $default-spacing: 4px;
     border-radius: 4px;
     border-color: $light_black;
   }
+
+  input[type="range"] {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 4px;
+    background: $light_gray_700;
+    border-radius: .1rem;
+    &:disabled, &[aria-disabled="true"] {
+      background: $light_gray_200;
+    }
+  }
+
+  input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 12px;
+    height: 12px;
+    background: #fff;
+    border-radius: 50%;
+    border: 1px solid $light_gray_700;    
+  }
+
+  input[type="range"]:disabled::-webkit-slider-thumb {
+    background: $light_gray_200;
+    border: none;    
+  }
 }
 
 .horizontalFlexContainer {

--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -10,6 +10,26 @@ $default-spacing: 4px;
   box-sizing: border-box;
 }
 
+@mixin slider-track {
+  width: 100%;
+  height: 4px;
+  background: $light_gray_700;
+  border-radius: .1rem;
+}
+
+@mixin slider-thumb {
+  width: 12px;
+  height: 12px;
+  background: $white;
+  border-radius: 50%;
+  border: 1px solid $light_gray_700;
+}
+
+@mixin disabled-slider-thumb {
+  background: $light_gray_200;
+  border: none;
+}
+
 .modelCustomizationWorkspace {
   @extend %panel-section;
   display: flex;
@@ -51,28 +71,39 @@ $default-spacing: 4px;
   }
 
   input[type="range"] {
-    -webkit-appearance: none;
-    width: 100%;
-    height: 4px;
-    background: $light_gray_700;
-    border-radius: .1rem;
+    -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
+
+    @include slider-track;
     &:disabled, &[aria-disabled="true"] {
       background: $light_gray_200;
     }
   }
 
   input[type="range"]::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    width: 12px;
-    height: 12px;
-    background: #fff;
-    border-radius: 50%;
-    border: 1px solid $light_gray_700;    
+    -webkit-appearance: none; /* Hides the thumb so that custom thumb can be made */
+
+    @include slider-thumb;
   }
 
   input[type="range"]:disabled::-webkit-slider-thumb {
+    @include disabled-slider-thumb;
+  }
+
+  /* Firefox */
+  input[type="range"]::-moz-range-track {
+    @include slider-track;
+  }
+
+  input[type="range"]:disabled::-moz-range-track {
     background: $light_gray_200;
-    border: none;    
+  }
+
+  input[type="range"]::-moz-range-thumb {    
+    @include slider-thumb;
+  }
+
+  input[type="range"]:disabled::-moz-range-thumb {
+    @include disabled-slider-thumb;
   }
 }
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the styling of the temperature slide in the setup customizations panel.

Before update:
<img width="420" alt="Screenshot 2024-08-27 at 6 33 27 PM" src="https://github.com/user-attachments/assets/cf585914-11b3-4b62-ae02-cd3fe38f52ea">


After update:
<img width="423" alt="Screenshot 2024-08-27 at 6 34 41 PM" src="https://github.com/user-attachments/assets/d973afa4-8ff1-4fc0-8555-1c88f6f83a04">


Here are after update screencast videos showing sliders when active and disabled:
On Chrome:

https://github.com/user-attachments/assets/d19ed674-e2de-4304-be78-6722e113bc71



On Firefox:


https://github.com/user-attachments/assets/a8b0f43e-0d44-44b7-8330-011182d36a9a



## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-844)


<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested in a teacher account on Chrome, Firefox, Safari, and Edge so I could view slider in both active and disabled (when viewing as student) mode.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Note that the left-hand side of the slider track is not a different color. I was unable to find a CSS solution to do this. I had a similar issue when creating the slider for the Music Play View and ended up creating the `ProgressSlider` component - see https://github.com/code-dot-org/code-dot-org/pull/58373. However, the music lab play view slider is read-only so I was unable to use it for the aichat temperature slider.

I consulted with @markabarrett and @samantha-code about this and Mark shared that there are plans to use an interactive input slider in Music Lab so that a DSCO slider is in queue to be created.
If the DSCO slider is created by @levadadenys before the Gen AI UI lock, then we'll replace the HTML range input with the DSCO component before launch. If not, then we'll replace AFTER launch.



<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
