### PR TITLE
Only show state question for U.S. students in new sign-up flow

### DIFF
--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -26,8 +26,9 @@ import style from './signUpFlowStyles.module.scss';
 
 const FinishStudentAccount: React.FunctionComponent<{
   ageOptions: {value: string; text: string}[];
+  usIp: boolean;
   usStateOptions: {value: string; text: string}[];
-}> = ({ageOptions, usStateOptions}) => {
+}> = ({ageOptions, usIp, usStateOptions}) => {
   // Fields
   const [isParent, setIsParent] = useState(false);
   const [parentEmail, setParentEmail] = useState('');
@@ -190,21 +191,23 @@ const FinishStudentAccount: React.FunctionComponent<{
             </BodyThreeText>
           )}
         </div>
-        <div>
-          <SimpleDropdown
-            name="userState"
-            labelText={locale.what_state_are_you_in()}
-            size="m"
-            items={usStateOptions}
-            selectedValue={state}
-            onChange={onStateChange}
-          />
-          {showStateError && (
-            <BodyThreeText className={style.errorMessage}>
-              {locale.state_error_message()}
-            </BodyThreeText>
-          )}
-        </div>
+        {usIp && (
+          <div>
+            <SimpleDropdown
+              name="userState"
+              labelText={locale.what_state_are_you_in()}
+              size="m"
+              items={usStateOptions}
+              selectedValue={state}
+              onChange={onStateChange}
+            />
+            {showStateError && (
+              <BodyThreeText className={style.errorMessage}>
+                {locale.state_error_message()}
+              </BodyThreeText>
+            )}
+          </div>
+        )}
         <TextField
           name="userGender"
           label={locale.what_is_your_gender()}
@@ -228,7 +231,7 @@ const FinishStudentAccount: React.FunctionComponent<{
           disabled={
             name === '' ||
             age === '' ||
-            state === '' ||
+            (usIp && state === '') ||
             (isParent && parentEmail === '')
           }
         />

--- a/apps/src/sites/studio/pages/devise/registrations/finish_student_account.js
+++ b/apps/src/sites/studio/pages/devise/registrations/finish_student_account.js
@@ -7,11 +7,13 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 
 $(document).ready(() => {
   const ageOptions = getScriptData('ageOptions');
+  const usIp = getScriptData('usIp');
   const usStateOptions = getScriptData('usStateOptions');
 
   ReactDOM.render(
     <FinishStudentAccount
       ageOptions={ageOptions}
+      usIp={usIp}
       usStateOptions={usStateOptions}
     />,
     document.getElementById('finish-student-account-root')

--- a/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
@@ -42,10 +42,11 @@ describe('FinishStudentAccount', () => {
     });
   });
 
-  function renderDefault() {
+  function renderDefault(usIp: boolean = true) {
     render(
       <FinishStudentAccount
         ageOptions={ageOptions}
+        usIp={usIp}
         usStateOptions={usStateOptions}
       />
     );
@@ -94,6 +95,13 @@ describe('FinishStudentAccount', () => {
 
     // Renders button that finishes sign-up
     screen.getByText(locale.go_to_my_account());
+  });
+
+  it('does not render state question if user is not detected in the U.S.', () => {
+    renderDefault(false);
+
+    expect(screen.queryByText(locale.what_state_are_you_in())).toBe(null);
+    expect(screen.queryByText(locale.state_error_message())).toBe(null);
   });
 
   it('userName is tracked in sessionStorage', () => {

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -84,6 +84,10 @@ class RegistrationsController < Devise::RegistrationsController
       {value: age.to_s, text: age.to_s}
     end
 
+    # Get the request location
+    location = Geocoder.search(request.ip).try(:first)
+    country_code = location&.country_code.to_s.upcase
+    @us_ip = ['US', 'RD'].include?(country_code)
     @us_state_options = [{value: '', text: ''}] + User.us_state_dropdown_options.map do |code, name|
       {value: code, text: name}
     end

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -84,10 +84,7 @@ class RegistrationsController < Devise::RegistrationsController
       {value: age.to_s, text: age.to_s}
     end
 
-    # Get the request location
-    location = Geocoder.search(request.ip).try(:first)
-    country_code = location&.country_code.to_s.upcase
-    @us_ip = ['US', 'RD'].include?(country_code)
+    @us_ip = us_ip?
     @us_state_options = [{value: '', text: ''}] + User.us_state_dropdown_options.map do |code, name|
       {value: code, text: name}
     end
@@ -99,10 +96,7 @@ class RegistrationsController < Devise::RegistrationsController
   # Get /users/new_sign_up/finish_teacher_account
   #
   def finish_teacher_account
-    # Get the request location
-    location = Geocoder.search(request.ip).try(:first)
-    country_code = location&.country_code.to_s.upcase
-    @us_ip = ['US', 'RD'].include?(country_code)
+    @us_ip = us_ip?
     render 'finish_teacher_account'
   end
 
@@ -671,5 +665,12 @@ class RegistrationsController < Devise::RegistrationsController
     User.ignore_deleted_at_index.destroy(user_ids_to_destroy)
 
     log_account_deletion_to_firehose(current_user, dependent_users)
+  end
+
+  private def us_ip?
+    # Get the request location
+    location = Geocoder.search(request.ip).try(:first)
+    country_code = location&.country_code.to_s.upcase
+    ['US', 'RD'].include?(country_code)
   end
 end

--- a/dashboard/app/views/devise/registrations/finish_student_account.haml
+++ b/dashboard/app/views/devise/registrations/finish_student_account.haml
@@ -1,5 +1,5 @@
 = render 'devise/registrations/new_sign_up_locale'
 
-%script{src: webpack_asset_path('js/devise/registrations/finish_student_account.js'), data: {ageOptions: @age_options.to_json, usStateOptions: @us_state_options.to_json}}
+%script{src: webpack_asset_path('js/devise/registrations/finish_student_account.js'), data: {ageOptions: @age_options.to_json, usIp: @us_ip.to_json, usStateOptions: @us_state_options.to_json}}
 
 #finish-student-account-root


### PR DESCRIPTION
Currently the state question is shown to students in the new sign-up flow regardless of their location. With this PR, it will only show when the student is detected in the U.S.

### Currently shows regardless
![oldShowsStateRegardless](https://github.com/user-attachments/assets/072c1778-86c0-4969-97a4-3fd0647fac9c)

### Now does not show if not in the U.S.
![nonUs](https://github.com/user-attachments/assets/3177a27d-75a1-4431-97e0-f3458733f04c)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2362)

## Testing story
Local testing and added a unit test.
