### PR TITLE
GenAI: Add helper message to example prompt input that indicates whether requirements have been met or not.

### DIFF
--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -216,3 +216,20 @@ $default-spacing: 4px;
   font-size: 14px;
   margin: 16px 0 8px 0;
 }
+
+@mixin example-prompt-alert {
+  padding: 0;
+  background-color: white;
+}
+
+.examplePromptAlert {
+  @include example-prompt-alert;
+}
+
+.examplePromptAlertSuccess {
+  @include example-prompt-alert;
+}
+
+.examplePromptAlertSuccess i {
+  color: $teal !important;
+}

--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -190,10 +190,10 @@ $default-spacing: 4px;
   border: 1px solid;
   color: $light_gray_500;
   border-color: $neutral_dark20;
-}
 
-.itemContainer span {
-  padding: 6px 12px;
+  span {
+    padding: 6px 12px;
+  }
 }
 
 .removeItemIcon {

--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -187,9 +187,9 @@ $default-spacing: 4px;
   justify-content: space-between;
   align-items: start;
   border-radius: 4px;
-  border-color: $neutral_gray10;
   border: 1px solid;
   color: $light_gray_500;
+  border-color: $neutral_dark20;
 }
 
 .itemContainer span {

--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -233,6 +233,9 @@ $default-spacing: 4px;
   @include example-prompt-alert;
 }
 
+// The !important is required here to override the color in the Alert component
+// This begs the question of whether this should use the default success green instead of teal,
+// Since that is the way the component normally works.
 .examplePromptAlertSuccess i {
   color: $teal !important;
 }

--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -185,17 +185,20 @@ $default-spacing: 4px;
 .itemContainer {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  margin: 0 5px;
-  padding: 4px 12px;
+  align-items: start;
   border-radius: 4px;
-  border-color: $light_gray_500;
+  border-color: $neutral_gray10;
   border: 1px solid;
   color: $light_gray_500;
 }
 
