### PR TITLE
Misc Codebridge fixes

### DIFF
--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -5,10 +5,9 @@ import Button from '@cdo/apps/componentLibrary/button';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
-import {setHasRun} from '@cdo/apps/lab2/redux/systemRedux';
+import {setHasRun, setIsRunning} from '@cdo/apps/lab2/redux/systemRedux';
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
-import {setIsRunning} from '@cdo/apps/redux/runState';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {useCodebridgeContext} from '../codebridgeContext';

--- a/apps/src/codebridge/Console/console.module.scss
+++ b/apps/src/codebridge/Console/console.module.scss
@@ -3,7 +3,6 @@
 .consoleContainer {
   grid-area: console;
   color: $white;
-  //margin: 0 5px 10px 0;
   overflow: hidden;
   height: 100%;
   white-space: pre;

--- a/apps/src/codebridge/Console/console.module.scss
+++ b/apps/src/codebridge/Console/console.module.scss
@@ -3,7 +3,7 @@
 .consoleContainer {
   grid-area: console;
   color: $white;
-  margin: 0 5px 10px 0;
+  //margin: 0 5px 10px 0;
   overflow: hidden;
   height: 100%;
   white-space: pre;

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -13,7 +13,11 @@ import GraphModal from './GraphModal';
 
 import moduleStyles from './console.module.scss';
 
-const Console: React.FunctionComponent = () => {
+interface ConsoleProps {
+  style?: React.CSSProperties;
+}
+
+const Console: React.FunctionComponent<ConsoleProps> = ({style}) => {
   const codeOutput = useAppSelector(state => state.codebridgeConsole.output);
   const dispatch = useDispatch();
   const levelId = useAppSelector(state => state.lab.levelProperties?.id);
@@ -75,6 +79,7 @@ const Console: React.FunctionComponent = () => {
       rightHeaderContent={headerButton()}
       leftHeaderContent={<ControlButtons />}
       headerClassName={moduleStyles.consoleHeader}
+      style={style}
     >
       <div className={moduleStyles.console}>
         {codeOutput.map((outputLine, index) => {

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -13,11 +13,7 @@ import GraphModal from './GraphModal';
 
 import moduleStyles from './console.module.scss';
 
-interface ConsoleProps {
-  style?: React.CSSProperties;
-}
-
-const Console: React.FunctionComponent<ConsoleProps> = ({style}) => {
+const Console: React.FunctionComponent = () => {
   const codeOutput = useAppSelector(state => state.codebridgeConsole.output);
   const dispatch = useDispatch();
   const levelId = useAppSelector(state => state.lab.levelProperties?.id);
@@ -79,7 +75,6 @@ const Console: React.FunctionComponent<ConsoleProps> = ({style}) => {
       rightHeaderContent={headerButton()}
       leftHeaderContent={<ControlButtons />}
       headerClassName={moduleStyles.consoleHeader}
-      style={style}
     >
       <div className={moduleStyles.console}>
         {codeOutput.map((outputLine, index) => {

--- a/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
+++ b/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
@@ -3,13 +3,16 @@ import Workspace from '@codebridge/Workspace';
 import {debounce} from 'lodash';
 import React, {useEffect, useMemo} from 'react';
 
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
+import globalStyleConstants from '@cdo/apps/styleConstants';
 import HeightResizer from '@cdo/apps/templates/instructions/HeightResizer';
 
 import moduleStyles from './workspace.module.scss';
 
 // The top Y coordinate of the panel.  Above them is just the common site
 // header and then a bit of empty space.
-const PANEL_TOP_COORDINATE = 60;
+const PANEL_TOP_COORDINATE = 80;
 
 // A component that combines the Workspace and Console component into a single component,
 // with a horizontal resizer between them.
@@ -30,6 +33,13 @@ const WorkspaceAndConsole: React.FunctionComponent = () => {
     handleColumnResize();
 
     window.addEventListener('resize', debounce(handleColumnResize, 10));
+
+    // Ensure we resize appropriately when switching levels.
+    const lifecycleNotifier = Lab2Registry.getInstance().getLifecycleNotifier();
+    lifecycleNotifier.addListener(
+      LifecycleEvent.LevelLoadCompleted,
+      handleColumnResize
+    );
   }, []);
 
   useEffect(() => {
@@ -51,7 +61,6 @@ const WorkspaceAndConsole: React.FunctionComponent = () => {
     // Minimum height fits 4 lines of text.
     const consoleHeightMin = 120;
     const consoleHeightMax = window.innerHeight - 200;
-
     setConsoleHeight(
       Math.max(
         consoleHeightMin,
@@ -61,24 +70,21 @@ const WorkspaceAndConsole: React.FunctionComponent = () => {
   };
 
   const editorHeight = useMemo(
-    () => columnHeight - consoleHeight,
+    () =>
+      columnHeight - consoleHeight + globalStyleConstants['resize-bar-width'],
     [columnHeight, consoleHeight]
   );
 
   return (
     <div className={moduleStyles.workspaceAndConsole}>
-      <div style={{height: editorHeight}}>
-        <Workspace />
-      </div>
+      <Workspace style={{height: editorHeight}} />
       <HeightResizer
         resizeItemTop={() => PANEL_TOP_COORDINATE}
         position={editorHeight}
         onResize={handleResize}
         style={{position: 'static'}}
       />
-      <div style={{height: consoleHeight}}>
-        <Console />
-      </div>
+      <Console style={{height: consoleHeight}} />
     </div>
   );
 };

--- a/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
+++ b/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
@@ -3,8 +3,6 @@ import Workspace from '@codebridge/Workspace';
 import {debounce} from 'lodash';
 import React, {useEffect, useMemo} from 'react';
 
-import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import globalStyleConstants from '@cdo/apps/styleConstants';
 import HeightResizer from '@cdo/apps/templates/instructions/HeightResizer';
 
@@ -33,13 +31,6 @@ const WorkspaceAndConsole: React.FunctionComponent = () => {
     handleColumnResize();
 
     window.addEventListener('resize', debounce(handleColumnResize, 10));
-
-    // Ensure we resize appropriately when switching levels.
-    const lifecycleNotifier = Lab2Registry.getInstance().getLifecycleNotifier();
-    lifecycleNotifier.addListener(
-      LifecycleEvent.LevelLoadCompleted,
-      handleColumnResize
-    );
   }, []);
 
   useEffect(() => {
@@ -61,6 +52,7 @@ const WorkspaceAndConsole: React.FunctionComponent = () => {
     // Minimum height fits 4 lines of text.
     const consoleHeightMin = 120;
     const consoleHeightMax = window.innerHeight - 200;
+
     setConsoleHeight(
       Math.max(
         consoleHeightMin,

--- a/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
+++ b/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
@@ -69,7 +69,9 @@ const WorkspaceAndConsole: React.FunctionComponent = () => {
     );
   };
 
-  // The editor height is computed based on the console height.
+  // The editor height is computed based on the column height, console height,
+  // and the height of the resize bar. The resize bar gets positioned at the bottom
+  // of the editor, and seemingly expects to be included in the height of the editor.
   const editorHeight = useMemo(
     () =>
       columnHeight - consoleHeight + globalStyleConstants['resize-bar-width'],

--- a/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
+++ b/apps/src/codebridge/Workspace/WorkspaceAndConsole.tsx
@@ -10,8 +10,8 @@ import HeightResizer from '@cdo/apps/templates/instructions/HeightResizer';
 
 import moduleStyles from './workspace.module.scss';
 
-// The top Y coordinate of the panel.  Above them is just the common site
-// header and then a bit of empty space.
+// The top Y coordinate of the panel. This includes the top header and the header
+// of the workspace, which is absolutely positioned.
 const PANEL_TOP_COORDINATE = 80;
 
 // A component that combines the Workspace and Console component into a single component,
@@ -69,6 +69,7 @@ const WorkspaceAndConsole: React.FunctionComponent = () => {
     );
   };
 
+  // The editor height is computed based on the console height.
   const editorHeight = useMemo(
     () =>
       columnHeight - consoleHeight + globalStyleConstants['resize-bar-width'],
@@ -77,14 +78,18 @@ const WorkspaceAndConsole: React.FunctionComponent = () => {
 
   return (
     <div className={moduleStyles.workspaceAndConsole}>
-      <Workspace style={{height: editorHeight}} />
+      <div style={{height: editorHeight}}>
+        <Workspace />
+      </div>
       <HeightResizer
         resizeItemTop={() => PANEL_TOP_COORDINATE}
         position={editorHeight}
         onResize={handleResize}
         style={{position: 'static'}}
       />
-      <Console style={{height: consoleHeight}} />
+      <div style={{height: consoleHeight}}>
+        <Console />
+      </div>
     </div>
   );
 };

--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -18,7 +18,11 @@ import HeaderButtons from './HeaderButtons';
 
 import moduleStyles from './workspace.module.scss';
 
-const Workspace = () => {
+interface WorkspaceProps {
+  style?: React.CSSProperties;
+}
+
+const Workspace: React.FunctionComponent<WorkspaceProps> = ({style}) => {
   const {config} = useCodebridgeContext();
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
@@ -47,6 +51,7 @@ const Workspace = () => {
       headerContent={headerContent}
       rightHeaderContent={<HeaderButtons />}
       className={moduleStyles.workspace}
+      style={style}
     >
       <FileTabs />
       {isStartMode && (

--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -18,11 +18,7 @@ import HeaderButtons from './HeaderButtons';
 
 import moduleStyles from './workspace.module.scss';
 
-interface WorkspaceProps {
-  style?: React.CSSProperties;
-}
-
-const Workspace: React.FunctionComponent<WorkspaceProps> = ({style}) => {
+const Workspace = () => {
   const {config} = useCodebridgeContext();
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
@@ -51,7 +47,6 @@ const Workspace: React.FunctionComponent<WorkspaceProps> = ({style}) => {
       headerContent={headerContent}
       rightHeaderContent={<HeaderButtons />}
       className={moduleStyles.workspace}
-      style={style}
     >
       <FileTabs />
       {isStartMode && (

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -18,7 +18,8 @@
 }
 
 .workspaceAndConsole {
-  height: 100%;
+  height: auto;
+  width: 100%;
   grid-area: workspace-and-console;
   background-color: $darkest_gray;
   color: $white;

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -18,8 +18,7 @@
 }
 
 .workspaceAndConsole {
-  height: auto;
-  width: 100%;
+  height: 100%;
   grid-area: workspace-and-console;
   background-color: $darkest_gray;
   color: $white;

--- a/apps/src/codebridge/styles/cdoIDE.scss
+++ b/apps/src/codebridge/styles/cdoIDE.scss
@@ -6,6 +6,7 @@
   height: 100%;
   scrollbar-color: $neutral_dark70 $darkest_gray;
   gap: 1px;
+  justify-items: start;
 }
 
 .cdo-ide-outer {

--- a/apps/src/codebridge/styles/cdoIDE.scss
+++ b/apps/src/codebridge/styles/cdoIDE.scss
@@ -6,7 +6,6 @@
   height: 100%;
   scrollbar-color: $neutral_dark70 $darkest_gray;
   gap: 1px;
-  justify-items: start;
 }
 
 .cdo-ide-outer {

--- a/apps/src/lab2/views/components/PanelContainer.tsx
+++ b/apps/src/lab2/views/components/PanelContainer.tsx
@@ -14,7 +14,6 @@ interface PanelContainerProps {
   hideHeaders?: boolean;
   className?: string;
   headerClassName?: string;
-  style?: React.CSSProperties;
 }
 
 /**
@@ -33,7 +32,6 @@ const PanelContainer: React.FunctionComponent<PanelContainerProps> = ({
   hideHeaders,
   className,
   headerClassName,
-  style,
 }) => {
   const {theme} = useContext(ThemeContext);
 
@@ -45,7 +43,6 @@ const PanelContainer: React.FunctionComponent<PanelContainerProps> = ({
         className
       )}
       id={id}
-      style={style}
     >
       {!hideHeaders && (
         <div

--- a/apps/src/lab2/views/components/PanelContainer.tsx
+++ b/apps/src/lab2/views/components/PanelContainer.tsx
@@ -14,6 +14,7 @@ interface PanelContainerProps {
   hideHeaders?: boolean;
   className?: string;
   headerClassName?: string;
+  style?: React.CSSProperties;
 }
 
 /**
@@ -32,6 +33,7 @@ const PanelContainer: React.FunctionComponent<PanelContainerProps> = ({
   hideHeaders,
   className,
   headerClassName,
+  style,
 }) => {
   const {theme} = useContext(ThemeContext);
 
@@ -43,6 +45,7 @@ const PanelContainer: React.FunctionComponent<PanelContainerProps> = ({
         className
       )}
       id={id}
+      style={style}
     >
       {!hideHeaders && (
         <div


### PR DESCRIPTION
A couple fixes relating to my recent changes:
- When I moved buttons around, I imported the wrong `setIsRunning` so our run button never became a stop button. This imports the right method.
- Following up #60933 I noticed when switching levels the workspace header would get bumped off the screen, and there was some extra space at the bottom of the console. There were two fixes needed. First, update the top coordinate for the height resizer to include the absolutely positioned panel header. Second, I needed to include the height of the height resizer in the computed editor height. I'm still not quite sure why it expects to be included rather than excluded, but that fixed the issue. I also removed a previous margin around the console that was occasionally causing extra whitespace.

## Screenshots
### Before (after switching levels)
![Screenshot 2024-09-11 at 3 44 00 PM](https://github.com/user-attachments/assets/bae4a6f2-b49b-4ea4-b69e-231bc8480621)

Note workspace header is cut off, and there is a lighter gray bar below the console

### After (after switching levels)
![Screenshot 2024-09-11 at 3 44 15 PM](https://github.com/user-attachments/assets/45ded499-e227-4f01-9396-32f625b66cad)

Full workspace header, console takes up all remaining space.

## Testing story
Tested locally.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
