### PR TITLE
Add canvas to iframe buster list

### DIFF
--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -193,7 +193,7 @@ class Policies::Lti
     ['Canvas'].include?(issuer_name(issuer))
   end
 
-  # Force Schoology through iframe mitigation flow
+  # Force Schoology and Canvas through iframe mitigation flow
   def self.force_iframe_launch?(issuer)
     %w[Schoology Canvas].include?(issuer_name(issuer))
   end

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -195,7 +195,7 @@ class Policies::Lti
 
   # Force Schoology through iframe mitigation flow
   def self.force_iframe_launch?(issuer)
-    ['Schoology'].include?(issuer_name(issuer))
+    %w[Schoology Canvas].include?(issuer_name(issuer))
   end
 
   def self.feedback_available?(user)

--- a/dashboard/test/lib/policies/lti_test.rb
+++ b/dashboard/test/lib/policies/lti_test.rb
@@ -150,9 +150,9 @@ class Policies::LtiTest < ActiveSupport::TestCase
     end
   end
 
-  test 'force_iframe_launch? should return true for Schoology and false for other LMS platforms' do
+  test 'force_iframe_launch? should return true for Schoology and Canvas' do
     assert Policies::Lti.force_iframe_launch?('https://schoology.schoology.com')
-    refute Policies::Lti.force_iframe_launch?('https://canvas.instructure.com')
+    assert Policies::Lti.force_iframe_launch?('https://canvas.instructure.com')
   end
 
   class FeedbackAvailabilityTest < ActiveSupport::TestCase


### PR DESCRIPTION
This PR is adding Canvas to the list of providers to send through the iframe buster to prevent some teachers from encountering issues with Canvas integrations because they don’t have the new tab box checked. 
![image](https://github.com/user-attachments/assets/0f3b65e9-6e65-4150-aef2-eef8c1be675e)


## Links
- Jira ticket: [P20-1100](https://codedotorg.atlassian.net/browse/P20-1100)

## Testing story
Added a line to test that Canvas is also sent through the iframe buster in `/policies/lti_test.rb`