### PR TITLE
Hide example solution link on cached script

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -734,7 +734,9 @@ class ScriptLevel < ApplicationRecord
         end
       end
     elsif level.ideal_level_source_id && script # old style 'solutions' for blockly-type levels
-      level_example_links.push(build_script_level_url(self, {solution: true}.merge(section_id ? {section_id: section_id} : {})))
+      unless ScriptConfig.allows_public_caching_for_script(script.name)
+        level_example_links.push(build_script_level_url(self, {solution: true}.merge(section_id ? {section_id: section_id} : {})))
+      end
     end
 
     level_example_links


### PR DESCRIPTION
Revives @bethanyaconnor 's PR to hide example solution links for non-project examples on cached scripts.

This is to fix a bug with example links redirecting to home on the Frozen levels.

Before:
<img width="1128" alt="Screenshot 2024-09-04 at 12 29 11 PM" src="https://github.com/user-attachments/assets/8823ffe0-6bf1-444c-849d-335fbbe46ce2">

After:
<img width="1128" alt="Screenshot 2024-09-04 at 12 29 47 PM" src="https://github.com/user-attachments/assets/f6fa5fd4-f2b0-4494-9312-99f41330a5fa">

## Links

Bethany's previous PR: https://github.com/code-dot-org/code-dot-org/pull/49346
Jira ticket: https://codedotorg.atlassian.net/browse/AITT-733

## Testing story

No tests changed

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
