### PR TITLE
Stub AWS Comprehend in Drone

### DIFF
--- a/dashboard/app/helpers/aichat_comprehend_helper.rb
+++ b/dashboard/app/helpers/aichat_comprehend_helper.rb
@@ -1,6 +1,9 @@
 module AichatComprehendHelper
   def self.create_comprehend_client
-    Aws::Comprehend::Client.new
+    # Stubbed Comprehend allows UI tests (without the roundtrip to the model) to run in CI environments (ie, Drone)
+    Rails.application.config.respond_to?(:stub_aichat_aws_services) && Rails.application.config.stub_aichat_aws_services ?
+      StubbedComprehendClient.new :
+      Aws::Comprehend::Client.new
   end
 
   # Moderate given text for inappropriate/toxic content using AWS Comprehend client.
@@ -17,5 +20,38 @@ module AichatComprehendHelper
       toxicity: comprehend_response.result_list[0].toxicity,
       max_category: categories.max_by(&:score),
     }
+  end
+end
+
+# Classes that allow us to stub Comprehend in Drone, which does not have permission to access Comprehend.
+class StubbedComprehendClient
+  def detect_toxic_content(__)
+    StubbedComprehendResponse.new
+  end
+end
+
+class StubbedComprehendResponse
+  def result_list
+    [StubbedComprehendResult.new]
+  end
+end
+
+class StubbedComprehendResult
+  def toxicity
+    0.1
+  end
+
+  def labels
+    [StubbedComprehendLabel.new]
+  end
+end
+
+class StubbedComprehendLabel
+  def name
+    'INSULT'
+  end
+
+  def score
+    0.1
   end
 end

--- a/dashboard/test/ui/features/star_labs/aichat/chat.feature
+++ b/dashboard/test/ui/features/star_labs/aichat/chat.feature
@@ -1,7 +1,4 @@
 @no_mobile
-@no_circle
-# As of 9/4/24, cannot access AWS SageMaker or Comprehend in Drone.
-# More discussion in this Slack thread: https://codedotorg.slack.com/archives/C03CK49G9/p1725475362107969
 
 Feature: AI Chat
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds stubbing for AWS Comprehend in Drone, and follows up @bencodeorg 's work in https://github.com/code-dot-org/code-dot-org/pull/60961 which stubbed AWS Sagemaker in Drone. 

Now that both services are stubbed, we can enable the aichat UI test in Drone 🎉 !

## After update
`chat.feature` passes on Drone:
![Screenshot 2024-09-12 at 11 10 43 AM](https://github.com/user-attachments/assets/d9655cb7-ccbd-465c-8673-415c274318f9)


## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1016)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
