### PR TITLE
lab2: use DSCO Button component in Instructions 

### DIFF
--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -312,16 +312,6 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   handleInstructionsTextClick={handleInstructionsTextClick}
                 />
               )}
-              {/*{canShowContinueButton && (*/}
-              {/*  <button*/}
-              {/*    id="instructions-continue-button"*/}
-              {/*    type="button"*/}
-              {/*    onClick={onNextPanel}*/}
-              {/*    className={moduleStyles.buttonInstruction}*/}
-              {/*  >*/}
-              {/*    {commonI18n.continue()}*/}
-              {/*  </button>*/}
-              {/*)}*/}
               {canShowContinueButton && (
                 <Button
                   id="instructions-continue-button"
@@ -332,15 +322,13 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
               )}
               {canShowFinishButton && (
                 <>
-                  <button
+                  <Button
                     id="instructions-finish-button"
-                    type="button"
                     onClick={onFinish}
                     disabled={isFinished}
                     className={moduleStyles.buttonInstruction}
-                  >
-                    {commonI18n.finish()}
-                  </button>
+                    text={commonI18n.finish()}
+                  />
                   {isFinished && <Heading6>{finalMessage}</Heading6>}
                 </>
               )}

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -4,6 +4,7 @@ import {useSelector} from 'react-redux';
 
 import {navigateToNextLevel} from '@cdo/apps/code-studio/progressRedux';
 import {nextLevelId} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {Button} from '@cdo/apps/componentLibrary/button';
 import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import {LevelPredictSettings} from '@cdo/apps/lab2/levelEditors/types';
 import {
@@ -311,15 +312,23 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   handleInstructionsTextClick={handleInstructionsTextClick}
                 />
               )}
+              {/*{canShowContinueButton && (*/}
+              {/*  <button*/}
+              {/*    id="instructions-continue-button"*/}
+              {/*    type="button"*/}
+              {/*    onClick={onNextPanel}*/}
+              {/*    className={moduleStyles.buttonInstruction}*/}
+              {/*  >*/}
+              {/*    {commonI18n.continue()}*/}
+              {/*  </button>*/}
+              {/*)}*/}
               {canShowContinueButton && (
-                <button
+                <Button
                   id="instructions-continue-button"
-                  type="button"
+                  text={commonI18n.continue()}
                   onClick={onNextPanel}
                   className={moduleStyles.buttonInstruction}
-                >
-                  {commonI18n.continue()}
-                </button>
+                />
               )}
               {canShowFinishButton && (
                 <>

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -146,22 +146,22 @@
 }
 
 .buttonInstruction {
-  font-size: 14px;
-  background-color: $brand_secondary_default;
-  border-color: $brand_secondary_default;
-  color: $neutral_light;
+  //font-size: 14px;
+  //background-color: $brand_secondary_default;
+  //border-color: $brand_secondary_default;
+  //color: $neutral_light;
   width: 100%;
   padding: 5px 10px;
   border-radius: 4px;
   height: 38px;
   margin: 0 0 10px 0;
-  &:disabled,
-  &[aria-disabled='true'] {
-    cursor: not-allowed;
-    border-color: $light_gray_200;
-    background-color: $light_gray_200;
-    color: $light_white;
-  }
+  //&:disabled,
+  //&[aria-disabled='true'] {
+  //  cursor: not-allowed;
+  //  border-color: $light_gray_200;
+  //  background-color: $light_gray_200;
+  //  color: $light_white;
+  //}
 }
 
 .markdownText {

--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -146,22 +146,9 @@
 }
 
 .buttonInstruction {
-  //font-size: 14px;
-  //background-color: $brand_secondary_default;
-  //border-color: $brand_secondary_default;
-  //color: $neutral_light;
   width: 100%;
-  padding: 5px 10px;
-  border-radius: 4px;
   height: 38px;
   margin: 0 0 10px 0;
-  //&:disabled,
-  //&[aria-disabled='true'] {
-  //  cursor: not-allowed;
-  //  border-color: $light_gray_200;
-  //  background-color: $light_gray_200;
-  //  color: $light_white;
-  //}
 }
 
 .markdownText {


### PR DESCRIPTION
Switch to using the DSCO Button component for the "Finish" and "Continue" buttons that appear in the Instructions in lab2 levels. Main difference is the text is slightly larger, and there's now a hover effect (button darkens slightly), which matches other buttons in the lab.

| Button/State | Before | After |
| - | - | - |
| Finish, enabled | <img width="441" alt="image" src="https://github.com/user-attachments/assets/493b1829-c23e-42f1-befd-2ba94d1231bc"> | <img width="443" alt="image" src="https://github.com/user-attachments/assets/eeeabae5-1489-4763-9e6f-80a604f07f9a"> |
| Finish, disabled | <img width="442" alt="image" src="https://github.com/user-attachments/assets/547ec503-8b4f-4165-8c0d-639e45c46e3a"> | <img width="441" alt="image" src="https://github.com/user-attachments/assets/fc4709c1-eef2-4273-ade8-bc07b1e41887"> |
| Continue, enabled | <img width="441" alt="image" src="https://github.com/user-attachments/assets/c39d69d1-607a-43a2-99d9-a3b23161301c"> | <img width="444" alt="image" src="https://github.com/user-attachments/assets/4c8a0ae5-ccda-4f79-9518-5193fb3bf481"> |

## Links

- [Slack discussion](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1725924768642449)

## Testing story

Tested manually on AI Chat allthethings levels.