### PR TITLE
Update teacher and student sign-up flow tests

### DIFF
--- a/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
@@ -244,7 +244,7 @@ describe('FinishStudentAccount', () => {
     expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
   });
 
-  it('leaving the state field empty shows error message and disabled submit button until state is entered', () => {
+  it('leaving the state field empty shows error message and disabled submit button until state is entered for US users', () => {
     renderDefault();
     const stateInput = screen.getAllByRole('combobox')[1];
     const finishSignUpButton = screen.getByRole('button', {
@@ -274,6 +274,22 @@ describe('FinishStudentAccount', () => {
     // Error shows and button is disabled with empty state
     screen.getByText(locale.state_error_message());
     expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('state field is not required if user is not detected in the U.S.', () => {
+    renderDefault(false);
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
+
+    // Set all required fields (which excludes 'state' in this case)
+    const displayNameInput = screen.getAllByDisplayValue('')[1];
+    const ageInput = screen.getAllByRole('combobox')[0];
+    fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
+    fireEvent.change(ageInput, {target: {value: '6'}});
+
+    // Button is enabled without having to enter anything for 'state'
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
   });
 
   it('parentEmail error shows if parent checkbox is selected and parentEmail is selected then cleared', () => {

--- a/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
@@ -29,17 +29,7 @@ describe('FinishStudentAccount', () => {
   ];
 
   afterEach(() => {
-    [
-      DISPLAY_NAME_SESSION_KEY,
-      IS_PARENT_SESSION_KEY,
-      PARENT_EMAIL_SESSION_KEY,
-      PARENT_EMAIL_OPT_IN_SESSION_KEY,
-      USER_AGE_SESSION_KEY,
-      USER_STATE_SESSION_KEY,
-      USER_GENDER_SESSION_KEY,
-    ].forEach((session_key: string) => {
-      sessionStorage.removeItem(session_key);
-    });
+    sessionStorage.clear();
   });
 
   function renderDefault(usIp: boolean = true) {
@@ -190,143 +180,139 @@ describe('FinishStudentAccount', () => {
     expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
   });
 
-  it('displayName error shows if name is entered then deleted', () => {
+  it('leaving the displayName field empty shows error message and disabled submit button until display name is entered', () => {
     renderDefault();
     const displayNameInput = screen.getAllByDisplayValue('')[1];
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
 
-    // Error message doesn't show by default
+    // Set other required fields
+    const ageInput = screen.getAllByRole('combobox')[0];
+    const stateInput = screen.getAllByRole('combobox')[1];
+    fireEvent.change(ageInput, {target: {value: '6'}});
+    fireEvent.change(stateInput, {target: {value: 'WA'}});
+
+    // Error message doesn't show and button is disabled by default
     expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
 
     // Enter display name
     fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
 
-    // Error message doesn't show when display name is entered
+    // Error does not show and button is enabled when display name is entered
     expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
 
     // Clear display name
     fireEvent.change(displayNameInput, {target: {value: ''}});
 
-    // Error shows with empty display name
+    // Error shows and button is disabled with empty display name
     screen.getByText(locale.display_name_error_message());
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
   });
 
-  it('age error shows if age is selected then cleared', () => {
+  it('leaving the age field empty shows error message and disabled submit button until age is entered', () => {
     renderDefault();
     const ageInput = screen.getAllByRole('combobox')[0];
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
 
-    // Error message doesn't show by default
+    // Set other required fields
+    const displayNameInput = screen.getAllByDisplayValue('')[1];
+    const stateInput = screen.getAllByRole('combobox')[1];
+    fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
+    fireEvent.change(stateInput, {target: {value: 'WA'}});
+
+    // Error message doesn't show and button is disabled by default
     expect(screen.queryByText(locale.age_error_message())).toBe(null);
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
 
     // Enter age
     fireEvent.change(ageInput, {target: {value: '6'}});
 
-    // Error message doesn't show when age is selected
+    // Error does not show and button is enabled when age is entered
     expect(screen.queryByText(locale.age_error_message())).toBe(null);
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
 
     // Clear age
     fireEvent.change(ageInput, {target: {value: ''}});
 
-    // Error shows with empty age
+    // Error shows and button is disabled with empty age
     screen.getByText(locale.age_error_message());
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
   });
 
-  it('state error shows if state is selected then cleared', () => {
+  it('leaving the state field empty shows error message and disabled submit button until state is entered', () => {
     renderDefault();
     const stateInput = screen.getAllByRole('combobox')[1];
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
 
-    // Error message doesn't show by default
+    // Set other required fields
+    const displayNameInput = screen.getAllByDisplayValue('')[1];
+    const ageInput = screen.getAllByRole('combobox')[0];
+    fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
+    fireEvent.change(ageInput, {target: {value: '6'}});
+
+    // Error message doesn't show and button is disabled by default
     expect(screen.queryByText(locale.state_error_message())).toBe(null);
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
 
     // Enter state
     fireEvent.change(stateInput, {target: {value: 'WA'}});
 
-    // Error message doesn't show when state is selected
+    // Error does not show and button is enabled when state is entered
     expect(screen.queryByText(locale.state_error_message())).toBe(null);
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
 
     // Clear state
     fireEvent.change(stateInput, {target: {value: ''}});
 
-    // Error shows with empty state
+    // Error shows and button is disabled with empty state
     screen.getByText(locale.state_error_message());
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
   });
 
   it('parentEmail error shows if parent checkbox is selected and parentEmail is selected then cleared', () => {
     renderDefault();
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
+
+    // Set other required fields
+    const displayNameInput = screen.getAllByDisplayValue('')[1];
+    const stateInput = screen.getAllByRole('combobox')[1];
+    const ageInput = screen.getAllByRole('combobox')[0];
+    fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
+    fireEvent.change(stateInput, {target: {value: 'WA'}});
+    fireEvent.change(ageInput, {target: {value: '6'}});
+
+    // Button is enabled after required fields are filled before parent checkbox is checked
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
 
     // Check parent checkbox
     fireEvent.click(screen.getAllByRole('checkbox')[0]);
 
-    // Error message doesn't show by default
+    // Error message doesn't show and button is disabled after parent checkbox is checked
     const parentEmailInput = screen.getAllByDisplayValue('')[1];
     expect(screen.queryByText(locale.email_error_message())).toBe(null);
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
 
     // Enter state
     fireEvent.change(parentEmailInput, {target: {value: 'parent@email.com'}});
 
-    // Error message doesn't show when state is selected
+    // Error does not show and button is enabled when email is entered
     expect(screen.queryByText(locale.email_error_message())).toBe(null);
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
 
     // Clear state
     fireEvent.change(parentEmailInput, {target: {value: ''}});
 
-    // Error shows with empty state
+    // Error shows and button is disabled with empty email
     screen.getByText(locale.email_error_message());
-  });
-
-  it('finish student signup button starts disabled', () => {
-    renderDefault();
-
-    const finishSignUpButton = screen.getByRole('button', {
-      name: locale.go_to_my_account(),
-    });
     expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
-  });
-
-  it('finish student signup button is disabled until required fields are entered without errors', () => {
-    renderDefault();
-
-    // Cause an error in each required field by filling it in then clearing it
-    fireEvent.click(screen.getAllByRole('checkbox')[0]);
-
-    const parentEmailInput = screen.getAllByDisplayValue('')[1];
-    fireEvent.change(parentEmailInput, {target: {value: 'parent@email.com'}});
-    fireEvent.change(parentEmailInput, {target: {value: ''}});
-
-    const displayNameInput = screen.getAllByDisplayValue('')[3];
-    fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
-    fireEvent.change(displayNameInput, {target: {value: ''}});
-
-    const ageInput = screen.getAllByRole('combobox')[0];
-    fireEvent.change(ageInput, {target: {value: '6'}});
-    fireEvent.change(ageInput, {target: {value: ''}});
-
-    const stateInput = screen.getAllByRole('combobox')[1];
-    fireEvent.change(stateInput, {target: {value: 'WA'}});
-    fireEvent.change(stateInput, {target: {value: ''}});
-
-    screen.getByText(locale.display_name_error_message());
-    screen.getByText(locale.email_error_message());
-    screen.getByText(locale.age_error_message());
-    screen.getByText(locale.state_error_message());
-
-    // Finish student signup button is disabled
-    const finishSignUpButton = screen.getByRole('button', {
-      name: locale.go_to_my_account(),
-    });
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
-
-    // Fill in fields to remove errors
-    fireEvent.change(parentEmailInput, {target: {value: 'parent@email.com'}});
-    fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
-    fireEvent.change(ageInput, {target: {value: '6'}});
-    fireEvent.change(stateInput, {target: {value: 'WA'}});
-
-    expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
-    expect(screen.queryByText(locale.email_error_message())).toBe(null);
-    expect(screen.queryByText(locale.age_error_message())).toBe(null);
-    expect(screen.queryByText(locale.state_error_message())).toBe(null);
-
-    // Finish student signup button is now enabled
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
   });
 });

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -14,15 +14,7 @@ import i18n from '@cdo/locale';
 
 describe('FinishTeacherAccount', () => {
   afterEach(() => {
-    [
-      DISPLAY_NAME_SESSION_KEY,
-      EMAIL_OPT_IN_SESSION_KEY,
-      SCHOOL_ID_SESSION_KEY,
-      SCHOOL_ZIP_SESSION_KEY,
-      SCHOOL_NAME_SESSION_KEY,
-    ].forEach((session_key: string) => {
-      sessionStorage.removeItem(session_key);
-    });
+    sessionStorage.clear();
   });
 
   function renderDefault(usIp: boolean = true) {


### PR DESCRIPTION
As per [this request](https://github.com/code-dot-org/code-dot-org/pull/60883#discussion_r1747661468) in [this PR](https://github.com/code-dot-org/code-dot-org/pull/60883) (which ensured that the state question was only shown to students in the U.S.), this PR adds tests for the student flow to check that the submit button is disabled/enabled when the required fields are empty/completed.

In addition, I simplified the clearing of `sessionStorage` in both the teacher and student test files.

## Links
PR comment: [here](https://github.com/code-dot-org/code-dot-org/pull/60883#discussion_r1747661468)

## Testing story
Successfully ran new tests locally.
