### PR TITLE
fix(lms): do not set primary contact info on partial registration

### DIFF
--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -16,11 +16,7 @@ module PartialRegistration
       cache_key = session[SESSION_KEY]
       json = CDO.shared_cache.read(cache_key)
       attributes = JSON.parse(json)
-      user = new(attributes, &block)
-      if user.primary_contact_info.nil?
-        user.primary_contact_info = user.authentication_options&.first
-      end
-      user
+      new(attributes, &block)
     end
   end
 

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -32,7 +32,7 @@
       .span10
         %p
           - if is_lti
-            = t('activerecord.attributes.user.finish_sign_up_subheader_provider_markdown', provider: issuer_name, email: @user.email, markdown: :inline).html_safe
+            = t('activerecord.attributes.user.finish_sign_up_subheader_provider_markdown', provider: issuer_name, email: params.dig(:user, :email), markdown: :inline).html_safe
           - elsif @user.provider.present?
             - provider = t("auth.#{@user.provider}")
             = t('activerecord.attributes.user.finish_sign_up_subheader_provider_markdown', provider: provider, email: @user.email, markdown: :inline).html_safe


### PR DESCRIPTION
Previously, instantiation of a user during LMS SSO login set the primary contact info during account registration. However, setting the primary contact info during registration results in a circular model. When saving the user model, it will attempt to create the primary contact info association which doesn't yet exist resulting in a circular model that tries to create the child and parent at the same time. The net result is the potential creation of a duplicate user. For instance:

1. User -> primary_contact_info (AuthenticationOption): Create one user
2. primary_contact_info -> User: Create a second user

While saving the user, it is possible that the authentication option may not yet be created yet which allows the second user to be created. In most circumstances, the second user will silently fail to be created.

The primary_contact_info is set in the AuthenticationOption `after_create` hook anyway so the setting of the primary contact info upfront is not necessary.

Since teacher's emails are optional on the LMS side, during a user's creation it is now possible for the email to be `nil` but we will prompt the teacher for their email upon login. Additionally, emails (if supplied by the LMS) will be posted to the finish signup registration controller.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

## Scenario 1: Tested LMS SSO Login creation of a student

![Screenshot from 2024-09-03 10-53-53](https://github.com/user-attachments/assets/67a272f8-66fd-48cb-9971-8ffa8769a7d3)

## Scenario 2: Tested LMS SSO Login creation of a teacher

![Screenshot from 2024-09-03 11-02-25](https://github.com/user-attachments/assets/1fea8cf7-31f3-4849-afdc-e8eb982e3a3a)


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
