### PR TITLE
[Music Lab] +/- Procedures for Advanced Mode

### DIFF
--- a/apps/i18n/music/en_us.json
+++ b/apps/i18n/music/en_us.json
@@ -94,5 +94,6 @@
   "effectsLabelsOff": "Off",
   "effectsLabelsVolume": "Volume",
   "effectsLabelsDelay": "Delay",
-  "effectsLabelsFilter": "Filter"
+  "effectsLabelsFilter": "Filter",
+  "parameter": "parameter"
 }

--- a/apps/package.json
+++ b/apps/package.json
@@ -173,6 +173,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^1.5.4",
+    "@blockly/block-plus-minus": "^8.0.9",
     "@blockly/block-shareable-procedures": "~4.0.5",
     "@blockly/field-bitmap": "^4.1.0",
     "@blockly/field-grid-dropdown": "~4.0.9",

--- a/apps/src/Globals.d.ts
+++ b/apps/src/Globals.d.ts
@@ -33,6 +33,7 @@ declare module '*.svg' {
 }
 
 // Modules without types
+declare module '@blockly/block-plus-minus';
 declare module '@blockly/plugin-scroll-options';
 declare module '@blockly/keyboard-navigation';
 declare module '@blockly/field-angle';

--- a/apps/src/music/blockly/advancedProcedures.ts
+++ b/apps/src/music/blockly/advancedProcedures.ts
@@ -1,0 +1,8 @@
+import musicI18n from '../locale';
+
+export function installAdvancedProcedures() {
+  Blockly.Extensions.unregister('procedure_caller_mutator');
+  Blockly.Extensions.unregister('procedure_def_mutator');
+  require('@blockly/block-plus-minus');
+  Blockly.Msg['PROCEDURE_VARIABLE'] = musicI18n.parameter();
+}

--- a/apps/src/music/blockly/advancedProcedures.ts
+++ b/apps/src/music/blockly/advancedProcedures.ts
@@ -4,5 +4,6 @@ export function installAdvancedProcedures() {
   Blockly.Extensions.unregister('procedure_caller_mutator');
   Blockly.Extensions.unregister('procedure_def_mutator');
   require('@blockly/block-plus-minus');
+  // We use the label 'parameter' to align to CSTA standards and our curriculum.
   Blockly.Msg['PROCEDURE_VARIABLE'] = musicI18n.parameter();
 }

--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -2,6 +2,7 @@ import {getBlockMode} from '../appConfig';
 import {BlockMode} from '../constants';
 import musicI18n from '../locale';
 
+import {installAdvancedProcedures} from './advancedProcedures';
 import {
   DEFAULT_TRACK_NAME_EXTENSION,
   DOCS_BASE_URL,
@@ -62,6 +63,8 @@ export function setUpBlocklyForMusicLab() {
     // we don't want.
     delete Blockly.Blocks.procedures_defreturn;
     delete Blockly.Blocks.procedures_ifreturn;
+  } else {
+    installAdvancedProcedures();
   }
 
   Blockly.fieldRegistry.register(FIELD_SOUNDS_TYPE, FieldSounds);

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -2586,6 +2586,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@blockly/block-plus-minus@npm:^8.0.9":
+  version: 8.0.9
+  resolution: "@blockly/block-plus-minus@npm:8.0.9"
+  peerDependencies:
+    blockly: ^11.0.0
+  checksum: f684c0d3c4e08d0996de8abda94accf78d657a6774558bd1149a72e1fa5811edc8cf66f03e2e70bff27de984f48993795585bafd9f6c16792d27ea10a71945a0
+  languageName: node
+  linkType: hard
+
 "@blockly/block-shareable-procedures@npm:~4.0.5":
   version: 4.0.6
   resolution: "@blockly/block-shareable-procedures@npm:4.0.6"
@@ -8539,6 +8548,7 @@ __metadata:
     "@babel/polyfill": ^7.12.1
     "@babel/preset-env": ^7.24.4
     "@babel/preset-react": ^7.24.1
+    "@blockly/block-plus-minus": ^8.0.9
     "@blockly/block-shareable-procedures": ~4.0.5
     "@blockly/field-bitmap": ^4.1.0
     "@blockly/field-grid-dropdown": ~4.0.9


### PR DESCRIPTION
This is a follow up to:
- https://github.com/code-dot-org/code-dot-org/pull/60860

We now having function blocks in advanced mode that support parameters and return values. However, the team is looking to improve the user experience with these blocks. Particularly, adding parameters via the current mutator (a separate flyout) has been found to be undesirable:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/2df4509c-687a-40a7-8134-da96a44de8a1">

Mainline Blockly affords us the ability to utilize their extensive plugin library, including `@blockly/block-plus-minus` which offers a group of blocks that replace the built-in mutator UI with a +/- based UI. The plugin includes blocks for functions, conditionals, lists, and text concatenation, all of which can be used at the demo page here: 
https://google.github.io/blockly-samples/plugins/block-plus-minus/test/index.html
https://www.npmjs.com/package/@blockly/block-plus-minus

Unfortunately, the plugin is not modular; importing it immediately attempts to install all of its included blocks. Our Google Blockly labs already use the +/- UI for `if` and `text join` blocks, although we don't use the plugin to accomplish this. This is because the plus-minus procedure blocks weren't compatible with our old labs, and we needed to slightly modify the others to make them compatible with our legacy XML sources. 

Since Music Lab doesn't have the challenge of supporting old sources, it is safe to use the blocks from the plugin right out of the box. At this time, the only modification I've made is to change a "variable" label to "parameter" to better align with the language of the CSTA standards.

<img width="1198" alt="image" src="https://github.com/user-attachments/assets/6f29f929-6b82-4af2-a005-73a9f53c0eff">

With the new UI, parameters can be added or removed by clicking `+` or `-` and renamed directly on the block field.



## Links

https://docs.google.com/document/d/1NROqFS9gA4wklBNsxdrFQbou9HHI-fwPEetKGNm-Eho/edit#heading=h.kmcm7f8wnkm2
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## Follow-up work


The curriculum team is interested in pursuing further improvements to parameters before launch, but that is out of scope for this task.
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
