### PR TITLE
[Aichat] Check user sources for toxicity first time user sources saved (bug fix)

### DIFF
--- a/apps/src/lab2/projects/SourcesStore.ts
+++ b/apps/src/lab2/projects/SourcesStore.ts
@@ -74,7 +74,7 @@ export class RemoteSourcesStore implements SourcesStore {
     projectType?: ProjectType,
     forceNewVersion = false
   ) {
-    let options: SaveSourceOptions | UpdateSourceOptions = {projectType};
+    let options: SaveSourceOptions = {projectType};
     if (this.currentVersionId) {
       // If forceNewVersion is set to true, we will not replace the existing version (i.e., we will create
       // a new version). Otherwise we check if we should replace the existing version based on the last new
@@ -91,7 +91,7 @@ export class RemoteSourcesStore implements SourcesStore {
         replace: replaceExistingVersion,
         firstSaveTimestamp: encodeURIComponent(this.firstSaveTime || ''),
         tabId: getTabId(),
-      };
+      } as UpdateSourceOptions;
     }
     const response = await sourcesApi.update(channelId, sources, options);
 

--- a/apps/src/lab2/projects/SourcesStore.ts
+++ b/apps/src/lab2/projects/SourcesStore.ts
@@ -68,29 +68,24 @@ export class RemoteSourcesStore implements SourcesStore {
     projectType?: ProjectType,
     forceNewVersion = false
   ) {
-    let options = undefined;
-    if (this.currentVersionId) {
-      // If forceNewVersion is set to true, we will not replace the existing version (i.e., we will create
-      // a new version). Otherwise we check if we should replace the existing version based on the last new
-      // version saved in this session.
-      const replaceExistingVersion =
-        !forceNewVersion && this.shouldReplaceExistingVersion();
-      if (!replaceExistingVersion) {
-        // If we're are creating a new version, update the last new version time.
-        this.lastNewVersionTime = Date.now();
-      }
-      options = {
-        currentVersion: this.currentVersionId,
-        replace: replaceExistingVersion,
-        firstSaveTimestamp: encodeURIComponent(this.firstSaveTime || ''),
-        tabId: getTabId(),
-        projectType,
-      };
-    } else {
-      options = {
-        projectType,
-      };
+    // If forceNewVersion is set to true, we will not replace the existing version (i.e., we will create
+    // a new version). Otherwise we check if we should replace the existing version based on the last new
+    // version saved in this session.
+    const replaceExistingVersion =
+      !forceNewVersion && this.shouldReplaceExistingVersion();
+    if (!replaceExistingVersion) {
+      // If we're are creating a new version, update the last new version time.
+      this.lastNewVersionTime = Date.now();
     }
+    const optionsWithoutVersionId = {
+      replace: replaceExistingVersion,
+      firstSaveTimestamp: encodeURIComponent(this.firstSaveTime || ''),
+      tabId: getTabId(),
+      projectType,
+    };
+    const options = this.currentVersionId
+      ? {...optionsWithoutVersionId, currentVersion: this.currentVersionId}
+      : optionsWithoutVersionId;
     const response = await sourcesApi.update(channelId, sources, options);
 
     if (response.ok) {

--- a/apps/src/lab2/projects/SourcesStore.ts
+++ b/apps/src/lab2/projects/SourcesStore.ts
@@ -84,7 +84,11 @@ export class RemoteSourcesStore implements SourcesStore {
         replace: replaceExistingVersion,
         firstSaveTimestamp: encodeURIComponent(this.firstSaveTime || ''),
         tabId: getTabId(),
-        projectType: projectType,
+        projectType,
+      };
+    } else {
+      options = {
+        projectType,
       };
     }
     const response = await sourcesApi.update(channelId, sources, options);

--- a/apps/src/lab2/projects/sourcesApi.ts
+++ b/apps/src/lab2/projects/sourcesApi.ts
@@ -7,7 +7,12 @@ import HttpClient, {GetResponse} from '@cdo/apps/util/HttpClient';
 
 import {SOURCE_FILE} from '../constants';
 import {SourceResponseValidator} from '../responseValidators';
-import {ProjectSources, ProjectVersion, SourceUpdateOptions} from '../types';
+import {
+  ProjectSources,
+  ProjectVersion,
+  SaveSourceOptions,
+  UpdateSourceOptions,
+} from '../types';
 
 const {stringifyQueryParams} = require('@cdo/apps/utils');
 
@@ -28,7 +33,7 @@ export async function get(
 export async function update(
   channelId: string,
   sources: ProjectSources,
-  options?: SourceUpdateOptions
+  options?: SaveSourceOptions | UpdateSourceOptions
 ): Promise<Response> {
   const url = rootUrl(channelId) + stringifyQueryParams(options);
   return fetch(url, {

--- a/apps/src/lab2/projects/sourcesApi.ts
+++ b/apps/src/lab2/projects/sourcesApi.ts
@@ -28,7 +28,7 @@ export async function get(
 export async function update(
   channelId: string,
   sources: ProjectSources,
-  options?: SourceUpdateOptions | {projectType: string | undefined}
+  options?: SourceUpdateOptions
 ): Promise<Response> {
   const url = rootUrl(channelId) + stringifyQueryParams(options);
   return fetch(url, {

--- a/apps/src/lab2/projects/sourcesApi.ts
+++ b/apps/src/lab2/projects/sourcesApi.ts
@@ -7,12 +7,7 @@ import HttpClient, {GetResponse} from '@cdo/apps/util/HttpClient';
 
 import {SOURCE_FILE} from '../constants';
 import {SourceResponseValidator} from '../responseValidators';
-import {
-  ProjectSources,
-  ProjectVersion,
-  SaveSourceOptions,
-  UpdateSourceOptions,
-} from '../types';
+import {ProjectSources, ProjectVersion, SaveSourceOptions} from '../types';
 
 const {stringifyQueryParams} = require('@cdo/apps/utils');
 
@@ -33,7 +28,7 @@ export async function get(
 export async function update(
   channelId: string,
   sources: ProjectSources,
-  options?: SaveSourceOptions | UpdateSourceOptions
+  options?: SaveSourceOptions
 ): Promise<Response> {
   const url = rootUrl(channelId) + stringifyQueryParams(options);
   return fetch(url, {

--- a/apps/src/lab2/projects/sourcesApi.ts
+++ b/apps/src/lab2/projects/sourcesApi.ts
@@ -28,7 +28,7 @@ export async function get(
 export async function update(
   channelId: string,
   sources: ProjectSources,
-  options?: SourceUpdateOptions
+  options?: SourceUpdateOptions | {projectType: string | undefined}
 ): Promise<Response> {
   const url = rootUrl(channelId) + stringifyQueryParams(options);
   return fetch(url, {

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -61,11 +61,11 @@ export interface ProjectSources {
 export type Source = BlocklySource | MultiFileSource;
 
 export interface SourceUpdateOptions {
-  currentVersion: string;
+  currentVersion?: string;
   replace: boolean;
   firstSaveTimestamp: string;
   tabId: string | null;
-  projectType?: ProjectType;
+  projectType: ProjectType | undefined;
 }
 
 // -- BLOCKLY -- //

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -60,12 +60,15 @@ export interface ProjectSources {
 // We will eventually make this a union type to include other source types.
 export type Source = BlocklySource | MultiFileSource;
 
-export interface SourceUpdateOptions {
-  currentVersion?: string;
+export interface SaveSourceOptions {
+  projectType?: string;
+}
+
+export interface UpdateSourceOptions extends SaveSourceOptions {
+  currentVersion: string;
   replace: boolean;
   firstSaveTimestamp: string;
   tabId: string | null;
-  projectType: ProjectType | undefined;
 }
 
 // -- BLOCKLY -- //

--- a/dashboard/test/ui/features/star_labs/aichat/chat.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/chat.feature
@@ -1,4 +1,8 @@
 @no_mobile
+@no_circle
+# As of 9/4/24, cannot access AWS SageMaker or Comprehend in Drone.
+# More discussion in this Slack thread: https://codedotorg.slack.com/archives/C03CK49G9/p1725475362107969
+
 Feature: AI Chat
 
   "AI Chat" is our lab that introduces students to generative AI
@@ -11,9 +15,6 @@ Feature: AI Chat
     And I wait until element "#ui-close-dialog" is not visible
     And I dismiss the teacher panel
 
-  # As of 9/4/24, cannot access SageMaker in Drone.
-  # More discussion in this Slack thread: https://codedotorg.slack.com/archives/C03CK49G9/p1725475362107969
-  @no_circle
   Scenario: Making chat request gets response
     When I press keys "Hello" for element "#uitest-chat-textarea"
     And I wait until element "#uitest-chat-submit" is enabled
@@ -33,8 +34,6 @@ Feature: AI Chat
     And I dismiss the teacher panel
     Then element "#system-prompt" has text "You are a silly chatbot"
 
-  # Cannot access AWS Comprehend in Drone. Refer to comment above.
-  @no_circle
   Scenario: Publishing model enables published view and saves
     When I click selector "#modelCustomizationTabs-tab-modelCardInfo"
     And I wait until element "#uitest-publish-notes-tab-content" is visible


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/60926 and fixes a bug when user sources are saved in an `aichat level` for the first time. See https://github.com/code-dot-org/code-dot-org/pull/60926#discussion_r1752530546.

Currently, when a user saves sources to S3 for the first time on an `aichat` level, the sources do NOT get checked for toxicity/profanity. The reason is that In `SourcesStore.ts` in `save`, [we check for this.currentVersionId](https://github.com/code-dot-org/code-dot-org/blob/4dbbb2ab334ebc37d68a852b7083b3f2232937dc/apps/src/lab2/projects/SourcesStore.ts#L65-L90) and if not defined, then `options` remains `undefined`. Thus, `projectType` is `undefined` so that in `files_api` in `put_file`, the call to `AichatComprehendHelper` is never made.

https://github.com/code-dot-org/code-dot-org/blob/fd596c0ba6bcd071b09b4715ca9d661e5f9e3a92/dashboard/legacy/middleware/files_api.rb#L426

To resolve this bug, in `SourcesStore` ~~I assign `options` the `projectType` if `this.currentVersionId` is `undefined`.~~
UPDATED according to PR feedback: I remove check to see if `currentVersionId` is defined and always assign `projectType` to `options`. I then updated `currentVersion` to be optional and include in options only if `currentVersionId` is assigned.

Temporarily, I skip the 'Editing system prompt produces success notification and saves' scenario on Drone that calls on AWS Comprehend when saving the system prompt. Once @bencodeorg 's [PR](https://github.com/code-dot-org/code-dot-org/pull/60961) is merged, I will stub Comprehend and enable these again on Drone.



## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1015)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I created a new teacher account and added levelbuilder permissions. The first time I saved model customizations on an `aichat` level, I saw that a profane phrase was filtered.
Screenshot of dev console first time sources are saved. `options` have only one field `projectType`:

![Screenshot 2024-09-10 at 4 47 04 PM](https://github.com/user-attachments/assets/81807c5f-1f33-4710-a639-2b42da8cc45c)


Screenshot of dev console when source are saved again on the same `aichat` level. 
![Screenshot 2024-09-10 at 4 48 15 PM](https://github.com/user-attachments/assets/d63231e5-f055-4be6-b90b-6001eded7eb6)

Note that `options` have the fields expected in `SourceUpdateOptions` type. https://github.com/code-dot-org/code-dot-org/blob/87e7f9c0391f2b1d636889785c77749893e769a5/apps/src/lab2/types.ts#L63-L69



<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
