### PR TITLE
Refactoring input TextField to support different input types

### DIFF
--- a/apps/src/componentLibrary/textField/CHANGELOG.md
+++ b/apps/src/componentLibrary/textField/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.2](https://github.com/code-dot-org/code-dot-org/pull/60852)
+
+* Added inputType options and stories for `TextField` component
+
 ## [0.2.1](https://github.com/code-dot-org/code-dot-org/pull/59052)
 
 * minor changelog update

--- a/apps/src/componentLibrary/textField/TextField.story.tsx
+++ b/apps/src/componentLibrary/textField/TextField.story.tsx
@@ -41,6 +41,27 @@ WithErrorTextField.args = {
   errorMessage: 'Error message',
 };
 
+export const PasswordTextField = SingleTemplate.bind({});
+PasswordTextField.args = {
+  ...defaultArgs,
+  name: 'textfield_password',
+  inputType: 'password',
+};
+
+export const NumberTextField = SingleTemplate.bind({});
+NumberTextField.args = {
+  ...defaultArgs,
+  name: 'textfield_number',
+  inputType: 'number',
+};
+
+export const EmailTextField = SingleTemplate.bind({});
+EmailTextField.args = {
+  ...defaultArgs,
+  name: 'textfield_email',
+  inputType: 'email',
+};
+
 export const WithHelperMessageTextField = SingleTemplate.bind({});
 WithHelperMessageTextField.args = {
   ...defaultArgs,

--- a/apps/src/componentLibrary/textField/TextField.tsx
+++ b/apps/src/componentLibrary/textField/TextField.tsx
@@ -14,6 +14,8 @@ export interface TextFieldProps extends AriaAttributes {
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   /** TextField id */
   id?: string;
+  /** Specifies the type of input; see included options below. */
+  inputType?: 'text' | 'email' | 'password' | 'number';
   /** The name attribute specifies the name of an input element.
      The name attribute is used to reference elements in a JavaScript,
      or to reference form data after a form is submitted.
@@ -58,6 +60,7 @@ export interface TextFieldProps extends AriaAttributes {
  */
 const TextField: React.FunctionComponent<TextFieldProps> = ({
   id,
+  inputType = 'text',
   label,
   onChange,
   name,
@@ -88,7 +91,7 @@ const TextField: React.FunctionComponent<TextFieldProps> = ({
       {label && <span className={moduleStyles.textFieldLabel}>{label}</span>}
       <input
         id={id}
-        type="text"
+        type={inputType}
         name={name}
         value={value}
         placeholder={placeholder}


### PR DESCRIPTION
This is a Design System component update that allows TextFields to have the input types of 'text', 'password', 'email', or 'number' (though the default will still be 'text'). 

I also updated the storybook component with these options and included notes in the changelog.

New stories:
<img width="999" alt="Screenshot 2024-09-05 at 9 53 09 AM" src="https://github.com/user-attachments/assets/0f1a7289-9340-48ff-945f-6123f2044cbd">
<img width="750" alt="Screenshot 2024-09-05 at 9 53 36 AM" src="https://github.com/user-attachments/assets/060c9340-5295-4063-87b4-2682ed187b37">
<img width="768" alt="Screenshot 2024-09-05 at 9 54 12 AM" src="https://github.com/user-attachments/assets/b1735db9-6dc4-42ac-8dca-98948248cfee">

## Links
- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2365

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
