### PR TITLE
Sort pilot participants

### DIFF
--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -100,7 +100,7 @@ class AdminSearchController < ApplicationController
     @pilot_name = params[:pilot_name]
     return head :bad_request unless Pilot.exists?(name: @pilot_name)
     user_ids = SingleUserExperiment.where(name: @pilot_name).map(&:min_user_id)
-    @emails = User.where(id: user_ids).pluck(:email)
+    @emails = User.where(id: user_ids).pluck(:email).sort
     @join_url = Pilot.find_by(name: @pilot_name).allow_joining_via_url ? "http://studio.code.org/experiments/set_single_user_experiment/#{@pilot_name}" : nil
   end
 


### PR DESCRIPTION
Small quality of life improvement for managing pilots. The list of emails for enrolled participants is now alphabetized making it easier to scan to see if someone is enrolled or not. 

BEFORE 
<img width="1247" alt="unsorted" src="https://github.com/user-attachments/assets/2e0b28af-5e56-4b2f-ae7f-3cbe68bade52">

AFTER 
<img width="1132" alt="abc" src="https://github.com/user-attachments/assets/560910ad-dc72-44bf-932f-afc68f32de7a">
