### PR TITLE
Music: simple2 execution improvements

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -12,7 +12,6 @@ import CustomMarshalingInterpreter from '../../lib/tools/jsinterpreter/CustomMar
 import {getBlockMode} from '../appConfig';
 import {BlockMode, Triggers} from '../constants';
 
-import {GeneratorHelpersSimple2} from './blocks/simple2';
 import {BlockTypes} from './blockTypes';
 import {
   FIELD_TRIGGER_START_NAME,
@@ -182,55 +181,6 @@ export default class MusicBlocklyWorkspace {
 
     const topBlocks = this.workspace.getTopBlocks();
 
-    // These are both used for BlockMode.SIMPLE2.
-    let functionCallsCode = '';
-    let functionImplementationsCode = '';
-
-    if (getBlockMode() === BlockMode.SIMPLE2) {
-      // Go through all blocks, specifically looking for functions.
-      // As they are found, accumulate one set of code to call all of them,
-      // and a second set of code that has their implementations.
-      // We'll use the calls only when simulating tracks mode, and the
-      // implementations will become part of the runtime code for both when_run,
-      // as well as for each new trigger handler.
-      topBlocks.forEach(functionBlock => {
-        if (functionBlock.type === 'procedures_defnoreturn') {
-          // Accumulate some custom code that calls all the functions
-          // together, simulating tracks mode.
-          const actualFunctionName =
-            GeneratorHelpersSimple2.getSafeFunctionName(
-              functionBlock.getFieldValue('NAME')
-            );
-          functionCallsCode += `${actualFunctionName}();
-          `;
-
-          // Accumulate some code that has all of the function implementations.
-          const functionCode = Blockly.JavaScript.blockToCode(
-            functionBlock.getChildren(false)[0]
-          );
-          functionImplementationsCode +=
-            GeneratorHelpersSimple2.getFunctionImplementation(
-              functionBlock.getFieldValue('NAME'),
-              functionCode
-            );
-        }
-      });
-
-      // If there's no when_run block, then we'll generate
-      // some custom code that first initializes things, and then calls all
-      // the functions together, simulating tracks mode.
-      if (
-        !topBlocks.some(block => block.type === BlockTypes.WHEN_RUN_SIMPLE2)
-      ) {
-        this.compiledEvents.whenRunButton = {
-          code: GeneratorHelpersSimple2.getDefaultWhenRunImplementation(
-            functionCallsCode,
-            functionImplementationsCode
-          ),
-        };
-      }
-    }
-
     topBlocks.forEach(block => {
       if (getBlockMode() !== BlockMode.SIMPLE2) {
         if (block.type === BlockTypes.WHEN_RUN) {
@@ -245,8 +195,8 @@ export default class MusicBlocklyWorkspace {
         if (block.type === BlockTypes.WHEN_RUN_SIMPLE2) {
           this.compiledEvents.whenRunButton = {
             code:
-              Blockly.JavaScript.blockToCode(block) +
-              functionImplementationsCode,
+              'var __context = "when_run";\n' +
+              Blockly.JavaScript.workspaceToCode(this.workspace),
           };
         }
       }

--- a/apps/src/music/blockly/blocks/events.js
+++ b/apps/src/music/blockly/blocks/events.js
@@ -1,5 +1,6 @@
 import musicI18n from '../../locale';
 import {BlockTypes} from '../blockTypes';
+import {TRIGGER_FIELD} from '../constants';
 import {fieldTriggerDefinition} from '../fields';
 
 export const whenRun = {
@@ -41,7 +42,7 @@ export const triggeredAt = {
     tooltip: musicI18n.blockly_blockTriggeredAtTooltip(),
   },
   generator: ctx => {
-    const id = ctx.getFieldValue('trigger');
+    const id = ctx.getFieldValue(TRIGGER_FIELD);
     const varName = Blockly.JavaScript.nameDB_.getName(
       ctx.getFieldValue('var'),
       Blockly.Names.NameType.VARIABLE

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -45,23 +45,6 @@ export class GeneratorHelpersSimple2 {
     `;
   }
 
-  // Given a block of code with function calls, and also function implementations,
-  // this returns the implementation of the when_run block to be used when the user
-  // didn't provide their own implementation.  In this implementation, all of the
-  // provided functions are called immediately, simulating tracks mode.
-  static getDefaultWhenRunImplementation(
-    functionCallsCode,
-    functionImplementationsCode
-  ) {
-    return `
-    Sequencer.newSequence();
-    Sequencer.playTogether();
-    Sequencer.startFunctionContext('when_run');
-    ${functionCallsCode}
-    ${functionImplementationsCode}
-  `;
-  }
-
   // Return a function name in JavaScript.
   // Adapted from Blockly.JavaScript.nameDB_.safeName_
   // at https://github.com/google/blockly/blob/498766b930287ab8ef86accf95e9453018997461/core/names.ts
@@ -91,12 +74,18 @@ export const whenRunSimple2 = {
     tooltip: musicI18n.blockly_blockWhenRunTooltip(),
     helpUrl: '',
   },
-  generator: () =>
-    `
-      Sequencer.newSequence();
-      Sequencer.startFunctionContext('when_run');
-      Sequencer.playSequential();
-    `,
+  generator: ctx => {
+    const nextBlock = ctx.nextConnection && ctx.nextConnection.targetBlock();
+    let handlerCode = Blockly.JavaScript.blockToCode(nextBlock, false);
+    ctx.skipNextBlockGeneration = true;
+    return `
+      if (__context == 'when_run') {
+        Sequencer.newSequence();
+        Sequencer.startFunctionContext('when_run');
+        Sequencer.playSequential();
+        ${handlerCode}
+      }`;
+  },
 };
 
 export const triggeredAtSimple2 = {
@@ -130,12 +119,19 @@ export const triggeredAtSimple2 = {
     tooltip: musicI18n.blockly_blockTriggeredTooltip(),
     helpUrl: DOCS_BASE_URL + 'trigger',
   },
-  generator: block =>
-    `
-      Sequencer.newSequence(startPosition, true);
-      Sequencer.startFunctionContext('${block.getFieldValue(TRIGGER_FIELD)}');
-      Sequencer.playSequential();
-    `,
+  generator: ctx => {
+    const id = ctx.getFieldValue(TRIGGER_FIELD);
+    const nextBlock = ctx.nextConnection && ctx.nextConnection.targetBlock();
+    let handlerCode = Blockly.JavaScript.blockToCode(nextBlock, false);
+    ctx.skipNextBlockGeneration = true;
+    return `
+      if (__context == "${id}") {
+        Sequencer.newSequence(startPosition, true);
+        Sequencer.startFunctionContext('${id}');
+        Sequencer.playSequential();
+        ${handlerCode}
+      }`;
+  },
 };
 
 export const playSoundAtCurrentLocationSimple2 = {


### PR DESCRIPTION
This updates the execution of `simple2` model code to use `Blockly.JavaScript.workspaceToCode` rather than `Blockly.JavaScript.blockToCode` for `when run` and each trigger.  This is the same change made to the `advanced` model in #60860.

We get the following improvements:
- we get Blockly's timeout detection for functions, so that infinite recursions when a function calls itself now break execution early.
- we get Blockly's handling of reserved keyword function names, so that function names like `break` are now internally renamed.

Also:
- This fixes a regression in the `advanced` model made in #60860, in which one trigger would execute all code, including other triggers.
- This removes the `simple2` support for a `tracks`-like model of executing all functions simultaneously when there was no `when run` block.

### Details

As done for the description in https://github.com/code-dot-org/code-dot-org/pull/60860, here's an illustrative example of the JS generated for a trigger entrypoint:

```
var __context = "trigger1";

function break2() {
  executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}
  Sequencer.playPattern({"kit":"drums","events":[],"ai":false}, "play_pattern_at_current_location_simple2");
}

if (__context == 'when_run') {
  Sequencer.newSequence();
  Sequencer.startFunctionContext('when_run');
  Sequencer.playSequential();
  Sequencer.playSound("electro/drum_beat_cowbell", "play_sound_at_current_location_simple2");
}

if (__context == "trigger1") {
  Sequencer.newSequence(startPosition, true);
  Sequencer.startFunctionContext('trigger1');
  Sequencer.playSequential();
  break2();
}
```

