### PR TITLE
HoC 2024 - Add hero banners on hourofcode.com

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -174,6 +174,31 @@ section.banner {
     max-width: 850px;
     margin: 0 auto;
     padding: 2em 0 7em;
+
+    // 2024 soon-hoc hero banner styles
+    &.hoc-2024 {
+      flex-direction: column;
+      align-items: center;
+      gap: 2rem;
+      padding-block-end: 5rem;
+
+      h1, p, p > a {
+        color: var(--neutral_dark);
+      }
+
+      h1 {
+        font-size: 3rem;
+        margin-bottom: 1rem;
+      }
+
+      figure {
+        max-width: 344px;
+
+        img {
+          width: 100%;
+        }
+      }
+    }
   }
 
   a {

--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -7,7 +7,7 @@
   background-size: cover;
 
   &.hoc-2024 {
-    background: none; // this overrides the background image from the previous class
+    background: none; // this overrides the background image from above
     background: linear-gradient(110deg, #6977CD -10.82%, #BCDEDE 43.13%, #34DFE5 68.88%, #688AED 95.85%);
   }
 

--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -1,9 +1,15 @@
 @import 'color.scss', 'font.scss', 'breakpoints.scss';
 
+// TODO: clean up these styles once we move to 2024 soon-hoc
 #fullwidth {
   overflow: hidden;
   background: url('/images/hoc2023-hero-banner.svg') no-repeat center center;
   background-size: cover;
+
+  &.hoc-2024 {
+    background: none; // this overrides the background image from the previous class
+    background: linear-gradient(110deg, #6977CD -10.82%, #BCDEDE 43.13%, #34DFE5 68.88%, #688AED 95.85%);
+  }
 
   @media screen and (max-width: $width-sm) {
     background: url('/images/hoc2023-hero-banner-mobile.svg') no-repeat center center;
@@ -15,6 +21,7 @@
   background-color: rgba($neutral-white, .9);
 }
 
+// TODO: clean up these styles once we move to 2024 soon-hoc
 section.banner.homepage,
 section.banner {
 
@@ -125,6 +132,36 @@ section.banner.homepage {
           background-color: #121212;
         }
       }
+    }
+  }
+}
+
+// 2024 soon-hoc hero banner styles
+section.banner.homepage.hoc-2024 {
+
+  .wrapper {
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+  }
+
+  h1, p {
+    color: var(--neutral_dark);
+  }
+
+  h1 {
+    font-size: 3rem;
+  }
+
+  a.link-button {
+    text-decoration: none;
+  }
+
+  figure {
+    max-width: 344px;
+
+    img {
+      width: 100%;
     }
   }
 }

--- a/pegasus/sites.v3/hourofcode.com/public/images/hoc-2024-graphic.png
+++ b/pegasus/sites.v3/hourofcode.com/public/images/hoc-2024-graphic.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:612ad985f1cfd9eb0111949ff81b92e7b99708af8b7f09018b57c2274876518f
+size 252549

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -23,16 +23,29 @@ social:
 %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
 
 #top
-  #fullwidth
+  #fullwidth{class: hoc_mode == "soon-hoc" ? 'hoc-2024' : nil}
     = view :header
-    %section.banner.homepage
-      .wrapper
-        %p.hoc-label
-          =hoc_s(:hour_of_code)
-        %h1=hoc_s(:hoc2023_header)
-        %p.hero-desc
-          =hoc_s(:hoc2023_hero_desc_homepage)
-        = view :hoc2023_hero_banner_ctas
+    -# Show 2024 HOC banner if hoc_mode is "soon-hoc", otherwise show 2023 banner
+    - if hoc_mode == "soon-hoc"
+      %section.banner.homepage.hoc-2024
+        .wrapper.flex-container
+          %figure
+            %img{src: "/images/hoc-2024-graphic.png", alt: ""}
+          .text-wrapper
+            %h1=hoc_s("hoc_2024.header")
+            %p.body-one
+              =hoc_s("hoc_2024.banner.desc.join_millions")
+          %a.link-button.black{href: resolve_url("/events")}
+            =hoc_s("hoc_2024.button_host_an_event")
+    - else
+      %section.banner.homepage
+        .wrapper
+          %p.hoc-label
+            =hoc_s(:hour_of_code)
+          %h1=hoc_s(:hoc2023_header)
+          %p.hero-desc
+            =hoc_s(:hoc2023_hero_desc_homepage)
+          = view :hoc2023_hero_banner_ctas
 
 %main
   -# What is HoC?

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -10,9 +10,12 @@ social:
 
 %link{href: "/css/generated/hoc-banner.css", rel: "stylesheet", type: "text/css"}
 
