### PR TITLE
Design System - Link Component - Minor Types update

### DIFF
--- a/apps/src/componentLibrary/link/CHANGELOG.md
+++ b/apps/src/componentLibrary/link/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.3]()
+
+* minor types updates
+
 ## [0.2.2](https://github.com/code-dot-org/code-dot-org/pull/59819)
 * added support of `role` prop
 

--- a/apps/src/componentLibrary/link/Link.tsx
+++ b/apps/src/componentLibrary/link/Link.tsx
@@ -5,7 +5,7 @@ import {ComponentSizeXSToL} from '@cdo/apps/componentLibrary/common/types';
 
 import moduleStyles from './link.module.scss';
 
-type LinkBaseProps = {
+export interface LinkBaseProps {
   /** Link id */
   id?: string;
   /** Custom class name */
@@ -26,7 +26,7 @@ type LinkBaseProps = {
   type?: 'primary' | 'secondary';
   /** Role of link */
   role?: string;
-};
+}
 
 type LinkWithChildren = LinkBaseProps & {
   /** Link content */

--- a/apps/src/componentLibrary/link/index.ts
+++ b/apps/src/componentLibrary/link/index.ts
@@ -1,2 +1,2 @@
-export type {LinkProps} from './Link';
+export type {LinkProps, LinkBaseProps} from './Link';
 export {default as default} from './Link';


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### Design System - Link Component - Minor Types update

* minor types update

While working on https://github.com/code-dot-org/code-dot-org/pull/61009 I found out that we need to update types slightly so that we'll be able to import them if needed. This PR does this.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
