### PR TITLE
Default to V2 on redirect

### DIFF
--- a/apps/src/templates/teacherDashboard/EmptySectionV1.jsx
+++ b/apps/src/templates/teacherDashboard/EmptySectionV1.jsx
@@ -1,13 +1,17 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useEffect} from 'react';
+import {connect} from 'react-redux';
 import {NavLink} from 'react-router-dom';
 
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import {LinkButton} from '@cdo/apps/componentLibrary/button';
 import {
   Heading3,
   BodyTwoText,
   Heading1,
 } from '@cdo/apps/componentLibrary/typography';
+import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
+import {setShowProgressTableV2} from '@cdo/apps/templates/currentUserRedux';
 import emptyDesk from '@cdo/apps/templates/teacherDashboard/images/empty_desk.svg';
 import blankScreen from '@cdo/apps/templates/teacherDashboard/images/no_curriculum_assigned.svg';
 import i18n from '@cdo/locale';
@@ -22,10 +26,19 @@ function EmptySectionV1({
   hasCurriculumAssigned,
   showProgressPageHeader = false,
   element,
+  setShowProgressTableV2,
 }) {
   const textDescription = !hasStudents
     ? i18n.emptySectionDescription()
     : i18n.noCurriculumAssigned();
+
+  useEffect(() => {
+    const params = queryParams('view');
+    if (params === 'v2') {
+      setShowProgressTableV2(true);
+      new UserPreferences().setShowProgressTableV2(true);
+    }
+  }, [setShowProgressTableV2]);
 
   const displayedImage = !hasStudents ? (
     <img src={emptyDesk} alt="empty desk" />
@@ -80,6 +93,14 @@ EmptySectionV1.propTypes = {
   hasCurriculumAssigned: PropTypes.bool,
   showProgressPageHeader: PropTypes.bool,
   element: PropTypes.element,
+  setShowProgressTableV2: PropTypes.func.isRequired,
 };
 
-export default EmptySectionV1;
+export const UnconnectedEmptySectionV1 = EmptySectionV1;
+
+const mapDispatchToProps = dispatch => ({
+  setShowProgressTableV2: showProgressTableV2 =>
+    dispatch(setShowProgressTableV2(showProgressTableV2)),
+});
+
+export default connect(null, mapDispatchToProps)(EmptySectionV1);

--- a/apps/test/unit/templates/teacherDashboard/EmptySectionsV1Test.jsx
+++ b/apps/test/unit/templates/teacherDashboard/EmptySectionsV1Test.jsx
@@ -2,7 +2,7 @@ import {render, screen} from '@testing-library/react';
 import React from 'react';
 import {BrowserRouter as Router} from 'react-router-dom';
 
-import EmptySectionV1 from '@cdo/apps/templates/teacherDashboard/EmptySectionV1';
+import {UnconnectedEmptySectionV1 as EmptySectionV1} from '@cdo/apps/templates/teacherDashboard/EmptySectionV1';
 import i18n from '@cdo/locale';
 
 const TEST_ELEMENT_TEXT = 'Test Element';


### PR DESCRIPTION
If a user uses the re-direct link (https://studio.code.org/teacher_dashboard/sections/first_section_progress) and their most recent section doesn't have students and/or a curriculum, they will still see V2 of the progress view when they have assigned students and/or a curriculum (and they re-load the page).  We know the re-loading is not ideal, but is not a regression... it is something that will need to be fixed in the future.  I created [this](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1307) ticket to track the work. 

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65/backlog?selectedIssue=TEACH-1228)