### PR TITLE
[Aichat] Add user_has_aichat_access action to backend - part 1

### DIFF
--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -160,9 +160,9 @@ class AichatController < ApplicationController
     render(status: :ok, json: response_body)
   end
 
-  # GET /aichat/has_access
-  def has_access?
-    render(status: :ok, json: {hasAccess: current_user&.has_aichat_access?})
+  # GET /aichat/user_has_access
+  def user_has_access
+    render(status: :ok, json: {userHasAccess: current_user&.has_aichat_access?})
   end
 
   private def chat_completion_has_required_params?

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -160,6 +160,11 @@ class AichatController < ApplicationController
     render(status: :ok, json: response_body)
   end
 
+  # GET /aichat/user_has_aichat_access
+  def user_has_aichat_access
+    render(status: :ok, json: current_user&.has_aichat_access?)
+  end
+
   private def chat_completion_has_required_params?
     begin
       params.require([:newMessage, :aichatModelCustomizations, :aichatContext])

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -160,9 +160,9 @@ class AichatController < ApplicationController
     render(status: :ok, json: response_body)
   end
 
-  # GET /aichat/user_has_aichat_access
-  def user_has_aichat_access
-    render(status: :ok, json: current_user&.has_aichat_access?)
+  # GET /aichat/has_access
+  def has_access?
+    render(status: :ok, json: {hasAccess: current_user&.has_aichat_access?})
   end
 
   private def chat_completion_has_required_params?

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -491,7 +491,7 @@ class Ability
       can :student_chat_history, :aichat do
         user.teacher_can_access_ai_chat?
       end
-      can :has_access, :aichat
+      can :user_has_access, :aichat
     end
 
     if user.persisted? && user.permission?(UserPermission::PROJECT_VALIDATOR)

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -491,7 +491,7 @@ class Ability
       can :student_chat_history, :aichat do
         user.teacher_can_access_ai_chat?
       end
-      can :user_has_aichat_access, :aichat
+      can :has_access, :aichat
     end
 
     if user.persisted? && user.permission?(UserPermission::PROJECT_VALIDATOR)

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -491,6 +491,7 @@ class Ability
       can :student_chat_history, :aichat do
         user.teacher_can_access_ai_chat?
       end
+      can :user_has_aichat_access, :aichat
     end
 
     if user.persisted? && user.permission?(UserPermission::PROJECT_VALIDATOR)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1557,6 +1557,10 @@ class User < ApplicationRecord
       sections_as_student.any?(&:assigned_gen_ai?)
   end
 
+  def has_aichat_access?
+    teacher_can_access_ai_chat? || student_can_access_ai_chat?
+  end
+
   # Students
   def has_ai_tutor_access?
     return false if ai_tutor_access_denied || ai_tutor_feature_globally_disabled?

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1174,7 +1174,7 @@ Dashboard::Application.routes.draw do
     post '/aichat/check_message_safety', to: 'aichat#check_message_safety'
     post '/aichat/start_chat_completion', to: 'aichat#start_chat_completion'
     get '/aichat/chat_request/:id', to: 'aichat#chat_request'
-    get '/aichat/user_has_aichat_access', to: 'aichat#user_has_aichat_access'
+    get '/aichat/has_access', to: 'aichat#has_access'
 
     post 'ai_diff/chat_completion', to: 'ai_diff#chat_completion'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1174,6 +1174,7 @@ Dashboard::Application.routes.draw do
     post '/aichat/check_message_safety', to: 'aichat#check_message_safety'
     post '/aichat/start_chat_completion', to: 'aichat#start_chat_completion'
     get '/aichat/chat_request/:id', to: 'aichat#chat_request'
+    get '/aichat/user_has_aichat_access', to: 'aichat#user_has_aichat_access'
 
     post 'ai_diff/chat_completion', to: 'ai_diff#chat_completion'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1174,7 +1174,7 @@ Dashboard::Application.routes.draw do
     post '/aichat/check_message_safety', to: 'aichat#check_message_safety'
     post '/aichat/start_chat_completion', to: 'aichat#start_chat_completion'
     get '/aichat/chat_request/:id', to: 'aichat#chat_request'
-    get '/aichat/has_access', to: 'aichat#has_access'
+    get '/aichat/user_has_access', to: 'aichat#user_has_access'
 
     post 'ai_diff/chat_completion', to: 'ai_diff#chat_completion'
 

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -147,6 +147,7 @@ class AichatControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  # log_chat_event tests
   test 'authorized teacher has access to log_chat_event test' do
     sign_in(@authorized_teacher1)
     post :log_chat_event, params: @valid_params_log_chat_event, as: :json
@@ -243,5 +244,34 @@ class AichatControllerTest < ActionController::TestCase
     assert_equal json_response.keys, ['executionStatus', 'response']
     assert_equal json_response['executionStatus'], execution_status
     assert_equal json_response['response'], response
