### PR TITLE
[Python Lab] Set isRunning to false after error

### DIFF
--- a/apps/src/pythonlab/pyodideWebWorker.js
+++ b/apps/src/pythonlab/pyodideWebWorker.js
@@ -61,7 +61,7 @@ self.onmessage = async event => {
   // make sure loading is done
   await initializePyodide();
   const {id, python, source} = event.data;
-  let results = '';
+  let results = undefined;
   try {
     writeSource(source, DEFAULT_FOLDER_ID, '', self.pyodide);
     await importPackagesFromFiles(source, self.pyodide);

--- a/apps/src/pythonlab/pyodideWorkerManager.js
+++ b/apps/src/pythonlab/pyodideWorkerManager.js
@@ -7,6 +7,7 @@ import {
 } from '@codebridge/redux/consoleRedux';
 
 import {setAndSaveProjectSource} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
+import {setIsRunning} from '@cdo/apps/lab2/redux/systemRedux';
 import MetricsReporter from '@cdo/apps/lib/metrics/MetricsReporter';
 import {getStore} from '@cdo/apps/redux';
 
@@ -49,6 +50,7 @@ const setUpPyodideWorker = () => {
         break;
       case 'error':
         getStore().dispatch(appendErrorMessage(parseErrorMessage(message)));
+        getStore().dispatch(setIsRunning(false));
         break;
       case 'system_error':
         getStore().dispatch(appendSystemError(message));

--- a/apps/src/pythonlab/pyodideWorkerManager.js
+++ b/apps/src/pythonlab/pyodideWorkerManager.js
@@ -7,7 +7,6 @@ import {
 } from '@codebridge/redux/consoleRedux';
 
 import {setAndSaveProjectSource} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
-import {setIsRunning} from '@cdo/apps/lab2/redux/systemRedux';
 import MetricsReporter from '@cdo/apps/lib/metrics/MetricsReporter';
 import {getStore} from '@cdo/apps/redux';
 
@@ -50,7 +49,6 @@ const setUpPyodideWorker = () => {
         break;
       case 'error':
         getStore().dispatch(appendErrorMessage(parseErrorMessage(message)));
-        getStore().dispatch(setIsRunning(false));
         break;
       case 'system_error':
         getStore().dispatch(appendSystemError(message));


### PR DESCRIPTION
Last week, @ebeastlake observed that hitting an error in Python Lab unexpectedly leaves the program in a running state. She then needed to manually stop the program before she could edit. 
![Screenshot 2024-08-28 at 11 50 51 AM](https://github.com/user-attachments/assets/26ae5ef9-ec34-4a7e-8db2-60a32fba366c)

@molly-moen confirmed that is unexpected and that hrowing an error should flip the button back to run. I observed that the `isRunning` state continues to be `true` after encountering an error. To fix the problem, I found where we would show the student the error message (parsed from Pyodide) and added a step to flip the `isRunning` state back to false.

Now, when an error is encountered, the lab state reflects that the program has stopped running and so the button switches back from "Stop" to "Run". The student can also immediately resume editing their code.

https://github.com/user-attachments/assets/93d35ea8-1fe9-4790-a741-577e955a06c9


## Links

Slack thread: https://codedotorg.slack.com/archives/C06JELCAPT9/p1724871434116449

Jira: https://codedotorg.atlassian.net/browse/CT-760

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
