### PR TITLE
[Music Lab] Add bubble choice fields to level edit page 

### DIFF
--- a/dashboard/app/views/levels/editors/_music.html.haml
+++ b/dashboard/app/views/levels/editors/_music.html.haml
@@ -1,5 +1,6 @@
 = render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/music_level_data', locals: {f: f}
+= render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
 = render partial: 'levels/editors/fields/validations', locals: {f: f}


### PR DESCRIPTION
Choice levels are a requirement for the new K5 module. Fortunately, we just need add the editor field to levels in order to enable this. Similar to:

- https://github.com/code-dot-org/code-dot-org/pull/59134

With this these fields, curriculum writers will now be able to add a title, description, and thumbnail image:
![image](https://github.com/user-attachments/assets/2dffd47b-be3e-45b2-986d-ad73a8f0f311)

There are no changes here to how choice levels worked, but I've confirmed things work as expected. Music Lab level names can be added to the choice level configuration:

![image](https://github.com/user-attachments/assets/c7409afe-75d3-4317-876e-98b3dbc67e4e)

The choice level renders the text and images as expected:

![image](https://github.com/user-attachments/assets/9b923dd5-0e11-45d6-b30b-f896506a12e1)



## Links

https://docs.google.com/document/d/1NROqFS9gA4wklBNsxdrFQbou9HHI-fwPEetKGNm-Eho/edit#heading=h.w1c3gxdkagpg

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Locally, I added the level shown above to a progression, surrounded on either side by a standard Music level. 
I tested that:
- completing the prior level directed you to the choice level
- selecting an option loads the expected Music sublevel
- completing the sublevel directs you back to the choice level as expected
- pressing Finish from the choice level directs you to the next level as expected
- progress bubbles fill as expected for the sublevels (when completed individually) and the main level (when at least one choice is completed)
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
