### PR TITLE
wait until ai assessments announcement is marked as seen

### DIFF
--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -42,6 +42,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         us_state_code: current_user.us_state_code,
         in_section: current_user.student? ? current_user.sections_as_student.present? : nil,
         created_at: current_user.created_at,
+        has_seen_ai_assessments_announcement: current_user.has_seen_ai_assessments_announcement?,
       }
     else
       render json: {

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1537,3 +1537,10 @@ And(/^I validate rubric ai config for all lessons$/) do
     expect(response_code).to eq(200), "Error code #{response_code}:\n#{response.body}"
   end
 end
+
+And(/^I wait until ai assessments announcement is marked as seen$/) do
+  wait_short_until do
+    response = browser_request(url: '/api/v1/users/current')
+    response['has_seen_ai_assessments_announcement']
+  end
+end

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_assessments_announcement.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_assessments_announcement.feature
@@ -1,6 +1,5 @@
 @no_mobile
 Feature: Announcement for AI Assessments
-  @no_safari
   Scenario: Teacher views and closes announcement
     Given I am a teacher
 
@@ -19,6 +18,7 @@ Feature: Announcement for AI Assessments
     # announcement is not visible after closing
     When I click selector "#ui-close-dialog"
     Then I wait until element "#uitest-ai-assessments-announcement" is not visible
+    And I wait until ai assessments announcement is marked as seen
 
     # announcement still not visible after reloading the page
     When I reload the page

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -108,7 +108,7 @@ namespace :circle do
     end
     RakeUtils.wait_for_url('http://localhost-studio.code.org:3000')
     Dir.chdir('dashboard/test/ui') do
-      container_features = `find ./features -name 'ai_assessments_announcement.feature' | sort`.split("\n").map {|f| f[2..]}
+      container_features = `find ./features -name '*.feature' | sort`.split("\n").map {|f| f[2..]}
       eyes_features = `grep -lr '@eyes' features`.split("\n")
       container_eyes_features = container_features & eyes_features
       # Use --local to configure the UI tests to run against localhost and

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -108,7 +108,7 @@ namespace :circle do
     end
     RakeUtils.wait_for_url('http://localhost-studio.code.org:3000')
     Dir.chdir('dashboard/test/ui') do
-      container_features = `find ./features -name '*.feature' | sort`.split("\n").map {|f| f[2..]}
+      container_features = `find ./features -name 'ai_assessments_announcement.feature' | sort`.split("\n").map {|f| f[2..]}
       eyes_features = `grep -lr '@eyes' features`.split("\n")
       container_eyes_features = container_features & eyes_features
       # Use --local to configure the UI tests to run against localhost and


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-770. The fix is to explicitly wait for the data on the server to be updated after making the call to mark the dialog as having been seen.

## Testing story

* test is passing in all browsers in drone
