### PR TITLE
Aichat: add webpurify and blocklist + update data format

### DIFF
--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -59,7 +59,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
     # Moderate user input for toxicity.
     # get_toxicity returns an object with the following fields:
     # text: string, toxicity: number, and max_category {name: string, score: number}
-    user_toxicity = find_toxicity(new_message[:chatMessageText], get_toxicity_threshold_user_input, locale)
+    user_toxicity = find_toxicity('user', new_message[:chatMessageText], get_toxicity_threshold_user_input, locale)
     return [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:USER_PROFANITY], user_toxicity.to_json] if user_toxicity
 
     user_pii = find_pii(new_message[:chatMessageText], locale)
@@ -69,7 +69,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
     response = AichatSagemakerHelper.get_sagemaker_assistant_response(model_customizations, stored_messages, new_message, level_id)
 
     # Moderate model output for toxicity. Report to HoneyBadger if the model returns toxicity.
-    model_toxicity = find_toxicity(response, get_toxicity_threshold_model_output, locale)
+    model_toxicity = find_toxicity('assistant', response, get_toxicity_threshold_model_output, locale)
     if model_toxicity
       Honeybadger.notify(
         'Toxicity returned from aichat model (blocked before reaching student)',
@@ -89,19 +89,19 @@ class AichatRequestChatCompletionJob < ApplicationJob
 
   # Checks for toxicity in the given text using various services, determined by DCDO settings.
   # Returns {text: input (string), blocked_by: serviced that detected toxicity (string), details: filtering details (hash)}
-  private def find_toxicity(text, threshold, locale)
-    if blocklist_enabled?
+  private def find_toxicity(role, text, threshold, locale)
+    if blocklist_enabled?(role)
       text.split.each do |word|
         return {text: text, blocked_by: 'blocklist', details: {blocked_word: word}} if profane_word_blocklist.include? word
       end
     end
 
-    if webpurify_enabled?
+    if webpurify_enabled?(role)
       profanity = ShareFiltering.find_profanity_failure(text, locale)
       return {text: text, blocked_by: 'webpurify', details: profanity.to_h} if profanity
     end
 
-    if comprehend_enabled?
+    if comprehend_enabled?(role)
       comprehend_response = AichatComprehendHelper.get_toxicity(text, locale)
       return {text: text, blocked_by: 'comprehend', details: comprehend_response} if comprehend_response && comprehend_response[:toxicity] > threshold
     end
@@ -112,16 +112,16 @@ class AichatRequestChatCompletionJob < ApplicationJob
     # TODO: Check for PII. Currently we don't check for PII but we plan to add post-launch.
   end
 
-  private def comprehend_enabled?
-    DCDO.get("aichat_safety_comprehend_enabled", true)
+  private def comprehend_enabled?(role)
+    DCDO.get("aichat_safety_comprehend_enabled_#{role}", true)
   end
 
-  private def webpurify_enabled?
-    DCDO.get("aichat_safety_webpurify_enabled", false)
+  private def webpurify_enabled?(role)
+    DCDO.get("aichat_safety_webpurify_enabled_#{role}", false)
   end
 
-  private def blocklist_enabled?
-    DCDO.get("aichat_safety_blocklist_enabled", false)
+  private def blocklist_enabled?(role)
+    DCDO.get("aichat_safety_blocklist_enabled_#{role}", false)
   end
 
   private def profane_word_blocklist

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -103,7 +103,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
 
     if comprehend_enabled?
       comprehend_response = AichatComprehendHelper.get_toxicity(text, locale)
-      return {text: text, blocked_by: 'comprehend', details: comprehend_response} if comprehend_response[:toxicity] > threshold
+      return {text: text, blocked_by: 'comprehend', details: comprehend_response} if comprehend_response && comprehend_response[:toxicity] > threshold
     end
   end
 

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -59,8 +59,8 @@ class AichatRequestChatCompletionJob < ApplicationJob
     # Moderate user input for toxicity.
     # get_toxicity returns an object with the following fields:
     # text: string, toxicity: number, and max_category {name: string, score: number}
-    user_comprehend_response = AichatComprehendHelper.get_toxicity(new_message[:chatMessageText], locale)
-    return [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:USER_PROFANITY], "Profanity detected in user input: #{user_comprehend_response}"] if user_comprehend_response[:toxicity] > get_toxicity_threshold_user_input
+    user_toxicity = find_toxicity(new_message[:chatMessageText], get_toxicity_threshold_user_input, locale)
+    return [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:USER_PROFANITY], user_toxicity.to_json] if user_toxicity
 
     user_pii = find_pii(new_message[:chatMessageText], locale)
     return [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:USER_PII], "PII detected in user input: #{user_pii}"] if user_pii
