### PR TITLE
check verification status of teacher on server before rendering ta rubrics

### DIFF
--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -95,67 +95,47 @@ function initPage() {
     }
   }
 
-  const taRubricSetup = verified => {
-    if (verified && hasScriptData('script[data-rubricdata]')) {
-      const rubricData = getScriptData('rubricdata');
-      const {rubric, studentLevelInfo} = rubricData;
-      const reportingData = {
-        unitName: config.script_name,
-        courseName: config.course_name,
-        levelName: config.level_name,
-      };
-      getStore().dispatch(setTaRubric(rubric));
+  if (hasScriptData('script[data-rubricdata]')) {
+    const rubricData = getScriptData('rubricdata');
+    const {rubric, studentLevelInfo} = rubricData;
+    const reportingData = {
+      unitName: config.script_name,
+      courseName: config.course_name,
+      levelName: config.level_name,
+    };
+    getStore().dispatch(setTaRubric(rubric));
 
-      const rubricFabMountPoint = document.getElementById(
-        'rubric-fab-mount-point'
-      );
-      if (rubricFabMountPoint) {
-        //rubric fab mount point is only true for teachers
-        if (
-          !!rubric &&
-          rubric.learningGoals.some(lg => lg.aiEnabled) &&
-          config.level_name === rubric.level.name
-        ) {
-          analyticsReporter.sendEvent(
-            EVENTS.TA_RUBRIC_AI_PAGE_VISITED,
-            {
-              ...reportingData,
-              studentId: !!studentLevelInfo ? studentLevelInfo.user_id : '',
-            },
-            PLATFORMS.BOTH
-          );
-        }
-        ReactDOM.render(
-          <Provider store={getStore()}>
-            <RubricFloatingActionButton
-              rubric={rubric}
-              studentLevelInfo={studentLevelInfo}
-              reportingData={reportingData}
-              currentLevelName={config.level_name}
-              aiEnabled={rubric.learningGoals.some(lg => lg.aiEnabled)}
-            />
-          </Provider>,
-          rubricFabMountPoint
+    const rubricFabMountPoint = document.getElementById(
+      'rubric-fab-mount-point'
+    );
+    if (rubricFabMountPoint) {
+      //rubric fab mount point is only true for teachers
+      if (
+        !!rubric &&
+        rubric.learningGoals.some(lg => lg.aiEnabled) &&
+        config.level_name === rubric.level.name
+      ) {
+        analyticsReporter.sendEvent(
+          EVENTS.TA_RUBRIC_AI_PAGE_VISITED,
+          {
+            ...reportingData,
+            studentId: !!studentLevelInfo ? studentLevelInfo.user_id : '',
+          },
+          PLATFORMS.BOTH
         );
       }
+      ReactDOM.render(
+        <Provider store={getStore()}>
+          <RubricFloatingActionButton
+            rubric={rubric}
+            studentLevelInfo={studentLevelInfo}
+            reportingData={reportingData}
+            currentLevelName={config.level_name}
+            aiEnabled={rubric.learningGoals.some(lg => lg.aiEnabled)}
+          />
+        </Provider>,
+        rubricFabMountPoint
+      );
     }
-  };
-  HttpClient.fetchJson('/api/v1/users/current').then(user => {
-    let verified;
-    if (user.value.user_type === 'student') {
-      const body = JSON.stringify({
-        userId: user.value.id,
-      });
-      HttpClient.post(`/sections/section_instructors_verified`, body, true, {
-        'Content-Type': 'application/json',
-      })
-        .then(response => response.json())
-        .then(json => {
-          verified = json.verified;
-          taRubricSetup(verified);
-        });
-    } else {
-      taRubricSetup(user.value.is_verified_instructor);
-    }
-  });
+  }
 }

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -18,7 +18,6 @@ import instructions, {
 } from '@cdo/apps/redux/instructions';
 import RubricFloatingActionButton from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
 import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
-import HttpClient from '@cdo/apps/util/HttpClient';
 
 $(document).ready(initPage);
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -181,7 +181,7 @@ class ScriptLevelsController < ApplicationController
     @body_classes = @level.properties['background']
 
     @rubric = @script_level.lesson.rubric
-    ai_rubrics_enabled_for_user = @view_as_user&.verified_teacher? || @view_as_user&.teachers.any?(&:verified_teacher?)
+    ai_rubrics_enabled_for_user = @view_as_user&.verified_teacher? || @view_as_user&.teachers&.any?(&:verified_teacher?)
     if @rubric && ai_rubrics_enabled_for_user
       @rubric_data = {rubric: @rubric.summarize}
       if @script_level.lesson.rubric && view_as_other

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -181,7 +181,8 @@ class ScriptLevelsController < ApplicationController
     @body_classes = @level.properties['background']
 
     @rubric = @script_level.lesson.rubric
-    if @rubric
+    ai_rubrics_enabled_for_user = @view_as_user&.verified_teacher? || @view_as_user&.teachers.any?(&:verified_teacher?)
+    if @rubric && ai_rubrics_enabled_for_user
       @rubric_data = {rubric: @rubric.summarize}
       if @script_level.lesson.rubric && view_as_other
         viewing_user_level = @view_as_user.user_levels.find_by(script: @script_level.script, level: @level)


### PR DESCRIPTION
Since TA depends on data provided on initial page load anyway, eliminate some race conditions by checking teacher verification status on the server.