### PR TITLE
DSCO: update LegacyButton to DSCO Button in Challenge Dialog

### DIFF
--- a/apps/src/templates/ChallengeDialog.jsx
+++ b/apps/src/templates/ChallengeDialog.jsx
@@ -3,10 +3,10 @@ import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
 import assetUrl from '@cdo/apps/code-studio/assetUrl';
+import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
 import {getStore} from '@cdo/apps/redux';
 import i18n from '@cdo/locale';
 
-import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
 import color from '../util/color';
 
 import BackToFrontConfetti from './BackToFrontConfetti';

--- a/apps/src/templates/ChallengeDialog.jsx
+++ b/apps/src/templates/ChallengeDialog.jsx
@@ -6,7 +6,7 @@ import assetUrl from '@cdo/apps/code-studio/assetUrl';
 import {getStore} from '@cdo/apps/redux';
 import i18n from '@cdo/locale';
 
-import LegacyButton from '../legacySharedComponents/LegacyButton';
+import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
 import color from '../util/color';
 
 import BackToFrontConfetti from './BackToFrontConfetti';
@@ -61,6 +61,10 @@ class ChallengeDialog extends React.Component {
 
   render() {
     const isRtl = getStore().getState().isRtl;
+    const bannerStyle = {
+      ...styles.banner,
+      ...(this.props.complete ? styles.bannerComplete : {}),
+    };
 
     return (
       <BaseDialog
@@ -75,12 +79,7 @@ class ChallengeDialog extends React.Component {
           src={this.props.avatar}
           alt={i18n.cheeringInstructorAltText()}
         />
-        <div
-          style={{
-            ...styles.banner,
-            ...(this.props.complete ? styles.bannerComplete : {}),
-          }}
-        >
+        <div style={bannerStyle}>
           <h1 style={styles.title} id="uitest-challenge-title">
             {this.props.title}
           </h1>
@@ -93,21 +92,21 @@ class ChallengeDialog extends React.Component {
           {this.props.text && <div style={styles.text}>{this.props.text}</div>}
           {this.props.children}
         </div>
-        <LegacyButton
-          type="cancel"
-          onClick={this.handleCancel}
+        <Button
           id="challengeCancelButton"
-        >
-          {this.props.cancelButtonLabel}
-        </LegacyButton>
-        <LegacyButton
-          type="primary"
-          style={isRtl ? styles.primaryButtonRtl : styles.primaryButton}
-          onClick={this.handlePrimary}
+          onClick={this.handleCancel}
+          text={this.props.cancelButtonLabel}
+          type="secondary"
+          color={buttonColors.gray}
+        />
+        <Button
           id="challengePrimaryButton"
-        >
-          {this.props.primaryButtonLabel}
-        </LegacyButton>
+          onClick={this.handlePrimary}
+          text={this.props.primaryButtonLabel}
+          type="primary"
+          color={buttonColors.purple}
+          style={isRtl ? styles.primaryButtonRtl : styles.primaryButton}
+        />
         {this.props.showPuzzleRatingButtons && (
           <div style={styles.footer}>
             <PuzzleRatingButtons useLegacyStyles />


### PR DESCRIPTION
[XTEAM-430](https://codedotorg.atlassian.net/browse/XTEAM-430) partial 

Removing one more usage of `LegacyButton` in favor of the DSCO `Button` component.  Small modernization improvement with minimal visual change for the sake of progress toward finally deprecating `LegacyButton`, which is now two generations older than DSCO components. The Challenge Dialog can be found, for example, here: https://studio.code.org/s/express-2024/lessons/1/levels/8 

BEFORE 
![LTR_before](https://github.com/user-attachments/assets/e08ff56e-cd50-4328-9c4a-9b8d36d6e293)

AFTER 
![LTR_after](https://github.com/user-attachments/assets/6f75a4f4-9dd5-4791-82ca-75fd5026a0ff)

RTL BEFORE 
![RTL_before](https://github.com/user-attachments/assets/e7427d3b-a4c3-4384-b271-e5d9c5b1a51c)

RTL AFTER 
![RTL_after](https://github.com/user-attachments/assets/096f128a-0d71-46ea-a6bd-f18b46abc135)

Side by side comparison in "completed" state
![LTR_complete](https://github.com/user-attachments/assets/390c4575-9993-4fa0-9f42-619b85105cfd)

