### PR TITLE
Music: make level data JSON editable, add none sound pack option

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, {useEffect, useMemo, useState} from 'react';
 
+import Alert from '@cdo/apps/componentLibrary/alert/Alert';
 import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
 import {DEFAULT_LIBRARY} from '@cdo/apps/music/constants';
@@ -103,7 +104,7 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
                 labelText="Selected Artist Pack"
                 name="packId"
                 size="s"
-                items={restrictedPacks}
+                items={[{value: 'none', text: '(none)'}, ...restrictedPacks]}
                 selectedValue={levelData.packId}
                 onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
                   const packId =
@@ -188,10 +189,19 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
           </>
         );
       })}
-      <CollapsibleSection headerContent="Current Level Data JSON">
-        <p className={moduleStyles.renderedJson}>
-          {JSON.stringify(levelData, null, 2)}
-        </p>
+      <CollapsibleSection headerContent="Edit Level Data JSON">
+        <div className={moduleStyles.section}>
+          <Alert
+            type="warning"
+            text="Editing level data JSON directly will override any changes made in other sections"
+            size="xs"
+          />
+          <RawJsonEditor
+            currentValue={levelData}
+            fieldName={'levelData'}
+            onChange={newValue => setLevelData(newValue as MusicLevelData)}
+          />
+        </div>
       </CollapsibleSection>
     </div>
   );

--- a/apps/src/lab2/levelEditors/levelData/RawJsonEditor.tsx
+++ b/apps/src/lab2/levelEditors/levelData/RawJsonEditor.tsx
@@ -1,7 +1,7 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
+import Alert from '@cdo/apps/componentLibrary/alert/Alert';
 import {Button} from '@cdo/apps/componentLibrary/button';
-import {BodyThreeText} from '@cdo/apps/componentLibrary/typography';
 
 import moduleStyles from './edit-music-level-data.module.scss';
 
@@ -17,36 +17,67 @@ const RawJsonEditor: React.FunctionComponent<RawJsonEditorProps> = ({
   onChange,
 }) => {
   const [status, setStatus] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
   const [currentValueString, setCurrentValueString] = useState<string>(
     currentValue ? JSON.stringify(currentValue, null, 2) : ''
   );
 
-  const onUpdate = (newValue: string) => {
+  const onUpdate = (newValue: string, closeEditor = false) => {
     try {
       onChange(JSON.parse(newValue));
       setStatus(`Updated at ${new Date().toLocaleTimeString()}`);
+      if (closeEditor) {
+        setEditing(false);
+      }
     } catch (error) {
       setStatus(`ERROR: ${(error as Error).message}`);
     }
   };
 
+  useEffect(() => {
+    if (currentValue) {
+      setCurrentValueString(JSON.stringify(currentValue, null, 2));
+    }
+  }, [currentValue]);
+
   return (
     <div className={moduleStyles.section}>
-      <textarea
-        name={fieldName}
-        value={currentValueString}
-        onChange={event => setCurrentValueString(event.target.value)}
-        className={moduleStyles.textarea}
-      />
+      {editing ? (
+        <textarea
+          name={fieldName}
+          value={currentValueString}
+          onChange={event => setCurrentValueString(event.target.value)}
+          className={moduleStyles.textarea}
+        />
+      ) : (
+        <p className={moduleStyles.renderedJson}>{currentValueString}</p>
+      )}
       <div className={moduleStyles.row}>
         <Button
-          text="Update"
-          onClick={() => onUpdate(currentValueString)}
+          text={editing ? 'Done' : 'Edit'}
+          onClick={() => {
+            editing ? onUpdate(currentValueString, true) : setEditing(true);
+          }}
           size="s"
+          iconLeft={{iconName: editing ? 'circle-check' : 'edit'}}
         />
-        <BodyThreeText className={moduleStyles.noMargin}>
-          {status}
-        </BodyThreeText>
+        {editing && (
+          <Button
+            text="Update"
+            onClick={() => onUpdate(currentValueString)}
+            size="s"
+            iconLeft={{iconName: 'upload'}}
+            color="gray"
+            type="secondary"
+          />
+        )}
+        {status && (
+          <Alert
+            text={status}
+            type={status.includes('ERROR') ? 'danger' : 'success'}
+            size="xs"
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/src/lab2/levelEditors/levelData/edit-music-level-data.module.scss
+++ b/apps/src/lab2/levelEditors/levelData/edit-music-level-data.module.scss
@@ -26,7 +26,7 @@
 .textarea {
   width: 100%;
   box-sizing: border-box;
-  height: 200px;
+  height: 300px;
 }
 
 .row {


### PR DESCRIPTION
Two requested levelbuilder fixes for the Music level edit page:

1) Add a 'none' option to the selected pack dropdown so we're not required to choose a pack ID with the artist library
2) Make the level data JSON editable

For #2, I updated the RawJsonEditor component to toggle between view and edit mode, which will apply to the start sources editor as well.

View mode:
<img width="1512" alt="Screenshot 2024-09-12 at 8 07 08 PM" src="https://github.com/user-attachments/assets/dc684c4e-502f-49fe-995c-872d0d2735b7">

Edit mode:
<img width="867" alt="Screenshot 2024-09-12 at 8 07 26 PM" src="https://github.com/user-attachments/assets/e7fd8854-910f-4ebe-9bd9-3403a80736d5">

Edit mode with error:
<img width="811" alt="Screenshot 2024-09-12 at 8 07 36 PM" src="https://github.com/user-attachments/assets/0b4c2e80-5397-4ccb-85b2-a696c57a2798">

## Testing story

Tested locally.