+-# Get the default HOC mode
+-hoc_mode = DCDO.get("hoc_mode", CDO.default_hoc_mode)
+
 = view :analytics_event_log_helper, event_name: AnalyticsConstants::HOC_ACTIVITIES_PAGE_VISITED
 
-#fullwidth
+#fullwidth{class: hoc_mode == "soon-hoc" ? 'hoc-2024' : nil}
   = view :header
   %section.banner
     = view :learn_banner_text

--- a/pegasus/sites.v3/hourofcode.com/styles/040-page.css
+++ b/pegasus/sites.v3/hourofcode.com/styles/040-page.css
@@ -648,6 +648,17 @@ a.link-button.secondary.white {
   color: var(--neutral_white);
 }
 
+a.link-button.black {
+  background: var(--neutral_dark);
+  border-color: var(--neutral_dark);
+  color: var(--neutral_white);
+
+  &:hover {
+    background: black;
+    border-color: black;
+  }
+}
+
 .continue-btn{
   background-color: rgb(255, 255, 255);
   border-color: var(--brand_secondary_default);

--- a/pegasus/sites.v3/hourofcode.com/views/learn_banner_text.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/learn_banner_text.haml
@@ -1,10 +1,24 @@
-.wrapper
-  %p.hoc-label
-    =hoc_s(:hour_of_code)
-  %h1=hoc_s(:hoc2023_header)
-  %p.hero-desc
-    =hoc_s(:hoc2023_hero_desc_learn_page)
-  %p!= hoc_s(:learn_banner_beyond_markdown, markdown: :inline, locals: {url: "/beyond"})
-  %p
-    %i{:class=>"fa fa-graduation-cap", :style=>"font-size: larger"}
-    != hoc_s(:learn_banner_teachers_markdown, markdown: :inline, locals: {host_url: "/events", howto_url: "/how-to"})
+-# Get the default HOC mode
+-hoc_mode = DCDO.get("hoc_mode", CDO.default_hoc_mode)
+
+-# Show 2024 HOC banner if hoc_mode is "soon-hoc", otherwise show 2023 banner
+- if hoc_mode == "soon-hoc"
+  .wrapper.hoc-2024.flex-container
+    %figure
+      %img{src: "/images/hoc-2024-graphic.png", alt: ""}
+    .text-wrapper
+      %h1=hoc_s("hoc_activities.heading")
+      %p.body-two
+        %i{:class=>"fa fa-graduation-cap", :style=>"font-size: larger"}
+        != hoc_s(:learn_banner_teachers_markdown, markdown: :inline, locals: {host_url: "/events", howto_url: "/how-to"})
+- else
+  .wrapper
+    %p.hoc-label
+      =hoc_s(:hour_of_code)
+    %h1=hoc_s(:hoc2023_header)
+    %p.hero-desc
+      =hoc_s(:hoc2023_hero_desc_learn_page)
+    %p!= hoc_s(:learn_banner_beyond_markdown, markdown: :inline, locals: {url: "/beyond"})
+    %p
+      %i{:class=>"fa fa-graduation-cap", :style=>"font-size: larger"}
+      != hoc_s(:learn_banner_teachers_markdown, markdown: :inline, locals: {host_url: "/events", howto_url: "/how-to"})


### PR DESCRIPTION
Adds hero banners on https://hourofcode.com homepage and https://hourofcode.com/learn. These will show up when the `hoc_mode` is set to `soon-hoc`.

## Links
Jira ticket: 
Figma mocks: [homepage](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=2710-2389&t=zJwKUCz8k7xuGGwA-1), [activities (/learn) page](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=2710-2466&t=zJwKUCz8k7xuGGwA-1)

## Testing story
Tested locally to make sure the banners only show up for `soon-hoc`.

## Followup
After the September launch update this page to remove `soon-hoc` logic. Jira ticket: [ACQ-2376](https://codedotorg.atlassian.net/browse/ACQ-2376)

----

## hourofcode.com homepage
![homepage](https://github.com/user-attachments/assets/c70bead3-2279-431b-805e-5e165e24a563)

### Responsive

https://github.com/user-attachments/assets/cdad3bbb-3208-4392-8e6a-d14e62ae3f29


## hourofcode.com/learn

![activities](https://github.com/user-attachments/assets/1e980ce1-4522-4857-8a71-c067041f0e48)


### Responsive


https://github.com/user-attachments/assets/71443116-392e-459c-817c-7435d439f8fd