+.itemContainer span {
+  padding: 6px 12px;
+}
+
 .removeItemIcon {
   color: $light_gray_500;
+  margin: 6px;
 
   &:hover {
     color: $light_negative_500;
@@ -214,7 +217,7 @@ $default-spacing: 4px;
 .addedItemsHeaderContainer {
   border-bottom: 1px solid $light_gray_200;
   font-size: 14px;
-  margin: 16px 0 8px 0;
+  margin-top: 8px;
 }
 
 @mixin example-prompt-alert {

--- a/apps/src/aichat/views/model-customization-workspace.module.scss
+++ b/apps/src/aichat/views/model-customization-workspace.module.scss
@@ -220,22 +220,7 @@ $default-spacing: 4px;
   margin-top: 8px;
 }
 
-@mixin example-prompt-alert {
+.examplePromptAlert {
   padding: 0;
   background-color: white;
-}
-
-.examplePromptAlert {
-  @include example-prompt-alert;
-}
-
-.examplePromptAlertSuccess {
-  @include example-prompt-alert;
-}
-
-// The !important is required here to override the color in the Alert component
-// This begs the question of whether this should use the default success green instead of teal,
-// Since that is the way the component normally works.
-.examplePromptAlertSuccess i {
-  color: $teal !important;
 }

--- a/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
+++ b/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
@@ -1,11 +1,14 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useMemo} from 'react';
 
+import Alert, {alertTypes} from '@cdo/apps/componentLibrary/alert/Alert';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import {setModelCardProperty} from '../../redux/aichatRedux';
 import {Visibility} from '../../types';
 
 import MultiInputCustomization from './MultiInputCustomization';
+
+import modelCustomizationStyles from '../model-customization-workspace.module.scss';
 
 const ExampleTopicsInputs: React.FunctionComponent<{
   fieldLabel: string;
@@ -29,6 +32,37 @@ const ExampleTopicsInputs: React.FunctionComponent<{
     [dispatch]
   );
 
+  const examplePromptAlerts = useMemo(() => {
+    return {
+      success: {
+        text: 'Must add at least one example prompt',
+        type: alertTypes.success,
+        className: modelCustomizationStyles.examplePromptAlertSuccess,
+      },
+      warning: {
+        text: 'Must add at least one example prompt',
+        type: alertTypes.warning,
+        className: modelCustomizationStyles.examplePromptAlert,
+      },
+    };
+  }, []);
+
+  const examplePromptAlert =
+    topics.length > 0
+      ? examplePromptAlerts.success
+      : examplePromptAlerts.warning;
+
+  const validationAlert = useMemo(() => {
+    return (
+      <Alert
+        text={examplePromptAlert.text}
+        type={examplePromptAlert.type}
+        size="s"
+        className={examplePromptAlert.className}
+      />
+    );
+  }, [examplePromptAlert]);
+
   return (
     <MultiInputCustomization
       label={fieldLabel}
@@ -39,6 +73,7 @@ const ExampleTopicsInputs: React.FunctionComponent<{
       isReadOnly={readOnly}
       hideInputBoxWhenReadOnly={false}
       onUpdateItems={onUpdateItems}
+      validationAlert={validationAlert}
     />
   );
 };

--- a/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
+++ b/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
@@ -32,38 +32,16 @@ const ExampleTopicsInputs: React.FunctionComponent<{
     [dispatch]
   );
 
-  // text is duplicated here in case we want the text to change for success.
-  // todo: Dry it up if we don't change the text.
-  const examplePromptAlerts = useMemo(() => {
-    return {
-      success: {
-        text: 'Must add at least one example prompt',
-        type: alertTypes.success,
-        className: modelCustomizationStyles.examplePromptAlertSuccess,
-      },
-      warning: {
-        text: 'Must add at least one example prompt',
-        type: alertTypes.warning,
-        className: modelCustomizationStyles.examplePromptAlert,
-      },
-    };
-  }, []);
-
-  const examplePromptAlert =
-    topics.length > 0
-      ? examplePromptAlerts.success
-      : examplePromptAlerts.warning;
-
   const validationAlert = useMemo(() => {
     return (
       <Alert
-        text={examplePromptAlert.text}
-        type={examplePromptAlert.type}
+        text="Must add at least one example prompt"
+        type={alertTypes.warning}
         size="s"
-        className={examplePromptAlert.className}
+        className={modelCustomizationStyles.examplePromptAlert}
       />
     );
-  }, [examplePromptAlert]);
+  }, []);
 
   return (
     <MultiInputCustomization
@@ -75,7 +53,7 @@ const ExampleTopicsInputs: React.FunctionComponent<{
       isReadOnly={readOnly}
       hideInputBoxWhenReadOnly={false}
       onUpdateItems={onUpdateItems}
-      validationAlert={validationAlert}
+      validationAlert={topics?.length <= 0 ? validationAlert : undefined}
     />
   );
 };

--- a/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
+++ b/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
@@ -53,7 +53,7 @@ const ExampleTopicsInputs: React.FunctionComponent<{
       isReadOnly={readOnly}
       hideInputBoxWhenReadOnly={false}
       onUpdateItems={onUpdateItems}
-      validationAlert={topics?.length <= 0 ? validationAlert : undefined}
+      validationAlert={topics?.length === 0 ? validationAlert : undefined}
     />
   );
 };

--- a/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
+++ b/apps/src/aichat/views/modelCustomization/ExampleTopicsInputs.tsx
@@ -32,6 +32,8 @@ const ExampleTopicsInputs: React.FunctionComponent<{
     [dispatch]
   );
 
