### PR TITLE
Grant comprehend:DetectToxicContent permissions to execution role

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -191,13 +191,22 @@ Resources:
           - Effect: Allow
             Action: 's3:*'
             Resource: '*'
-          # SageMaker Invoke Endpoint access
+          # TODO: Move to dedicated policy for GenAI
+          # GenAI Sagemaker access
           - Effect: Allow
-            Action: 'sagemaker:InvokeEndpoint'
+            Action:
+              - 'sagemaker:InvokeEndpoint'
             Resource: !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:endpoint/gen-ai-*"
-          # Comprehend Detect Toxic Content access
+          # GenAI Comprehend access
           - Effect: Allow
-            Action: 'comprehend:DetectToxicContent'
+            Action:
+              - 'comprehend:DetectToxicContent'
+            Resource: '*'
+          # TODO: Move to dedicated policy for AI TA
+          # AI TA Sagemaker access
+          - Effect: Allow
+            Action:
+              - 'bedrock:RetrieveAndGenerate'
             Resource: '*'
 
   # ---------------------------------------------

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -207,6 +207,8 @@ Resources:
           - Effect: Allow
             Action:
               - 'bedrock:RetrieveAndGenerate'
+              - 'bedrock:Retrieve' # TODO: scope to custom knowledge base
+              - 'bedrock:InvokeModel' # TODO: scope to allowed models
             Resource: '*'
 
   # ---------------------------------------------

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -195,6 +195,10 @@ Resources:
           - Effect: Allow
             Action: 'sagemaker:InvokeEndpoint'
             Resource: !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:endpoint/gen-ai-*"
+          # Comprehend Detect Toxicity access
+          - Effect: Allow
+            Action: 'comprehend:DetectToxicContent'
+            Resource: '*'
 
   # ---------------------------------------------
   # Frontend Servers

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -195,7 +195,7 @@ Resources:
           - Effect: Allow
             Action: 'sagemaker:InvokeEndpoint'
             Resource: !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:endpoint/gen-ai-*"
-          # Comprehend Detect Toxicity access
+          # Comprehend Detect Toxic Content access
           - Effect: Allow
             Action: 'comprehend:DetectToxicContent'
             Resource: '*'


### PR DESCRIPTION
Grant the `comprehend:DetectToxicContent` permission to the frontend execution role. This is needed for toxicity detection & safety in the AI Chat lab used in the Gen AI curriculum.

## Links

https://codedotorg.slack.com/archives/C06UT1E2796/p1726075719780999

## Testing story

Not tested yet; adhoc deploy in progress.