### PR TITLE
Fixed loading selected section data on every new page selection

### DIFF
--- a/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
+++ b/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
@@ -19,7 +19,10 @@ import {
 export const asyncLoadSelectedSection = async (sectionId: string) => {
   const state = getStore().getState().teacherSections;
 
-  if (state.selectedSectionId === sectionId || state.isLoadingSectionData) {
+  if (
+    state.selectedSectionId === parseInt(sectionId) ||
+    state.isLoadingSectionData
+  ) {
     return;
   }
 


### PR DESCRIPTION
From [this](https://codedotorg.slack.com/archives/C06ERUABG01/p1725026403345569) conversation, I found that we were overwriting the selected script (unit) on every route change. This was because the logic to only load the selected section data if the selected section has changed was flawed. We were comparing a string to an int, so it was always false.

This fixes the bug and makes sure that we only load selected section data if the selected section has actually changed.