+  // text is duplicated here in case we want the text to change for success.
+  // todo: Dry it up if we don't change the text.
   const examplePromptAlerts = useMemo(() => {
     return {
       success: {

--- a/apps/src/aichat/views/modelCustomization/MultiInputCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/MultiInputCustomization.tsx
@@ -1,5 +1,6 @@
 import React, {useState, useCallback} from 'react';
 
+import Alert, {alertTypes} from '@cdo/apps/componentLibrary/alert/Alert';
 import Button from '@cdo/apps/componentLibrary/button/Button';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
@@ -47,6 +48,24 @@ const MultiInputCustomization: React.FunctionComponent<{
     document.getElementById(fieldId)?.focus();
   }, [newItem, addedItems, fieldId, onUpdateItems]);
 
+  const examplePromptAlerts = {
+    success: {
+      text: 'Must add at least one example prompt',
+      type: alertTypes.success,
+      className: modelCustomizationStyles.examplePromptAlertSuccess,
+    },
+    warning: {
+      text: 'Must add at least one example prompt',
+      type: alertTypes.warning,
+      className: modelCustomizationStyles.examplePromptAlert,
+    },
+  };
+
+  const examplePromptAlert =
+    addedItems.length > 0
+      ? examplePromptAlerts.success
+      : examplePromptAlerts.warning;
+
   return (
     <>
       {(!isReadOnly || !hideInputBoxWhenReadOnly) && (
@@ -58,6 +77,12 @@ const MultiInputCustomization: React.FunctionComponent<{
               onChange={event => setNewItem(event.target.value)}
               value={newItem}
               disabled={isReadOnly}
+            />
+            <Alert
+              text={examplePromptAlert.text}
+              type={examplePromptAlert.type}
+              size="s"
+              className={examplePromptAlert.className}
             />
           </div>
           <div className={modelCustomizationStyles.addItemContainer}>

--- a/apps/src/aichat/views/modelCustomization/MultiInputCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/MultiInputCustomization.tsx
@@ -1,6 +1,5 @@
 import React, {useState, useCallback} from 'react';
 
-import Alert, {alertTypes} from '@cdo/apps/componentLibrary/alert/Alert';
 import Button from '@cdo/apps/componentLibrary/button/Button';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import {StrongText} from '@cdo/apps/componentLibrary/typography/TypographyElements';
@@ -21,6 +20,7 @@ const MultiInputCustomization: React.FunctionComponent<{
   isReadOnly: boolean;
   hideInputBoxWhenReadOnly: boolean;
   onUpdateItems: (updatedItems: string[]) => void;
+  validationAlert?: React.ReactNode;
 }> = ({
   label,
   fieldId,
@@ -30,6 +30,7 @@ const MultiInputCustomization: React.FunctionComponent<{
   isReadOnly,
   hideInputBoxWhenReadOnly,
   onUpdateItems,
+  validationAlert,
 }) => {
   const [newItem, setNewItem] = useState('');
 
@@ -48,24 +49,6 @@ const MultiInputCustomization: React.FunctionComponent<{
     document.getElementById(fieldId)?.focus();
   }, [newItem, addedItems, fieldId, onUpdateItems]);
 
-  const examplePromptAlerts = {
-    success: {
-      text: 'Must add at least one example prompt',
-      type: alertTypes.success,
-      className: modelCustomizationStyles.examplePromptAlertSuccess,
-    },
-    warning: {
-      text: 'Must add at least one example prompt',
-      type: alertTypes.warning,
-      className: modelCustomizationStyles.examplePromptAlert,
-    },
-  };
-
-  const examplePromptAlert =
-    addedItems.length > 0
-      ? examplePromptAlerts.success
-      : examplePromptAlerts.warning;
-
   return (
     <>
       {(!isReadOnly || !hideInputBoxWhenReadOnly) && (
@@ -78,12 +61,7 @@ const MultiInputCustomization: React.FunctionComponent<{
               value={newItem}
               disabled={isReadOnly}
             />
-            <Alert
-              text={examplePromptAlert.text}
-              type={examplePromptAlert.type}
-              size="s"
-              className={examplePromptAlert.className}
-            />
+            {!isReadOnly && validationAlert}
           </div>
           <div className={modelCustomizationStyles.addItemContainer}>
             <Button


### PR DESCRIPTION
This change adds an alert under the `Example Prompts and Topics` section of the `Publish` tab in Aichat levels. This alert appears when there are no prompts added and disappears when at least 1 prompt has been added.

https://github.com/user-attachments/assets/3655c1d7-f8ea-4b42-8bbc-36aef5c78824

It also tweaks the spacing around the "Added" items to match up better with the figma design. (follow-up from https://github.com/code-dot-org/code-dot-org/pull/60461#discussion_r1737027249)

Figma design:
![image](https://github.com/user-attachments/assets/3013296e-32e8-4a4c-ba2c-7d1fb02a417f)

Comparing prod to local:
- Removed extra space above `Add` button and below `Added` header
- Changed padding to be around the text inside the container rather than around the container, making the container full width and giving space between text and `x` button
- Changed `x` button to appear at the top right rather than centered on the right side.

https://github.com/user-attachments/assets/1055566c-2dc4-4229-906e-da288b81d6aa

## Links

- jira ticket: [Add helper message to example prompt input that indicates whether requirements have been met or not.](https://codedotorg.atlassian.net/browse/LABS-875)

## Testing story

- Tested locally the css updates with Retrieval and Publish tabs. 
- Tested the validation message only shows on the Publish tab and only when there are no added prompts, on first load and while interacting with the control.