### PR TITLE
Update angle picker step to accept a small range of pixel values

### DIFF
--- a/dashboard/test/ui/features/step_definitions/angleHelper.rb
+++ b/dashboard/test/ui/features/step_definitions/angleHelper.rb
@@ -46,7 +46,9 @@ When(/^I drag the Angle Helper circle to coordinates \((\d*),(\d*)\)$/) do |x, y
 end
 
 Then(/^the angle text is at "(\d*)"$/) do |val|
-  expect(@browser.execute_script("return $('.blocklyWidgetDiv .blocklyHtmlInput').val()")).to be_between(val - 1, val + 1)
+  val_int = val.to_i
+  # Firefox and Chrome are off by one in the pixel location of the angle text, so we need to allow for a small range in values.
+  expect(@browser.execute_script("return $('.blocklyWidgetDiv .blocklyHtmlInput').val()").to_i).to be_between(val_int - 1, val_int + 1)
 end
 
 Then(/^the angle dropdown is at "(\d*)"$/) do |val|

--- a/dashboard/test/ui/features/step_definitions/angleHelper.rb
+++ b/dashboard/test/ui/features/step_definitions/angleHelper.rb
@@ -46,7 +46,7 @@ When(/^I drag the Angle Helper circle to coordinates \((\d*),(\d*)\)$/) do |x, y
 end
 
 Then(/^the angle text is at "(\d*)"$/) do |val|
-  expect(@browser.execute_script("return $('.blocklyWidgetDiv .blocklyHtmlInput').val()")).to eq(val)
+  expect(@browser.execute_script("return $('.blocklyWidgetDiv .blocklyHtmlInput').val()")).to be_between(val - 1, val + 1)
 end
 
 Then(/^the angle dropdown is at "(\d*)"$/) do |val|


### PR DESCRIPTION
We found that the angle_helper test was failing on Firefox due to an off-by-one pixel issue. This updates the step to allow plus or minus one to the expected pixel value.

I confirmed without this change, Firefox version of the test fails, and with it it passes.

## Links

- [slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1724876400867179?thread_ts=1724870324.112929&cid=C03DBDN67B7)



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
