### PR TITLE
[Google Blockly] Allow '???' in number fields

### DIFF
--- a/apps/src/blockly/addons/cdoFieldNumber.ts
+++ b/apps/src/blockly/addons/cdoFieldNumber.ts
@@ -3,6 +3,7 @@ import GoogleBlockly, {
   FieldNumberValidator,
 } from 'blockly/core';
 
+import {EMPTY_OPTION} from '../constants';
 import {
   ExtendedBlockSvg,
   ExtendedConnection,
@@ -165,5 +166,21 @@ export default class CdoFieldNumber extends GoogleBlockly.FieldNumber {
   doValueUpdate_(newValue: number) {
     super.doValueUpdate_(newValue);
     this.angleHelper?.animateAngleChange(newValue);
+  }
+
+  /**
+   * Ensure that the input value is a valid number (must fulfill the
+   * constraints placed on the field).
+   *
+   * @param newValue The input value.
+   * @returns A valid number, our special case '???' value, or null if invalid
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected override doClassValidation_(newValue: any): number | null {
+    if (newValue === EMPTY_OPTION) {
+      return newValue; // Return the original value if it's our special case "???"
+    }
+
+    return super.doClassValidation_(newValue);
   }
 }


### PR DESCRIPTION
In certain older levels, we use a default `???` value in number blocks:

<img width="474" alt="image" src="https://github.com/user-attachments/assets/036c8815-220a-4c98-b73d-501a1f3ed9c0">

The validation in Blockly Core's number fields do not allow this as any invalid values are converted to 0:

<img width="463" alt="image" src="https://github.com/user-attachments/assets/ddb473db-d72f-48ef-a8a9-3eea636c0e62">

By overriding `doClassValidation_` we can add a special case to continue to allow `???`. 

<img width="468" alt="image" src="https://github.com/user-attachments/assets/a8c8cdca-1dc5-480b-bc02-647a7dc8abb3">

In this case, the student code can still be run, even before replacing these values (although it won't solve the puzzle). And we can already detect that the values are there and provide appropriate feedback:

<img width="991" alt="image" src="https://github.com/user-attachments/assets/3b554d26-5942-43b9-9eb5-e33b60baa4ca">

We have already made similar changes to support `???` in our dropdown fields:

https://github.com/code-dot-org/code-dot-org/blob/mike/question-numbers/apps/src/blockly/addons/cdoFieldDropdown.ts#L43


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