+  end
+
+  # user_has_aichat_access tests
+  test 'GET user_has_aichat_access returns false for unauthorized teacher' do
+    sign_in(create(:teacher))
+    get :user_has_aichat_access
+    assert_response :success
+    assert_equal json_response, false
+  end
+
+  test 'GET user_has_aichat_access returns true for authorized teacher' do
+    sign_in(@authorized_teacher1)
+    get :user_has_aichat_access
+    assert_response :success
+    assert_equal json_response, true
+  end
+
+  test 'GET user_has_aichat_access returns false for unauthorized student' do
+    sign_in(create(:student))
+    get :user_has_aichat_access
+    assert_response :success
+    assert_equal json_response, false
+  end
+
+  test 'GET user_has_aichat_access returns true for student of authorized teacher' do
+    sign_in(@authorized_student1)
+    get :user_has_aichat_access
+    assert_response :success
+    assert_equal json_response, true
   end
 end

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -246,37 +246,37 @@ class AichatControllerTest < ActionController::TestCase
     assert_equal json_response['response'], response
   end
 
-  # has_access tests
-  test 'signed out user does not have access to has_access test' do
-    get :has_access
+  # user_has_access tests
+  test 'signed out user does not have access to user_has_access test' do
+    get :user_has_access
     assert_response :forbidden
   end
 
-  test 'GET has_access returns false for unauthorized teacher' do
+  test 'GET user_has_access returns false for unauthorized teacher' do
     sign_in(create(:teacher))
-    get :has_access
+    get :user_has_access
     assert_response :success
-    assert_equal json_response['hasAccess'], false
+    assert_equal json_response['userHasAccess'], false
   end
 
-  test 'GET has_access returns true for authorized teacher' do
+  test 'GET user_has_access returns true for authorized teacher' do
     sign_in(@authorized_teacher1)
-    get :has_access
+    get :user_has_access
     assert_response :success
-    assert_equal json_response['hasAccess'], true
+    assert_equal json_response['userHasAccess'], true
   end
 
-  test 'GET has_access returns false for unauthorized student' do
+  test 'GET user_has_access returns false for unauthorized student' do
     sign_in(create(:student))
-    get :has_access
+    get :user_has_access
     assert_response :success
-    assert_equal json_response['hasAccess'], false
+    assert_equal json_response['userHasAccess'], false
   end
 
-  test 'GET has_access returns true for student of authorized teacher' do
+  test 'GET user_has_access returns true for student of authorized teacher' do
     sign_in(@authorized_student1)
-    get :has_access
+    get :user_has_access
     assert_response :success
-    assert_equal json_response['hasAccess'], true
+    assert_equal json_response['userHasAccess'], true
   end
 end

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -247,6 +247,11 @@ class AichatControllerTest < ActionController::TestCase
   end
 
   # user_has_aichat_access tests
+  test 'signed out user does not have access to user_has_aichat_access test' do
+    get :user_has_aichat_access
+    assert_response :forbidden
+  end
+
   test 'GET user_has_aichat_access returns false for unauthorized teacher' do
     sign_in(create(:teacher))
     get :user_has_aichat_access

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -246,37 +246,37 @@ class AichatControllerTest < ActionController::TestCase
     assert_equal json_response['response'], response
   end
 
-  # user_has_aichat_access tests
-  test 'signed out user does not have access to user_has_aichat_access test' do
-    get :user_has_aichat_access
+  # has_access tests
+  test 'signed out user does not have access to has_access test' do
+    get :has_access
     assert_response :forbidden
   end
 
-  test 'GET user_has_aichat_access returns false for unauthorized teacher' do
+  test 'GET has_access returns false for unauthorized teacher' do
     sign_in(create(:teacher))
-    get :user_has_aichat_access
+    get :has_access
     assert_response :success
-    assert_equal json_response, false
+    assert_equal json_response['hasAccess'], false
   end
 
-  test 'GET user_has_aichat_access returns true for authorized teacher' do
+  test 'GET has_access returns true for authorized teacher' do
     sign_in(@authorized_teacher1)
-    get :user_has_aichat_access
+    get :has_access
     assert_response :success
-    assert_equal json_response, true
+    assert_equal json_response['hasAccess'], true
   end
 
-  test 'GET user_has_aichat_access returns false for unauthorized student' do
+  test 'GET has_access returns false for unauthorized student' do
     sign_in(create(:student))
-    get :user_has_aichat_access
+    get :has_access
     assert_response :success
-    assert_equal json_response, false
+    assert_equal json_response['hasAccess'], false
   end
 
-  test 'GET user_has_aichat_access returns true for student of authorized teacher' do
+  test 'GET has_access returns true for student of authorized teacher' do
     sign_in(@authorized_student1)
-    get :user_has_aichat_access
+    get :has_access
     assert_response :success
-    assert_equal json_response, true
+    assert_equal json_response['hasAccess'], true
   end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds an `aichat` api endpoint that returns whether a signed-in user has `aichat` access, e.g., if the user is authorized to have access to other `aichat` actions (`chat_completion`, `log_chat_event`, ...).

We will use this endpoint to add a `has_aichat_access` field to analytics reporting on the frontend.

## Links
[Slack thread](https://codedotorg.slack.com/archives/C06UT1E2796/p1724789586740819)
[jira](https://codedotorg.atlassian.net/browse/LABS-991)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Added a handful of unit tests.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
