### PR TITLE
Migration to support Schoology reporting

### DIFF
--- a/dashboard/db/migrate/20240911181608_add_lti_deployment_to_lti_user_identities.rb
+++ b/dashboard/db/migrate/20240911181608_add_lti_deployment_to_lti_user_identities.rb
@@ -1,0 +1,5 @@
+class AddLtiDeploymentToLtiUserIdentities < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :lti_user_identities, :lti_deployment, foreign_key: true
+  end
+end

--- a/dashboard/db/migrate/20240911181608_add_lti_deployment_to_lti_user_identities.rb
+++ b/dashboard/db/migrate/20240911181608_add_lti_deployment_to_lti_user_identities.rb
@@ -1,5 +1,0 @@
-class AddLtiDeploymentToLtiUserIdentities < ActiveRecord::Migration[6.1]
-  def change
-    add_reference :lti_user_identities, :lti_deployment, foreign_key: true
-  end
-end

--- a/dashboard/db/migrate/20240912194834_create_join_table_lti_deployments_lti_user_identities.rb
+++ b/dashboard/db/migrate/20240912194834_create_join_table_lti_deployments_lti_user_identities.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableLtiDeploymentsLtiUserIdentities < ActiveRecord::Migration[6.1]
+  def change
+    create_join_table :lti_deployments, :lti_user_identities do |t|
+      t.index :lti_deployment_id
+      t.index :lti_user_identity_id
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -2183,14 +2183,6 @@ ActiveRecord::Schema.define(version: 2024_09_11_181608) do
     t.index ["user_level_id"], name: "index_teacher_scores_on_user_level_id"
   end
 
-  create_table "trophies", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "name"
-    t.string "image_name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["name"], name: "index_trophies_on_name", unique: true
-  end
-
   create_table "unit_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
@@ -2373,15 +2365,6 @@ ActiveRecord::Schema.define(version: 2024_09_11_181608) do
     t.datetime "deleted_at"
     t.index ["script_id"], name: "index_user_scripts_on_script_id"
     t.index ["user_id", "script_id", "deleted_at"], name: "index_user_scripts_on_user_id_and_script_id_and_deleted_at", unique: true
-  end
-
-  create_table "user_trophies", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "trophy_id", null: false
-    t.integer "concept_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["user_id", "trophy_id", "concept_id"], name: "index_user_trophies_on_user_id_and_trophy_id_and_concept_id", unique: true
   end
 
   create_table "users", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_07_174943) do
+ActiveRecord::Schema.define(version: 2024_09_11_181608) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -981,7 +981,9 @@ ActiveRecord::Schema.define(version: 2024_08_07_174943) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "deleted_at"
+    t.bigint "lti_deployment_id"
     t.index ["deleted_at"], name: "index_lti_user_identities_on_deleted_at"
+    t.index ["lti_deployment_id"], name: "index_lti_user_identities_on_lti_deployment_id"
     t.index ["lti_integration_id"], name: "index_lti_user_identities_on_lti_integration_id"
     t.index ["subject"], name: "index_lti_user_identities_on_subject"
     t.index ["user_id"], name: "index_lti_user_identities_on_user_id"
@@ -2181,6 +2183,14 @@ ActiveRecord::Schema.define(version: 2024_08_07_174943) do
     t.index ["user_level_id"], name: "index_teacher_scores_on_user_level_id"
   end
 
+  create_table "trophies", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name"
+    t.string "image_name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["name"], name: "index_trophies_on_name", unique: true
+  end
+
   create_table "unit_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
@@ -2365,6 +2375,15 @@ ActiveRecord::Schema.define(version: 2024_08_07_174943) do
     t.index ["user_id", "script_id", "deleted_at"], name: "index_user_scripts_on_user_id_and_script_id_and_deleted_at", unique: true
   end
 
+  create_table "user_trophies", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "trophy_id", null: false
+    t.integer "concept_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["user_id", "trophy_id", "concept_id"], name: "index_user_trophies_on_user_id_and_trophy_id_and_concept_id", unique: true
+  end
+
   create_table "users", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "studio_person_id"
     t.string "email", default: "", null: false
