### PR TITLE
[Music] Add pattern and chord blocks to advanced mode

### DIFF
--- a/apps/i18n/music/en_us.json
+++ b/apps/i18n/music/en_us.json
@@ -21,6 +21,8 @@
   "blockly_blockPlayTuneTooltip": "play tune",
   "blockly_blockPlayPattern": "play drums {pattern}",
   "blockly_blockPlayPatternTooltip": "play drums",
+  "blockly_blockPlayPatternAtMeasure": "play drums {pattern} at {measure}",
+  "blockly_blockPlayPatternAtMeasureTooltip": "play drums",
   "blockly_blockPlayPatternAi": "{bot} play AI drums {pattern}",
   "blockly_blockPlayPatternAiTooltip": "play AI drums",
   "blockly_blockRest": "rest for {duration}",

--- a/apps/i18n/music/en_us.json
+++ b/apps/i18n/music/en_us.json
@@ -7,6 +7,8 @@
   "blockly_blockNewTrackOnTriggerTooltip": "new track on trigger",
   "blockly_blockPlayChord": "play notes {chord}",
   "blockly_blockPlayChordTooltip": "play notes",
+  "blockly_blockPlayChordAtMeasure": "play notes {chord} at {measure}",
+  "blockly_blockPlayChordAtMeasureTooltip": "play notes",
   "blockly_blockPlaySound": "play {sound}",
   "blockly_blockPlaySoundTooltip": "play sound",
   "blockly_blockPlaySoundAtMeasure": "play {sound} at {measure}",

