### PR TITLE
[test Chrome] Flaky test: teacher_homepage fixing check for href loading state.

### DIFF
--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -285,7 +285,11 @@ Then /^the url contains the section id$/ do
 end
 
 Then /^the href of selector "([^"]*)" contains the section id$/ do |selector|
-  href = @browser.execute_script("return $(\"#{selector}\").attr('href');")
+  href = nil
+  wait_until do
+    href = @browser.execute_script("return $(\"#{selector}\").attr('href');")
+    href != nil?
+  end
   expect(@section_id).to be > 0
 
   # make sure the query params do not come after the # symbol
@@ -344,9 +348,15 @@ end
 # @return [Number] the section id for the corresponding row in the sections table
 def get_section_id_from_table(row_index)
   # e.g. https://studio-code.org/teacher_dashboard/sections/54
-  href = @browser.execute_script(
-    "return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(1) a').attr('href')"
-  )
+
+  href = nil
+  wait_until do
+    href = @browser.execute_script(
+      "return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(1) a').attr('href')"
+    )
+    !href.nil?
+  end
+
   section_id = href.split('/').last.to_i
   expect(section_id).to be > 0
   section_id

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -263,14 +263,12 @@ end
 Then /^the section table row at index (\d+) has (primary|secondary) assignment path "([^"]+)"$/ do |row_index, assignment_type, expected_path|
   link_index = (assignment_type == 'primary') ? 0 : 1
   # Wait until the link loads in the table
+  href = nil
   wait_until do
-    @browser.execute_script("return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(3) a:eq(#{link_index})').attr('href') !== null;")
+    href = @browser.execute_script("return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(3) a:eq(#{link_index})').attr('href');")
+    !href.nil?
   end
 
-  # Then grab it
-  href = @browser.execute_script(
-    "return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(3) a:eq(#{link_index})').attr('href');"
-  )
   # ignore query params
   actual_path = href.split('?')[0]
   expect(actual_path).to eq(expected_path)


### PR DESCRIPTION
Context: UI test checks the href attribute on sections table's curriculum field. Since the assigned curriculum is fetched async, the herf attribute retrieved was null. To account for these cases, the tests had a check to ensure the href attribute isn't null, through the check below
```
{
	"args": [],
	"script": "return $('.uitest-owned-sections tbody tr:eq(0) td:eq(3) a:eq(0)').attr('href') !== null;"
}
```
Issue: When the href isn't loaded, it returns undefined, so the above check will return true even if the href isn't loaded.

Fix: Updating the check to retrieve the href and validate it isn't null in steps.rb

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1144

## Testing story

Drone run - https://app.saucelabs.com/dashboard/tests?tag=vijaya%2Fteacher_dashboard&status=passed&ownerId=myorganization&ownerType=organization&ownerName=My+organization&search=teacher_homepage&start=last7days

## Deployment strategy

Regular DTTs

## Follow-up work

Validate the error rates fall through sauce labs and DOTD health dashboard

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
