### PR TITLE
Add logging of copy chat event

### DIFF
--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -8,6 +8,7 @@ import {Role} from '../aiComponentLibrary/chatMessage/types';
 import type {ValueOf} from '../types/utils';
 
 export const ChatEventDescriptions = {
+  COPY_CHAT: 'The user copied the chat history.',
   CLEAR_CHAT: 'The user cleared the chat workspace.',
   LOAD_LEVEL: 'The user loaded the aichat level.',
 } as const;

--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import {useSelector} from 'react-redux';
 
-import {selectAllVisibleMessages} from '@cdo/apps/aichat/redux/aichatRedux';
+import {
+  selectAllVisibleMessages,
+  addChatEvent,
+} from '@cdo/apps/aichat/redux/aichatRedux';
 import Button from '@cdo/apps/componentLibrary/button/Button';
 import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
 import {timestampToDateTime} from '../redux/utils';
@@ -20,6 +24,7 @@ import {AI_CUSTOMIZATIONS_LABELS} from './modelCustomization/constants';
 
 const CopyButton: React.FunctionComponent = () => {
   const messages = useSelector(selectAllVisibleMessages);
+  const dispatch = useAppDispatch();
 
   const handleCopy = () => {
     const textToCopy = messages.map(chatEventToFormattedString).join('\n');
@@ -36,6 +41,13 @@ const CopyButton: React.FunctionComponent = () => {
         action: 'Copy chat history',
       },
       PLATFORMS.BOTH
+    );
+    dispatch(
+      addChatEvent({
+        timestamp: Date.now(),
+        descriptionKey: 'COPY_CHAT',
+        hideForParticipants: true,
+      })
     );
   };
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds the backend logging of the user copying their chat history on an `aichat` level. Clearing chat history and loading the `aichat` level was added by https://github.com/code-dot-org/code-dot-org/pull/60053.

Note that the analytics logging of the copy chat history event is already implemented (Amplitude/Statsig). This PR just adds this event to `AichatEvents` table so it will be displayed as teacher view of student chat history.

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-940)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Locally, I clicked on 'Copy chat', then checked the DB and saw the 'COPY_CHAT' entry in `AichatEvents` table.

![Screenshot 2024-08-30 at 8 41 45 AM](https://github.com/user-attachments/assets/a0e9d8d3-79d8-4ecc-919a-ef9be256ebe6)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
