### PR TITLE
Aichat: Fix empty tab bug when changing levels

### DIFF
--- a/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
+++ b/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
@@ -107,6 +107,10 @@ const ModelCustomizationWorkspace: React.FunctionComponent = () => {
     [setSelectedTab]
   );
 
+  if (visibleTabs.length === 0) {
+    return null;
+  }
+
   const tabArgs: TabsProps = {
     name: 'modelCustomizationTabs',
     tabs: visibleTabs,

--- a/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
+++ b/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
@@ -107,6 +107,8 @@ const ModelCustomizationWorkspace: React.FunctionComponent = () => {
     [setSelectedTab]
   );
 
+  // When switching levels, visible tabs can momentarily become empty.
+  // Don't render anything if there are no visible tabs.
   if (visibleTabs.length === 0) {
     return null;
   }

--- a/apps/src/componentLibrary/tabs/Tabs.tsx
+++ b/apps/src/componentLibrary/tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
 import {ComponentSizeXSToL} from '@cdo/apps/componentLibrary/common/types';
 import _Tab, {TabModel} from '@cdo/apps/componentLibrary/tabs/_Tab';
@@ -72,6 +72,11 @@ const Tabs: React.FunctionComponent<TabsProps> = ({
     },
     [setSelectedValue, onChange]
   );
+
+  // Reset selected tab whenever default selected value changes.
+  useEffect(() => {
+    setSelectedValue(defaultSelectedTabValue);
+  }, [defaultSelectedTabValue]);
 
   const nameStripped = name.replace(' ', '-');
 


### PR DESCRIPTION
Fix for a bug where the list of visibleTabs was momentarily empty when switching between levels that have different tabs. The fix is just to early return `null` if there are no visible tabs.

I also added logic to `Tabs.tsx` to update the selected tab whenever the default selected tab changes. After fixing this bug, I noticed that when going back to level 2, the one tab (Publish) was not selected, because the Tabs component still had a different selected tab stored in its state.

### Details
Technically no level should ever have empty tabs, and in this case the two levels do have one tab each. However, due to the specifics of the level transition and how redux changes come in, there's one in-between render pass where the list of `visibleTabs` is empty so `visibleTabs[0].value` throws an error. Specifically, here's what happens when changing from level 2 to level 3.

1) Render level 2: `modelCardInfo` is `readonly` and `hidePresentationPanel` is false, so visibleTabs only contains the publish tab ("modelCardInfo")
2) Switch to level 3: Lab2 loads new level properties which makes `hidePresentationPanel` true. Other visibilities are **not** yet changed because AichatView has not called `setStartingAiCustomizations` yet. Because `hidePresentationPanel` is true and no other fields are `visible`, we compute visibleTabs to be an empty array (and this is where the error was thrown). However, once fixed:
3) Next render pass: `AichatView` dispatches `setStartingAiCustomizations` with the new level info, and field visibilities are updated with `temperature: 'editable'`. As a result, `visibleTabs` contains the setup tab and we render the setup tab with just temperature.

## Links

Slack thread: https://codedotorg.slack.com/archives/C06FELVTV0Q/p1726157729779319

## Testing story

Tested locally with the above level transition, as well as others.