### PR TITLE
HoC 2024 - Add hero banners on code.org

### DIFF
--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -1,7 +1,7 @@
 {
   "pages": {
     "homepage": [
-      "hoc2023-soon-hoc",
+      "hoc2024-soon-hoc",
       "hoc2023-actual-hoc",
       "pl-launch-superhero",
       "curriculum-launch-2024",
@@ -10,35 +10,20 @@
   },
 
   "banners": {
-    "hoc2023-soon-hoc": {
+    "hoc2024-soon-hoc": {
       "hoc_modes": ["soon-hoc"],
       "class": "hoc-banner homepage",
-      "desktopImage": "/images/hoc2023-codeorg-hero-banner.png",
-      "mobileImage": "/images/hoc2023-codeorg-hero-banner-mobile.png",
-      "leftImage": "/images/hoc2023-codeorg-hero-banner-left.svg",
-      "rightImage": "/images/hoc2023-codeorg-hero-banner-right.svg",
+      "desktopImage": "",
       "actions": [
         {
-          "type": "text",
-          "text": "homepage_hero_hoc_is_coming"
-        },
-        {
-          "type": "heading",
-          "text": "curriculum_name_dance_party_ai_edition"
-        },
-        {
-          "type": "heading-two",
-          "text": "codeorg_homepage_hoc2023_body"
-        },
-        {
-          "type": "cta_button_solid_yellow",
-          "text": "hoc2022_cta_primary",
-          "url": "/dance"
-        },
-        {
-          "type": "cta_button_solid_white",
-          "text": "hoc2022_cta_secondary",
-          "url": "https://hourofcode.com/learn"
+          "type": "flex-container",
+          "text_h1": "hoc_2024.header",
+          "text_desc": "hoc_2024.banner.desc.make_everything",
+          "external_link": true,
+          "button_color_black": true,
+          "button_link": "https://hourofcode.com/events",
+          "button_text": "hoc_2024.button_host_an_event",
+          "img_src": "/images/banners/banner-hoc-2024.png"
         }
       ]
     },

--- a/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
@@ -1,123 +1,56 @@
-@import 'color.scss', 'font.scss', 'breakpoints.scss';
+@import 'breakpoints';
 
-// Code.org HoC homepage banner
-#bars {
-  height: 450px;
-  position: relative;
-
-  @media screen and (max-width: $width-md) {
-    height: 400px;
-  }
-
-  @media screen and (max-width: $width-sm) {
-    height: 500px;
-  }
-
-  & > div.col-33 {
-    position: absolute;
-
-    // Left image
-    &:nth-of-type(1) {
-      height: inherit;
-      max-width: 500px;
-      left: 0;
-      top: -10%;
-
-      @media (min-width: 768px) and (max-width: 1190px) {
-        width: 45%;
-        left: -9%;
-        top: -15%;
-      }
-
-      @media screen and (max-width: 800px) {
-        display: none;
-      }
-    }
-
-    // Copy and buttons (.hoc-banner.homepage)
-    &:nth-of-type(2) {
-      width: 700px;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-
-      @media screen and (max-width: $width-lg) {
-        width: 610px;
-        margin-top: 0;
-      }
-
-      @media screen and (max-width: $width-sm) {
-        width: 100%;
-      }
-    }
-
-    // Right image
-    &:nth-of-type(3) {
-      height: inherit;
-      max-width: 500px;
-      right: 0;
-      bottom: 0;
-
-      @media screen and (max-width: $width-md) {
-        width: 45%;
-        right: -5%;
-      }
-    }
-  }
+// Styles for the 2024 Hour of Code homepage banner on code.org
+body #hero {
+  background: linear-gradient(110deg, #6977CD -10.82%, #BCDEDE 43.13%, #34DFE5 68.88%, #688AED 95.85%);
 }
 
+// Code.org homepage banner
 .hoc-banner.homepage {
   text-align: center;
-  color: $white;
   line-height: 1.4;
-  max-width: 860px;
-  margin: 2rem auto 4rem;
-  padding: 0 1rem;
+  max-width: 1020px;
+  margin: 4rem auto;
 
-  h1, h2 {
-    color: $white
+  @media (max-width: $width-md) {
+    margin: 0 auto;
   }
 
-  h1 {
-    font-size: 4rem;
-    font-family: var(--barlowSemiCondensed-semibold);
-    font-weight: var(--bold-font-weight);
-    margin: 0 auto 0.5em;
+  .flex-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
 
-    @media screen and (max-width: 1024px) {
-      font-size: 3.5rem;
-    }
-    @media screen and (max-width: $width-sm) {
-      font-size: 3rem;
-    }
-  }
-
-  h2 {
-    margin: 0 auto 1rem;
-    font-family: var(--main-font);
-    font-size: 1.25rem;
-
-    @media screen and (max-width: $width-md) {
-      width: 80%;
+    @media (max-width: $width-md) {
+      flex-direction: column-reverse;
     }
 
-    @media screen and (max-width: $width-sm) {
-      width: 100%;
+    .text-wrapper {
+      text-align: initial;
+      flex: 1.25;
+
+      @media (max-width: $width-md) {
+        text-align: center;
+
+        p {
+          text-wrap: balance;
+        }
+      }
+
+      h1 {
+        margin-block-start: 0;
+      }
     }
-  }
 
-  // The Hour of Code is coming/here text
-  p {
-    font-size: 2em;
-    font-family: var(--main-font);
-    font-weight: var(--semi-bold-font-weight);
+    figure {
+      margin: 0;
+      max-width: 400px;
+      flex: 1;
 
-    @media screen and (max-width: $width-md) {
-      font-size: 1.75em;
-    }
-
-    @media screen and (max-width: $width-sm) {
-      font-size: 1.35em;
+      img {
+        width: 100%;
+      }
     }
   }
 }
@@ -125,9 +58,4 @@
 // Misc styles that need to be overridden
 .widehero_do_not_hide.phone-feature {
   background-position: 50% 0% !important;
-}
-
-#homepage #actions .herohocbutton-solid-yellow {
-  background-color: #1AADBB;
-  border-color: #1AADBB;
 }

--- a/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
@@ -1,11 +1,11 @@
+// Styles for the 2024 Hour of Code homepage banner on code.org
+
 @import 'breakpoints';
 
-// Styles for the 2024 Hour of Code homepage banner on code.org
 body #hero {
   background: linear-gradient(110deg, #6977CD -10.82%, #BCDEDE 43.13%, #34DFE5 68.88%, #688AED 95.85%);
 }
 
-// Code.org homepage banner
 .hoc-banner.homepage {
   text-align: center;
   line-height: 1.4;

--- a/pegasus/sites.v3/code.org/public/css/page/hour-of-code-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/page/hour-of-code-styles.scss
@@ -3,6 +3,7 @@
 
 @import 'breakpoints';
 
+// TODO: clean up these styles once we move to 2024 soon-hoc
 // Hero banner
 .hero-banner-basic {
   background: url('/images/hoc2023-hero-banner.svg') no-repeat center center;
@@ -46,6 +47,30 @@
     @media screen and (max-width: $width-sm) {
       font-size: 1.25em;
     }
+  }
+}
+
+// 2024 soon-hoc hero banner styles
+.hero-banner-basic.hoc-2024 {
+  background: none;
+  background: linear-gradient(110deg, #6977CD -10.82%, #BCDEDE 43.13%, #34DFE5 68.88%, #688AED 95.85%);
+
+  .wrapper {
+    padding: 0;
+  }
+
+  figure {
+    max-width: 344px;
+
+    img {
+      width: 100%;
+    }
+  }
+
+  h1 {
+    font-size: 3rem;
+    margin-bottom: 2rem;
+    color: unset;
   }
 }
 

--- a/pegasus/sites.v3/code.org/public/css/page/hour-of-code-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/page/hour-of-code-styles.scss
@@ -52,7 +52,7 @@
 
 // 2024 soon-hoc hero banner styles
 .hero-banner-basic.hoc-2024 {
-  background: none;
+  background: none; // this overrides the background image from the previous class
   background: linear-gradient(110deg, #6977CD -10.82%, #BCDEDE 43.13%, #34DFE5 68.88%, #688AED 95.85%);
 
   .wrapper {

--- a/pegasus/sites.v3/code.org/public/hourofcode/index.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/index.haml
@@ -3,15 +3,27 @@ title: Hour of Code
 theme: responsive_full_width
 ---
 
+:ruby
+  hoc_mode = DCDO.get('hoc_mode', CDO.default_hoc_mode)
 
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/hour-of-code-styles.css", rel: "stylesheet", type: "text/css"}
 
-%section.hero-banner-basic
-  .wrapper.centered
-    %p.hoc-label
-      =hoc_s(:hour_of_code)
-    %h1=hoc_s(:hoc2023_header)
+- if hoc_mode == "soon-hoc"
+  %section.hero-banner-basic.hoc-2024
+    .wrapper.centered.flex-container.align-items-center.flex-direction-column.gap-2
+      %figure
+        %img{src: "/images/banners/banner-hoc-2024.png", alt: ""}
+      .text-wrapper
+        %h1=hoc_s("hoc_2024.header")
+        %a.link-button.black.has-external-link{href: "https://hourofcode.com/events", target: "_blank", rel: "noopener noreferrer"}
+          =hoc_s("hoc_2024.button_host_an_event")
+- else
+  %section.hero-banner-basic
+    .wrapper.centered
+      %p.hoc-label
+        =hoc_s(:hour_of_code)
+      %h1=hoc_s(:hoc2023_header)
 
 %section.bg-neutral-light
   .wrapper.flex-container.justify-space-between.wrap

--- a/pegasus/sites.v3/code.org/public/hourofcode/index.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/index.haml
@@ -9,6 +9,7 @@ theme: responsive_full_width
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/hour-of-code-styles.css", rel: "stylesheet", type: "text/css"}
 
+-# Show 2024 HOC banner if hoc_mode is "soon-hoc", otherwise show 2023 banner
 - if hoc_mode == "soon-hoc"
   %section.hero-banner-basic.hoc-2024
     .wrapper.centered.flex-container.align-items-center.flex-direction-column.gap-2

--- a/pegasus/sites.v3/code.org/public/images/banners/banner-hoc-2024.png
+++ b/pegasus/sites.v3/code.org/public/images/banners/banner-hoc-2024.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:173da4c22e3f3cda9d8237e553e8a406d3a6c8730492da0ec268c987ec3047af
+size 241331

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -13,9 +13,12 @@ style_min: true
 :ruby
   @header["title"] = hoc_s(:hoc2020_header)
 
+  hoc_mode = DCDO.get('hoc_mode', CDO.default_hoc_mode)
+
 =inline_css 'homepage.css'
--# Comment this out when we are out of HoC season
--# =inline_css '/generated/hoc-banner.css'
+-# Apply this stylesheet when 'hoc_mode' is set to 'soon-hoc'
+- if hoc_mode == "soon-hoc"
+  =inline_css '/generated/hoc-banner.css'
 -# Apply this stylesheet when 'pl-launch-hero-banner' is set to 'true'
 - if !!DCDO.get('pl-launch-hero-banner', false)
   =inline_css '/generated/pl-hero-banner.css'

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -63,9 +63,9 @@
           .text-wrapper
             %h1
               = I18n.t(entry[:text_h1])
-            %p
+            %p.body-one
               = I18n.t(entry[:text_desc])
-            %a.link-button{href: entry[:studio_button_link] ? CDO.studio_url(entry[:studio_button_link]) : entry[:button_link], class: [(entry[:external_link] ? "has-external-link" : nil), (entry[:button_color_white] ? "white" : nil)].compact.join(' '), target: (entry[:external_link] ? "_blank" : nil), rel: (entry[:external_link] ? "noopener noreferrer" : nil)}
+            %a.link-button{href: entry[:studio_button_link] ? CDO.studio_url(entry[:studio_button_link]) : entry[:button_link], class: [(entry[:external_link] ? "has-external-link" : nil), (entry[:button_color_white] ? "white" : nil), (entry[:button_color_black] ? "black" : nil)].compact.join(' '), target: (entry[:external_link] ? "_blank" : nil), rel: (entry[:external_link] ? "noopener noreferrer" : nil)}
               = I18n.t(entry[:button_text])
           %figure
             %img{src: entry[:img_src], alt: ""}

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -253,6 +253,7 @@ class Homepage
           text_overline: action["text_overline"],
           external_link: action["external_link"],
           button_color_white: action["button_color_white"],
+          button_color_black: action["button_color_black"],
           button_link: action["button_link"],
           studio_button_link: action["studio_button_link"],
           button_label_primary: action["button_label_primary"],


### PR DESCRIPTION
Adds hero banners on https://code.org homepage and https://code.org/hourofcode. These will show up when the `hoc_mode` is set to `soon-hoc`.

## Links
Jira ticket: [ACQ-2371](https://codedotorg.atlassian.net/browse/ACQ-2371)
Figma mocks: [homepage](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=2710-505&t=eLDkWuLbvgyadov4-1), [hoc landing page](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=2710-1607&t=eLDkWuLbvgyadov4-1)

## Testing story
Tested locally to make sure the banners only show up for `soon-hoc`.

## Followup
After the September launch update this page to remove `soon-hoc` logic. Jira ticket: [ACQ-2376](https://codedotorg.atlassian.net/browse/ACQ-2376)

----

## code.org homepage
![homepage](https://github.com/user-attachments/assets/272d1346-0f76-4544-98e5-9c38638dfd58)

### Responsive

https://github.com/user-attachments/assets/7c1e15db-47c9-4ed3-bfe7-c11ff8cad9e3


### RTL
![localhost code org_3000_(Code org - 1366x768)](https://github.com/user-attachments/assets/2d943087-c523-41dd-94c3-9b2fb02f744b)


## code.org/hourofcode
![hoc-landing-page](https://github.com/user-attachments/assets/00548585-d90d-4626-bbef-48a1a384692d)

### Responsive


https://github.com/user-attachments/assets/d95b1d0a-7b88-4a46-afaa-d49aa1b76b50

### RTL
![localhost code org_3000_hourofcode(Code org - 1366x768)](https://github.com/user-attachments/assets/18947343-b8b5-494b-b41a-8bf4b69015ca)
