### PR TITLE
speculative fix for data loss in learning goal teacher evaluations

### DIFF
--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -420,49 +420,48 @@ export default function LearningGoals({
       setLoaded(teacherFeedbacksLoaded.current[currentLearningGoal]);
       setDisplayUnderstanding(understandingLevels.current[currentLearningGoal]);
 
-      // Only load prior learning goal feedback once
-      learningGoals
-        .filter((learningGoal, index) => {
-          return !teacherFeedbacksLoaded.current[index];
-        })
-        .forEach((learningGoal, index) => {
-          const body = JSON.stringify({
-            userId: studentLevelInfo.user_id,
-            learningGoalId: learningGoal.id,
-          });
-          HttpClient.post(
-            `${base_teacher_evaluation_endpoint}/get_or_create_evaluation`,
-            body,
-            true,
-            {
-              'Content-Type': 'application/json',
-            }
-          )
-            .then(response => response.json())
-            .then(json => {
-              learningGoalEvalIds.current[index] = json.id;
-              if (json.feedback) {
-                teacherFeedbacks.current[index] = json.feedback;
-              }
-              teacherFeedbacksLoaded.current[index] = true;
-              if (json.understanding >= 0 && json.understanding !== null) {
-                understandingLevels.current[index] = json.understanding;
-              }
-
-              // Uses the redundant ref here instead of state to defeat a race
-              // condition where the current learning goal changes before the
-              // fetch resolves.
-              if (index === currentLearningGoalRef.current) {
-                setDisplayFeedback(teacherFeedbacks.current[index]);
-                setLoaded(teacherFeedbacksLoaded.current[index]);
-                setDisplayUnderstanding(understandingLevels.current[index]);
-              }
-              if (index === learningGoals.length - 1) {
-                setDoneLoading(true);
-              }
-            })
-            .catch(error => console.error(error));
+      learningGoals.forEach((learningGoal, index) => {
+        // Only load prior learning goal feedback once
+        if (teacherFeedbacksLoaded.current[index]) {
+          return;
+        }
+        const body = JSON.stringify({
+          userId: studentLevelInfo.user_id,
+          learningGoalId: learningGoal.id,
         });
+        HttpClient.post(
+          `${base_teacher_evaluation_endpoint}/get_or_create_evaluation`,
+          body,
+          true,
+          {
+            'Content-Type': 'application/json',
+          }
+        )
+          .then(response => response.json())
+          .then(json => {
+            learningGoalEvalIds.current[index] = json.id;
+            if (json.feedback) {
+              teacherFeedbacks.current[index] = json.feedback;
+            }
+            teacherFeedbacksLoaded.current[index] = true;
+            if (json.understanding >= 0 && json.understanding !== null) {
+              understandingLevels.current[index] = json.understanding;
+            }
+
+            // Uses the redundant ref here instead of state to defeat a race
+            // condition where the current learning goal changes before the
+            // fetch resolves.
+            if (index === currentLearningGoalRef.current) {
+              setDisplayFeedback(teacherFeedbacks.current[index]);
+              setLoaded(teacherFeedbacksLoaded.current[index]);
+              setDisplayUnderstanding(understandingLevels.current[index]);
+            }
+            if (index === learningGoals.length - 1) {
+              setDoneLoading(true);
+            }
+          })
+          .catch(error => console.error(error));
+      });
     }
   }, [studentLevelInfo, learningGoals, currentLearningGoal, open, productTour]);
 

--- a/dashboard/app/controllers/learning_goal_teacher_evaluations_controller.rb
+++ b/dashboard/app/controllers/learning_goal_teacher_evaluations_controller.rb
@@ -2,21 +2,21 @@ class LearningGoalTeacherEvaluationsController < ApplicationController
   load_and_authorize_resource
 
   def create
-    @learning_goal_teacher_evaluation.update!(learning_goal_teacher_evaluation_params.merge(teacher_id: current_user.id))
+    @learning_goal_teacher_evaluation.update!(eval_params.merge(teacher_id: current_user.id))
     render json: @learning_goal_teacher_evaluation
   end
 
   def update
-    @learning_goal_teacher_evaluation.update!(learning_goal_teacher_evaluation_params)
+    @learning_goal_teacher_evaluation.update!(update_params)
     return head :not_found unless @learning_goal_teacher_evaluation
     render json: @learning_goal_teacher_evaluation
   end
 
   def get_evaluation
     learning_goal_teacher_evaluation = LearningGoalTeacherEvaluation.find_by(
-      user_id: learning_goal_teacher_evaluation_params[:user_id],
+      user_id: eval_params[:user_id],
       teacher_id: current_user.id,
-      learning_goal_id: learning_goal_teacher_evaluation_params[:learning_goal_id]
+      learning_goal_id: eval_params[:learning_goal_id]
     )
     if learning_goal_teacher_evaluation&.teacher_id == current_user.id
       render json: learning_goal_teacher_evaluation
@@ -27,21 +27,26 @@ class LearningGoalTeacherEvaluationsController < ApplicationController
 
   def get_or_create_evaluation
     learning_goal_teacher_evaluation = LearningGoalTeacherEvaluation.find_or_create_by!(
-      user_id: learning_goal_teacher_evaluation_params[:user_id],
+      user_id: eval_params[:user_id],
       teacher_id: current_user.id,
-      learning_goal_id: learning_goal_teacher_evaluation_params[:learning_goal_id],
+      learning_goal_id: eval_params[:learning_goal_id],
     )
     render json: learning_goal_teacher_evaluation
   end
 
-  private def learning_goal_teacher_evaluation_params
-    eval_params = params.transform_keys(&:underscore)
-    eval_params = eval_params.permit(
+  private def eval_params
+    params.transform_keys(&:underscore).permit(
       :user_id,
       :learning_goal_id,
       :understanding,
       :feedback,
     )
-    eval_params
+  end
+
+  private def update_params
+    params.transform_keys(&:underscore).permit(
+      :understanding,
+      :feedback,
+      )
   end
 end


### PR DESCRIPTION
speculative fix for https://codedotorg.atlassian.net/browse/AITT-766. See analysis in that bug report from Vijaya and Wilkie, both of which were instrumental to understanding what is going on here. The analysis goes like this:

#### bug report
* UI test fails when a teacher leaves feedback (LearningGoalTeacherEvaluation) for a student, waits for it to save, refreshes the page, and expects to see the feedback still there. bug: on reload, no feedback is visible.

#### observations from Vijaya (short version)
* the Network tab in Saucelabs reveals that the JS code is sending a PUT request to update an existing LearningGoalTeacherEvaluation to point to a different learning goal, indicating that there is a bug in the client code which is causing a bad update to be sent to the server.

#### observations from Wilkie
* there's a potential problem with this code: https://github.com/code-dot-org/code-dot-org/blob/aadd3e487b8caebefa63a24d136959b5b1f37a75/apps/src/templates/rubrics/LearningGoals.jsx#L425-L443 because we should be using the original index and not the filtered index to update our local state when the network request completes.

I didn't want to just blindly fix the issue wilkie found without some confidence that it might fix the issue, so I did some more digging to come up with a plausible explanation.

#### key insight

you can see from Vijaya's data that we call get_or_create_evaluation for the following learning goals around the time the page loads: 2, 1, 3, 1, 3. the positions of these learning goals are 1st, 2nd, 3rd, 2nd, 3rd. this suggests we are rendering the component twice:
* render 1: fetch data for learning goal positions 1st, 2nd, 3rd
* render 2: fetch data for learning goal positions 2nd, 3rd

this more or less proves we are hitting the bug wilkie spotted on the second render, which would explain the buggy behavior. but, how is this even possible that we are fetching only 2 of 3 learning goals, given our expectation that all would be already loaded on the second render?

#### speculative sequence of events

1. initial page render triggers network requests for all 3 learning goals
2. network request for 1st learning goal completes -- other two requests are pending
3. in the success handler for the network request, we set some state variables, which is enough to trigger a re-render: https://github.com/code-dot-org/code-dot-org/blob/c7239d2adb0bb08bc49dc63dd876b8da7eb85d46/apps/src/templates/rubrics/LearningGoals.jsx#L454-L457
4. the LearningGoals component re-renders before the 2nd and 3rd learning goal fetches complete. 1st learning goal already has its data loaded, so it gets filtered out and we re-request data for 2nd and 3rd learning goals (see wilkie's code snippet above)
5. when we get the response for the 2nd learning goal, we use the wrong index and overwrite the data on the client for the 1st learning goal

#### race condition?

is this a race condition? yes, once the 1st learning goal fetch completes, it is a race between (a) the 2nd and 3rd learning goal fetches completing (and their success handlers completing) and (b) the react re-render triggered by the state updates shown above. if the rerender happens first, the bug occurs. this is kind of interesting because it is not a race between two competing network requests.

#### also in this PR
* I restricted which params can be modified when updating a LearningGoalTeacherEvaluation so that only feedback and understanding are allowed. this alone wouldn't solve the problem here, but is a best practice and could prevent other data loss problems in the future.

## Testing story

* existing test coverage for changes to LearningGoalTeacherEvaluation route
* UI test flakiness report will hopefully tell us over time whether the speculative fix was the correct one or not
* no new js tests because the bug here seems a bit hard to set up -- but I'm open to ideas for this.