### PR TITLE
Removing TLS 1.0 and 1.1 in CloudFormation scripts

### DIFF
--- a/aws/cloudformation/s3_backed_subdomain.yml
+++ b/aws/cloudformation/s3_backed_subdomain.yml
@@ -93,7 +93,7 @@ Resources:
               OriginAccessIdentity: ""
         ViewerCertificate:
           AcmCertificateArn: !Ref CertificateArn
-          MinimumProtocolVersion: TLSv1
+          MinimumProtocolVersion: TLSv1.2_2021
           SslSupportMethod: sni-only
       Tags:
         - Key: environment

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -183,7 +183,7 @@ module AWS
               Id: app_name == proxy ? 'cdo' : app_name,
               CustomOriginConfig: {
                 OriginProtocolPolicy: 'match-viewer',
-                OriginSSLProtocols: %w(TLSv1.2 TLSv1.1),
+                OriginSSLProtocols: %w(TLSv1.2),
                 OriginReadTimeout: rack_env?(:levelbuilder) ? 60 : 30
               },
               DomainName: origin,
@@ -225,7 +225,7 @@ module AWS
         },
         ViewerCertificate: ssl_cert ? ssl_cert : {
           CloudFrontDefaultCertificate: true,
-          MinimumProtocolVersion: 'TLSv1' # accepts SSLv3, TLSv1
+          MinimumProtocolVersion: 'TLSv1.2_2021'
         },
         HttpVersion: 'http2'
       }.to_json

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -190,7 +190,7 @@ To specify an alternate branch name, run `rake adhoc:start branch=BRANCH`."
           [subdomain] + CDO.partners.map {|x| subdomain(nil, x)},
         {
           AcmCertificateArn: certificate_arn,
-          MinimumProtocolVersion: 'TLSv1',
+          MinimumProtocolVersion: 'TLSv1.2_2021',
           SslSupportMethod: domain == 'code.org' ? 'vip' : 'sni-only'
         }
       )


### PR DESCRIPTION
This removes TLS 1.0. and 1.1 in CloudFormation Stacks for prod, adhocs and S3 frontends.

## Links
- jira ticket: [INF-1286](https://codedotorg.atlassian.net/browse/INF-1286)

## Testing story
Tested using Python scanner to find all CloudFront distros and ping them various TLS cipher suites.  See Jira ticket.

Manual tests on each:
1. Run a curl only accepting TLS 1.1 as a max, to see if it fails: ```curl --tls-max 1.0 -vvvv https://DOMAIN```
2. Run a test on TLS 1.2 to make sure it DOES still work: ```curl --tlsv1.2 -vvvv https://DOMAIN```

## Deployment strategy

1. Try rebuilding BugCrowd Target adhoc first
2. Push to prod and watch the CloudFormation templates update
3. Check the TLS versions allowed manually post deploy
4. Re-test code.org with SSL labs to make sure they also now see us as compliant.