@@ -69,16 +69,16 @@ class AichatRequestChatCompletionJob < ApplicationJob
     response = AichatSagemakerHelper.get_sagemaker_assistant_response(model_customizations, stored_messages, new_message, level_id)
 
     # Moderate model output for toxicity. Report to HoneyBadger if the model returns toxicity.
-    model_comprehend_response = AichatComprehendHelper.get_toxicity(response, locale)
-    if model_comprehend_response[:toxicity] > get_toxicity_threshold_model_output
+    model_toxicity = find_toxicity(response, get_toxicity_threshold_model_output, locale)
+    if model_toxicity
       Honeybadger.notify(
         'Toxicity returned from aichat model (blocked before reaching student)',
         context: {
           response: response,
-          flagged_content: model_comprehend_response,
+          flagged_content: model_toxicity.to_json,
         }
       )
-      return [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:MODEL_PROFANITY], "Profanity detected in model output: #{model_comprehend_response}"]
+      return [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:MODEL_PROFANITY], model_toxicity.to_json]
     end
 
     model_pii = find_pii(response, locale)
@@ -87,8 +87,44 @@ class AichatRequestChatCompletionJob < ApplicationJob
     [SharedConstants::AI_REQUEST_EXECUTION_STATUS[:SUCCESS], response]
   end
 
+  # Checks for toxicity in the given text using various services, determined by DCDO settings.
+  # Returns {text: input (string), blocked_by: serviced that detected toxicity (string), details: filtering details (hash)}
+  private def find_toxicity(text, threshold, locale)
+    if blocklist_enabled?
+      text.split.each do |word|
+        return {text: text, blocked_by: 'blocklist', details: {blocked_word: word}} if profane_word_blocklist.include? word
+      end
+    end
+
+    if webpurify_enabled?
+      profanity = ShareFiltering.find_profanity_failure(text, locale)
+      return {text: text, blocked_by: 'webpurify', details: profanity.to_h} if profanity
+    end
+
+    if comprehend_enabled?
+      comprehend_response = AichatComprehendHelper.get_toxicity(text, locale)
+      return {text: text, blocked_by: 'comprehend', details: comprehend_response} if comprehend_response[:toxicity] > threshold
+    end
+  end
+
   # Check the given text for PII.
   private def find_pii(text, locale)
     # TODO: Check for PII. Currently we don't check for PII but we plan to add post-launch.
+  end
+
+  private def comprehend_enabled?
+    DCDO.get("aichat_safety_comprehend_enabled", true)
+  end
+
+  private def webpurify_enabled?
+    DCDO.get("aichat_safety_webpurify_enabled", false)
+  end
+
+  private def blocklist_enabled?
+    DCDO.get("aichat_safety_blocklist_enabled", false)
+  end
+
+  private def profane_word_blocklist
+    DCDO.get("aichat_safety_profane_word_blocklist", [])
   end
 end

