### PR TITLE
NAV - create lesson materials page with data

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1524,6 +1524,7 @@
   "lessonName": "Lesson Name",
   "lessonNumber": "Lesson Number",
   "lessonNumbered": "Lesson {lessonNumber}: {lessonName}",
+  "lessonNumberAndName": "Lesson {lessonNumber} — {lessonName}",
   "lessonPlans": "Lesson Plans",
   "lessonsAttempted": "Lessons attempted in",
   "lessonsAvailableWithColon": "Lessons available: ",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -464,6 +464,7 @@
   "choose": "Choose",
   "chooseActivity": "Choose from the following activities:",
   "chooseAssets": "Choose Assets",
+  "chooseLesson": "Choose a lesson",
   "chooseAtLeastOne": "Please choose at least one option",
   "chooseColumn": "Choose a column from \"{table}\"",
   "chooseGrades": "Grade (choose all that apply)",

--- a/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
@@ -9,7 +9,7 @@ import i18n from '@cdo/locale';
 
 import ResourceRow from './ResourceRow';
 
-export type Lesson = {
+type Lesson = {
   name: string;
   id: number;
   position: number;
@@ -59,7 +59,10 @@ export const lessonMaterialsLoader =
   };
 
 const createDisplayName = (lessonName: string, lessonPosition: number) => {
-  return i18n.lesson() + ' ' + lessonPosition + ' - ' + lessonName;
+  return i18n.lessonNumberAndName({
+    lessonNumber: lessonPosition,
+    lessonName: lessonName,
+  });
 };
 
 const LessonMaterialsContainer: React.FC = () => {
@@ -108,11 +111,13 @@ const LessonMaterialsContainer: React.FC = () => {
         size="s"
       />
       {/* Note that this is just a "proof of concept row" - the actual implementation would be more complex */}
-      <ResourceRow
-        unitNumber={5} // note that this is a placeholder value
-        lessonNumber={selectedLesson?.position || null}
-        resource={selectedLesson?.resources.Teacher[0] || null} // note that this is a placeholder value
-      />
+      {selectedLesson && (
+        <ResourceRow
+          unitNumber={5} // note that this is a placeholder value
+          lessonNumber={selectedLesson.position}
+          resource={selectedLesson.resources.Teacher[0] || null} // note that this is a placeholder value
+        />
+      )}
     </div>
   );
 };

--- a/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
@@ -1,0 +1,104 @@
+import _ from 'lodash';
+import React, {useState, useMemo, useCallback} from 'react';
+import {useLoaderData} from 'react-router-dom';
+
+import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
+import {getStore} from '@cdo/apps/redux';
+import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
+import i18n from '@cdo/locale';
+
+export type Lesson = {
+  name: string;
+  id: number;
+  position: number;
+};
+
+interface LessonMaterialsData {
+  title: string;
+  lessons: Lesson[];
+}
+
+const lessonMaterialsCachedLoader = _.memoize(async assignedUnitId =>
+  getAuthenticityToken()
+    .then(token =>
+      fetch(`/dashboardapi/lesson_materials/${assignedUnitId}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': token,
+        },
+      })
+    )
+    .then(response => response.json())
+);
+
+export const lessonMaterialsLoader =
+  async (): Promise<LessonMaterialsData | null> => {
+    const state = getStore().getState().teacherSections;
+    const selectedSectionId = state.selectedSectionId;
+    const sectionData = state.sections[selectedSectionId];
+
+    if (!selectedSectionId || !sectionData.unitId) {
+      return null;
+    }
+
+    return lessonMaterialsCachedLoader(sectionData.unitId);
+  };
+
+const createDisplayName = (lessonName: string, lessonPosition: number) => {
+  return i18n.lesson() + ' ' + lessonPosition + ' - ' + lessonName;
+};
+
+const LessonMaterialsContainer: React.FC = () => {
+  const loadedData = useLoaderData() as LessonMaterialsData | null;
+
+  // Memoize the lessons to ensure they only change when loadedData changes
+  const lessons = useMemo(() => loadedData?.lessons || [], [loadedData]);
+
+  const [selectedLesson, setSelectedLesson] = useState({
+    text: 'No lesson available',
+    value: '',
+  });
+
+  // UseEffect to update selected lesson once data is available
+  React.useEffect(() => {
+    if (lessons.length > 0) {
+      setSelectedLesson({
+        text: createDisplayName(lessons[0].name, lessons[0].position),
+        value: createDisplayName(lessons[0].name, lessons[0].position),
+      });
+    }
+  }, [lessons]);
+
+  const generateLessonDropdownOptions = useCallback(() => {
+    return lessons.map((lesson: Lesson) => {
+      const displayName = createDisplayName(lesson.name, lesson.position);
+      return {text: displayName, value: displayName};
+    });
+  }, [lessons]);
+
+  const lessonOptions = useMemo(
+    () => generateLessonDropdownOptions(),
+    [generateLessonDropdownOptions]
+  );
+
+  return (
+    <div>
+      <SimpleDropdown
+        labelText={i18n.lesson()}
+        selectedValue={selectedLesson.value}
+        onChange={event =>
+          setSelectedLesson({
+            text: event.target.value,
+            value: event.target.value,
+          })
+        }
+        items={lessonOptions}
+        name={'lessons-in-assigned-unit-dropdown'}
+        size="s"
+      />
+    </div>
+  );
+};
+
+export default LessonMaterialsContainer;

--- a/apps/src/templates/teacherNavigation/ResourceRow.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceRow.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import {BodyTwoText, StrongText} from '@cdo/apps/componentLibrary/typography';
+
+import styles from './lesson-materials.module.scss';
+
+export type Lesson = {
+  name: string;
+  id: number;
+};
+
+type ResourceRowProps = {
+  lessonNumber: number | null;
+  unitNumber: number | null;
+  resource: {
+    key: string;
+    name: string;
+    url: string;
+    downloadUrl: string | null;
+    audience: string;
+    type: string;
+  } | null;
+};
+
+const ResourceRow: React.FC<ResourceRowProps> = ({
+  lessonNumber,
+  unitNumber,
+  resource,
+}) => {
+  const resourcePositionLabel = (
+    <strong>{unitNumber + '.' + lessonNumber + ' '}</strong>
+  );
+  return (
+    <div className={styles.rowContainer}>
+      <BodyTwoText>
+        <StrongText>{resourcePositionLabel}</StrongText>
+        {resource?.name}
+      </BodyTwoText>
+    </div>
+  );
+};
+
+export default ResourceRow;

--- a/apps/src/templates/teacherNavigation/ResourceRow.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceRow.tsx
@@ -4,14 +4,9 @@ import {BodyTwoText, StrongText} from '@cdo/apps/componentLibrary/typography';
 
 import styles from './lesson-materials.module.scss';
 
-export type Lesson = {
-  name: string;
-  id: number;
-};
-
 type ResourceRowProps = {
-  lessonNumber: number | null;
-  unitNumber: number | null;
+  lessonNumber: number;
+  unitNumber: number;
   resource: {
     key: string;
     name: string;
@@ -19,7 +14,7 @@ type ResourceRowProps = {
     downloadUrl: string | null;
     audience: string;
     type: string;
-  } | null;
+  };
 };
 
 const ResourceRow: React.FC<ResourceRowProps> = ({

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -237,9 +237,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
               <ElementOrEmptyPage
                 showNoStudents={studentCount === 0}
                 showNoCurriculumAssigned={!anyStudentHasProgress}
-                element={applyV1TeacherDashboardWidth(
-                  <LessonMaterialsContainer />
-                )}
+                element={<LessonMaterialsContainer />}
               />
             }
           />

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -27,6 +27,9 @@ import TextResponses from '../textResponses/TextResponses';
 
 import DefaultTeacherNavRedirect from './DefaultTeacherNavRedirect';
 import ElementOrEmptyPage from './ElementOrEmptyPage';
+import LessonMaterialsContainer, {
+  lessonMaterialsLoader,
+} from './LessonMaterialsContainer';
 import PageHeader from './PageHeader';
 import {asyncLoadSelectedSection} from './selectedSectionLoader';
 import TeacherNavigationBar from './TeacherNavigationBar';
@@ -52,6 +55,7 @@ export interface Section {
   name: string;
   courseVersionName: string;
   courseOfferingId: number;
+  unitId: number;
 }
 
 const applyV1TeacherDashboardWidth = (children: React.ReactNode) => {
@@ -228,11 +232,14 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
           />
           <Route
             path={TEACHER_NAVIGATION_PATHS.lessonMaterials}
+            loader={lessonMaterialsLoader}
             element={
               <ElementOrEmptyPage
                 showNoStudents={studentCount === 0}
                 showNoCurriculumAssigned={!anyStudentHasProgress}
-                element={applyV1TeacherDashboardWidth(<TemporaryBlankPage />)}
+                element={applyV1TeacherDashboardWidth(
+                  <LessonMaterialsContainer />
+                )}
               />
             }
           />

--- a/apps/src/templates/teacherNavigation/lesson-materials.module.scss
+++ b/apps/src/templates/teacherNavigation/lesson-materials.module.scss
@@ -1,0 +1,9 @@
+.rowContainer {
+  display: flex;
+  height: 48px;
+  padding: 0 16px;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+  border: 1px solid #f92828; // to be changed
+}

--- a/apps/test/unit/templates/teacherNavigation/LessonMaterialsContainerTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/LessonMaterialsContainerTest.tsx
@@ -4,7 +4,6 @@ import {useLoaderData} from 'react-router-dom';
 
 import LessonMaterialsContainer from '@cdo/apps/templates/teacherNavigation/LessonMaterialsContainer';
 
-// Mock the useLoaderData hook from react-router-dom
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLoaderData: jest.fn(),

--- a/apps/test/unit/templates/teacherNavigation/LessonMaterialsContainerTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/LessonMaterialsContainerTest.tsx
@@ -13,8 +13,40 @@ describe('LessonMaterialsContainer', () => {
   const mockLessonData = {
     title: 'Unit 1',
     lessons: [
-      {name: 'First lesson', id: 1, position: 1},
-      {name: 'Second lesson', id: 2, position: 2},
+      {
+        name: 'First lesson',
+        id: 1,
+        position: 1,
+        resources: {
+          Teacher: [
+            {
+              type: 'Slides',
+              key: 'resourceKey1',
+              name: 'my resource',
+              url: 'google.com',
+              downloadUrl: 'google.com',
+              audience: 'Teacher',
+            },
+          ],
+        },
+      },
+      {
+        name: 'Second lesson',
+        id: 2,
+        position: 2,
+        resources: {
+          Teacher: [
+            {
+              type: 'Slides',
+              key: 'resourceKey2',
+              name: 'my resource',
+              url: 'google.com',
+              downloadUrl: 'google.com',
+              audience: 'Teacher',
+            },
+          ],
+        },
+      },
     ],
   };
 
@@ -24,8 +56,6 @@ describe('LessonMaterialsContainer', () => {
 
   it('renders the component and dropdown with lessons', () => {
     render(<LessonMaterialsContainer />);
-
-    screen.getByText('Lesson');
 
     screen.getByRole('combobox');
     screen.getByRole('option', {name: 'Lesson 1 - First lesson'});

--- a/apps/test/unit/templates/teacherNavigation/LessonMaterialsContainerTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/LessonMaterialsContainerTest.tsx
@@ -1,0 +1,35 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+import {useLoaderData} from 'react-router-dom';
+
+import LessonMaterialsContainer from '@cdo/apps/templates/teacherNavigation/LessonMaterialsContainer';
+
+// Mock the useLoaderData hook from react-router-dom
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLoaderData: jest.fn(),
+}));
+
+describe('LessonMaterialsContainer', () => {
+  const mockLessonData = {
+    title: 'Unit 1',
+    lessons: [
+      {name: 'First lesson', id: 1, position: 1},
+      {name: 'Second lesson', id: 2, position: 2},
+    ],
+  };
+
+  beforeEach(() => {
+    (useLoaderData as jest.Mock).mockReturnValue(mockLessonData);
+  });
+
+  it('renders the component and dropdown with lessons', () => {
+    render(<LessonMaterialsContainer />);
+
+    screen.getByText('Lesson');
+
+    screen.getByRole('combobox');
+    screen.getByRole('option', {name: 'Lesson 1 - First lesson'});
+    screen.getByRole('option', {name: 'Lesson 2 - Second lesson'});
+  });
+});

--- a/apps/test/unit/templates/teacherNavigation/LessonMaterialsContainerTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/LessonMaterialsContainerTest.tsx
@@ -58,7 +58,7 @@ describe('LessonMaterialsContainer', () => {
     render(<LessonMaterialsContainer />);
 
     screen.getByRole('combobox');
-    screen.getByRole('option', {name: 'Lesson 1 - First lesson'});
-    screen.getByRole('option', {name: 'Lesson 2 - Second lesson'});
+    screen.getByRole('option', {name: 'Lesson 1 — First lesson'});
+    screen.getByRole('option', {name: 'Lesson 2 — Second lesson'});
   });
 });

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -413,6 +413,12 @@ class ApiController < ApplicationController
     render json: standards
   end
 
+  def lesson_materials
+    unit_id = params[:unit_id]
+    script = Unit.get_from_cache(unit_id)
+    render json: script.summarize_for_lesson_materials_view(current_user)
+  end
+
   def course_summary
     course_name = params[:course_name]
     unit_group = UnitGroup.get_from_cache(course_name)

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -484,6 +484,21 @@ class Lesson < ApplicationRecord
     }
   end
 
+  def summarize_for_lesson_materials(user)
+    {
+      id: id,
+      unit: script.summarize_for_lesson_show,
+      position: relative_position,
+      key: key,
+      duration: total_lesson_duration,
+      name: localized_name,
+      resources: resources_for_lesson_plan(user&.verified_instructor?),
+      lessonPlanPdfUrl: lesson_plan_pdf_url,
+      lessonPlanHtmlUrl: lesson_plan_html_url,
+      scriptResourcesPdfUrl: script.get_unit_resources_pdf_url
+    }
+  end
+
   def summarize_for_student_lesson_plan
     all_resources = resources_for_lesson_plan(false)
     {

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -490,7 +490,6 @@ class Lesson < ApplicationRecord
       unit: script.summarize_for_lesson_show,
       position: relative_position,
       key: key,
-      duration: total_lesson_duration,
       name: localized_name,
       resources: resources_for_lesson_plan(user&.verified_instructor?),
       lessonPlanPdfUrl: lesson_plan_pdf_url,

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1598,6 +1598,28 @@ class Unit < ApplicationRecord
     lessons.none?(&:has_lesson_plan)
   end
 
+  def summarize_for_lesson_materials_view(user)
+    summary = {
+      id: id,
+      title: title_for_display,
+      name: name,
+      link: script_path(self),
+      version_year: version_year,
+      course_id: unit_group.try(:id),
+      courseVersionId: get_course_version&.id,
+      courseOfferingId: get_course_version&.course_offering&.id,
+      scriptOverviewPdfUrl: get_unit_overview_pdf_url,
+      scriptResourcesPdfUrl: get_unit_resources_pdf_url,
+      teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
+      student_resources: student_resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
+    }
+    # Only get lessons with lesson plans
+    filtered_lessons = lessons.select(&:has_lesson_plan)
+    summary[:lessons] = filtered_lessons.map {|lesson| lesson.summarize_for_lesson_materials(user)}
+
+    summary
+  end
+
   def summarize_for_rollup(user = nil)
     summary = {
       title: title_for_display,

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1604,6 +1604,7 @@ class Unit < ApplicationRecord
       title: title_for_display,
       name: name,
       link: script_path(self),
+      unitNumber: unit_number,
       version_year: version_year,
       course_id: unit_group.try(:id),
       courseVersionId: get_course_version&.id,
@@ -1762,6 +1763,15 @@ class Unit < ApplicationRecord
       scope: [:data, :script, :name, name],
       smart: true
     )
+  end
+
+  def unit_number
+    has_prefix = unit_group&.has_numbered_units
+
+    return nil unless has_prefix
+
+    position = unit_group_units&.first&.position
+    return position
   end
 
   def title_for_display

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1603,14 +1603,8 @@ class Unit < ApplicationRecord
       id: id,
       title: title_for_display,
       name: name,
-      link: script_path(self),
       unitNumber: unit_number,
-      version_year: version_year,
-      course_id: unit_group.try(:id),
-      courseVersionId: get_course_version&.id,
-      courseOfferingId: get_course_version&.course_offering&.id,
       scriptOverviewPdfUrl: get_unit_overview_pdf_url,
-      scriptResourcesPdfUrl: get_unit_resources_pdf_url,
       teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
       student_resources: student_resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
     }
@@ -1770,8 +1764,7 @@ class Unit < ApplicationRecord
 
     return nil unless has_prefix
 
-    position = unit_group_units&.first&.position
-    return position
+    unit_group_units&.first&.position
   end
 
   def title_for_display

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -882,6 +882,7 @@ Dashboard::Application.routes.draw do
     end
 
     get 'dashboardapi/course_summary/:course_name', to: 'api#course_summary'
+    get 'dashboardapi/lesson_materials/:unit_id', to: 'api#lesson_materials'
 
     # Wildcard routes for API controller: select all public instance methods in the controller,
     # and all template names in `app/views/api/*`.


### PR DESCRIPTION
This PR:

- Creates a container component for the lesson materials page 
- Adds a dropdown to select lessons in the assigned unit
- Shows ONE resource from the lesson selected (this is not complete - more of a "proof of concept")
- Sets up the data for adding resources to the page
- Creates tests for ONE new component created



https://github.com/user-attachments/assets/e14779f0-f629-481b-b3cc-ed77d4118647



This PR does NOT:
- Smooth out all UI requirements for the children components (there is some work to do on the dropdown yet). 
- Create test for "Resource Row" - this is just in the EARLY stages of development.  My hope is that with this PR, someone else can develop "Resource Row" more completely with tests.  This is in part why the border around it is red - it is far from ready to go live :) 

## Links

- [Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1313)
- [Figma](https://www.figma.com/design/5ILfiJkPQpjskBwksMDeZl/Teacher-Dashboard?node-id=3104-2079&node-type=CANVAS&m=dev)
- T[ech Spec](https://docs.google.com/document/d/1k46_Ovu0afDKS5cLrkySKMALI42_yn-WlZnneXdWlnU/edit#heading=h.4schd43y1qoc)