### PR TITLE
Update teach page text

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1558,7 +1558,7 @@
   resources_tabs_assessments_desc: "These include rubrics, checklists, mini-projects, end-of-chapter projects, student-facing rubrics, sample projects, and post-project tests — all designed to support teachers in measuring student growth, providing feedback, and evaluating student understanding."
 
   teach_page_top_heading: "Teach computer science & ignite possibilities"
-  teach_page_top_desc_01: "Tap into your students' full potential with Code.org's free Computer Science (CS) curriculum."
+  teach_page_top_desc_01: "Tap into your students' full potential with Code.org's free Computer Science (CS) and Artificial Intelligence (AI) curriculum."
   teach_page_top_desc_02: "Join the global community of over 2 million educators empowering the next generation of innovators, problem solvers, and digital citizens! Code.org supports teachers the whole way with professional learning, comprehensive curricula, and support when you need it."
   teach_page_why_teach_cs_heading: "Why teach computer science with Code.org?"
   teach_page_why_teach_cs_block_heading_01: "Build foundational CS skills"


### PR DESCRIPTION
This was a request from Cameron. I figure we'll simply wait for translations to catch up rather than making a new string, but open for push back.

It does push the text into an extra line but it still looks fine to me.

![Screenshot 2024-09-09 at 10 46 35 AM](https://github.com/user-attachments/assets/c247e75a-429f-4213-aff7-40163cffddb2)


Note to DOTD: I believe this will cause an eyes diff.


