### PR TITLE
Restructure flaky Hour of Code eyes test

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -238,6 +238,7 @@ Scenario: congrats certificate pages show social media icons
   And element "#uitest-certificate" is visible
   And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
+  Then the href of selector ".social-print-link" contains "/print_certificates/"
 
   When I am on "http://code.org/api/hour/finish/flappy"
   And I wait until current URL contains "/congrats"
@@ -246,6 +247,7 @@ Scenario: congrats certificate pages show social media icons
   And I wait for image "#uitest-certificate img" to load
   And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
+  Then the href of selector ".social-print-link" contains "/print_certificates/"
 
   When I am on "http://code.org/api/hour/finish/oceans"
   And I wait until current URL contains "/congrats"
@@ -254,6 +256,7 @@ Scenario: congrats certificate pages show social media icons
   And I wait for image "#uitest-certificate img" to load
   And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
+  Then the href of selector ".social-print-link" contains "/print_certificates/"
 
   When I am on "http://code.org/api/hour/finish/accelerated"
   And I wait until current URL contains "/congrats"
@@ -262,6 +265,7 @@ Scenario: congrats certificate pages show social media icons
   And I wait for image "#uitest-certificate img" to load
   And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
+  Then the href of selector ".social-print-link" contains "/print_certificates/"
 
   When I am on "http://code.org/api/hour/finish/coursea-2017"
   And I wait until current URL contains "/congrats"
@@ -270,3 +274,4 @@ Scenario: congrats certificate pages show social media icons
   And I wait for image "#uitest-certificate img" to load
   And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
+  Then the href of selector ".social-print-link" contains "/print_certificates/"

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -267,7 +267,7 @@ Scenario: congrats certificate pages show social media icons
   And I wait until element ".fa-twitter" is visible
   Then the href of selector ".social-print-link" contains "/print_certificates/"
 
-   When I am on "http://code.org/congrats/coursea-2017"
+  When I am on "http://code.org/congrats/coursea-2017"
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -231,3 +231,42 @@ Scenario: congrats certificate pages
   And I see no difference for "customized Course A 2017 certificate"
 
   And I close my eyes
+
+Scenario: congrats certificate pages show social media icons
+  Given I am on "http://studio.code.org/congrats"
+  And I wait until element "#uitest-certificate" is visible
+  And element "#uitest-certificate" is visible
+  And I wait until element ".fa-facebook" is visible
+  And I wait until element ".fa-twitter" is visible
+
+  When I am on "http://code.org/api/hour/finish/flappy"
+  And I wait until current URL contains "/congrats"
+  And I wait to see element with ID "uitest-certificate"
+  And element "#uitest-certificate" is visible
+  And I wait for image "#uitest-certificate img" to load
+  And I wait until element ".fa-facebook" is visible
+  And I wait until element ".fa-twitter" is visible
+
+  When I am on "http://code.org/api/hour/finish/oceans"
+  And I wait until current URL contains "/congrats"
+  And I wait to see element with ID "uitest-certificate"
+  And element "#uitest-certificate" is visible
+  And I wait for image "#uitest-certificate img" to load
+  And I wait until element ".fa-facebook" is visible
+  And I wait until element ".fa-twitter" is visible
+
+  When I am on "http://code.org/api/hour/finish/accelerated"
+  And I wait until current URL contains "/congrats"
+  And I wait to see element with ID "uitest-certificate"
+  And element "#uitest-certificate" is visible
+  And I wait for image "#uitest-certificate img" to load
+  And I wait until element ".fa-facebook" is visible
+  And I wait until element ".fa-twitter" is visible
+
+  When I am on "http://code.org/api/hour/finish/coursea-2017"
+  And I wait until current URL contains "/congrats"
+  And I wait to see element with ID "uitest-certificate"
+  And element "#uitest-certificate" is visible
+  And I wait for image "#uitest-certificate img" to load
+  And I wait until element ".fa-facebook" is visible
+  And I wait until element ".fa-twitter" is visible

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -258,7 +258,7 @@ Scenario: congrats certificate pages show social media icons
   And I wait until element ".fa-twitter" is visible
   Then the href of selector ".social-print-link" contains "/print_certificates/"
 
-  When I am on "http://code.org/api/hour/finish/accelerated"
+  When I am on "http://code.org/congrats/accelerated"
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
@@ -267,7 +267,7 @@ Scenario: congrats certificate pages show social media icons
   And I wait until element ".fa-twitter" is visible
   Then the href of selector ".social-print-link" contains "/print_certificates/"
 
-  When I am on "http://code.org/api/hour/finish/coursea-2017"
+   When I am on "http://code.org/congrats/coursea-2017"
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible


### PR DESCRIPTION
This PR restructures the flaky Hour of Code eyes test that waits to see a loading Facebook icon. The new structure checks for the Facebook, Twitter, and Print Certificate icons in a non-eyes UI test, while an ignore region is added to cover the icons. This way we can check that the icon elements are present without it being as flaky.

Unfortunately, this comes with the cost of not being able to test that the icons fully load reliably (but in [this discussion](https://codedotorg.slack.com/archives/C04540KNGDQ/p1724874020055869) it sounds like we don't want to expend more dev time investigating since we've had [several attempts](https://github.com/code-dot-org/code-dot-org/pull/56321/files) at fixing it).

New ignore region example:
![ignoreregion](https://github.com/user-attachments/assets/84a9b596-70d8-4e5d-bbcb-31a1ec54f37e)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1917)

## Testing
Tested successfully locally.
