### PR TITLE
Use locale to determine redirect version

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -210,6 +210,7 @@ class CoursesController < ApplicationController
     # are assigned.
     redirect_unit_group = UnitGroup.latest_assigned_version(unit_group.family_name, current_user)
     redirect_unit_group ||= UnitGroup.latest_stable_version(unit_group.family_name, locale: request.locale)
+    redirect_unit_group ||= UnitGroup.latest_stable_version(unit_group.family_name)
 
     # Do not redirect if we are already on the correct unit_group.
     return nil if redirect_unit_group == unit_group

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -153,7 +153,7 @@ class CoursesController < ApplicationController
 
     # When the url of a course family is requested, redirect to a specific course version.
     if UnitGroup.family_names.include?(params[:course_name])
-      unit_group = UnitGroup.latest_stable_version(params[:course_name])
+      unit_group = UnitGroup.latest_stable_version(params[:course_name], locale: request.locale)
       if unit_group
         redirect_path = url_for(action: params[:action], course_name: unit_group.name)
         redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -153,7 +153,11 @@ class CoursesController < ApplicationController
 
     # When the url of a course family is requested, redirect to a specific course version.
     if UnitGroup.family_names.include?(params[:course_name])
-      unit_group = UnitGroup.latest_stable_version(params[:course_name], locale: request.locale)
+      # Look for latest version in the user's locale, fall back to latest version
+      # in English if no translated version exists.
+      unit_group =
+        UnitGroup.latest_stable_version(params[:course_name], locale: request.locale) ||
+        UnitGroup.latest_stable_version(params[:course_name])
       if unit_group
         redirect_path = url_for(action: params[:action], course_name: unit_group.name)
         redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -200,12 +200,12 @@ class CoursesController < ApplicationController
 
   private def redirect_unit_group(unit_group)
     # Return nil if unit_group is nil or we know the user can view the version requested.
-    return nil if !unit_group || unit_group.can_view_version?(current_user)
+    return nil if !unit_group || unit_group.can_view_version?(current_user, request.locale)
 
     # Redirect the user to the latest assigned unit_group in this family, or to the latest unit_group in this family if none
     # are assigned.
     redirect_unit_group = UnitGroup.latest_assigned_version(unit_group.family_name, current_user)
-    redirect_unit_group ||= UnitGroup.latest_stable_version(unit_group.family_name)
+    redirect_unit_group ||= UnitGroup.latest_stable_version(unit_group.family_name, locale: request.locale)
 
     # Do not redirect if we are already on the correct unit_group.
     return nil if redirect_unit_group == unit_group

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -497,12 +497,9 @@ class UnitGroup < ApplicationRecord
     if locale_str&.start_with?('en')
       stable_course_versions.first
     else
-      localized_version = stable_course_versions.find do |cv|
+      stable_course_versions.find do |cv|
         cv.default_unit_group_units.all? {|unit_group_unit| unit_group_unit.script.supported_locales&.include?(locale_str)}
       end
-      # Return latest English version if no version has been translated to the
-      # requested language
-      localized_version || stable_course_versions.first 
     end
   end
 

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -461,18 +461,16 @@ class UnitGroup < ApplicationRecord
   end
 
   # @param user [User]
+  # @param locale_code [String] Locale code for user or request. Optional.
   # @return [Boolean] Whether the user can view the course.
-  #
-  # locale_code is added so that it matches the signature of `unit.can_view_version?`.
-  # This is necessary because course_version.content_root is either a unit or a unit_group
-  # and script.summarize_for_unit_edit calls `can_view_version?` on the content_root with two arguments.
   def can_view_version?(user = nil, locale_code = 'en-us')
     return false unless Ability.new(user).can?(:read, self)
 
-    latest_course_version = UnitGroup.latest_stable_version(family_name, locale: locale_code)
-    is_latest = latest_course_version == self
+    latest_course_version = UnitGroup.latest_stable_version(family_name)
+    latest_in_locale = UnitGroup.latest_stable_version(family_name, locale: locale_code)
+    is_latest = latest_course_version == self || latest_in_locale == self
 
-    # All users can see the latest course version.
+    # All users can see the latest course version in English and in their locale.
     return true if is_latest
 
     # Restrictions only apply to participants and logged out users.

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -497,9 +497,12 @@ class UnitGroup < ApplicationRecord
     if locale_str&.start_with?('en')
       stable_course_versions.first
     else
-      stable_course_versions.find do |cv|
+      localized_version = stable_course_versions.find do |cv|
         cv.default_unit_group_units.all? {|unit_group_unit| unit_group_unit.script.supported_locales&.include?(locale_str)}
       end
+      # Return latest English version if no version has been translated to the
+      # requested language
+      localized_version || stable_course_versions.first 
     end
   end
 

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -469,7 +469,7 @@ class UnitGroup < ApplicationRecord
   def can_view_version?(user = nil, locale_code = 'en-us')
     return false unless Ability.new(user).can?(:read, self)
 
-    latest_course_version = UnitGroup.latest_stable_version(family_name)
+    latest_course_version = UnitGroup.latest_stable_version(family_name, locale: locale_code)
     is_latest = latest_course_version == self
 
     # All users can see the latest course version.

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -232,6 +232,45 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to '/courses/csp-2018/?redirect_warning=true'
   end
 
