### PR TITLE
[JIMT][CT-758] - added overflow:scroll to InfoPanel

### DIFF
--- a/apps/src/codebridge/InfoPanel/styles/info-panel.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/info-panel.module.scss
@@ -1,4 +1,4 @@
-@import "color";
+@import 'color';
 
 .infoPanel {
   white-space: pre-wrap;
@@ -7,6 +7,7 @@
   color: $white;
   background-color: $neutral_dark;
   border: 1px solid $neutral_dark80;
+  overflow: scroll;
 }
 
 // This is adapted from customDropdown.module.scss in the component library.
@@ -21,12 +22,12 @@
   margin: 0.25rem 0;
   list-style: none;
   background-color: $dark_gray;
-  border: 1px solid rgba(0 0 0 / .15);
+  border: 1px solid rgba(0 0 0 / 0.15);
   border-radius: 4px;
-  -webkit-box-shadow: 0 6px 12px rgba(0 0 0 / .175);
-  box-shadow: 0 6px 12px rgba(0 0 0 / .175);
+  -webkit-box-shadow: 0 6px 12px rgba(0 0 0 / 0.175);
+  box-shadow: 0 6px 12px rgba(0 0 0 / 0.175);
   background-clip: padding-box;
-  padding: .25rem 0 0;
+  padding: 0.25rem 0 0;
 
   ul {
     margin: 0;
@@ -65,7 +66,8 @@
         }
       }
 
-      label, .dropdownItem {
+      label,
+      .dropdownItem {
         flex-grow: 1;
         margin-bottom: 0;
       }


### PR DESCRIPTION
Per discussion here: https://codedotorg.slack.com/archives/C06JELCAPT9/p1724864895382039

If instructions were too long, they'd overflow the grid and push the file browser off the screen.

So this just adds an `overflow: scroll` to the `InfoPanel` to ensure it stays put.

Note that there's a ton of other tweaks in this file due to the linter waking up and making a bunch of formatting changes. `overflow: scroll` is the only real one.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CT-758](https://codedotorg.atlassian.net/browse/CT-758)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
