### PR TITLE
[Google Blockly] create parameters label when toggling flyout field

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
@@ -14,7 +14,6 @@ import procedureCallerOnChangeMixin from './mixins/procedureCallerOnChangeMixin'
 import procedureCallerMutator from './mutators/procedureCallerMutator';
 import {procedureDefMutator} from './mutators/procedureDefMutator';
 
-const PARAMETERS_LABEL = 'PARAMETERS_LABEL';
 /**
  * A dictionary of our custom procedure block definitions, used across labs.
  * Replaces blocks that are part of core Blockly.
@@ -188,14 +187,6 @@ GoogleBlockly.Extensions.register(
     );
     // Open mini-toolbox by default
     flyoutToggleButton.setIcon(false);
-    // If we added a flyout, place a 'Parameters' label before it.
-    const flyoutInput = this.getInput('flyout_input');
-    if (flyoutInput) {
-      flyoutInput.insertFieldAt(
-        0,
-        new Blockly.FieldLabel(commonI18n.parameters(), PARAMETERS_LABEL)
-      );
-    }
   }
 );
 

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.ts
@@ -32,6 +32,8 @@ const INPUTS = {
   STACK: 'STACK',
 };
 
+const PARAMETERS_LABEL = 'PARAMETERS_LABEL';
+
 // This file contains customizations to Google Blockly Sprite Lab blocks.
 export const blocks = {
   // Creates and returns a toggle button field. This field should be
@@ -49,7 +51,11 @@ export const blocks = {
         name: 'FLYOUT',
       });
 
-      block.appendDummyInput(INPUTS.FLYOUT).appendField(flyoutField, flyoutKey);
+      const newDummyInput = block.appendDummyInput(INPUTS.FLYOUT);
+      if (block.type === BLOCK_TYPES.procedureDefinition) {
+        newDummyInput.appendField(commonI18n.parameters(), PARAMETERS_LABEL);
+      }
+      newDummyInput.appendField(flyoutField, flyoutKey);
       // By default, the flyout is added after the stack input (at the bottom of the block).
       // This flag is used by behavior and function definitions, mainly in the modal function editor,
       // to add the flyout before the stack input (at the top of the block).


### PR DESCRIPTION
We now use a mini-toolbox for the parameters of a function definition. Before migrating Maze, we decided to add a "Parameters" label before the flyout field to indicate its purpose. Unfortunately, if you collapse and expand the flyout field using the toggle button, the label doesn't come back.

![broken](https://github.com/user-attachments/assets/bb2fd788-7bb8-44c0-a157-cc8cf4a05734)

This is because we were just creating the label when the block was first created. Instead, we should create it during the toggle action. We can move the extra field into `createFlyoutField` which is called by `toggleFlyout`. Because these functions are used by other Sprite Lab event blocks, we need to add a block type check to make sure the label only ever shows on function blocks. Now the "Parameters" label appears to persist across toggles.

![fixed](https://github.com/user-attachments/assets/305259ac-fcd6-4512-bcc3-b60859c38e09)



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
