### PR TITLE
Add 2024 best of stem logo to code.org/donate

### DIFF
--- a/pegasus/sites.v3/code.org/public/images/about/seals/best_of_stem_2023.png
+++ b/pegasus/sites.v3/code.org/public/images/about/seals/best_of_stem_2023.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ecac6aa1172e48da37d319f7352cfedbca089e44b269385fa0047136d3ea2b63
-size 116675

--- a/pegasus/sites.v3/code.org/public/images/about/seals/best_of_stem_2024.png
+++ b/pegasus/sites.v3/code.org/public/images/about/seals/best_of_stem_2024.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f2d8d21255f39e8219f440681b176d8b8aa7859c07a3ca45d87d22d512f0008
+size 127952

--- a/pegasus/sites.v3/code.org/views/about_seals.haml
+++ b/pegasus/sites.v3/code.org/views/about_seals.haml
@@ -55,7 +55,7 @@
 
 %div.about-seals
   %a{href: "https://www.bestofstemawards.com/", target: "_blank", rel: "noopener noreferrer"}
-    %img.best-of-stem{src: "/images/about/seals/best_of_stem_2023.png"}
+    %img.best-of-stem{src: "/images/about/seals/best_of_stem_2024.png"}
   %a{href: "https://www.commonsense.org/education/reviews/codeorg", target: "_blank", rel: "noopener noreferrer"}
     %img.common-sense{src: "/images/about/seals/common_sense_selection_seals_learning.svg"}
   %a{href:"https://www.guidestar.org/profile/46-0858543", target: "_blank", rel: "noopener noreferrer", class: "guidestar"}


### PR DESCRIPTION
Adds the Best of STEM 2024 logo on https://code.org/donate.

## Links
Jira ticket: [ACQ-2330](https://codedotorg.atlassian.net/browse/ACQ-2330)

----

<img width="1064" alt="Screenshot 2024-08-28 at 9 48 43 AM" src="https://github.com/user-attachments/assets/e5603012-957e-4397-b4dd-0c8e72ff559a">
