### PR TITLE
CodeBridge: use DSCO Buttons in Lab2 GenericDialog

### DIFF
--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -105,6 +105,7 @@ const InnerFileBrowser = React.memo(
         title,
         message,
         confirmText: codebridgeI18n.delete(),
+        destructive: true,
       });
     };
 
@@ -146,6 +147,7 @@ const InnerFileBrowser = React.memo(
         title,
         message,
         confirmText: codebridgeI18n.delete(),
+        destructive: true,
       });
     };
 

--- a/apps/src/lab2/views/dialogs/GenericConfirmationDialog.tsx
+++ b/apps/src/lab2/views/dialogs/GenericConfirmationDialog.tsx
@@ -8,6 +8,7 @@ export type GenericConfirmationDialogProps = Required<
   handleConfirm?: () => void;
   handleCancel?: () => void;
   confirmText?: string;
+  destructive?: boolean;
 };
 
 /**
@@ -17,7 +18,14 @@ export type GenericConfirmationDialogProps = Required<
  */
 const GenericConfirmationDialog: React.FunctionComponent<
   GenericConfirmationDialogProps
-> = ({title, message, handleConfirm, handleCancel, confirmText}) => (
+> = ({
+  title,
+  message,
+  handleConfirm,
+  handleCancel,
+  confirmText,
+  destructive,
+}) => (
   <GenericDialog
     title={title}
     message={message}
@@ -25,6 +33,7 @@ const GenericConfirmationDialog: React.FunctionComponent<
       confirm: {
         callback: handleConfirm,
         text: confirmText,
+        destructive: destructive,
       },
       cancel: {
         callback: handleCancel,

--- a/apps/src/lab2/views/dialogs/GenericDialog.tsx
+++ b/apps/src/lab2/views/dialogs/GenericDialog.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
 import Typography from '@cdo/apps/componentLibrary/typography';
 import commonI18n from '@cdo/locale';
 
@@ -91,49 +93,50 @@ const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
       <div className={moduleStyles.buttonContainer}>
         <div className={moduleStyles.outerButtonContainer}>
           {buttons?.cancel ? (
-            <button
-              className={moduleStyles.cancel}
-              type="button"
+            <Button
               onClick={closingCallback(
                 dialogControl.closeDialog,
                 'cancel',
                 buttons.cancel.callback
               )}
-              disabled={buttons?.cancel?.disabled}
-            >
-              {buttons.cancel.text || commonI18n.cancel()}
-            </button>
+              className={moduleStyles.cancel}
+              type="secondary"
+              disabled={buttons.cancel.disabled}
+              color={buttonColors.gray}
+              text={buttons.cancel.text || commonI18n.cancel()}
+            />
           ) : (
             <div />
           )}
           <div className={moduleStyles.innerButtonContainer}>
             {buttons?.neutral && (
-              <button
-                className={moduleStyles.neutral}
-                type="button"
+              <Button
                 onClick={closingCallback(
                   dialogControl.closeDialog,
                   'neutral',
                   buttons.neutral.callback
                 )}
-                disabled={buttons?.neutral?.disabled}
-              >
-                {buttons.neutral.text}
-              </button>
+                type="secondary"
+                disabled={buttons.neutral.disabled}
+                color={buttonColors.gray}
+                text={buttons.neutral.text}
+              />
             )}
-
-            <button
-              className={moduleStyles.confirm}
-              type="button"
+            <Button
               onClick={closingCallback(
                 dialogControl.closeDialog,
                 'confirm',
                 buttons?.confirm?.callback
               )}
               disabled={buttons?.confirm?.disabled}
-            >
-              {buttons?.confirm?.text || commonI18n.dialogOK()}
-            </button>
+              type="primary"
+              color={
+                buttons?.confirm?.text === codebridgeI18n.delete()
+                  ? buttonColors.destructive
+                  : buttonColors.purple
+              }
+              text={buttons?.confirm?.text || commonI18n.dialogOK()}
+            />
           </div>
         </div>
       </div>

--- a/apps/src/lab2/views/dialogs/GenericDialog.tsx
+++ b/apps/src/lab2/views/dialogs/GenericDialog.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
 import Typography from '@cdo/apps/componentLibrary/typography';
 import commonI18n from '@cdo/locale';
@@ -39,6 +38,7 @@ export type GenericDialogProps = GenericDialogTitleProps &
         text?: string;
         callback?: dialogCallback;
         disabled?: boolean;
+        destructive?: boolean;
       };
     };
   };
@@ -50,7 +50,9 @@ import moduleStyles from './generic-dialog.module.scss';
  * Allows a title component or title message
  * a body component or message
  * a list of up to three buttons - confirm, cancel, neutral
- * each button takes up to two args - a callback (if not a default will be provided), and a label.
+ * each button takes up to four args - a callback (if not a default will be provided), a label,
+ * a disabled flag, and a destructive flag. The confirm button is the only one that can be destructive,
+ * and it will be styled as such (red) to provide extra visual warning when attempting to delete something.
  * An accept button is always added, with the default "OK" text if not provided.
  * dialogs maintain a context, which can provide data to any of the callbacks.
  * The title, message, and confirm button text can be customized.
@@ -131,7 +133,7 @@ const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
               disabled={buttons?.confirm?.disabled}
               type="primary"
               color={
-                buttons?.confirm?.text === codebridgeI18n.delete()
+                buttons?.confirm?.destructive
                   ? buttonColors.destructive
                   : buttonColors.purple
               }

--- a/apps/src/lab2/views/dialogs/generic-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/generic-dialog.module.scss
@@ -33,36 +33,4 @@
       justify-content: flex-end;
     }
   }
-
-  .cancel {
-    @extend %button;
-    background-color: $neutral_light;
-    border-color: $neutral_dark;
-
-    &:hover:enabled {
-      background-color: $neutral_dark20;
-    }
-  }
-
-  .neutral {
-    @extend %button;
-    background-color: $neutral_light;
-    border-color: $neutral_dark;
-
-    &:hover:enabled {
-      background-color: $neutral_dark20;
-    }
-  }
-
-  .confirm {
-    @extend %button;
-    background-color: $brand_secondary_default;
-    border-color: $brand_secondary_default;
-    color: $neutral_light;
-
-    &:hover:enabled {
-      background-color: $brand_secondary_dark;
-      border-color: $brand_secondary_dark;
-    }
-  }
 }


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/CT-629 <- Use DSCO Buttons in Dialog
https://codedotorg.atlassian.net/browse/CT-630 <- Delete button should be red 

A couple of button updates for the dialogs used in CodeBridge. 

Before on left, After on right 
![Screenshot 2024-09-12 at 12 08 48 PM](https://github.com/user-attachments/assets/0c6e6b62-6bd7-4116-88fb-5a1915c78ef5)
