### PR TITLE
Lab2: instructions list style

### DIFF
--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -164,7 +164,7 @@
     line-height: 1.2em;
   }
 
-  ol {
+  ol, ul {
     line-height: 0;
   }
 


### PR DESCRIPTION
Update the Lab2 instructions' line height in an unordered list to match that in an ordered one. 

### before

<img width="510" alt="Screenshot 2024-09-11 at 5 01 12 PM" src="https://github.com/user-attachments/assets/c0bd81b6-d32d-4027-9100-9490477a11eb">


### after

<img width="510" alt="Screenshot 2024-09-11 at 5 01 31 PM" src="https://github.com/user-attachments/assets/a3cc64e7-eb35-4a92-8ce3-a0e4237dabb3">
