### PR TITLE
Revert new copyright dialog

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -90,6 +90,8 @@ import {parseElement as parseXmlElement} from './xml';
 
 var codegen = require('./lib/tools/jsinterpreter/codegen');
 
+var copyrightStrings;
+
 /**
  * If the bigPlayspace is enabled, either by experiment or by level property,
  * then the padding can be configured via query param as well.
@@ -337,6 +339,7 @@ StudioApp.prototype.init = function (config) {
   this.config = config;
 
   config.getCode = this.getCode.bind(this);
+  copyrightStrings = config.copyrightStrings;
 
   if (config.legacyShareStyle && config.hideSource) {
     $('body').addClass('legacy-share-view');
@@ -1025,6 +1028,7 @@ StudioApp.prototype.renderShareFooter_ = function (container) {
     i18nDropdown: '',
     privacyPolicyInBase: false,
     copyrightInBase: false,
+    copyrightStrings: copyrightStrings,
     baseMoreMenuString: msg.builtOnCodeStudio(),
     baseStyle: {
       paddingLeft: 0,

--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -101,6 +101,14 @@ const APP_OPTIONS_ALLOWLIST = {
   },
   isUS: true,
   send_to_phone_url: true,
+  copyrightStrings: {
+    thanks: true,
+    help_from_html: true,
+    art_from_html: true,
+    code_from_html: true,
+    powered_by_aws: true,
+    trademark: true,
+  },
   teacherMarkdown: false,
   dialog: {
     skipSound: true,

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -116,6 +116,7 @@ consoleApi.setClearMethod(Applab.clear);
 
 var level;
 var skin;
+var copyrightStrings;
 
 //TODO: Make configurable.
 studioApp().setCheckForEmptyBlocks(true);
@@ -233,6 +234,7 @@ function renderFooterInSharedGame() {
       i18nDropdown={''}
       privacyPolicyInBase={false}
       copyrightInBase={false}
+      copyrightStrings={copyrightStrings}
       baseMoreMenuString={commonMsg.builtOnCodeStudio()}
       rowHeight={applabConstants.FOOTER_HEIGHT}
       style={{fontSize: 18}}
@@ -366,6 +368,7 @@ Applab.initReadonly = function (config) {
   // we can ensure that the blocks are appropriately modified for this level
   skin = config.skin;
   level = config.level;
+  copyrightStrings = config.copyrightStrings;
   config.appMsg = applabMsg;
   loadLevel();
 
@@ -429,6 +432,7 @@ Applab.init = function (config) {
   skin.winAvatar = null;
   skin.failureAvatar = null;
   level = config.level;
+  copyrightStrings = config.copyrightStrings;
   Applab.user = {
     labUserId: config.labUserId,
     isSignedIn: config.isSignedIn,

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -53,6 +53,7 @@
  * @property {ReportOptions} report
  * @property {boolean} isUS
  * @property {string} send_to_phone_url
+ * @property {CopyrightStrings} copyrightStrings
  * @property {string} teacherMarkdown
  * @property {DialogOptions} dialog
  * @property {string} locale
@@ -191,6 +192,7 @@
  */
 
 /**
+ * @typedef {Object} CopyrightStrings
  * @property {string} thanks
  * @property {string} help_from_html
  * @property {string} art_from_html

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -6,6 +6,7 @@ https://github.com/code-dot-org/code-dot-org/blob/b2efc7ca8331f8261ebd55a326e23f
 
 /* eslint-disable react/jsx-no-target-blank */
 /* eslint-disable react/no-danger */
+import $ from 'jquery';
 import _ from 'lodash';
 import debounce from 'lodash/debounce';
 import PropTypes from 'prop-types';
@@ -13,8 +14,10 @@ import React from 'react';
 
 import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
-import CopyrightDialog from '@cdo/apps/sharedComponents/footer/CopyrightDialog';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import i18n from '@cdo/locale';
+
+import color from '../../util/color';
 
 const MenuState = {
   MINIMIZING: 'MINIMIZING',
@@ -29,6 +32,14 @@ export default class SmallFooter extends React.Component {
     // encode string of html
     i18nDropdown: PropTypes.string,
     copyrightInBase: PropTypes.bool.isRequired,
+    copyrightStrings: PropTypes.shape({
+      thanks: PropTypes.string.isRequired,
+      help_from_html: PropTypes.string.isRequired,
+      art_from_html: PropTypes.string.isRequired,
+      code_from_html: PropTypes.string.isRequired,
+      trademark: PropTypes.string.isRequired,
+      built_on_github: PropTypes.string.isRequired,
+    }),
     baseCopyrightString: PropTypes.string,
     baseMoreMenuString: PropTypes.string.isRequired,
     baseStyle: PropTypes.object,
@@ -72,6 +83,33 @@ export default class SmallFooter extends React.Component {
     });
   };
 
