### PR TITLE
Adds new Statsig events to login page

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -17,6 +17,8 @@ const EVENTS = {
   ABANDON_SECTION_SETUP_SIGN_IN_EVENT: 'Abandon Section Setup Sign In',
   TEACHER_LOGIN_EVENT: 'Teacher Login',
   ACCOUNT_SETTINGS_PAGE_VISITED: 'Account Settings Page Visited',
+  LOGIN_PAGE_VISITED: 'Login Page Visited',
+  LOGIN_PAGE_CREATE_ACCOUNT_CLICKED: 'Login Page Create Account Button Clicked',
 
   // School Association
   // Update School Info Dialog

--- a/apps/src/sites/studio/pages/devise/sessions/_login.js
+++ b/apps/src/sites/studio/pages/devise/sessions/_login.js
@@ -1,0 +1,16 @@
+import $ from 'jquery';
+
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+
+$(document).ready(() => {
+  analyticsReporter.sendEvent(EVENTS.LOGIN_PAGE_VISITED, {}, PLATFORMS.STATSIG);
+
+  document.getElementById('user_signup').addEventListener('click', () => {
+    analyticsReporter.sendEvent(
+      EVENTS.LOGIN_PAGE_CREATE_ACCOUNT_CLICKED,
+      {},
+      PLATFORMS.STATSIG
+    );
+  });
+});

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -54,6 +54,7 @@ const CODE_STUDIO_ENTRIES = {
   'programming_expressions/show': './src/sites/studio/pages/programming_expressions/show.js',
   'sessions/lockout': './src/sites/studio/pages/sessions/lockout.js',
   'devise/sessions/new': './src/sites/studio/pages/devise/sessions/new.js',
+  'devise/sessions/_login': './src/sites/studio/pages/devise/sessions/_login.js',
   'devise/registrations/_sign_up': './src/sites/studio/pages/devise/registrations/_sign_up.js',
   'devise/registrations/login_type': './src/sites/studio/pages/devise/registrations/login_type.js',
   'devise/registrations/finish_student_account': './src/sites/studio/pages/devise/registrations/finish_student_account.js',

--- a/dashboard/app/views/devise/sessions/_login.html.haml
+++ b/dashboard/app/views/devise/sessions/_login.html.haml
@@ -1,3 +1,7 @@
+
+- content_for :head do
+  %script{src: webpack_asset_path('js/devise/sessions/_login.js')}
+
 %h2= t('signin_form.title')
 
 .flex-container


### PR DESCRIPTION
Adds two new events to the Login page as seen below. I was able to test both locally and with localmode turned off. I am calling these 'login' instead of 'signin' because we as a team seem to frequently misuse/mixup 'signin' and 'signup'. 

<img width="392" alt="Screenshot 2024-09-12 at 1 55 36 PM" src="https://github.com/user-attachments/assets/d69b3f70-19a6-4311-8bfb-186bf61739b3">
<img width="1293" alt="Screenshot 2024-09-12 at 3 24 32 PM" src="https://github.com/user-attachments/assets/454ab5ae-6c79-4cd0-a629-6094bd5cd2e5">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2387

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
