### PR TITLE
Music: multiple play togethers validation

### DIFF
--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -38,6 +38,10 @@ export const MusicConditions: ConditionNames = {
     valueType: 'number',
   },
   PLAYED_PATTERNS_AI: {name: 'played_patterns_ai', valueType: 'number'},
+  PLAYED_DIFFERENT_SOUNDS_TOGETHER_MULTIPLE_TIMES: {
+    name: 'played_different_sounds_together_multiple_times',
+    valueType: 'number',
+  },
 };
 
 export default class MusicValidator extends Validator {
@@ -151,6 +155,45 @@ export default class MusicValidator extends Validator {
         }
       }
     });
+
+    // How many unique start times for different blocks have we found?
+    //for each sound
+    // record ID + start time if not already in list
+    // then group that list by start time
+    // filter to how many have already started
+    // if bigger than value, we have multiple play togthers
+    const uniqueStarts: Array<Array<{id: string; when: number}>> = [];
+    this.getPlaybackEvents().forEach((eventData: PlaybackEvent) => {
+      const entry = {id: eventData.id, when: eventData.when};
+      if (!uniqueStarts[eventData.when]) {
+        uniqueStarts[eventData.when] = [];
+      }
+      if (
+        !uniqueStarts[eventData.when].find(
+          uniqueStart =>
+            uniqueStart.id === entry.id && uniqueStart.when === entry.when
+        )
+      ) {
+        uniqueStarts[eventData.when].push(entry);
+      }
+    });
+
+    const filteredItems = Object.keys(uniqueStarts).filter(when => {
+      return Number(when) <= currentPlayheadPosition;
+    });
+
+    let numBuckets = 0;
+    filteredItems.forEach(item => {
+      if (uniqueStarts[Number(item)].length >= 2) {
+        numBuckets++;
+      }
+    });
+    console.log(numBuckets);
+
+    this.addPlayedConditions(
+      MusicConditions.PLAYED_DIFFERENT_SOUNDS_TOGETHER_MULTIPLE_TIMES.name,
+      numBuckets
+    );
 
     // Check for up to a certain number of sounds playing simultaneously.
     // Note that if, for example, 3 sounds are playing, then we'll consider

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -231,9 +231,10 @@ export default class MusicValidator extends Validator {
   ) {
     // An array of arrays of unique sound starts.
     // The outer array is sparsely indexed by start time in measures.
-    // Each inner array is a list of unique sound IDs.
+    // Each inner array is a list of unique sound IDs that start at
+    // that measure.
     // This means that the same sound started at the same time will
-    // only be recorded once, even if encountered multiple times.
+    // only be recorded once, even if played multiple times.
     const uniqueStarts: Array<Array<string>> = [];
 
     this.getPlaybackEvents()
@@ -247,9 +248,13 @@ export default class MusicValidator extends Validator {
         }
       });
 
+    // At least 2 sounds must be played together at the same time to be
+    // counted.
+    const numSoundsForPlayTogether = 2;
+
     let playTogetherStarts = 0;
     Object.keys(uniqueStarts).forEach(when => {
-      if (uniqueStarts[Number(when)].length >= 2) {
+      if (uniqueStarts[Number(when)].length >= numSoundsForPlayTogether) {
         playTogetherStarts++;
       }
     });


### PR DESCRIPTION
This adds a rather specific validation to Music Lab called `played_different_sounds_together_multiple_times`.  Its job is to identify how many separate `play together` blocks, that each play at least 2 different sounds, have been played.  It takes a numerical value specifying how many such blocks must exist to pass.

Because it can take a few measures for this to succed, this works well in conjunction with the `validationTimeout` parameter in `level_data`.

For a value of 3, this will pass at measure 5:

<img width="233" alt="Screenshot 2024-09-14 at 10 12 54 PM" src="https://github.com/user-attachments/assets/38eef98f-840c-41ee-91e3-8c5b9b3c8623">
<img width="410" alt="Screenshot 2024-09-14 at 10 20 40 PM" src="https://github.com/user-attachments/assets/cc505f2c-5491-4d70-a744-7e684bb6faf5">

###

This will not, because the first `play together` only plays one unique sound:

<img width="239" alt="Screenshot 2024-09-14 at 10 15 41 PM" src="https://github.com/user-attachments/assets/92fa7107-bbdb-4944-93de-f0918dfe97c3">
<img width="410" alt="Screenshot 2024-09-14 at 10 20 34 PM" src="https://github.com/user-attachments/assets/90d2f4ef-be89-4a81-99f3-b05ececb7791">

The validation doesn't actually look for the use of the `play together` block, but instead examines the set of resulting sounds.  For each starting time, it creates a list of unique sounds that are played at that time.  It counts each such time that has 2 or more unique sounds that has already been passed, and if it reaches the specified count, then it's a pass.