### PR TITLE
HoC 2024 - Add Spanish video back to Portuguese version of the page

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -51,19 +51,20 @@ layout: wide_index
       %p.centered.body-two.wrap-balance
         =hoc_s("hoc_homepage.what_is_hoc.desc")
       -# Spanish video and banner
-      - if @language == 'es' || @language == 'la'
+      - if ['es', 'la', 'pt', 'po'].include?(@language)
         .spanish-content
           = view :index_video
-          %hr
-          .action-block.action-block--two-col.white
-            %img{src: '/images/hora-del-codigo-en-vivo.png', alt: hoc_s(:hoc_live)}
-            .content-wrapper
-              %h2.heading-lg.no-margin-top
-                = hoc_s(:hoc_live_learn_title)
-              %p
-                = hoc_s(:hoc_live_learn_message)
-              %a.link-button{href: 'https://code.org/envivo'}
-                = hoc_s(:hoc_live_learn_more)
+          - unless @language == 'pt' || @language == 'po'
+            %hr
+            .action-block.action-block--two-col.white
+              %img{src: '/images/hora-del-codigo-en-vivo.png', alt: hoc_s(:hoc_live)}
+              .content-wrapper
+                %h2.heading-lg.no-margin-top
+                  = hoc_s(:hoc_live_learn_title)
+                %p
+                  = hoc_s(:hoc_live_learn_message)
+                %a.link-button{href: 'https://code.org/envivo'}
+                  = hoc_s(:hoc_live_learn_more)
 
   -# Host an Hour of Code
   %section.no-padding-bottom


### PR DESCRIPTION
I had a brain fart yesterday when I [approved this Eyes diff](https://codedotorg.slack.com/archives/C0T0PNTM3/p1726092270906399?thread_ts=1726066224.074709&cid=C0T0PNTM3) and realized last night that new logic I applied to show the Spanish language content on the https://hourofcode.com homepage left off the video for Portuguese languages. I added that back here, and the banner will only show for Spanish languages now. 

_Note to reviewer:_ hide whitespace when reviewing for a cleaner experience!

## Testing story
Tested locally that the video shows and the Spanish banner doesn't when `Português (Brasil)` is selected. Also confirmed everything is still showing correctly on the Spanish version of the page.

----

<img width="1294" alt="Screenshot 2024-09-12 at 12 27 06 PM" src="https://github.com/user-attachments/assets/0b4b421d-ca77-4c1f-956e-545d1ea621b8">

| Before | After | 
| ---- | ---- |
| ![Before](https://github.com/user-attachments/assets/72d72c3f-ed44-45e1-9458-93a14f76f141) | ![After](https://github.com/user-attachments/assets/11249898-f9f7-4de9-9281-e32995da64ca) |

