### PR TITLE
Add hourofcode.com to list of production environments on utils.js

### DIFF
--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -931,7 +931,11 @@ export function getEnvironment() {
   if (hostname.includes('localhost') || hostname.includes('127.0.0.1')) {
     return Environments.development;
   }
-  if (hostname === 'code.org' || hostname === 'studio.code.org') {
+  if (
+    hostname === 'code.org' ||
+    hostname === 'studio.code.org' ||
+    hostname === 'hourofcode.com'
+  ) {
     return Environments.production;
   }
   return Environments.unknown;


### PR DESCRIPTION
Adds hourofcode.com to the list of production environments. This fixes an issue where Stasig events weren't being logged on hourofcode.com. Thank you @bethanyaconnor for finding where this needed to be added!

## Links
Slack convo: [here](https://codedotorg.slack.com/archives/C0453TUMLE7/p1724967202806969) and [here](https://codedotorg.slack.com/archives/C074Q3ELL3B/p1724968616308219)

## Testing story
I don't think I can test this locally so we'll have to see if it works once this PR goes live. 