### PR TITLE
Aichat: don't call comprehend with blank text

### DIFF
--- a/dashboard/app/helpers/aichat_comprehend_helper.rb
+++ b/dashboard/app/helpers/aichat_comprehend_helper.rb
@@ -11,6 +11,8 @@ module AichatComprehendHelper
 
   # Moderate given text for inappropriate/toxic content using AWS Comprehend client.
   def self.get_toxicity(text, locale)
+    return nil if text.blank?
+
     text_segment_lists = get_text_segment_lists(text)
     all_results = []
     text_segment_lists.each do |list|

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -1108,6 +1108,8 @@ class FilesApi < Sinatra::Base
       source = JSON.parse(body)['source']
       source_json = JSON.parse(source)
       text = source_json['systemPrompt'] + ' ' + source_json['retrievalContexts'].join(' ')
+      # Nothing to check if there is no system prompt or retrieval
+      return nil if text.blank?
       # Use AWS Comprehend to check AI Chat contents for toxicity.
       # get_toxicity returns an object with the following fields:
       # text: string, toxicity: number, and max_category {name: string, score: number}

--- a/dashboard/test/helpers/aichat_comprehend_helper_test.rb
+++ b/dashboard/test/helpers/aichat_comprehend_helper_test.rb
@@ -69,6 +69,12 @@ class AichatComprehendHelperTest < ActionView::TestCase
     assert_equal 0.9, response[:max_category].score
   end
 
+  test 'returns nil if text is nil, empty, or blank' do
+    assert_nil AichatComprehendHelper.get_toxicity(nil, 'en')
+    assert_nil AichatComprehendHelper.get_toxicity("", 'en')
+    assert_nil AichatComprehendHelper.get_toxicity("         ", 'en')
+  end
+
   test 'correctly chunks long text inputs' do
     # 5 characters * 3000 = 15000 bytes.
     long_message = "abcd " * 3000


### PR DESCRIPTION
Our UI test caught an error where if Comprehend was called with blank text (empty text segments), it would produce an error. This adds checks so we don't call Comprehend if the provided text is blank.

## Links

https://codedotorg.slack.com/archives/C0T0PNTM3/p1726251110135579

## Testing story

Tested locally + unit. Currently trying to run UI test locally.