### PR TITLE
[JIMT]updated use reducer hook

### DIFF
--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -1,6 +1,7 @@
 import {
   CodebridgeContextProvider,
   projectReducer,
+  PROJECT_REDUCER_ACTIONS,
   useProjectUtilities,
 } from '@codebridge/codebridgeContext';
 import {FileBrowser} from '@codebridge/FileBrowser';
@@ -15,7 +16,7 @@ import {
   SetConfigFunction,
   OnRunFunction,
 } from '@codebridge/types';
-import React, {useReducer} from 'react';
+import React, {useEffect, useReducer, useRef} from 'react';
 
 import './styles/cdoIDE.scss';
 import {ProjectSources} from '@cdo/apps/lab2/types';
@@ -31,6 +32,7 @@ type CodebridgeProps = {
   startSource: ProjectSources;
   onRun?: OnRunFunction;
   onStop?: () => void;
+  projectVersion: number;
 };
 
 export const Codebridge = React.memo(
@@ -42,10 +44,12 @@ export const Codebridge = React.memo(
     startSource,
     onRun,
     onStop,
+    projectVersion,
   }: CodebridgeProps) => {
     const reducerWithCallback = useReducerWithCallback(
       projectReducer,
-      setProject
+      setProject,
+      new Set(PROJECT_REDUCER_ACTIONS.REPLACE_PROJECT)
     );
     const [internalProject, dispatch] = useReducer(
       reducerWithCallback,
@@ -53,6 +57,14 @@ export const Codebridge = React.memo(
     );
 
     const projectUtilities = useProjectUtilities(dispatch);
+
+    const currentProjectVersion = useRef(projectVersion);
+    useEffect(() => {
+      if (projectVersion !== currentProjectVersion.current) {
+        projectUtilities.replaceProject(project);
+        currentProjectVersion.current = projectVersion;
+      }
+    }, [currentProjectVersion, project, projectUtilities, projectVersion]);
 
     const ComponentMap = {
       'file-browser': FileBrowser,

--- a/apps/src/codebridge/codebridgeContext/index.ts
+++ b/apps/src/codebridge/codebridgeContext/index.ts
@@ -1,3 +1,4 @@
 export * from './codebridgeContext';
 export * from './codebridgeContextProjectReducer';
+export * from './constants';
 export * from './utils';

--- a/apps/src/codebridge/hooks/useSource.ts
+++ b/apps/src/codebridge/hooks/useSource.ts
@@ -1,4 +1,4 @@
-import {useMemo, useEffect, useCallback, useRef} from 'react';
+import {useEffect, useMemo, useRef} from 'react';
 
 import header from '@cdo/apps/code-studio/header';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
@@ -39,8 +39,9 @@ export const useSource = (defaultSources: ProjectSources) => {
   // keep track of whatever project the user has set locally. This happens after any change in CodeBridge
   // in the setSource function below
   const localProjectRef = useRef(source);
-  // keep track of the key to use for the <CodeBridge/> component in the UI
-  const codeBridgeKeyRef = useRef(0);
+  // keep an internal version number for the project used in the <Codebridge/> component.
+  // This lets us replace the project if it was swapped out externally.
+  const projectVersionRef = useRef(0);
   const levelId = useAppSelector(state => state.lab.levelProperties?.id);
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
 
@@ -62,7 +63,7 @@ export const useSource = (defaultSources: ProjectSources) => {
     [setSourceHelper]
   );
 
-  const getStartSource = useCallback(() => {
+  const startSource = useMemo(() => {
     // When resetting in start mode, we always use the level start source.
     return {
       source:
@@ -109,13 +110,13 @@ export const useSource = (defaultSources: ProjectSources) => {
   // from an external source (such as the version history button). In that case, we want to set our localProjectRef
   // to whatever that new source is AND increment our key. This'll ensure that the CodeBridge layout reflows and
   // the project is properly kept in sync.
-  const codeBridgeKey = useMemo(() => {
+  const projectVersion = useMemo(() => {
     if (source !== localProjectRef.current) {
       localProjectRef.current = source;
-      codeBridgeKeyRef.current++;
+      projectVersionRef.current++;
     }
-    return codeBridgeKeyRef.current;
+    return projectVersionRef.current;
   }, [source]);
 
-  return {source, setSource, getStartSource, codeBridgeKey};
+  return {source, setSource, startSource, projectVersion};
 };

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, {useState} from 'react';
+import React, {useCallback, useState} from 'react';
 
 import Alert from '@cdo/apps/componentLibrary/alert';
 import {Button} from '@cdo/apps/componentLibrary/button';
@@ -38,39 +38,44 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
   const [loadError, setLoadError] = useState(false);
 
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
-  const toggleVersionHistory = (
-    e: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLAnchorElement>
-  ) => {
-    setVersionList([]);
-    if (loading) {
-      return;
-    }
-    if (loadError) {
-      setLoadError(false);
-      return;
-    }
-    const projectManager = Lab2Registry.getInstance().getProjectManager();
-    if (!projectManager) {
-      setLoadError(true);
-      return;
-    }
-    if (!isVersionHistoryOpen) {
-      setLoading(true);
-      projectManager
-        .getVersionList()
-        .then(versionList => {
-          setIsVersionHistoryOpen(true);
-          setVersionList(versionList);
-          setLoading(false);
-        })
-        .catch(() => {
-          setLoadError(true);
-          setLoading(false);
-        });
-    } else {
-      setIsVersionHistoryOpen(false);
-    }
-  };
+  const toggleVersionHistory = useCallback(
+    (
+      e:
+        | React.MouseEvent<HTMLButtonElement>
+        | React.MouseEvent<HTMLAnchorElement>
+    ) => {
+      setVersionList([]);
+      if (loading) {
+        return;
+      }
+      if (loadError) {
+        setLoadError(false);
+        return;
+      }
+      const projectManager = Lab2Registry.getInstance().getProjectManager();
+      if (!projectManager) {
+        setLoadError(true);
+        return;
+      }
+      if (!isVersionHistoryOpen) {
+        setLoading(true);
+        projectManager
+          .getVersionList()
+          .then(versionList => {
+            setIsVersionHistoryOpen(true);
+            setVersionList(versionList);
+            setLoading(false);
+          })
+          .catch(() => {
+            setLoadError(true);
+            setLoading(false);
+          });
+      } else {
+        setIsVersionHistoryOpen(false);
+      }
+    },
+    [isVersionHistoryOpen, loadError, loading]
+  );
 
   return (
     <>
@@ -118,4 +123,4 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
   );
 };
 
-export default VersionHistoryButton;
+export default React.memo(VersionHistoryButton);

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -110,10 +110,13 @@ const VersionHistoryDropdown: React.FunctionComponent<
     return dateFormatter.format(dateObject);
   };
 
-  const onVersionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // TODO: preview this version
-    setSelectedVersion(e.target.value);
-  };
+  const onVersionChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      // TODO: preview this version
+      setSelectedVersion(e.target.value);
+    },
+    []
+  );
 
   return (
     <div>
@@ -180,4 +183,4 @@ const VersionHistoryDropdown: React.FunctionComponent<
   );
 };
 
-export default VersionHistoryDropdown;
+export default React.memo(VersionHistoryDropdown);

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryRow.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryRow.tsx
@@ -55,4 +55,4 @@ const VersionHistoryRow: React.FunctionComponent<VersionHistoryRowProps> = ({
   );
 };
 
-export default VersionHistoryRow;
+export default React.memo(VersionHistoryRow);

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -94,7 +94,7 @@ const defaultConfig: ConfigType = {
 
 const PythonlabView: React.FunctionComponent = () => {
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
-  const {source, setSource, getStartSource, codeBridgeKey} =
+  const {source, setSource, startSource, projectVersion} =
     useSource(defaultProject);
   const isPredictLevel = useAppSelector(
     state => state.lab.levelProperties?.predictSettings?.isPredictLevel
@@ -138,10 +138,10 @@ const PythonlabView: React.FunctionComponent = () => {
           config={config}
           setProject={setSource}
           setConfig={setConfig}
-          startSource={getStartSource()}
+          startSource={startSource}
           onRun={onRun}
           onStop={stopPythonCode}
-          key={codeBridgeKey}
+          projectVersion={projectVersion}
         />
       )}
     </div>

--- a/apps/src/weblab2/Weblab2View.tsx
+++ b/apps/src/weblab2/Weblab2View.tsx
@@ -152,7 +152,7 @@ const defaultProject: ProjectSources = {source: defaultSource};
 
 const Weblab2View = () => {
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
-  const {source, setSource, getStartSource, codeBridgeKey} =
+  const {source, setSource, startSource, projectVersion} =
     useSource(defaultProject);
   const [showConfig, setShowConfig] = useState<
     'project' | 'config' | 'layout' | ''
@@ -184,8 +184,8 @@ const Weblab2View = () => {
             config={config}
             setProject={setSource}
             setConfig={setConfig}
-            startSource={getStartSource()}
-            key={codeBridgeKey}
+            startSource={startSource}
+            projectVersion={projectVersion}
           />
         )}
 


### PR DESCRIPTION
Retooling of useReducerWithCallback so a new key isn't necessary so as to keep the VerisionHistoryButton open.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