@@ -2471,6 +2490,7 @@ ActiveRecord::Schema.define(version: 2024_08_07_174943) do
   add_foreign_key "lti_feedbacks", "users"
   add_foreign_key "lti_sections", "lti_courses"
   add_foreign_key "lti_sections", "sections"
+  add_foreign_key "lti_user_identities", "lti_deployments"
   add_foreign_key "lti_user_identities", "lti_integrations"
   add_foreign_key "lti_user_identities", "users"
   add_foreign_key "new_feature_feedbacks", "users"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_09_11_181608) do
+ActiveRecord::Schema.define(version: 2024_09_12_194834) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -935,6 +935,13 @@ ActiveRecord::Schema.define(version: 2024_09_11_181608) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
+  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.bigint "lti_deployment_id", null: false
+    t.bigint "lti_user_identity_id", null: false
+    t.index ["lti_deployment_id"], name: "index_lti_deployments_user_identities_on_lti_deployment_id"
+    t.index ["lti_user_identity_id"], name: "index_lti_deployments_user_identities_on_lti_user_identity_id"
+  end
+
   create_table "lti_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "satisfied", null: false
@@ -981,9 +988,7 @@ ActiveRecord::Schema.define(version: 2024_09_11_181608) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "deleted_at"
-    t.bigint "lti_deployment_id"
     t.index ["deleted_at"], name: "index_lti_user_identities_on_deleted_at"
-    t.index ["lti_deployment_id"], name: "index_lti_user_identities_on_lti_deployment_id"
     t.index ["lti_integration_id"], name: "index_lti_user_identities_on_lti_integration_id"
     t.index ["subject"], name: "index_lti_user_identities_on_subject"
     t.index ["user_id"], name: "index_lti_user_identities_on_user_id"
@@ -2473,7 +2478,6 @@ ActiveRecord::Schema.define(version: 2024_09_11_181608) do
   add_foreign_key "lti_feedbacks", "users"
   add_foreign_key "lti_sections", "lti_courses"
   add_foreign_key "lti_sections", "sections"
-  add_foreign_key "lti_user_identities", "lti_deployments"
   add_foreign_key "lti_user_identities", "lti_integrations"
   add_foreign_key "lti_user_identities", "users"
   add_foreign_key "new_feature_feedbacks", "users"


### PR DESCRIPTION
This migration adds a join table to support a many-to-many relationship between LtiUserIdentity to LtiDeployment.

### Background

Institutions that install the Code.org LTI tool via the Schoology app store (the primary recommended mechanism) end up sharing the same client_id, therefore the same LtiIntegration in our system. This is due to how Schoology has implemented their app store, essentially using the same LTI Tool instance across multiple institutions/accounts. This is fine from a functionality standpoint, however presents an issue when trying to report numbers on individual Schoology installations and users, as there is no way to differentiate which schools users belong to, as they are all associated to this single LTI Integration.

### Solution

In order to associate a group of users to a specific institution, we can use LtiDeployment. Schoology does provide us a unique deployment ID per institution/account, which is how we can determine individual school installations of our LTI tool. However, there is currently no way to associate an LTI User to an LTI Deployment.

This PR (1 of 2) adds a join table for LtiUserIdentity and LtiDeployment. This allows us to query the total number of users for a particular deployment. An example using an Active Record query is: `LtiDeployment.find(<some id>).lti_user_identities.count`, which would return the number of users associated to a particular LTI Deployment. Or similarly, an SQL query
```
SELECT COUNT(*)
FROM lti_user_identities
WHERE lti_deployment_id = <some_id>;
```

NOTE: I considered adding a `name` column to `LtiDeployment` as well, to make it easier when visually grepping through a list of LTI Deployments, however I think that may be unnecessary for the reporting needed. I'm open to feedback on this decision. We could grab the name of the institution from the `https://purl.imsglobal.org/spec/lti/claim/tool_platform` claim in the JWT


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