--- a/dashboard/test/jobs/aichat_request_chat_completion_job_test.rb
+++ b/dashboard/test/jobs/aichat_request_chat_completion_job_test.rb
@@ -5,6 +5,22 @@ class AichatRequestChatCompletionJobTest < ActiveJob::TestCase
     @student = create :student
     @model_customizations = {temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test"}
     @new_message = {chatMessageText: 'hello', role: 'user', status: 'unknown', timestamp: Time.now.to_i}
+    @blocklist_blocked_word = "blocked_profanity"
+    @comprehend_response = {
+      flagged_segment: 'comprehend-toxicity',
+      toxicity: 0.9,
+      max_category: {
+        score: 0.7,
+        name: "INSULT"
+      }
+    }
+    @profane_message = "profanity hello #{@blocklist_blocked_word}"
+
+    DCDO.stubs(:get).with("aichat_toxicity_threshold_user_input", anything).returns(AichatRequestChatCompletionJob::DEFAULT_TOXICITY_THRESHOLD_USER_INPUT)
+    DCDO.stubs(:get).with("aichat_toxicity_threshold_model_output", anything).returns(AichatRequestChatCompletionJob::DEFAULT_TOXICITY_THRESHOLD_MODEL_OUTPUT)
+    DCDO.stubs(:get).with("aichat_safety_profane_word_blocklist", anything).returns([@blocklist_blocked_word])
+
+    stub_safety_services(nil, 'user')
   end
 
   test 'execution status is set to QUEUED before perform' do
@@ -13,38 +29,37 @@ class AichatRequestChatCompletionJobTest < ActiveJob::TestCase
     assert_equal SharedConstants::AI_REQUEST_EXECUTION_STATUS[:QUEUED], request.reload.execution_status
   end
 
-  test 'execution status is set to USER_PROFANITY if profanity is detected in the input' do
-    profanity = 'expletive'
-    AichatComprehendHelper.stubs(:get_toxicity).returns({toxicity: 0.3, text: profanity})
+  %w[blocklist webpurify comprehend].each do |service|
+    test "execution status is set to USER_PROFANITY if user input is blocked by #{service}" do
+      stub_safety_services(service, 'user')
+      request = create :aichat_request, new_message: {chatMessageText: @profane_message, role: 'user', status: 'unknown', timestamp: Time.now.to_i}.to_json
+      perform_enqueued_jobs do
+        AichatRequestChatCompletionJob.perform_later(request: request, locale: 'en')
+      end
 
-    request = create :aichat_request
-    perform_enqueued_jobs do
-      AichatRequestChatCompletionJob.perform_later(request: request, locale: 'en')
+      assert_equal SharedConstants::AI_REQUEST_EXECUTION_STATUS[:USER_PROFANITY], request.reload.execution_status
+      response = JSON.parse(request.response).deep_symbolize_keys
+      verify_safety_response(service, response)
     end
-
-    assert_equal SharedConstants::AI_REQUEST_EXECUTION_STATUS[:USER_PROFANITY], request.reload.execution_status
-    assert request.response.include?(profanity)
   end
 
-  test 'execution status is set to MODEL_PROFANITY if profanity is detected in the output' do
-    model_response = 'profane response'
-    profanity = 'expletive'
-    AichatComprehendHelper.stubs(:get_toxicity).returns({toxicity: 0.1, text: 'test'})
-    AichatSagemakerHelper.stubs(:get_sagemaker_assistant_response).returns(model_response)
-    AichatComprehendHelper.stubs(:get_toxicity).with(model_response, 'en').returns(toxicity: 0.7, text: profanity)
+  %w[blocklist webpurify comprehend].each do |service|
+    test "execution status is set to MODEL_PROFANITY if model response is blocked by #{service}" do
+      stub_safety_services(service, 'assistant')
+      request = create :aichat_request
+      AichatSagemakerHelper.stubs(:get_sagemaker_assistant_response).returns(@profane_message)
+      perform_enqueued_jobs do
+        AichatRequestChatCompletionJob.perform_later(request: request, locale: 'en')
+      end
 
-    request = create :aichat_request
-    perform_enqueued_jobs do
-      AichatRequestChatCompletionJob.perform_later(request: request, locale: 'en')
+      assert_equal SharedConstants::AI_REQUEST_EXECUTION_STATUS[:MODEL_PROFANITY], request.reload.execution_status
+      response = JSON.parse(request.response).deep_symbolize_keys
+      verify_safety_response(service, response)
     end
-
-    assert_equal SharedConstants::AI_REQUEST_EXECUTION_STATUS[:MODEL_PROFANITY], request.reload.execution_status
-    assert request.response.include?(profanity)
   end
 
   test 'execution status is set to SUCCESS if no profanity is detected' do
     model_response = 'response'
-    AichatComprehendHelper.stubs(:get_toxicity).returns({toxicity: 0.1, text: 'test'})
     AichatSagemakerHelper.stubs(:get_sagemaker_assistant_response).returns(model_response)
 
     request = create :aichat_request
@@ -58,7 +73,6 @@ class AichatRequestChatCompletionJobTest < ActiveJob::TestCase
 
   test 'execution status is set to FAILURE and an exception is raised if an unexpected error occurs' do
     error_message = 'error'
-    AichatComprehendHelper.stubs(:get_toxicity).returns({toxicity: 0.1, text: 'test'})
     AichatSagemakerHelper.stubs(:get_sagemaker_assistant_response).raises(StandardError.new(error_message))
 
     request = create :aichat_request
@@ -74,7 +88,6 @@ class AichatRequestChatCompletionJobTest < ActiveJob::TestCase
 
   test 'execution status is set to USER_INPUT_TOO_LARGE and an exception is raised if the input validation error occurs' do
     error_message = 'Input validation error: `inputs` must have less than 3000 tokens'
-    AichatComprehendHelper.stubs(:get_toxicity).returns({toxicity: 0.1, text: 'test'})
     AichatSagemakerHelper.stubs(:get_sagemaker_assistant_response).raises(StandardError.new(error_message))
 
     request = create :aichat_request
@@ -86,5 +99,35 @@ class AichatRequestChatCompletionJobTest < ActiveJob::TestCase
     assert request.response.include?(error_message)
     assert exception.message.include?(error_message)
     assert exception.message.include?(request.to_json)
+  end
+
+  def stub_safety_services(enabled_service, role)
+    DCDO.stubs(:get).with("aichat_safety_blocklist_enabled", anything).returns(enabled_service == 'blocklist')
+    DCDO.stubs(:get).with("aichat_safety_webpurify_enabled", anything).returns(enabled_service == 'webpurify')
+    DCDO.stubs(:get).with("aichat_safety_comprehend_enabled", anything).returns(enabled_service == 'comprehend')
+
+    if role == 'user'
+      ShareFiltering.stubs(:find_profanity_failure).returns(ShareFailure.new(ShareFiltering::FailureType::PROFANITY, 'webpurify-profanity'))
+      AichatComprehendHelper.stubs(:get_toxicity).returns(@comprehend_response)
+    else
+      # If assistant (not user), only return profanity response on the second call
+      ShareFiltering.stubs(:find_profanity_failure).returns(nil, ShareFailure.new(ShareFiltering::FailureType::PROFANITY, 'webpurify-profanity'))
+      AichatComprehendHelper.stubs(:get_toxicity).returns(nil, @comprehend_response)
+    end
+  end
+
+  def verify_safety_response(enabled_service, response)
+    assert_equal @profane_message, response[:text]
+    assert_equal enabled_service, response[:blocked_by]
+    details = response[:details]
+    case enabled_service
+    when 'blocklist'
+      assert_equal @blocklist_blocked_word, details[:blocked_word]
+    when 'webpurify'
+      assert_equal ShareFiltering::FailureType::PROFANITY, details[:type]
+      assert_equal 'webpurify-profanity', details[:content]
+    when 'comprehend'
+      assert_equal @comprehend_response, details
+    end
   end
 end


### PR DESCRIPTION
Extends the AI Chat safety layer with the option to check a DCDO-defined blocklist and webpurify in addition to Amazon Comprehend. This came out of bug bash findings where we wanted to add additional filtering mechanisms in case a single one wasn't meeting our standards.

**Note**: this change also updates the format in which we store the response if the user input or model response is flagged for profanity. I changed the format so it would be consistent across the different safety mechanisms, and also to remove some of the Ruby-specific struct syntax we were storing previously. However this does mean that existing scripts that rely on the previous format will need to be updated once this is merged (FYI @fisher-alice). Also happy to discuss alternate formats if it makes it easier for parsing/scripting.

The response format is now (JSON):
```
{
  "text": <full input text that was blocked>,
  "blocked_by": <service that blocked the text (blocklist, webpurify, comprehend)>
  "details": <service specific details (see below)>
}
```
The `"details"` portion differs based on the service that blocked the request:
- Our blocklist: 
```
{ 
  "blocked_word": <specific word that was blocked> 
}
```
- WebPurify: 
```
{ 
  "type": <ShareFailure type, always PROFANITY>, 
  "content": <specific content that was flagged> 
}
```
- Comprehend: 
```
{ 
  "flagged_segment": <specific segment that was flagged>, 
  "toxicity": <overall toxicity score>, 
  "max_category": {
    "name": <max category name>,
    "score": <category score>
  }
}
```

Examples of the JSON stored in the `response` column of `AichatRequests`:
- Blocklist:
<img width="397" alt="Screenshot 2024-09-13 at 3 49 19 PM" src="https://github.com/user-attachments/assets/d127f21d-0b41-47bc-b7fd-e8bc5d678c7e">

- WebPurify:
<img width="329" alt="Screenshot 2024-09-13 at 3 50 35 PM" src="https://github.com/user-attachments/assets/a8f50527-39f0-437c-9e7a-adce41fc4354">

- Comprehend (using a large input to show how the specific segment is highlighted):
<img width="724" alt="Screenshot 2024-09-13 at 3 53 31 PM" src="https://github.com/user-attachments/assets/eb7ff7da-c9eb-4a4d-96c7-856fe11e6f9d">

## Testing story

Tested locally with various types of input + unit