### PR TITLE
Add section name to header

### DIFF
--- a/apps/src/templates/teacherNavigation/PageHeader.tsx
+++ b/apps/src/templates/teacherNavigation/PageHeader.tsx
@@ -1,12 +1,30 @@
 import _ from 'lodash';
 import React from 'react';
+import {useSelector} from 'react-redux';
 import {matchPath, useLocation} from 'react-router-dom';
 
 import {Heading1} from '@cdo/apps/componentLibrary/typography';
 
 import {LABELED_TEACHER_NAVIGATION_PATHS} from './TeacherNavigationPaths';
+import {Section} from './TeacherNavigationRouter';
+
+import styles from './teacher-navigation.module.scss';
 
 const PageHeader: React.FC = () => {
+  const selectedSection = useSelector(
+    (state: {
+      teacherSections: {
+        selectedSectionId: number | null;
+        sections: {[id: number]: Section};
+      };
+    }) =>
+      state.teacherSections.selectedSectionId
+        ? state.teacherSections.sections[
+            state.teacherSections.selectedSectionId
+          ]
+        : null
+  );
+
   const location = useLocation();
   const pathName = React.useMemo(
     () =>
@@ -16,7 +34,15 @@ const PageHeader: React.FC = () => {
       )?.label || 'unknown path',
     [location]
   );
-  return <Heading1>{pathName}</Heading1>;
+
+  const sectionName = selectedSection ? selectedSection.name : '';
+
+  return (
+    <div className={styles.header}>
+      <span className={styles.headerSectionName}>{sectionName}</span>
+      <Heading1>{pathName}</Heading1>
+    </div>
+  );
 };
 
 export default PageHeader;

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -111,3 +111,15 @@
   width: 20px;
   text-align: center;
 }
+
+.header {
+  display: flex;
+  flex-direction: column;
+}
+
+.headerSectionName {
+  font-size: 12px;
+  font-weight: 600;
+  color: $light_primary_500;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
Adds the section name to the header of each page with a sidebar

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/1417cad1-a798-44c3-8c2d-88494c1a7e5d">


https://github.com/user-attachments/assets/7ffe82be-2cd2-4a28-9481-8247f43b3ac8

## Links
https://codedotorg.atlassian.net/browse/TEACH-1266

Figma:
https://www.figma.com/design/5ILfiJkPQpjskBwksMDeZl/Teacher-Dashboard?node-id=3107-4555&m=dev
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
