### PR TITLE
Two updates to student list leads to intermittent failures when editing student names.

### DIFF
--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -170,14 +170,14 @@ export const startLoadingStudents = () => ({type: START_LOADING_STUDENTS});
 export const finishLoadingStudents = () => ({type: FINISH_LOADING_STUDENTS});
 
 export const setLoginType = loginType => ({type: SET_LOGIN_TYPE, loginType});
-export const setStudents = (studentData) => ({
+export const setStudents = studentData => ({
   type: SET_STUDENTS,
-  studentData
+  studentData,
 });
-export const setSectionInfo = (sectionId) => ({
+export const setSectionInfo = sectionId => ({
   type: SET_SECTION_INFO,
-  sectionId
-})
+  sectionId,
+});
 export const startEditingStudent = studentId => ({
   type: START_EDITING_STUDENT,
   studentId,
@@ -512,14 +512,14 @@ export default function manageStudents(state = initialState, action) {
       ...state,
       studentData: studentData,
       addStatus: {status: null, numStudents: null},
-      isLoadingStudents: false
+      isLoadingStudents: false,
     };
   }
   if (action.type === SET_SECTION_INFO) {
     return {
       ...state,
-      sectionId: action.sectionId
-    }
+      sectionId: action.sectionId,
+    };
   }
   if (action.type === START_EDITING_STUDENT) {
     return {

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -974,10 +974,8 @@ export const loadSectionStudentData = sectionId => {
   return (dispatch, getState) => {
     const state = getState().manageStudents;
 
-    // Don't load data if it's already stored in redux.
-    const alreadyHaveStudentData = state.sectionId === sectionId;
-
-    if (!alreadyHaveStudentData) {
+    // Don't load data if it's already being fetched.
+    if (!state.isLoadingStudents) {
       dispatch(startLoadingStudents());
       $.ajax({
         method: 'GET',

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -139,6 +139,7 @@ const initialState = {
 
 const SET_LOGIN_TYPE = 'manageStudents/SET_LOGIN_TYPE';
 const SET_STUDENTS = 'manageStudents/SET_STUDENTS';
+const SET_SECTION_INFO = 'manageStudents/SET_SECTION_INFO';
 const START_EDITING_STUDENT = 'manageStudents/START_EDITING_STUDENT';
 const CANCEL_EDITING_STUDENT = 'manageStudents/CANCEL_EDITING_STUDENT';
 const REMOVE_STUDENT = 'manageStudents/REMOVE_STUDENT';
@@ -169,11 +170,14 @@ export const startLoadingStudents = () => ({type: START_LOADING_STUDENTS});
 export const finishLoadingStudents = () => ({type: FINISH_LOADING_STUDENTS});
 
 export const setLoginType = loginType => ({type: SET_LOGIN_TYPE, loginType});
-export const setStudents = (studentData, sectionId) => ({
+export const setStudents = (studentData) => ({
   type: SET_STUDENTS,
-  studentData,
-  sectionId,
+  studentData
 });
+export const setSectionInfo = (sectionId) => ({
+  type: SET_SECTION_INFO,
+  sectionId
+})
 export const startEditingStudent = studentId => ({
   type: START_EDITING_STUDENT,
   studentId,
@@ -508,9 +512,14 @@ export default function manageStudents(state = initialState, action) {
       ...state,
       studentData: studentData,
       addStatus: {status: null, numStudents: null},
-      isLoadingStudents: false,
-      sectionId: action.sectionId,
+      isLoadingStudents: false
     };
+  }
+  if (action.type === SET_SECTION_INFO) {
+    return {
+      ...state,
+      sectionId: action.sectionId
+    }
   }
   if (action.type === START_EDITING_STUDENT) {
     return {
@@ -974,8 +983,10 @@ export const loadSectionStudentData = sectionId => {
   return (dispatch, getState) => {
     const state = getState().manageStudents;
 
+    // if section ID matches, don't do anything and say isLoading is false
     // Don't load data if it's already being fetched.
-    if (!state.isLoadingStudents) {
+    if (state.sectionId !== sectionId) {
+      dispatch(setSectionInfo(sectionId));
       dispatch(startLoadingStudents());
       $.ajax({
         method: 'GET',
@@ -987,7 +998,7 @@ export const loadSectionStudentData = sectionId => {
           state.loginType,
           sectionId
         );
-        dispatch(setStudents(convertedStudentData, sectionId));
+        dispatch(setStudents(convertedStudentData));
       });
     } else {
       dispatch(finishLoadingStudents());

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -1005,7 +1005,7 @@ export const loadSectionStudentData = sectionId => {
         .fail(() => {
           // revert to old section ID in case of failure to backend call
           dispatch(setSectionInfo(oldSectionId));
-          dispatch(setSectionInfo(sectionId));
+          dispatch(finishLoadingStudents());
         });
     } else {
       dispatch(finishLoadingStudents());

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -993,18 +993,20 @@ export const loadSectionStudentData = sectionId => {
         method: 'GET',
         url: `/dashboardapi/sections/${sectionId}/students`,
         dataType: 'json',
-      }).done(studentData => {
-        const convertedStudentData = convertStudentServerData(
-          studentData,
-          state.loginType,
-          sectionId
-        );
-        dispatch(setStudents(convertedStudentData));
-      }).fail(() => {
-        // revert to old section ID in case of failure to backend call
-        dispatch(setSectionInfo(oldSectionId));
-        dispatch(setSectionInfo(sectionId));
-    });
+      })
+        .done(studentData => {
+          const convertedStudentData = convertStudentServerData(
+            studentData,
+            state.loginType,
+            sectionId
+          );
+          dispatch(setStudents(convertedStudentData));
+        })
+        .fail(() => {
+          // revert to old section ID in case of failure to backend call
+          dispatch(setSectionInfo(oldSectionId));
+          dispatch(setSectionInfo(sectionId));
+        });
     } else {
       dispatch(finishLoadingStudents());
     }

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -1003,7 +1003,8 @@ export const loadSectionStudentData = sectionId => {
       }).fail(() => {
         // revert to old section ID in case of failure to backend call
         dispatch(setSectionInfo(oldSectionId));
-      });
+        dispatch(setSectionInfo(sectionId));
+    });
     } else {
       dispatch(finishLoadingStudents());
     }

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -982,10 +982,11 @@ const transferStudentsOnServer = (
 export const loadSectionStudentData = sectionId => {
   return (dispatch, getState) => {
     const state = getState().manageStudents;
+    let oldSectionId = state.sectionId;
 
-    // if section ID matches, don't do anything and say isLoading is false
-    // Don't load data if it's already being fetched.
+    // Load data only if section Id doesn't already match
     if (state.sectionId !== sectionId) {
+      // Set section ID to indicate student data for current section.
       dispatch(setSectionInfo(sectionId));
       dispatch(startLoadingStudents());
       $.ajax({
@@ -999,6 +1000,9 @@ export const loadSectionStudentData = sectionId => {
           sectionId
         );
         dispatch(setStudents(convertedStudentData));
+      }).fail(() => {
+        // revert to old section ID in case of failure to backend call
+        dispatch(setSectionInfo(oldSectionId));
       });
     } else {
       dispatch(finishLoadingStudents());

--- a/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
+++ b/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
@@ -29,10 +29,15 @@ import manageStudents, {
   transferStudentsFailure,
   addStudentsFull,
   transferStudentsFull,
+  loadSectionStudentData
 } from '@cdo/apps/templates/manageStudents/manageStudentsRedux';
 
 import {sectionLoginFactory} from '../../../factories/sectionLogin';
 import {assert} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
+import {getStore, registerReducers, stubRedux, restoreRedux} from '@cdo/apps/redux';
+
+import sinon from 'sinon';
+import { expect } from 'chai';
 
 const sectionLoginData = {
   1: sectionLoginFactory.build({id: 1, name: 'StudentNameA', sectionId: 53}),
@@ -1082,6 +1087,122 @@ describe('manageStudentsRedux', () => {
         sectionCode: 'ABCEDF',
         sectionStudentCount: 500,
       });
+    });
+  });
+
+  describe('load student data', () => {
+    const successResponse = (body = {}) => [
+      200,
+      {'Content-Type': 'application/json'},
+      JSON.stringify(body),
+    ];
+
+    const mockStudentData = [{
+        "id": 229,
+        "name": "new student",
+        "username": "coder_abc",
+        "family_name": "fam name",
+        "age": 17,
+        "sharing_disabled": true,
+        "has_ever_signed_in": false,
+        "ai_tutor_access_denied": false,
+        "at_risk_age_gated": false,
+        "child_account_compliance_state": null,
+        "latest_permission_request_sent_at": null,
+        "depends_on_this_section_for_login": true
+    }];
+
+    let store, server;
+
+    let state = () => store.getState().manageStudents;
+
+    beforeEach(function() {
+      server = sinon.fakeServer.create();
+
+      stubRedux();
+      registerReducers({manageStudents:manageStudents});
+      store = getStore();
+    });
+
+    afterEach(function() {
+      server.restore();
+      restoreRedux();
+    });
+
+    it('loadSectionStudentData fetches student info from server', async () => {
+      let store = getStore();
+      let sectionId = 1;
+
+      // assert initial state
+      assert.equal(state().sectionId, null);
+      assert.deepEqual(state().studentData, {});
+      assert.equal(state().isLoadingStudents, true);
+
+      server.respondWith(
+        'GET',
+        `/dashboardapi/sections/${sectionId}/students`,
+        successResponse(mockStudentData)
+      );
+
+      store.dispatch(loadSectionStudentData(sectionId));
+
+      // assert section Id is set before getting response from server
+      assert.equal(state().sectionId, sectionId);
+
+      server.respond();
+      assert.equal(state().isLoadingStudents, false);
+      assert.equal(Object.keys(state().studentData).length, 1);
+    });
+
+    it('loadSectionStudentData is idempotent in fetching student info from server', async () => {
+      let store = getStore();
+      let sectionId = 1;
+
+      // assert initial state
+      assert.equal(state().sectionId, null);
+      assert.deepEqual(state().studentData, {});
+      assert.equal(state().isLoadingStudents, true);
+
+      server.respondWith(
+        'GET',
+        `/dashboardapi/sections/${sectionId}/students`,
+        successResponse(mockStudentData)
+      );
+
+      // send two events to load student data
+      store.dispatch(loadSectionStudentData(sectionId));
+      store.dispatch(loadSectionStudentData(sectionId));
+
+      server.respond();
+
+      // Assert only one request was made to set student data to ensure idempotency.
+      assert.equal(server.requests.length, 1);
+
+      assert.equal(state().sectionId, sectionId);
+      assert.equal(state().isLoadingStudents, false);
+      assert.equal(Object.keys(state().studentData).length, 1);
+    });
+
+    it('loadSectionStudentData failure fetching student info from server', async () => {
+      let store = getStore();
+      let sectionId = 1;
+
+      // assert initial state
+      assert.equal(state().sectionId, null);
+      assert.deepEqual(state().studentData, {});
+      assert.equal(state().isLoadingStudents, true);
+
+      server.respondWith(
+        'GET',
+        `/dashboardapi/sections/${sectionId}/students`,
+        [404, {}, ""]
+      );
+
+      store.dispatch(loadSectionStudentData(sectionId));
+      server.respond();
+
+      assert.equal(state().sectionId, null);
+      assert.equal(state().isLoadingStudents, true);
     });
   });
 });

--- a/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
+++ b/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
@@ -1,3 +1,11 @@
+import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
+
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux,
+} from '@cdo/apps/redux';
 import manageStudents, {
   setLoginType,
   setStudents,
@@ -29,15 +37,11 @@ import manageStudents, {
   transferStudentsFailure,
   addStudentsFull,
   transferStudentsFull,
-  loadSectionStudentData
+  loadSectionStudentData,
 } from '@cdo/apps/templates/manageStudents/manageStudentsRedux';
 
 import {sectionLoginFactory} from '../../../factories/sectionLogin';
 import {assert} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
-import {getStore, registerReducers, stubRedux, restoreRedux} from '@cdo/apps/redux';
-
-import sinon from 'sinon';
-import { expect } from 'chai';
 
 const sectionLoginData = {
   1: sectionLoginFactory.build({id: 1, name: 'StudentNameA', sectionId: 53}),
@@ -1097,34 +1101,36 @@ describe('manageStudentsRedux', () => {
       JSON.stringify(body),
     ];
 
-    const mockStudentData = [{
-        "id": 229,
-        "name": "new student",
-        "username": "coder_abc",
-        "family_name": "fam name",
-        "age": 17,
-        "sharing_disabled": true,
-        "has_ever_signed_in": false,
-        "ai_tutor_access_denied": false,
-        "at_risk_age_gated": false,
-        "child_account_compliance_state": null,
-        "latest_permission_request_sent_at": null,
-        "depends_on_this_section_for_login": true
-    }];
+    const mockStudentData = [
+      {
+        id: 229,
+        name: 'new student',
+        username: 'coder_abc',
+        family_name: 'fam name',
+        age: 17,
+        sharing_disabled: true,
+        has_ever_signed_in: false,
+        ai_tutor_access_denied: false,
+        at_risk_age_gated: false,
+        child_account_compliance_state: null,
+        latest_permission_request_sent_at: null,
+        depends_on_this_section_for_login: true,
+      },
+    ];
 
     let store, server;
 
     let state = () => store.getState().manageStudents;
 
-    beforeEach(function() {
+    beforeEach(function () {
       server = sinon.fakeServer.create();
 
       stubRedux();
-      registerReducers({manageStudents:manageStudents});
+      registerReducers({manageStudents: manageStudents});
       store = getStore();
     });
 
-    afterEach(function() {
+    afterEach(function () {
       server.restore();
       restoreRedux();
     });
@@ -1195,7 +1201,7 @@ describe('manageStudentsRedux', () => {
       server.respondWith(
         'GET',
         `/dashboardapi/sections/${sectionId}/students`,
-        [404, {}, ""]
+        [404, {}, '']
       );
 
       store.dispatch(loadSectionStudentData(sectionId));

--- a/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
+++ b/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
@@ -1202,7 +1202,7 @@ describe('manageStudentsRedux', () => {
       server.respond();
 
       assert.equal(state().sectionId, null);
-      assert.equal(state().isLoadingStudents, true);
+      assert.equal(state().isLoadingStudents, false);
     });
   });
 });


### PR DESCRIPTION
Issue: When loading the manage students page, there are two events sent to redux store to SET_STUDENTS, one from component initialization and another through a call back on mount. This results in an experience where if user clicks "Edit all" between the two events, the input box would revert back to a read-only state. This also causes flakiness in the UI test `manage_students_tab_views_eyes`.

Root cause: The action creator `loadSectionStudentData` which is called twice ensures idempotency by checking if the sectionId is set, which is initially null and updated once the API call to get students is returned. But, given the update happens as a result of an async ajax call, the sectionId is updated after a delay and is null if `loadSectionStudentData` is called twice in quick succession (like it happens when manage students page is loaded).

Fix: Split the update to the store into a two step process, one to just update the section ID, which can be done in an sync fashion as it doesn't depend on an API call. Then only update the student data through another action once the API call returns.

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1262
PR comment where the issue is called out:  https://github.com/code-dot-org/code-dot-org/pull/60837#discussion_r1747804762

## Testing story

- Validated locally by looking at the network tab upon loading the manage students page and confirmed only one network call is outgoing
- Unit tests to assert the idempotency
- Drone

## Deployment strategy

Regular DTP

## Follow-up work

Merge other fixes for flaky UI test https://github.com/code-dot-org/code-dot-org/pull/60837

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
