### PR TITLE
remove ai-rubrics experiment

### DIFF
--- a/apps/src/p5lab/gamelab/GameLab.js
+++ b/apps/src/p5lab/gamelab/GameLab.js
@@ -73,7 +73,10 @@ export default class GameLab extends P5Lab {
   }
 
   runButtonClick() {
-    if (hasScriptData('script[data-rubricdata]')) {
+    if (
+      getStore().getState().verifiedInstructor.isVerified &&
+      hasScriptData('script[data-rubricdata]')
+    ) {
       const rubricData = getScriptData('rubricdata');
       const teacherId = getStore().getState().currentUser.userId;
       const {rubric, studentLevelInfo} = rubricData;

--- a/apps/src/p5lab/gamelab/GameLab.js
+++ b/apps/src/p5lab/gamelab/GameLab.js
@@ -73,10 +73,13 @@ export default class GameLab extends P5Lab {
   }
 
   runButtonClick() {
-    if (
-      getStore().getState().verifiedInstructor.isVerified &&
-      hasScriptData('script[data-rubricdata]')
-    ) {
+    let verified;
+    if (getStore().getState().verifiedInstructor) {
+      verified = getStore().getState().verifiedInstructor.isVerified;
+    } else {
+      verified = false;
+    }
+    if (verified && hasScriptData('script[data-rubricdata]')) {
       const rubricData = getScriptData('rubricdata');
       const teacherId = getStore().getState().currentUser.userId;
       const {rubric, studentLevelInfo} = rubricData;

--- a/apps/src/p5lab/gamelab/GameLab.js
+++ b/apps/src/p5lab/gamelab/GameLab.js
@@ -3,7 +3,6 @@ import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {getStore} from '@cdo/apps/redux';
 import color from '@cdo/apps/util/color';
-import experiments from '@cdo/apps/util/experiments';
 import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 import msg from '@cdo/gamelab/locale';
 
@@ -74,11 +73,7 @@ export default class GameLab extends P5Lab {
   }
 
   runButtonClick() {
-    // For AI Rubrics Pilot
-    const inRubricsPilot =
-      experiments.isEnabled('ai-rubrics') ||
-      experiments.isEnabled('non-ai-rubrics');
-    if (inRubricsPilot && hasScriptData('script[data-rubricdata]')) {
+    if (hasScriptData('script[data-rubricdata]')) {
       const rubricData = getScriptData('rubricdata');
       const teacherId = getStore().getState().currentUser.userId;
       const {rubric, studentLevelInfo} = rubricData;

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -17,7 +17,6 @@ import instructions, {
   setTaRubric,
 } from '@cdo/apps/redux/instructions';
 import RubricFloatingActionButton from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
-import experiments from '@cdo/apps/util/experiments';
 import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 
 $(document).ready(initPage);
@@ -95,10 +94,7 @@ function initPage() {
     }
   }
 
-  const inRubricsPilot =
-    experiments.isEnabled('ai-rubrics') ||
-    experiments.isEnabled('non-ai-rubrics');
-  if (inRubricsPilot && hasScriptData('script[data-rubricdata]')) {
+  if (hasScriptData('script[data-rubricdata]')) {
     const rubricData = getScriptData('rubricdata');
     const {rubric, studentLevelInfo} = rubricData;
     const reportingData = {
@@ -114,7 +110,6 @@ function initPage() {
     if (rubricFabMountPoint) {
       //rubric fab mount point is only true for teachers
       if (
-        experiments.isEnabled('ai-rubrics') &&
         !!rubric &&
         rubric.learningGoals.some(lg => lg.aiEnabled) &&
         config.level_name === rubric.level.name
@@ -135,10 +130,7 @@ function initPage() {
             studentLevelInfo={studentLevelInfo}
             reportingData={reportingData}
             currentLevelName={config.level_name}
-            aiEnabled={
-              experiments.isEnabled('ai-rubrics') &&
-              rubric.learningGoals.some(lg => lg.aiEnabled)
-            }
+            aiEnabled={rubric.learningGoals.some(lg => lg.aiEnabled)}
           />
         </Provider>,
         rubricFabMountPoint

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -94,7 +94,10 @@ function initPage() {
     }
   }
 
-  if (hasScriptData('script[data-rubricdata]')) {
+  if (
+    getStore().getState().verifiedInstructor.isVerified &&
+    hasScriptData('script[data-rubricdata]')
+  ) {
     const rubricData = getScriptData('rubricdata');
     const {rubric, studentLevelInfo} = rubricData;
     const reportingData = {

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -140,26 +140,22 @@ function initPage() {
       }
     }
   };
-
-  let verified;
-  if (getStore().getState().currentUser.userType === 'student') {
-    const body = JSON.stringify({
-      userId: getStore().getState().currentUser.userId,
-    });
-    HttpClient.post(`/sections/section_instructors_verified`, body, true, {
-      'Content-Type': 'application/json',
-    })
-      .then(response => response.json())
-      .then(json => {
-        verified = json.verified;
-        taRubricSetup(verified);
+  HttpClient.fetchJson('/api/v1/users/current').then(user => {
+    let verified;
+    if (user.value.user_type === 'student') {
+      const body = JSON.stringify({
+        userId: user.value.id,
       });
-  } else {
-    if (getStore().getState().verifiedInstructor) {
-      verified = getStore().getState().verifiedInstructor.isVerified;
+      HttpClient.post(`/sections/section_instructors_verified`, body, true, {
+        'Content-Type': 'application/json',
+      })
+        .then(response => response.json())
+        .then(json => {
+          verified = json.verified;
+          taRubricSetup(verified);
+        });
     } else {
-      verified = false;
+      taRubricSetup(user.value.is_verified_instructor);
     }
-    taRubricSetup(verified);
-  }
+  });
 }

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -93,11 +93,13 @@ function initPage() {
       );
     }
   }
-
-  if (
-    getStore().getState().verifiedInstructor.isVerified &&
-    hasScriptData('script[data-rubricdata]')
-  ) {
+  let verified;
+  if (getStore().getState().verifiedInstructor) {
+    verified = getStore().getState().verifiedInstructor.isVerified;
+  } else {
+    verified = false;
+  }
+  if (verified && hasScriptData('script[data-rubricdata]')) {
     const rubricData = getScriptData('rubricdata');
     const {rubric, studentLevelInfo} = rubricData;
     const reportingData = {

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -145,7 +145,6 @@ function initPage() {
   if (getStore().getState().currentUser.userType === 'student') {
     const body = JSON.stringify({
       userId: getStore().getState().currentUser.userId,
-      unitId: getStore().getState().progress.scriptId,
     });
     HttpClient.post(`/sections/section_instructors_verified`, body, true, {
       'Content-Type': 'application/json',

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -45,8 +45,6 @@ experiments.GENDER_FEATURE_ENABLED = 'gender';
 experiments.CPA_EXPERIENCE = 'cpa_experience';
 // Experiment for enabling the AI-TA differentiation chat
 experiments.AI_DIFFERENTIATION = 'ai-differentiation';
-experiments.AI_RUBRICS = 'ai-rubrics';
-experiments.NON_AI_RUBRICS = 'non-ai-rubrics';
 // Experiment for showing the toggle a teacher can use to turn on AI Tutor for their section
 experiments.AI_TUTOR_ACCESS = 'ai-tutor';
 // Uses Google Blockly for a given user across labs/levels until the experiment is disabled

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -122,10 +122,9 @@ class ActivitiesController < ApplicationController
         track_progress_in_session
       end
 
-      # If a student in the pilot is submitting work on an AI-enabled level, and their teachers haven't opted-out, trigger the AI evaluation job.
-      is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, script: @script_level&.script, experiment_name: 'ai-rubrics') && Policies::Ai.ai_rubrics_enabled_for_script_level?(current_user, @script_level)
+      # If a student is submitting work on an AI-enabled level, and their teachers haven't opted-out, trigger the AI evaluation job.
       is_level_ai_enabled = AiRubricConfig.ai_enabled?(@script_level)
-      if is_ai_experiment_enabled && is_level_ai_enabled && params[:submitted] == 'true'
+      if is_level_ai_enabled && params[:submitted] == 'true'
         metadata = {
           'studentId' => current_user.id,
           'unitName' => @script_level.script.name,

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -123,7 +123,7 @@ class ActivitiesController < ApplicationController
       end
 
       # If a student is submitting work on an AI-enabled level, and their teachers haven't opted-out, trigger the AI evaluation job.
-      is_ai_enabled = current_user && Policies::Ai.ai_rubrics_enabled?(current_user, @script_level)
+      is_ai_enabled = current_user && Policies::Ai.ai_rubrics_enabled_for_script_level?(current_user, @script_level)
       is_level_ai_enabled = AiRubricConfig.ai_enabled?(@script_level)
       if is_ai_enabled && is_level_ai_enabled && params[:submitted] == 'true'
         metadata = {

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -123,8 +123,9 @@ class ActivitiesController < ApplicationController
       end
 
       # If a student is submitting work on an AI-enabled level, and their teachers haven't opted-out, trigger the AI evaluation job.
+      is_ai_enabled = current_user && Policies::Ai.ai_rubrics_enabled_for_script_level?(current_user, @script_level)
       is_level_ai_enabled = AiRubricConfig.ai_enabled?(@script_level)
-      if is_level_ai_enabled && params[:submitted] == 'true'
+      if is_ai_enabled && is_level_ai_enabled && params[:submitted] == 'true'
         metadata = {
           'studentId' => current_user.id,
           'unitName' => @script_level.script.name,

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -123,7 +123,7 @@ class ActivitiesController < ApplicationController
       end
 
       # If a student is submitting work on an AI-enabled level, and their teachers haven't opted-out, trigger the AI evaluation job.
-      is_ai_enabled = current_user && Policies::Ai.ai_rubrics_enabled_for_script_level?(current_user, @script_level)
+      is_ai_enabled = current_user && Policies::Ai.ai_rubrics_enabled?(current_user, @script_level)
       is_level_ai_enabled = AiRubricConfig.ai_enabled?(@script_level)
       if is_ai_enabled && is_level_ai_enabled && params[:submitted] == 'true'
         metadata = {

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -142,9 +142,6 @@ class RubricsController < ApplicationController
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
 
-    is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, script: script_level.script, experiment_name: 'ai-rubrics')
-    return head :forbidden unless is_ai_experiment_enabled
-
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)
     return head :bad_request unless is_level_ai_enabled
 
@@ -168,9 +165,6 @@ class RubricsController < ApplicationController
     return head :bad_request unless @rubric
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
-
-    is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, script: script_level.script, experiment_name: 'ai-rubrics')
-    return head :forbidden unless is_ai_experiment_enabled
 
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)
     return head :bad_request unless is_level_ai_enabled
@@ -220,9 +214,6 @@ class RubricsController < ApplicationController
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
 
-    is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, script: script_level&.script, experiment_name: 'ai-rubrics')
-    return head :forbidden unless is_ai_experiment_enabled
-
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)
     return head :bad_request unless is_level_ai_enabled
 
@@ -250,9 +241,6 @@ class RubricsController < ApplicationController
     section_id = params.transform_keys(&:underscore).require(:section_id)
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
-
-    is_ai_experiment_enabled = current_user && Experiment.enabled?(user: current_user, script: script_level&.script, experiment_name: 'ai-rubrics')
-    return head :forbidden unless is_ai_experiment_enabled
 
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)
     return head :bad_request unless is_level_ai_enabled

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -142,10 +142,7 @@ class RubricsController < ApplicationController
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
 
-    is_teacher_verified = current_user.verified_teacher?
-    return head :forbidden unless is_teacher_verified
-
-    is_teacher_verified = current_user.verified_teacher?
+    is_teacher_verified = current_user&.verified_teacher?
     return head :forbidden unless is_teacher_verified
 
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)
@@ -172,7 +169,7 @@ class RubricsController < ApplicationController
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
 
-    is_teacher_verified = current_user.verified_teacher?
+    is_teacher_verified = current_user&.verified_teacher?
     return head :forbidden unless is_teacher_verified
 
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)
@@ -223,7 +220,7 @@ class RubricsController < ApplicationController
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
 
-    is_teacher_verified = current_user.verified_teacher?
+    is_teacher_verified = current_user&.verified_teacher?
     return head :forbidden unless is_teacher_verified
 
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)
@@ -254,7 +251,7 @@ class RubricsController < ApplicationController
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
 
-    is_teacher_verified = current_user.verified_teacher?
+    is_teacher_verified = current_user&.verified_teacher?
     return head :forbidden unless is_teacher_verified
 
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)

--- a/dashboard/app/controllers/rubrics_controller.rb
+++ b/dashboard/app/controllers/rubrics_controller.rb
@@ -142,6 +142,12 @@ class RubricsController < ApplicationController
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
 
+    is_teacher_verified = current_user.verified_teacher?
+    return head :forbidden unless is_teacher_verified
+
+    is_teacher_verified = current_user.verified_teacher?
+    return head :forbidden unless is_teacher_verified
+
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)
     return head :bad_request unless is_level_ai_enabled
 
@@ -165,6 +171,9 @@ class RubricsController < ApplicationController
     return head :bad_request unless @rubric
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
+
+    is_teacher_verified = current_user.verified_teacher?
+    return head :forbidden unless is_teacher_verified
 
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)
     return head :bad_request unless is_level_ai_enabled
@@ -214,6 +223,9 @@ class RubricsController < ApplicationController
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
 
+    is_teacher_verified = current_user.verified_teacher?
+    return head :forbidden unless is_teacher_verified
+
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)
     return head :bad_request unless is_level_ai_enabled
 
@@ -241,6 +253,9 @@ class RubricsController < ApplicationController
     section_id = params.transform_keys(&:underscore).require(:section_id)
 
     script_level = @rubric.lesson.script_levels.find {|sl| sl.levels.include?(@rubric.level)}
+
+    is_teacher_verified = current_user.verified_teacher?
+    return head :forbidden unless is_teacher_verified
 
     is_level_ai_enabled = AiRubricConfig.ai_enabled?(script_level)
     return head :bad_request unless is_level_ai_enabled

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -50,6 +50,26 @@ class SectionsController < ApplicationController
     end
   end
 
+  def section_instructors_verified
+    new_params = params.transform_keys(&:underscore)
+    sections = User.find_by(id: new_params[:user_id]).sections_as_student
+    unit = Unit.find_by(id: new_params[:unit_id])
+    unit_group = unit&.unit_group
+    section = if unit_group
+                sections.find_by(course_id: unit_group.id)
+              else
+                sections.find_by(script_id: unit.id)
+              end
+
+    section&.instructors&.each do |instructor|
+      instructor.permissions.each do |permission|
+        if permission.permission == "authorized_teacher"
+          render json: {verified: true}
+        end
+      end
+    end
+  end
+
   private def redirect_to_section_script_or_course
     if @section.script
       redirect_to script_path(@section.script)

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -52,21 +52,12 @@ class SectionsController < ApplicationController
 
   def section_instructors_verified
     new_params = params.transform_keys(&:underscore)
-    sections = User.find_by(id: new_params[:user_id]).sections_as_student
-    unit = Unit.find_by(id: new_params[:unit_id])
-    unit_group = unit&.unit_group
-    section = if unit_group
-                sections.find_by(course_id: unit_group.id)
-              else
-                sections.find_by(script_id: unit.id)
-              end
+    teachers = User.find_by(id: new_params[:user_id]).teachers
 
-    section&.instructors&.each do |instructor|
-      instructor.permissions.each do |permission|
-        if permission.permission == "authorized_teacher"
-          render json: {verified: true}
-        end
-      end
+    if teachers.any?(&:verified_teacher?)
+      render json: {verified: true}
+    else
+      render json: {verified: false}
     end
   end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -115,6 +115,9 @@ Dashboard::Application.routes.draw do
       member do
         post 'log_in'
       end
+      collection do
+        post 'section_instructors_verified'
+      end
     end
     # Section API routes (JSON only)
     concern :section_api_routes do

--- a/dashboard/lib/policies/ai.rb
+++ b/dashboard/lib/policies/ai.rb
@@ -3,8 +3,7 @@ require 'user'
 class Policies::Ai
   # Whether or not AI rubric features (AI TA) are enabled.
   def self.ai_rubrics_enabled?(user)
-    return false if user.nil?
-
+    return false if user.nil? || !user.verified_teacher?
     !user.ai_rubrics_disabled
   end
 

--- a/dashboard/lib/policies/ai.rb
+++ b/dashboard/lib/policies/ai.rb
@@ -3,7 +3,8 @@ require 'user'
 class Policies::Ai
   # Whether or not AI rubric features (AI TA) are enabled.
   def self.ai_rubrics_enabled?(user)
-    return false if user.nil? || !user.verified_teacher?
+    return false if user.nil?
+    return false unless user.verified_teacher?
     !user.ai_rubrics_disabled
   end
 

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -1153,7 +1153,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'milestone with student in experiment but where teacher disables AI does not triggers rubric eval job' do
+  test 'milestone where teacher disables AI does not triggers rubric eval job' do
     @teacher.ai_rubrics_disabled = true
     @teacher.save!
     section = create :section, teacher: @teacher, script: @script
@@ -1167,7 +1167,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'milestone with student in experiment on non ai level does not trigger rubric eval job' do
+  test 'milestone with student on non ai level does not trigger rubric eval job' do
     section = create :section, teacher: @teacher, script: @script
     create :follower, section: section, student_user: @student
     Metrics::Events.stubs(:log_event).never
@@ -1179,7 +1179,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'milestone with teacher in experiment does not trigger rubric eval job' do
+  test 'milestone with teacher does not trigger rubric eval job' do
     Metrics::Events.stubs(:log_event).never
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).never

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -1143,7 +1143,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   test 'milestone with student in experiment triggers rubric eval job' do
     section = create :section, teacher: @teacher, script: @script
     create :follower, section: section, student_user: @student
-    create :single_section_experiment, section: section, name: 'ai-rubrics', script: @script
     Metrics::Events.stubs(:log_event).once
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).with(user_id: @student.id, requester_id: @student.id, script_level_id: @script_level.id).once
@@ -1158,7 +1157,6 @@ class ActivitiesControllerTest < ActionController::TestCase
     @teacher.save!
     section = create :section, teacher: @teacher, script: @script
     create :follower, section: section, student_user: @student
-    create :single_section_experiment, section: section, name: 'ai-rubrics', script: @script
     Metrics::Events.stubs(:log_event).never
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).never
@@ -1171,7 +1169,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   test 'milestone with student in experiment on non ai level does not trigger rubric eval job' do
     section = create :section, teacher: @teacher, script: @script
     create :follower, section: section, student_user: @student
-    create :single_section_experiment, section: section, name: 'ai-rubrics', script: @script
     Metrics::Events.stubs(:log_event).never
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(false)
     EvaluateRubricJob.expects(:perform_later).never
@@ -1182,7 +1179,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test 'milestone with teacher in experiment does not trigger rubric eval job' do
-    create :single_section_experiment, section: @section, name: 'ai-rubrics'
     Metrics::Events.stubs(:log_event).never
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).never
@@ -1197,20 +1193,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'milestone with student not in experiment does not trigger rubric eval job' do
-    # some other section is added to the experiment
-    create :single_section_experiment, name: 'ai-rubrics'
-    Metrics::Events.stubs(:log_event).never
-    AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
-    EvaluateRubricJob.expects(:perform_later).never
-    sign_in @student
-
-    post :milestone, params: @milestone_rubric_params
-    assert_response :success
-  end
-
   test 'milestone on level without ai enabled does not trigger rubric eval job' do
-    create :single_section_experiment, section: @section, name: 'ai-rubrics'
     Metrics::Events.stubs(:log_event).never
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(false)
     EvaluateRubricJob.expects(:perform_later).never

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -67,7 +67,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     }
 
     # set up params for testing rubric evaluation
-    @teacher = create :teacher
+    @teacher = create :authorized_teacher
     @section = create :section, teacher: @teacher
     @student = create :student
     create :follower, section: @section, student_user: @student
@@ -1140,9 +1140,10 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert_equal 100, parent_user_level.best_result
   end
 
-  test 'milestone with student in experiment triggers rubric eval job' do
+  test 'milestone triggers AI rubric eval job' do
     section = create :section, teacher: @teacher, script: @script
     create :follower, section: section, student_user: @student
+
     Metrics::Events.stubs(:log_event).once
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).with(user_id: @student.id, requester_id: @student.id, script_level_id: @script_level.id).once

--- a/dashboard/test/controllers/rubrics_controller_test.rb
+++ b/dashboard/test/controllers/rubrics_controller_test.rb
@@ -359,23 +359,9 @@ class RubricsControllerTest < ActionController::TestCase
     assert_equal 0, json_response.length
   end
 
-  test "returns forbidden when getting aggregate status if ai experiment isn't enabled" do
-    sign_in @teacher
-
-    Experiment.expects(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(false)
-
-    get :ai_evaluation_status_for_all, params: {
-      id: @rubric.id,
-      sectionId: @follower.section.id,
-    }
-
-    assert_response :forbidden
-  end
-
   test "returns bad request when getting aggregate status if ai isn't enabled for script level" do
     sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.expects(:ai_enabled?).with(@script_level).returns(false)
 
     get :ai_evaluation_status_for_all, params: {
@@ -397,7 +383,6 @@ class RubricsControllerTest < ActionController::TestCase
     end
     sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
 
     get :ai_evaluation_status_for_all, params: {
@@ -417,7 +402,6 @@ class RubricsControllerTest < ActionController::TestCase
   test "returns ok and attempted count when getting aggregate status if work is attempted" do
     sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
 
     get :ai_evaluation_status_for_all, params: {
@@ -437,7 +421,6 @@ class RubricsControllerTest < ActionController::TestCase
   test "returns ok and pending count when getting aggregate status if work is queued" do
     sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
 
     Timecop.freeze do
@@ -469,7 +452,6 @@ class RubricsControllerTest < ActionController::TestCase
   test "returns ok and pending count when getting aggregate status if work is running" do
     sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
 
     Timecop.freeze do
@@ -544,7 +526,6 @@ class RubricsControllerTest < ActionController::TestCase
     end
     sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
 
     get :ai_evaluation_status_for_all, params: {
@@ -561,24 +542,9 @@ class RubricsControllerTest < ActionController::TestCase
     assert json_response['csrfToken']
   end
 
-  test "returns forbidden when running ai evals for all if experiment isn't enabled" do
-    sign_in @teacher
-
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(false)
-    Metrics::Events.stubs(:log_event).never
-
-    get :run_ai_evaluations_for_all, params: {
-      id: @rubric.id,
-      sectionId: @follower.section.id,
-    }
-
-    assert_response :forbidden
-  end
-
   test "returns bad request when running ai evals for all if ai isn't enabled" do
     sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.expects(:ai_enabled?).with(@script_level).returns(false)
     Metrics::Events.stubs(:log_event).never
 
@@ -602,7 +568,6 @@ class RubricsControllerTest < ActionController::TestCase
 
     sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).never
     Metrics::Events.stubs(:log_event).never
@@ -661,7 +626,6 @@ class RubricsControllerTest < ActionController::TestCase
     end
     sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
     EvaluateRubricJob.expects(:perform_later).once
     Metrics::Events.stubs(:log_event).once
@@ -714,7 +678,6 @@ class RubricsControllerTest < ActionController::TestCase
     end
     sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.stubs(:ai_enabled?).with(@script_level).returns(true)
 
     get :ai_evaluation_status_for_all, params: {
@@ -854,7 +817,6 @@ class RubricsControllerTest < ActionController::TestCase
   test "run ai evaluations for user calls EvaluateRubricJob" do
     sign_in @teacher
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.stubs(:ai_enabled?).returns(true)
     EvaluateRubricJob.expects(:perform_later).with(user_id: @student.id, requester_id: @teacher.id, script_level_id: @script_level.id).once
 
@@ -886,7 +848,6 @@ class RubricsControllerTest < ActionController::TestCase
 
     stub_project_source_data(new_channel_id)
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.stubs(:ai_enabled?).returns(true)
     EvaluateRubricJob.expects(:perform_later).with(user_id: new_student.id, requester_id: @teacher.id, script_level_id: @script_level.id).once
 
@@ -913,7 +874,6 @@ class RubricsControllerTest < ActionController::TestCase
     create :follower, student_user: new_student, user: @teacher
     create_storage_id_for_user(new_student.id)
 
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
     AiRubricConfig.stubs(:ai_enabled?).returns(true)
     EvaluateRubricJob.expects(:perform_later).never
 
@@ -971,7 +931,6 @@ class RubricsControllerTest < ActionController::TestCase
       Timecop.travel 1.minute
       sign_in @teacher
 
-      Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
       AiRubricConfig.stubs(:ai_enabled?).returns(true)
       EvaluateRubricJob.expects(:perform_later).never
 
@@ -1013,8 +972,6 @@ class RubricsControllerTest < ActionController::TestCase
       create :user_level, user: @student, script: @script_level.script, level: @level
       sign_in @teacher
 
-      Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(true)
-
       AiRubricConfig.stubs(:ai_enabled?).returns(true)
       EvaluateRubricJob.expects(:perform_later).with(user_id: @student.id, requester_id: @teacher.id, script_level_id: @script_level.id).once
 
@@ -1033,19 +990,6 @@ class RubricsControllerTest < ActionController::TestCase
       }
       assert_response :success
     end
-  end
-
-  test "run ai evaluations for user does not call EvaluateRubricJob if ai experiment is disabled" do
-    sign_in @teacher
-
-    Experiment.stubs(:enabled?).with(user: @teacher, script: @script_level.script, experiment_name: 'ai-rubrics').returns(false)
-    EvaluateRubricJob.expects(:perform_later).never
-
-    post :run_ai_evaluations_for_user, params: {
-      id: @rubric.id,
-      userId: @student.id,
-    }
-    assert_response :forbidden
   end
 
   test "cannot run ai evaluations for user if not teacher of student" do

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -103,7 +103,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     sl = create(:script, :with_levels, levels_count: 3).script_levels[2]
     params = {program: 'fake program', testResult: 0, result: 'false'}
 
-    assert_cached_queries(9) do
+    assert_cached_queries(10) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id

--- a/dashboard/test/lib/policies/ai_test.rb
+++ b/dashboard/test/lib/policies/ai_test.rb
@@ -5,7 +5,7 @@ require 'policies/ai'
 class Policies::AiTest < ActiveSupport::TestCase
   class AiRubricsEnabledTest < ActiveSupport::TestCase
     setup do
-      @user = create :user
+      @user = create :authorized_teacher
     end
 
     test 'ai_rubrics_enabled? should return true when the user ai_rubrics_disabled field is false' do
@@ -29,11 +29,11 @@ class Policies::AiTest < ActiveSupport::TestCase
       script = create :script
 
       # Create a student/teacher/section
-      @teacher = create :teacher
+      @teacher = create :authorized_teacher
       @section = create :section, user: @teacher, script: script
       @user = create(:follower, section: @section).student_user
 
-      opt_out_teacher = create :teacher
+      opt_out_teacher = create :authorized_teacher
       opt_out_teacher.ai_rubrics_disabled = true
       opt_out_teacher.save!
       opt_out_section = create :section, user: opt_out_teacher, script: script
@@ -81,7 +81,7 @@ class Policies::AiTest < ActiveSupport::TestCase
       @teacher.save!
 
       # Create a section without a Unit
-      alt_teacher = create :teacher
+      alt_teacher = create :authorized_teacher
       alt_section = create :section, user: alt_teacher
       create(:follower, student_user: @user, section: alt_section)
 

--- a/dashboard/test/ui/features/platform/user_settings.feature
+++ b/dashboard/test/ui/features/platform/user_settings.feature
@@ -10,8 +10,6 @@ Feature: Updating account settings
   Scenario: Teacher wants to disable AI rubrics
     Given I create a teacher named "Haplo"
     And I give user "Haplo" authorized teacher permission
-    Given there is a pilot called "ai-rubrics"
-    And I add the current user to the "ai-rubrics" pilot
     Given I am on "http://studio.code.org/users/edit"
     Then I wait to see "#user_ai_rubrics_disabled"
     And element "#user_ai_rubrics_disabled" is not checked

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -9,7 +9,7 @@ Feature: Evaluate student code against rubrics using AI
     Given I validate rubric ai config for all lessons
 
   Scenario: Student code is evaluated by AI when student submits project
-    Given I create a teacher-associated student named "Aiden"
+    Given I create an authorized teacher-associated student named "Aiden"
     And I get debug info for the current user
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
@@ -56,7 +56,7 @@ Feature: Evaluate student code against rubrics using AI
     Then element ".uitest-ai-assessment" contains text "Aiden has achieved Extensive or Convincing Evidence"
 
   Scenario: Student code is evaluated by AI when teacher requests individual evaluation
-    Given I create a teacher-associated student named "Aiden"
+    Given I create an authorized teacher-associated student named "Aiden"
     And I get debug info for the current user
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
@@ -105,7 +105,7 @@ Feature: Evaluate student code against rubrics using AI
     Then element ".uitest-ai-assessment" contains text "Aiden has achieved Extensive or Convincing Evidence"
 
   Scenario: Student code is evaluated by AI when teacher requests evaluation for entire class
-    Given I create a teacher-associated student named "Aiden"
+    Given I create an authorized teacher-associated student named "Aiden"
     And I get debug info for the current user
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -37,6 +37,7 @@ Feature: Evaluate student code against rubrics using AI
     And element ".teacher-panel td:eq(1)" contains text "Aiden"
     And I click selector ".teacher-panel td:eq(1)" to load a new page
     And I wait for the lab page to fully load
+    And I wait until element "#ui-floatingActionButton" is visible
     And I click selector ".introjs-skipbutton" once I see it
     Then I verify progress in the header of the current page is "perfect_assessment" for level 2
     And element "#ui-floatingActionButton" is visible
@@ -81,6 +82,7 @@ Feature: Evaluate student code against rubrics using AI
     And element ".teacher-panel td:eq(1)" contains text "Aiden"
     And I click selector ".teacher-panel td:eq(1)" to load a new page
     And I wait for the lab page to fully load
+    And I wait until element "#ui-floatingActionButton" is visible
     And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
     And I click selector ".introjs-skipbutton" once I see it
     And I wait until element ".congrats" is gone
@@ -130,6 +132,7 @@ Feature: Evaluate student code against rubrics using AI
     And element ".teacher-panel td:eq(1)" contains text "Aiden"
     And I click selector ".teacher-panel td:eq(1)" to load a new page
     And I wait for the lab page to fully load
+    And I wait until element "#ui-floatingActionButton" is visible
     And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
     And I click selector ".introjs-skipbutton" once I see it
     And I wait until element ".congrats" is gone

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -13,7 +13,6 @@ Feature: Evaluate student code against rubrics using AI
     And I get debug info for the current user
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
-    And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "not_tried" for level 2
@@ -33,7 +32,6 @@ Feature: Evaluate student code against rubrics using AI
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
-    And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
     And element ".teacher-panel td:eq(1)" contains text "Aiden"
@@ -62,7 +60,6 @@ Feature: Evaluate student code against rubrics using AI
     And I get debug info for the current user
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
-    And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "not_tried" for level 2
@@ -79,7 +76,6 @@ Feature: Evaluate student code against rubrics using AI
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
-    And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
     And element ".teacher-panel td:eq(1)" contains text "Aiden"
@@ -113,7 +109,6 @@ Feature: Evaluate student code against rubrics using AI
     And I get debug info for the current user
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
-    And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "not_tried" for level 2
@@ -130,7 +125,6 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element "#homepage-container" is visible
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
     And I get debug info for the current user
-    And I add the current user to the "ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
     And element ".teacher-panel td:eq(1)" contains text "Aiden"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/student_completes_rubric_level.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/student_completes_rubric_level.feature
@@ -1,7 +1,7 @@
 Feature: Student can complete rubric-enabled level
-  Scenario: Student can complete rubric-enabled level
-    # Create student in AI experiment
-    Given I create a teacher-associated student named "Reuben"
+  Scenario: Student of verified teacher can complete rubric-enabled level
+    # Create student with verified teacher
+    Given I create an authorized teacher-associated student named "Reuben"
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "not_tried" for level 2
@@ -16,6 +16,27 @@ Feature: Student can complete rubric-enabled level
     And I wait until element "#confirm-button" is visible
     And I click selector "#confirm-button" to load a new page
 
+    # Student can see new progress in header
+    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
+    And I wait for the lab page to fully load
+    Then I verify progress in the header of the current page is "perfect_assessment" for level 2
+
+  Scenario: Student of unverified teacher can complete rubric-enabled level
+    # Create student in non-AI experiment
+    Given I create a teacher-associated student named "Reuben"
+    And I add the current user to the "non-ai-rubrics" single user experiment
+    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
+    And I wait for the lab page to fully load
+    And I verify progress in the header of the current page is "not_tried" for level 2
+    # Student submits code
+    When I ensure droplet is in text mode
+    And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
+    And I click selector "#runButton"
+    And I wait until element ".project_updated_at" contains text "Saved"
+    And I wait until element "#submitButton" is visible
+    And I click selector "#submitButton"
+    And I wait until element "#confirm-button" is visible
+    And I click selector "#confirm-button" to load a new page
     # Student can see new progress in header
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load

--- a/dashboard/test/ui/features/teacher_tools/rubrics/student_completes_rubric_level.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/student_completes_rubric_level.feature
@@ -1,53 +1,7 @@
 Feature: Student can complete rubric-enabled level
-  Scenario: Normal student can complete rubric-enabled level
-    # Create student not in an experiment
-    Given I create a teacher-associated student named "Reuben"
-    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the lab page to fully load
-    And I verify progress in the header of the current page is "not_tried" for level 2
-
-    # Student submits code
-    When I ensure droplet is in text mode
-    And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
-    And I click selector "#runButton"
-    And I wait until element ".project_updated_at" contains text "Saved"
-    And I wait until element "#submitButton" is visible
-    And I click selector "#submitButton"
-    And I wait until element "#confirm-button" is visible
-    And I click selector "#confirm-button" to load a new page
-
-    # Student can see new progress in header
-    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the lab page to fully load
-    Then I verify progress in the header of the current page is "perfect_assessment" for level 2
-
-  Scenario: AI pilot student can complete rubric-enabled level
+  Scenario: Student can complete rubric-enabled level
     # Create student in AI experiment
     Given I create a teacher-associated student named "Reuben"
-    And I add the current user to the "ai-rubrics" single user experiment
-    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the lab page to fully load
-    And I verify progress in the header of the current page is "not_tried" for level 2
-
-    # Student submits code
-    When I ensure droplet is in text mode
-    And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
-    And I click selector "#runButton"
-    And I wait until element ".project_updated_at" contains text "Saved"
-    And I wait until element "#submitButton" is visible
-    And I click selector "#submitButton"
-    And I wait until element "#confirm-button" is visible
-    And I click selector "#confirm-button" to load a new page
-
-    # Student can see new progress in header
-    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
-    And I wait for the lab page to fully load
-    Then I verify progress in the header of the current page is "perfect_assessment" for level 2
-
-  Scenario: Non-AI pilot student can complete rubric-enabled level
-    # Create student in non-AI experiment
-    Given I create a teacher-associated student named "Reuben"
-    And I add the current user to the "non-ai-rubrics" single user experiment
     And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
     And I verify progress in the header of the current page is "not_tried" for level 2

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -18,7 +18,6 @@ Scenario: Teachers can give and send feedback on the rubric to students.
 
   # Teacher can see and submit feedback for a student
   Then I sign in as "Teacher_Lillian" and go home
-  And I give use "Teacher_Lillian" authorized teacher permission
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait to see "#ui-floatingActionButton"
   And I wait until element "#teacher-panel-container" is visible

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -18,6 +18,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
 
   # Teacher can see and submit feedback for a student
   Then I sign in as "Teacher_Lillian" and go home
+  And I get debug info for the current user
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait to see "#ui-floatingActionButton"
   And I wait until element "#teacher-panel-container" is visible

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -25,6 +25,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I wait until element ".student-table" is visible
   And I click selector ".student-table tr:nth(1)" to load a new page
   And I wait for the lab page to fully load
+  And I wait until element "#ui-floatingActionButton" is visible
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
   And I click selector ".introjs-skipbutton" once I see it
   And I wait for 2 seconds
@@ -66,6 +67,7 @@ Scenario: Teacher views rubric product tour
   And element ".teacher-panel td:eq(1)" contains text "Aiden"
   And I click selector ".teacher-panel td:eq(1)" to load a new page
   And I wait for the lab page to fully load
+  And I wait until element "#ui-floatingActionButton" is visible
 
   # Teacher views product tour step 1
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
@@ -148,6 +150,7 @@ Scenario: Teacher views Rubric and Settings tabs
   And element ".teacher-panel td:eq(1)" contains text "Aiden"
   And I click selector ".teacher-panel td:eq(1)" to load a new page
   And I wait for the lab page to fully load
+  And I wait until element "#ui-floatingActionButton" is visible
   And I click selector ".introjs-skipbutton" if it exists
 
   When I open my eyes to test "teaching assistant rubric"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -56,7 +56,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
 
 Scenario: Teacher views rubric product tour
   # Teacher signs in and navigates to assessment page
-  Given I create a teacher-associated student named "Aiden"
+  Given I create an authorized teacher-associated student named "Aiden"
   And I sign in as "Teacher_Aiden" and go home
   And I wait until element "#homepage-container" is visible
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
@@ -138,7 +138,7 @@ Scenario: Teacher views rubric product tour
 
 @eyes
 Scenario: Teacher views Rubric and Settings tabs
-  Given I create a teacher-associated student named "Aiden"
+  Given I create an authorized teacher-associated student named "Aiden"
   And I sign in as "Teacher_Aiden" and go home
   And I wait until element "#homepage-container" is visible
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
@@ -171,7 +171,7 @@ Scenario: Teacher views Rubric and Settings tabs
 @eyes
 Scenario: Teacher views product tour
   # Teacher signs in and navigates to assessment page
-  Given I create a teacher-associated student named "Aiden"
+  Given I create an authorized teacher-associated student named "Aiden"
   And I sign in as "Teacher_Aiden" and go home
   And I wait until element "#homepage-container" is visible
   And element "#sign_in_or_user" contains text "Teacher_Aiden"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -18,6 +18,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
 
   # Teacher can see and submit feedback for a student
   Then I sign in as "Teacher_Lillian" and go home
+  And I give use "Teacher_Lillian" authorized teacher permission
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait to see "#ui-floatingActionButton"
   And I wait until element "#teacher-panel-container" is visible

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -24,7 +24,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I wait until element ".student-table" is visible
   And I click selector ".student-table tr:nth(1)" to load a new page
   And I wait for the lab page to fully load
-  And I wait until element "#ui-floatingActionButton" is visible
+  And I wait until selector "#ui-floatingActionButton" is visible
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
   And I click selector ".introjs-skipbutton" once I see it
   And I wait for 2 seconds
@@ -66,7 +66,7 @@ Scenario: Teacher views rubric product tour
   And element ".teacher-panel td:eq(1)" contains text "Aiden"
   And I click selector ".teacher-panel td:eq(1)" to load a new page
   And I wait for the lab page to fully load
-  And I wait until element "#ui-floatingActionButton" is visible
+  And I wait until selector "#ui-floatingActionButton" is visible
 
   # Teacher views product tour step 1
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
@@ -149,7 +149,7 @@ Scenario: Teacher views Rubric and Settings tabs
   And element ".teacher-panel td:eq(1)" contains text "Aiden"
   And I click selector ".teacher-panel td:eq(1)" to load a new page
   And I wait for the lab page to fully load
-  And I wait until element "#ui-floatingActionButton" is visible
+  And I wait until selector "#ui-floatingActionButton" is visible
   And I click selector ".introjs-skipbutton" if it exists
 
   When I open my eyes to test "teaching assistant rubric"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -24,7 +24,6 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   And I wait until element ".student-table" is visible
   And I click selector ".student-table tr:nth(1)" to load a new page
   And I wait for the lab page to fully load
-  And I wait until selector "#ui-floatingActionButton" is visible
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
   And I click selector ".introjs-skipbutton" once I see it
   And I wait for 2 seconds
@@ -66,7 +65,6 @@ Scenario: Teacher views rubric product tour
   And element ".teacher-panel td:eq(1)" contains text "Aiden"
   And I click selector ".teacher-panel td:eq(1)" to load a new page
   And I wait for the lab page to fully load
-  And I wait until selector "#ui-floatingActionButton" is visible
 
   # Teacher views product tour step 1
   And I wait until element "h1:contains(Getting Started with Your AI Teaching Assistant)" is visible
@@ -149,7 +147,6 @@ Scenario: Teacher views Rubric and Settings tabs
   And element ".teacher-panel td:eq(1)" contains text "Aiden"
   And I click selector ".teacher-panel td:eq(1)" to load a new page
   And I wait for the lab page to fully load
-  And I wait until selector "#ui-floatingActionButton" is visible
   And I click selector ".introjs-skipbutton" if it exists
 
   When I open my eyes to test "teaching assistant rubric"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/teacher_view_of_rubric.feature
@@ -5,7 +5,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
   Given I create an authorized teacher-associated student named "Lillian"
 
   # Student can see the rubric and submit work
-  And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2?enableExperiments=ai-rubrics"
+  And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I click selector ".uitest-taRubricTab" once I see it
   Then I wait to see "#runButton"
   And I press "runButton"
@@ -18,8 +18,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
 
   # Teacher can see and submit feedback for a student
   Then I sign in as "Teacher_Lillian" and go home
-  And I add the current user to the "ai-rubrics" single section experiment for the "allthethings" course
-  And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2?enableExperiments=ai-rubrics"
+  And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait to see "#ui-floatingActionButton"
   And I wait until element "#teacher-panel-container" is visible
   And I wait until element ".student-table" is visible
@@ -49,7 +48,7 @@ Scenario: Teachers can give and send feedback on the rubric to students.
 
   # The teacher given feedback is received by the student
   Then I sign in as "Lillian" and go home
-  And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2?enableExperiments=ai-rubrics"
+  And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I click selector ".uitest-taRubricTab" once I see it
   And I wait until element "p:contains(Extensive Evidence)" is visible
   And I click selector "h6:contains(Code Quality)" once I see it
@@ -59,10 +58,8 @@ Scenario: Teacher views rubric product tour
   # Teacher signs in and navigates to assessment page
   Given I create a teacher-associated student named "Aiden"
   And I sign in as "Teacher_Aiden" and go home
-  And I add the current user to the "ai-rubrics" single section experiment for the "allthethings" course
   And I wait until element "#homepage-container" is visible
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
-  And I add the current user to the "ai-rubrics" single user experiment
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait for the lab page to fully load
   And element ".teacher-panel td:eq(1)" contains text "Aiden"
@@ -143,10 +140,8 @@ Scenario: Teacher views rubric product tour
 Scenario: Teacher views Rubric and Settings tabs
   Given I create a teacher-associated student named "Aiden"
   And I sign in as "Teacher_Aiden" and go home
-  And I add the current user to the "ai-rubrics" single section experiment for the "allthethings" course
   And I wait until element "#homepage-container" is visible
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
-  And I add the current user to the "ai-rubrics" single user experiment
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait for the lab page to fully load
   And element ".teacher-panel td:eq(1)" contains text "Aiden"
@@ -178,10 +173,8 @@ Scenario: Teacher views product tour
   # Teacher signs in and navigates to assessment page
   Given I create a teacher-associated student named "Aiden"
   And I sign in as "Teacher_Aiden" and go home
-  And I add the current user to the "ai-rubrics" single section experiment for the "allthethings" course
   And I wait until element "#homepage-container" is visible
   And element "#sign_in_or_user" contains text "Teacher_Aiden"
-  And I add the current user to the "ai-rubrics" single user experiment
   And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
   And I wait for the lab page to fully load
   And element ".teacher-panel td:eq(1)" contains text "Aiden"


### PR DESCRIPTION
This removes code related to the ai-rubrics and non-ai-rubrics experiments in preparation for the full release of the AI teaching assistant.

## Links
[AITT-768](https://codedotorg.atlassian.net/browse/AITT-768)

## Testing story
Updated unit and UI tests to account for universal release of AI teaching assistant:
- Removed all experiment checks in tests
- Removed tests for behavior without experiment enabled

## Deployment strategy

## Follow-up work

Clean up any remaining code related to experiments: [AITT-769](https://codedotorg.atlassian.net/browse/AITT-769)

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
