### PR TITLE
Send name to MailJet when creating a contact on signup

### DIFF
--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -65,7 +65,7 @@ module MailJet
     contact = find_or_create_contact(user.email, user.name)
     update_contact_fields(contact,
       [
-        {name: 'firstname', value: user.name},
+        {name: 'firstname', value: user.name}, # existing templates use 'firstname'
         {name: 'display_name', value: user.name},
         {name: 'sign_up_date', value: user.created_at.to_datetime.rfc3339}
       ]
@@ -93,6 +93,13 @@ module MailJet
     Mailjet::Contact.find(email)
   end
 
+  # data must be in the format:
+  # [
+  #   {
+  #     name: "field_name",
+  #     value: "field_value"
+  #   }
+  # ]
   def self.update_contact_fields(contact, fields)
     return unless enabled?
     return if contact.nil?
@@ -100,6 +107,7 @@ module MailJet
     contactdata = Mailjet::Contactdata.find(contact.id)
     return unless contactdata
 
+    # Fields need to be sent separately or else only the first field is reflected in MailJet
     fields.each do |field|
       contactdata.update_attributes(
         data: [

--- a/lib/cdo/mailjet.rb
+++ b/lib/cdo/mailjet.rb
@@ -63,7 +63,13 @@ module MailJet
     return unless user.teacher?
 
     contact = find_or_create_contact(user.email, user.name)
-    update_contact_field(contact, 'sign_up_date', user.created_at.to_datetime.rfc3339)
+    update_contact_fields(contact,
+      [
+        {name: 'firstname', value: user.name},
+        {name: 'display_name', value: user.name},
+        {name: 'sign_up_date', value: user.created_at.to_datetime.rfc3339}
+      ]
+    )
 
     subaccount_contact_list_config = CONTACT_LISTS[:welcome_series][subaccount.to_sym]
     contact_list_id = subaccount_contact_list_config[locale.to_sym] || subaccount_contact_list_config[:default]
@@ -87,19 +93,20 @@ module MailJet
     Mailjet::Contact.find(email)
   end
 
-  def self.update_contact_field(contact, field_name, field_value)
+  def self.update_contact_fields(contact, fields)
     return unless enabled?
     return if contact.nil?
 
     contactdata = Mailjet::Contactdata.find(contact.id)
-    contactdata.update_attributes(
-      data: [
-        {
-          name: field_name,
-          value: field_value
-        }
-      ]
-    )
+    return unless contactdata
+
+    fields.each do |field|
+      contactdata.update_attributes(
+        data: [
+          field
+        ]
+      )
+    end
   end
 
   def self.delete_contact(email)

--- a/lib/test/cdo/test_mailjet.rb
+++ b/lib/test/cdo/test_mailjet.rb
@@ -45,7 +45,7 @@ class MailJetTest < Minitest::Test
     assert_nil MailJet.find_or_create_contact(email, name)
   end
 
-  def test_update_contact_field
+  def test_update_contact_fields
     mock_contactdata = mock('Mailjet::Contactdata')
     mock_contactdata.stubs(:update_attributes).with(data: [{name: 'field_name', value: 'field_value'}])
 
@@ -54,7 +54,7 @@ class MailJetTest < Minitest::Test
     mock_contact = mock('Mailjet::Contact')
     mock_contact.stubs(:id).returns(mock_contact_id)
 
-    MailJet.update_contact_field(mock_contact, 'field_name', 'field_value')
+    MailJet.update_contact_fields(mock_contact, [{name: 'field_name', value: 'field_value'}])
   end
 
   def test_send_template_email_default_locale_with_variables
@@ -183,13 +183,21 @@ class MailJetTest < Minitest::Test
     user.stubs(:teacher?).returns(true)
     user.stubs(:created_at).returns(sign_up_time)
 
+    mock_contact_id = 123
     mock_contactdata = mock('Mailjet::Contactdata')
-    MailJet.expects(:find_or_create_contact).with(email, user.name).returns(mock_contactdata)
+    mock_contact = mock('Mailjet::Contact')
+    mock_contact.stubs(:id).returns(mock_contact_id)
 
-    MailJet.expects(:update_contact_field).with(mock_contactdata, 'sign_up_date', sign_up_time.rfc3339)
+    MailJet.expects(:find_or_create_contact).with(email, user.name).returns(mock_contact)
+
+    Mailjet::Contactdata.expects(:find).with(mock_contact_id).returns(mock_contactdata)
+
+    mock_contactdata.expects(:update_attributes).with(data: [{name: 'sign_up_date', value: sign_up_time.to_datetime.rfc3339}])
+    mock_contactdata.expects(:update_attributes).with(data: [{name: "firstname", value: "Fake Name"}])
+    mock_contactdata.expects(:update_attributes).with(data: [{name: "display_name", value: "Fake Name"}])
 
     MailJet.stubs(:subaccount).returns('development')
-    MailJet.expects(:add_to_contact_list).with(mock_contactdata, MailJet::CONTACT_LISTS[:welcome_series][:development][:default])
+    MailJet.expects(:add_to_contact_list).with(mock_contact, MailJet::CONTACT_LISTS[:welcome_series][:development][:default])
 
     MailJet.create_contact_and_add_to_welcome_series(user)
   end
@@ -205,13 +213,20 @@ class MailJetTest < Minitest::Test
     user.stubs(:teacher?).returns(true)
     user.stubs(:created_at).returns(sign_up_time)
 
+    mock_contact_id = 123
+    mock_contact = mock('Mailjet::Contact')
     mock_contactdata = mock('Mailjet::Contactdata')
-    MailJet.expects(:find_or_create_contact).with(email, user.name).returns(mock_contactdata)
+    Mailjet::Contactdata.expects(:find).with(mock_contact_id).returns(mock_contactdata)
+    mock_contact.stubs(:id).returns(mock_contact_id)
 
-    MailJet.expects(:update_contact_field).with(mock_contactdata, 'sign_up_date', sign_up_time.rfc3339)
+    MailJet.expects(:find_or_create_contact).with(email, user.name).returns(mock_contact)
+
+    mock_contactdata.expects(:update_attributes).with(data: [{name: 'sign_up_date', value: sign_up_time.to_datetime.rfc3339}])
+    mock_contactdata.expects(:update_attributes).with(data: [{name: "firstname", value: "Fake Name"}])
+    mock_contactdata.expects(:update_attributes).with(data: [{name: "display_name", value: "Fake Name"}])
 
     MailJet.stubs(:subaccount).returns('development')
-    MailJet.expects(:add_to_contact_list).with(mock_contactdata, MailJet::CONTACT_LISTS[:welcome_series][:development][:'es-MX'])
+    MailJet.expects(:add_to_contact_list).with(mock_contact, MailJet::CONTACT_LISTS[:welcome_series][:development][:'es-MX'])
 
     MailJet.create_contact_and_add_to_welcome_series(user, 'es-MX')
   end
@@ -267,52 +282,5 @@ class MailJetTest < Minitest::Test
     Mailjet::Listrecipient.expects(:create).with(list_id: list_id, contact_id: 123)
 
     MailJet.add_to_contact_list(contact, list_id)
-  end
-
-  def test_sending_email_with_template
-    template_name = :email_template_name
-    template_config = 'email_template_config'
-    contact_email = 'contact_email'
-    contact_name = 'contact_name'
-    mailjet_contact = 'mailjet_contact'
-
-    MailJetConstants.stub_const(:EMAILS, {template_name => template_config}) do
-      MailJet.expects(:find_or_create_contact).with(contact_email, contact_name).returns(mailjet_contact)
-      MailJet.expects(:send_template_email).with(mailjet_contact, template_config, 'en-US', variables: {}).once
-
-      MailJet.send_email(template_name, contact_email, contact_name)
-    end
-  end
-
-  def test_sending_email_with_template_vars_and_locale
-    template_name = :email_template_name
-    template_config = 'email_template_config'
-    contact_email = 'contact_email'
-    contact_name = 'contact_name'
-    mailjet_contact = 'mailjet_contact'
-    vars = {variables: 'variables'}
-    locale = 'locale'
-
-    MailJetConstants.stub_const(:EMAILS, {template_name => template_config}) do
-      MailJet.expects(:find_or_create_contact).with(contact_email, contact_name).returns(mailjet_contact)
-      MailJet.expects(:send_template_email).with(mailjet_contact, template_config, locale, variables: vars).once
-
-      MailJet.send_email(template_name, contact_email, contact_name, vars: vars, locale: locale)
-    end
-  end
-
-  def test_sending_email_with_invalid_template
-    template_name = :email_template_name
-    contact_email = 'contact_email'
-    contact_name = 'contact_name'
-    mailjet_contact = 'mailjet_contact'
-
-    MailJetConstants.stub_const(:EMAILS, {template_name => nil}) do
-      MailJet.expects(:find_or_create_contact).with(contact_email, contact_name).returns(mailjet_contact).never
-      MailJet.expects(:send_template_email).with(mailjet_contact, anything).never
-
-      actual_error = assert_raises(ArgumentError) {MailJet.send_email(template_name, contact_email, contact_name)}
-      assert_equal "Invalid email template: #{template_name}", actual_error.message
-    end
   end
 end


### PR DESCRIPTION
Sends both `firstname` and `display_name` (which have the same value) to MailJet when we create a user on signup. This is for customization of our email templates. Our existing templates use `firstname`, but, as that's inaccurate, I'd love to support `display_name` going forward.

### Testing Story

- Added a unit test (and refactored a couple existing ones)
- Manual testing