### PR TITLE
Add events for starting AI chat request and errors

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -400,6 +400,9 @@ export const submitChatContents = createAsyncThunk(
 
     let chatApiResponse;
     try {
+      Lab2Registry.getInstance()
+        .getMetricsReporter()
+        .incrementCounter('Aichat.ChatCompletionRequestInitiated');
       chatApiResponse = await postAichatCompletionMessage(
         newUserMessage,
         chatEventsCurrent.filter(isChatMessage) as ChatMessage[],
@@ -449,6 +452,9 @@ async function handleChatCompletionError(
   // Display specific error notifications if the user was rate limited (HTTP 429) or not authorized (HTTP 403).
   // Otherwise, display a generic error assistant response.
   if (error instanceof NetworkError && error.response.status === 429) {
+    Lab2Registry.getInstance()
+      .getMetricsReporter()
+      .incrementCounter('Aichat.ChatCompletionErrorRateLimited');
     dispatch(
       addChatEvent({
         id: getNewMessageId(),
@@ -478,6 +484,9 @@ async function handleChatCompletionError(
       })
     );
   } else {
+    Lab2Registry.getInstance()
+      .getMetricsReporter()
+      .incrementCounter('Aichat.ChatCompletionErrorUnhandled');
     dispatch(
       addChatEvent({
         role: Role.ASSISTANT,


### PR DESCRIPTION
Logs CloudWatch Metrics when:
- a request for a chat completion is initiated,
- a request is throttled, or
- and request returns an error.

Doesn't log if we see a request from an unauthorized user, as that represents a handled/expected case that I'd think would occur pretty frequently.

I was a little unsure on whether to include a dimension with the error type (eg, "throttled" or "unknown"), but since CloudWatch considers unique dimension value as a separate metric anyway, I just used separate metric names.

## Links

- Jira: https://codedotorg.atlassian.net/browse/LABS-987

## Testing story

Tested manually that I saw the appropriate event in the dev console being generated for the initiation and the unhandled error case. Didn't test the throttling case.