### PR TITLE
Associate lti_user_identities with lti_deployments

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -183,6 +183,12 @@ class LtiV1Controller < ApplicationController
           metadata: metadata,
         )
 
+        # Add user's lti_user_identity to deployment if it doesn't exist
+        lti_user_identity = Queries::Lti.lti_user_identity(user, integration)
+        unless deployment.lti_user_identities.include?(lti_user_identity)
+          deployment.lti_user_identities << lti_user_identity
+        end
+
         # If this is the user's first login, send them into the account linking flow
         unless user.lms_landing_opted_out
           Services::Lti.initialize_lms_landing_session(session, integration[:platform_name], 'continue', user.user_type)

--- a/dashboard/app/models/lti_deployment.rb
+++ b/dashboard/app/models/lti_deployment.rb
@@ -15,4 +15,5 @@
 #
 class LtiDeployment < ApplicationRecord
   belongs_to :lti_integration
+  has_and_belongs_to_many :lti_user_identities
 end

--- a/dashboard/app/models/lti_user_identity.rb
+++ b/dashboard/app/models/lti_user_identity.rb
@@ -21,6 +21,7 @@ class LtiUserIdentity < ApplicationRecord
   acts_as_paranoid
   belongs_to :lti_integration
   belongs_to :user
+  has_and_belongs_to_many :lti_deployments
 
   validates :subject, presence: true
 end

--- a/dashboard/lib/queries/lti.rb
+++ b/dashboard/lib/queries/lti.rb
@@ -12,6 +12,10 @@ class Queries::Lti
     user.lti_user_identities.find_by(lti_integration_id: lti_integration.id)&.subject
   end
 
+  def self.lti_user_identity(user, lti_integration)
+    user.lti_user_identities.find_by(lti_integration_id: lti_integration[:id])
+  end
+
   def self.get_lti_integration(issuer, client_id)
     LtiIntegration.find_by(issuer: issuer, client_id: client_id)
   end

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -192,12 +192,13 @@ module Services
         user_was_new = user.new_record?
         had_changes ||= (user_was_new || user.changed?)
         user.save!
-        lti_user_identity = Queries::Lti.lti_user_identity(user, lti_integration)
-        deployment = lti_section.lti_course&.lti_deployment
-        unless deployment.lti_user_identities.include?(lti_user_identity) || deployment.nil?
-          deployment.lti_user_identities << lti_user_identity
-        end
         if user_was_new
