### PR TITLE
Skip test for assessments on Safari

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_assessments_announcement.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_assessments_announcement.feature
@@ -1,5 +1,6 @@
 @no_mobile
 Feature: Announcement for AI Assessments
+  @no_safari
   Scenario: Teacher views and closes announcement
     Given I am a teacher
 


### PR DESCRIPTION
[Slack message thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1725541015374779)

This PR is intended to skip a test that was failing only on Safari.  This is also a brand new test. It has never passed on Safari because Drone doesn’t test on Safari.  There was concern that this was a legitimate failure in Safari rather than a "flaky test" issue.   The plan is to only merge this in once we get confirmation from the TA team that this is the right move.
