### PR TITLE
Remove 'isAssigned' which is never used

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -42,8 +42,7 @@ class CoursesController < ApplicationController
       return
     end
 
-    sections = current_user.try {|u| u.sections_instructed.all.reject(&:hidden).map(&:summarize)}
-    @sections_with_assigned_info = sections&.map {|section| section.merge!({"isAssigned" => section[:course_id] == @unit_group.id})}
+    @sections = current_user.try {|u| u.sections_instructed.all.reject(&:hidden).map(&:summarize)}
 
     @locale_code = request.locale
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -51,8 +51,7 @@ class ScriptsController < ApplicationController
     @show_redirect_warning = params[:redirect_warning] == 'true'
     unless current_user&.student?
       @section = current_user&.sections_instructed&.all&.find {|s| s.id.to_s == params[:section_id]}&.summarize
-      sections = current_user.try {|u| u.sections_instructed.all.reject(&:hidden).map(&:summarize)}
-      @sections_with_assigned_info = sections&.map {|section| section.merge!({"isAssigned" => section[:script_id] == @script.id})}
+      @sections = current_user.try {|u| u.sections_instructed.all.reject(&:hidden).map(&:summarize)}
     end
 
     @show_unversioned_redirect_warning = !!session[:show_unversioned_redirect_warning] && !@script.is_course
@@ -74,7 +73,7 @@ class ScriptsController < ApplicationController
       locale_code: request.locale,
       course_link: @script.course_link(params[:section_id]),
       course_title: @script.course_title || I18n.t('view_all_units'),
-      sections: @sections_with_assigned_info
+      sections: @sections
     }
 
     @script_data = @script.summarize(true, current_user, false, request.locale).merge(additional_script_data)

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -6,7 +6,7 @@
 
 - data = {}
 - data[:course_summary] = unit_group.summarize(@current_user, for_edit: false, locale_code: @locale_code)
-- data[:sections] = @sections_with_assigned_info || []
+- data[:sections] = @sections || []
 - data[:is_instructor] = unit_group.can_be_instructor?(@current_user)
 - data[:is_verified_instructor] = @current_user.try(:verified_instructor?) || false
 - data[:hidden_scripts] = @current_user.try(:get_hidden_unit_ids, unit_group)


### PR DESCRIPTION
During writing my tech spec, I noticed and became confused about the `isAssigned` variable that gets added to sections on the course and unit overview pages. As far as I can tell:
* Redux does contain [isAssigned](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/templates/teacherDashboard/shapes.jsx#L84), but it is populated [manually](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/templates/teacherDashboard/teacherSectionsRedux.js#L1557) for both the [unit](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx#L335) and [course](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/templates/courseOverview/CourseOverview.js#L292) overview page

It would be great if the reviewer could double check by searching for `isAssigned` in both FE and BE to make sure I didn't miss anything

## Testing story
Manually tested that course and unit overview pages still showed assigned section information correctly.
Existing tests.
