### PR TITLE
Lab2: change default size of predict free response textarea to 50px

### DIFF
--- a/apps/src/lab2/constants.ts
+++ b/apps/src/lab2/constants.ts
@@ -37,3 +37,6 @@ export enum WARNING_BANNER_MESSAGES {
   STANDARD = 'You are editing start sources.',
   TEMPLATE = 'WARNING: You are editing start sources for a level with a template. Start sources should be defined on the template.',
 }
+
+// Default height of the predict question free response text area.
+export const PREDICT_FREE_RESPONSE_DEFAULT_HEIGHT = 50;

--- a/apps/src/lab2/levelEditors/predictSettings/EditPredictSettings.tsx
+++ b/apps/src/lab2/levelEditors/predictSettings/EditPredictSettings.tsx
@@ -4,6 +4,7 @@ import Checkbox from '@cdo/apps/componentLibrary/checkbox';
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
 import {BodyThreeText} from '@cdo/apps/componentLibrary/typography';
 
+import {PREDICT_FREE_RESPONSE_DEFAULT_HEIGHT} from '../../constants';
 import {LevelPredictSettings, PredictQuestionType} from '../types';
 
 import FreeResponseFields from './FreeResponseFields';
@@ -26,7 +27,7 @@ const EditPredictSettings: React.FunctionComponent<
     allowMultipleAttempts: false,
     placeholderText: '',
     multipleChoiceOptions: [''],
-    freeResponseHeight: 20,
+    freeResponseHeight: PREDICT_FREE_RESPONSE_DEFAULT_HEIGHT,
     codeEditableAfterSubmit: false,
   };
 

--- a/apps/src/lab2/levelEditors/predictSettings/FreeResponseFields.tsx
+++ b/apps/src/lab2/levelEditors/predictSettings/FreeResponseFields.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import TextField from '@cdo/apps/componentLibrary/textField';
 
+import {PREDICT_FREE_RESPONSE_DEFAULT_HEIGHT} from '../../constants';
 import {LevelPredictSettings} from '../types';
 
 import moduleStyles from './edit-predict-settings.module.scss';
@@ -48,7 +49,8 @@ const FreeResponseFields: React.FunctionComponent<FreeResponseFieldsProps> = ({
       </label>
       <label className={moduleStyles.fieldArea}>
         <div className={moduleStyles.label}>
-          Height of the answer textarea in px. Default is 20px.
+          Height of the answer textarea in px. Default is{' '}
+          {PREDICT_FREE_RESPONSE_DEFAULT_HEIGHT}px.
         </div>
         <input
           type="number"

--- a/apps/src/lab2/views/components/PredictQuestion.tsx
+++ b/apps/src/lab2/views/components/PredictQuestion.tsx
@@ -5,6 +5,8 @@ import {
   PredictQuestionType,
 } from '@cdo/apps/lab2/levelEditors/types';
 
+import {PREDICT_FREE_RESPONSE_DEFAULT_HEIGHT} from '../../constants';
+
 import PredictResetButton from './PredictResetButton';
 
 import moduleStyles from './predict.module.scss';
@@ -49,7 +51,11 @@ const PredictQuestion: React.FunctionComponent<PredictQuestionProps> = ({
           value={predictResponse}
           placeholder={predictSettings.placeholderText}
           onChange={e => setPredictResponse(e.target.value)}
-          style={{height: predictSettings.freeResponseHeight || 20}}
+          style={{
+            height:
+              predictSettings.freeResponseHeight ||
+              PREDICT_FREE_RESPONSE_DEFAULT_HEIGHT,
+          }}
           className={moduleStyles.freeResponse}
           readOnly={predictAnswerLocked}
         />


### PR DESCRIPTION
Change the default from 20px to 50px, and make a constant for this value so we don't have multiple magic numbers floating around.

## Links

- jira ticket: [CT-789](https://codedotorg.atlassian.net/browse/CT-789)
- [slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1725989144498909)

## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
