### PR TITLE
[Design2-136] DSCO - Add support of onFocus,OnBlur, onMouseEnter, onMouseLeave, etc. native html props pt.2

### DIFF
--- a/apps/src/componentLibrary/alert/Alert.tsx
+++ b/apps/src/componentLibrary/alert/Alert.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, {useMemo} from 'react';
+import React, {HTMLAttributes, useMemo} from 'react';
 
 import CloseButton from '@cdo/apps/componentLibrary/closeButton';
 import {ComponentSizeXSToL} from '@cdo/apps/componentLibrary/common/types';
@@ -21,7 +21,7 @@ export const alertTypes: {[key in AlertType]: AlertType} = {
   gray: 'gray',
 };
 
-export interface AlertProps {
+export interface AlertProps extends HTMLAttributes<HTMLDivElement> {
   /** Alert text */
   text: string;
   /** Alert link */
@@ -90,6 +90,7 @@ const Alert: React.FunctionComponent<AlertProps> = ({
   isImmediateImportance = true,
   type = 'primary',
   size = 'm',
+  ...rest
 }) => {
   const iconToRender = useMemo(
     () => icon || getDefaultAlertIconFromType(type),
@@ -107,6 +108,7 @@ const Alert: React.FunctionComponent<AlertProps> = ({
         className
       )}
       role={isImmediateImportance ? 'alert' : 'status'}
+      {...rest}
     >
       <div className={moduleStyles.alertContentContainer}>
         {showIcon && iconToRender && <FontAwesomeV6Icon {...iconToRender} />}

--- a/apps/src/componentLibrary/alert/Alert.tsx
+++ b/apps/src/componentLibrary/alert/Alert.tsx
@@ -90,7 +90,7 @@ const Alert: React.FunctionComponent<AlertProps> = ({
   isImmediateImportance = true,
   type = 'primary',
   size = 'm',
-  ...rest
+  ...HTMLAttributes
 }) => {
   const iconToRender = useMemo(
     () => icon || getDefaultAlertIconFromType(type),
@@ -108,7 +108,7 @@ const Alert: React.FunctionComponent<AlertProps> = ({
         className
       )}
       role={isImmediateImportance ? 'alert' : 'status'}
-      {...rest}
+      {...HTMLAttributes}
     >
       <div className={moduleStyles.alertContentContainer}>
         {showIcon && iconToRender && <FontAwesomeV6Icon {...iconToRender} />}

--- a/apps/src/componentLibrary/alert/CHANGELOG.md
+++ b/apps/src/componentLibrary/alert/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0]()
+
+* updated `Alert` props to support native HTML Div element attributes
+
 ## [0.1.0](https://github.com/code-dot-org/code-dot-org/pull/59159)
 
 * implemented component

--- a/apps/src/componentLibrary/alert/CHANGELOG.md
+++ b/apps/src/componentLibrary/alert/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.0]()
+## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/60911)
 
 * updated `Alert` props to support native HTML Div element attributes
 

--- a/apps/src/componentLibrary/checkbox/CHANGELOG.md
+++ b/apps/src/componentLibrary/checkbox/CHANGELOG.md
@@ -2,20 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] ()
+
+* updated `Checkbox` props to support native HTML Input element attributes
+
 ## [0.3.4](https://github.com/code-dot-org/code-dot-org/pull/56220)
+
 * update checkbox vertical alignment after font change
 
 ## [0.3.3](https://github.com/code-dot-org/code-dot-org/pull/53962)
+
 * update indeterminate state
 * add stories for supernova
 
 ## [0.3.2](https://github.com/code-dot-org/code-dot-org/pull/)
+
 * focus-styles update - display focus outline only on keyboard (not mouse) navigation
 
 ## [0.3.1](https://github.com/code-dot-org/code-dot-org/pull/53526)
+
 * added tests for Checkbox component
 
 ## [0.3.0](https://github.com/code-dot-org/code-dot-org/pull/52753)
+
 * update README.md
 * create CHANGELOG.md
 * fix rtl support and vertical alignment of the checkbox
@@ -24,12 +33,15 @@ All notable changes to this project will be documented in this file.
 * add different sizes of labels support
 
 ## [0.2.1](https://github.com/code-dot-org/code-dot-org/pull/52338)
+
 * update checkbox storybook category
 
 ## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/52270)
+
 * add checkbox disabled state
 * add indeterminate state support
 * add sizes support (once updated typography is ready we'll need to update label/span sizes)
 
 ## [0.1.0](https://github.com/code-dot-org/code-dot-org/pull/52154)
+
 * Initial release

--- a/apps/src/componentLibrary/checkbox/CHANGELOG.md
+++ b/apps/src/componentLibrary/checkbox/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.0] ()
+## [0.4.0] (https://github.com/code-dot-org/code-dot-org/pull/60911)
 
 * updated `Checkbox` props to support native HTML Input element attributes
 

--- a/apps/src/componentLibrary/checkbox/Checkbox.tsx
+++ b/apps/src/componentLibrary/checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, {useRef, useEffect, ChangeEvent} from 'react';
+import React, {useRef, useEffect, ChangeEvent, HTMLAttributes} from 'react';
 
 import {componentSizeToBodyTextSizeMap} from '@cdo/apps/componentLibrary/common/constants';
 import {ComponentSizeXSToL} from '@cdo/apps/componentLibrary/common/types';
@@ -7,15 +7,15 @@ import Typography from '@cdo/apps/componentLibrary/typography';
 
 import moduleStyles from './checkbox.module.scss';
 
-export interface CheckboxProps {
+export interface CheckboxProps extends HTMLAttributes<HTMLInputElement> {
   /** Checkbox checked state */
   checked: boolean;
   /** Checkbox onChange handler*/
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   /** The name attribute specifies the name of an input element.
-   The name attribute is used to reference elements in a JavaScript,
-   or to reference form data after a form is submitted.
-   Note: Only form elements with a name attribute will have their values passed when submitting a form. */
+     The name attribute is used to reference elements in a JavaScript,
+     or to reference form data after a form is submitted.
+     Note: Only form elements with a name attribute will have their values passed when submitting a form. */
   name: string;
   /** The value attribute specifies the value of an input element. */
   value?: string;
@@ -51,6 +51,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   disabled = false,
   indeterminate = false,
   size = 'm',
+  ...rest
 }) => {
   const checkboxRef = useRef<HTMLInputElement>(null);
   const bodyTextSize = componentSizeToBodyTextSizeMap[size];
@@ -73,6 +74,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
         checked={checked}
         disabled={disabled}
         onChange={onChange}
+        {...rest}
       />
       <i className="fa-solid" />
       {label && (

--- a/apps/src/componentLibrary/checkbox/Checkbox.tsx
+++ b/apps/src/componentLibrary/checkbox/Checkbox.tsx
@@ -51,7 +51,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   disabled = false,
   indeterminate = false,
   size = 'm',
-  ...rest
+  ...HTMLAttributes
 }) => {
   const checkboxRef = useRef<HTMLInputElement>(null);
   const bodyTextSize = componentSizeToBodyTextSizeMap[size];
@@ -74,7 +74,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
         checked={checked}
         disabled={disabled}
         onChange={onChange}
-        {...rest}
+        {...HTMLAttributes}
       />
       <i className="fa-solid" />
       {label && (

--- a/apps/src/componentLibrary/chips/CHANGELOG.md
+++ b/apps/src/componentLibrary/chips/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.0] ()
+## [0.3.0] (https://github.com/code-dot-org/code-dot-org/pull/60911)
 
 * updated `Chip` props to support native HTML Input element attributes
 

--- a/apps/src/componentLibrary/chips/CHANGELOG.md
+++ b/apps/src/componentLibrary/chips/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] ()
+
+* updated `Chip` props to support native HTML Input element attributes
+
 ## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/58809)
 
 * Added `gray` color

--- a/apps/src/componentLibrary/chips/_Chip.tsx
+++ b/apps/src/componentLibrary/chips/_Chip.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
-import React, {useEffect, useRef, memo} from 'react';
+import React, {useEffect, useRef, memo, HTMLAttributes} from 'react';
 
 import moduleStyles from './chip.module.scss';
 
 const commonI18n = require('@cdo/locale');
 
-interface ChipProps {
+interface ChipProps extends HTMLAttributes<HTMLInputElement> {
   /** Chip label */
   label: string;
   /** Chip name*/

--- a/apps/src/componentLibrary/chips/_Chip.tsx
+++ b/apps/src/componentLibrary/chips/_Chip.tsx
@@ -33,6 +33,7 @@ const Chip: React.FunctionComponent<ChipProps> = ({
   textThickness,
   disabled,
   onCheckedChange,
+  ...HTMLAttributes
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -71,6 +72,7 @@ const Chip: React.FunctionComponent<ChipProps> = ({
               commonI18n.chooseAtLeastOne()
             );
           }}
+          {...HTMLAttributes}
         />
         {label}
       </label>


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [Design2-136] DSCO - Add support of onFocus,OnBlur, onMouseEnter, onMouseLeave, etc. native html props pt.2

* added native HTML attributes support to `Alert`, `Checkbox`, `Chip` components

## Links
- jira ticket: [DESIGN2-136](https://codedotorg.atlassian.net/browse/DESIGN2-136)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
