### PR TITLE
Removing TLS 1.0 and 1.1 in CloudFormation scripts (fixing www.studio redirect CDN)

### DIFF
--- a/aws/cloudformation/components/www_redirect.yml.erb
+++ b/aws/cloudformation/components/www_redirect.yml.erb
@@ -45,6 +45,7 @@
           RealtimeLogConfigArn: !ImportValue AccessLogs-Config
         ViewerCertificate:
           AcmCertificateArn: !Ref <%=app%>RedirectedDomainCertificate
+          MinimumProtocolVersion: TLSv1.2_2021
           SslSupportMethod: sni-only
 
   <%=app%>RedirectedDomainCertificate:

--- a/aws/cloudformation/domain_redirect.yml.erb
+++ b/aws/cloudformation/domain_redirect.yml.erb
@@ -83,6 +83,7 @@ Resources:
           RealtimeLogConfigArn: !ImportValue AccessLogs-Config
         ViewerCertificate:
           AcmCertificateArn: !Ref RedirectedDomainCertificate
+          MinimumProtocolVersion: TLSv1.2_2021
           SslSupportMethod: sni-only
 
   <%

--- a/aws/cloudformation/standalone/teachai_dns.yml
+++ b/aws/cloudformation/standalone/teachai_dns.yml
@@ -111,6 +111,7 @@ Resources:
           RealtimeLogConfigArn: !ImportValue AccessLogs-Config
         ViewerCertificate:
           AcmCertificateArn: !Ref RedirectedDomainCertificate
+          MinimumProtocolVersion: TLSv1.2_2021
           SslSupportMethod: sni-only
 
   RedirectedDomainCertificate:


### PR DESCRIPTION
All the previous CDN's rolled out cleanly, there were still these remaining:
- [www.staging.code.org](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/E13EGOBTZKJ8XJ)
- [www.test.code.org](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/E17HVLLOCL0464)
- [www.adhoc-hbergam-adhoc-sa.cdn-code.org](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/E1KG9P6DCMWH8H)
- [www.autoscale-prod.code.org, www.code.org](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/EBDK5FYUQKI9R)
- [www.levelbuilder.code.org](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/EHJ7IO8MC94OI)

These CF templates didn't explicitly ask for TLS 1.0, so I missed them.  It looks like by default it falls back to the oldest.  The explicitly chooses TLS 1.2.

## Links

- jira ticket: [INF-1286](https://codedotorg.atlassian.net/browse/INF-1286)

## Testing / Deployment strategy

1. Manually deploy BugCrowd Target (which uses CDN config), with manual mod to the template
2. Then merge into staging and watch it apply to each tier as it rolls out.
