### PR TITLE
Python Lab: Make horizontal console/editor resizable

### DIFF
--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -23,6 +23,7 @@ import {ProjectSources} from '@cdo/apps/lab2/types';
 
 import Console from './Console';
 import Workspace from './Workspace';
+import WorkspaceAndConsole from './Workspace/WorkspaceAndConsole';
 
 type CodebridgeProps = {
   project: ProjectType;
@@ -73,6 +74,7 @@ export const Codebridge = React.memo(
       'info-panel': config.Instructions || InfoPanel,
       workspace: Workspace,
       console: Console,
+      'workspace-and-console': WorkspaceAndConsole,
     };
 
     let gridLayout: string;
@@ -94,6 +96,11 @@ export const Codebridge = React.memo(
     } else {
       throw new Error('Cannot render codebridge - no layout provided');
     }
+    const gridLayoutKeys = gridLayout
+      .trim()
+      .replaceAll(`"`, '')
+      .split(' ')
+      .map(key => key.trim());
 
     return (
       <CodebridgeContextProvider
@@ -117,7 +124,7 @@ export const Codebridge = React.memo(
           }}
         >
           {(Object.keys(ComponentMap) as Array<keyof typeof ComponentMap>)
-            .filter(key => gridLayout.match(key))
+            .filter(key => gridLayoutKeys.includes(key))
             .map(key => {
               const Component = ComponentMap[key];
               return <Component key={key} />;

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -96,7 +96,7 @@ export const Codebridge = React.memo(
     } else {
       throw new Error('Cannot render codebridge - no layout provided');
     }
-    // gridLayout is a css string the defines the components in the grid layout.
+    // gridLayout is a css string that defines the components in the grid layout.
     // In order to find which components are in the grid layout, we remove all quotes
     // from the string and tokenize it.
     const gridLayoutKeys = gridLayout

--- a/apps/src/codebridge/Codebridge.tsx
+++ b/apps/src/codebridge/Codebridge.tsx
@@ -96,6 +96,9 @@ export const Codebridge = React.memo(
     } else {
       throw new Error('Cannot render codebridge - no layout provided');
     }
+    // gridLayout is a css string the defines the components in the grid layout.
+    // In order to find which components are in the grid layout, we remove all quotes
+    // from the string and tokenize it.
     const gridLayoutKeys = gridLayout
       .trim()
       .replaceAll(`"`, '')

--- a/apps/src/codebridge/Console/console.module.scss
+++ b/apps/src/codebridge/Console/console.module.scss
@@ -7,6 +7,7 @@
   overflow: hidden;
   height: 100%;
   white-space: pre;
+  background-color: $black;
 }
 
 .console {

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -11,6 +11,7 @@
   color: $white;
   scrollbar-width: none;
   grid-area: file-tabs;
+  min-height: 30px;
 }
 
 .fileTab {

--- a/apps/src/codebridge/InfoPanel/styles/info-panel.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/info-panel.module.scss
@@ -6,7 +6,6 @@
   grid-area: info-panel;
   color: $white;
   background-color: $neutral_dark;
-  border: 1px solid $neutral_dark80;
   overflow: hidden;
 }
 

--- a/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
+++ b/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
@@ -1,0 +1,47 @@
+import Console from '@codebridge/Console';
+import Workspace from '@codebridge/Workspace';
+import React, {useEffect, useMemo} from 'react';
+
+import HeightResizer from '@cdo/apps/templates/instructions/HeightResizer';
+
+import moduleStyles from './workspace.module.scss';
+
+// The top Y coordinate of the panel.  Above them is just the common site
+// header and then a bit of empty space.
+const PANEL_TOP_COORDINATE = 60;
+
+const WorkspaceAndConsole: React.FunctionComponent = () => {
+  const [consoleHeight, setConsoleHeight] = React.useState(200);
+  const [columnHeight, setColumnHeight] = React.useState(600);
+
+  useEffect(() => {
+    setColumnHeight(window.innerHeight - PANEL_TOP_COORDINATE);
+  }, []);
+
+  const handleResize = (desiredHeight: number) => {
+    setConsoleHeight(columnHeight - desiredHeight);
+  };
+
+  const editorHeight = useMemo(
+    () => columnHeight - consoleHeight,
+    [columnHeight, consoleHeight]
+  );
+
+  return (
+    <div className={moduleStyles.workspaceAndConsole}>
+      <div style={{height: editorHeight}}>
+        <Workspace />
+      </div>
+      <HeightResizer
+        resizeItemTop={() => PANEL_TOP_COORDINATE}
+        position={editorHeight}
+        onResize={handleResize}
+      />
+      <div style={{height: consoleHeight}}>
+        <Console />
+      </div>
+    </div>
+  );
+};
+
+export default WorkspaceAndConsole;

--- a/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
+++ b/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
@@ -14,8 +14,8 @@ const PANEL_TOP_COORDINATE = 60;
 // A component that combines the Workspace and Console component into a single component,
 // with a horizontal resizer between them.
 const WorkspaceAndConsole: React.FunctionComponent = () => {
-  const [consoleHeight, setConsoleHeight] = React.useState(200);
-  const [columnHeight, setColumnHeight] = React.useState(600);
+  const [consoleHeight, setConsoleHeight] = React.useState(350);
+  const [columnHeight, setColumnHeight] = React.useState(800);
 
   useEffect(() => {
     const handleColumnResize = () => {

--- a/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
+++ b/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
@@ -13,6 +13,10 @@ const PANEL_TOP_COORDINATE = 60;
 
 // A component that combines the Workspace and Console component into a single component,
 // with a horizontal resizer between them.
+// This component is intended to get us through the Python Lab pilot, where we just need a resizable
+// console. We will likely want a different pattern long-term, as we will want other components to
+// be resizable, and don't want to have to make a bunch of different combination components to achieve that.
+// We may want to investigate more general solution for this, such as a panel manager component.
 const WorkspaceAndConsole: React.FunctionComponent = () => {
   const [consoleHeight, setConsoleHeight] = React.useState(350);
   const [columnHeight, setColumnHeight] = React.useState(800);

--- a/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
+++ b/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
@@ -17,6 +17,8 @@ const PANEL_TOP_COORDINATE = 60;
 // console. We will likely want a different pattern long-term, as we will want other components to
 // be resizable, and don't want to have to make a bunch of different combination components to achieve that.
 // We may want to investigate more general solution for this, such as a panel manager component.
+// We also will want resizing to be accessible, and the HeightResizer component only works with mouse and touch
+// events.
 const WorkspaceAndConsole: React.FunctionComponent = () => {
   const [consoleHeight, setConsoleHeight] = React.useState(350);
   const [columnHeight, setColumnHeight] = React.useState(800);

--- a/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
+++ b/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
@@ -11,6 +11,8 @@ import moduleStyles from './workspace.module.scss';
 // header and then a bit of empty space.
 const PANEL_TOP_COORDINATE = 60;
 
+// A component that combines the Workspace and Console component into a single component,
+// with a horizontal resizer between them.
 const WorkspaceAndConsole: React.FunctionComponent = () => {
   const [consoleHeight, setConsoleHeight] = React.useState(200);
   const [columnHeight, setColumnHeight] = React.useState(600);
@@ -37,9 +39,11 @@ const WorkspaceAndConsole: React.FunctionComponent = () => {
     normalizeConsoleHeight(consoleDesiredHeight);
   };
 
+  // Given a desired console height, ensure it is between the minimum and maximum
+  // console height.
   const normalizeConsoleHeight = (desiredConsoleHeight: number) => {
-    // Minimum height fits 3 lines of text
-    const consoleHeightMin = 140;
+    // Minimum height fits 4 lines of text.
+    const consoleHeightMin = 120;
     const consoleHeightMax = window.innerHeight - 200;
 
     setConsoleHeight(
@@ -64,6 +68,7 @@ const WorkspaceAndConsole: React.FunctionComponent = () => {
         resizeItemTop={() => PANEL_TOP_COORDINATE}
         position={editorHeight}
         onResize={handleResize}
+        style={{position: 'static'}}
       />
       <div style={{height: consoleHeight}}>
         <Console />

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -16,3 +16,11 @@
   width: 100%;
   color: $black;
 }
+
+.workspaceAndConsole {
+  height: 100%;
+  grid-area: workspace-and-console;
+  background-color: $darkest_gray;
+  color: $white;
+  overflow: hidden;
+}

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -45,8 +45,8 @@ const labeledGridLayouts = {
     gridLayoutRows: '2fr 1fr ',
     gridLayoutColumns: '300px minmax(0, 1fr)',
     gridLayout: `
-  "info-panel workspace"
-  "file-browser console"
+  "info-panel workspace-and-console"
+  "file-browser workspace-and-console"
   `,
   },
   vertical: {


### PR DESCRIPTION
Make the horizontal console/editor in Python Lab resizable with a horizontal `HeightResizer`. This was achieved by making a new combined Workspace and Console component in Codebridge, which includes the resizing logic.

This approach works fine for the pilot need, which is to have a resizable console. However, long term we should investigate a more robust solution, such as a Panel Manager, as we will want other elements to be resizable. We also will need to improve or make a v2 of `HeightResizer` that is accessible, as `HeightResizer` only responds to mouse and touch events.

The vertical layout is unchanged; you can still switch between horizontal and vertical layouts, but vertical has no resizing.

## Screen recording
https://github.com/user-attachments/assets/ceb6d2f1-b8e9-4c47-adb8-12af0489abc6


## Links

- jira ticket: [CT-653](https://codedotorg.atlassian.net/browse/CT-653)
- [slack discussion](https://codedotorg.slack.com/archives/C05DK21DAHK/p1725491879876159)


## Testing story
Tested locally.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
