### PR TITLE
Enabling manage_students_tab_view_eyes test with a fix merged in PR 60724

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -2,7 +2,6 @@
 @eyes
 Feature: Using the manage students tab of the teacher dashboard
 
-  @skip
   Scenario: Viewing the manage students tab in normal and edit mode
     When I open my eyes to test "manage students tab"
     Given I create an authorized teacher-associated student named "SallyHasAVeryVeryLongFirstName"


### PR DESCRIPTION
The original change to fix the issue didn't have the test skipped in the branch, as seen in PR below, but not sure how as staging still has the test marked as skipped.

![image](https://github.com/user-attachments/assets/7add025b-9054-4151-a373-ab13f7f7b8cf)

## Links

https://codedotorg.atlassian.net/browse/TEACH-1262

## Testing story

Validated locally 

## Deployment strategy

Regular DTT

## Follow-up work

Validate error rates are falling

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
