### PR TITLE
Update link on the progress tab of resources view

### DIFF
--- a/pegasus/sites.v3/code.org/views/tabs_section/resources/resources_tabs_content_progress.haml
+++ b/pegasus/sites.v3/code.org/views/tabs_section/resources/resources_tabs_content_progress.haml
@@ -5,5 +5,5 @@
     %h3=hoc_s(:"resources_tabs.progress.heading")
     %p.body-three
       =hoc_s(:"resources_tabs.progress.desc")
-    %a.link-button{href: CDO.studio_url("/projects/public"), target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button{href: CDO.studio_url("/users/sign_up"), target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:"resources_tabs.progress.call_to_action")


### PR DESCRIPTION
I noticed that the link on the Progress tab of the Resources view on code.org/teach was linking to projects still and should link to sign up.