### PR TITLE
Update to ProxySQL 2.7.0

### DIFF
--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -20,6 +20,7 @@ remote_file proxysql_file do
   checksum "5e92844617aa1666a65475bd22c7fda1939ef5604e4b7ea08625ff2465b87482"
   action :create_if_missing
 end
+
 dpkg_package('proxysql') do
   source proxysql_file
   version '2.7.0'

--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -13,16 +13,16 @@
 #   action :upgrade
 # end
 
-proxysql_filename = 'proxysql_2.6.2-ubuntu20_amd64.deb'
+proxysql_filename = 'proxysql_2.7.0-ubuntu20_amd64.deb'
 proxysql_file = "#{Chef::Config[:file_cache_path]}/#{proxysql_filename}"
 remote_file proxysql_file do
-  source "https://github.com/sysown/proxysql/releases/download/v2.6.2/#{proxysql_filename}"
-  checksum "bd4e4bf310927789d387341160c5a44b74d5fa0cd3d65783d40a75dd983791e1"
+  source "https://github.com/sysown/proxysql/releases/download/v2.7.0/#{proxysql_filename}"
+  checksum "5e92844617aa1666a65475bd22c7fda1939ef5604e4b7ea08625ff2465b87482"
   action :create_if_missing
 end
 dpkg_package('proxysql') do
   source proxysql_file
-  version '2.6.2'
+  version '2.7.0'
   options '--force-confold'
 end
 


### PR DESCRIPTION
Update from ProxySQL 2.6.2 to latest release ([2.7.0](https://github.com/sysown/proxysql/releases/tag/v2.7.0)) as a speculative mitigation of recent database availability / performance issues.

We've had several incidents since upgrading to Aurora 3 / MySQL 8 where an increase in throughput of queries that exert high database load on the primary / writer database instance have caused increased HTTP error rates due to ProxySQL classifying the writer database instance as being offline or ProxySQL encountering errors opening new connections to the writer database.

While the likely solution will involve improving various ProxySQL configuration settings (such as monitor timeouts) and configuring Aurora to handle spikes in new client connections, there's at least [one fix](https://github.com/sysown/proxysql/pull/4578) since ProxySQL 2.6.2 that resolves an ERROR in the ProxySQL Monitor module that could help with this issue and there are several other improvements https://github.com/sysown/proxysql/releases

## Testing story

Merge this feature branch and the feature branch in #56255 and provision a full stack adhoc:
`bundle exec rake adhoc:full_stack:start RAILS_ENV=adhoc STACK_NAME=adhoc-update-proxysql4 ALARMS=yes`

This adhoc provisioned successfully:
https://adhoc-update-proxysql4-studio.cdn-code.org/

Chef Client logs from this adhoc's AMI Builder:
```
Recipe: cdo-mysql::proxy
  * remote_file[/etc/chef/local-mode-cache/cache/proxysql_2.7.0-ubuntu20_amd64.deb] action create_if_missing
    - create new file /etc/chef/local-mode-cache/cache/proxysql_2.7.0-ubuntu20_amd64.deb
    - update content in file /etc/chef/local-mode-cache/cache/proxysql_2.7.0-ubuntu20_amd64.deb from none to 5e9284
    (file sizes exceed 10000000 bytes, diff output suppressed)
  * dpkg_package[proxysql] action install
    - install version 2.7.0 of package proxysql
 ```

ProxySQL runtime configuration looks good on the adhoc's auto scaling web application servers:
```
mysql> SELECT hostgroup_id, hostname, status, weight, max_connections FROM runtime_mysql_servers;
+--------------+-------------------------------------------------------------------+--------+----------+-----------------+
| hostgroup_id | hostname                                                          | status | weight   | max_connections |
+--------------+-------------------------------------------------------------------+--------+----------+-----------------+
| 0            | adhoc-update-proxysql4-1.ceidnfhvpbck.us-east-1.rds.amazonaws.com | ONLINE | 10000000 | 16              |
| 1            | adhoc-update-proxysql4-0.ceidnfhvpbck.us-east-1.rds.amazonaws.com | ONLINE | 10000000 | 16              |
| 1            | adhoc-update-proxysql4-1.ceidnfhvpbck.us-east-1.rds.amazonaws.com | ONLINE | 1        | 16              |
| 2            | adhoc-update-proxysql4-0.ceidnfhvpbck.us-east-1.rds.amazonaws.com | ONLINE | 1        | 1000            |
| 2            | adhoc-update-proxysql4-1.ceidnfhvpbck.us-east-1.rds.amazonaws.com | ONLINE | 10000000 | 1000            |
+--------------+-------------------------------------------------------------------+--------+----------+-----------------+
5 rows in set (0.00 sec)
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
