### PR TITLE
HoC 2024 - Update code.org/hourofcode

### DIFF
--- a/pegasus/sites.v3/code.org/public/hourofcode/index.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/index.haml
@@ -27,27 +27,23 @@ theme: responsive_full_width
       %h1=hoc_s(:hoc2023_header)
 
 %section.bg-neutral-light
-  .wrapper.flex-container.justify-space-between.wrap
-    .text-wrapper.col-50
-      %h2=hoc_s(:hoc_page_what_is_hoc_heading)
-      %p.body-three.has-external-link
-        =hoc_s(:hoc_page_desc, markdown: :inline, locals:{hoc_url: "https://hourofcode.com"})
-      %p.body-three
-        =hoc_s(:hoc_page_desc_2023)
-    %div.col-45
-      = view :display_video_thumbnail, id: "hoc_celebrities_2023", video_code: "ybBUd9-0ZJQ", play_button: 'center', letterbox: 'false', download_path: "//videos.code.org/hour_of_code_celebrities_2023.mp4"
-      %a.body-three{href: "/educate/resources/videos"}
-        =hoc_s(:call_to_action_see_more_insp_videos)
-  .clear
+  .wrapper
+    %h2=hoc_s("hoc_page.what_is_hoc.heading")
+    .flex-container.justify-space-between.wrap.gap-2
+      .text-wrapper.col-50
+        %p.body-three.has-external-link
+          =hoc_s("hoc_page.what_is_hoc.desc_01", markdown: :inline, locals:{hoc_url: "https://hourofcode.com"})
+        - if hoc_mode == "soon-hoc"
+          %p.body-three
+            =hoc_s("hoc_page.what_is_hoc.desc_02", markdown: :inline)
+      %figure.col-45
+        %img{src: "/images/hoc-page-kids-computer.png", alt: "", style: "width: 100%"}
 
 %section
   .wrapper
-    %p.heading-sm.centered{style: "margin-bottom: 4rem"}
-      =hoc_s(:hoc_page_place_to_start)
-    %hr
-    %h2=hoc_s(:hoc_page_lead_activity_heading)
+    %h2=hoc_s("hoc_page.activities.heading")
     %p.has-external-link
-      =hoc_s(:hoc_page_lead_activity_desc, markdown: :inline, locals:{register_activity_url: "https://hourofcode.com/events"})
+      =hoc_s("hoc_page.activities.desc", markdown: :inline, locals:{register_url: "https://hourofcode.com/events"})
     = view :hoc_activites_featured
     .centered{style: "margin-top: 3rem"}
       %hr
@@ -61,52 +57,9 @@ theme: responsive_full_width
       %a.link-button.secondary{href: CDO.studio_url("/catalog?marketingInitiative=hoc")}
         =hoc_s(:call_to_action_explore_activities)
 
-= view :section_divider_line
-
-%section
-  .wrapper
-    %h2=hoc_s(:learn_how_ai_works)
-    %p=hoc_s(:hoc_page_how_ai_works_desc)
-    .action-block.action-block--two-col
-      .media-wrapper.col-50
-        = view :display_video_thumbnail, id: "intro_csp", video_code: "YlwVMtNEWKA", play_button: 'center', letterbox: 'false', download_path: "//videos.code.org/ai_series/ai-intro-to-how-ai-works-lessons.mp4"
-      .text-wrapper.col-50
-        .flex-container.justify-space-between.align-items-start
-          %p.overline
-            =hoc_s(:module_label_grades)
-            =hoc_s(:module_grade_6_12)
-        %h3.heading-md
-          = hoc_s(:hoc_page_how_ai_works_title)
-        %p
-          = hoc_s(:how_ai_works_intro_desc)
-        %a.link-button{href: "/ai/how-ai-works"}
-          = hoc_s(:call_to_action_explore_how_ai_works)
-      .clear
-
-= view :section_divider_line
-
-%section
-  .wrapper
-    %h2=hoc_s(:hoc_page_ai_101_heading)
-    %p=hoc_s(:hoc_page_ai_101_desc)
-    .action-block.action-block--two-col
-      .media-wrapper.col-50
-        %img{src: "shared/images/social-media/ai-101-social.png", alt: hoc_s(:hoc_live)}
-      .text-wrapper.col-50
-        .flex-container.justify-space-between.align-items-start
-          %p.overline
-            =hoc_s(:module_professional_learning)
-        %h3.heading-md
-          = hoc_s(:hoc_page_ai_101_block_title)
-        %p
-          = hoc_s(:hoc_page_ai_101_block_desc)
-        %a.link-button{href: "/ai/pl/101"}
-          = hoc_s(:csa_ai_page_learn_more_title)
-      .clear
-
 %section.bg-neutral-light
   .wrapper.centered
-    %h2=hoc_s(:hoc_page_go_beyond_hoc)
+    %h2=hoc_s("hoc_page.beyond.heading")
     = view :hoc_page_beyond
 
 = view :analytics_event_log_helper, event_name: AnalyticsConstants::HOC_LANDING_PAGE_VISITED

--- a/pegasus/sites.v3/code.org/public/hourofcode/index.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/index.haml
@@ -30,7 +30,7 @@ theme: responsive_full_width
 %section.bg-neutral-light
   .wrapper
     %h2=hoc_s("hoc_page.what_is_hoc.heading")
-    .flex-container.justify-space-between.wrap.gap-2
+    .flex-container.justify-space-between.wrap.gap-1
       .text-wrapper.col-50
         %p.body-three.has-external-link
           =hoc_s("hoc_page.what_is_hoc.desc_01", markdown: :inline, locals:{hoc_url: "https://hourofcode.com"})

