### PR TITLE
Stub Sagemaker in Drone

### DIFF
--- a/dashboard/app/helpers/aichat_sagemaker_helper.rb
+++ b/dashboard/app/helpers/aichat_sagemaker_helper.rb
@@ -1,27 +1,10 @@
-class StubbedSagemakerClient
-  def invoke_endpoint(_)
-    StubbedSagemakerResponse.new
-  end
-end
-
-class StubbedSagemakerResponse
-  def body
-    StubbedSagemakerResponseBody.new
-  end
-end
-
-class StubbedSagemakerResponseBody
-  def string
-    JSON.generate([{"generated_text" => "Hello there!"}])
-  end
-end
-
 module AichatSagemakerHelper
   MAX_NEW_TOKENS = 512
   TOP_P = 0.9
 
   def self.create_sagemaker_client
-    ENV['CIRCLECI'] ?
+    # Stubbed SageMaker allows UI tests (without the roundtrip to the model) to run in CI environments (ie, Drone)
+    Rails.application.config.respond_to?(:stub_sagemaker) && Rails.application.config.stub_sagemaker ?
       StubbedSagemakerClient.new :
       Aws::SageMakerRuntime::Client.new
   end
@@ -88,5 +71,24 @@ module AichatSagemakerHelper
 
   def self.can_request_aichat_chat_completion?
     DCDO.get("aichat_chat_completion", true)
+  end
+end
+
+# Classes that allow us to stub Sagemaker in Drone, which does not have permission to access SageMaker.
+class StubbedSagemakerClient
+  def invoke_endpoint(_)
+    StubbedSagemakerResponse.new
+  end
+end
+
+class StubbedSagemakerResponse
+  def body
+    StubbedSagemakerResponseBody.new
+  end
+end
+
+class StubbedSagemakerResponseBody
+  def string
+    JSON.generate([{"generated_text" => "Hello there!"}])
   end
 end

--- a/dashboard/app/helpers/aichat_sagemaker_helper.rb
+++ b/dashboard/app/helpers/aichat_sagemaker_helper.rb
@@ -1,9 +1,29 @@
+class StubbedSagemakerClient
+  def invoke_endpoint(_)
+    StubbedSagemakerResponse.new
+  end
+end
+
+class StubbedSagemakerResponse
+  def body
+    StubbedSagemakerResponseBody.new
+  end
+end
+
+class StubbedSagemakerResponseBody
+  def string
+    JSON.generate([{"generated_text" => "Hello there!"}])
+  end
+end
+
 module AichatSagemakerHelper
   MAX_NEW_TOKENS = 512
   TOP_P = 0.9
 
   def self.create_sagemaker_client
-    Aws::SageMakerRuntime::Client.new
+    ENV['CIRCLECI'] ?
+      StubbedSagemakerClient.new :
+      Aws::SageMakerRuntime::Client.new
   end
 
   def self.get_instructions(system_prompt, level_system_prompt, retrieval_contexts)

--- a/dashboard/app/helpers/aichat_sagemaker_helper.rb
+++ b/dashboard/app/helpers/aichat_sagemaker_helper.rb
@@ -4,7 +4,7 @@ module AichatSagemakerHelper
 
   def self.create_sagemaker_client
     # Stubbed SageMaker allows UI tests (without the roundtrip to the model) to run in CI environments (ie, Drone)
-    Rails.application.config.respond_to?(:stub_sagemaker) && Rails.application.config.stub_sagemaker ?
+    Rails.application.config.respond_to?(:stub_aichat_aws_services) && Rails.application.config.stub_aichat_aws_services ?
       StubbedSagemakerClient.new :
       Aws::SageMakerRuntime::Client.new
   end

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -17,9 +17,11 @@ Dashboard::Application.configure do
   config.public_file_server.enabled = true
   config.public_file_server.headers = {'Cache-Control' => "public, max-age=3600, s-maxage=1800"}
 
+  is_ci = !!ENV.fetch('CI', nil)
+
   # test environment should use precompiled, minified, digested assets like production,
   # unless it's being used for unit tests.
-  ci_test = !!(ENV['UNIT_TEST'] || ENV.fetch('CI', nil))
+  ci_test = !!(ENV['UNIT_TEST'] || is_ci)
 
   unless ci_test
     # Compress JavaScripts and CSS.
@@ -33,6 +35,11 @@ Dashboard::Application.configure do
     # Avoid loading all i18n files up front, which can significantly slow down initialization.
     # Instead, it only loads i18n files that belong to the current locale.
     config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
+  end
+
+  # In CI environments (ie, Drone), stub AWS SageMaker so we can run UI tests
+  if is_ci
+    config.stub_sagemaker = true
   end
 
   config.assets.quiet = true

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -37,9 +37,12 @@ Dashboard::Application.configure do
     config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
   end
 
-  # In CI environments (ie, Drone), stub AWS SageMaker so we can run UI tests
+  # config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
+
+  # In CI environments (ie, Drone), stub relevant AWS services (currently just SageMaker)
+  # so we can run UI tests for our AI Chat (ie, Generative AI) lab.
   if is_ci
-    config.stub_sagemaker = true
+    config.stub_aichat_aws_services = true
   end
 
   config.assets.quiet = true

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -37,8 +37,6 @@ Dashboard::Application.configure do
     config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
   end
 
-  # config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
-
   # In CI environments (ie, Drone), stub relevant AWS services (currently just SageMaker)
   # so we can run UI tests for our AI Chat (ie, Generative AI) lab.
   if is_ci

--- a/dashboard/test/ui/features/star_labs/aichat/chat.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/chat.feature
@@ -11,9 +11,6 @@ Feature: AI Chat
     And I wait until element "#ui-close-dialog" is not visible
     And I dismiss the teacher panel
 
-  # As of 9/4/24, cannot access SageMaker in Drone.
-  # More discussion in this Slack thread: https://codedotorg.slack.com/archives/C03CK49G9/p1725475362107969
-  @no_circle
   Scenario: Making chat request gets response
     When I press keys "Hello" for element "#uitest-chat-textarea"
     And I wait until element "#uitest-chat-submit" is enabled


### PR DESCRIPTION
(cherry pick of two commits from [this initial PR](https://github.com/code-dot-org/code-dot-org/pull/60861), which is a mess due to merge conflicts.)

Stubs AWS SageMaker in Drone so that we can run UI tests without configuring complex permissions to allow Drone access to our SageMaker instances. Unstubbed SageMaker will still be used in UI tests run via our test server.