### PR TITLE
New Sign Up flow login type will submit on enter if button enabled

### DIFF
--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -1,3 +1,4 @@
+import {screen} from '@testing-library/react';
 import React, {useState, useEffect} from 'react';
 
 import {Button} from '@cdo/apps/componentLibrary/button';
@@ -59,6 +60,24 @@ const LoginTypeSelection: React.FunctionComponent = () => {
       setCreateAccountButtonDisabled(true);
     }
   }, [passwordIcon, confirmPasswordIcon, emailIcon]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        const button = screen.getByRole('button', {
+          name: locale.create_my_account(),
+        }) as HTMLButtonElement;
+        if (button && !button.disabled) {
+          button.click();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
 
   const handlePasswordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(event.target.value);

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -1,4 +1,3 @@
-import {screen} from '@testing-library/react';
 import React, {useState, useEffect} from 'react';
 
 import {Button} from '@cdo/apps/componentLibrary/button';
@@ -64,9 +63,9 @@ const LoginTypeSelection: React.FunctionComponent = () => {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Enter') {
-        const button = screen.getByRole('button', {
-          name: locale.create_my_account(),
-        }) as HTMLButtonElement;
+        const button = document.getElementById(
+          'createAccountButton'
+        ) as HTMLButtonElement;
         if (button && !button.disabled) {
           button.click();
         }
@@ -253,6 +252,7 @@ const LoginTypeSelection: React.FunctionComponent = () => {
             </div>
           </div>
           <Button
+            id="createAccountButton"
             className={style.shortButton}
             text={locale.create_my_account()}
             disabled={createAccountButtonDisabled}

--- a/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
+++ b/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
@@ -69,6 +69,42 @@ describe('LoginTypeSelection', () => {
     expect(finishSignUpButton).not.toBeDisabled();
   });
 
+  it('clicks the create account button when Enter is pressed if the button is enabled', () => {
+    renderDefault();
+
+    const emailInput = screen.getByLabelText(locale.email_address());
+    const passwordInput = screen.getByLabelText(locale.password());
+    const confirmPasswordInput = screen.getByLabelText(
+      locale.confirm_password()
+    );
+
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.create_my_account(),
+    }) as HTMLButtonElement;
+
+    // Mock the click handler
+    const handleClick = jest.fn();
+    finishSignUpButton.onclick = handleClick;
+
+    // Simulate pressing Enter when button is not enabled
+    fireEvent.keyDown(document, {key: 'Enter', code: 'Enter', charCode: 13});
+
+    // Verify the button's click handler was never called
+    expect(handleClick).not.toHaveBeenCalled();
+
+    // Ensure the button is enabled
+    fireEvent.change(emailInput, {target: {value: 'myrandomemail@gmail.com'}});
+    fireEvent.change(passwordInput, {target: {value: 'password'}});
+    fireEvent.change(confirmPasswordInput, {target: {value: 'password'}});
+    expect(finishSignUpButton).not.toBeDisabled();
+
+    // Simulate pressing Enter
+    fireEvent.keyDown(document, {key: 'Enter', code: 'Enter', charCode: 13});
+
+    // Verify the button's click handler was called
+    expect(handleClick).toHaveBeenCalled();
+  });
+
   it('if user selected student then finish sign up button sends user to finish student page', () => {
     sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, 'student');
     renderDefault();


### PR DESCRIPTION
This adds a new event listener so that if a user presses enter when all three email/pass fields are valid, the button will click. 

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2344

## Testing story

Tested locally, and also added a test event to verify that enter while the button is disabled doesn't work, but that it will work if the button is enabled.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