--- a/pegasus/sites.v3/code.org/public/hourofcode/index.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/index.haml
@@ -9,6 +9,7 @@ theme: responsive_full_width
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/hour-of-code-styles.css", rel: "stylesheet", type: "text/css"}
 
+-# TODO - clean up soon-hoc logic once this is launched
 -# Show 2024 HOC banner if hoc_mode is "soon-hoc", otherwise show 2023 banner
 - if hoc_mode == "soon-hoc"
   %section.hero-banner-basic.hoc-2024
@@ -36,6 +37,9 @@ theme: responsive_full_width
         - if hoc_mode == "soon-hoc"
           %p.body-three
             =hoc_s("hoc_page.what_is_hoc.desc_02", markdown: :inline)
+        - else
+          %p.body-three
+            =hoc_s(:hoc_page_desc_2023)
       %figure.col-45
         %img{src: "/images/hoc-page-kids-computer.png", alt: "", style: "width: 100%"}
 

--- a/pegasus/sites.v3/code.org/public/images/action-blocks/action-block-teach.png
+++ b/pegasus/sites.v3/code.org/public/images/action-blocks/action-block-teach.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8dc3a972c6aa2d4647742b4da2113df881b1196b628ad7cf5215ae496c000d6
+size 144983

--- a/pegasus/sites.v3/code.org/public/images/hoc-page-kids-computer.png
+++ b/pegasus/sites.v3/code.org/public/images/hoc-page-kids-computer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08e212090d12cc95a868f555185dd9c0457a50a924ab61c8715498cad5be8517
+size 203685

--- a/pegasus/sites.v3/code.org/views/hoc_page_beyond.haml
+++ b/pegasus/sites.v3/code.org/views/hoc_page_beyond.haml
@@ -1,40 +1,37 @@
 :ruby
-  card_item = [
+  block_items = [
     {
-      title: hoc_s(:teach_computer_science),
-      image: "/images/square-teacher-with-student.png",
-      desc: hoc_s(:hoc_page_go_beyond_hoc_card_desc_teach),
-      url: "/teach",
-      button_label: hoc_s(:call_to_action_learn_more),
-      aria_label: hoc_s(:aria_label_call_to_action_learn_more_teach)
-    },
-    {
-      title: hoc_s(:explore_our_curriculum),
-      image: "/images/square-students-at-computer.png",
-      desc: hoc_s(:hoc_page_go_beyond_hoc_card_desc_curriculum),
+      title: hoc_s("hoc_page.beyond.catalog.title"),
+      image: "/images/action-blocks/action-block-catalog.png",
+      desc: hoc_s("hoc_page.beyond.catalog.desc"),
       url: CDO.studio_url("/catalog"),
-      button_label: hoc_s(:call_to_action_view_curriculum_catalog),
-      aria_label: ""
+      button_label: hoc_s("hoc_page.beyond.catalog.button"),
     },
     {
-      title: hoc_s(:start_professional_learning),
-      image: "/images/teach-page-pl-offerings-self-paced.png",
-      desc: hoc_s(:hoc_page_go_beyond_hoc_card_desc_pl),
-      url: "/educate/professional-development-online",
-      button_label: hoc_s(:call_to_action_learn_more),
-      aria_label: hoc_s(:aria_label_call_to_action_learn_more_self_paced_pl)
+      title: hoc_s("hoc_page.beyond.teach.title"),
+      image: "/images/action-blocks/action-block-teach.png",
+      desc: hoc_s("hoc_page.beyond.teach.desc"),
+      url: "/teach",
+      button_label: hoc_s("hoc_page.beyond.teach.button"),
+    },
+    {
+      title: hoc_s("hoc_page.beyond.professional_learning.title"),
+      image: "/images/action-blocks/action-block-self-paced-pl.png",
+      desc: hoc_s("hoc_page.beyond.professional_learning.desc"),
+      url: "/educate/professional-learning/self-paced",
+      button_label: hoc_s("hoc_page.beyond.professional_learning.button"),
     },
   ]
 
-%div.editorial-cards-wrapper
-  - card_item.each do |card_item|
-    .flex-container.justify-space-between.align-content-baseline.wrap
+.action-block__wrapper.action-block__wrapper--three-col
+  - block_items.each do |block_item|
+    .action-block.action-block--one-col.flex-space-between.white
       .content-wrapper
-        %img{src: card_item[:image], alt: ""}
-        %h3.heading-sm
-          = card_item[:title]
-        %p.no-margin-bottom
-          = card_item[:desc]
+        %h3
+          = block_item[:title]
+        %img{src: block_item[:image], alt: ""}
+        %p
+          = block_item[:desc]
       .content-footer
-        %a.link-button{href: card_item[:url], "aria-label": card_item[:aria_label]}
-          = card_item[:button_label]
+        %a.link-button{href: block_item[:url]}
+          = block_item[:button_label]


### PR DESCRIPTION
Updates https://code.org/hourofcode in preparation for Hour of Code 2024.

## Links
Jira ticket: [ACQ-2305](https://codedotorg.atlassian.net/browse/ACQ-2305)
Figma mock: [here](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=2710-1607&t=yUYNQDSQ9CCvi300-1)

## Testing story
Tested locally to make sure the banners only show up for `soon-hoc`.

## Followup
After the September launch update this page to remove `soon-hoc` logic. Jira ticket: [ACQ-2376](https://codedotorg.atlassian.net/browse/ACQ-2376)

----

## When `soon-hoc` is true
![soon-hoc](https://github.com/user-attachments/assets/4c82f44f-f17e-4e23-9761-f8c6adeff563)

## When `soon-hoc` is false
![localhost code org_3000_hourofcode](https://github.com/user-attachments/assets/bf168b11-a469-4229-8a32-c2368ee30e14)
