### PR TITLE
Music: AI drums validations

### DIFF
--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -50,6 +50,7 @@ export const BlockMode = {
 export const DEFAULT_PATTERN = {
   kit: 'drums',
   events: [],
+  ai: false,
 };
 
 export const DEFAULT_PATTERN_LENGTH = 1;
@@ -60,6 +61,7 @@ export const DEFAULT_PATTERN_AI = {
   kit: 'drums',
   length: 2,
   events: [],
+  ai: true,
 };
 
 export const DEFAULT_PATTERN_AI_LENGTH = 2;

--- a/apps/src/music/player/interfaces/PatternEvent.ts
+++ b/apps/src/music/player/interfaces/PatternEvent.ts
@@ -12,6 +12,7 @@ export interface PatternEventValue {
   kit: string;
   length?: 1 | 2;
   events: PatternTickEvent[];
+  ai?: boolean;
 }
 
 export interface PatternTickEvent {

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -33,6 +33,11 @@ export const MusicConditions: ConditionNames = {
   PLAYED_CHORDS: {name: 'played_chords', valueType: 'number'},
   PLAYED_EMPTY_PATTERNS: {name: 'played_empty_patterns', valueType: 'number'},
   PLAYED_PATTERNS: {name: 'played_patterns', valueType: 'number'},
+  PLAYED_EMPTY_PATTERNS_AI: {
+    name: 'played_empty_patterns_ai',
+    valueType: 'number',
+  },
+  PLAYED_PATTERNS_AI: {name: 'played_patterns_ai', valueType: 'number'},
 };
 
 export default class MusicValidator extends Validator {
@@ -72,6 +77,10 @@ export default class MusicValidator extends Validator {
     // that are empty and those with events.
     let playedNumberEmptyPatterns = 0;
     let playedNumberPatterns = 0;
+
+    // And the same for patterns made with AI.
+    let playedNumberEmptyPatternsAi = 0;
+    let playedNumberPatternsAi = 0;
 
     // Get number of chords that have been started, separately counting those
     // that are empty and those with notes.
@@ -121,9 +130,17 @@ export default class MusicValidator extends Validator {
       } else if (eventData.type === 'pattern') {
         const patternEvent = eventData as PatternEvent;
         if (patternEvent.value.events.length === 0) {
-          playedNumberEmptyPatterns++;
+          if (patternEvent.value.ai) {
+            playedNumberEmptyPatternsAi++;
+          } else {
+            playedNumberEmptyPatterns++;
+          }
         } else {
-          playedNumberPatterns++;
+          if (patternEvent.value.ai) {
+            playedNumberPatternsAi++;
+          } else {
+            playedNumberPatterns++;
+          }
         }
       } else if (eventData.type === 'chord') {
         const chordEvent = eventData as ChordEvent;
@@ -177,6 +194,16 @@ export default class MusicValidator extends Validator {
     this.addPlayedConditions(
       MusicConditions.PLAYED_PATTERNS.name,
       playedNumberPatterns
+    );
+
+    // And the same for patterns made with AI.
+    this.addPlayedConditions(
+      MusicConditions.PLAYED_EMPTY_PATTERNS_AI.name,
+      playedNumberEmptyPatternsAi
+    );
+    this.addPlayedConditions(
+      MusicConditions.PLAYED_PATTERNS_AI.name,
+      playedNumberPatternsAi
     );
 
     // Add satisfied conditions for the played chords.


### PR DESCRIPTION
Add validations for the AI drums block: `played_patterns_ai` and `played_empty_patterns_ai`.  

Each takes a numerical value for how many times such a block is encountered.  

They mirror the existing `played_patterns` and `played_empty_patterns` validations.
