### PR TITLE
Music: increase measures

### DIFF
--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -86,7 +86,7 @@ export const LOCAL_STORAGE = 'local';
 export const REMOTE_STORAGE = 'remote';
 
 // Minimum number of measures in a song
-export const MIN_NUM_MEASURES = 30;
+export const MIN_NUM_MEASURES = 40;
 
 export const LEGACY_DEFAULT_LIBRARY = 'default';
 export const DEFAULT_LIBRARY = 'intro2024';


### PR DESCRIPTION
This increases the minimum number of measures rendered, from 30 to 40, mainly so that users on particularly wide monitors see the full width utilised.