+  minimizeOnClickAnywhere(event) {
+    // The first time we click anywhere, hide any open children
+    $(document.body).one(
+      'click',
+      function (event) {
+        // menu copyright has its own click handler
+        if (event.target === this.refs.menuCopyright) {
+          return;
+        }
+
+        this.setState({
+          menuState: MenuState.MINIMIZING,
+          moreOffset: 0,
+        });
+
+        // Create a window during which we can't show again, so that clicking
+        // on copyright doesnt immediately hide/reshow
+        setTimeout(
+          function () {
+            this.setState({menuState: MenuState.MINIMIZED});
+          }.bind(this),
+          200
+        );
+      }.bind(this)
+    );
+  }
+
   clickBase = e => {
     if (this.props.copyrightInBase) {
       // When we have multiple items in our base row, ignore clicks to the
@@ -95,18 +133,13 @@ export default class SmallFooter extends React.Component {
     }
 
     this.setState({menuState: MenuState.COPYRIGHT});
+    this.minimizeOnClickAnywhere();
   };
 
   clickMenuCopyright = event => {
     event.stopPropagation();
     this.setState({menuState: MenuState.COPYRIGHT});
-  };
-
-  closeCopyrightDialog = e => {
-    if (e !== undefined) {
-      e.stopPropagation();
-    }
-    this.setState({menuState: MenuState.MINIMIZED});
+    this.minimizeOnClickAnywhere();
   };
 
   clickBaseMenu = e => {
@@ -124,6 +157,7 @@ export default class SmallFooter extends React.Component {
     }
 
     this.setState({menuState: MenuState.EXPANDED});
+    this.minimizeOnClickAnywhere();
   };
 
   render() {
@@ -140,10 +174,35 @@ export default class SmallFooter extends React.Component {
         width: '100%',
         boxSizing: 'border-box',
       },
+      copyright: {
+        display: this.state.menuState === MenuState.COPYRIGHT ? 'flex' : 'none',
+        position: 'absolute',
+        bottom: 0,
+        width: 650,
+        maxWidth: '50%',
+        minWidth: this.state.baseWidth,
+      },
+      copyrightXClose: {
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        padding: 0,
+        color: color.neutral_dark30,
+        backgroundColor: color.background_gray,
+        cursor: 'pointer',
+        border: 'none',
+      },
+      copyrightScrollArea: {
+        maxHeight: this.props.phoneFooter ? 210 : undefined,
+        marginBottom: this.state.baseHeight - 1,
+      },
       moreMenu: {
         display: this.state.menuState === MenuState.EXPANDED ? 'block' : 'none',
         bottom: this.state.baseHeight,
         width: this.state.baseWidth,
+      },
+      awsLogo: {
+        width: 190,
       },
       version: {
         margin: 'auto 0',
@@ -170,10 +229,6 @@ export default class SmallFooter extends React.Component {
         >
           {this.renderI18nDropdown()}
           {this.renderCopyright()}
-          <CopyrightDialog
-            isOpen={this.state.menuState === MenuState.COPYRIGHT}
-            closeModal={this.closeCopyrightDialog}
-          />
           {!!this.props.unitYear && yearIsNumeric && (
             <p style={styles.version}>
               <span className="version-caption">{i18n.version()}: </span>
@@ -181,6 +236,51 @@ export default class SmallFooter extends React.Component {
             </p>
           )}
           {this.renderMoreMenuButton()}
+        </div>
+        <div id="copyright-flyout" style={styles.copyright}>
+          <div id="copyright-scroll-area" style={styles.copyrightScrollArea}>
+            <h4>{this.props.baseCopyrightString}</h4>
+            <SafeMarkdown
+              markdown={decodeURIComponent(this.props.copyrightStrings.thanks)}
+            />
+            <p>{this.props.copyrightStrings.help_from_html}</p>
+            <SafeMarkdown
+              markdown={decodeURIComponent(
+                this.props.copyrightStrings.art_from_html
+              )}
+            />
+            <SafeMarkdown
+              markdown={decodeURIComponent(
+                this.props.copyrightStrings.code_from_html
+              )}
+            />
+            <p>{this.props.copyrightStrings.built_on_github}</p>
+            <a href="https://aws.amazon.com/what-is-cloud-computing">
+              <img
+                src="/shared/images/Powered-By_logo-horiz_RGB.png"
+                alt="Powered by AWS Cloud Computing"
+                style={styles.awsLogo}
+              />
+            </a>
+            <SafeMarkdown
+              markdown={decodeURIComponent(
+                this.props.copyrightStrings.trademark
+              )}
+            />
+            <Button
+              aria-label={i18n.closeDialog()}
+              icon={{
+                iconName: 'xmark',
+                iconStyle: 'light',
+              }}
+              id="x-close-copyright"
+              isIconOnly
+              onClick={() => this.setState({menuState: MenuState.MINIMIZED})}
+              size="l"
+              style={styles.copyrightXClose}
+              type="primary"
+            />
+          </div>
         </div>
         {this.renderMoreMenu(styles)}
       </div>

--- a/apps/test/unit/applab/ExporterTest.js
+++ b/apps/test/unit/applab/ExporterTest.js
@@ -218,6 +218,19 @@ describe('Applab Exporter,', function () {
       },
       isUS: true,
       send_to_phone_url: 'http://localhost-studio.code.org:3000/sms/send',
+      copyrightStrings: {
+        thanks:
+          'We%20thank%20our%20%3Ca%20href=%22https://code.org/about/donors%22%3Edonors%3C/a%3E,%20%3Ca%20href=%22https://code.org/about/partners%22%3Epartners%3C/a%3E,%20our%20%3Ca%20href=%22https://code.org/about/team%22%3Eextended%20team%3C/a%3E,%20and%20our%20video%20cast%20for%20their%20support%20in%20creating%20Code%20Studio.',
+        help_from_html:
+          'We especially want to recognize the engineers from Amazon, Google, and Microsoft who helped create these materials.',
+        art_from_html:
+          'Minecraft\u0026%238482;%20\u0026copy;%202017%20Microsoft.%20All%20Rights%20Reserved.%3Cbr%20/%3EStar%20Wars\u0026%238482;%20\u0026copy;%202017%20Disney%20and%20Lucasfilm.%20All%20Rights%20Reserved.%3Cbr%20/%3EFrozen\u0026%238482;%20\u0026copy;%202017%20Disney.%20All%20Rights%20Reserved.%3Cbr%20/%3EIce%20Age\u0026%238482;%20\u0026copy;%202017%2020th%20Century%20Fox.%20All%20Rights%20Reserved.%3Cbr%20/%3EAngry%20Birds\u0026%238482;%20\u0026copy;%202009-2017%20Rovio%20Entertainment%20Ltd.%20All%20Rights%20Reserved.%3Cbr%20/%3EPlants%20vs.%20Zombies\u0026%238482;%20\u0026copy;%202017%20Electronic%20Arts%20Inc.%20All%20Rights%20Reserved.%3Cbr%20/%3EThe%20Amazing%20World%20of%20Gumball%20is%20trademark%20and%20\u0026copy;%202017%20Cartoon%20Network.',
+        code_from_html:
+          'Code.org%20uses%20p5.play,%20which%20is%20licensed%20under%20%3Ca%20href=%22http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html%22%3Ethe%20GNU%20LGPL%202.1%3C/a%3E.',
+        powered_by_aws: 'Powered by Amazon Web Services',
+        trademark:
+          '\u0026copy;%20Code.org,%202017.%20Code.org\u0026reg;,%20the%20CODE%20logo%20and%20Hour%20of%20Code\u0026reg;%20are%20trademarks%20of%20Code.org.',
+      },
       teacherMarkdown: null,
       dialog: {
         skipSound: false,

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -539,6 +539,10 @@ module LevelsHelper
       sublevelCallback: @sublevel_callback,
     }
 
+    if @game&.owns_footer_for_share? || @legacy_share_style
+      app_options[:copyrightStrings] = build_copyright_strings
+    end
+
     app_options
   end
 
@@ -697,6 +701,10 @@ module LevelsHelper
     end
     app_options[:send_to_phone_url] = send_to_phone_url if app_options[:isUS]
 
+    if @game&.owns_footer_for_share? || @legacy_share_style
+      app_options[:copyrightStrings] = build_copyright_strings
+    end
+
     app_options
   end
 
@@ -715,6 +723,21 @@ module LevelsHelper
     end
     app_options[:share] = level_options[:share] if level_options[:share]
     app_options.camelize_keys
+  end
+
+  def build_copyright_strings
+    # These would ideally also go in _javascript_strings.html right now, but it can't
+    # deal with params.
+    {
+      thanks: ERB::Util.url_encode(I18n.t('footer.thanks')),
+      help_from_html: I18n.t('footer.help_from_html'),
+      art_from_html: ERB::Util.url_encode(I18n.t('footer.art_from_html', current_year: Time.now.year)),
+      code_from_html: ERB::Util.url_encode(I18n.t('footer.code_from_html')),
+      powered_by_aws: I18n.t('footer.powered_by_aws'),
+      trademark: ERB::Util.url_encode(I18n.t('footer.trademark', current_year: Time.now.year, cs_discoveries: "CS Discoveries&reg;")),
+      built_on_github: I18n.t('footer.built_on_github'),
+      google_copyright: ERB::Util.url_encode(I18n.t('footer.google_copyright'))
+    }
   end
 
   def match_answer_as_image(path, width)

--- a/dashboard/app/views/layouts/_small_footer.html.haml
+++ b/dashboard/app/views/layouts/_small_footer.html.haml
@@ -8,6 +8,7 @@
     baseCopyrightString: I18n.t('footer.copyright'),
     baseMoreMenuString: I18n.t('footer.more'),
     menuItems: [],
+    copyrightStrings: build_copyright_strings,
     # false because we're not rendering into a phone wireframe here
     phoneFooter: false,
     fullWidth: full_width,

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -636,8 +636,13 @@ en:
     student: 'Student'
     teacher: 'Teacher'
   footer:
+    thanks: 'We thank our <a href="https://code.org/about/donors">donors</a>, <a href="https://code.org/about/partners">partners</a>, our <a href="https://code.org/about/team">extended team</a>, and our video cast for their support in creating Code Studio.'
+    help_from_html: 'We especially want to recognize the engineers from Amazon, Google, and Microsoft who helped create these materials.'
     help_from_html_old: 'Engineers from Amazon, Google, and Microsoft helped create these materials.'
+    art_from_html: 'Minecraft&#8482; &copy; %{current_year} Microsoft. All Rights Reserved.<br />Star Wars&#8482; &copy; %{current_year} Disney and Lucasfilm. All Rights Reserved.<br />Frozen&#8482; &copy; %{current_year} Disney. All Rights Reserved.<br />Ice Age&#8482; &copy; %{current_year} 20th Century Fox. All Rights Reserved.<br />Angry Birds&#8482; &copy; 2009-%{current_year} Rovio Entertainment Ltd. All Rights Reserved.<br />Plants vs. Zombies&#8482; &copy; %{current_year} Electronic Arts Inc. All Rights Reserved.<br />DreamWorks The Bad Guys &copy; %{current_year} DreamWorks Animation LLC. All Rights Reserved.<br />Paramount Pictures Transformers One &copy; %{current_year} Paramount Pictures. All Rights Reserved.'
     art_from_html_old: 'Minecraft&#8482; &copy; %{current_year} Microsoft. All Rights Reserved. Star Wars&#8482; &copy; %{current_year} Disney and Lucasfilm. All Rights Reserved. Frozen&#8482; &copy; %{current_year} Disney. All Rights Reserved. Ice Age&#8482; &copy; %{current_year} 20th Century Fox. All Rights Reserved. Angry Birds&#8482; &copy; 2009-%{current_year} Rovio Entertainment Ltd. All Rights Reserved. Plants vs. Zombies&#8482; &copy; %{current_year} Electronic Arts Inc. All Rights Reserved. DreamWorks The Bad Guys &copy; %{current_year} DreamWorks Animation LLC. All Rights Reserved. Paramount Pictures Transformers One &copy; %{current_year} Paramount Pictures. All Rights Reserved.'
+    code_from_html: 'Code.org uses p5.play, which is licensed under <a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html">the GNU LGPL 2.1</a>.'
+    powered_by_aws: 'Amazon Web Services and the “Powered by AWS” logo are trademarks of Amazon.com, Inc. or its affiliates in the United States and/or other countries.'
     built_on_github: 'Built on GitHub from Microsoft'
     trademark: '&copy; Code.org, %{current_year}. Code.org&reg;, the CODE logo, Hour of Code&reg; and %{cs_discoveries} are trademarks of Code.org.'
     copyright: 'Copyright'

--- a/dashboard/test/ui/features/foundations/footer.feature
+++ b/dashboard/test/ui/features/foundations/footer.feature
@@ -10,9 +10,28 @@ Feature: Checking the footer appearance
 
     When I press the first ".copyright-link" element
     And I wait for 0.25 seconds
-    Then I see no difference for "copyright dialog"
-    And I press the first "#ui-close-dialog" element
+    Then I see no difference for "copyright flyout"
+    And I press the first ".copyright-link" element
     And I wait for 0.25 seconds
+
+    When I drag the visualization grippy by -400 pixels
+    Then I see no difference for "smaller small footer"
+    And I wait for 0.25 seconds
+
+    When I press the first ".copyright-link" element
+    And I wait for 0.25 seconds
+    Then I see no difference for "smaller copyright flyout"
+    And I press the first ".copyright-link" element
+    And I wait for 0.25 seconds
+
+    # Now, variations where we resize while the flyouts are open, to make
+    # sure they update their size/position properly during the resize
+
+    When I press the first ".copyright-link" element
+    And I wait for 0.25 seconds
+    Then I see no difference for "copyright resize before"
+    When I drag the visualization grippy by -400 pixels
+    Then I see no difference for "copyright resize after"
 
     Then I close my eyes
 
@@ -26,7 +45,7 @@ Feature: Checking the footer appearance
 
     When I press the first ".copyright-link" element
     And I wait for 0.25 seconds
-    Then I see no difference for "copyright dialog"
+    Then I see no difference for "copyright flyout"
 
     Then I close my eyes
 
@@ -48,7 +67,7 @@ Feature: Checking the footer appearance
     Then I see no difference for "footer menu"
 
     When I press menu item "Copyright"
-    Then I see no difference for "copyright dialog"
+    Then I see no difference for "copyright flyout"
     And I wait for 0.25 seconds
     And I close the small footer menu
 
@@ -60,7 +79,7 @@ Feature: Checking the footer appearance
 
     When I press the first ".copyright-link" element
     And I wait for 0.25 seconds
-    Then I see no difference for "how it works copyright dialog"
+    Then I see no difference for "how it works copyright flyout"
 
     Then I close my eyes
 
@@ -81,7 +100,7 @@ Feature: Checking the footer appearance
     Then I see no difference for "footer menu"
 
     When I press menu item "Copyright"
-    Then I see no difference for "copyright dialog"
+    Then I see no difference for "copyright flyout"
     And I wait for 0.25 seconds
     And I close the small footer menu
 
@@ -99,7 +118,7 @@ Feature: Checking the footer appearance
 
     When I press the first ".copyright-link" element
     And I wait for 0.25 seconds
-    Then I see no difference for "how it works copyright dialog"
+    Then I see no difference for "how it works copyright flyout"
 
     Then I close my eyes
 
@@ -117,7 +136,7 @@ Feature: Checking the footer appearance
     Then I see no difference for "footer menu"
 
     When I press menu item "Copyright"
-    Then I see no difference for "copyright dialog"
+    Then I see no difference for "copyright flyout"
 
     Then I close my eyes
 
@@ -145,7 +164,7 @@ Feature: Checking the footer appearance
     Then I see no difference for "footer menu"
 
     When I press menu item "Copyright"
-    Then I see no difference for "copyright dialog"
+    Then I see no difference for "copyright flyout"
 
     Then I close my eyes
 
@@ -172,7 +191,7 @@ Feature: Checking the footer appearance
     Then I see no difference for "footer menu"
 
     When I press menu item "Copyright"
-    Then I see no difference for "copyright dialog"
+    Then I see no difference for "copyright flyout"
 
     Then I close my eyes
 
@@ -195,6 +214,6 @@ Feature: Checking the footer appearance
     Then I see no difference for "footer menu"
 
     When I press menu item "Copyright"
-    Then I see no difference for "copyright dialog"
+    Then I see no difference for "copyright flyout"
 
     Then I close my eyes


### PR DESCRIPTION
This PR partially reverts #60531
During the test build, I noticed a couple of changes that should not be deployed. 
I revert the usage of the new Dialog without removing the Dialog from the codebase to work on style changes.
the following Screenshot shows the changes that needed to be reverted.
![Screenshot 2024-09-11 at 12 30 54](https://github.com/user-attachments/assets/fd9cb949-c4f3-4314-a896-f2cda4aeface)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
