### PR TITLE
NAV - Add resource row for a lesson material

### DIFF
--- a/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
@@ -51,6 +51,9 @@ export const lessonMaterialsLoader =
     const selectedSectionId = state.selectedSectionId;
     const sectionData = state.sections[selectedSectionId];
 
+    // NOTE: this page is not working for stand alone courses.
+    // this is because there is no "unitId" in the sectionData for stand alone courses.
+
     if (!selectedSectionId || !sectionData.unitId) {
       return null;
     }
@@ -68,6 +71,7 @@ const createDisplayName = (lessonName: string, lessonPosition: number) => {
 const LessonMaterialsContainer: React.FC = () => {
   const loadedData = useLoaderData() as LessonMaterialsData | null;
   const lessons = useMemo(() => loadedData?.lessons || [], [loadedData]);
+  const unitNumber = useMemo(() => loadedData?.unitNumber || 0, [loadedData]);
 
   const getLessonFromId = (lessonId: number): Lesson | null => {
     return lessons.find(lesson => lesson.id === lessonId) || null;
@@ -110,13 +114,18 @@ const LessonMaterialsContainer: React.FC = () => {
         name={'lessons-in-assigned-unit-dropdown'}
         size="s"
       />
-      {/* Note that this is just a "proof of concept row" - the actual implementation would be more complex */}
+      {/*  Note that this only goes through Teacher resources - we have separate tickets to make sure that this is presented for all resources */}
       {selectedLesson && (
-        <ResourceRow
-          unitNumber={5} // note that this is a placeholder value
-          lessonNumber={selectedLesson.position}
-          resource={selectedLesson.resources.Teacher[0] || null} // note that this is a placeholder value
-        />
+        <div>
+          {selectedLesson.resources.Teacher.map(resource => (
+            <ResourceRow
+              key={resource.key}
+              unitNumber={unitNumber}
+              lessonNumber={selectedLesson.position}
+              resource={resource}
+            />
+          ))}
+        </div>
       )}
     </div>
   );

--- a/apps/src/templates/teacherNavigation/ResourceIcon.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceIcon.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import {isGDocsUrl} from '@cdo/apps/templates/lessonOverview/googleDocsUtils';
 
+import {RESOURCE_TYPE} from './ResourceIconType';
+
 import styles from './lesson-materials.module.scss';
 
 type ResourceIconProps = {
@@ -32,36 +34,22 @@ const ResourceIcon: React.FC<ResourceIconProps> = ({
   const iconType = () => {
     if (isGDocsUrl(resourceUrl)) {
       if (resourceType === 'Slides') {
-        return 'presentation-screen';
+        return RESOURCE_TYPE.SLIDES;
       } else {
-        return 'files';
+        return RESOURCE_TYPE.GOOGLE_DOC;
       }
     } else if (resourceType === 'Video') {
-      return 'video';
+      return RESOURCE_TYPE.VIDEO;
     } else if (resourceType === 'Lesson Plan') {
-      return 'file-lines';
+      return RESOURCE_TYPE.LESSON_PLAN;
     } else {
-      return 'link-simple';
+      return RESOURCE_TYPE.LINK;
     }
   };
 
-  const getIconClass = () => {
-    switch (iconType()) {
-      case 'presentation-screen':
-        return styles.slides;
-      case 'video':
-        return styles.video;
-      case 'file-lines':
-        return styles.lessonPlan;
-      case 'files':
-        return styles.files;
-      default:
-        return styles.link;
-    }
-  };
   return (
-    <div className={classNames(styles.resourceIconContainer, getIconClass())}>
-      <FontAwesomeV6Icon iconName={iconType()} className={styles.icon} />
+    <div className={classNames(styles.resourceIconContainer, iconType().class)}>
+      <FontAwesomeV6Icon iconName={iconType().icon} className={styles.icon} />
     </div>
   );
 };

--- a/apps/src/templates/teacherNavigation/ResourceIcon.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceIcon.tsx
@@ -1,0 +1,69 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
+import {isGDocsUrl} from '@cdo/apps/templates/lessonOverview/googleDocsUtils';
+
+import styles from './lesson-materials.module.scss';
+
+type ResourceIconProps = {
+  // the resourceType is connected to how curriculum writers designate a resource
+  // when building a lesson. The Lesson Plan is unique in that a curriculum writer
+  // doesn't add this resource in the same way as the others in this list.  However
+  // we are displaying the lesson plans in the Lesson Materials page.
+  // resourceType:
+  //   | 'Slides'
+  //   | 'Video'
+  //   | 'Lesson Plan'
+  //   | 'Resource'
+  //   | 'Rubric'
+  //   | 'Handout'
+  //   | 'Activity Guide'
+  //   | 'Exemplar'
+  //   | 'Answer Key';
+  resourceType: string | null | undefined;
+  resourceUrl: string | null | undefined;
+};
+
+const ResourceIcon: React.FC<ResourceIconProps> = ({
+  resourceType,
+  resourceUrl,
+}) => {
+  const iconType = () => {
+    if (isGDocsUrl(resourceUrl)) {
+      if (resourceType === 'Slides') {
+        return 'presentation-screen';
+      } else {
+        return 'files';
+      }
+    } else if (resourceType === 'Video') {
+      return 'video';
+    } else if (resourceType === 'Lesson Plan') {
+      return 'file-lines';
+    } else {
+      return 'link-simple';
+    }
+  };
+
+  const getIconClass = () => {
+    switch (iconType()) {
+      case 'presentation-screen':
+        return styles.slides;
+      case 'video':
+        return styles.video;
+      case 'file-lines':
+        return styles.lessonPlan;
+      case 'files':
+        return styles.files;
+      default:
+        return styles.link;
+    }
+  };
+  return (
+    <div className={classNames(styles.resourceIconContainer, getIconClass())}>
+      <FontAwesomeV6Icon iconName={iconType()} className={styles.icon} />
+    </div>
+  );
+};
+
+export default ResourceIcon;

--- a/apps/src/templates/teacherNavigation/ResourceIcon.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceIcon.tsx
@@ -9,22 +9,8 @@ import {RESOURCE_TYPE} from './ResourceIconType';
 import styles from './lesson-materials.module.scss';
 
 type ResourceIconProps = {
-  // the resourceType is connected to how curriculum writers designate a resource
-  // when building a lesson. The Lesson Plan is unique in that a curriculum writer
-  // doesn't add this resource in the same way as the others in this list.  However
-  // we are displaying the lesson plans in the Lesson Materials page.
-  // resourceType:
-  //   | 'Slides'
-  //   | 'Video'
-  //   | 'Lesson Plan'
-  //   | 'Resource'
-  //   | 'Rubric'
-  //   | 'Handout'
-  //   | 'Activity Guide'
-  //   | 'Exemplar'
-  //   | 'Answer Key';
-  resourceType: string | null | undefined;
-  resourceUrl: string | null | undefined;
+  resourceType: string;
+  resourceUrl: string;
 };
 
 const ResourceIcon: React.FC<ResourceIconProps> = ({
@@ -48,7 +34,10 @@ const ResourceIcon: React.FC<ResourceIconProps> = ({
   };
 
   return (
-    <div className={classNames(styles.resourceIconContainer, iconType().class)}>
+    <div
+      data-testid={'resource-icon-' + iconType().icon}
+      className={classNames(styles.resourceIconContainer, iconType().class)}
+    >
       <FontAwesomeV6Icon iconName={iconType().icon} className={styles.icon} />
     </div>
   );

--- a/apps/src/templates/teacherNavigation/ResourceIcon.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceIcon.tsx
@@ -17,7 +17,7 @@ const ResourceIcon: React.FC<ResourceIconProps> = ({
   resourceType,
   resourceUrl,
 }) => {
-  const iconType = () => {
+  const computeIconType = () => {
     if (isGDocsUrl(resourceUrl)) {
       if (resourceType === 'Slides') {
         return RESOURCE_TYPE.SLIDES;
@@ -33,12 +33,14 @@ const ResourceIcon: React.FC<ResourceIconProps> = ({
     }
   };
 
+  const iconType = computeIconType();
+
   return (
     <div
-      data-testid={'resource-icon-' + iconType().icon}
-      className={classNames(styles.resourceIconContainer, iconType().class)}
+      data-testid={'resource-icon-' + iconType.icon}
+      className={classNames(styles.resourceIconContainer, iconType.class)}
     >
-      <FontAwesomeV6Icon iconName={iconType().icon} className={styles.icon} />
+      <FontAwesomeV6Icon iconName={iconType.icon} className={styles.icon} />
     </div>
   );
 };

--- a/apps/src/templates/teacherNavigation/ResourceIconType.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceIconType.tsx
@@ -17,9 +17,3 @@ export const RESOURCE_TYPE = Object.freeze({
   GOOGLE_DOC: makeObjectType('files', styles.files),
   VIDEO: makeObjectType('video', styles.video),
 } as const);
-
-export type ResourceTypeValues =
-  (typeof RESOURCE_TYPE)[keyof typeof RESOURCE_TYPE];
-
-export const ITEM_TYPE_SHAPE: ResourceTypeValues[] =
-  Object.values(RESOURCE_TYPE);

--- a/apps/src/templates/teacherNavigation/ResourceIconType.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceIconType.tsx
@@ -1,0 +1,25 @@
+import styles from './lesson-materials.module.scss';
+
+interface ResourceType {
+  icon: string;
+  class: string;
+}
+
+const makeObjectType = (icon: string, className: string): ResourceType => ({
+  icon,
+  class: className,
+});
+
+export const RESOURCE_TYPE = Object.freeze({
+  SLIDES: makeObjectType('presentation-screen', styles.slides),
+  LESSON_PLAN: makeObjectType('file-lines', styles.lessonPlan),
+  LINK: makeObjectType('link-simple', styles.link),
+  GOOGLE_DOC: makeObjectType('files', styles.files),
+  VIDEO: makeObjectType('video', styles.video),
+} as const);
+
+export type ResourceTypeValues =
+  (typeof RESOURCE_TYPE)[keyof typeof RESOURCE_TYPE];
+
+export const ITEM_TYPE_SHAPE: ResourceTypeValues[] =
+  Object.values(RESOURCE_TYPE);

--- a/apps/src/templates/teacherNavigation/ResourceRow.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceRow.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 
 import {BodyTwoText, StrongText} from '@cdo/apps/componentLibrary/typography';
 
+import ResourceIcon from './ResourceIcon';
+import ResourceViewOptionsDropdown from './ResourceViewOptionsDropdown';
+
 import styles from './lesson-materials.module.scss';
 
 type ResourceRowProps = {
@@ -27,10 +30,12 @@ const ResourceRow: React.FC<ResourceRowProps> = ({
   );
   return (
     <div className={styles.rowContainer}>
+      <ResourceIcon resourceType={resource?.type} resourceUrl={resource?.url} />
       <BodyTwoText>
         <StrongText>{resourcePositionLabel}</StrongText>
         {resource?.name}
       </BodyTwoText>
+      <ResourceViewOptionsDropdown resource={resource} />
     </div>
   );
 };

--- a/apps/src/templates/teacherNavigation/ResourceRow.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceRow.tsx
@@ -29,23 +29,16 @@ const ResourceRow: React.FC<ResourceRowProps> = ({
     <strong>{unitNumber + '.' + lessonNumber + ' '}</strong>
   );
   return (
-    <>
-      {resource && (
-        <div className={styles.rowContainer}>
-          <div className={styles.iconAndName}>
-            <ResourceIcon
-              resourceType={resource.type}
-              resourceUrl={resource.url}
-            />
-            <BodyTwoText className={styles.resourceLabel}>
-              <StrongText>{resourcePositionLabel}</StrongText>
-              {resource.name}
-            </BodyTwoText>
-          </div>
-          <ResourceViewOptionsDropdown resource={resource} />
-        </div>
-      )}
-    </>
+    <div className={styles.rowContainer}>
+      <div className={styles.iconAndName}>
+        <ResourceIcon resourceType={resource.type} resourceUrl={resource.url} />
+        <BodyTwoText className={styles.resourceLabel}>
+          <StrongText>{resourcePositionLabel}</StrongText>
+          {resource.name}
+        </BodyTwoText>
+      </div>
+      <ResourceViewOptionsDropdown resource={resource} />
+    </div>
   );
 };
 

--- a/apps/src/templates/teacherNavigation/ResourceRow.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceRow.tsx
@@ -29,14 +29,23 @@ const ResourceRow: React.FC<ResourceRowProps> = ({
     <strong>{unitNumber + '.' + lessonNumber + ' '}</strong>
   );
   return (
-    <div className={styles.rowContainer}>
-      <ResourceIcon resourceType={resource?.type} resourceUrl={resource?.url} />
-      <BodyTwoText>
-        <StrongText>{resourcePositionLabel}</StrongText>
-        {resource?.name}
-      </BodyTwoText>
-      <ResourceViewOptionsDropdown resource={resource} />
-    </div>
+    <>
+      {resource && (
+        <div className={styles.rowContainer}>
+          <div className={styles.iconAndName}>
+            <ResourceIcon
+              resourceType={resource.type}
+              resourceUrl={resource.url}
+            />
+            <BodyTwoText className={styles.resourceLabel}>
+              <StrongText>{resourcePositionLabel}</StrongText>
+              {resource.name}
+            </BodyTwoText>
+          </div>
+          <ResourceViewOptionsDropdown resource={resource} />
+        </div>
+      )}
+    </>
   );
 };
 

--- a/apps/src/templates/teacherNavigation/ResourceViewOptionsDropdown.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceViewOptionsDropdown.tsx
@@ -13,6 +13,7 @@ type ResourceViewOptionsDropdownProps = {
 const ResourceViewOptionsDropdown: React.FC<
   ResourceViewOptionsDropdownProps
 > = ({resource}) => {
+  // This is a dummy options array that will be replaced with actual options in TEACH-1326
   const dummyOptions = [
     {
       value: 'option-1',
@@ -29,9 +30,9 @@ const ResourceViewOptionsDropdown: React.FC<
   ];
 
   return (
-    <div>
+    <div data-testid={'view-options-dropdown'}>
       <ActionDropdown
-        name="view-options-dropdown"
+        name="view-options"
         labelText="View options dropdown"
         options={dummyOptions}
         size="s"

--- a/apps/src/templates/teacherNavigation/ResourceViewOptionsDropdown.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceViewOptionsDropdown.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import {ActionDropdown} from '@cdo/apps/componentLibrary/dropdown';
+
+type ResourceViewOptionsDropdownProps = {
+  resource: {
+    url: string;
+    downloadUrl: string | null;
+    type: string;
+  };
+};
+
+const ResourceViewOptionsDropdown: React.FC<
+  ResourceViewOptionsDropdownProps
+> = ({resource}) => {
+  const dummyOptions = [
+    {
+      value: 'option-1',
+      label: 'View',
+      icon: {iconName: 'check'},
+      onClick: () => console.log('option 1 with URL '),
+    },
+    {
+      value: 'option-2',
+      label: 'Download',
+      icon: {iconName: 'xmark'},
+      onClick: () => console.log('option 2'),
+    },
+  ];
+
+  return (
+    <div>
+      <ActionDropdown
+        name="view options dropdown"
+        labelText="label text that I don't think I want..."
+        options={dummyOptions}
+        size="s"
+        triggerButtonProps={{
+          color: 'black',
+          type: 'tertiary',
+          isIconOnly: true,
+          icon: {
+            iconName: 'ellipsis-vertical',
+            iconStyle: 'solid',
+          },
+        }}
+      />
+    </div>
+  );
+};
+
+export default ResourceViewOptionsDropdown;

--- a/apps/src/templates/teacherNavigation/ResourceViewOptionsDropdown.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceViewOptionsDropdown.tsx
@@ -18,7 +18,7 @@ const ResourceViewOptionsDropdown: React.FC<
       value: 'option-1',
       label: 'View',
       icon: {iconName: 'check'},
-      onClick: () => console.log('option 1 with URL '),
+      onClick: () => console.log('option 1 with of types' + resource.type),
     },
     {
       value: 'option-2',
@@ -31,10 +31,11 @@ const ResourceViewOptionsDropdown: React.FC<
   return (
     <div>
       <ActionDropdown
-        name="view options dropdown"
-        labelText="label text that I don't think I want..."
+        name="view-options-dropdown"
+        labelText="View options dropdown"
         options={dummyOptions}
         size="s"
+        menuPlacement="right"
         triggerButtonProps={{
           color: 'black',
           type: 'tertiary',

--- a/apps/src/templates/teacherNavigation/lesson-materials.module.scss
+++ b/apps/src/templates/teacherNavigation/lesson-materials.module.scss
@@ -9,7 +9,7 @@
   justify-content: space-between;
   align-items: center;
   align-self: stretch;
-  border: 1px solid #f92828; // to be changed
+  border: 1px solid var(--borders-neutral-primary); // to be changed
 }
 
 .resourceIconContainer {
@@ -19,6 +19,16 @@
   align-items: center;
   border-radius: 4px;
   display: flex;
+}
+
+.iconAndName {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.resourceLabel {
+  margin-bottom: 0 !important;
 }
 
 .icon {

--- a/apps/src/templates/teacherNavigation/lesson-materials.module.scss
+++ b/apps/src/templates/teacherNavigation/lesson-materials.module.scss
@@ -9,7 +9,7 @@
   justify-content: space-between;
   align-items: center;
   align-self: stretch;
-  border: 1px solid var(--borders-neutral-primary); // to be changed
+  border: 1px solid var(--borders-neutral-primary);
 }
 
 .resourceIconContainer {

--- a/apps/src/templates/teacherNavigation/lesson-materials.module.scss
+++ b/apps/src/templates/teacherNavigation/lesson-materials.module.scss
@@ -1,3 +1,7 @@
+@import 'color.scss';
+@import 'style-constants';
+@import '@cdo/apps/componentLibrary/common/styles/colors.css';
+
 .rowContainer {
   display: flex;
   height: 48px;
@@ -6,4 +10,43 @@
   align-items: center;
   align-self: stretch;
   border: 1px solid #f92828; // to be changed
+}
+
+.resourceIconContainer {
+  height: 32px;
+  width: 32px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+  display: flex;
+}
+
+.icon {
+  text-align: center;
+  font-size: 16px;
+}
+
+.slides {
+  background-color: var(--sentiment-warning-20);
+  color: var(--sentiment-warning-60);
+}
+
+.video {
+  background-color: var(--sentiment-success-10);
+  color: var(--sentiment-success-50);
+}
+
+.lessonPlan {
+  background-color: var(--background-brand-purple-extra-light);
+  color: var(--text-brand-purple-primary);
+}
+
+.link {
+  background-color: var(--accent-strawberry-10, #ffe3e3);
+  color: var(--accent-strawberry-50, #ed6060);
+}
+
+.files {
+  background-color: var(--sentiment-information-10);
+  color: var(--sentiment-information-50);
 }

--- a/apps/test/unit/templates/teacherNavigation/ResourceIconTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/ResourceIconTest.tsx
@@ -1,0 +1,58 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import ResourceIcon from '@cdo/apps/templates/teacherNavigation/ResourceIcon';
+import {RESOURCE_TYPE} from '@cdo/apps/templates/teacherNavigation/ResourceIconType';
+
+describe('ResourceIcon', () => {
+  const googleSlidesUrl =
+    'https://docs.google.com/presentation/d/randomCode/view';
+  const googleDocsUrl = 'https://docs.google.com/document/d/randomCode/view';
+  const nonGoogleResourceUrl = 'https://code.org';
+
+  it('renders the icon for a slides resource correctly', () => {
+    render(
+      <ResourceIcon resourceType={'Slides'} resourceUrl={googleSlidesUrl} />
+    );
+    screen.getByTestId('font-awesome-v6-icon');
+    screen.getByTestId('resource-icon-' + RESOURCE_TYPE.SLIDES.icon);
+  });
+
+  it('renders the icon for a google doc resource correctly', () => {
+    render(
+      <ResourceIcon resourceType={'Handout'} resourceUrl={googleDocsUrl} />
+    );
+    screen.getByTestId('font-awesome-v6-icon');
+    screen.getByTestId('resource-icon-' + RESOURCE_TYPE.GOOGLE_DOC.icon);
+  });
+
+  it('renders the icon for a video resource correctly', () => {
+    render(
+      <ResourceIcon resourceType={'Video'} resourceUrl={nonGoogleResourceUrl} />
+    );
+    screen.getByTestId('font-awesome-v6-icon');
+    screen.getByTestId('resource-icon-' + RESOURCE_TYPE.VIDEO.icon);
+  });
+
+  it('renders the icon for a lesson plan resource correctly', () => {
+    render(
+      <ResourceIcon
+        resourceType={'Lesson Plan'}
+        resourceUrl={nonGoogleResourceUrl}
+      />
+    );
+    screen.getByTestId('font-awesome-v6-icon');
+    screen.getByTestId('resource-icon-' + RESOURCE_TYPE.LESSON_PLAN.icon);
+  });
+
+  it('renders the icon for a non-google doc, non-lesson-plan, non-video resource correctly', () => {
+    render(
+      <ResourceIcon
+        resourceType={'Exemplar'}
+        resourceUrl={nonGoogleResourceUrl}
+      />
+    );
+    screen.getByTestId('font-awesome-v6-icon');
+    screen.getByTestId('resource-icon-' + RESOURCE_TYPE.LINK.icon);
+  });
+});

--- a/apps/test/unit/templates/teacherNavigation/ResourceRowTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/ResourceRowTest.tsx
@@ -1,0 +1,38 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {RESOURCE_TYPE} from '@cdo/apps/templates/teacherNavigation/ResourceIconType';
+import ResourceRow from '@cdo/apps/templates/teacherNavigation/ResourceRow';
+
+describe('LessonMaterialsContainer', () => {
+  const mockResourceData = {
+    key: 'resourceKey1',
+    name: 'Handout for teacher',
+    url: 'code.org',
+    downloadUrl: null,
+    audience: 'Teacher',
+    type: 'Handout',
+  };
+
+  const renderDefault = (props = {}) => {
+    return render(
+      <ResourceRow
+        lessonNumber={2}
+        unitNumber={3}
+        resource={mockResourceData}
+        {...props}
+      />
+    );
+  };
+
+  it('renders the resource name, position, icon, and dropdown correctly', () => {
+    renderDefault();
+
+    screen.getByText('Handout for teacher');
+    screen.getByText('3.2');
+
+    screen.getByTestId('resource-icon-' + RESOURCE_TYPE.LINK.icon);
+
+    screen.getByTestId('view-options-dropdown');
+  });
+});

--- a/apps/test/unit/templates/teacherNavigation/ResourceRowTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/ResourceRowTest.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {RESOURCE_TYPE} from '@cdo/apps/templates/teacherNavigation/ResourceIconType';
 import ResourceRow from '@cdo/apps/templates/teacherNavigation/ResourceRow';
 
-describe('LessonMaterialsContainer', () => {
+describe('ResourceRow', () => {
   const mockResourceData = {
     key: 'resourceKey1',
     name: 'Handout for teacher',


### PR DESCRIPTION
This is intended to create a row that will eventually be used in the StudentResources table and TeacherResources table.    

https://github.com/user-attachments/assets/b870ac6d-322f-4284-a655-c8a462f85a52



This does not:
- Have a working action dropdown.  The dropdown contains just a placeholder at the moment (this is the `view` and `download` text). 
- Work for stand-alone units.  Currently there is an issue pulling in this data for stand alone units.  [This](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1353) ticket has been created to address that issue.
- Have the correct unit working for *some* courses.  For some reason, the `unitNumber` data is not pulling in correctly (specifically CSD Unit 4 - but that is just one case... there are likely more...).  [This](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1354) ticket has been created to  address that issue. 

## Links

- [Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1323)
- [Figma](https://www.figma.com/design/5ILfiJkPQpjskBwksMDeZl/Teacher-Dashboard?node-id=3104-2079&node-type=CANVAS&m=dev)
- [Tech Spec](https://docs.google.com/document/d/1k46_Ovu0afDKS5cLrkySKMALI42_yn-WlZnneXdWlnU/edit#heading=h.4schd43y1qoc)

## Testing story

- Added unit tests for components.
- Eyes tests are accounted for in a separate ticket
