### PR TITLE
Add SagemakerFullAccess Role for Gen AI

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -821,6 +821,20 @@ roles.each do |name, config| %>
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+  # TODO: Move this to gen_ai_curriculum.yml.erb
+  SagemakerFullAccessRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: SagemakerFullAccessRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: sagemaker.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonSageMakerFullAccess'
   SessionPermissions:
     Type: AWS::IAM::ManagedPolicy
     Properties:

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -822,10 +822,11 @@ roles.each do |name, config| %>
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
   # TODO: Move this to gen_ai_curriculum.yml.erb
-  SagemakerFullAccessRole:
+  # Execution role for GenAI Sagemaker Models
+  SagemakerModelExecutionRole:
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: SagemakerFullAccessRole
+      RoleName: SagemakerModelExecutionRole
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -889,3 +889,7 @@ Outputs:
     Description: Session Permissions
     Value: !Ref SessionPermissions
     Export: {Name: !Sub "${AWS::StackName}-SessionPermissions"}
+  SagemakerModelExecutionRoleARN:
+    Description: Execution Role for GenAI Sagemaker Models
+    Value: !GetAtt SagemakerModelExecutionRole.Arn
+    Export: {Name: !Sub "${AWS::StackName}-SagemakerExecutionRoleARN"}


### PR DESCRIPTION
Create a new execution role will full Sagemaker access, for use in creating Gen AI resources.
Ideally, this execution role would defined alongside the related Gen AI resources in the same stack. However, currently the cdo-readwrite account does not have permissions to create execution roles. This is a short term mitigation to unblock creating resources for the Gen AI curriculum launch.

## Links

Gen AI Curriculum cloudformation template PR: https://github.com/code-dot-org/code-dot-org/pull/60614