### PR TITLE
AI Tutor: log Javalab "Run" and "Test" button clicks 

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -300,7 +300,12 @@ export default class JavabuilderConnection {
         this.onOutputMessage(data.value);
         break;
       case WebSocketMessageType.TEST_RESULT:
-        testResult = onTestResult(data, this.onOutputMessage, this.miniAppType);
+        testResult = onTestResult(
+          data,
+          this.onOutputMessage,
+          this.miniAppType,
+          this.levelId
+        );
         if (testResult.isValidation) {
           this.sawValidationTests = true;
           if (!testResult.success) {

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -1,4 +1,6 @@
 import project from '@cdo/apps/code-studio/initApp/project';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import logToCloud from '@cdo/apps/logToCloud';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import javalabMsg from '@cdo/javalab/locale';
@@ -11,6 +13,7 @@ import {
   AuthorizerSignalType,
   CsaViewMode,
   JavabuilderLockoutType,
+  JavabuilderExceptionType,
 } from './constants';
 import {handleException} from './javabuilderExceptionHandler';
 import {onTestResult} from './testResultHandler';
@@ -227,6 +230,9 @@ export default class JavabuilderConnection {
         lineBreakCount = 1;
         break;
       case StatusMessageType.COMPILATION_SUCCESSFUL:
+        analyticsReporter.sendEvent(EVENTS.JAVALAB_COMPILATION_SUCCESS, {
+          levelId: this.levelId,
+        });
         message = javalabMsg.compilationSuccess();
         lineBreakCount = 1;
         break;
@@ -318,6 +324,11 @@ export default class JavabuilderConnection {
         }
         break;
       case WebSocketMessageType.EXCEPTION:
+        if (data.value === JavabuilderExceptionType.COMPILER_ERROR) {
+          analyticsReporter.sendEvent(EVENTS.JAVALAB_COMPILATION_ERROR, {
+            levelId: this.levelId,
+          });
+        }
         this.onNewlineMessage();
         handleException(data, this.onOutputMessage, this.miniAppType);
         this.onNewlineMessage();

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -6,6 +6,8 @@ import {showLevelBuilderSaveButton} from '@cdo/apps/code-studio/header';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {lockContainedLevelAnswers} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {TestResults} from '@cdo/apps/constants';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import javalabMsg from '@cdo/javalab/locale';
 
@@ -94,6 +96,7 @@ Javalab.prototype.init = function (config) {
 
   this.skin = config.skin;
   this.level = config.level;
+  this.levelIdForAnalytics = config.serverLevelId;
   // Sets display theme based on displayTheme user preference
   this.displayTheme = getDisplayThemeFromString(config.displayTheme);
   this.isStartMode = !!config.level.editBlocks;
@@ -115,7 +118,6 @@ Javalab.prototype.init = function (config) {
   config.noInstructionsWhenCollapsed = true;
 
   config.pinWorkspaceToBottom = true;
-
   config.getCode = this.getCode.bind(this);
   config.afterClearPuzzle = this.afterClearPuzzle.bind(this);
   const onRun = this.onRun.bind(this);
@@ -355,10 +357,16 @@ Javalab.prototype.onRun = function () {
   }
 
   this.miniApp?.reset?.();
+  analyticsReporter.sendEvent(EVENTS.JAVALAB_RUN_BUTTON_CLICK, {
+    levelId: this.levelIdForAnalytics,
+  });
   this.executeJavabuilder(ExecutionType.RUN);
 };
 
 Javalab.prototype.onTest = function () {
+  analyticsReporter.sendEvent(EVENTS.JAVALAB_TEST_BUTTON_CLICK, {
+    levelId: this.levelIdForAnalytics,
+  });
   this.executeJavabuilder(ExecutionType.TEST);
 };
 

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -364,8 +364,11 @@ Javalab.prototype.onRun = function () {
 };
 
 Javalab.prototype.onTest = function () {
+  const validation = this.level.validation;
+  const validated = !!validation && Object.keys(validation).length !== 0;
   analyticsReporter.sendEvent(EVENTS.JAVALAB_TEST_BUTTON_CLICK, {
     levelId: this.levelIdForAnalytics,
+    validated: validated,
   });
   this.executeJavabuilder(ExecutionType.TEST);
 };

--- a/apps/src/javalab/testResultHandler.js
+++ b/apps/src/javalab/testResultHandler.js
@@ -1,3 +1,5 @@
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import msg from '@cdo/javalab/locale';
 
 import {UserTestResultSignalType, TestStatus} from './constants';
@@ -6,7 +8,7 @@ import {getExceptionMessage} from './javabuilderExceptionHandler';
 const CHECK_MARK = '✔';
 const HEAVY_X = '✖';
 
-export function onTestResult(data, callback, miniAppType) {
+export function onTestResult(data, callback, miniAppType, levelId) {
   let message = '';
   const {
     status,
@@ -24,8 +26,18 @@ export function onTestResult(data, callback, miniAppType) {
   switch (data.value) {
     case UserTestResultSignalType.TEST_STATUS:
       if (status === TestStatus.SUCCESSFUL) {
+        analyticsReporter.sendEvent(EVENTS.JAVALAB_TEST_PASSED, {
+          levelId: levelId,
+          test: methodName,
+        });
         message = `${CHECK_MARK} ${msg.successfulTestResult(statusDetails)}`;
       } else if (status === TestStatus.FAILED) {
+        if (methodName) {
+          analyticsReporter.sendEvent(EVENTS.JAVALAB_TEST_FAILED, {
+            levelId: levelId,
+            test: methodName,
+          });
+        }
         message = `${HEAVY_X} ${msg.failedTestResult(statusDetails)}`;
         successful = false;
       } else {

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -253,6 +253,8 @@ const EVENTS = {
   JAVALAB_TEST_BUTTON_CLICK: 'Javalab Test Button Clicked',
   JAVALAB_COMPILATION_ERROR: 'Javalab Compilation Error',
   JAVALAB_COMPILATION_SUCCESS: 'Javalab Compilation Success',
+  JAVALAB_TEST_PASSED: 'Javalab Test Passed',
+  JAVALAB_TEST_FAILED: 'Javalab Test Failed',
 
   // Hour of Code
   AGE_21_SELECTED_EVENT: 'Age 21+ Selected',

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -248,6 +248,12 @@ const EVENTS = {
   AI_TUTOR_DISABLED: 'Teacher disabled AI Tutor for a section',
   AI_TUTOR_ENABLED: 'Teacher enabled AI Tutor for a section',
 
+  // Javalab
+  JAVALAB_RUN_BUTTON_CLICK: 'Javalab Run Button Clicked',
+  JAVALAB_TEST_BUTTON_CLICK: 'Javalab Test Button Clicked',
+  JAVALAB_COMPILATION_ERROR: 'Javalab Compilation Error',
+  JAVALAB_COMPILATION_SUCCESS: 'Javalab Compilation Success',
+
   // Hour of Code
   AGE_21_SELECTED_EVENT: 'Age 21+ Selected',
   HOC_GUIDE_DIALOG_SHOWN: 'HOC Guide Dialog Shown',


### PR DESCRIPTION
[CT-750](https://codedotorg.atlassian.net/browse/CT-750) partial 

More [metrics](https://docs.google.com/document/d/1EoeR4VhVjjuquh1DSVlrpyVJFiD_pCUmppRlQz7HeYA/edit) logging for AI Tutor CSA pilot. 

In this PR, I handling the Javalab-specific metrics we'd like to track. 

When a student clicks the run button 
![run_button](https://github.com/user-attachments/assets/ad6c3bc1-b05b-4fd2-a024-a70533cd3f56)

When code compilation fails 
![compilation_error](https://github.com/user-attachments/assets/ee601702-ebb9-41af-bd07-b98d438b8fc3)

When code compilation succeeds 
![compilation_success](https://github.com/user-attachments/assets/096788a9-cc06-4e7f-9222-7890aeaff9b1)

When a student clicks the test button 
<img width="399" alt="test_button" src="https://github.com/user-attachments/assets/3affb3c1-2a1a-4437-8027-b66180877a55">

When a test passes
![test_pass](https://github.com/user-attachments/assets/d4db0cd4-d890-44fa-be0f-e6ac84cc093a)

When a test fails 
![test_fail](https://github.com/user-attachments/assets/497a405b-7b27-4f97-b206-7c09cf66d325)

