### PR TITLE
Fixing firehose events where event property was incorrectly set to a large payload that is leading to data loss.

### DIFF
--- a/apps/src/templates/progress/SendLesson.jsx
+++ b/apps/src/templates/progress/SendLesson.jsx
@@ -2,7 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
+<<<<<<< HEAD
 import firehoseClient from '@cdo/apps/metrics/firehose';
+=======
+>>>>>>> linter fixes.
 import i18n from '@cdo/locale';
 
 import SendLessonDialog from './SendLessonDialog';

--- a/apps/src/templates/progress/SendLesson.jsx
+++ b/apps/src/templates/progress/SendLesson.jsx
@@ -2,10 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
-<<<<<<< HEAD
 import firehoseClient from '@cdo/apps/metrics/firehose';
-=======
->>>>>>> linter fixes.
 import i18n from '@cdo/locale';
 
 import SendLessonDialog from './SendLessonDialog';
@@ -30,6 +27,16 @@ export default class SendLesson extends React.Component {
 
   openDialog() {
     this.setState({isDialogOpen: true});
+
+    firehoseClient.putRecord(
+      {
+        study: 'send-to-students-button',
+        study_group: 'v0',
+        event: 'send-lesson-to-students',
+        data_json: this.props.analyticsData,
+      },
+      {includeUserId: true}
+    );
   }
 
   closeDialog() {

--- a/apps/src/templates/progress/SendLesson.jsx
+++ b/apps/src/templates/progress/SendLesson.jsx
@@ -27,16 +27,6 @@ export default class SendLesson extends React.Component {
 
   openDialog() {
     this.setState({isDialogOpen: true});
-
-    firehoseClient.putRecord(
-      {
-        study: 'send-to-students-button',
-        study_group: 'v0',
-        event: event,
-        data_json: this.props.analyticsData,
-      },
-      {includeUserId: true}
-    );
   }
 
   closeDialog() {

--- a/apps/src/templates/progress/SendLessonDialog.jsx
+++ b/apps/src/templates/progress/SendLessonDialog.jsx
@@ -42,7 +42,6 @@ class SendLessonDialog extends Component {
       this.setState({showLinkCopied: false});
     }, 4000);
 
-
     firehoseClient.putRecord(
       {
         study: 'copy-lesson-link-button',

--- a/apps/src/templates/progress/SendLessonDialog.jsx
+++ b/apps/src/templates/progress/SendLessonDialog.jsx
@@ -41,6 +41,17 @@ class SendLessonDialog extends Component {
     setTimeout(() => {
       this.setState({showLinkCopied: false});
     }, 4000);
+
+
+    firehoseClient.putRecord(
+      {
+        study: 'copy-lesson-link-button',
+        study_group: 'v0',
+        event: 'copy-lesson-link',
+        data_json: this.props.analyticsData,
+      },
+      {includeUserId: true}
+    );
   }
 
   renderCopyToClipboardRow() {

--- a/apps/src/templates/progress/SendLessonDialog.jsx
+++ b/apps/src/templates/progress/SendLessonDialog.jsx
@@ -41,16 +41,6 @@ class SendLessonDialog extends Component {
     setTimeout(() => {
       this.setState({showLinkCopied: false});
     }, 4000);
-
-    firehoseClient.putRecord(
-      {
-        study: 'copy-lesson-link-button',
-        study_group: 'v0',
-        event: event,
-        data_json: this.props.analyticsData,
-      },
-      {includeUserId: true}
-    );
   }
 
   renderCopyToClipboardRow() {


### PR DESCRIPTION
An issue was recently identified where some firehose events having payloads that are larger than the 128 character limit, resulted in failure processing all events in the batch to red shift. 

Root cause: Upon further investigation, the event payload set was accidentally set to the [event property on the DOM window object](https://developer.mozilla.org/en-US/docs/Web/API/Window/event). This seems like a bug where setting the actual value for event, which should have been the event name was missed out in the [original change](https://github.com/code-dot-org/code-dot-org/commit/c40b97e021eac4ae59d956c0d1246277e33ffd0b).

Fix: Updating the event property to an appropriate event name.

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1201

## Testing story

- Drone
- TBD: Validate on Redshift that these events were never successfully processed

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