+          lti_user_identity = Queries::Lti.lti_user_identity(user, lti_integration)
+          deployment = lti_section.lti_course&.lti_deployment
+          unless deployment.lti_user_identities.include?(lti_user_identity) || deployment.nil?
+            deployment.lti_user_identities << lti_user_identity
+          end
+
           Metrics::Events.log_event(
             user: user,
             event_name: 'lti_user_created',

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -194,7 +194,7 @@ module Services
         user.save!
         lti_user_identity = Queries::Lti.lti_user_identity(user, lti_integration)
         deployment = lti_section.lti_course&.lti_deployment
-        unless deployment.lti_user_identities.include?(lti_user_identity)
+        unless deployment.lti_user_identities.include?(lti_user_identity) || deployment.nil?
           deployment.lti_user_identities << lti_user_identity
         end
         if user_was_new

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -195,7 +195,7 @@ module Services
         if user_was_new
           lti_user_identity = Queries::Lti.lti_user_identity(user, lti_integration)
           deployment = lti_section.lti_course&.lti_deployment
-          unless deployment.lti_user_identities.include?(lti_user_identity) || deployment.nil?
+          unless deployment&.lti_user_identities&.include?(lti_user_identity)
             deployment.lti_user_identities << lti_user_identity
           end
 

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -192,6 +192,11 @@ module Services
         user_was_new = user.new_record?
         had_changes ||= (user_was_new || user.changed?)
         user.save!
+        lti_user_identity = Queries::Lti.lti_user_identity(user, lti_integration)
+        deployment = lti_section.lti_course&.lti_deployment
+        unless deployment.lti_user_identities.include?(lti_user_identity)
+          deployment.lti_user_identities << lti_user_identity
+        end
         if user_was_new
           Metrics::Events.log_event(
             user: user,

--- a/dashboard/test/controllers/lti_v1_controller_test.rb
+++ b/dashboard/test/controllers/lti_v1_controller_test.rb
@@ -509,7 +509,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
   test 'auth - given an existing deployment_id in our system, do not create a new LtiDeployment' do
     payload = get_valid_payload
     jwt = create_jwt_and_stub(payload)
-    deployment = LtiDeployment.create(deployment_id: @deployment_id, lti_integration_id: @integration.id)
+    deployment = create(:lti_deployment, deployment_id: @deployment_id, lti_integration: @integration)
     assert deployment
     post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
     assert_equal deployment, @integration.lti_deployments.first
@@ -520,7 +520,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     payload = get_valid_payload
     jwt = create_jwt_and_stub(payload)
     user = create_preexisting_user(payload)
-    deployment = LtiDeployment.create(deployment_id: @deployment_id, lti_integration_id: @integration.id)
+    deployment = create(:lti_deployment, deployment_id: @deployment_id, lti_integration: @integration)
     assert_equal deployment.lti_user_identities.count, 0
     post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}
     assert_equal deployment.lti_user_identities.count, 1
@@ -531,7 +531,7 @@ class LtiV1ControllerTest < ActionDispatch::IntegrationTest
     payload = get_valid_payload
     jwt = create_jwt_and_stub(payload)
     user = create_preexisting_user(payload)
-    deployment = LtiDeployment.create(deployment_id: @deployment_id, lti_integration_id: @integration.id)
+    deployment = create(:lti_deployment, deployment_id: @deployment_id, lti_integration: @integration)
     deployment.lti_user_identities << user.lti_user_identities.first
     assert_equal deployment.lti_user_identities.count, 1
     post '/lti/v1/authenticate', params: {id_token: jwt, state: @state}

--- a/dashboard/test/lib/queries/lti_test.rb
+++ b/dashboard/test/lib/queries/lti_test.rb
@@ -89,4 +89,19 @@ class Services::LtiTest < ActiveSupport::TestCase
 
     assert_nil Queries::Lti.lti_user_id(lti_user_identity.user, other_lti_integration)
   end
+
+  test 'lti_user_identity should return the lti_user_identity for a given user' do
+    lti_integration = create :lti_integration
+    lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
+
+    assert_equal lti_user_identity, Queries::Lti.lti_user_identity(lti_user_identity.user, lti_integration)
+  end
+
+  test 'lti_user_identity should return nil if there are no matching identities' do
+    lti_integration = create :lti_integration
+    other_lti_integration = create :lti_integration
+    lti_user_identity = create :lti_user_identity, lti_integration: lti_integration
+
+    assert_nil Queries::Lti.lti_user_identity(lti_user_identity.user, other_lti_integration)
+  end
 end


### PR DESCRIPTION
This PR implements the migration introduced in [this PR](https://github.com/code-dot-org/code-dot-org/pull/60992). It uses the new join table to add a user's lti_user_identity to an lti_deployment. This is done in order to report Schoology metrics, where an lti_deployment represents a School/District account. It allows us to associate a number of users to a specific Schoology installation, since Schoology installation of our LTI tool uses the same Client ID and LTI Integration in our system.

This new functionality will add a user's LtiUserIdentity to the related LtiDeployment on _either_ an LTI launch _or_ a course sync action. As a result, this should start populating the join table with users, which will enable us to report on individual Schoology integrations metrics.

**Screen Recording Demo**

https://github.com/user-attachments/assets/42e967a1-3131-4ad0-857b-d9cf251f7f5d

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

```
bundle exec spring testunit ./test/controllers/lti_v1_controller_test.rb

Since there is no EDITOR or BETTER_ERRORS_EDITOR environment variable, using Textmate by default.===============================                                              ] 72% Time: 00:00:09,  ETA: 00:00:04
  51/51: [===================================================================================================================================================================] 100% Time: 00:00:12, Time: 00:00:12

Finished in 12.43427s
51 tests, 125 assertions, 0 failures, 0 errors, 0 skips
```
```
bundle exec spring testunit ./test/lib/queries/lti_test.rb
Running via Spring preloader in process 33852
Started with run options --seed 46536

  11/11: [===================================================================================================================================================================] 100% Time: 00:00:00, Time: 00:00:00

Finished in 0.63768s
11 tests, 11 assertions, 0 failures, 0 errors, 0 skips
```
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
