### PR TITLE
remove unused Slack functions

### DIFF
--- a/lib/cdo/chat_client.rb
+++ b/lib/cdo/chat_client.rb
@@ -46,10 +46,6 @@ class ChatClient
     )
   end
 
-  def self.snippet(message)
-    Slack.snippet(CDO.slack_log_room, message)
-  end
-
   def self.wrap(name, backtrace: false)
     start_time = Time.now
     ChatClient.log "Running #{name}..."

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -167,15 +167,6 @@ class Slack
     return !!result
   end
 
-  # @param room [String] Channel name or id to post the snippet.
-  # @param text [String] Snippet text.
-  def self.snippet(room, text)
-    # omit leading '#' when passing channel names to this API
-    channel = CHANNEL_MAP[room] || room
-    result = post_to_slack("https://slack.com/api/files.upload?channels=#{channel}&content=#{URI.encode_www_form_component(text)}")
-    return !!result
-  end
-
   # @param name [String] Name of the Slack channel to join.
   def self.join_room(name)
     channel = get_channel_id(name)


### PR DESCRIPTION
The `files.upload` API is being deprecated next year. As far as I can tell, we're not using it, so I'm deleting this dead code.

## Links

Slack Dev Blog: https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
