### PR TITLE
Moving section table class name to the table element to fix flaky test.

### DIFF
--- a/apps/src/templates/teacherDashboard/OwnedPlSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedPlSectionsTable.jsx
@@ -285,7 +285,7 @@ class OwnedPlSectionsTable extends Component {
     })(this.props.sectionRows);
 
     return (
-      <Table.Provider columns={columns}>
+      <Table.Provider className='uitest-owned-pl-sections' columns={columns}>
         <Table.Header />
         <Table.Body
           className="uitest-sorted-rows"

--- a/apps/src/templates/teacherDashboard/OwnedPlSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedPlSectionsTable.jsx
@@ -285,7 +285,7 @@ class OwnedPlSectionsTable extends Component {
     })(this.props.sectionRows);
 
     return (
-      <Table.Provider className='uitest-owned-pl-sections' columns={columns}>
+      <Table.Provider className="uitest-owned-pl-sections" columns={columns}>
         <Table.Header />
         <Table.Body
           className="uitest-sorted-rows"

--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -92,11 +92,7 @@ class OwnedSections extends React.Component {
     const hasSections = sectionIds.length > 0;
 
     return (
-      <div
-        className={
-          isPlSections ? 'uitest-owned-pl-sections' : 'uitest-owned-sections'
-        }
-      >
+      <div>
         {hasSections && (
           <div>
             <LtiFeedbackBanner />

--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -86,7 +86,7 @@ class OwnedSections extends React.Component {
   };
 
   render() {
-    const {isPlSections, sectionIds, hiddenSectionIds} = this.props;
+    const {sectionIds, hiddenSectionIds} = this.props;
     const {viewHidden} = this.state;
 
     const hasSections = sectionIds.length > 0;

--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
@@ -340,7 +340,10 @@ class OwnedSectionsTable extends Component {
     })(this.props.sectionRows);
 
     return (
-      <Table.Provider className='uitest-owned-sections' columns={columns} style={tableLayoutStyles.table}>
+      <Table.Provider
+        className="uitest-owned-sections"
+        columns={columns}
+        style={tableLayoutStyles.table}>
         <Table.Header />
         <Table.Body
           className="uitest-sorted-rows"

--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
@@ -340,7 +340,7 @@ class OwnedSectionsTable extends Component {
     })(this.props.sectionRows);
 
     return (
-      <Table.Provider columns={columns} style={tableLayoutStyles.table}>
+      <Table.Provider className='uitest-owned-sections' columns={columns} style={tableLayoutStyles.table}>
         <Table.Header />
         <Table.Body
           className="uitest-sorted-rows"

--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
@@ -343,7 +343,8 @@ class OwnedSectionsTable extends Component {
       <Table.Provider
         className="uitest-owned-sections"
         columns={columns}
-        style={tableLayoutStyles.table}>
+        style={tableLayoutStyles.table}
+      >
         <Table.Header />
         <Table.Body
           className="uitest-sorted-rows"


### PR DESCRIPTION
Issue: features/teacher_tools/pl_sections UI test fails when validating the number of sections that show up in the instructor center. 

https://app.saucelabs.com/tests/aad0b1f6ec9a48b5b53048af1f61e8c3#127
![image](https://github.com/user-attachments/assets/31b5773a-dab4-48fa-b653-6bae66353e59)

In the sample failure above, we see that the check for section table visibility passes, but the table is actually rendered much later. 

Root cause: The table visibility is checked on a div which is displayed before the section data is loaded.

Fix: Moving the class attribute from the div to the table element.

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1303

## Testing story

- Kicked off 4 drone runs to check for reliability. https://app.saucelabs.com/dashboard/tests?tag=vijaya%2Fpl_secs&ownerId=myorganization&ownerType=organization&ownerName=My+organization&search=pl_sections&start=last7days 
- Drone run

## Deployment strategy

DTT

## Follow-up work

Validate if there are no further failure hits for this root cause.

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
