### PR TITLE
Aichat: chunk text input to Amazon Comprehend

### DIFF
--- a/dashboard/app/helpers/aichat_comprehend_helper.rb
+++ b/dashboard/app/helpers/aichat_comprehend_helper.rb
@@ -1,4 +1,7 @@
 module AichatComprehendHelper
+  MAX_SEGMENT_SIZE_BYTES = 1000
+  MAX_SEGMENTS_PER_LIST = 10
+
   def self.create_comprehend_client
     # Stubbed Comprehend allows UI tests (without the roundtrip to the model) to run in CI environments (ie, Drone)
     Rails.application.config.respond_to?(:stub_aichat_aws_services) && Rails.application.config.stub_aichat_aws_services ?
@@ -8,18 +11,80 @@ module AichatComprehendHelper
 
   # Moderate given text for inappropriate/toxic content using AWS Comprehend client.
   def self.get_toxicity(text, locale)
-    comprehend_response = create_comprehend_client.detect_toxic_content(
-      {
-        text_segments: [{text: text}],
-        language_code: locale,
-      }
-    )
-    categories = comprehend_response.result_list[0].labels
+    text_segment_lists = get_text_segment_lists(text)
+    print_lists(text_segment_lists)
+
+    max_toxicity = 0
+    max_category = nil
+    text_segment_lists.each_with_index do |list, idx|
+      comprehend_response = create_comprehend_client.detect_toxic_content(
+        {
+          text_segments: list.map {|segment| {text: segment}},
+          language_code: locale,
+        }
+      )
+      print_comprehend_response(comprehend_response, idx)
+      max_toxicity = [max_toxicity, comprehend_response.result_list.map(&:toxicity).max].max
+      list_max_category = comprehend_response.result_list.map(&:labels).flatten.max_by(&:score)
+      max_category = max_category.nil? ? list_max_category : [max_category, list_max_category].max_by(&:score)
+    end
+
+    puts "\nOVERALL RESULTS"
+    puts "Max Toxicity: #{max_toxicity.round(3)}"
+    puts "Max Category: #{max_category}"
     {
       text: text,
-      toxicity: comprehend_response.result_list[0].toxicity,
-      max_category: categories.max_by(&:score),
+      toxicity: max_toxicity,
+      max_category: max_category
     }
+  end
+
+  # Returns a collection of text segment lists, each with a list of individual text segments to check for toxicity.
+  # Comprehend limits the amount of bytes per segment, and the amount of overall bytes per list.
+  def self.get_text_segment_lists(text)
+    text_segment_lists = [[""]]
+    text.split.each do |word|
+      new_word_size = " #{word}".bytesize
+      current_list = text_segment_lists.last
+      current_segment = current_list.last
+
+      if current_segment.bytesize + new_word_size >= MAX_SEGMENT_SIZE_BYTES
+        if current_list.size >= MAX_SEGMENTS_PER_LIST
+          # If we've exceeded the limit for the current list, create a new list
+          text_segment_lists << [""]
+          current_list = text_segment_lists.last
+        else
+          # Otherwise, start a new segment in the current list
+          current_list << ""
+        end
+        current_segment = current_list.last
+      end
+
+      current_segment << (current_segment.empty? ? word : " #{word}")
+    end
+    text_segment_lists
+  end
+
+  def self.print_lists(lists)
+    puts "\n\nComputed Segments\n"
+    lists.each_with_index do |list, idx|
+      size = list.inject(0) {|sum, segment| sum + segment.bytesize}
+      puts "List #{idx + 1} (#{list.size} items, #{size} Bytes)"
+      list.each_with_index do |segment, idx2|
+        puts "\tSegment #{idx2 + 1} (#{segment.bytesize}/#{MAX_SEGMENT_SIZE_BYTES} Bytes): #{segment.truncate(150)}"
+      end
+    end
+  end
+
+  def self.print_comprehend_response(comprehend_response, index)
+    list_max = comprehend_response.result_list.map(&:toxicity).max
+    list_max_category = comprehend_response.result_list.map(&:labels).flatten.max_by(&:score)
+    puts "\n\nResponse for List #{index + 1}. List Max Toxicity: #{list_max.round(3)}. Max Category: #{list_max_category}"
+    comprehend_response.result_list.each_with_index do |result, idx|
+      puts "Segment #{idx + 1} Toxicity: #{result.toxicity.round(3)}"
+      puts "\t#{result.labels.map {|label| label.name + ': ' + label.score.round(3).to_s}.join(', ')}"
+      puts "\tMax Category: #{result.labels.max_by(&:score)}"
+    end
   end
 end
 

--- a/dashboard/app/helpers/aichat_comprehend_helper.rb
+++ b/dashboard/app/helpers/aichat_comprehend_helper.rb
@@ -36,8 +36,26 @@ module AichatComprehendHelper
   # Returns a collection of text segment lists, each with a list of individual text segments to check for toxicity.
   # Comprehend limits the amount of bytes per segment, and the amount of overall bytes per list.
   def self.get_text_segment_lists(text)
