### PR TITLE
Music: allow AI

### DIFF
--- a/apps/src/music/blockly/toolbox/definitions.ts
+++ b/apps/src/music/blockly/toolbox/definitions.ts
@@ -58,9 +58,8 @@ export const defaultMaps: {
     Play: [
       BlockTypes.PLAY_SOUND_AT_CURRENT_LOCATION_SIMPLE2,
       BlockTypes.PLAY_PATTERN_AT_CURRENT_LOCATION_SIMPLE2,
-      ...(appConfig.getValue('play-pattern-ai-block') === 'true'
-        ? [BlockTypes.PLAY_PATTERN_AI_AT_CURRENT_LOCATION_SIMPLE2]
-        : []),
+
+      BlockTypes.PLAY_PATTERN_AI_AT_CURRENT_LOCATION_SIMPLE2,
       BlockTypes.PLAY_CHORD_AT_CURRENT_LOCATION_SIMPLE2,
       ...(appConfig.getValue('play-tune-block') === 'true'
         ? [BlockTypes.PLAY_TUNE_AT_CURRENT_LOCATION_SIMPLE2]

--- a/apps/src/music/blockly/toolbox/index.ts
+++ b/apps/src/music/blockly/toolbox/index.ts
@@ -2,8 +2,10 @@ import {ToolboxInfo, ToolboxItemInfo} from 'blockly/core/utils/toolbox';
 
 import {getTypedKeys, ValueOf} from '@cdo/apps/types/utils';
 
+import appConfig from '../../appConfig';
 import {BlockMode} from '../../constants';
 import musicI18n from '../../locale';
+import {BlockTypes} from '../blockTypes';
 
 import {defaultMaps, options} from './definitions';
 import toolboxBlocks from './toolboxBlocks';
@@ -62,6 +64,16 @@ export function getToolbox(
         allowList &&
         allowList[category] &&
         !allowList[category].includes(blockName)
+      ) {
+        continue;
+      }
+
+      if (
+        blockName === BlockTypes.PLAY_PATTERN_AI_AT_CURRENT_LOCATION_SIMPLE2 &&
+        !(
+          levelToolbox?.includeAi ||
+          appConfig.getValue('play-pattern-ai-block') === 'true'
+        )
       ) {
         continue;
       }

--- a/apps/src/music/blockly/toolbox/types.ts
+++ b/apps/src/music/blockly/toolbox/types.ts
@@ -43,4 +43,5 @@ export type ToolboxType = 'category' | 'flyout';
 export interface ToolboxData {
   blocks: CategoryBlocksMap;
   type?: ToolboxType;
+  includeAi?: boolean;
 }


### PR DESCRIPTION
With this change, a level may include the `play AI drums` block by specifying the following field:

```
"toolbox": {
  "includeAi": true
}
```

The `?play-pattern-ai-block=true` URL parameter continues to work as well.
