### PR TITLE
updated xCloseButton styles to respond to language direction

### DIFF
--- a/apps/src/sharedComponents/accessible-dialogue.module.scss
+++ b/apps/src/sharedComponents/accessible-dialogue.module.scss
@@ -38,7 +38,7 @@
 
   position: absolute;
   top: 1rem;
-  right: 1rem;
+  inset-inline-end: 1rem; // Logical property for right in LTR, left in RTL
 
   i {
     color: $light_gray_300;


### PR DESCRIPTION
While working with Accessible Dialog I noticed the close button did not shift when changing the language direction and overlapped with the Dialog header in some instances.

This PR changes the `xCloseButton` property to be `inset-inline-end`, which will be `right` in LTR and `left` in RTL.

## Testing story
Production vs Development
![Screenshot 2024-09-13 at 13 13 16](https://github.com/user-attachments/assets/05d35c55-84ce-4bed-af9d-9b06b6515595)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
