### PR TITLE
[Aichat] Save temperature value as number/add better type safety

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -635,11 +635,11 @@ const aichatSlice = createSlice({
     ) => {
       state.savedAiCustomizations = action.payload;
     },
-    setAiCustomizationProperty: (
-      state,
+    setAiCustomizationProperty: <T extends keyof AiCustomizations>(
+      state: AichatState,
       action: PayloadAction<{
-        property: keyof AiCustomizations;
-        value: AiCustomizations[typeof property];
+        property: T;
+        value: AiCustomizations[T];
       }>
     ) => {
       const {property, value} = action.payload;

--- a/apps/src/aichat/redux/utils.ts
+++ b/apps/src/aichat/redux/utils.ts
@@ -29,6 +29,10 @@ const haveDifferentValues = (
   if (typeof value1 === 'object' && typeof value2 === 'object') {
     return JSON.stringify(value1) !== JSON.stringify(value2);
   }
+  // In the case that field values are saved as different types, compare as strings.
+  if (typeof value1 !== typeof value2) {
+    return value1.toString() !== value2.toString();
+  }
 
   return value1 !== value2;
 };

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -152,7 +152,7 @@ const SetupCustomization: React.FunctionComponent = () => {
                 dispatch(
                   setAiCustomizationProperty({
                     property: 'temperature',
-                    value: event.target.value,
+                    value: parseFloat(event.target.value),
                   })
                 )
               }

--- a/apps/src/lab2/levelEditors/aichatSettings/FieldSection.tsx
+++ b/apps/src/lab2/levelEditors/aichatSettings/FieldSection.tsx
@@ -47,7 +47,14 @@ const FieldSection: React.FunctionComponent<FieldSectionProps> = ({
               id={fieldName}
               type={inputType}
               value={initialCustomizations[fieldName] as string | number}
-              onChange={e => setPropertyValue(fieldName, e.target.value)}
+              onChange={e =>
+                setPropertyValue(
+                  fieldName,
+                  fieldName === 'temperature'
+                    ? parseFloat(e.target.value)
+                    : e.target.value
+                )
+              }
               className={classNames(
                 inputType === 'textarea' && moduleStyles.textarea
               )}

--- a/apps/src/lab2/levelEditors/aichatSettings/UpdateContext.ts
+++ b/apps/src/lab2/levelEditors/aichatSettings/UpdateContext.ts
@@ -11,9 +11,9 @@ import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
 
 export const UpdateContext = createContext({
   aichatSettings: {} as LevelAichatSettings,
-  setPropertyValue: (
-    property: keyof AiCustomizations,
-    value: AiCustomizations[keyof AiCustomizations]
+  setPropertyValue: <T extends keyof AiCustomizations>(
+    property: T,
+    value: AiCustomizations[T]
   ) => {},
   setPropertyVisibility: (
     property: keyof AiCustomizations,

--- a/apps/test/unit/aichat/utilsTest.ts
+++ b/apps/test/unit/aichat/utilsTest.ts
@@ -1,0 +1,40 @@
+import * as utils from '@cdo/apps/aichat/redux/utils';
+import {AiCustomizations} from '@cdo/apps/aichat/types';
+import {EMPTY_MODEL_CARD_INFO} from '@cdo/apps/aichat/views/modelCustomization/constants';
+import {AiChatModelIds} from '@cdo/generated-scripts/sharedConstants';
+
+describe('aichatRedux utils', () => {
+  let aiCustomizations1: AiCustomizations;
+  let aiCustomizations2: AiCustomizations;
+  let aiCustomizations3: AiCustomizations;
+  let aiCustomizations4: AiCustomizations;
+  beforeEach(() => {
+    aiCustomizations1 = {
+      selectedModelId: AiChatModelIds.ARITHMO,
+      temperature: 0.5,
+      retrievalContexts: ['123'],
+      systemPrompt: 'hello',
+      modelCardInfo: EMPTY_MODEL_CARD_INFO,
+    };
+    aiCustomizations2 = {...aiCustomizations1};
+    aiCustomizations2.selectedModelId = AiChatModelIds.KAREN;
+    aiCustomizations3 = {...aiCustomizations1};
+    aiCustomizations4 = {...aiCustomizations2};
+    aiCustomizations4.systemPrompt = 'hi';
+  });
+  it('haveDifferentValues returns field name whose value is different.', async () => {
+    expect(
+      utils.findChangedProperties(aiCustomizations1, aiCustomizations2)[0]
+    ).toBe('selectedModelId');
+  });
+  it('haveDifferentValues returns empty array if no values are different.', async () => {
+    expect(
+      utils.findChangedProperties(aiCustomizations1, aiCustomizations3).length
+    ).toBe(0);
+  });
+  it('haveDifferentValues returns array with length 2 if two values are different.', async () => {
+    expect(
+      utils.findChangedProperties(aiCustomizations1, aiCustomizations4).length
+    ).toBe(2);
+  });
+});


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR ensures that the `temperature` value is saved as a `number` and not a `string`.
In some `aichat` level files, `temperature` is saved [as a `number`](https://github.com/code-dot-org/code-dot-org/blob/cc4d31d4284c6be4b708a93645c83c9baf184e36/dashboard/config/levels/custom/aichat/AI%20Chat%20Test%20Level.level#L18) and in other files, it is saved [as a `string`](https://github.com/code-dot-org/code-dot-org/blob/cc4d31d4284c6be4b708a93645c83c9baf184e36/dashboard/config/levels/custom/aichat/gen-ai-customizing-intro-L1.level#L18). This resulted in a bug if when [checking if AI customization fields were changed by the user](https://github.com/code-dot-org/code-dot-org/blob/f4b2125b94a8b49d95d75ab1a490faae55b44129/apps/src/aichat/redux/utils.ts#L36-L56), if the value was saved as a number in the .level file, a 'change' was detected since for example `0.3 !== '0.3'` evaluates to `true`.
We just need consistency and since `temperature` should technically be a number, we now save it as that type.


This was a bug first observed by @ebeastlake in [this Slack thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1724096959505919?thread_ts=1724096748.219919&cid=C06FELVTV0Q).

## Before update
Notice that after starting over on '/s/allthethings/lessons/47/levels/1' in which `temperature` is saved as a `number`, the value is initially `0.5`. When it is changed to a different value and then changed back without updating, a change is detected since the user's current value is `"0.5"` is saved as a string. Therefore, 'You have unsaved changes' message is displayed. 


https://github.com/user-attachments/assets/2edd0095-f785-4205-a6db-5df8e195599f



## After update
Now that the user's current value is saved as a `number`, when the user changes the value back to the initial value `0.5`, no change is detected so that 'Remember to save your changes' message is displayed.



https://github.com/user-attachments/assets/fc66e105-a68b-4b4e-9bf5-07c609628087




Note that these reminder messages to save customizations were implemented in https://github.com/code-dot-org/code-dot-org/pull/60585#issuecomment-2313004649 where this bug was noted.

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-982)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
See after update screencast video above. I checked locally that in `main.json`, `temperature` is now being saved as a `number`.

<img width="1228" alt="Screenshot 2024-08-29 at 12 52 02 PM" src="https://github.com/user-attachments/assets/023c1ce5-d71e-41b5-a0c6-e367d935ee6b">

I also added unit tests for `haveDifferentValues`.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
