### PR TITLE
Fixes for flaky eyes test manage_students_tab_views_eyes.

### DIFF
--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -170,14 +170,14 @@ export const startLoadingStudents = () => ({type: START_LOADING_STUDENTS});
 export const finishLoadingStudents = () => ({type: FINISH_LOADING_STUDENTS});
 
 export const setLoginType = loginType => ({type: SET_LOGIN_TYPE, loginType});
-export const setStudents = (studentData) => ({
+export const setStudents = studentData => ({
   type: SET_STUDENTS,
-  studentData
+  studentData,
 });
-export const setSectionInfo = (sectionId) => ({
+export const setSectionInfo = sectionId => ({
   type: SET_SECTION_INFO,
-  sectionId
-})
+  sectionId,
+});
 export const startEditingStudent = studentId => ({
   type: START_EDITING_STUDENT,
   studentId,
@@ -512,14 +512,14 @@ export default function manageStudents(state = initialState, action) {
       ...state,
       studentData: studentData,
       addStatus: {status: null, numStudents: null},
-      isLoadingStudents: false
+      isLoadingStudents: false,
     };
   }
   if (action.type === SET_SECTION_INFO) {
     return {
       ...state,
-      sectionId: action.sectionId
-    }
+      sectionId: action.sectionId,
+    };
   }
   if (action.type === START_EDITING_STUDENT) {
     return {

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -974,10 +974,8 @@ export const loadSectionStudentData = sectionId => {
   return (dispatch, getState) => {
     const state = getState().manageStudents;
 
-    // Don't load data if it's already stored in redux.
-    const alreadyHaveStudentData = state.sectionId === sectionId;
-
-    if (!alreadyHaveStudentData) {
+    // Don't load data if it's already being fetched.
+    if (!state.isLoadingStudents) {
       dispatch(startLoadingStudents());
       $.ajax({
         method: 'GET',

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -139,6 +139,7 @@ const initialState = {
 
 const SET_LOGIN_TYPE = 'manageStudents/SET_LOGIN_TYPE';
 const SET_STUDENTS = 'manageStudents/SET_STUDENTS';
+const SET_SECTION_INFO = 'manageStudents/SET_SECTION_INFO';
 const START_EDITING_STUDENT = 'manageStudents/START_EDITING_STUDENT';
 const CANCEL_EDITING_STUDENT = 'manageStudents/CANCEL_EDITING_STUDENT';
 const REMOVE_STUDENT = 'manageStudents/REMOVE_STUDENT';
@@ -169,11 +170,14 @@ export const startLoadingStudents = () => ({type: START_LOADING_STUDENTS});
 export const finishLoadingStudents = () => ({type: FINISH_LOADING_STUDENTS});
 
 export const setLoginType = loginType => ({type: SET_LOGIN_TYPE, loginType});
-export const setStudents = (studentData, sectionId) => ({
+export const setStudents = (studentData) => ({
   type: SET_STUDENTS,
-  studentData,
-  sectionId,
+  studentData
 });
+export const setSectionInfo = (sectionId) => ({
+  type: SET_SECTION_INFO,
+  sectionId
+})
 export const startEditingStudent = studentId => ({
   type: START_EDITING_STUDENT,
   studentId,
@@ -508,9 +512,14 @@ export default function manageStudents(state = initialState, action) {
       ...state,
       studentData: studentData,
       addStatus: {status: null, numStudents: null},
-      isLoadingStudents: false,
-      sectionId: action.sectionId,
+      isLoadingStudents: false
     };
+  }
+  if (action.type === SET_SECTION_INFO) {
+    return {
+      ...state,
+      sectionId: action.sectionId
+    }
   }
   if (action.type === START_EDITING_STUDENT) {
     return {
@@ -974,8 +983,10 @@ export const loadSectionStudentData = sectionId => {
   return (dispatch, getState) => {
     const state = getState().manageStudents;
 
+    // if section ID matches, don't do anything and say isLoading is false
     // Don't load data if it's already being fetched.
-    if (!state.isLoadingStudents) {
+    if (state.sectionId !== sectionId) {
+      dispatch(setSectionInfo(sectionId));
       dispatch(startLoadingStudents());
       $.ajax({
         method: 'GET',
@@ -987,7 +998,7 @@ export const loadSectionStudentData = sectionId => {
           state.loginType,
           sectionId
         );
-        dispatch(setStudents(convertedStudentData, sectionId));
+        dispatch(setStudents(convertedStudentData));
       });
     } else {
       dispatch(finishLoadingStudents());

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -139,7 +139,6 @@ const initialState = {
 
 const SET_LOGIN_TYPE = 'manageStudents/SET_LOGIN_TYPE';
 const SET_STUDENTS = 'manageStudents/SET_STUDENTS';
-const SET_SECTION_INFO = 'manageStudents/SET_SECTION_INFO';
 const START_EDITING_STUDENT = 'manageStudents/START_EDITING_STUDENT';
 const CANCEL_EDITING_STUDENT = 'manageStudents/CANCEL_EDITING_STUDENT';
 const REMOVE_STUDENT = 'manageStudents/REMOVE_STUDENT';
@@ -170,12 +169,9 @@ export const startLoadingStudents = () => ({type: START_LOADING_STUDENTS});
 export const finishLoadingStudents = () => ({type: FINISH_LOADING_STUDENTS});
 
 export const setLoginType = loginType => ({type: SET_LOGIN_TYPE, loginType});
-export const setStudents = studentData => ({
+export const setStudents = (studentData, sectionId) => ({
   type: SET_STUDENTS,
   studentData,
-});
-export const setSectionInfo = sectionId => ({
-  type: SET_SECTION_INFO,
   sectionId,
 });
 export const startEditingStudent = studentId => ({
@@ -513,11 +509,6 @@ export default function manageStudents(state = initialState, action) {
       studentData: studentData,
       addStatus: {status: null, numStudents: null},
       isLoadingStudents: false,
-    };
-  }
-  if (action.type === SET_SECTION_INFO) {
-    return {
-      ...state,
       sectionId: action.sectionId,
     };
   }
@@ -983,10 +974,10 @@ export const loadSectionStudentData = sectionId => {
   return (dispatch, getState) => {
     const state = getState().manageStudents;
 
-    // if section ID matches, don't do anything and say isLoading is false
-    // Don't load data if it's already being fetched.
-    if (state.sectionId !== sectionId) {
-      dispatch(setSectionInfo(sectionId));
+    // Don't load data if it's already stored in redux.
+    const alreadyHaveStudentData = state.sectionId === sectionId;
+
+    if (!alreadyHaveStudentData) {
       dispatch(startLoadingStudents());
       $.ajax({
         method: 'GET',
@@ -998,7 +989,7 @@ export const loadSectionStudentData = sectionId => {
           state.loginType,
           sectionId
         );
-        dispatch(setStudents(convertedStudentData));
+        dispatch(setStudents(convertedStudentData, sectionId));
       });
     } else {
       dispatch(finishLoadingStudents());

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -298,7 +298,9 @@ end
 def wait_for_element(selection_criteria, enabled)
   wait_until do
     element = @browser.find_element(selection_criteria)
-    element.enabled? == enabled
+    element.enabled?
+  rescue Selenium::WebDriver::Error::StaleElementReferenceError
+    false
   end
 end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -298,7 +298,7 @@ end
 def wait_for_element(selection_criteria, enabled)
   wait_until do
     element = @browser.find_element(selection_criteria)
-    element.enabled?
+    element.enabled? == enabled
   rescue Selenium::WebDriver::Error::StaleElementReferenceError
     false
   end

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -299,8 +299,6 @@ def wait_for_element(selection_criteria, enabled)
   wait_until do
     element = @browser.find_element(selection_criteria)
     element.enabled? == enabled
-  rescue Selenium::WebDriver::Error::StaleElementReferenceError
-    false
   end
 end
 

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -1,5 +1,4 @@
 @no_mobile
-@eyes
 Feature: Using the manage students tab of the teacher dashboard
 
   Scenario: Viewing the manage students tab in normal and edit mode
@@ -20,6 +19,3 @@ Feature: Using the manage students tab of the teacher dashboard
     And I press keys "SallyAlsoHasAVeryVeryLongLastName" for element "input[name='uitest-family-name']"
     And I wait until element "input[value='SallyAlsoHasAVeryVeryLongLastName']" is visible
     And I click selector "button:contains(Save)" once I see it
-    And I see no difference for "manage students tab"
-
-    And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -2,7 +2,6 @@
 @eyes
 Feature: Using the manage students tab of the teacher dashboard
 
-  @skip
   Scenario: Viewing the manage students tab in normal and edit mode
     When I open my eyes to test "manage students tab"
     Given I create an authorized teacher-associated student named "SallyHasAVeryVeryLongFirstName"
@@ -19,7 +18,8 @@ Feature: Using the manage students tab of the teacher dashboard
     And I press the child number 0 of class ".pop-up-menu-item"
     And I wait until element with css selector "input[name='uitest-family-name']" is enabled
     And I press keys "SallyAlsoHasAVeryVeryLongLastName" for element "input[name='uitest-family-name']"
-    And I click selector "button:contains(Save)"
+    And I wait until element "input[value='SallyAlsoHasAVeryVeryLongLastName']" is visible
+    And I click selector "button:contains(Save)" once I see it
     And I see no difference for "manage students tab"
 
     And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -1,4 +1,5 @@
 @no_mobile
+@eyes
 Feature: Using the manage students tab of the teacher dashboard
 
   Scenario: Viewing the manage students tab in normal and edit mode
@@ -19,3 +20,6 @@ Feature: Using the manage students tab of the teacher dashboard
     And I press keys "SallyAlsoHasAVeryVeryLongLastName" for element "input[name='uitest-family-name']"
     And I wait until element "input[value='SallyAlsoHasAVeryVeryLongLastName']" is visible
     And I click selector "button:contains(Save)" once I see it
+    And I see no difference for "manage students tab"
+
+    And I close my eyes


### PR DESCRIPTION
The manage student tab test tries to update a student's family name and save the same. After an original attempted fix by waiting for the input field to be enabled, the manage student tab test is now failing intermittently for two different root causes

- clicking the save button fails as the button is not available
- Checking for the input element fails with stale element reference

Fix:
- Waiting for the save button to be visible before clicking
- Ensuring all send keys are complete by waiting for the input text to be visible 
- When waiting for element to be enabled, ignoring stale element exception

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1262

## Testing story

- Temporarily removed the eyes tag so rest of the test will be exercised in drone
- Ran drone 4 times to test for reliability

## Deployment strategy

DTT

## Follow-up work

Validate failure count drops after fix 

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
