### PR TITLE
Codebridge Version History: add confirm dialog on start over

### DIFF
--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -17,6 +17,7 @@ import {
   setPreviousVersionSource,
 } from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import {ProjectSources, ProjectVersion} from '@cdo/apps/lab2/types';
+import {DialogType, useDialogControl} from '@cdo/apps/lab2/views/dialogs';
 import {commonI18n} from '@cdo/apps/types/locale';
 import currentLocale from '@cdo/apps/util/currentLocale';
 import useOutsideClick from '@cdo/apps/util/hooks/useOutsideClick';
@@ -65,6 +66,8 @@ const VersionHistoryDropdown: React.FunctionComponent<
   const viewingOldVersion = useAppSelector(
     state => state.lab2Project.viewingOldVersion
   );
+
+  const dialogControl = useDialogControl();
 
   const dateFormatter = useMemo(() => {
     return new Intl.DateTimeFormat(locale, {
@@ -118,16 +121,22 @@ const VersionHistoryDropdown: React.FunctionComponent<
   );
 
   const startOver = useCallback(() => {
-    // TODO: confirm
     dispatch(setAndSaveProjectSource(startSource));
     successfulRestoreCleanUp(startSource);
     closeDropdown();
   }, [dispatch, startSource, successfulRestoreCleanUp, closeDropdown]);
 
+  const confirmStartOver = useCallback(() => {
+    dialogControl?.showDialog({
+      type: DialogType.StartOver,
+      handleConfirm: startOver,
+    });
+  }, [dialogControl, startOver]);
+
   const restoreSelectedVersion = useCallback(() => {
     const projectManager = Lab2Registry.getInstance().getProjectManager();
     if (selectedVersion === INITIAL_VERSION_ID) {
-      startOver();
+      confirmStartOver();
     } else if (projectManager && selectedVersion) {
       setLoading(true);
       setLoadError(false);
@@ -150,7 +159,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
     }
   }, [
     selectedVersion,
-    startOver,
+    confirmStartOver,
     closeDropdown,
     dispatch,
     successfulRestoreCleanUp,


### PR DESCRIPTION
This adds a confirmation dialog on start over (or "restore initial version") for Codebridge labs. This is the same start over confirmation modal we had before when we only had a start over button.

![Screenshot 2024-09-10 at 10 01 33 AM](https://github.com/user-attachments/assets/bc04d088-60b5-4a54-89df-70e947a4b3d7)

## Links

- jira ticket: [CT-720](https://codedotorg.atlassian.net/browse/CT-720)

## Testing story
Tested locally that we see this modal on start over now.

## Follow-up work
I started a [thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1725987894302349) to ask if we should make the start over button red, as it is in other labs. This would be a follow-up ticket. 


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
