### PR TITLE
Ceara/aitt 745 preset prompt text backend

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -85,38 +85,18 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
     };
 
     setMessageHistory(prevMessages => [...prevMessages, newUserMessage]);
-    setIsWaitingForResponse(true);
-
-    const body = JSON.stringify({
-      inputText: message,
-      lessonId: lessonId,
-      unitDisplayName: unitDisplayName,
-      sessionId: sessionId,
-    });
-    HttpClient.post(`${aiDiffChatMessageEndpoint}`, body, true, {
-      'Content-Type': 'application/json',
-    })
-      .then(response => response.json())
-      .then(json => {
-        const newAiMessage = {
-          role: Role.ASSISTANT,
-          chatMessageText: json.chat_message_text,
-          status: json.status,
-        };
-        setSessionId(json.session_id);
-        setMessageHistory(prevMessages => [...prevMessages, newAiMessage]);
-      })
-      .catch(error => console.log(error))
-      .finally(() => {
-        setIsWaitingForResponse(false);
-      });
+    getAIResponse(message);
   };
 
   const onPromptSelect = (prompt: ChatPrompt) => {
+    getAIResponse(prompt.prompt);
+  };
+
+  const getAIResponse = (prompt: string) => {
     setIsWaitingForResponse(true);
 
     const body = JSON.stringify({
-      inputText: prompt.prompt,
+      inputText: prompt,
       lessonId: lessonId,
       unitDisplayName: unitDisplayName,
       sessionId: sessionId,

--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -12,7 +12,7 @@ import HttpClient from '../util/HttpClient';
 
 import AiDiffChatFooter from './AiDiffChatFooter';
 import AiDiffSuggestedPrompts from './AiDiffSuggestedPrompts';
-import {ChatItem} from './types';
+import {ChatItem, ChatPrompt} from './types';
 
 import style from './ai-differentiation.module.scss';
 
@@ -48,10 +48,27 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
       status: Status.OK,
     },
     [
-      'Explain a concept',
-      'Give an example to use with my class',
-      'Write an extension activity for students who finish early',
-      'Write an extension activity for students who need extra practice',
+      {
+        label: 'Explain a concept',
+        prompt:
+          'I need an explanation of a concept. You can ask me a follow-up question to find out what concept needs to be explained.',
+      },
+      {
+        label: 'Give an example to use with my class',
+        prompt:
+          'Can I have an example to use with my class? You can ask me a follow-up question to get more details for the kind of example needed.',
+      },
+      {
+        label: 'Write an extension activity for students who finish early',
+        prompt:
+          'Write an extension activity for this lesson for students who finish early',
+      },
+      {
+        label:
+          'Write an extension activity for students who need extra practice',
+        prompt:
+          'Write an extension activity for this lesson for students who need extra practice',
+      },
     ],
   ]);
 
@@ -95,10 +112,10 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
       });
   };
 
-  const onPromptSelect = (prompt: string) => {
+  const onPromptSelect = (prompt: ChatPrompt) => {
     const newAiMessage = {
       role: Role.ASSISTANT,
-      chatMessageText: `You selected "${prompt}". This is a placeholder response.`,
+      chatMessageText: `You selected "${prompt.label}" with prompt "${prompt.prompt}". This is a placeholder response.`,
       status: Status.OK,
     };
 

--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -113,13 +113,31 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
   };
 
   const onPromptSelect = (prompt: ChatPrompt) => {
-    const newAiMessage = {
-      role: Role.ASSISTANT,
-      chatMessageText: `You selected "${prompt.label}" with prompt "${prompt.prompt}". This is a placeholder response.`,
-      status: Status.OK,
-    };
+    setIsWaitingForResponse(true);
 
-    setMessageHistory([...messageHistory, newAiMessage]);
+    const body = JSON.stringify({
+      inputText: prompt.prompt,
+      lessonId: lessonId,
+      unitDisplayName: unitDisplayName,
+      sessionId: sessionId,
+    });
+    HttpClient.post(`${aiDiffChatMessageEndpoint}`, body, true, {
+      'Content-Type': 'application/json',
+    })
+      .then(response => response.json())
+      .then(json => {
+        const newAiMessage = {
+          role: Role.ASSISTANT,
+          chatMessageText: json.chat_message_text,
+          status: json.status,
+        };
+        setSessionId(json.session_id);
+        setMessageHistory(prevMessages => [...prevMessages, newAiMessage]);
+      })
+      .catch(error => console.log(error))
+      .finally(() => {
+        setIsWaitingForResponse(false);
+      });
   };
 
   return (

--- a/apps/src/aiDifferentiation/AiDiffSuggestedPrompts.tsx
+++ b/apps/src/aiDifferentiation/AiDiffSuggestedPrompts.tsx
@@ -2,10 +2,12 @@ import React, {useState} from 'react';
 
 import SuggestedPrompts from '@cdo/apps/aiComponentLibrary/suggestedPrompt/SuggestedPrompts';
 
+import {ChatPrompt} from './types';
+
 interface ComponentProps {
-  suggestedPrompts: string[];
+  suggestedPrompts: ChatPrompt[];
   isLatest: boolean;
-  onSubmit: (selectedPrompt: string) => void;
+  onSubmit: (selectedPrompt: ChatPrompt) => void;
 }
 
 const AiDiffSuggestedPrompts: React.FC<ComponentProps> = ({
@@ -13,9 +15,9 @@ const AiDiffSuggestedPrompts: React.FC<ComponentProps> = ({
   isLatest,
   onSubmit,
 }) => {
-  const [selectedPrompt, setSelectedPrompt] = useState<string>('');
+  const [selectedPrompt, setSelectedPrompt] = useState<ChatPrompt>();
 
-  const onClick = (prompt: string) => () => {
+  const onClick = (prompt: ChatPrompt) => () => {
     // The first prompt selected is final.
     // Can't select a prompt after something else has happened.
     if (selectedPrompt || !isLatest) {
@@ -28,7 +30,7 @@ const AiDiffSuggestedPrompts: React.FC<ComponentProps> = ({
 
   const structuredPrompts = suggestedPrompts.map(prompt => {
     return {
-      label: prompt,
+      label: prompt.label,
       selected: prompt === selectedPrompt,
       onClick: onClick(prompt),
       show: true,

--- a/apps/src/aiDifferentiation/types.ts
+++ b/apps/src/aiDifferentiation/types.ts
@@ -6,4 +6,9 @@ export type ChatTextMessage = {
   status: string;
 };
 
-export type ChatItem = ChatTextMessage | string[];
+export type ChatPrompt = {
+  label: string;
+  prompt: string;
+};
+
+export type ChatItem = ChatTextMessage | ChatPrompt[];


### PR DESCRIPTION
This sends the preset prompt content to the backend to generate AI responses for selecting a preset prompt. It also modifies the type for the suggested prompts to allow the label for the choice chips to differ from the text that is sent to the backend for generation. 

This PR has my commits cherry-picked from the draft PR here: https://github.com/code-dot-org/code-dot-org/pull/60878

AI response to a preset prompt:

![Screenshot 2024-09-05 at 2 55 33 PM](https://github.com/user-attachments/assets/ca3258bd-5ff2-4073-a613-c85718f60ebe)

## Links

Jira:
https://codedotorg.atlassian.net/browse/AITT-745 

## Testing story

No tests added

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
