### PR TITLE
Remove aichat-polling experiment

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -41,7 +41,6 @@ export async function postAichatCompletionMessage(
   storedMessages: ChatMessage[],
   aiCustomizations: AiCustomizations,
   aichatContext: AichatContext,
-  useAsyncPolling = false,
   // Configurable for testing
   maxPollingTimeMs = MAX_POLLING_TIME_MS
 ): Promise<ChatCompletionApiResponse> {
@@ -52,32 +51,13 @@ export async function postAichatCompletionMessage(
     systemPrompt: aiCustomizations.systemPrompt,
   };
 
-  if (useAsyncPolling) {
-    return postChatCompletionAsyncPolling(
-      newMessage,
-      storedMessages,
-      aichatModelCustomizations,
-      aichatContext,
-      maxPollingTimeMs
-    );
-  }
-
-  const payload = {
+  return postChatCompletionAsyncPolling(
     newMessage,
     storedMessages,
     aichatModelCustomizations,
     aichatContext,
-  };
-  const response = await HttpClient.post(
-    paths.CHAT_COMPLETION_URL,
-    JSON.stringify(payload),
-    true,
-    {
-      'Content-Type': 'application/json; charset=UTF-8',
-    }
+    maxPollingTimeMs
   );
-
-  return await response.json();
 }
 
 /**

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -18,7 +18,6 @@ import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {registerReducers} from '@cdo/apps/redux';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {RootState} from '@cdo/apps/types/redux';
-import experiments from '@cdo/apps/util/experiments';
 import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
@@ -404,8 +403,7 @@ export const submitChatContents = createAsyncThunk(
         newUserMessage,
         chatEventsCurrent.filter(isChatMessage) as ChatMessage[],
         aiCustomizations,
-        aichatContext,
-        experiments.isEnabled(experiments.AICHAT_POLLING)
+        aichatContext
       );
     } catch (error) {
       await handleChatCompletionError(error as Error, newUserMessage, dispatch);

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -70,8 +70,6 @@ experiments.VIEW_CHAT_HISTORY = 'view_chat_history';
 experiments.TEACHER_LOCAL_NAV_V2 = 'teacher-local-nav-v2';
 // Enables LMS cards in the LoginTypePicker during section creation
 experiments.SECTION_CREATE_LMS_CARDS = 'section_create_lms_cards';
-// Use the polling API for fetching chat responses in the AI Chat lab
-experiments.AICHAT_POLLING = 'aichat-polling';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/test/unit/aichat/aichatApiTest.ts
+++ b/apps/test/unit/aichat/aichatApiTest.ts
@@ -120,7 +120,6 @@ describe('aichatApi', () => {
           storedMessages,
           aiCustomizations,
           aichatContext,
-          true,
           maxPollingTime
         )
       ).messages;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR documents the testing of the ActiveJob API for aichat completion (currently hidden behind experiment 'aichat-polling') on production and removes the experiment flag.
This is the final step to a multi-PR process implemented by @sanchitmalhotra126 .
- https://github.com/code-dot-org/code-dot-org/pull/60391
- https://github.com/code-dot-org/code-dot-org/pull/60323
- https://github.com/code-dot-org/code-dot-org/pull/60289
- https://github.com/code-dot-org/code-dot-org/pull/60257

Screencast video of dev network tab with experiment when sending a chat request on an aichat level on production:


https://github.com/user-attachments/assets/d9249870-de29-4de3-9ff5-e9383492e381

This is a screenshot of the dev network tab with the experiment disabled. Note that the api endpoint called is `chat_completion` instead of `start_chat_completion` / `chat_request`.

![Screenshot 2024-08-28 at 1 31 13 PM](https://github.com/user-attachments/assets/1518056c-50e0-45e4-ae34-90c5edfbab54)

After submitting multiple aichat requests, I checked the `AichatRequests` table to confirm that the requests were logged as expected.

Here's a screenshot of the `AichatRequests` table while polling is taking place and then when the request was resolved (see row 12):

<img width="1286" alt="Screenshot 2024-08-28 at 10 36 57 AM" src="https://github.com/user-attachments/assets/cc41575b-7b73-47f7-a86d-08e598d10fa6">

As requested by @sanchitmalhotra126 , I let infra team know about this update - [Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1724870724670449).


## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-981)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
After removing the experiment, I disabled the experiment locally and then confirmed that the Active Job API was now being called successfully.

![Screenshot 2024-08-28 at 1 34 57 PM](https://github.com/user-attachments/assets/0e640427-1f9b-450d-8a43-d2ee1fcb6d50)
<!--


  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Remove `chat_completion` action and associated code. Update tests!

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
