### PR TITLE
Remove AI TA banner from /curriculum/csd

### DIFF
--- a/pegasus/sites.v3/code.org/public/curriculum/csd.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/csd.haml
@@ -6,10 +6,6 @@ theme: responsive_full_width
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/csd-styles.css", rel: "stylesheet"}
 
--# TODO - Remove the DCDO logic after the AI Teaching Assistant launch
-- if !!DCDO.get('ai-teaching-assistant-launch', false)
-  = view :top_skinny_banner, banner_id: "banner-csd", banner_url: nil, banner_icon: "fa fa-megaphone", banner_text: hoc_s("ai_ta_page.announcement_banner_csd_page", markdown: :inline, locals: {learn_url: "/ai/teaching-assistant"}), external_link: false, light_theme: true
-
 %section.hero-banner-basic.overlay
   .wrapper.flex-container.justify-space-between.align-items-center.wrap
     .text-wrapper


### PR DESCRIPTION
Removes the AI TA skinny banner from [/curriculum/csd](https://code.org/curriculum/csd).

Current:
![csd prev](https://github.com/user-attachments/assets/8f93ec44-327e-40a4-9c57-387f6e98b3bf)

New:
![csd new](https://github.com/user-attachments/assets/bcf724c5-7706-44cb-adef-8a427f67a60b)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2269)

## Testing story
Local testing.
