### PR TITLE
P20-1087: Update omniauth gem from v1.9.2 to v2.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -171,7 +171,7 @@ gem 'omniauth-microsoft_v2_auth', github: 'dooly-ai/omniauth-microsoft_v2_auth'
 
 # Resolve CVE 2015 9284
 # see: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284
-gem 'omniauth-rails_csrf_protection', '~> 0.1'
+gem 'omniauth-rails_csrf_protection', '~> 1.0.2'
 
 gem 'bootstrap-sass', '~> 2.3.2.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -611,9 +611,9 @@ GEM
     omniauth-oauth2 (1.7.3)
       oauth2 (>= 1.4, < 3)
       omniauth (>= 1.9, < 3)
-    omniauth-rails_csrf_protection (0.1.2)
+    omniauth-rails_csrf_protection (1.0.2)
       actionpack (>= 4.2)
-      omniauth (>= 1.3.1)
+      omniauth (~> 2.0)
     open-uri (0.1.0)
       stringio
       time
@@ -1028,7 +1028,7 @@ DEPENDENCIES
   omniauth-facebook (~> 4.0.0)
   omniauth-google-oauth2 (~> 0.6.0)
   omniauth-microsoft_v2_auth!
-  omniauth-rails_csrf_protection (~> 0.1)
+  omniauth-rails_csrf_protection (~> 1.0.2)
   open_uri_redirections
   os
   parallel

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -598,9 +598,10 @@ GEM
     oily_png (1.2.0)
       chunky_png (~> 1.3.1)
     oj (3.14.2)
-    omniauth (1.9.2)
+    omniauth (2.1.2)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
+      rack (>= 2.2.3)
+      rack-protection
     omniauth-facebook (4.0.0)
       omniauth-oauth2 (~> 1.2)
     omniauth-google-oauth2 (0.6.0)


### PR DESCRIPTION
Fixed the vulnerability [CVE-2015-9284](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284) in the omniauth gem v1.9.2 and below.

## Google Auth
![google-auth](https://github.com/user-attachments/assets/56782587-674e-40cd-b7bc-36ca7d15e083)

## Microsoft Auth
![microsoft-auth](https://github.com/user-attachments/assets/46dcbe25-11e3-412b-8443-1a40b633e257)

## Clever Auth
![clever-auth](https://github.com/user-attachments/assets/9b91284b-2fe5-49e3-acfc-992470016822)

## Links
- JIRA ticket: [P20-1087](https://codedotorg.atlassian.net/browse/P20-1087)
- Dependabot: [OmniAuth Ruby gem Cross-site Request Forgery in request phase](https://github.com/code-dot-org/code-dot-org/security/dependabot/394)