### PR TITLE
[Aichat] Update analytics

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -15,7 +15,6 @@ import {
   ChatEvent,
   ChatMessage,
   LogChatEventApiResponse,
-  UserHasAichatAccessResponse,
 } from './types';
 
 const ROOT_URL = '/aichat';
@@ -32,6 +31,10 @@ const paths = {
 const MAX_POLLING_TIME_MS = 45000;
 const MIN_POLLING_INTERVAL_MS = 1000;
 const DEFAULT_BACKOFF_RATE = 1;
+
+interface UserHasAichatAccessResponse {
+  userHasAccess: boolean;
+}
 
 /**
  * This function formats chat completion messages and aichatParameters, sends a POST request

--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -26,7 +26,7 @@ const paths = {
   LOG_CHAT_EVENT_URL: `${ROOT_URL}/log_chat_event`,
   START_CHAT_COMPLETION_URL: `${ROOT_URL}/start_chat_completion`,
   STUDENT_CHAT_HISTORY_URL: `${ROOT_URL}/student_chat_history`,
-  USER_HAS_AICHAT_ACCESS_URL: `${ROOT_URL}/user_has_aichat_access`,
+  USER_HAS_AICHAT_ACCESS_URL: `${ROOT_URL}/user_has_access`,
 };
 
 const MAX_POLLING_TIME_MS = 45000;

--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -15,16 +15,18 @@ import {
   ChatEvent,
   ChatMessage,
   LogChatEventApiResponse,
+  UserHasAichatAccessResponse,
 } from './types';
 
 const ROOT_URL = '/aichat';
 const paths = {
-  CHAT_COMPLETION_URL: `${ROOT_URL}/chat_completion`,
   CHAT_CHECK_SAFETY_URL: `${ROOT_URL}/check_message_safety`,
+  CHAT_COMPLETION_URL: `${ROOT_URL}/chat_completion`,
+  GET_CHAT_REQUEST_URL: `${ROOT_URL}/chat_request`,
   LOG_CHAT_EVENT_URL: `${ROOT_URL}/log_chat_event`,
   START_CHAT_COMPLETION_URL: `${ROOT_URL}/start_chat_completion`,
-  GET_CHAT_REQUEST_URL: `${ROOT_URL}/chat_request`,
   STUDENT_CHAT_HISTORY_URL: `${ROOT_URL}/student_chat_history`,
+  USER_HAS_AICHAT_ACCESS_URL: `${ROOT_URL}/user_has_aichat_access`,
 };
 
 const MAX_POLLING_TIME_MS = 45000;
@@ -265,4 +267,15 @@ function getUpdatedMessages(
     default:
       throw new Error(`Unexpected status: ${executionStatus}`);
   }
+}
+
+/**
+ * This function sends a GET request to the aichat's userHasAichatAccess backend controller action,
+ * then returns true if the user has aichat access and false otherwise.
+ */
+export async function getUserHasAichatAccess(): Promise<UserHasAichatAccessResponse> {
+  const response = await HttpClient.fetchJson<UserHasAichatAccessResponse>(
+    paths.USER_HAS_AICHAT_ACCESS_URL
+  );
+  return response.value;
 }

--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -273,9 +273,9 @@ function getUpdatedMessages(
  * This function sends a GET request to the aichat's userHasAichatAccess backend controller action,
  * then returns true if the user has aichat access and false otherwise.
  */
-export async function getUserHasAichatAccess(): Promise<UserHasAichatAccessResponse> {
+export async function getUserHasAichatAccess(): Promise<boolean> {
   const response = await HttpClient.fetchJson<UserHasAichatAccessResponse>(
     paths.USER_HAS_AICHAT_ACCESS_URL
   );
-  return response.value;
+  return response.value.userHasAccess;
 }

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -90,7 +90,7 @@ export interface AichatState {
   saveInProgress: boolean;
   // The type of save action being performed (customization update, publish, model card save, etc).
   currentSaveType: SaveType | undefined;
-  userHasAichatAccess: UserHasAichatAccessType | undefined;
+  userHasAichatAccess: AichatAccess | undefined;
 }
 
 const initialState: AichatState = {

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -38,7 +38,6 @@ import {
   LevelAichatSettings,
   ModelCardInfo,
   SaveType,
-  AichatAccess,
   ViewMode,
   Visibility,
   isModelUpdate,
@@ -90,7 +89,7 @@ export interface AichatState {
   saveInProgress: boolean;
   // The type of save action being performed (customization update, publish, model card save, etc).
   currentSaveType: SaveType | undefined;
-  userHasAichatAccess: AichatAccess | undefined;
+  userHasAichatAccess: boolean | undefined;
 }
 
 const initialState: AichatState = {
@@ -242,7 +241,7 @@ export const onSaveComplete =
       )
         ? currentAiCustomizations[typedProperty]
         : 'NULL';
-      if (currentSaveType && userHasAichatAccess === AichatAccess.YES) {
+      if (currentSaveType && userHasAichatAccess) {
         analyticsReporter.sendEvent(
           saveTypeToAnalyticsEvent[currentSaveType],
           {
@@ -386,11 +385,7 @@ export const fetchUserHasAichatAccess = createAsyncThunk(
   async (__, thunkAPI) => {
     try {
       const {userHasAccess} = await getUserHasAichatAccess();
-      thunkAPI.dispatch(
-        setUserHasAichatAccess(
-          userHasAccess ? AichatAccess.YES : AichatAccess.NO
-        )
-      );
+      thunkAPI.dispatch(setUserHasAichatAccess(userHasAccess));
     } catch (error) {
       if (!(error instanceof NetworkError && error.response.status === 403)) {
         Lab2Registry.getInstance()
@@ -592,7 +587,7 @@ const aichatSlice = createSlice({
     },
     setUserHasAichatAccess: (
       state,
-      action: PayloadAction<AichatAccess | undefined>
+      action: PayloadAction<boolean | undefined>
     ) => {
       state.userHasAichatAccess = action.payload;
     },

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -38,6 +38,7 @@ import {
   LevelAichatSettings,
   ModelCardInfo,
   SaveType,
+  AichatAccess,
   ViewMode,
   Visibility,
   isModelUpdate,
@@ -89,7 +90,7 @@ export interface AichatState {
   saveInProgress: boolean;
   // The type of save action being performed (customization update, publish, model card save, etc).
   currentSaveType: SaveType | undefined;
-  userHasAichatAccess: 'yes' | 'no' | undefined;
+  userHasAichatAccess: UserHasAichatAccessType | undefined;
 }
 
 const initialState: AichatState = {
@@ -241,7 +242,7 @@ export const onSaveComplete =
       )
         ? currentAiCustomizations[typedProperty]
         : 'NULL';
-      if (currentSaveType && userHasAichatAccess === 'yes') {
+      if (currentSaveType && userHasAichatAccess === AichatAccess.YES) {
         analyticsReporter.sendEvent(
           saveTypeToAnalyticsEvent[currentSaveType],
           {
@@ -385,7 +386,11 @@ export const fetchUserHasAichatAccess = createAsyncThunk(
   async (__, thunkAPI) => {
     try {
       const {userHasAccess} = await getUserHasAichatAccess();
-      thunkAPI.dispatch(setUserHasAichatAccess(userHasAccess ? 'yes' : 'no'));
+      thunkAPI.dispatch(
+        setUserHasAichatAccess(
+          userHasAccess ? AichatAccess.YES : AichatAccess.NO
+        )
+      );
     } catch (error) {
       if (!(error instanceof NetworkError && error.response.status === 403)) {
         Lab2Registry.getInstance()
@@ -570,7 +575,7 @@ const aichatSlice = createSlice({
     },
     setUserHasAichatAccess: (
       state,
-      action: PayloadAction<'yes' | 'no' | undefined>
+      action: PayloadAction<AichatAccess | undefined>
     ) => {
       state.userHasAichatAccess = action.payload;
     },

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -22,11 +22,7 @@ import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {AppDispatch} from '@cdo/apps/util/reduxHooks';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
-import {
-  getStudentChatHistory,
-  getUserHasAichatAccess,
-  postAichatCompletionMessage,
-} from '../aichatApi';
+import {getStudentChatHistory, postAichatCompletionMessage} from '../aichatApi';
 import ChatEventLogger from '../chatEventLogger';
 import {saveTypeToAnalyticsEvent} from '../constants';
 import {
@@ -89,7 +85,7 @@ export interface AichatState {
   saveInProgress: boolean;
   // The type of save action being performed (customization update, publish, model card save, etc).
   currentSaveType: SaveType | undefined;
-  userHasAichatAccess: boolean | undefined;
+  userHasAichatAccess: boolean;
 }
 
 const initialState: AichatState = {
@@ -107,7 +103,7 @@ const initialState: AichatState = {
   viewMode: ViewMode.EDIT,
   saveInProgress: false,
   currentSaveType: undefined,
-  userHasAichatAccess: undefined,
+  userHasAichatAccess: false,
 };
 
 // THUNKS
@@ -378,24 +374,6 @@ export const addChatEvent =
       ChatEventLogger.getInstance().logChatEvent(chatEvent, aichatContext);
     }
   };
-
-// This thunk's callback function returns if a user has aichat acess.
-export const fetchUserHasAichatAccess = createAsyncThunk(
-  'aichat/fetchUserHasAichatAccess',
-  async (__, thunkAPI) => {
-    try {
-      const {userHasAccess} = await getUserHasAichatAccess();
-      thunkAPI.dispatch(setUserHasAichatAccess(userHasAccess));
-    } catch (error) {
-      if (!(error instanceof NetworkError && error.response.status === 403)) {
-        Lab2Registry.getInstance()
-          .getMetricsReporter()
-          .logError('Error in fetching user aichat access', error as Error);
-        return;
-      }
-    }
-  }
-);
 
 // This thunk's callback function submits a user's chat content and AI customizations to
 // the chat completion endpoint, then waits for a chat completion response, and updates

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -328,6 +328,9 @@ const dispatchSaveFailNotification = (
   dispatch(endSave());
 };
 
+// This thunk sends aichat analytics events to Amplitude and Statsig.
+// The event is sent for authorized users and if skipAccessCheck is true,
+// then the event is sent regardless of user aichat access.
 export const sendAnalytics =
   (event: string, properties: object, skipAccessCheck = false) =>
   (dispatch: AppDispatch, getState: () => RootState) => {

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -13,7 +13,7 @@ import {
   getCurrentLevel,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {registerReducers} from '@cdo/apps/redux';
 import {commonI18n} from '@cdo/apps/types/locale';
@@ -441,6 +441,14 @@ export const submitChatContents = createAsyncThunk(
         aiCustomizations,
         aichatContext
       );
+      analyticsReporter.sendEvent(
+        EVENTS.SUBMIT_AICHAT_REQUEST_SUCCESS,
+        {
+          levelPath: window.location.pathname,
+          userMessage: newUserMessageText,
+        },
+        PLATFORMS.BOTH
+      );
     } catch (error) {
       await handleChatCompletionError(error as Error, newUserMessage, dispatch);
       return;
@@ -513,6 +521,15 @@ async function handleChatCompletionError(
         notificationType: 'error',
         timestamp: Date.now(),
       })
+    );
+    analyticsReporter.sendEvent(
+      EVENTS.SUBMIT_AICHAT_REQUEST_UNAUTHORIZED,
+      {
+        levelPath: window.location.pathname,
+        userType,
+        userMessage: newUserMessage.chatMessageText,
+      },
+      PLATFORMS.BOTH
     );
   } else {
     Lab2Registry.getInstance()

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -65,10 +65,6 @@ export interface LogChatEventApiResponse {
   chat_event: ChatMessage;
 }
 
-export interface UserHasAichatAccessResponse {
-  userHasAccess: boolean;
-}
-
 export type AichatContext = {
   currentLevelId: number | null;
   scriptId: number | null;

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -133,11 +133,6 @@ export enum Visibility {
   EDITABLE = 'editable',
 }
 
-export enum AichatAccess {
-  YES = 'yes',
-  NO = 'no',
-}
-
 /**
  * Level-defined AI customizations for student chat bots set by levelbuilders on the level's properties.
  * Levelbuilders can define initial default values for each field, as well as their visibilities.

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -65,6 +65,10 @@ export interface LogChatEventApiResponse {
   chat_event: ChatMessage;
 }
 
+export interface UserHasAichatAccessResponse {
+  userHasAccess: boolean;
+}
+
 export type AichatContext = {
   currentLevelId: number | null;
   scriptId: number | null;

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -133,6 +133,11 @@ export enum Visibility {
   EDITABLE = 'editable',
 }
 
+export enum AichatAccess {
+  YES = 'yes',
+  NO = 'no',
+}
+
 /**
  * Level-defined AI customizations for student chat bots set by levelbuilders on the level's properties.
  * Levelbuilders can define initial default values for each field, as well as their visibilities.

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -124,20 +124,19 @@ const AichatView: React.FunctionComponent = () => {
 
   useEffect(() => {
     if (signInState === SignInState.SignedIn) {
-      try {
-        getUserHasAichatAccess().then(hasAccess =>
-          dispatch(setUserHasAichatAccess(hasAccess))
-        );
-      } catch (error) {
-        if (!(error instanceof NetworkError && error.response.status === 403)) {
-          Lab2Registry.getInstance()
-            .getMetricsReporter()
-            .logError('Error in fetching user aichat access', error as Error);
-          return;
-        }
-      }
+      getUserHasAichatAccess()
+        .then(hasAccess => dispatch(setUserHasAichatAccess(hasAccess)))
+        .catch(error => {
+          if (
+            !(error instanceof NetworkError && error.response.status === 403)
+          ) {
+            Lab2Registry.getInstance()
+              .getMetricsReporter()
+              .logError('Error in fetching user aichat access', error as Error);
+          }
+        });
     }
-  }, [signInState, dispatch]);
+  }, [dispatch, signInState]);
 
   // When the level changes or if we are viewing aichat level as a different user
   // (e.g., teacher viewing student work), clear the chat message history and start a new session.

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -34,12 +34,7 @@ import {
   updateAiCustomization,
 } from '../redux/aichatRedux';
 import {getNewMessageId} from '../redux/utils';
-import {
-  AichatAccess,
-  AichatLevelProperties,
-  Notification,
-  ViewMode,
-} from '../types';
+import {AichatLevelProperties, Notification, ViewMode} from '../types';
 
 import ChatWorkspace from './ChatWorkspace';
 import {isDisabled} from './modelCustomization/utils';
@@ -199,7 +194,7 @@ const AichatView: React.FunctionComponent = () => {
 
   const sendAnalytics = useCallback(
     (event: string, properties: object) => {
-      if (userHasAichatAccess === AichatAccess.YES) {
+      if (userHasAichatAccess) {
         analyticsReporter.sendEvent(event, properties, PLATFORMS.BOTH);
       }
     },

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -17,19 +17,21 @@ import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import ProjectTemplateWorkspaceIcon from '@cdo/apps/templates/ProjectTemplateWorkspaceIcon';
 import {commonI18n} from '@cdo/apps/types/locale';
+import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {getUserHasAichatAccess} from '../aichatApi';
 import aichatI18n from '../locale';
 import {
   addChatEvent,
   clearChatMessages,
-  fetchUserHasAichatAccess,
   onSaveComplete,
   onSaveFail,
   onSaveNoop,
   resetToDefaultAiCustomizations,
   selectAllFieldsHidden,
   setStartingAiCustomizations,
+  setUserHasAichatAccess,
   setViewMode,
   updateAiCustomization,
 } from '../redux/aichatRedux';
@@ -117,10 +119,24 @@ const AichatView: React.FunctionComponent = () => {
         hideForParticipants: true,
       })
     );
+  }, [dispatch, initialSources, levelAichatSettings]);
+
+  useEffect(() => {
     if (signInState === SignInState.SignedIn) {
-      dispatch(fetchUserHasAichatAccess());
+      try {
+        getUserHasAichatAccess().then(hasAccess =>
+          dispatch(setUserHasAichatAccess(hasAccess))
+        );
+      } catch (error) {
+        if (!(error instanceof NetworkError && error.response.status === 403)) {
+          Lab2Registry.getInstance()
+            .getMetricsReporter()
+            .logError('Error in fetching user aichat access', error as Error);
+          return;
+        }
+      }
     }
-  }, [dispatch, initialSources, levelAichatSettings, signInState]);
+  }, [signInState, dispatch]);
 
   // When the level changes or if we are viewing aichat level as a different user
   // (e.g., teacher viewing student work), clear the chat message history and start a new session.

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -34,7 +34,12 @@ import {
   updateAiCustomization,
 } from '../redux/aichatRedux';
 import {getNewMessageId} from '../redux/utils';
-import {AichatLevelProperties, Notification, ViewMode} from '../types';
+import {
+  AichatAccess,
+  AichatLevelProperties,
+  Notification,
+  ViewMode,
+} from '../types';
 
 import ChatWorkspace from './ChatWorkspace';
 import {isDisabled} from './modelCustomization/utils';
@@ -194,7 +199,7 @@ const AichatView: React.FunctionComponent = () => {
 
   const sendAnalytics = useCallback(
     (event: string, properties: object) => {
-      if (userHasAichatAccess === 'yes') {
+      if (userHasAichatAccess === AichatAccess.YES) {
         analyticsReporter.sendEvent(event, properties, PLATFORMS.BOTH);
       }
     },

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -14,6 +14,7 @@ import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import ProjectTemplateWorkspaceIcon from '@cdo/apps/templates/ProjectTemplateWorkspaceIcon';
 import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -22,6 +23,7 @@ import aichatI18n from '../locale';
 import {
   addChatEvent,
   clearChatMessages,
+  fetchUserHasAichatAccess,
   onSaveComplete,
   onSaveFail,
   onSaveNoop,
@@ -72,9 +74,11 @@ const AichatView: React.FunctionComponent = () => {
 
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
 
-  const {currentAiCustomizations, viewMode} = useAppSelector(
-    state => state.aichat
-  );
+  const {currentAiCustomizations, userHasAichatAccess, viewMode} =
+    useAppSelector(state => state.aichat);
+
+  const signInState = useAppSelector(state => state.currentUser.signInState);
+
   const {botName, isPublished} = currentAiCustomizations.modelCardInfo;
 
   const allFieldsHidden = useAppSelector(selectAllFieldsHidden);
@@ -113,7 +117,10 @@ const AichatView: React.FunctionComponent = () => {
         hideForParticipants: true,
       })
     );
-  }, [dispatch, initialSources, levelAichatSettings]);
+    if (signInState === SignInState.SignedIn) {
+      dispatch(fetchUserHasAichatAccess());
+    }
+  }, [dispatch, initialSources, levelAichatSettings, signInState]);
 
   // When the level changes or if we are viewing aichat level as a different user
   // (e.g., teacher viewing student work), clear the chat message history and start a new session.
@@ -185,6 +192,15 @@ const AichatView: React.FunctionComponent = () => {
     }
   }, [dialogControl, resetProject]);
 
+  const sendAnalytics = useCallback(
+    (event: string, properties: object) => {
+      if (userHasAichatAccess === 'yes') {
+        analyticsReporter.sendEvent(event, properties, PLATFORMS.BOTH);
+      }
+    },
+    [userHasAichatAccess]
+  );
+
   const onClear = useCallback(() => {
     dispatch(clearChatMessages());
     dispatch(
@@ -194,14 +210,10 @@ const AichatView: React.FunctionComponent = () => {
         hideForParticipants: true,
       })
     );
-    analyticsReporter.sendEvent(
-      EVENTS.CHAT_ACTION,
-      {
-        action: 'Clear chat history',
-      },
-      PLATFORMS.BOTH
-    );
-  }, [dispatch]);
+    sendAnalytics(EVENTS.CHAT_ACTION, {
+      action: 'Clear chat history',
+    });
+  }, [dispatch, sendAnalytics]);
 
   return (
     <div id="aichat-lab" className={moduleStyles.aichatLab}>
@@ -236,13 +248,9 @@ const AichatView: React.FunctionComponent = () => {
                   rightHeaderContent={renderModelCustomizationHeaderRight(
                     () => {
                       onClickStartOver();
-                      analyticsReporter.sendEvent(
-                        EVENTS.AICHAT_START_OVER,
-                        {
-                          levelPath: window.location.pathname,
-                        },
-                        PLATFORMS.BOTH
-                      );
+                      sendAnalytics(EVENTS.AICHAT_START_OVER, {
+                        levelPath: window.location.pathname,
+                      });
                     }
                   )}
                 >

--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -12,8 +12,7 @@ import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import Instructions from '@cdo/apps/lab2/views/components/Instructions';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
-import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import ProjectTemplateWorkspaceIcon from '@cdo/apps/templates/ProjectTemplateWorkspaceIcon';
 import {commonI18n} from '@cdo/apps/types/locale';
@@ -30,6 +29,7 @@ import {
   onSaveNoop,
   resetToDefaultAiCustomizations,
   selectAllFieldsHidden,
+  sendAnalytics,
   setStartingAiCustomizations,
   setUserHasAichatAccess,
   setViewMode,
@@ -76,8 +76,9 @@ const AichatView: React.FunctionComponent = () => {
 
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
 
-  const {currentAiCustomizations, userHasAichatAccess, viewMode} =
-    useAppSelector(state => state.aichat);
+  const {currentAiCustomizations, viewMode} = useAppSelector(
+    state => state.aichat
+  );
 
   const signInState = useAppSelector(state => state.currentUser.signInState);
 
@@ -208,15 +209,6 @@ const AichatView: React.FunctionComponent = () => {
     }
   }, [dialogControl, resetProject]);
 
-  const sendAnalytics = useCallback(
-    (event: string, properties: object) => {
-      if (userHasAichatAccess) {
-        analyticsReporter.sendEvent(event, properties, PLATFORMS.BOTH);
-      }
-    },
-    [userHasAichatAccess]
-  );
-
   const onClear = useCallback(() => {
     dispatch(clearChatMessages());
     dispatch(
@@ -226,10 +218,12 @@ const AichatView: React.FunctionComponent = () => {
         hideForParticipants: true,
       })
     );
-    sendAnalytics(EVENTS.CHAT_ACTION, {
-      action: 'Clear chat history',
-    });
-  }, [dispatch, sendAnalytics]);
+    dispatch(
+      sendAnalytics(EVENTS.CHAT_ACTION, {
+        action: 'Clear chat history',
+      })
+    );
+  }, [dispatch]);
 
   return (
     <div id="aichat-lab" className={moduleStyles.aichatLab}>
@@ -264,9 +258,11 @@ const AichatView: React.FunctionComponent = () => {
                   rightHeaderContent={renderModelCustomizationHeaderRight(
                     () => {
                       onClickStartOver();
-                      sendAnalytics(EVENTS.AICHAT_START_OVER, {
-                        levelPath: window.location.pathname,
-                      });
+                      dispatch(
+                        sendAnalytics(EVENTS.AICHAT_START_OVER, {
+                          levelPath: window.location.pathname,
+                        })
+                      );
                     }
                   )}
                 >

--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -9,7 +9,7 @@ import Button from '@cdo/apps/componentLibrary/button/Button';
 import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
 import {timestampToDateTime} from '../redux/utils';
@@ -25,6 +25,9 @@ import {AI_CUSTOMIZATIONS_LABELS} from './modelCustomization/constants';
 const CopyButton: React.FunctionComponent = () => {
   const messages = useSelector(selectAllVisibleMessages);
   const dispatch = useAppDispatch();
+  const userHasAichatAccess = useAppSelector(
+    state => state.aichat.userHasAichatAccess
+  );
 
   const handleCopy = () => {
     const textToCopy = messages.map(chatEventToFormattedString).join('\n');
@@ -35,13 +38,15 @@ const CopyButton: React.FunctionComponent = () => {
         console.error('Error in copying text');
       }
     );
-    analyticsReporter.sendEvent(
-      EVENTS.CHAT_ACTION,
-      {
-        action: 'Copy chat history',
-      },
-      PLATFORMS.BOTH
-    );
+    if (userHasAichatAccess === 'yes') {
+      analyticsReporter.sendEvent(
+        EVENTS.CHAT_ACTION,
+        {
+          action: 'Copy chat history',
+        },
+        PLATFORMS.BOTH
+      );
+    }
     dispatch(
       addChatEvent({
         timestamp: Date.now(),

--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import {useSelector} from 'react-redux';
 
 import {
-  selectAllVisibleMessages,
   addChatEvent,
+  selectAllVisibleMessages,
+  sendAnalytics,
 } from '@cdo/apps/aichat/redux/aichatRedux';
 import Button from '@cdo/apps/componentLibrary/button/Button';
-import {EVENTS, PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 
 import {timestampToDateTime} from '../redux/utils';
@@ -25,9 +25,6 @@ import {AI_CUSTOMIZATIONS_LABELS} from './modelCustomization/constants';
 const CopyButton: React.FunctionComponent = () => {
   const messages = useSelector(selectAllVisibleMessages);
   const dispatch = useAppDispatch();
-  const userHasAichatAccess = useAppSelector(
-    state => state.aichat.userHasAichatAccess
-  );
 
   const handleCopy = () => {
     const textToCopy = messages.map(chatEventToFormattedString).join('\n');
@@ -38,15 +35,12 @@ const CopyButton: React.FunctionComponent = () => {
         console.error('Error in copying text');
       }
     );
-    if (userHasAichatAccess) {
-      analyticsReporter.sendEvent(
-        EVENTS.CHAT_ACTION,
-        {
-          action: 'Copy chat history',
-        },
-        PLATFORMS.BOTH
-      );
-    }
+    dispatch(
+      sendAnalytics(EVENTS.CHAT_ACTION, {
+        action: 'Copy chat history',
+      })
+    );
+
     dispatch(
       addChatEvent({
         timestamp: Date.now(),

--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -14,7 +14,6 @@ import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConsta
 
 import {timestampToDateTime} from '../redux/utils';
 import {
-  AichatAccess,
   ChatEvent,
   isChatMessage,
   isModelUpdate,
@@ -39,7 +38,7 @@ const CopyButton: React.FunctionComponent = () => {
         console.error('Error in copying text');
       }
     );
-    if (userHasAichatAccess === AichatAccess.YES) {
+    if (userHasAichatAccess) {
       analyticsReporter.sendEvent(
         EVENTS.CHAT_ACTION,
         {

--- a/apps/src/aichat/views/CopyButton.tsx
+++ b/apps/src/aichat/views/CopyButton.tsx
@@ -14,6 +14,7 @@ import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConsta
 
 import {timestampToDateTime} from '../redux/utils';
 import {
+  AichatAccess,
   ChatEvent,
   isChatMessage,
   isModelUpdate,
@@ -38,7 +39,7 @@ const CopyButton: React.FunctionComponent = () => {
         console.error('Error in copying text');
       }
     );
-    if (userHasAichatAccess === 'yes') {
+    if (userHasAichatAccess === AichatAccess.YES) {
       analyticsReporter.sendEvent(
         EVENTS.CHAT_ACTION,
         {

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -369,6 +369,9 @@ const EVENTS = {
   SAVE_MODEL_CARD_INFO: 'Student saves their model card info',
   PUBLISH_MODEL_CARD_INFO: 'Student publishes their model card info',
   AICHAT_START_OVER: 'Student starts over and resets to default model settings',
+  SUBMIT_AICHAT_REQUEST_SUCCESS: 'User submits aichat request successfully',
+  SUBMIT_AICHAT_REQUEST_UNAUTHORIZED:
+    'Unauthorized user attempts to submit aichat request and fails',
 };
 
 const EVENT_GROUP_NAMES = {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds a call to `/aichat/user_has_access` to the frontend.in `aichatApi` and then stores its value in `aichat` redux. 
Analytics for current `aichat` events are now only sent if the user is authorized, i.e., has `aichat` access.

Two new analytics event are added in this PR:
- `SUBMIT_AICHAT_REQUEST_SUCCESS`
- `SUBMIT_AICHAT_REQUEST_UNAUTHORIZED`

The first event is sent for authorized users only. The second event is sent for only unauthorized users (including signed-out users).


## Links
[jira - Add analytics event for unauthorized teacher attempt to submit chat message](https://codedotorg.atlassian.net/browse/LABS-993)
[jira - Update current aichat analytics to include only authorized users](https://codedotorg.atlassian.net/browse/LABS-991)
[Slack thread](https://codedotorg.slack.com/archives/C06UT1E2796/p1725389260114929)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

## After update - Submitting Chat Message analytics

Screenshot of signed-out user attempting to submit chat message.
<img width="1375" alt="Screenshot 2024-09-04 at 8 50 41 AM" src="https://github.com/user-attachments/assets/9b03f318-8fd3-4002-8fad-bb1eefa9cd69">


Screenshot of signed-in, unauthorized student user attempting to submit chat message:
<img width="1369" alt="Screenshot 2024-09-04 at 8 45 54 AM" src="https://github.com/user-attachments/assets/b4d92452-646f-43b6-9792-491ff0ce1784">


Screenshot of signed-in, authorized teacher user after successfully submitting chat message:
<img width="1364" alt="Screenshot 2024-09-04 at 9 01 33 AM" src="https://github.com/user-attachments/assets/bfab43d4-1509-4f75-8627-bfd7dc7f2cdf">


## After update - Other aichat analytics

Screenshot of signed-in teacher user with current aichat analytics events logged in dev console:
<img width="1304" alt="Screenshot 2024-09-04 at 9 09 00 AM" src="https://github.com/user-attachments/assets/d8b3139a-d390-4587-94b4-3da8dcdb6685">

Screenshot of signed-in, unauthorized, student user - you can see from notifications in workspace that user made model customization updates, but corresponding aichat analytics were NOT sent:
<img width="1234" alt="Screenshot 2024-09-04 at 9 19 51 AM" src="https://github.com/user-attachments/assets/c6d607ef-86a0-4b79-b0b2-cbf55ee57a81">



Screenshot of signed-out user - you can see from notifications in workspace that user made model customization updates, but corresponding aichat analytics were NOT sent:
<img width="1260" alt="Screenshot 2024-09-04 at 9 10 07 AM" src="https://github.com/user-attachments/assets/41598f94-56d8-4258-98e4-3282f118ce61">

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
