### PR TITLE
Codebridge: fix behavior when no files are open

### DIFF
--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -29,6 +29,7 @@
   "newFilePrompt": "Please name your new file",
   "newFolderPrompt": "Please name your new folder",
   "noFileExtensionError": "Please include a file extension",
+  "noOpenFiles": "Open a file to get started!",
   "predictRunDisabledTooltip": "You must answer the question in the instructions before running the code.",
   "renameFile": "Rename file",
   "renameFolder": "Rename folder",

--- a/apps/src/codebridge/Editor/index.tsx
+++ b/apps/src/codebridge/Editor/index.tsx
@@ -2,11 +2,14 @@ import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {LanguageSupport} from '@codemirror/language';
 import React, {useCallback, useMemo} from 'react';
 
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import {BodyOneText} from '@cdo/apps/componentLibrary/typography';
 import {getActiveFileForProject} from '@cdo/apps/lab2/projects/utils';
 import CodeEditor from '@cdo/apps/lab2/views/components/editor/CodeEditor';
 
-import './styles/editor.css';
 import {editableFileType} from '../utils';
+
+import moduleStyles from './styles/editor.module.scss';
 
 interface EditorProps {
   langMapping: {[key: string]: LanguageSupport};
@@ -40,8 +43,8 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
   }
 
   return (
-    <div className="editor-container">
-      {file && (
+    <div className={moduleStyles.editorContainer}>
+      {file ? (
         <CodeEditor
           key={`${file.id}/${1}`}
           darkMode={true}
@@ -49,6 +52,10 @@ export const Editor = ({langMapping, editableFileTypes}: EditorProps) => {
           startCode={file.contents}
           editorConfigExtensions={editorConfigExtensions}
         />
+      ) : (
+        <BodyOneText className={moduleStyles.noOpenFilesMessage}>
+          {codebridgeI18n.noOpenFiles()}
+        </BodyOneText>
       )}
     </div>
   );

--- a/apps/src/codebridge/Editor/styles/editor.css
+++ b/apps/src/codebridge/Editor/styles/editor.css
@@ -1,6 +1,0 @@
-.editor-container {
-  width: 100%;
-  height: 100%;
-  background-color: #292f36;
-  overflow: hidden;
-}

--- a/apps/src/codebridge/Editor/styles/editor.module.scss
+++ b/apps/src/codebridge/Editor/styles/editor.module.scss
@@ -1,0 +1,13 @@
+@import 'color.scss';
+
+.editorContainer {
+  width: 100%;
+  height: 100%;
+  background-color: #292f36;
+  overflow: hidden;
+}
+
+.noOpenFilesMessage {
+  color: $white;
+  padding: 8px;
+}

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -106,7 +106,7 @@ export function getFileByName(
 /**
  * Given a map of {fileId: ProjectFile}, return the first non-hidden, active file.
  * @param project - The folders and files for a given project.
- * @returns The first non-hidden, active file, or the first file.
+ * @returns The first non-hidden, active file, or undefined if no files are active.
  */
 export function getActiveFileForProject(project: MultiFileSource) {
   const files = Object.values(project.files);
@@ -117,8 +117,8 @@ export function getActiveFileForProject(project: MultiFileSource) {
     f => isStartMode || !f.type || f.type === ProjectFileType.STARTER
   );
 
-  // Get the first active file, or the first file.
-  return visibleFiles.find(f => f.active) || visibleFiles[0];
+  // Get the first active file, or undefined if no files are active.
+  return visibleFiles.find(f => f.active);
 }
 
 /**


### PR DESCRIPTION
Previously, if no files were open in a Codebridge project, the editor would show the contents of the first file in the file list, with no tabs above it.

This PR updates it so it now shows a friendly message when no files are open. While I was here I converted a css file to a css module.

## Before
![Screenshot 2024-09-13 at 4 28 37 PM](https://github.com/user-attachments/assets/ae437c5b-eee2-4cb9-833c-af5fc199af0d)

## After
![Screenshot 2024-09-13 at 4 23 11 PM](https://github.com/user-attachments/assets/c0da0512-07ce-41c8-a1a8-7d63f0582fa3)


## Links
- jira ticket: [CT-386](https://codedotorg.atlassian.net/browse/CT-386)

## Testing story
Tested locally

## Follow-up work
I considered adding some sort of help text pointing to the file browser, but couldn't find a nice way to format it. We can extend this text in the future if we decide we want to have tips about using codebridge in there.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
