### PR TITLE
Revert "NAV - fix top left corner alignment"

### DIFF
--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useState} from 'react';
@@ -28,7 +27,6 @@ function SectionProgressSelector({
   progressTableV2ClosedBeta,
   sectionId,
   hasSeenProgressTableInvite,
-  isInV1Navigaton,
 }) {
   const [hasJustToggledViews, setHasJustToggledViews] = useState(false);
 
@@ -144,19 +142,14 @@ function SectionProgressSelector({
   };
 
   return (
-    <div
-      className={classNames(
-        styles.pageContent,
-        !isInV1Navigaton && styles.navView
-      )}
-    >
+    <div className={styles.pageContent}>
       {displayV2 && (
         <ProgressBanners hasJustSwitchedToV2={hasJustToggledViews} />
       )}
       {toggleV1OrV2Link()}
 
       {displayV2 ? (
-        <SectionProgressV2 hideTopHeading={!isInV1Navigaton} />
+        <SectionProgressV2 />
       ) : (
         <>
           {includeModalIfAvailable()}
@@ -173,7 +166,6 @@ SectionProgressSelector.propTypes = {
   setShowProgressTableV2: PropTypes.func.isRequired,
   sectionId: PropTypes.number,
   hasSeenProgressTableInvite: PropTypes.bool,
-  isInV1Navigaton: PropTypes.bool,
 };
 
 export const UnconnectedSectionProgressSelector = SectionProgressSelector;

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -30,7 +30,6 @@ function SectionProgressV2({
   isLevelProgressLoaded,
   expandedLessonIds,
   loadExpandedLessonsFromLocalStorage,
-  hideTopHeading,
 }) {
   React.useEffect(() => {
     loadExpandedLessonsFromLocalStorage(scriptId, sectionId);
@@ -60,7 +59,7 @@ function SectionProgressV2({
 
   return (
     <div className={styles.progressV2Page} data-testid="section-progress-v2">
-      {!hideTopHeading && <Heading1>{i18n.progressBeta()}</Heading1>}
+      <Heading1>{i18n.progressBeta()}</Heading1>
       <IconKey
         isViewingValidatedLevel={isViewingValidatedLevel}
         expandedLessonIds={expandedLessonIds}
@@ -89,7 +88,6 @@ SectionProgressV2.propTypes = {
   isLevelProgressLoaded: PropTypes.bool.isRequired,
   expandedLessonIds: PropTypes.array,
   loadExpandedLessonsFromLocalStorage: PropTypes.func.isRequired,
-  hideTopHeading: PropTypes.bool,
 };
 
 export default connect(

--- a/apps/src/templates/sectionProgressV2/progress-header.module.scss
+++ b/apps/src/templates/sectionProgressV2/progress-header.module.scss
@@ -20,8 +20,4 @@
 
 .pageContent {
   padding: 24px 64px 64px 64px;
-
-  &.navView {
-    padding: 0;
-  }
 }

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -169,7 +169,7 @@ function TeacherDashboard({
             <EmptySectionV1
               hasStudents={studentCount > 0}
               hasCurriculumAssigned={anyStudentHasProgress}
-              element={<SectionProgressSelector isInV1Navigaton={true} />}
+              element={<SectionProgressSelector />}
               showProgressPageHeader={true}
             />
           }

--- a/apps/src/templates/teacherDashboard/teacher-dashboard.module.scss
+++ b/apps/src/templates/teacherDashboard/teacher-dashboard.module.scss
@@ -71,7 +71,6 @@
 
 .emptyClassroomDiv {
   margin: 24px 64px 82px 64px;
-  text-align: center;
 }
 
 .header {

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -197,7 +197,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
               <ElementOrEmptyPage
                 showNoStudents={studentCount === 0}
                 showNoCurriculumAssigned={!anyStudentHasProgress}
-                element={<SectionProgressSelector isInV1Navigaton={false} />}
+                element={<SectionProgressSelector />}
               />
             }
           />

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -9,13 +9,13 @@
 
 .pageWithHeader {
   flex-grow: 1;
-  padding: 20px 48px 28px 38px;
+  padding: 20px;
   overflow-y: auto;
 }
 
 .widthLockedPage {
   max-width: $content-width;
-  padding: 10px 0 64px 0;
+  padding: 10px 64px 64px 64px;
 }
 
 .sidebarContainer {

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
@@ -29,7 +29,7 @@ const V2_PAGE_LINK_TEXT = 'Switch to old progress view';
 const V1_TEST_ID = 'section-progress-v1';
 const V2_TEST_ID = 'section-progress-v2';
 
-const DEFAULT_PROPS = {isInV1Navigaton: true};
+const DEFAULT_PROPS = {};
 
 jest.mock('@cdo/apps/templates/sectionProgress/sectionProgressLoader');
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#60692

Unintentionally moved heading text to center for "empty section" pages in V1.  Reverting so that can be fixed.