### PR TITLE
NAV - add rough calendar to options

### DIFF
--- a/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
@@ -7,7 +7,7 @@ import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import {unitCalendarLesson} from '@cdo/apps/templates/progress/unitCalendarLessonShapes';
 import i18n from '@cdo/locale';
 
-import UnitCalendar from './UnitCalendar';
+import UnitCalendarGrid from './UnitCalendarGrid';
 
 const WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS = [
   45, 90, 135, 180, 225, 270, 315, 360, 405, 450,
@@ -86,7 +86,7 @@ export default class UnitCalendarDialog extends Component {
             {this.generateDropdownOptions()}
           </select>
         </div>
-        <UnitCalendar
+        <UnitCalendarGrid
           lessons={lessons}
           weeklyInstructionalMinutes={this.state.instructionalMinutes}
           weekWidth={WEEK_WIDTH}

--- a/apps/src/code-studio/components/progress/UnitCalendarGrid.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarGrid.jsx
@@ -9,7 +9,7 @@ import i18n from '@cdo/locale';
 
 import UnitCalendarLessonChunk from './UnitCalendarLessonChunk';
 
-export default class UnitCalendar extends React.Component {
+export default class UnitCalendarGrid extends React.Component {
   static propTypes = {
     weeklyInstructionalMinutes: PropTypes.number.isRequired,
     lessons: PropTypes.arrayOf(unitCalendarLesson).isRequired,

--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -24,7 +24,7 @@ import {
 } from '@cdo/apps/util/dismissVersionRedirect';
 import i18n from '@cdo/locale';
 
-import UnitCalendar from './UnitCalendar';
+import UnitCalendarGrid from './UnitCalendarGrid';
 import UnitOverviewHeader from './UnitOverviewHeader';
 import UnitOverviewTopRow from './UnitOverviewTopRow';
 
@@ -184,7 +184,7 @@ class UnitOverview extends React.Component {
           />
           {showCalendar && viewAs === ViewType.Instructor && (
             <div className="unit-calendar-for-printing print-only">
-              <UnitCalendar
+              <UnitCalendarGrid
                 lessons={unitCalendarLessons}
                 weeklyInstructionalMinutes={weeklyInstructionalMinutes || 225}
                 weekWidth={550}

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -36,6 +36,7 @@ import {
   TEACHER_NAVIGATION_PATHS,
   TEACHER_NAVIGATION_SECTIONS_URL,
 } from './TeacherNavigationPaths';
+import UnitCalendar from './UnitCalendar';
 
 import styles from './teacher-navigation.module.scss';
 
@@ -241,7 +242,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
               <ElementOrEmptyPage
                 showNoStudents={studentCount === 0}
                 showNoCurriculumAssigned={!anyStudentHasProgress}
-                element={applyV1TeacherDashboardWidth(<TemporaryBlankPage />)}
+                element={applyV1TeacherDashboardWidth(<UnitCalendar />)}
               />
             }
           />

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -1,20 +1,28 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
+import {useSelector} from 'react-redux';
 
+import UnitCalendarGrid from '@cdo/apps//code-studio/components/progress/UnitCalendarGrid';
 import i18n from '@cdo/locale';
+
+import {getCurrentUnitData} from '../sectionProgress/sectionProgressRedux';
 
 const WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS = [
   45, 90, 135, 180, 225, 270, 315, 360, 405, 450,
 ];
 export const WEEK_WIDTH = 585;
 
-// interface UnitCalendarProps {
-//   weeklyInstructionalMinutes: number;
-//   scriptId: number;
-// }
-
 const UnitCalendar: React.FC = () => {
+  const lessons = useSelector(state => getCurrentUnitData(state)?.lessons);
+  const [isLoading, setIsLoading] = useState(true);
   const [weeklyInstructionalMinutes, setWeeklyInstructionalMinutes] =
     useState<number>(WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS[0]);
+
+  useEffect(() => {
+    if (lessons) {
+      setIsLoading(false);
+    }
+  }, [lessons]);
+
   const generateDropdownOptions = () => {
     const options = WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS;
     if (!options.includes(weeklyInstructionalMinutes)) {
@@ -32,7 +40,9 @@ const UnitCalendar: React.FC = () => {
     <div>
       <h2>{i18n.weeklyLessonLayout()}</h2>
       <div style={styles.minutesPerWeekWrapper}>
-        <div>{i18n.instructionalMinutesPerWeek()}</div>
+        <div style={styles.minutesPerWeekDescription}>
+          {i18n.instructionalMinutesPerWeek()}
+        </div>
         <select
           onChange={e =>
             setWeeklyInstructionalMinutes(parseInt(e.target.value))
@@ -43,6 +53,13 @@ const UnitCalendar: React.FC = () => {
           {generateDropdownOptions()}
         </select>
       </div>
+      {!isLoading && (
+        <UnitCalendarGrid
+          lessons={lessons}
+          weeklyInstructionalMinutes={weeklyInstructionalMinutes}
+          weekWidth={WEEK_WIDTH}
+        />
+      )}
     </div>
   );
 };
@@ -70,7 +87,7 @@ const styles = {
     alignItems: 'center',
   },
   minutesPerWeekDescription: {
-    fontWeight: 'bold',
+    fontWeight: 'bold' as const,
     marginRight: 10,
   },
 };

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -1,0 +1,76 @@
+import React, {useState} from 'react';
+
+import i18n from '@cdo/locale';
+
+const WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS = [
+  45, 90, 135, 180, 225, 270, 315, 360, 405, 450,
+];
+export const WEEK_WIDTH = 585;
+
+// interface UnitCalendarProps {
+//   weeklyInstructionalMinutes: number;
+//   scriptId: number;
+// }
+
+const UnitCalendar: React.FC = () => {
+  const [weeklyInstructionalMinutes, setWeeklyInstructionalMinutes] =
+    useState<number>(WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS[0]);
+  const generateDropdownOptions = () => {
+    const options = WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS;
+    if (!options.includes(weeklyInstructionalMinutes)) {
+      options.push(weeklyInstructionalMinutes);
+    }
+    options.sort((a, b) => a - b);
+    return options.map(val => (
+      <option value={parseInt(val.toString())} key={`minutes-${val}`}>
+        {i18n.minutesLabel({number: val})}
+      </option>
+    ));
+  };
+
+  return (
+    <div>
+      <h2>{i18n.weeklyLessonLayout()}</h2>
+      <div style={styles.minutesPerWeekWrapper}>
+        <div>{i18n.instructionalMinutesPerWeek()}</div>
+        <select
+          onChange={e =>
+            setWeeklyInstructionalMinutes(parseInt(e.target.value))
+          }
+          value={weeklyInstructionalMinutes}
+          style={styles.dropdown}
+        >
+          {generateDropdownOptions()}
+        </select>
+      </div>
+    </div>
+  );
+};
+
+export default UnitCalendar;
+
+const styles = {
+  dialog: {
+    textAlign: 'left',
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingBottom: 20,
+  },
+  button: {
+    float: 'right',
+    marginTop: 30,
+  },
+  dropdown: {
+    width: 'fit-content',
+    marginBottom: 0,
+  },
+  minutesPerWeekWrapper: {
+    display: 'flex',
+    marginBottom: 10,
+    alignItems: 'center',
+  },
+  minutesPerWeekDescription: {
+    fontWeight: 'bold',
+    marginRight: 10,
+  },
+};

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarDialogTest.jsx
@@ -1,7 +1,7 @@
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
-import UnitCalendar from '@cdo/apps/code-studio/components/progress/UnitCalendar';
+import UnitCalendarGrid from '@cdo/apps/code-studio/components/progress/UnitCalendar';
 import UnitCalendarDialog, {
   WEEK_WIDTH,
 } from '@cdo/apps/code-studio/components/progress/UnitCalendarDialog';
@@ -21,7 +21,7 @@ describe('UnitCalendarDialog', () => {
     );
     expect(
       wrapper.containsMatchingElement(
-        <UnitCalendar
+        <UnitCalendarGrid
           lessons={testLessons}
           weeklyInstructionalMinutes={90}
           weekWidth={WEEK_WIDTH}
@@ -50,7 +50,7 @@ describe('UnitCalendarDialog', () => {
     ).toBe(true);
     expect(
       wrapper.containsMatchingElement(
-        <UnitCalendar
+        <UnitCalendarGrid
           lessons={testLessons}
           weeklyInstructionalMinutes={45}
           weekWidth={WEEK_WIDTH}
@@ -79,7 +79,7 @@ describe('UnitCalendarDialog', () => {
     ).toBe(true);
     expect(
       wrapper.containsMatchingElement(
-        <UnitCalendar
+        <UnitCalendarGrid
           lessons={testLessons}
           weeklyInstructionalMinutes={20}
           weekWidth={WEEK_WIDTH}
@@ -103,7 +103,7 @@ describe('UnitCalendarDialog', () => {
     expect(wrapper.state('instructionalMinutes')).toBe(90);
     expect(
       wrapper.containsMatchingElement(
-        <UnitCalendar
+        <UnitCalendarGrid
           lessons={testLessons}
           weeklyInstructionalMinutes={90}
           weekWidth={WEEK_WIDTH}

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarDialogTest.jsx
@@ -1,10 +1,10 @@
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
-import UnitCalendarGrid from '@cdo/apps/code-studio/components/progress/UnitCalendar';
 import UnitCalendarDialog, {
   WEEK_WIDTH,
 } from '@cdo/apps/code-studio/components/progress/UnitCalendarDialog';
+import UnitCalendarGrid from '@cdo/apps/code-studio/components/progress/UnitCalendarGrid';
 
 import {testLessons} from './unitCalendarTestData';
 

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarGridTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarGridTest.jsx
@@ -1,14 +1,14 @@
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
-import UnitCalendar from '@cdo/apps/code-studio/components/progress/UnitCalendar';
+import UnitCalendarGrid from '@cdo/apps/code-studio/components/progress/UnitCalendar';
 
 import {testLessonSchedule, testLessons} from './unitCalendarTestData';
 
 describe('UnitCalendar', () => {
   it('creates lesson chunks for all of the pieces of the schedule across weeks', () => {
     const wrapper = shallow(
-      <UnitCalendar
+      <UnitCalendarGrid
         lessons={testLessons}
         weeklyInstructionalMinutes={90}
         weekWidth={585}

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarGridTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarGridTest.jsx
@@ -1,7 +1,7 @@
 import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
-import UnitCalendarGrid from '@cdo/apps/code-studio/components/progress/UnitCalendar';
+import UnitCalendarGrid from '@cdo/apps/code-studio/components/progress/UnitCalendarGrid';
 
 import {testLessonSchedule, testLessons} from './unitCalendarTestData';
 

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTest.js
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTest.js
@@ -84,17 +84,17 @@ describe('UnitOverview', () => {
 
   it('renders a UnitCalendar if viewAs is Instructor and showCalendar is true', () => {
     const wrapper = setUp({viewAs: ViewType.Instructor, showCalendar: true});
-    expect(wrapper.find('UnitCalendar').length).toEqual(1);
+    expect(wrapper.find('UnitCalendarGrid').length).toEqual(1);
   });
 
   it('does not render a UnitCalendar if viewAs is not Instructor and showCalendar is true', () => {
     const wrapper = setUp({viewAs: ViewType.Participant, showCalendar: true});
-    expect(wrapper.find('UnitCalendar').length).toEqual(0);
+    expect(wrapper.find('UnitCalendarGrid').length).toEqual(0);
   });
 
   it('does not render a UnitCalendar if viewAs is Instructor and showCalendar is false', () => {
     const wrapper = setUp({viewAs: ViewType.Instructor, showCalendar: false});
-    expect(wrapper.find('UnitCalendar').length).toEqual(0);
+    expect(wrapper.find('UnitCalendarGrid').length).toEqual(0);
   });
 
   it('renders a UnitOverviewTopRow', () => {

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -300,7 +300,8 @@ class Lesson < ApplicationRecord
         description_teacher: description_teacher,
         unplugged: unplugged,
         lessonEditPath: get_uncached_edit_path,
-        lessonStartUrl: start_url
+        lessonStartUrl: start_url,
+        duration: total_lesson_duration,
       }
       # Use to_a here so that we get access to the cached script_levels.
       # Without it, script_levels.last goes back to the database.


### PR DESCRIPTION
This is an initial PR to get the calendar in place for new navigation.  

<img width="918" alt="image" src="https://github.com/user-attachments/assets/95868018-0833-47e2-b79b-5e208771a891">

It still needs some finessing, specifically, there is an issue with getting the lessons to load in a timely manner, but if you start with the lessons loaded (like if you go to progress and then wait for the lessons to load there) and then go to the calendar option, it will show up as in this picture.   Again this is intended to be a VERY rough draft with the follow up tickets documented in Jira.

## Links

[Figma](https://www.figma.com/design/5ILfiJkPQpjskBwksMDeZl/Teacher-Dashboard?node-id=4121-18467&node-type=TEXT&m=dev)