+  test "show: redirect to latest stable version in course family and language for student" do
+    csp_2017 = create :unit_group, name: 'csp-2017', family_name: 'csp', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    csp1_2017 = create(:script, name: 'csp1-2017', supported_locales: ['en-US', 'es-MX'])
+    create :unit_group_unit, unit_group: csp_2017, script: csp1_2017, position: 1
+    csp_2018 = create :unit_group, name: 'csp-2018', family_name: 'csp', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    csp1_2018 = create(:script, name: 'csp1-2018', supported_locales: ['en-US'])
+    create :unit_group_unit, unit_group: csp_2018, script: csp1_2018, position: 1
+    csp_2019 = create :unit_group, name: 'csp-2019', family_name: 'csp', version_year: '2019', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta
+
+    offering = create :course_offering, key: 'csp'
+    create :course_version, course_offering: offering, content_root: csp_2017, key: '2017'
+    create :course_version, course_offering: offering, content_root: csp_2018, key: '2018'
+    create :course_version, course_offering: offering, content_root: csp_2019, key: '2019'
+
+
+    sign_in create(:student)
+    with_default_locale('es-MX') do
+      get :show, params: {course_name: 'csp'}
+      assert_redirected_to '/courses/csp-2017'
+
+      get :show, params: {course_name: 'csp-2017'}
+      assert_response :ok
+
+      get :show, params: {course_name: 'csp-2019'}
+      assert_redirected_to '/courses/csp-2017/?redirect_warning=true'
+    end
+
+    with_default_locale('fi-FI') do
+      get :show, params: {course_name: 'csp'}
+      assert_redirected_to '/courses/csp-2018'
+
+      get :show, params: {course_name: 'csp-2017'}
+      assert_redirected_to '/courses/csp-2018/?redirect_warning=true'
+
+      get :show, params: {course_name: 'csp-2019'}
+      assert_redirected_to '/courses/csp-2018/?redirect_warning=true'
+    end
+  end
+
   test "show: redirect to latest stable version in course family for participant" do
     create :unit_group, name: 'pl-csp-2017', family_name: 'pl-csp', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher
     create :unit_group, name: 'pl-csp-2018', family_name: 'pl-csp', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -246,7 +246,6 @@ class CoursesControllerTest < ActionController::TestCase
     create :course_version, course_offering: offering, content_root: csp_2018, key: '2018'
     create :course_version, course_offering: offering, content_root: csp_2019, key: '2019'
 
-
     sign_in create(:student)
     with_default_locale('es-MX') do
       get :show, params: {course_name: 'csp'}

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -898,9 +898,11 @@ class UnitGroupTest < ActiveSupport::TestCase
       @plc_reviewer = create :plc_reviewer
 
       @csp_2017 = create(:unit_group, name: 'csp-2017', family_name: 'csp', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
-      @csp1_2017 = create(:script, name: 'csp1-2017')
+      @csp1_2017 = create(:script, name: 'csp1-2017', supported_locales: ['en-US', 'es-MX'])
       create :unit_group_unit, unit_group: @csp_2017, script: @csp1_2017, position: 1
       @csp_2018 = create(:unit_group, name: 'csp-2018', family_name: 'csp', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
+      @csp1_2018 = create(:script, name: 'csp1-2018', supported_locales: ['en-US'])
+      create :unit_group_unit, unit_group: @csp_2018, script: @csp1_2018, position: 1
       create(:unit_group, name: 'csp-2019', family_name: 'csp', version_year: '2019')
 
       @pl_csp_2017 = create(:unit_group, name: 'pl-csp-2017', family_name: 'pl-csp', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator)
@@ -938,6 +940,12 @@ class UnitGroupTest < ActiveSupport::TestCase
     test 'student can view version if it is the latest version in course family and participant audience is student' do
       assert @csp_2018.can_view_version?(@student)
       refute @csp_2017.can_view_version?(@student)
+    end
+
+    test 'student can view version if it is the latest version in course family in their language and participant audience is student' do
+      assert @csp_2017.can_view_version?(@student, 'es-MX')
+      refute @csp_2017.can_view_version?(@student, 'fr-FR')
+      refute @csp_2017.can_view_version?(@student, 'en-US')
     end
 
     test 'student can not view version if not participant audience' do


### PR DESCRIPTION
Links such as https://studio.code.org/courses/csd were redirecting to the current year's English version of the curriculum, even for students who are using Code.org in a non-English language. Attempts to navigate directly to the most recent translated year would fail and redirect to the current year's English-language curriculum.

This change modifies the redirect logic to go to the latest version of the curriculum that is in their language except for when they name the current year's curriculum in the URL explicitly. We have [existing logic for units](https://github.com/code-dot-org/code-dot-org/blob/458bf68a06b96f5cc561019e5b9544cfe75eab67/dashboard/app/models/unit.rb#L699) that allows any user to see the latest English-language version even if they're browsing in a different language. I mirrored that logic for unit groups in this PR.

### New behavior (for signed-out user):
If browsing in English or a language where no version of the curriculum is translated (i.e. Finnish):
* `/courses/csd` redirects to 2024-2025 version in English
* `/courses/csd-2023` redirects to 2024-2025 version in English
* `/courses/csd-2024` loads 2024-2025 version in English

If browsing in Latin American Spanish:
* `/courses/csd` redirects to 2021-2022 version in Spanish
* `/courses/csd-2023` redirects to 2021-2022 version in Spanish
* `/courses/csd-2024` loads 2024-2025 version in English

## Links

* [JIRA](https://codedotorg.atlassian.net/browse/AITT-763)
* [Original Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1718749887800329?thread_ts=1718749887.800329&cid=C045UAX4WKH)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Added tests for the new redirect behavior and change to `UnitGroup.can_view_version?`
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
