### PR TITLE
AI Tutor: update set_ai_tutor_available script to include sublevels

### DIFF
--- a/bin/oneoff/set_ai_tutor_available_for_csa_levels.rb
+++ b/bin/oneoff/set_ai_tutor_available_for_csa_levels.rb
@@ -7,15 +7,23 @@ require_relative '../../dashboard/config/environment'
 require src_dir 'database'
 
 count_levels_updated = 0
+count_sublevels_updated = 0
 
 time_taken = Benchmark.realtime do
   ActiveRecord::Base.transaction do
     Level.includes(:script_levels).all.select {|level| level.script_levels.any? {|sl| sl.script.csa?}}.each do |csa_level|
       csa_level.properties["ai_tutor_available"] = true
       csa_level.save!
+      sublevel_ids = ParentLevelsChildLevel.where(parent_level: csa_level).pluck(:child_level_id)
+      sublevels = Level.where(id: sublevel_ids)
+      sublevels.each do |sublevel|
+        sublevel.properties["ai_tutor_available"] = true
+        sublevel.save!
+        count_sublevels_updated += 1
+      end
       count_levels_updated += 1
     end
   end
 end
 
-puts "It took #{time_taken} seconds to set ai_tutor_available to true for #{count_levels_updated} CSA levels."
+puts "It took #{time_taken} seconds to set ai_tutor_available to true for #{count_levels_updated} levels and #{count_sublevels_updated} contained levels."


### PR DESCRIPTION
[CT-780](https://codedotorg.atlassian.net/browse/CT-780)

Follow up to https://github.com/code-dot-org/code-dot-org/pull/56692

I updated the script that we used to set the`ai_tutor_available` level property to `true` for CSA levels to include contained levels (i.e. "sublevels") which were previously erroneously excluded. 

Adding in sublevels does increase the time it takes to run the script, but it still doesn't seem to be a big performance concern from my perspective, but let me know if you disagree! 

<img width="1063" alt="Screenshot 2024-09-09 at 12 00 48 PM" src="https://github.com/user-attachments/assets/21590221-d645-405a-b9f5-5668700c49cb">

