### PR TITLE
[Aichat] Check both read-only and disabled before showing save alert

### DIFF
--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -140,7 +140,7 @@ const PublishNotes: React.FunctionComponent = () => {
           className={modelCustomizationStyles.updateButton}
         />
       </div>
-      <SaveChangesAlerts />
+      <SaveChangesAlerts isReadOnly={isReadOnly} />
     </div>
   );
 };

--- a/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/RetrievalCustomization.tsx
@@ -52,7 +52,7 @@ const RetrievalCustomization: React.FunctionComponent = () => {
       <div className={modelCustomizationStyles.footerButtonContainer}>
         <UpdateButton isDisabledDefault={isReadOnly} />
       </div>
-      <SaveChangesAlerts />
+      <SaveChangesAlerts isReadOnly={isReadOnly} />
     </div>
   );
 };

--- a/apps/src/aichat/views/modelCustomization/SaveChangesAlerts.tsx
+++ b/apps/src/aichat/views/modelCustomization/SaveChangesAlerts.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {useSelector} from 'react-redux';
 
 import {
   selectCurrentCustomizationsMatchInitial,
@@ -7,13 +6,13 @@ import {
   selectSavedCustomizationsMatchInitial,
 } from '@cdo/apps/aichat/redux/aichatRedux';
 import Alert, {alertTypes} from '@cdo/apps/componentLibrary/alert/Alert';
-import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import styles from '../model-customization-workspace.module.scss';
 
-const SaveChangesAlerts: React.FunctionComponent = () => {
-  const isReadOnly = useSelector(isReadOnlyWorkspace);
+const SaveChangesAlerts: React.FunctionComponent<{isReadOnly: boolean}> = ({
+  isReadOnly,
+}) => {
   const saveInProgress = useAppSelector(state => state.aichat.saveInProgress);
   const havePropertiesChanged = useAppSelector(selectHavePropertiesChanged);
   const isCurrentDefault = useAppSelector(

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -185,7 +185,7 @@ const SetupCustomization: React.FunctionComponent = () => {
       <div className={styles.footerButtonContainer}>
         <UpdateButton isDisabledDefault={allFieldsDisabled} />
       </div>
-      <SaveChangesAlerts />
+      <SaveChangesAlerts isReadOnly={allFieldsDisabled} />
     </div>
   );
 };


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR fixes the bug when “Remember to save your changes” warning is shown even when all fields are disabled.

I added the prop `readOnly` to`SaveChangesAlerts` that is passed from the customization, retrieval, and model card info panels. This `readOnly` value is already determined in each of the panels from checking the `isReadOnlyWorkspace` value and whether the customization fields are disabled. Prior to this fix, only the `isReadOnlyWorkspace` state was checked.




## Before update

https://github.com/user-attachments/assets/e54c0810-8c8b-4ccb-8d38-5f320212e750


## After update

https://github.com/user-attachments/assets/d33290a1-cf73-4954-845a-dee3899500c7



## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1019)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I checked locally on a level contained a panel with disabled fields: '/s/gen-ai-staging/lessons/12/levels/2'.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
