### PR TITLE
migration to add ai-ta-enabled column to course_offerings

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -22,6 +22,7 @@
 #  video                            :string(255)
 #  published_date                   :datetime
 #  self_paced_pl_course_offering_id :integer
+#  ai_teaching_assistant_available  :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -22,7 +22,7 @@
 #  video                            :string(255)
 #  published_date                   :datetime
 #  self_paced_pl_course_offering_id :integer
-#  ai_teaching_assistant_available  :boolean          default(FALSE)
+#  ai_teaching_assistant_available  :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20240911165129_add_ai_teaching_assistant_available_to_course_offerings.rb
+++ b/dashboard/db/migrate/20240911165129_add_ai_teaching_assistant_available_to_course_offerings.rb
@@ -1,0 +1,5 @@
+class AddAiTeachingAssistantAvailableToCourseOfferings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :course_offerings, :ai_teaching_assistant_available, :boolean, default: false
+  end
+end

--- a/dashboard/db/migrate/20240911165129_add_ai_teaching_assistant_available_to_course_offerings.rb
+++ b/dashboard/db/migrate/20240911165129_add_ai_teaching_assistant_available_to_course_offerings.rb
@@ -1,5 +1,5 @@
 class AddAiTeachingAssistantAvailableToCourseOfferings < ActiveRecord::Migration[6.1]
   def change
-    add_column :course_offerings, :ai_teaching_assistant_available, :boolean, default: false
+    add_column :course_offerings, :ai_teaching_assistant_available, :boolean, default: false, null: false
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -450,7 +450,7 @@ ActiveRecord::Schema.define(version: 2024_09_20_175046) do
     t.string "video"
     t.datetime "published_date"
     t.integer "self_paced_pl_course_offering_id"
-    t.boolean "ai_teaching_assistant_available", default: false
+    t.boolean "ai_teaching_assistant_available", default: false, null: false
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -450,6 +450,7 @@ ActiveRecord::Schema.define(version: 2024_09_20_175046) do
     t.string "video"
     t.datetime "published_date"
     t.integer "self_paced_pl_course_offering_id"
+    t.boolean "ai_teaching_assistant_available", default: false
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 


### PR DESCRIPTION
migration PR for https://github.com/code-dot-org/code-dot-org/pull/60990 . See that PR for details.