### PR TITLE
fix(dependabot): limit open pull requests to only the main app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
     groups:
       auth:
         patterns:
@@ -40,8 +39,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/apps"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
+    open-pull-requests-limit: 0
     groups:
       amplitude:
         patterns:
@@ -167,8 +166,8 @@ updates:
     - "/bin/i18n"
     - "/tools/scripts/brokenLinkChecker"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
+    open-pull-requests-limit: 0
   # Infrastructure NPM/Yarn Packages
   - package-ecosystem: "npm"
     directories: 
@@ -177,23 +176,23 @@ updates:
     - "/aws/offsite/aurora-snapshots-fargate"
     - "/aws/offsite/prune-aurora-backups/src"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
+    open-pull-requests-limit: 0
   # Teacher Tools NPM/Yarn Packages
   - package-ecosystem: "npm"
     directories: 
     - "/bin/generate-pdf"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
+    open-pull-requests-limit: 0
   # Docker Images
   - package-ecosystem: "docker"
     directories: 
     - "/aws/offsite/aurora-snapshots-fargate"
     - "/docker/dockerfiles"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
+    open-pull-requests-limit: 0
   # Github Actions
   - package-ecosystem: "github-actions"
     directories: 
@@ -201,11 +200,10 @@ updates:
     - "/.github/actions/**/"
     - "/.github/workflows"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "daily"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: 'pip'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: "sunday"
+      interval: 'daily'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     groups:
       auth:
         patterns:
@@ -39,8 +40,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/apps"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0
+      interval: "weekly"
+      day: "sunday"
     groups:
       amplitude:
         patterns:
@@ -161,49 +162,55 @@ updates:
       - "dependencies"
   # Platform NPM/Yarn Packages
   - package-ecosystem: "npm"
+    open-pull-requests: 0
     directories: 
     - "/apps/eslint"
     - "/bin/i18n"
     - "/tools/scripts/brokenLinkChecker"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0
+      interval: "weekly"
+      day: "sunday"
   # Infrastructure NPM/Yarn Packages
   - package-ecosystem: "npm"
-    directories: 
+    open-pull-requests: 0
+    directories:
     - "/aws/cloudformation"
     - "/aws/cloudformation/lambdas/sql-user"
     - "/aws/offsite/aurora-snapshots-fargate"
     - "/aws/offsite/prune-aurora-backups/src"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0
+      interval: "weekly"
+      day: "sunday"
   # Teacher Tools NPM/Yarn Packages
   - package-ecosystem: "npm"
     directories: 
     - "/bin/generate-pdf"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0
+      interval: "weekly"
+      day: "sunday"
   # Docker Images
   - package-ecosystem: "docker"
-    directories: 
+    open-pull-requests: 0
+    directories:
     - "/aws/offsite/aurora-snapshots-fargate"
     - "/docker/dockerfiles"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0
+      interval: "weekly"
+      day: "sunday"
   # Github Actions
   - package-ecosystem: "github-actions"
-    directories: 
+    open-pull-requests: 0
+    directories:
     - "/.github"
     - "/.github/actions/**/"
     - "/.github/workflows"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0
+      interval: "weekly"
+      day: "sunday"
 
   - package-ecosystem: 'pip'
+    open-pull-requests: 0
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: "sunday"

--- a/.github/workflows/assign-dependabot-reviewer.yml
+++ b/.github/workflows/assign-dependabot-reviewer.yml
@@ -1,9 +1,5 @@
 name: Assign Reviewer for Dependabot
 
-permissions:
-  pull-requests: write
-  issues: write
-
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
@@ -35,7 +31,7 @@ jobs:
 
       - name: Determine and assign reviewer
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_REVIEWER_GH_TOKEN }}
           REPO: ${{ github.repository }}
           REPO_OWNER: ${{ github.repository_owner }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/assign-dependabot-reviewer.yml
+++ b/.github/workflows/assign-dependabot-reviewer.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Determine and assign reviewer
         env:
-          GH_TOKEN: ${{ secrets.DEPENDABOT_REVIEWER_GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           REPO_OWNER: ${{ github.repository_owner }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/assign-dependabot-reviewer.yml
+++ b/.github/workflows/assign-dependabot-reviewer.yml
@@ -1,5 +1,9 @@
 name: Assign Reviewer for Dependabot
 
+permissions:
+  pull-requests: write
+  issues: write
+
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]


### PR DESCRIPTION
Dependabot has a hard limit on the number of open pull requests it tracks at a time. 

Given the number of PRs that were opened in the misc scripts, it has resulted in the main app from not being able to open dependabot PRs against it.
    
Due to this, temporarily disable PRs except for the main app (apps, dashboard, and pegasus)

## Links

- [Documentation on dependabot PR limit](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/troubleshooting-dependabot-errors#dependabot-cannot-open-any-more-pull-requests)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Ran test on https://github.com/code-dot-org/code-dot-org/pull/60968#issuecomment-2347391829

Workflow was able to run successfully

![image](https://github.com/user-attachments/assets/0824a7f7-413c-4639-bbfe-40a898922bbe)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
