### PR TITLE
Dont store the CdoTutorials class in cache

### DIFF
--- a/pegasus/src/database.rb
+++ b/pegasus/src/database.rb
@@ -32,7 +32,7 @@ class Tutorials
     end.deep_dup
 
     @contents = JSON.parse(json_contents, object_class: DB[@table]).each do |tutorial|
-      tutorial.values.symbolize_keys!
+      tutorial.values.symbolize_keys!.to_h
     end
   end
 

--- a/pegasus/src/database.rb
+++ b/pegasus/src/database.rb
@@ -31,8 +31,8 @@ class Tutorials
       DB[@table].select(*@column_aliases).all.to_json
     end.deep_dup
 
-    @contents = JSON.parse(json_contents, object_class: DB[@table]).each do |tutorial|
-      tutorial.values.symbolize_keys!.to_h
+    @contents = JSON.parse(json_contents, object_class: DB[@table]).map do |tutorial|
+      tutorial.instance_values['values'].symbolize_keys!
     end
   end
 


### PR DESCRIPTION
This is a speculative fix for the persistent Honeybadger error `TypeError: CdoTutorials can't be referred to`. I found this potentially related issue: https://github.com/rails/rails/issues/43856 (while this is happening in our Sinatra app, the cache [uses](https://github.com/code-dot-org/code-dot-org/blob/540cbf55f399bbc30e501f5beff2e71cbf765072/lib/cdo/cache.rb#L13) `ActiveSupport::Cache::MemoryStore`). That issue does specifically reference the development environment, but around changing the model definition during development. As the `CdoTutorials` class is dynamically defined, my theory is that, on occasion, the class is reinstantiated after the cache is created (likely a race condition), causing this issue.

I could change the implementation of this feature to not dynamically create a class, but that feature is used in a variety of spaces and it could be difficult to separate it out. Instead I went for a variant of the suggestion in the issue linked above, which is to simply not store the object itself in cache. Instead, this is storing a hash of attributes.

## Testing Story

Some of the routes that use this class were already covered by unit tests. I added another unit test to ensure the pixel tracking continued to work.