### PR TITLE
UI tests for Onetrust

### DIFF
--- a/dashboard/test/ui/features/platform/one_trust.feature
+++ b/dashboard/test/ui/features/platform/one_trust.feature
@@ -11,7 +11,7 @@ Feature: OneTrust integration
   @eyes
   Scenario: User sees OneTrust cookie pop-up when self-hosting OneTrust libraries on code.org
     Given I create a student named "Alice"
-    Given I am on "http://studio.code.org/home?otreset=false&otgeo=gb"
+    Given I am on "http://studio.code.org/home?otreset=true&otgeo=gb"
     
     And I open my eyes to test "Code.org Onetrust pop up"
     And I wait until element "#onetrust-banner-sdk" is visible 

--- a/dashboard/test/ui/features/platform/one_trust.feature
+++ b/dashboard/test/ui/features/platform/one_trust.feature
@@ -1,16 +1,65 @@
 @single_session
 Feature: OneTrust integration
+  @eyes
+  Scenario: User sees OneTrust cookie pop-up when self-hosting OneTrust libraries on hourofcode
+    Given I am on "http://hourofcode.com/uk?otreset=true&otgeo=gb"
+    And I open my eyes to test "Hour of code Onetrust pop up"
+    And I wait until element "#onetrust-banner-sdk" is visible
+    And I see no difference for "Onetrust pop up: Hour of Code" using stitch mode "none"
+    And I close my eyes
+
+  @eyes
+  Scenario: User sees OneTrust cookie pop-up when self-hosting OneTrust libraries on code.org
+    Given I create a student named "Alice"
+    Given I am on "http://studio.code.org/home?otreset=false&otgeo=gb"
+    
+    And I open my eyes to test "Code.org Onetrust pop up"
+    And I wait until element "#onetrust-banner-sdk" is visible 
+    And I see no difference for "Onetrust pop up: code.org" using stitch mode "none"
+    And I close my eyes
+
+  Scenario: OneTrust cookie pop-up shows when self-hosting OneTrust libraries on hourofocode
+    Given I am on "http://hourofcode.com/uk?otreset=true&otgeo=gb"
+    And I wait until element "#onetrust-banner-sdk" is visible
+
+  Scenario: OneTrust cookie pop-up shows when self-hosting OneTrust libraries on code.org
+    Given I create a student named "Alice"
+    Given I am on "http://studio.code.org/home?otreset=false&otgeo=gb"
+    And I wait until element "#onetrust-banner-sdk" is visible
+  
+  Scenario: The pages load the self hosted OneTrust libraries.
+    Given I am on "http://studio.code.org/users/sign_in"
+    Then element "script[src$='onetrust/scripttemplates/otSDKStub.js']" does exist
+    Then element "script[src$='977d/OtAutoBlock.js']" does exist
+    Then element "script[src$='977d-test/OtAutoBlock.js']" does not exist
+
+    Given I am on "http://code.org/index"
+    Then element "script[src$='onetrust/scripttemplates/otSDKStub.js']" does exist
+    Then element "script[src$='977d/OtAutoBlock.js']" does exist
+    Then element "script[src$='977d-test/OtAutoBlock.js']" does not exist
+
+    Given I am on "http://hourofcode.com/us"
+    Then element "script[src$='otSDKStub.js']" does exist
+    Then element "script[src$='e345/OtAutoBlock.js']" does exist
+    Then element "script[src$='e345-test/OtAutoBlock.js']" does not exist
+
   Scenario: The pages load the prod OneTrust libraries.
+    Given I am on "http://studio.code.org/users/sign_in"
+    When I use a cookie to mock the DCDO key "onetrust_cookie_scripts" as "prod"
     Given I am on "http://studio.code.org/users/sign_in"
     Then element "script[src$='otSDKStub.js']" does exist
     Then element "script[src$='977d/OtAutoBlock.js']" does exist
     Then element "script[src$='977d-test/OtAutoBlock.js']" does not exist
+    Then element "script[src$='onetrust/scripttemplates/otSDKStub.js']" does not exist
 
     Given I am on "http://code.org/index"
     Then element "script[src$='otSDKStub.js']" does exist
     Then element "script[src$='977d/OtAutoBlock.js']" does exist
     Then element "script[src$='977d-test/OtAutoBlock.js']" does not exist
-
+    Then element "script[src$='onetrust/scripttemplates/otSDKStub.js']" does not exist
+    
+    Given I am on "http://hourofcode.com/us"
+    And I use a cookie to mock the DCDO key "onetrust_cookie_scripts" as "prod"
     Given I am on "http://hourofcode.com/us"
     Then element "script[src$='otSDKStub.js']" does exist
     Then element "script[src$='e345/OtAutoBlock.js']" does exist

--- a/dashboard/test/ui/features/platform/one_trust.feature
+++ b/dashboard/test/ui/features/platform/one_trust.feature
@@ -43,7 +43,7 @@ Feature: OneTrust integration
     Then element "script[src$='e345/OtAutoBlock.js']" does exist
     Then element "script[src$='e345-test/OtAutoBlock.js']" does not exist
 
-  Scenario: The pages load the prod OneTrust libraries.
+  Scenario: The pages load the Onetrust hosted prod libraries.
     Given I am on "http://studio.code.org/users/sign_in"
     When I use a cookie to mock the DCDO key "onetrust_cookie_scripts" as "prod"
     Given I am on "http://studio.code.org/users/sign_in"

--- a/shared/haml/onetrust_cookie_scripts.haml
+++ b/shared/haml/onetrust_cookie_scripts.haml
@@ -2,7 +2,7 @@
 
 -# OneTrust Cookies Consent Notice scripts for code.org
 -# default to loading the prod OneTrust configuration.
-- onetrust_version = experiment_value('onetrust_cookie_scripts', request) || 'prod'
+- onetrust_version = experiment_value('onetrust_cookie_scripts', request) || 'self_hosted'
 - cookie_script_env = onetrust_version == 'self_hosted' ? 'prod' : onetrust_version
 -# The OneTrust config to load should be passed in.
 - domain ||= nil


### PR DESCRIPTION
Adds Eyes test for the Onetrust pop ups and UI tests for the self hosted Onetrust scripts.
Also sets the default value of the onetrust_version to `self_hosted`