-    text_segment_lists = [[""]]
+    words = []
+    # Split the text by words. If a single word exceeds our segment size limit, split up the word.
     text.split.each do |word|
+      if word.bytesize >= MAX_SEGMENT_SIZE_BYTES
+        word_segments = [""]
+        word.each_char do |char|
+          if word_segments.last.bytesize + char.bytesize < MAX_SEGMENT_SIZE_BYTES
+            word_segments.last << char
+          else
+            word_segments << char
+          end
+        end
+        words.concat(word_segments)
+      else
+        words << word
+      end
+    end
+
+    text_segment_lists = [[""]]
+    words.each do |word|
       new_word_size = " #{word}".bytesize
       current_list = text_segment_lists.last
       current_segment = current_list.last

--- a/dashboard/test/helpers/aichat_comprehend_helper_test.rb
+++ b/dashboard/test/helpers/aichat_comprehend_helper_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class AichatComprehendHelperTest < ActionView::TestCase
+  include AichatComprehendHelper
+
+  test 'correctly chunks long text inputs' do
+    # 5 characters * 3000 = 15000 bytes.
+    long_message = "abcd " * 3000
+    # Comprehend's segment limit is 1000 bytes, and lists are limited to 10 segments.
+    # Expect to convert this to two lists with 10 and 5 segments respectively
+    text_segment_lists = AichatComprehendHelper.get_text_segment_lists(long_message)
+    assert_equal 2, text_segment_lists.size
+    assert_equal 10, text_segment_lists[0].size
+    assert_equal 5, text_segment_lists[1].size
+    text_segment_lists.flatten.each {|segment| assert segment.bytesize <= 1000}
+  end
+
+  test "text with single words above segment limit are split up" do
+    small_word = "hello"
+    # 5 characters (no space) * 500 = 2500 bytes.
+    long_word = "abcde" * 500
+    # Expect the long word to be split into 2 1000-byte chunks and 1 500-byte chunk
+    # Expect to convert this to one list with 4 segments (small_word + 3 segments of large_word)
+    text_segment_lists = AichatComprehendHelper.get_text_segment_lists("#{small_word} #{long_word}")
+    assert_equal 1, text_segment_lists.size
+    assert_equal 4, text_segment_lists[0].size
+    text_segment_lists.flatten.each {|segment| assert segment.bytesize <= 1000}
+  end
+
+  test "emojis and special characters are handled correctly" do
+    # 4 bytes per emoji * 4 emojis = 16 * 1000 = 16000
+    # No spaces so we can test splitting up a UTF-8 string by bytes
+    emoji_string = "😊🚀🔥🪩" * 1000
+    # These are all 2-byte UTF-8 characters. 2 bytes * 10 characters + 1 space = 21 * 1000 = 21000
+    special_chars_string = "դϬƵӋ֚»˙ыۨΚ " * 1000
+    # Total expected bytes: 16000 + 21000 = 37000
+    # Expect 4 lists with 10, 10, 10, and 8 respectively (due to how the characters are chunked, we end up with an extra segment)
+    puts "total byte size: #{(emoji_string + special_chars_string).bytesize}"
+    text_segment_lists = AichatComprehendHelper.get_text_segment_lists(emoji_string + special_chars_string)
+    assert_equal 4, text_segment_lists.size
+    assert_equal 10, text_segment_lists[0].size
+    assert_equal 10, text_segment_lists[1].size
+    assert_equal 10, text_segment_lists[2].size
+    assert_equal 8, text_segment_lists[3].size
+    text_segment_lists.flatten.each {|segment| assert segment.bytesize <= 1000}
+  end
+end


### PR DESCRIPTION
Amazon's Comprehend service, which the Gen AI unit is using for toxicity filtering, has a limit on is DetectToxicContent API of a max of 10 text segments, where each segment must be under 1000 bytes (API reference [here](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectToxicContent.html#API_DetectToxicContent_RequestParameters)).

This adds logic to the AichatComprehendHelper to break up text inputs into <1000 byte chunks, and split up over multiple calls if necessary.

#### Does this mean we'll be making even more calls per request?
In practice, not likely. In my testing, the largest input I could provide to that chatbot that didn't exceed other Sagemaker limits produced 2 separate comprehend calls (exceeded the max of 10 segments per call by just a few more segments). Based on pilot usage however, these long messages are pretty rare unless a student is copying a large amount of text, and even so, they are likely to hit our token limit after continuing such a conversation.

Here's some formatted input showing how large text is broken up:
<img width="672" alt="Screenshot 2024-09-12 at 3 27 07 PM" src="https://github.com/user-attachments/assets/b15a3468-9030-47a4-a8ae-9791401beb1b">

And each of the comprehend responses:
<img width="1051" alt="Screenshot 2024-09-12 at 3 27 18 PM" src="https://github.com/user-attachments/assets/0af13b4f-a3ad-4d26-b699-eb761bc5ca27">

## Testing story

Tested locally + with unit tests.