### PR TITLE
Revert "Revert "Adds skinny banner and teacher dashboard banner for Transformers""

### DIFF
--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -1,7 +1,7 @@
 {
   "pages": {
-    "/home": "user-research-aug-2024",
-    "/student-home": ""
+    "/home": "transformers-sept-2024",
+    "/student-home": "transformers-sept-2024"
   },
   "banners": {
     "superhero": {
@@ -36,6 +36,14 @@
       "buttonText": "Join our research community",
       "buttonUrl": "https://greatquestion.co/codedotorg/userresearch",
       "buttonId": "user-research-aug-2024"
+    },
+    "transformers-sept-2024": {
+      "image": "/shared/images/banners/transformers_action_poster.png",
+      "title": "Get in the fun! Easy-to-learn code with Transformers One",
+      "body": "Autobots, roll out! In this Transformers One-themed introduction to our Sprite Lab, students learn the basics of computer science by building fun, interactive projects.",
+      "buttonText": "Try it now",
+      "buttonUrl": "https://studio.code.org/s/hello-world-transformers-one-2024/lessons/1/levels/1",
+      "buttonId": "transformers-sept-2024"
     }
   }
 }

--- a/pegasus/sites.v3/code.org/public/student/elementary.haml
+++ b/pegasus/sites.v3/code.org/public/student/elementary.haml
@@ -13,6 +13,8 @@ theme: responsive_full_width
     %p.body-one
       =hoc_s(:elementary_page_main_description)
 
+= view :"transformers/skinny_banner"
+
 %section
   .wrapper
     %h2

--- a/pegasus/sites.v3/code.org/views/transformers/skinny_banner.haml
+++ b/pegasus/sites.v3/code.org/views/transformers/skinny_banner.haml
@@ -1,0 +1,38 @@
+:scss
+
+  .skinny-banner {
+    background-image: url('/images/banners/banner-transformers-background.png');
+    background-size: cover;
+    background-position: center;
+    margin-top: 3rem;
+
+    img {
+      width: 165px;
+    }
+
+    @media (min-width: 753px) {
+      .text-wrapper {
+        width: 50%;
+      }
+    }
+
+    @media (max-width: 753px) {
+      .wrapper {
+        justify-content: center;
+      }
+    }
+  }
+
+- if request.language == "en"
+  %section.skinny-banner
+    .wrapper.flex-container.justify-space-between.align-items-center.wrap.gap-1
+      .text-wrapper.centered
+        %h1.heading-lg.white
+          =hoc_s("transformers.header")
+        %p.white
+          =hoc_s("transformers.desc")
+      %figure.col-30
+        %img{src:"/images/banners/banner-transformers-one.png", alt: "Transformers One"}
+      .cta-wrapper.col-30
+        %a.link-button.white{href: CDO.studio_url("s/hello-world-transformers-one-2024/lessons/1/levels/1"), target: "_blank", rel: "noopener noreferrer", "aria-label": "Start a Transformers One activity now"}
+          =hoc_s(:call_to_action_start_activity_short)

--- a/shared/images/banners/transformers_action_poster.png
+++ b/shared/images/banners/transformers_action_poster.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b84d1f214176df29ace2262c6faead45ace0e972c9061d761cd12241dfba8a84
+size 898542


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#60795

We held off on adding the banners for Transformers One because the tutorial wasn't quite ready. This pr is a clean revert of that revert, thus relaunching the banners.