### PR TITLE
No shadow on buttons by default?

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3390,9 +3390,6 @@ button.button-active-no-border:active {
   // an active button. (overriding button:active rule above)
   border: none !important;
 }
-button:hover {
-  @include box-shadow(2px 2px 5px $shadow);
-}
 button.disabled, button[disabled=disabled] {
   border: 1px solid $lighter_gray;
   background-color: $lighter_gray;


### PR DESCRIPTION
A proposal to remove an application-level piece of CSS that applies a shadow to buttons on hover by default. Our design system now uses the more modern flat button style, and I see `box-shadow: none` a couple hundred times in our code base, so I think we're overriding this styling a lot.

[Here's a Slack thread](https://codedotorg.slack.com/archives/C046G4TRLEN/p1707844459615579) where I mentioned this a while back, where design said we could remove it.

It's been around since [the first "Anybody can learn." commit](https://github.com/code-dot-org/code-dot-org-pre-lfs/blame/7d8d46ece3a0659fb8d040d8f2046b857f06de8c/dashboard/app/assets/stylesheets/application.css.scss).

I guess risks would be:
- some button hover styling that is intentional and accidentally removed, and 
- we have "clickable divs" that have been styled to match our existing button styling (ie, with shadow on hover) and this change introduces some inconsistency on the page. @hannahbergam noted this as a potential issue in the original Slack discussion above.

Initial inspiration for this change is some inconsistent button styling in AI Chat (ie, the "Continue" button has a shadow on hover, and other buttons do not), which can be traced to this default setting.

## Links

- jira ticket: https://codedotorg.atlassian.net/browse/LABS-742

## Testing story

The AI Chat UI inconsistency is resolved with this change. I didn't look at any other pages :).