### PR TITLE
stop notifying on Adhoc memory alarms

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "staging"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "staging"
-    ]
-}

--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -21,8 +21,8 @@
 <%    unless rack_env?(:adhoc) -%>
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-<%= rack_env?(:production) ? 'Urgent' : 'LowPriority'%>"
-        AlarmDescription: Daemon memory utilization exceeds 87% for 5 minutes
 <%    end -%>
+      AlarmDescription: Daemon memory utilization exceeds 87% for 5 minutes
       AlarmName: <%="#{stack_name}_daemon_high_memory_utilization" %>
       ComparisonOperator: GreaterThanThreshold
       Dimensions:

--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -22,7 +22,7 @@
 <%      unless rack_env?(:adhoc) -%>
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-<%= rack_env?(:production) ? 'Urgent' : 'LowPriority'%>"
 <%      end -%>
-      AlarmDescription: Send page if daemon memory utilization exceeds 87% for 5 minutes
+      AlarmDescription: Daemon memory utilization exceeds 87% for 5 minutes
       AlarmName: <%="#{stack_name}_daemon_high_memory_utilization" %>
       ComparisonOperator: GreaterThanThreshold
       Dimensions:

--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -18,11 +18,11 @@
   DaemonMemoryUtilizationAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
+<%    unless rack_env?(:adhoc) -%>
       AlarmActions:
-<%      unless rack_env?(:adhoc) -%>
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-<%= rack_env?(:production) ? 'Urgent' : 'LowPriority'%>"
-<%      end -%>
-      AlarmDescription: Daemon memory utilization exceeds 87% for 5 minutes
+        AlarmDescription: Daemon memory utilization exceeds 87% for 5 minutes
+<%    end -%>
       AlarmName: <%="#{stack_name}_daemon_high_memory_utilization" %>
       ComparisonOperator: GreaterThanThreshold
       Dimensions:

--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -19,7 +19,9 @@
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       AlarmActions:
+<%      unless rack_env?(:adhoc) -%>
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-<%= rack_env?(:production) ? 'Urgent' : 'LowPriority'%>"
+<%      end -%>
       AlarmDescription: Send page if daemon memory utilization exceeds 87% for 5 minutes
       AlarmName: <%="#{stack_name}_daemon_high_memory_utilization" %>
       ComparisonOperator: GreaterThanThreshold

--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -22,7 +22,7 @@
       AlarmActions:
         - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-<%= rack_env?(:production) ? 'Urgent' : 'LowPriority'%>"
 <%    end -%>
-      AlarmDescription: Daemon memory utilization exceeds 87% for 5 minutes
+      AlarmDescription: Daemon memory utilization exceeded 87% for 5 minutes
       AlarmName: <%="#{stack_name}_daemon_high_memory_utilization" %>
       ComparisonOperator: GreaterThanThreshold
       Dimensions:


### PR DESCRIPTION
Keep the alarm itself, but stop notifying the LowPriority SNS Topic when Adhoc environments breach the DaemonMemoryUtilizationAlarm.

Also adjusting the alarm description to not imply paging, which is separate from this config.

## Links

Slack convo: https://codedotorg.slack.com/archives/C03CK49G9/p1726256256186779

## Testing story

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
