### PR TITLE
gather more debug output in ai_evaluate_student_code.feature

### DIFF
--- a/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
+++ b/apps/src/templates/rubrics/RunAIAssessmentButton.jsx
@@ -188,7 +188,7 @@ export default function RunAIAssessmentButton({
       {canProvideFeedback && (
         <div>
           <Button
-            className="uitest-run-ai-assessment"
+            id="uitest-run-ai-assessment"
             text={studentButtonText()}
             color={Button.ButtonColor.neutralDark}
             onClick={handleRunAiAssessment}

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -73,6 +73,9 @@ Feature: Evaluate student code against rubrics using AI
     And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
     And I click selector "#runButton"
     And I wait until element ".project_updated_at" contains text "Saved"
+    # make sure the project source code really saved
+    And I reload the page
+    And I wait for the lab page to fully load
 
     # Teacher views student progress and floating action button
     When I sign in as "Teacher_Aiden"
@@ -125,6 +128,9 @@ Feature: Evaluate student code against rubrics using AI
     And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
     And I click selector "#runButton"
     And I wait until element ".project_updated_at" contains text "Saved"
+    # make sure the project source code really saved
+    And I reload the page
+    And I wait for the lab page to fully load
 
     # Teacher views student progress and floating action button
     When I sign in as "Teacher_Aiden"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -46,7 +46,8 @@ Feature: Evaluate student code against rubrics using AI
     # Teacher views AI evaluation status in rubric header
     When I click selector "#ui-floatingActionButton"
     And I wait until element "#uitest-rubric-content" is visible
-    And element ".uitest-run-ai-assessment" is disabled
+    And element "#uitest-run-ai-assessment" is disabled
+    And I hover over element with id "uitest-run-ai-assessment"
     Then I wait until element ".uitest-rubric-tab-buttons .__react_component_tooltip" contains text "AI analysis already completed for this project."
 
     # Teacher views AI evaluation results in rubric
@@ -94,10 +95,11 @@ Feature: Evaluate student code against rubrics using AI
     # Teacher views AI evaluation status in settings tab
     When I click selector "#ui-floatingActionButton"
     And I wait until element "#uitest-rubric-content" is visible
-    And I wait until element ".uitest-run-ai-assessment" is enabled
+    And I wait until element "#uitest-run-ai-assessment" is enabled
 
     # Teacher runs AI evaluation
-    When I click selector ".uitest-run-ai-assessment"
+    When I click selector "#uitest-run-ai-assessment"
+    And I hover over element with id "uitest-run-ai-assessment"
     Then I wait until element ".uitest-rubric-tab-buttons .__react_component_tooltip" contains text "AI analysis complete."
 
     # Teacher views AI evaluation results in rubric tab
@@ -145,7 +147,7 @@ Feature: Evaluate student code against rubrics using AI
     # Teacher views AI evaluation status in settings tab
     When I click selector "#ui-floatingActionButton"
     And I wait until element "#uitest-rubric-content" is visible
-    And I wait until element ".uitest-run-ai-assessment" is enabled
+    And I wait until element "#uitest-run-ai-assessment" is enabled
 
     # Teacher switches to Class Management tab
     When I click selector "button:contains('Class Data')"
@@ -160,6 +162,9 @@ Feature: Evaluate student code against rubrics using AI
 
     # Teacher views AI evaluation results in Student Rubric tab
     When I click selector "button:contains('Assess a Student')"
+    And I wait until element "#uitest-run-ai-assessment" is visible
+    And I hover over element with id "uitest-run-ai-assessment"
+    And element ".uitest-rubric-tab-buttons .__react_component_tooltip" contains text "AI analysis already completed for this project."
     And I wait until element "#uitest-next-goal" is visible
     And I click selector "#uitest-next-goal"
     Then I wait until element ".uitest-learning-goal-title" contains text "Sprites"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -161,7 +161,7 @@ Scenario: Teacher views Rubric and Settings tabs
   And I wait until element ".uitest-rubric-tab-buttons:contains('Class Data')" is visible
   And I wait until element "h5:contains(Code Quality)" is visible
   Then I see no difference for "rubric tab, Code Quality learning goal"
-  And element ".uitest-run-ai-assessment" is disabled
+  And element "#uitest-run-ai-assessment" is disabled
 
   When I click selector "#uitest-next-goal"
   And I wait until element "h5:contains(Sprites)" is visible


### PR DESCRIPTION
continues on https://codedotorg.atlassian.net/browse/AITT-719. https://github.com/code-dot-org/code-dot-org/pull/60629 appears to have resolved issues related to the product tour, which has uncovered a different issue near the end of the test file. The teacher is able to run AI for their entire classroom, but then when they go back to look at the result for one student, no AI results appear (see [cucumber logs](https://cucumber-logs.s3.amazonaws.com/test/test/Safari_teacher_tools_rubrics_ai_evaluate_student_code_output.html?versionId=ePNKOmh9yIfPF_xFHTqkb9SkmB0DmGUs), [saucelabs video](https://app.saucelabs.com/tests/0fc452139cf645509f357b1cb10a014c#148)).

We already print the username for the student and teacher into the cucumber logs:
![Screenshot 2024-09-04 at 7 17 52 AM](https://github.com/user-attachments/assets/920f91fb-1c66-4dc5-8fd8-49f89bc6704a)

when I look at this level for this student, I see this error:
![Screenshot 2024-09-03 at 9 53 06 PM](https://github.com/user-attachments/assets/bfced3fd-6276-446c-8fab-b1be4d43ea0d)

done in this PR:
1. hover over "Run AI Assessment for Project" button, so that we can see the state (only visible on hover as of https://github.com/code-dot-org/code-dot-org/pull/60432)
2. try harder to detect the error when a project fails to save

## Testing story

