### PR TITLE
HoC 2024 - Update hourofcode.com header to say "Resources" instead of "Promote"

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/404.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/404.haml
@@ -14,6 +14,6 @@ rightbar: blank
   %li<
     %a{href:resolve_url('/how-to')}= hoc_s(:header_menu_how_to)
   %li<
-    %a{href:resolve_url('/promote')}= hoc_s(:header_menu_promote)
+    %a{href:resolve_url('/promote')}= hoc_s(:header_menu_resources)
   %li<
     %a{href:resolve_url('/faq')}= hoc_s(:header_menu_faq)

--- a/pegasus/sites.v3/hourofcode.com/views/header.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/header.haml
@@ -16,7 +16,7 @@
           %li
             %a{href:resolve_url('/how-to'), title:hoc_s(:header_menu_how_to)}= hoc_s(:header_menu_how_to)
           %li
-            %a{href:resolve_url('/promote'), title:hoc_s(:header_menu_promote)}= hoc_s(:header_menu_promote)
+            %a{href:resolve_url('/promote'), title:hoc_s(:header_menu_resources)}= hoc_s(:header_menu_resources)
           %li
             %a{href:resolve_url('/faq'), title:hoc_s(:header_menu_faq)}= hoc_s(:header_menu_faq)
         %a#hoc-nav-hamburger{href: "#"}


### PR DESCRIPTION
Replaces the Promote link label with Resources in the hourofcode.com header nav to better reflect what this page will become (see [Figma](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=2710-2186&t=IrC4hEFzXzm8CXv2-1)).

## Links
Jira ticket: [ACQ-2336](https://codedotorg.atlassian.net/browse/ACQ-2336)

----

| Before | After |
| --- | ---- |
| <img width="1045" alt="Before" src="https://github.com/user-attachments/assets/7326fbcd-8692-4f90-8c97-b1949159cb5e"> | <img width="1045" alt="After" src="https://github.com/user-attachments/assets/dd7b851f-430f-4900-9546-400ded9c6a1f"> |

## Translated
| Spanish | French |
| ---- | ---- |
| <img width="1045" alt="Spanish" src="https://github.com/user-attachments/assets/9a9f49f5-b5ac-424f-b93b-9c707310e0b2"> | <img width="1045" alt="French" src="https://github.com/user-attachments/assets/928f19a3-0fe2-4d15-a45d-16556f64c2ed"> | 

## Hamburger
<img width="391" alt="Screenshot 2024-08-29 at 1 07 16 PM" src="https://github.com/user-attachments/assets/4b8b5230-e1b6-45c6-882e-9445d41ee90c">


