### PR TITLE
Music: pack selection in regular level

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -669,8 +669,7 @@ class UnconnectedMusicView extends React.Component {
           player={this.player}
           allowPackSelection={
             this.library?.getHasRestrictedPacks() &&
-            !this.props.levelProperties?.levelData?.packId &&
-            this.props.isProjectLevel
+            !this.props.levelProperties?.levelData?.packId
           }
           analyticsReporter={this.analyticsReporter}
         />


### PR DESCRIPTION
This relaxes the restriction that the pack selection dialog can only be shown in a project level.  The thinking is that a regular, non-project level that uses a library which contains restricted packs will usually specify a desired pack ID (which can include a restricted pack or the `"default"` pack), and it will deliberately omit the pack ID when it wants the pack selection dialog to be available.
