### PR TITLE
Only use carousel when there are multiple certificates

### DIFF
--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -195,6 +195,29 @@ function Certificate(props) {
 
   const print = getPrintPath(courseName);
 
+  const renderCertificateImage = certificateObj => {
+    return (
+      <>
+        <a href={getCertificateSharePath(certificateObj.courseName)}>
+          <img
+            src={getCertificateImagePath(certificateObj.courseName)}
+            alt={
+              studentName
+                ? i18n.certificateAltTextWithName({
+                    studentName,
+                    courseTitle: certificateObj.courseTitle,
+                  })
+                : i18n.certificateAltTextNoName({
+                    courseTitle: certificateObj.courseTitle,
+                  })
+            }
+            className={style.certificateImage}
+          />
+        </a>
+      </>
+    );
+  };
+
   return (
     <div className={style.container}>
       <div className={style.headerContainer}>
@@ -216,44 +239,35 @@ function Certificate(props) {
               className={style.confetti}
             />
           }
-          <swiper-container
-            init="false"
-            ref={swiperRef}
-            class={style.swiperContainer}
-            navigation-next-el="#certificate-swiper-next-el"
-            navigation-prev-el="#certificate-swiper-prev-el"
-          >
-            {certificateData.map(image => (
-              <swiper-slide key={image.courseName}>
-                <a href={getCertificateSharePath(image.courseName)}>
-                  <img
-                    src={getCertificateImagePath(image.courseName)}
-                    alt={
-                      studentName
-                        ? i18n.certificateAltTextWithName({
-                            studentName,
-                            courseTitle: image.courseTitle,
-                          })
-                        : i18n.certificateAltTextNoName({
-                            courseTitle: image.courseTitle,
-                          })
-                    }
-                    className={style.certificateImage}
-                  />
-                </a>
-              </swiper-slide>
-            ))}
-          </swiper-container>
-          <button
-            id="certificate-swiper-prev-el"
-            className={classNames(style.navButton, style.prevElNav)}
-            type="button"
-          />
-          <button
-            id="certificate-swiper-next-el"
-            className={classNames(style.navButton, style.nextElNav)}
-            type="button"
-          />
+          {certificateData.length > 1 && (
+            <>
+              <swiper-container
+                init="false"
+                ref={swiperRef}
+                class={style.swiperContainer}
+                navigation-next-el="#certificate-swiper-next-el"
+                navigation-prev-el="#certificate-swiper-prev-el"
+              >
+                {certificateData.map(image => (
+                  <swiper-slide key={image.courseName}>
+                    {renderCertificateImage(image)}
+                  </swiper-slide>
+                ))}
+              </swiper-container>
+              <button
+                id="certificate-swiper-prev-el"
+                className={classNames(style.navButton, style.prevElNav)}
+                type="button"
+              />
+              <button
+                id="certificate-swiper-next-el"
+                className={classNames(style.navButton, style.nextElNav)}
+                type="button"
+              />
+            </>
+          )}
+          {certificateData.length === 1 &&
+            renderCertificateImage(certificateData[0])}
         </div>
         <div className={`${certificateStyle} ${style.inputContainer}`}>
           {courseName && !personalized && (

--- a/apps/test/unit/templates/certificates/Certificate.karma.test.js
+++ b/apps/test/unit/templates/certificates/Certificate.karma.test.js
@@ -135,4 +135,20 @@ describe('Certificate', () => {
       '/s/csd1-2023'
     );
   });
+
+  it('does not render swiper for single certificate', () => {
+    const wrapper = wrapperWithParams({
+      certificateData: [
+        {
+          courseName: 'csd1-2023',
+          coursePath: '/s/csd1-2023',
+        },
+      ],
+      certificateId: 'sessionId',
+      isHocTutorial: false,
+    });
+    expect(wrapper.find('swiper-container').exists()).to.be.false;
+    expect(wrapper.find('#certificate-swiper-prev-el').exists()).to.be.false;
+    expect(wrapper.find('#certificate-swiper-next-el').exists()).to.be.false;
+  });
 });


### PR DESCRIPTION
Fixes a bug I introduced a couple months ago that shows the arrow buttons on the congrats page no matter how many certificates there are. This diff looks bigger than it really is as I moved some rendering into a function for reuse.

On production:
<img width="1147" alt="Screenshot 2024-09-04 at 12 32 48 PM" src="https://github.com/user-attachments/assets/5258b6fa-57aa-4269-a289-1385e78d3c88">

Locally:
<img width="1099" alt="Screenshot 2024-09-04 at 12 32 53 PM" src="https://github.com/user-attachments/assets/7b8da01b-9fa5-4b34-bb2f-31cffdad19b5">

Multiple certificates still works correctly:
https://github.com/user-attachments/assets/6f649fe1-2442-43fa-bf74-29b9e19797a2



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
