### PR TITLE
Codebridge/lab2 version history v2

### DIFF
--- a/apps/i18n/lab2/en_us.json
+++ b/apps/i18n/lab2/en_us.json
@@ -1,4 +1,5 @@
 {
+  "closeVersionHistory": "Close version history",
   "initialVersion": "Initial version",
   "versionHistoryLoadFailure": "Sorry, we couldn't load your version history. Please try again.",
   "versionHistoryLoading": "Loading version history...",

--- a/apps/i18n/lab2/en_us.json
+++ b/apps/i18n/lab2/en_us.json
@@ -1,4 +1,5 @@
 {
+  "initialVersion": "Initial version",
   "versionHistoryLoadFailure": "Sorry, we couldn't load your version history. Please try again.",
   "versionHistoryLoading": "Loading version history...",
   "versionLoadFailure": "Sorry, we couldn't load that version. Please try again."

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -1,10 +1,9 @@
 import classNames from 'classnames';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 import Alert from '@cdo/apps/componentLibrary/alert/Alert';
 import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import Tags from '@cdo/apps/componentLibrary/tags/Tags';
-import {BodyTwoText} from '@cdo/apps/componentLibrary/typography';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import lab2I18n from '@cdo/apps/lab2/locale';
 import {
@@ -13,6 +12,7 @@ import {
 } from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import {ProjectSources, ProjectVersion} from '@cdo/apps/lab2/types';
 import {commonI18n} from '@cdo/apps/types/locale';
+import currentLocale from '@cdo/apps/util/currentLocale';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import moduleStyles from './version-history.module.scss';
@@ -35,6 +35,16 @@ const VersionHistoryDropdown: React.FunctionComponent<
   const [loadError, setLoadError] = useState(false);
   const [loading, setLoading] = useState(false);
   const [selectedVersion, setSelectedVersion] = useState('');
+  const locale = currentLocale();
+
+  const dateFormatter = useMemo(() => {
+    return new Intl.DateTimeFormat(locale, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    });
+  }, [locale]);
 
   useEffect(() => {
     if (selectedVersion === '') {
@@ -81,8 +91,8 @@ const VersionHistoryDropdown: React.FunctionComponent<
   }, [dispatch, startSource, updatedSourceCallback, closeDropdown]);
 
   const parseDate = (date: string) => {
-    const parsedDate = new Date(date);
-    return parsedDate.toLocaleString();
+    const dateObject = new Date(date);
+    return dateFormatter.format(dateObject);
   };
 
   const onVersionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -95,7 +105,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
     <div>
       <div className={moduleStyles.versionHistoryList}>
         {versionList.map(version => (
-          <label className={moduleStyles.versionItem}>
+          <label className={moduleStyles.versionItem} key={version.versionId}>
             <input
               type="radio"
               name={version.versionId}
@@ -103,8 +113,8 @@ const VersionHistoryDropdown: React.FunctionComponent<
               onChange={onVersionChange}
               checked={selectedVersion === version.versionId}
             />
-            <BodyTwoText className={moduleStyles.versionLabel}>
-              {parseDate(version.lastModified)}
+            <div className={moduleStyles.versionLabel}>
+              <div>{parseDate(version.lastModified)}</div>
               {version.isLatest && (
                 <Tags
                   tagsList={[
@@ -122,7 +132,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
                   ]}
                 />
               )}
-            </BodyTwoText>
+            </div>
           </label>
         ))}
         <div className={moduleStyles.versionHistoryRow}>

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -147,19 +147,15 @@ const VersionHistoryDropdown: React.FunctionComponent<
         />
       </div>
 
+      {loadError && (
+        <div className={classNames(moduleStyles.versionLoadError)}>
+          <Alert type="danger" text={lab2I18n.versionLoadFailure()} size="s" />
+        </div>
+      )}
       <div className={moduleStyles.versionDropdownFooter}>
         {loading && (
           <div className={classNames(moduleStyles.loadingVersionSpinner)}>
             <i className="fa fa-spinner fa-spin" />
-          </div>
-        )}
-        {loadError && (
-          <div className={classNames(moduleStyles.versionLoadError)}>
-            <Alert
-              type="danger"
-              text={lab2I18n.versionLoadFailure()}
-              size="s"
-            />
           </div>
         )}
         <Button

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -3,6 +3,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 import Alert from '@cdo/apps/componentLibrary/alert/Alert';
 import {Button} from '@cdo/apps/componentLibrary/button';
+import CloseButton from '@cdo/apps/componentLibrary/closeButton/CloseButton';
 import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import lab2I18n from '@cdo/apps/lab2/locale';
@@ -109,14 +110,22 @@ const VersionHistoryDropdown: React.FunctionComponent<
   };
 
   const onVersionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // TODO: preview this version
     setSelectedVersion(e.target.value);
   };
 
   return (
     <div>
-      <Heading6 className={moduleStyles.versionHistoryHeader}>
-        {commonI18n.versionHistory_header()}
-      </Heading6>
+      <div className={moduleStyles.versionHistoryHeader}>
+        <Heading6 className={moduleStyles.versionHistoryTitle}>
+          {commonI18n.versionHistory_header()}
+        </Heading6>
+        <CloseButton
+          onClick={closeDropdown}
+          aria-label={lab2I18n.closeVersionHistory()}
+        />
+      </div>
+
       <div className={moduleStyles.versionHistoryList}>
         {versionList.map(version => (
           <VersionHistoryRow
@@ -159,7 +168,15 @@ const VersionHistoryDropdown: React.FunctionComponent<
           size={'m'}
           onClick={restoreSelectedVersion}
           disabled={loading}
-          className={moduleStyles.restoreButton}
+          className={moduleStyles.actionButton}
+        />
+        <Button
+          text={commonI18n.cancel()}
+          color={'white'}
+          size={'m'}
+          onClick={closeDropdown}
+          disabled={loading}
+          className={moduleStyles.actionButton}
         />
       </div>
     </div>

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -4,7 +4,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import Alert from '@cdo/apps/componentLibrary/alert/Alert';
 import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import Tags from '@cdo/apps/componentLibrary/tags/Tags';
-import {BodyTwoText, Heading6} from '@cdo/apps/componentLibrary/typography';
+import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import lab2I18n from '@cdo/apps/lab2/locale';
 import {
@@ -109,18 +109,22 @@ const VersionHistoryDropdown: React.FunctionComponent<
       </Heading6>
       <div className={moduleStyles.versionHistoryList}>
         {versionList.map(version => (
-          <label className={moduleStyles.versionItem} key={version.versionId}>
+          <label
+            className={moduleStyles.versionHistoryRow}
+            key={version.versionId}
+          >
             <input
               type="radio"
               name={version.versionId}
               value={version.versionId}
               onChange={onVersionChange}
               checked={selectedVersion === version.versionId}
+              className={moduleStyles.radioButton}
             />
             <div className={moduleStyles.versionLabel}>
-              <BodyTwoText className={moduleStyles.versionDate}>
+              <div className={moduleStyles.versionDate}>
                 {parseDate(version.lastModified)}
-              </BodyTwoText>
+              </div>
               {version.isLatest && (
                 <Tags
                   tagsList={[

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -4,6 +4,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import Alert from '@cdo/apps/componentLibrary/alert/Alert';
 import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import Tags from '@cdo/apps/componentLibrary/tags/Tags';
+import {BodyTwoText, Heading6} from '@cdo/apps/componentLibrary/typography';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import lab2I18n from '@cdo/apps/lab2/locale';
 import {
@@ -103,6 +104,9 @@ const VersionHistoryDropdown: React.FunctionComponent<
 
   return (
     <div>
+      <Heading6 className={moduleStyles.versionHistoryHeader}>
+        {commonI18n.versionHistory_header()}
+      </Heading6>
       <div className={moduleStyles.versionHistoryList}>
         {versionList.map(version => (
           <label className={moduleStyles.versionItem} key={version.versionId}>
@@ -114,7 +118,9 @@ const VersionHistoryDropdown: React.FunctionComponent<
               checked={selectedVersion === version.versionId}
             />
             <div className={moduleStyles.versionLabel}>
-              <div>{parseDate(version.lastModified)}</div>
+              <BodyTwoText className={moduleStyles.versionDate}>
+                {parseDate(version.lastModified)}
+              </BodyTwoText>
               {version.isLatest && (
                 <Tags
                   tagsList={[
@@ -128,8 +134,10 @@ const VersionHistoryDropdown: React.FunctionComponent<
                       },
                       tooltipContent: commonI18n.current(),
                       tooltipId: 'current-version-tag',
+                      ariaLabel: commonI18n.current(),
                     },
                   ]}
+                  className={moduleStyles.currentVersionTag}
                 />
               )}
             </div>
@@ -146,32 +154,29 @@ const VersionHistoryDropdown: React.FunctionComponent<
           />
         </div>
       </div>
-      {loading && (
-        <div
-          className={classNames(
-            moduleStyles.loadingVersionSpinner,
-            moduleStyles.versionDropdownFooter
-          )}
-        >
-          <i className="fa fa-spinner fa-spin" />
-        </div>
-      )}
-      {loadError && (
-        <div
-          className={classNames(
-            moduleStyles.versionLoadError,
-            moduleStyles.versionDropdownFooter
-          )}
-        >
-          <Alert type="danger" text={lab2I18n.versionLoadFailure()} size="s" />
-        </div>
-      )}
+
       <div className={moduleStyles.versionDropdownFooter}>
+        {loading && (
+          <div className={classNames(moduleStyles.loadingVersionSpinner)}>
+            <i className="fa fa-spinner fa-spin" />
+          </div>
+        )}
+        {loadError && (
+          <div className={classNames(moduleStyles.versionLoadError)}>
+            <Alert
+              type="danger"
+              text={lab2I18n.versionLoadFailure()}
+              size="s"
+            />
+          </div>
+        )}
         <Button
           text={commonI18n.restore()}
           color={'purple'}
           size={'m'}
           onClick={restoreSelectedVersion}
+          disabled={loading}
+          className={moduleStyles.restoreButton}
         />
       </div>
     </div>

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -3,7 +3,6 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 import Alert from '@cdo/apps/componentLibrary/alert/Alert';
 import {Button} from '@cdo/apps/componentLibrary/button';
-import Tags from '@cdo/apps/componentLibrary/tags/Tags';
 import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import lab2I18n from '@cdo/apps/lab2/locale';
@@ -15,6 +14,8 @@ import {ProjectSources, ProjectVersion} from '@cdo/apps/lab2/types';
 import {commonI18n} from '@cdo/apps/types/locale';
 import currentLocale from '@cdo/apps/util/currentLocale';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+
+import VersionHistoryRow from './VersionHistoryRow';
 
 import moduleStyles from './version-history.module.scss';
 
@@ -111,56 +112,30 @@ const VersionHistoryDropdown: React.FunctionComponent<
     setSelectedVersion(e.target.value);
   };
 
-  const getVersionRow = (version?: ProjectVersion) => {
-    const versionId = version?.versionId || INITIAL_VERSION_ID;
-    const isLatest = version?.isLatest || false;
-    const label = version
-      ? parseDate(version.lastModified)
-      : lab2I18n.initialVersion();
-    return (
-      <label className={moduleStyles.versionHistoryRow} key={versionId}>
-        <input
-          type="radio"
-          name={versionId}
-          value={versionId}
-          onChange={onVersionChange}
-          checked={selectedVersion === versionId}
-          className={moduleStyles.radioButton}
-        />
-        <div className={moduleStyles.versionLabel}>
-          <div className={moduleStyles.versionDate}>{label}</div>
-          {isLatest && (
-            <Tags
-              tagsList={[
-                {
-                  label: commonI18n.current(),
-                  icon: {
-                    iconName: 'check',
-                    iconStyle: 'regular',
-                    title: 'check',
-                    placement: 'left',
-                  },
-                  tooltipContent: commonI18n.current(),
-                  tooltipId: 'current-version-tag',
-                  ariaLabel: commonI18n.current(),
-                },
-              ]}
-              className={moduleStyles.currentVersionTag}
-            />
-          )}
-        </div>
-      </label>
-    );
-  };
-
   return (
     <div>
       <Heading6 className={moduleStyles.versionHistoryHeader}>
         {commonI18n.versionHistory_header()}
       </Heading6>
       <div className={moduleStyles.versionHistoryList}>
-        {versionList.map(version => getVersionRow(version))}
-        {getVersionRow()}
+        {versionList.map(version => (
+          <VersionHistoryRow
+            key={version.versionId}
+            versionId={version.versionId}
+            versionLabel={parseDate(version.lastModified)}
+            isLatest={version.isLatest}
+            isSelected={selectedVersion === version.versionId}
+            onChange={onVersionChange}
+          />
+        ))}
+        <VersionHistoryRow
+          key={INITIAL_VERSION_ID}
+          versionId={INITIAL_VERSION_ID}
+          versionLabel={lab2I18n.initialVersion()}
+          isLatest={versionList.length === 0}
+          isSelected={selectedVersion === INITIAL_VERSION_ID}
+          onChange={onVersionChange}
+        />
       </div>
 
       <div className={moduleStyles.versionDropdownFooter}>

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -125,18 +125,6 @@ const VersionHistoryDropdown: React.FunctionComponent<
             </BodyTwoText>
           </label>
         ))}
-
-        {/* {versionList.map(version => (
-          <div
-            key={version.versionId}
-            className={moduleStyles.versionHistoryRow}
-          >
-            <div>{parseDate(version.lastModified)}</div>
-            <div className={moduleStyles.versionOptions}>
-              {renderVersionOptions(version)}
-            </div>
-          </div>
-        ))} */}
         <div className={moduleStyles.versionHistoryRow}>
           <Button
             text={commonI18n.startOver()}

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -88,11 +88,12 @@ const VersionHistoryDropdown: React.FunctionComponent<
           } else {
             setLoadError(true);
           }
-          setLoading(false);
           closeDropdown();
         })
         .catch(() => {
           setLoadError(true);
+        })
+        .finally(() => {
           setLoading(false);
         });
     }

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryRow.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryRow.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import Tags from '@cdo/apps/componentLibrary/tags';
+import {commonI18n} from '@cdo/apps/types/locale';
+
+import moduleStyles from './version-history.module.scss';
+
+interface VersionHistoryRowProps {
+  versionId: string;
+  versionLabel: string;
+  isLatest: boolean;
+  isSelected: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const VersionHistoryRow: React.FunctionComponent<VersionHistoryRowProps> = ({
+  versionId,
+  versionLabel,
+  isLatest,
+  isSelected,
+  onChange,
+}) => {
+  return (
+    <label className={moduleStyles.versionHistoryRow} key={versionId}>
+      <input
+        type="radio"
+        name={versionId}
+        value={versionId}
+        onChange={onChange}
+        checked={isSelected}
+        className={moduleStyles.radioButton}
+      />
+      <div className={moduleStyles.versionLabel}>
+        <div className={moduleStyles.versionDate}>{versionLabel}</div>
+        {isLatest && (
+          <Tags
+            tagsList={[
+              {
+                label: commonI18n.current(),
+                icon: {
+                  iconName: 'check',
+                  iconStyle: 'regular',
+                  title: 'check',
+                  placement: 'left',
+                },
+                tooltipContent: commonI18n.current(),
+                tooltipId: 'current-version-tag',
+                ariaLabel: commonI18n.current(),
+              },
+            ]}
+            className={moduleStyles.currentVersionTag}
+          />
+        )}
+      </div>
+    </label>
+  );
+};
+
+export default VersionHistoryRow;

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryRow.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryRow.tsx
@@ -29,7 +29,7 @@ const VersionHistoryRow: React.FunctionComponent<VersionHistoryRowProps> = ({
         onChange={onChange}
         checked={isSelected}
       />
-      <div className={moduleStyles.versionLabel}>
+      <div className={moduleStyles.versionInfo}>
         <div className={moduleStyles.versionDate}>{versionLabel}</div>
         {isLatest && (
           <Tags

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryRow.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryRow.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Tags from '@cdo/apps/componentLibrary/tags';
 import {commonI18n} from '@cdo/apps/types/locale';
 
-import moduleStyles from './version-history.module.scss';
+import moduleStyles from './version-history-row.module.scss';
 
 interface VersionHistoryRowProps {
   versionId: string;
@@ -28,7 +28,6 @@ const VersionHistoryRow: React.FunctionComponent<VersionHistoryRowProps> = ({
         value={versionId}
         onChange={onChange}
         checked={isSelected}
-        className={moduleStyles.radioButton}
       />
       <div className={moduleStyles.versionLabel}>
         <div className={moduleStyles.versionDate}>{versionLabel}</div>

--- a/apps/src/lab2/views/components/versionHistory/version-history-row.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history-row.module.scss
@@ -1,0 +1,35 @@
+@import 'color.scss';
+
+.versionHistoryRow {
+  padding: 8px 12px;
+  height: 32px;
+  display: flex;
+  justify-content: space-between;
+  color: $white;
+
+  input[type="radio"] {
+    margin-top: 0;
+  }
+}
+
+.versionDate {
+  color: $white;
+}
+
+.versionLabel {
+  color: $white;
+  justify-content: space-between;
+  align-items: center;
+  display: flex;
+  width: 100%;
+  margin: 8px;
+  font-size: 16px;
+}
+
+.versionHistoryRow:has(input[type="radio"]:checked) {
+  background-color: #3F444B;
+}
+
+.currentVersionTag {
+  height: 24px;
+}

--- a/apps/src/lab2/views/components/versionHistory/version-history-row.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history-row.module.scss
@@ -16,7 +16,7 @@
   color: $white;
 }
 
-.versionLabel {
+.versionInfo {
   color: $white;
   justify-content: space-between;
   align-items: center;

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -34,10 +34,6 @@
   overflow-y: scroll;
 }
 
-.startOverButton {
-  width: 100%;
-}
-
 .versionDropdownFooter {
   margin-top: 8px;
   padding: 8px;

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -53,3 +53,7 @@
 .versionLoadError {
   font-size: 14px;
 }
+
+.versionLabel {
+  color: $white;
+}

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -14,9 +14,14 @@
 }
 
 .versionHistoryHeader {
-  color: $white;
   padding: 12px;
   border-bottom: 1px solid #54595E;
+  display: flex;
+  justify-content: space-between;
+}
+
+.versionHistoryTitle {
+  color: $white;
 }
 
 .versionHistoryMessage {
@@ -27,18 +32,6 @@
 .versionHistoryList {
   max-height: 300px;
   overflow-y: scroll;
-}
-
-.versionHistoryRow {
-  padding: 8px 12px;
-  height: 32px;
-  display: flex;
-  justify-content: space-between;
-  color: $white;
-
-  input[type="radio"] {
-    margin-top: 0;
-  }
 }
 
 .startOverButton {
@@ -62,28 +55,6 @@
   font-size: 14px;
 }
 
-.versionDate {
-  color: $white;
-}
-
-.versionLabel {
-  color: $white;
-  justify-content: space-between;
-  align-items: center;
-  display: flex;
-  width: 100%;
-  margin: 8px;
-  font-size: 16px;
-}
-
-.versionHistoryRow:has(input[type="radio"]:checked) {
-  background-color: #3F444B;
-}
-
-.restoreButton {
+.actionButton {
   margin-right: 8px;
-}
-
-.currentVersionTag {
-  height: 24px;
 }

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -13,6 +13,12 @@
   right: 0;
 }
 
+.versionHistoryHeader {
+  color: $white;
+  padding: 12px;
+  border-bottom: 1px solid #54595E;
+}
+
 .versionHistoryMessage {
   margin: 20px;
   font-size: 16px;
@@ -24,12 +30,14 @@
 }
 
 .versionHistoryRow {
-  margin: 8px 8px;
+  margin: 8px 12px;
+  //height: 48px;
+  line-height: 35px;
   display: flex;
   text-align: center;
   vertical-align: middle;
-  line-height: 35px;
   justify-content: space-between;
+  color: $white;
 }
 
 .latestVersionLabel {
@@ -43,15 +51,22 @@
 .versionDropdownFooter {
   margin-top: 8px;
   padding: 8px;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .loadingVersionSpinner {
   font-size: 32px;
   text-align: center;
+  margin-right: 12px;
 }
 
 .versionLoadError {
   font-size: 14px;
+}
+
+.versionDate {
+  color: $white;
 }
 
 .versionLabel {
@@ -64,4 +79,16 @@
 
 .versionItem {
   display: flex;
+}
+
+.versionItem:has(input[type="radio"]:checked) {
+  background-color: #3F444B;
+}
+
+.restoreButton {
+  margin-right: 8px;
+}
+
+.currentVersionTag {
+  height: 24px;
 }

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -56,4 +56,12 @@
 
 .versionLabel {
   color: $white;
+  justify-content: space-between;
+  display: flex;
+  width: 100%;
+  margin: 4px 8px;
+}
+
+.versionItem {
+  display: flex;
 }

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -30,18 +30,15 @@
 }
 
 .versionHistoryRow {
-  margin: 8px 12px;
-  //height: 48px;
-  line-height: 35px;
+  padding: 8px 12px;
+  height: 32px;
   display: flex;
-  text-align: center;
-  vertical-align: middle;
   justify-content: space-between;
   color: $white;
-}
 
-.latestVersionLabel {
-  font-size: 16px;
+  input[type="radio"] {
+    margin-top: 0;
+  }
 }
 
 .startOverButton {
@@ -72,16 +69,14 @@
 .versionLabel {
   color: $white;
   justify-content: space-between;
+  align-items: center;
   display: flex;
   width: 100%;
-  margin: 4px 8px;
+  margin: 8px;
+  font-size: 16px;
 }
 
-.versionItem {
-  display: flex;
-}
-
-.versionItem:has(input[type="radio"]:checked) {
+.versionHistoryRow:has(input[type="radio"]:checked) {
   background-color: #3F444B;
 }
 


### PR DESCRIPTION
V2 of version history for codebridge and lab2 labs, based on updated mocks from design (see figma in links). This is still missing a few features, and is pretty close to the mocks, but not pixel-perfect, see follow-up work for details.

## Screenshot
![Screenshot 2024-08-28 at 3 36 50 PM](https://github.com/user-attachments/assets/2de68d00-1a9b-4e96-b139-b26f9f23b531)

The list of versions will scroll if it becomes too large. The restore and cancel buttons will always be visible.

## Links

- jira ticket: [CT-717](https://codedotorg.atlassian.net/browse/CT-717)
- [figma](https://www.figma.com/design/vcNGOFsIks0HhRk6GEOfZf/Upper-Lab?node-id=4127-8075&node-type=INSTANCE&m=dev)

## Testing story
Tested locally that we can still restore a specific version or start over (which is now clicking "initial version" and "restoring" that version).

## Follow-up work
There's a few follow-ups to get version history fully ready to go:
- [CT-716](https://codedotorg.atlassian.net/browse/CT-716): view a specific version, rather than just restore.
- [CT-714](https://codedotorg.atlassian.net/browse/CT-714): update behavior for teacher viewing a student's code
- [CT-720](https://codedotorg.atlassian.net/browse/CT-720): confirmation on start over
- [CT-761](https://codedotorg.atlassian.net/browse/CT-761): General polish, see the ticket for details.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
