### PR TITLE
add setting to show AI Teaching Assistant available icon to quick assign view

### DIFF
--- a/apps/src/levelbuilder/CourseOfferingEditor.jsx
+++ b/apps/src/levelbuilder/CourseOfferingEditor.jsx
@@ -389,8 +389,8 @@ export default function CourseOfferingEditor(props) {
         AI Teaching Assistant Available
         <HelpTip>
           <p>
-            Select this checkbox to show the TA bot icon in the curriculum
-            catalog.
+            Select this checkbox to show the TA bot icon in the assignment
+            experience.
           </p>
         </HelpTip>
         <input

--- a/apps/src/levelbuilder/CourseOfferingEditor.jsx
+++ b/apps/src/levelbuilder/CourseOfferingEditor.jsx
@@ -385,6 +385,26 @@ export default function CourseOfferingEditor(props) {
           ))}
         </select>
       </label>
+      <label>
+        AI Teaching Assistant Available
+        <HelpTip>
+          <p>
+            Select this checkbox to show the TA bot icon in the curriculum
+            catalog.
+          </p>
+        </HelpTip>
+        <input
+          type="checkbox"
+          checked={courseOffering.ai_teaching_assistant_available}
+          style={styles.checkbox}
+          onChange={e =>
+            updateCourseOffering(
+              'ai_teaching_assistant_available',
+              e.target.checked
+            )
+          }
+        />
+      </label>
       <h3>Device Compatibility</h3>
       {DeviceTypes.map(device => (
         <label key={device}>

--- a/apps/src/templates/rubrics/images/ai-teaching-assistant-assign.png
+++ b/apps/src/templates/rubrics/images/ai-teaching-assistant-assign.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c30442182c47e6de2acba5c7f13b8a75797010db0ee30dc013029ff5f1a7d13f
+size 976

--- a/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTableHelpers.jsx
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 import React from 'react';
 
 import {Heading5} from '@cdo/apps/componentLibrary/typography';
+import taImage from '@cdo/apps/templates/rubrics/images/ai-teaching-assistant-assign.png';
 
 import moduleStyles from './sections-refresh.module.scss';
 
@@ -78,6 +79,13 @@ function renderOfferings(
       >
         {course.display_name}
       </label>
+      {course.ai_teaching_assistant_available && (
+        <img
+          src={taImage}
+          className={moduleStyles.taImage}
+          alt="AI Teaching Assistant available"
+        />
+      )}
     </div>
   ));
 }

--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -157,15 +157,15 @@ label.typographyLabelTwo {
 
 .courseOption {
   margin-top: 20px;
-  align-items: baseline;
+  align-items: center;
 }
 
 .flexDisplay .radio {
-  margin: 0 0 0 0;
+  margin: -2px 0 0 0;
 }
 
 .courseOptionLabel {
-  margin: 0 10px 0 5px;
+  margin: 0 0 0 5px;
 }
 
 .unitDropdown {
@@ -226,4 +226,9 @@ button.advancedSettingsButton {
       margin-left: 5px;
     }
   }
+}
+
+.taImage {
+  margin-left: 5px;
+  margin-top: -5px;
 }

--- a/apps/test/unit/templates/sectionsRefresh/CourseOfferingsTestData.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CourseOfferingsTestData.jsx
@@ -67,6 +67,7 @@ export const highSchoolCourseOfferings = {
           id: 74,
           key: 'csd',
           display_name: 'Computer Science Discoveries',
+          ai_teaching_assistant_available: true,
           course_versions: [
             [
               736,

--- a/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
@@ -80,4 +80,12 @@ describe('QuickAssignTable', () => {
     const radio = screen.getByLabelText('Computer Science A');
     expect(radio).toBeChecked();
   });
+
+  it('shows TA icon when course offering has TA enabled', () => {
+    setUpRtl();
+    const taIcon = screen.getByAltText('AI Teaching Assistant available');
+    expect(taIcon.previousSibling).toHaveTextContent(
+      'Computer Science Discoveries'
+    );
+  });
 });

--- a/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
@@ -1,4 +1,4 @@
-import {shallow, mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {fireEvent, render, screen} from '@testing-library/react';
 import React from 'react';
 
 import {MARKETING_AUDIENCE} from '@cdo/apps/templates/sectionsRefresh/CurriculumQuickAssign';
@@ -19,58 +19,50 @@ const DEFAULT_PROPS = {
   sectionCourse: {},
 };
 
-const setUpShallow = (overrideProps = {}) => {
+const setUpRtl = (overrideProps = {}) => {
   const props = {...DEFAULT_PROPS, ...overrideProps};
-  return shallow(<QuickAssignTable {...props} />);
-};
-
-const setUpMount = (overrideProps = {}) => {
-  const props = {...DEFAULT_PROPS, ...overrideProps};
-  return mount(<QuickAssignTable {...props} />);
+  return render(<QuickAssignTable {...props} />);
 };
 
 describe('QuickAssignTable', () => {
   it('renders Course as the first and only table/column header', () => {
-    const wrapper = setUpShallow({
+    setUpRtl({
       marketingAudience: MARKETING_AUDIENCE.ELEMENTARY,
       courseOfferings: elementarySchoolCourseOffering,
     });
-
-    expect(wrapper.find('table').length).toBe(1);
-    expect(wrapper.contains(i18n.courses())).toBe(true);
+    const tables = screen.getAllByRole('table');
+    expect(tables.length).toBe(1);
+    expect(screen.getByText(i18n.courses())).toBeInTheDocument();
   });
 
   it('renders two tables with correct headers', () => {
-    const wrapper = setUpShallow();
-    expect(wrapper.find('table').length).toBe(2);
-    expect(wrapper.contains(i18n.courses())).toBe(true);
-    expect(wrapper.contains(i18n.standaloneUnits())).toBe(true);
+    setUpRtl();
+    const tables = screen.getAllByRole('table');
+    expect(tables.length).toBe(2);
+    expect(screen.getByText(i18n.courses())).toBeInTheDocument();
+    expect(screen.getByText(i18n.standaloneUnits())).toBeInTheDocument();
   });
 
   it('calls updateSection when a radio button is pressed', () => {
     const updateSpy = jest.fn();
-    const wrapper = setUpMount({updateCourse: updateSpy});
+    setUpRtl({updateCourse: updateSpy});
 
-    const radio = wrapper.find("input[value='Computer Science A']");
+    const radio = screen.getByLabelText('Computer Science A');
     expect(updateSpy).not.toHaveBeenCalled();
-    radio.simulate('change', {
-      target: {value: 'Computer Science A', checked: true},
-    });
+    fireEvent.click(radio);
     expect(updateSpy).toHaveBeenCalled();
   });
 
   it('correctly falls back when a course has no recommended version', () => {
     const updateSpy = jest.fn();
-    const wrapper = setUpMount({
+    setUpRtl({
       updateCourse: updateSpy,
       courseOfferings: noRecommendedVersionsOfferings,
     });
 
-    const radio = wrapper.find('input');
+    const radio = screen.getByLabelText('Computer Science A');
     expect(updateSpy).not.toHaveBeenCalled();
-    radio.simulate('change', {
-      target: {value: 'Computer Science A', checked: true},
-    });
+    fireEvent.click(radio);
     expect(updateSpy).toHaveBeenCalledWith(
       expect.objectContaining({versionId: 373})
     );
@@ -84,8 +76,8 @@ describe('QuickAssignTable', () => {
       updateCourse: () => {},
       sectionCourse: {displayName: 'Computer Science A', courseOfferingId: 73},
     };
-    const wrapper = mount(<QuickAssignTable {...props} />);
-    const radio = wrapper.find("input[value='Computer Science A']");
-    expect(radio.props().checked).toBe(true);
+    render(<QuickAssignTable {...props} />);
+    const radio = screen.getByLabelText('Computer Science A');
+    expect(radio).toBeChecked();
   });
 });

--- a/dashboard/app/controllers/course_offerings_controller.rb
+++ b/dashboard/app/controllers/course_offerings_controller.rb
@@ -44,6 +44,6 @@ class CourseOfferingsController < ApplicationController
   end
 
   private def course_offering_params
-    params.permit(:display_name, :is_featured, :assignable, :grade_levels, :curriculum_type, :header, :marketing_initiative, :image, :cs_topic, :school_subject, :device_compatibility, :description, :professional_learning_program, :self_paced_pl_course_offering_id, :video, :published_date).to_h
+    params.permit(:display_name, :is_featured, :assignable, :grade_levels, :curriculum_type, :header, :marketing_initiative, :image, :cs_topic, :school_subject, :device_compatibility, :description, :professional_learning_program, :self_paced_pl_course_offering_id, :video, :published_date, :ai_teaching_assistant_available).to_h
   end
 end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -22,6 +22,7 @@
 #  video                            :string(255)
 #  published_date                   :datetime
 #  self_paced_pl_course_offering_id :integer
+#  ai_teaching_assistant_available  :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -323,6 +323,7 @@ class CourseOffering < ApplicationRecord
       video: video,
       published_date: published_date,
       self_paced_pl_course_offering_id: self_paced_pl_course_offering_id,
+      ai_teaching_assistant_available: ai_teaching_assistant_available,
     }
   end
 
@@ -350,7 +351,8 @@ class CourseOffering < ApplicationRecord
       video: video,
       published_date: published_date,
       self_paced_pl_course_offering_path: self_paced_pl_course_offering&.path_to_latest_published_version(locale_code),
-      available_resources: get_available_resources(locale_code)
+      available_resources: get_available_resources(locale_code),
+      ai_teaching_assistant_available: ai_teaching_assistant_available,
     }
   end
 
@@ -373,6 +375,7 @@ class CourseOffering < ApplicationRecord
       video: video,
       published_date: published_date,
       self_paced_pl_course_offering_key: self_paced_pl_course_offering&.key,
+      ai_teaching_assistant_available: ai_teaching_assistant_available,
     }
   end
 

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -22,7 +22,7 @@
 #  video                            :string(255)
 #  published_date                   :datetime
 #  self_paced_pl_course_offering_id :integer
-#  ai_teaching_assistant_available  :boolean          default(FALSE)
+#  ai_teaching_assistant_available  :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -269,7 +269,8 @@ class CourseOffering < ApplicationRecord
       id: id,
       key: key,
       display_name: any_versions_launched? ? localized_display_name : localized_display_name + ' *',
-      course_versions: course_versions.select {|cv| cv.course_assignable?(user)}.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}
+      course_versions: course_versions.select {|cv| cv.course_assignable?(user)}.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)},
+      ai_teaching_assistant_available: ai_teaching_assistant_available,
     }
   end
 
@@ -351,8 +352,7 @@ class CourseOffering < ApplicationRecord
       video: video,
       published_date: published_date,
       self_paced_pl_course_offering_path: self_paced_pl_course_offering&.path_to_latest_published_version(locale_code),
-      available_resources: get_available_resources(locale_code),
-      ai_teaching_assistant_available: ai_teaching_assistant_available,
+      available_resources: get_available_resources(locale_code)
     }
   end
 

--- a/dashboard/db/migrate/20240911165129_add_ai_teaching_assistant_available_to_course_offerings.rb
+++ b/dashboard/db/migrate/20240911165129_add_ai_teaching_assistant_available_to_course_offerings.rb
@@ -1,0 +1,5 @@
+class AddAiTeachingAssistantAvailableToCourseOfferings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :course_offerings, :ai_teaching_assistant_available, :boolean, default: false
+  end
+end

--- a/dashboard/db/migrate/20240911165129_add_ai_teaching_assistant_available_to_course_offerings.rb
+++ b/dashboard/db/migrate/20240911165129_add_ai_teaching_assistant_available_to_course_offerings.rb
@@ -1,5 +1,5 @@
 class AddAiTeachingAssistantAvailableToCourseOfferings < ActiveRecord::Migration[6.1]
   def change
-    add_column :course_offerings, :ai_teaching_assistant_available, :boolean, default: false
+    add_column :course_offerings, :ai_teaching_assistant_available, :boolean, default: false, null: false
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -450,7 +450,7 @@ ActiveRecord::Schema.define(version: 2024_09_20_175046) do
     t.string "video"
     t.datetime "published_date"
     t.integer "self_paced_pl_course_offering_id"
-    t.boolean "ai_teaching_assistant_available", default: false
+    t.boolean "ai_teaching_assistant_available", default: false, null: false
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -450,6 +450,7 @@ ActiveRecord::Schema.define(version: 2024_09_20_175046) do
     t.string "video"
     t.datetime "published_date"
     t.integer "self_paced_pl_course_offering_id"
+    t.boolean "ai_teaching_assistant_available", default: false
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -806,6 +806,19 @@ class CourseOfferingTest < ActiveSupport::TestCase
       self_paced_pl_course.id
   end
 
+  test "can seed ai_teaching_assistant_available" do
+    course_offering = create :course_offering, key: 'course-offering-1'
+    refute course_offering.ai_teaching_assistant_available
+    serialization = course_offering.serialize
+    serialization[:ai_teaching_assistant_available] = true
+
+    File.stubs(:read).returns(serialization.to_json)
+
+    CourseOffering.seed_record("config/course_offerings/course-offering-1.json")
+    new_course_offering = CourseOffering.find_by(key: course_offering.key)
+    assert new_course_offering.ai_teaching_assistant_available
+  end
+
   test "validates grade_levels" do
     assert_raises ActiveRecord::RecordInvalid do
       CourseOffering.create!(key: 'test-key', display_name: 'Test', grade_levels: '1,2,3, 4')


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-726. 

### screenshots

| before | after |
|--------|--------|
| ![Screenshot 2024-09-23 at 3 41 45 PM](https://github.com/user-attachments/assets/1a560bc4-2b35-4da0-aacb-7f8a78b71a07) | ![Screenshot 2024-09-23 at 3 41 29 PM](https://github.com/user-attachments/assets/a73690ab-f2a7-4103-912c-f12c84a34400) |
| ![Screenshot 2024-09-11 at 12 01 50 PM](https://github.com/user-attachments/assets/32f23931-7687-4821-9d93-20423dbe36be) | ![Screenshot 2024-09-11 at 11 59 13 AM](https://github.com/user-attachments/assets/f621c7d2-4625-4922-8815-1df4c699709f) |


## Testing story

* converted existing QuickAssignTableTest to RTL
* added new test case for showing TA icon, or not
* manual testing for saving via levelbuilder UI, seeing icon show up in assignment UI
* manually verified that saving via levelbuilder causes the right changes to be serialized to course_offerings json
* new unit test verifying that seeding works

## Follow-up work

Check that this is working on levelbuilder, and propagates to other environments (I had trouble verifying this locally)