### PR TITLE
fix(lms): do not set the primary contact info upfront

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -961,6 +961,7 @@ class User < ApplicationRecord
   # address associated with them because it wasn't required when they were
   # created. Those old accounts are allowed to skip the email validation.
   def teacher_email_required?
+    return false if Policies::Lti.lti? self
     # non-teachers are not relevant to this method.
     return false unless teacher? && purged_at.nil?
 
@@ -975,12 +976,12 @@ class User < ApplicationRecord
   end
 
   def email_or_hashed_email_required?
+    return false if Policies::Lti.lti? self
     return true if teacher?
     return false if manual?
     return false if sponsored?
     return false if oauth?
     return false if parent_managed_account?
-    return false if Policies::Lti.lti? self
     true
   end
 

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -122,8 +122,6 @@ module Services
         email: email_address,
         )
       user.authentication_options = [ao]
-      user.primary_contact_info = ao
-      # TODO As final step of the LTI user creation, create LtiUserIdentity for the new user. https://codedotorg.atlassian.net/browse/P20-788
       user
     end
 

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -369,6 +369,7 @@ class Services::LtiTest < ActiveSupport::TestCase
   test 'should create a teacher user given an LTI NRPS member object' do
     Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
     user = Services::Lti.initialize_lti_user_from_nrps(client_id: @id_token[:aud], issuer: @id_token[:iss], nrps_member: @nrps_teacher)
+    user.save!
     assert user
     assert_equal user.user_type, User::TYPE_TEACHER
     assert_equal "test-teacher@code.org", user.email


### PR DESCRIPTION
Previously, the LMS sync process set the user's primary contact info during the instantiation of a user model. Due to this, when saving the user model, it will attempt to create the primary contact info association which doesn't yet exist resulting in a circular model that tries to create the child and parent at the same time. The net result is the potential creation of a duplicate user. For instance:

1. User -> primary_contact_info (AuthenticationOption): Create one user
2. primary_contact_info -> User: Create a second user

While saving the user, it is possible that the authentication option may not yet be created yet which allows the second user to be created. In most circumstances, the second user will silently fail to be created.

The primary_contact_info is set in the AuthenticationOption `after_create` hook anyway so the setting of the primary contact info upfront is not necessary.

Since teacher's emails are optional on the LMS side, during a user's creation it is now possible for the email to be `nil` but we will prompt the teacher for their email upon login.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

To test this, I set a breakpoint on `user_helpers.rb` on the `generate_username` method. In the expected case, the username should be generated only once. Previously, the username is generated twice (for two different users).

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
