### PR TITLE
Revert "Revert "Add hourofcode.com to list of production environments on utils.js""

### DIFF
--- a/apps/src/sites/hourofcode.com/pages/views/analytics_event_log_helper.js
+++ b/apps/src/sites/hourofcode.com/pages/views/analytics_event_log_helper.js
@@ -1,10 +1,11 @@
 import $ from 'jquery';
 
+import {PLATFORMS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 
 // Log page visits on document.ready.
 $(document).ready(() => {
   const eventLogger = document.getElementById('analytics-event-log-helper');
   const pageVisitEventName = eventLogger?.dataset?.eventName;
-  analyticsReporter.sendEvent(pageVisitEventName);
+  analyticsReporter.sendEvent(pageVisitEventName, {}, PLATFORMS.STATSIG);
 });

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -931,7 +931,11 @@ export function getEnvironment() {
   if (hostname.includes('localhost') || hostname.includes('127.0.0.1')) {
     return Environments.development;
   }
-  if (hostname === 'code.org' || hostname === 'studio.code.org') {
+  if (
+    hostname === 'code.org' ||
+    hostname === 'studio.code.org' ||
+    hostname === 'hourofcode.com'
+  ) {
     return Environments.production;
   }
   return Environments.unknown;

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -10,6 +10,8 @@ social:
 
 %link{href: "/css/generated/hoc-banner.css", rel: "stylesheet", type: "text/css"}
 
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::HOC_ACTIVITIES_PAGE_VISITED
+
 #fullwidth
   = view :header
   %section.banner
@@ -48,8 +50,6 @@ social:
 #tutorials
 
 .clear{style: "clear: both"}
-
-= view :analytics_event_log_helper, event_name: AnalyticsConstants::HOC_ACTIVITIES_PAGE_VISITED
 
 :javascript
 

--- a/pegasus/sites.v3/hourofcode.com/views/analytics_event_log_helper.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/analytics_event_log_helper.haml
@@ -1,4 +1,3 @@
-%script{data: {'amplitude-api-key': CDO.safe_amplitude_api_key}}
 %script{data: {'statsig-api-client-key': CDO.safe_statsig_api_client_key}}
 %script{data: {'managed-test-server': "#{CDO.running_web_application? && CDO.test_system?}"}}
 %script{src: webpack_asset_path('js/hourofcode.com/views/analytics_event_log_helper.js')}


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#60834

The event logger was too far down in the DOM so the Statsig API was getting called before the `data-statsig-api-client-key` loaded. Was able to fix this w/ @hannahbergam's sleuthing skills by moving the event logger to the top of the file.

I also removed Amplitude from the HoC event logger so now we are only sending events to Statsig.

**Can confirm events will send to Statsig:**
![Screenshot 2024-09-04 at 4 19 21 PM](https://github.com/user-attachments/assets/50e228c0-5705-4be3-9002-7b67f3f61d79)

## Links
Jira ticket: [ACQ-2357](https://codedotorg.atlassian.net/browse/ACQ-2357)
Slack convo: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1725481534375899) • [acqs channel convo](https://codedotorg.slack.com/archives/C0453TUMLE7/p1725479709997369)