### PR TITLE
Adding disabled button state and tests for new Sign up 

### DIFF
--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -21,17 +21,24 @@ import {ACCOUNT_TYPE_SESSION_KEY} from './signUpFlowConstants';
 
 import style from './signUpFlowStyles.module.scss';
 
+const CHECK_ICON = 'circle-check';
+const X_ICON = 'circle-x';
+
 const LoginTypeSelection: React.FunctionComponent = () => {
   const [password, setPassword] = useState('');
+  const [passwordIcon, setPasswordIcon] = useState(X_ICON);
+  const [passwordIconClass, setPasswordIconClass] = useState(style.lightGray);
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [confirmPasswordIcon, setConfirmPasswordIcon] = useState('circle-x');
+  const [confirmPasswordIcon, setConfirmPasswordIcon] = useState(X_ICON);
   const [confirmPasswordIconClass, setConfirmPasswordIconClass] = useState(
     style.lightGray
   );
   const [email, setEmail] = useState('');
-  const [emailIcon, setEmailIcon] = useState('circle-x');
+  const [emailIcon, setEmailIcon] = useState(X_ICON);
   const [emailIconClass, setEmailIconClass] = useState(style.lightGray);
   const [authToken, setAuthToken] = useState('');
+  const [createAccountButtonDisabled, setCreateAccountButtonDisabled] =
+    useState(true);
 
   useEffect(() => {
     async function getToken() {
@@ -41,8 +48,34 @@ const LoginTypeSelection: React.FunctionComponent = () => {
     getToken();
   }, []);
 
+  useEffect(() => {
+    if (
+      passwordIcon === CHECK_ICON &&
+      confirmPasswordIcon === CHECK_ICON &&
+      emailIcon === CHECK_ICON
+    ) {
+      setCreateAccountButtonDisabled(false);
+    } else {
+      setCreateAccountButtonDisabled(true);
+    }
+  }, [passwordIcon, confirmPasswordIcon, emailIcon]);
+
   const handlePasswordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(event.target.value);
+    if (event.target.value.length >= 6) {
+      setPasswordIcon(CHECK_ICON);
+      setPasswordIconClass(style.teal);
+    } else {
+      setPasswordIcon(X_ICON);
+      setPasswordIconClass(style.lightGray);
+    }
+    if (event.target.value === confirmPassword) {
+      setConfirmPasswordIcon(CHECK_ICON);
+      setConfirmPasswordIconClass(style.teal);
+    } else {
+      setConfirmPasswordIcon(X_ICON);
+      setConfirmPasswordIconClass(style.lightGray);
+    }
   };
 
   const handleConfirmPasswordChange = (
@@ -50,10 +83,10 @@ const LoginTypeSelection: React.FunctionComponent = () => {
   ) => {
     setConfirmPassword(event.target.value);
     if (event.target.value === password) {
-      setConfirmPasswordIcon('circle-check');
+      setConfirmPasswordIcon(CHECK_ICON);
       setConfirmPasswordIconClass(style.teal);
     } else {
-      setConfirmPasswordIcon('circle-x');
+      setConfirmPasswordIcon(X_ICON);
       setConfirmPasswordIconClass(style.lightGray);
     }
   };
@@ -61,10 +94,10 @@ const LoginTypeSelection: React.FunctionComponent = () => {
   const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(event.target.value);
     if (isEmail(event.target.value)) {
-      setEmailIcon('circle-check');
+      setEmailIcon(CHECK_ICON);
       setEmailIconClass(style.teal);
     } else {
-      setEmailIcon('circle-x');
+      setEmailIcon(X_ICON);
       setEmailIconClass(style.lightGray);
     }
   };
@@ -73,8 +106,6 @@ const LoginTypeSelection: React.FunctionComponent = () => {
     sessionStorage.getItem(ACCOUNT_TYPE_SESSION_KEY) === 'teacher'
       ? studio('/users/new_sign_up/finish_teacher_account')
       : studio('/users/new_sign_up/finish_student_account');
-  const passwordIcon = password.length >= 6 ? 'circle-check' : 'circle-x';
-  const passwordIconClass = password.length >= 6 ? style.teal : style.lightGray;
 
   return (
     <div className={style.newSignupFlow}>
@@ -205,6 +236,7 @@ const LoginTypeSelection: React.FunctionComponent = () => {
           <Button
             className={style.shortButton}
             text={locale.create_my_account()}
+            disabled={createAccountButtonDisabled}
             onClick={() => navigateToHref(finishAccountUrl)}
           />
         </div>

--- a/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
+++ b/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
@@ -1,5 +1,6 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import React from 'react';
+import '@testing-library/jest-dom';
 
 import locale from '@cdo/apps/signUpFlow/locale';
 import LoginTypeSelection from '@cdo/apps/signUpFlow/LoginTypeSelection';
@@ -40,6 +41,32 @@ describe('LoginTypeSelection', () => {
 
     // Renders button that sends the user to the Finish Account page
     screen.getByRole('button', {name: locale.create_my_account()});
+  });
+
+  it('enables the confirm button only when all inputs are valid', () => {
+    renderDefault();
+
+    const emailInput = screen.getByLabelText(locale.email_address());
+    const passwordInput = screen.getByLabelText(locale.password());
+    const confirmPasswordInput = screen.getByLabelText(
+      locale.confirm_password()
+    );
+
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.create_my_account(),
+    }) as HTMLButtonElement;
+
+    expect(finishSignUpButton).toBeDisabled();
+
+    // Verify that the button is only enabled when all fields are valid
+    fireEvent.change(emailInput, {target: {value: 'myrandomemail@gmail.com'}});
+    expect(finishSignUpButton).toBeDisabled();
+
+    fireEvent.change(passwordInput, {target: {value: 'password'}});
+    expect(finishSignUpButton).toBeDisabled();
+
+    fireEvent.change(confirmPasswordInput, {target: {value: 'password'}});
+    expect(finishSignUpButton).not.toBeDisabled();
   });
 
   it('if user selected student then finish sign up button sends user to finish student page', () => {


### PR DESCRIPTION
This PR does a couple things:

1. Refactors the way we keep track of passwords a bit to be consistent with the state of the other inputs
2. Adds the extra check on the passwordUpdate function to make sure the 'password is the same' validation updates if the *first password changes to cause a mismatch (not just the second one)
3. Uses a constant for the icon string values so that if we ever want to update the icon, we only need to do it in one place
4. Adds a new state value to keep track of whether the create account button is enabled based on all three inputs being valid
5. Adds a comprehensive test to ensure that button is only enabled when all three fields are valid

How it looks in action:

https://github.com/user-attachments/assets/1d1d8271-453d-4067-97ba-d1ecc2dd4666

The ticket below isn't quite right, but after this PR all of these will be covered

## Links

- spec: https://www.figma.com/design/88sbry7xnl1wcyrOgbgFtn/Sign-Up-Flow?node-id=2911-1878&node-type=CANVAS&t=ECEAfDD9n8YkBUtC-0
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2339


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
