### PR TITLE
Move locale to lab2 utils

### DIFF
--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -1,4 +1,5 @@
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
+import currentLocale from '@cdo/apps/util/currentLocale';
 import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 
 import {MultiFileSource, ProjectFile, ProjectFileType} from '../types';
@@ -118,4 +119,11 @@ export function getActiveFileForProject(project: MultiFileSource) {
 
   // Get the first active file, or the first file.
   return visibleFiles.find(f => f.active) || visibleFiles[0];
+}
+
+/**
+ * Returns the value of the language cookie (eg, en-US, which is also the default if the cookie is not set).
+ */
+export function getCurrentLocale(): string {
+  return currentLocale();
 }

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -1,6 +1,6 @@
 import cloneDeep from 'lodash/cloneDeep';
 
-import currentLocale from '@cdo/apps/util/currentLocale';
+import {getCurrentLocale} from '@cdo/apps/lab2/projects/utils';
 import experiments from '@cdo/apps/util/experiments';
 import HttpClient, {
   ResponseValidator,
@@ -45,10 +45,10 @@ async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
       libraryJsonResponsePromise,
     ];
 
-    const jsLocale = currentLocale().toLowerCase().replace('-', '_');
-    if (jsLocale !== 'en_us') {
+    const locale = getCurrentLocale().toLowerCase().replace('-', '_');
+    if (locale !== 'en_us') {
       const translationPromise = HttpClient.fetchJson<Translations>(
-        getBaseAssetUrl() + libraryFilename + '-loc/' + jsLocale + '.json'
+        getBaseAssetUrl() + libraryFilename + '-loc/' + locale + '.json'
       );
       promises.push(translationPromise);
     }


### PR DESCRIPTION
Quick follow-up to [this Slack discussion](https://codedotorg.slack.com/archives/C03DBDN67B7/p1724257633829369?thread_ts=1723753781.524899&cid=C03DBDN67B7) to move checking locale in Music Lab localization to utils file.

## Testing story

Tested manually that translations still worked in Music Lab.