--- a/apps/src/music/blockly/blockTypes.ts
+++ b/apps/src/music/blockly/blockTypes.ts
@@ -5,6 +5,7 @@ export enum BlockTypes {
   TRIGGERED_AT_SIMPLE = 'triggered_at_simple',
   TRIGGERED_AT_SIMPLE2 = 'triggered_at_simple2',
   PLAY_SOUND = 'play_sound',
+  PLAY_PATTERN_AT_MEASURE = 'play_pattern_at_measure',
   FOR_LOOP = 'for_loop',
   PLAY_SOUND_AT_CURRENT_LOCATION = 'play_sound_at_current_location',
   SET_CURRENT_LOCATION_NEXT_MEASURE = 'set_current_location_next_measure',

--- a/apps/src/music/blockly/blockTypes.ts
+++ b/apps/src/music/blockly/blockTypes.ts
@@ -6,6 +6,7 @@ export enum BlockTypes {
   TRIGGERED_AT_SIMPLE2 = 'triggered_at_simple2',
   PLAY_SOUND = 'play_sound',
   PLAY_PATTERN_AT_MEASURE = 'play_pattern_at_measure',
+  PLAY_CHORD_AT_MEASURE = 'play_chord_at_measure',
   FOR_LOOP = 'for_loop',
   PLAY_SOUND_AT_CURRENT_LOCATION = 'play_sound_at_current_location',
   SET_CURRENT_LOCATION_NEXT_MEASURE = 'set_current_location_next_measure',

--- a/apps/src/music/blockly/blocks/advanced.js
+++ b/apps/src/music/blockly/blocks/advanced.js
@@ -1,8 +1,8 @@
 import musicI18n from '../../locale';
 import {BlockTypes} from '../blockTypes';
 import {isBlockInsideWhenRun} from '../blockUtils';
-import {FIELD_SOUNDS_NAME} from '../constants';
-import {fieldSoundsDefinition} from '../fields';
+import {FIELD_PATTERN_NAME, FIELD_SOUNDS_NAME} from '../constants';
+import {fieldPatternDefinition, fieldSoundsDefinition} from '../fields';
 
 export const playSound = {
   definition: {
@@ -39,4 +39,35 @@ export const playSound = {
     ', "' +
     ctx.id +
     '");\n',
+};
+
+export const playPatternAtMeasure = {
+  definition: {
+    type: BlockTypes.PLAY_PATTERN_AT_MEASURE,
+    message0: musicI18n.blockly_blockPlayPatternAtMeasure({
+      pattern: '%1',
+      measure: '%2',
+    }),
+    args0: [
+      fieldPatternDefinition,
+      {
+        type: 'input_value',
+        name: 'measure',
+      },
+    ],
+    inputsInline: true,
+    previousStatement: null,
+    nextStatement: null,
+    style: 'lab_blocks',
+    tooltip: musicI18n.blockly_blockPlayPatternAtMeasureTooltip(),
+    helpUrl: '',
+  },
+  generator: block =>
+    `Sequencer.playPatternAtMeasureById(${JSON.stringify(
+      block.getFieldValue(FIELD_PATTERN_NAME)
+    )}, ${Blockly.JavaScript.valueToCode(
+      block,
+      'measure',
+      Blockly.JavaScript.ORDER_ASSIGNMENT
+    )}, "${block.id}");`,
 };

--- a/apps/src/music/blockly/blocks/advanced.js
+++ b/apps/src/music/blockly/blocks/advanced.js
@@ -1,8 +1,16 @@
 import musicI18n from '../../locale';
 import {BlockTypes} from '../blockTypes';
 import {isBlockInsideWhenRun} from '../blockUtils';
-import {FIELD_PATTERN_NAME, FIELD_SOUNDS_NAME} from '../constants';
-import {fieldPatternDefinition, fieldSoundsDefinition} from '../fields';
+import {
+  FIELD_CHORD_NAME,
+  FIELD_PATTERN_NAME,
+  FIELD_SOUNDS_NAME,
+} from '../constants';
+import {
+  fieldChordDefinition,
+  fieldPatternDefinition,
+  fieldSoundsDefinition,
+} from '../fields';
 
 export const playSound = {
   definition: {
@@ -65,6 +73,37 @@ export const playPatternAtMeasure = {
   generator: block =>
     `Sequencer.playPatternAtMeasureById(${JSON.stringify(
       block.getFieldValue(FIELD_PATTERN_NAME)
+    )}, ${Blockly.JavaScript.valueToCode(
+      block,
+      'measure',
+      Blockly.JavaScript.ORDER_ASSIGNMENT
+    )}, "${block.id}");`,
+};
+
+export const playChordAtMeasure = {
+  definition: {
+    type: BlockTypes.PLAY_CHORD_AT_MEASURE,
+    message0: musicI18n.blockly_blockPlayChordAtMeasure({
+      chord: '%1',
+      measure: '%2',
+    }),
+    args0: [
+      fieldChordDefinition,
+      {
+        type: 'input_value',
+        name: 'measure',
+      },
+    ],
+    inputsInline: true,
+    previousStatement: null,
+    nextStatement: null,
+    style: 'lab_blocks',
+    tooltip: musicI18n.blockly_blockPlayChordAtMeasureTooltip(),
+    helpUrl: '',
+  },
+  generator: block =>
+    `Sequencer.playChordAtMeasureById(${JSON.stringify(
+      block.getFieldValue(FIELD_CHORD_NAME)
     )}, ${Blockly.JavaScript.valueToCode(
       block,
       'measure',

--- a/apps/src/music/blockly/musicBlocks.js
+++ b/apps/src/music/blockly/musicBlocks.js
@@ -1,4 +1,8 @@
-import {playSound, playPatternAtMeasure} from './blocks/advanced';
+import {
+  playSound,
+  playPatternAtMeasure,
+  playChordAtMeasure,
+} from './blocks/advanced';
 import {forLoop} from './blocks/control';
 import {whenRun, triggeredAt, triggeredAtSimple} from './blocks/events';
 import {valueSample} from './blocks/samples';
@@ -39,6 +43,7 @@ const blockList = [
   playSound,
   playSoundAtCurrentLocation,
   playPatternAtMeasure,
+  playChordAtMeasure,
   setCurrentLocationNextMeasure,
   playSoundAtCurrentLocationSimple2,
   playPatternAtCurrentLocationSimple2,

--- a/apps/src/music/blockly/musicBlocks.js
+++ b/apps/src/music/blockly/musicBlocks.js
@@ -1,4 +1,4 @@
-import {playSound} from './blocks/advanced';
+import {playSound, playPatternAtMeasure} from './blocks/advanced';
 import {forLoop} from './blocks/control';
 import {whenRun, triggeredAt, triggeredAtSimple} from './blocks/events';
 import {valueSample} from './blocks/samples';
@@ -38,6 +38,7 @@ const blockList = [
   triggeredAtSimple2,
   playSound,
   playSoundAtCurrentLocation,
+  playPatternAtMeasure,
   setCurrentLocationNextMeasure,
   playSoundAtCurrentLocationSimple2,
   playPatternAtCurrentLocationSimple2,

--- a/apps/src/music/blockly/toolbox/definitions.ts
+++ b/apps/src/music/blockly/toolbox/definitions.ts
@@ -37,7 +37,7 @@ export const defaultMaps: {
     Logic: ['controls_if', 'logic_compare'],
   },
   [BlockMode.ADVANCED]: {
-    Play: [BlockTypes.PLAY_SOUND],
+    Play: [BlockTypes.PLAY_SOUND, BlockTypes.PLAY_PATTERN_AT_MEASURE],
     Events: [BlockTypes.TRIGGERED_AT],
     Control: [BlockTypes.FOR_LOOP],
     Math: [

--- a/apps/src/music/blockly/toolbox/definitions.ts
+++ b/apps/src/music/blockly/toolbox/definitions.ts
@@ -37,7 +37,11 @@ export const defaultMaps: {
     Logic: ['controls_if', 'logic_compare'],
   },
   [BlockMode.ADVANCED]: {
-    Play: [BlockTypes.PLAY_SOUND, BlockTypes.PLAY_PATTERN_AT_MEASURE],
+    Play: [
+      BlockTypes.PLAY_SOUND,
+      BlockTypes.PLAY_PATTERN_AT_MEASURE,
+      BlockTypes.PLAY_CHORD_AT_MEASURE,
+    ],
     Events: [BlockTypes.TRIGGERED_AT],
     Control: [BlockTypes.FOR_LOOP],
     Math: [

--- a/apps/src/music/blockly/toolbox/toolboxBlocks.ts
+++ b/apps/src/music/blockly/toolbox/toolboxBlocks.ts
@@ -26,10 +26,23 @@ const toolboxBlocks: {[blockType in BlockTypes | string]: BlockInfo} = {
       },
     },
   },
-
   [BlockTypes.PLAY_PATTERN_AT_MEASURE]: {
     kind: 'block',
     type: BlockTypes.PLAY_PATTERN_AT_MEASURE,
+    inputs: {
+      measure: {
+        shadow: {
+          type: 'math_number',
+          fields: {
+            NUM: 1,
+          },
+        },
+      },
+    },
+  },
+  [BlockTypes.PLAY_CHORD_AT_MEASURE]: {
+    kind: 'block',
+    type: BlockTypes.PLAY_CHORD_AT_MEASURE,
     inputs: {
       measure: {
         shadow: {

--- a/apps/src/music/blockly/toolbox/toolboxBlocks.ts
+++ b/apps/src/music/blockly/toolbox/toolboxBlocks.ts
@@ -26,6 +26,21 @@ const toolboxBlocks: {[blockType in BlockTypes | string]: BlockInfo} = {
       },
     },
   },
+
+  [BlockTypes.PLAY_PATTERN_AT_MEASURE]: {
+    kind: 'block',
+    type: BlockTypes.PLAY_PATTERN_AT_MEASURE,
+    inputs: {
+      measure: {
+        shadow: {
+          type: 'math_number',
+          fields: {
+            NUM: 1,
+          },
+        },
+      },
+    },
+  },
   [BlockTypes.PLAY_SOUND_AT_CURRENT_LOCATION]: {
     kind: 'block',
     type: BlockTypes.PLAY_SOUND_AT_CURRENT_LOCATION,

--- a/apps/src/music/player/sequencer/AdvancedSequencer.ts
+++ b/apps/src/music/player/sequencer/AdvancedSequencer.ts
@@ -1,7 +1,7 @@
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 
-import {DEFAULT_PATTERN_LENGTH} from '../../constants';
+import {DEFAULT_CHORD_LENGTH, DEFAULT_PATTERN_LENGTH} from '../../constants';
 import {PatternEventValue} from '../interfaces/PatternEvent';
 import {PlaybackEvent} from '../interfaces/PlaybackEvent';
 import MusicLibrary from '../MusicLibrary';
@@ -55,6 +55,22 @@ export default class AdvancedSequencer extends Sequencer {
       id: JSON.stringify(value),
       type: 'pattern',
       length: length,
+      blockId,
+      triggered: false,
+      when: measure,
+      value,
+    } as PlaybackEvent);
+  }
+
+  playChordAtMeasureById(
+    value: PatternEventValue,
+    measure: number,
+    blockId: string
+  ) {
+    this.playbackEvents.push({
+      id: JSON.stringify(value),
+      type: 'chord',
+      length: DEFAULT_CHORD_LENGTH,
       blockId,
       triggered: false,
       when: measure,

--- a/apps/src/music/player/sequencer/AdvancedSequencer.ts
+++ b/apps/src/music/player/sequencer/AdvancedSequencer.ts
@@ -1,6 +1,8 @@
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 
+import {DEFAULT_PATTERN_LENGTH} from '../../constants';
+import {PatternEventValue} from '../interfaces/PatternEvent';
 import {PlaybackEvent} from '../interfaces/PlaybackEvent';
 import MusicLibrary from '../MusicLibrary';
 
@@ -39,6 +41,24 @@ export default class AdvancedSequencer extends Sequencer {
       blockId,
       triggered: false,
       when: measure,
+    } as PlaybackEvent);
+  }
+
+  playPatternAtMeasureById(
+    value: PatternEventValue,
+    measure: number,
+    blockId: string
+  ) {
+    const length = value.length || DEFAULT_PATTERN_LENGTH;
+
+    this.playbackEvents.push({
+      id: JSON.stringify(value),
+      type: 'pattern',
+      length: length,
+      blockId,
+      triggered: false,
+      when: measure,
+      value,
     } as PlaybackEvent);
   }
 


### PR DESCRIPTION
@onlinecsteacher needs pattern (drum machine) and chord (arpeggio) blocks for Advanced mode. Fortunately, it was pretty straight-forward to add them:

![image](https://github.com/user-attachments/assets/c87fbd2b-1fe6-4c72-9e97-a947ae56203f)

The new blocks use an additional number input for `measures`, similar to the `playSound` block. The toolbox instances include a shadow block with a good default value. The blocks work as expected in the "when run" context as well as with triggers. They also work with functions (not shown).

![2024-09-11 13-52-19 2024-09-11 13_54_02](https://github.com/user-attachments/assets/1c93d659-6c0a-4024-97e6-4120d94a5d59)



## Links

https://docs.google.com/document/d/1NROqFS9gA4wklBNsxdrFQbou9HHI-fwPEetKGNm-Eho/edit


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
