### PR TITLE
[test Chrome] Flaky test: Adding input element enabled check.

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -293,7 +293,7 @@ When /^I wait until (?:element )?"([.#])([^"]*)" is (not )?enabled$/ do |selecto
   end
 end
 
-When /^I wait testchange until element "([^"]*)" is enabled$/ do |_selector_symbol, _name, _negation|
+When /^I wait testchange until element "([^"]*)" is enabled$/ do |selection_criteria|
   wait_until do
     element = @browser.find_element(css: selection_criteria)
     element.enabled?

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -293,6 +293,13 @@ When /^I wait until (?:element )?"([.#])([^"]*)" is (not )?enabled$/ do |selecto
   end
 end
 
+When /^I wait testchange until element "([^"]*)" is enabled$/ do |_selector_symbol, _name, _negation|
+  wait_until do
+    element = @browser.find_element(css: selection_criteria)
+    element.enabled?
+  end
+end
+
 Then /^I wait up to ([\d\.]+) seconds for element "([^"]*)" to be visible$/ do |seconds, selector|
   wait_for_jquery
   Selenium::WebDriver::Wait.new(timeout: seconds.to_f).until do

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -287,16 +287,18 @@ end
 
 When /^I wait until (?:element )?"([.#])([^"]*)" is (not )?enabled$/ do |selector_symbol, name, negation|
   selection_criteria = selector_symbol == '#' ? {id: name} : {class: name}
-  wait_until do
-    element = @browser.find_element(selection_criteria)
-    element.enabled? == negation.nil?
-  end
+  wait_for_element(selection_criteria, negation.nil?)
 end
 
-When /^I wait testchange until element "([^"]*)" is enabled$/ do |selection_criteria|
+When /^I wait until element with css selector "([^"]*)" is (not )?enabled$/ do |css_selector, negation|
+  selection_criteria = {css: css_selector}
+  wait_for_element(selection_criteria, negation.nil?)
+end
+
+def wait_for_element(selection_criteria, enabled)
   wait_until do
-    element = @browser.find_element(css: selection_criteria)
-    element.enabled?
+    element = @browser.find_element(selection_criteria)
+    element.enabled? == enabled
   end
 end
 

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -16,7 +16,7 @@ Feature: Using the manage students tab of the teacher dashboard
     # Add a family name for Sally
     And I click selector ".ui-test-section-dropdown" once I see it
     And I press the child number 0 of class ".pop-up-menu-item"
-    And I wait testchange until element "input[name='uitest-family-name']" is enabled
+    And I wait until element with css selector "input[name='uitest-family-name']" is enabled
     And I press keys "SallyAlsoHasAVeryVeryLongLastName" for element "input[name='uitest-family-name']"
     And I click selector "button:contains(Save)"
     And I see no difference for "manage students tab"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -16,7 +16,7 @@ Feature: Using the manage students tab of the teacher dashboard
     # Add a family name for Sally
     And I click selector ".ui-test-section-dropdown" once I see it
     And I press the child number 0 of class ".pop-up-menu-item"
-    And I wait until element "input[name='uitest-family-name']" is visible
+    And I wait testchange until element "input[name='uitest-family-name']" is enabled
     And I press keys "SallyAlsoHasAVeryVeryLongLastName" for element "input[name='uitest-family-name']"
     And I click selector "button:contains(Save)"
     And I see no difference for "manage students tab"


### PR DESCRIPTION
Context: UI tests intermittently fails when executing send keys to an input element error `stale element reference: element is not attached to the page document` Specifically, the element in question is the family name text box which becomes editable after "Edit all" is clicked, as shown in screen shot.

![image](https://github.com/user-attachments/assets/887da845-f29d-4aee-83c2-2c21350f81d0)

There are couple of steps before the failure step which ensure the input element is visible, but that doesn't seem to help,
1. Checking for element visibility through JQuery

```
{
	"script_checksum": "a5ab9f4b7b2c6053b5282c3c4c89ee6a458cb88cc9c9d96dfc1ce7a55f49e2dc",
	"args": [],
	"script": "return $(\"input[name='uitest-family-name']\").is(':visible') && $(\"input[name='uitest-family-name']\").css('visibility')!== 'hidden'\")
}
```

2. and fetching the element 
```
{
	"using": "css selector",
	"value": "input[name='uitest-family-name']"
}
```

Hypothesis on the root cause: Between the time edit all is clicked and the input field becomes editable, there are a few different states the element goes through after the element is visible. 

Fix: Wait for the element to be enabled in addition to visibility

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1262

## Testing story

Validated the test by running it locally

## Deployment strategy

Regular DTT

## Follow-up work

Continue to monitor test for failures

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
