### PR TITLE
Music: advanced functions

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -214,7 +214,10 @@ export default class MusicBlocklyWorkspace {
       if (getBlockMode() !== BlockMode.SIMPLE2) {
         if (block.type === BlockTypes.WHEN_RUN) {
           this.compiledEvents.whenRunButton = {
-            code: Blockly.JavaScript.blockToCode(block),
+            code:
+              'var __context = "when_run";\n' +
+              Blockly.JavaScript.workspaceToCode(this.workspace),
+            args: ['startPosition'],
           };
         }
       } else {
@@ -255,7 +258,8 @@ export default class MusicBlocklyWorkspace {
         const id = block.getFieldValue(TRIGGER_FIELD);
         this.compiledEvents[triggerIdToEvent(id)] = {
           code:
-            Blockly.JavaScript.blockToCode(block) + functionImplementationsCode,
+            `var __context = "${id}";\n` +
+            Blockly.JavaScript.workspaceToCode(this.workspace),
           args: ['startPosition'],
         };
         // Also save the value of the trigger start field at compile time so we can
@@ -311,7 +315,7 @@ export default class MusicBlocklyWorkspace {
     console.log('Executing compiled song.');
 
     if (this.codeHooks.whenRunButton) {
-      this.callUserGeneratedCode(this.codeHooks.whenRunButton);
+      this.callUserGeneratedCode(this.codeHooks.whenRunButton, [0]);
     }
 
     if (this.codeHooks.tracks) {

--- a/apps/src/music/blockly/blocks/events.js
+++ b/apps/src/music/blockly/blocks/events.js
@@ -12,7 +12,15 @@ export const whenRun = {
     tooltip: musicI18n.blockly_blockWhenRunTooltip(),
     helpUrl: '',
   },
-  generator: () => 'var currentMeasureLocation = 1;\n',
+  generator: ctx => {
+    const nextBlock = ctx.nextConnection && ctx.nextConnection.targetBlock();
+    let handlerCode = Blockly.JavaScript.blockToCode(nextBlock, false);
+    ctx.skipNextBlockGeneration = true;
+    return `
+      if (__context == 'when_run') {
+       ${handlerCode}
+      }`;
+  },
 };
 
 export const triggeredAt = {
@@ -33,13 +41,19 @@ export const triggeredAt = {
     tooltip: musicI18n.blockly_blockTriggeredAtTooltip(),
   },
   generator: ctx => {
+    const id = ctx.getFieldValue('trigger');
     const varName = Blockly.JavaScript.nameDB_.getName(
       ctx.getFieldValue('var'),
       Blockly.Names.NameType.VARIABLE
     );
+    const nextBlock = ctx.nextConnection && ctx.nextConnection.targetBlock();
+    let handlerCode = Blockly.JavaScript.blockToCode(nextBlock, false);
+    ctx.skipNextBlockGeneration = true;
     return `
       ${varName} = startPosition;
-      \n`;
+      if (__context == "${id}") {
+        ${handlerCode}
+      }`;
   },
 };
 

--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -1,3 +1,5 @@
+import {getBlockMode} from '../appConfig';
+import {BlockMode} from '../constants';
 import musicI18n from '../locale';
 
 import {
@@ -52,17 +54,21 @@ export function setUpBlocklyForMusicLab() {
     Blockly.JavaScript[blockType] = blockConfig.generator;
   }
 
-  Blockly.cdoUtils.registerCustomProcedureBlocks();
+  if (getBlockMode() !== BlockMode.ADVANCED) {
+    // Override default function block implementation.
+    Blockly.cdoUtils.registerCustomProcedureBlocks();
+
+    // Remove two default entries in the toolbox's Functions category that
+    // we don't want.
+    delete Blockly.Blocks.procedures_defreturn;
+    delete Blockly.Blocks.procedures_ifreturn;
+  }
+
   Blockly.fieldRegistry.register(FIELD_SOUNDS_TYPE, FieldSounds);
   Blockly.fieldRegistry.register(FIELD_PATTERN_TYPE, FieldPattern);
   Blockly.fieldRegistry.register(FIELD_PATTERN_AI_TYPE, FieldPatternAi);
   Blockly.fieldRegistry.register(FIELD_CHORD_TYPE, FieldChord);
   Blockly.fieldRegistry.register(FIELD_TUNE_TYPE, FieldTune);
-
-  // Remove two default entries in the toolbox's Functions category that
-  // we don't want.
-  delete Blockly.Blocks.procedures_defreturn;
-  delete Blockly.Blocks.procedures_ifreturn;
 
   // Rename the new function placeholder text for Music Lab specifically.
   Blockly.Msg['PROCEDURES_DEFNORETURN_PROCEDURE'] =

--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -448,6 +448,7 @@ export function getToolbox(toolbox) {
         },
         {
           includeVariables: true,
+          includeFunctions: true,
         }
       );
     case BlockMode.SIMPLE2:


### PR DESCRIPTION
This adds full Blockly function support to the advanced model in Music Lab, for internal evaluation by the curriculum team.  

Here's an example demonstrating `when run`, triggers, and functions that support variable numbers of parameters and optional return values:
<img width="1045" alt="Screenshot 2024-09-05 at 12 12 24 PM" src="https://github.com/user-attachments/assets/3faea568-81aa-49da-92b7-55669aeee7d7">

And here is the functions category in the toobox:
<img width="329" alt="Screenshot 2024-09-05 at 12 12 57 PM" src="https://github.com/user-attachments/assets/25f99e88-5917-4704-a902-bf216941fe88">

### Details

While the `simple2` model continues to use `Blockly.JavaScript.blockToCode` for `when run` and each trigger, to get a separate piece of executable JS for each such "entrypoint", the `advanced` model now uses `Blockly.JavaScript.workspaceToCode` for each such entrypoint, and adds an internal context variable to each so that the JS code knows what it should run.  By using `Blockly.JavaScript.workspaceToCode`, each function's JS is generated properly and is available to all entrypoints.

Here's an illustrative example of the JS generated for a trigger entrypoint:

```
var __context = "trigger1";
var currentTime, offset;

function play_at_offset(offset) {
  Sequencer.playSoundAtMeasureById("electro/synth_cave", offset, false, "82{1N}kn{he?^ze9x$|~");
}

if (__context == 'when_run') {
  Sequencer.playSoundAtMeasureById("electro/whua", 1, true, "P6;omww?#*zzN?m|IJgd");
}

currentTime = startPosition;
if (__context == "trigger1") {
  play_at_offset(9);
}
```

I did look into behaving more like Sprite Lab and and having the block generator for a trigger register a callback.  However, it appears that for `CustomMarshalingInterpreter.createNativeFunctionFromInterpreterFunction` to be available, we need to initialize `JSInterpreter` which in turn has a dependency on `studioApp`.  So I opted for the above approach instead.
