### PR TITLE
Header: improve saved layout

### DIFF
--- a/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
+++ b/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
@@ -74,7 +74,7 @@ class ProjectUpdatedAt extends React.Component {
 const styles = {
   container: {
     display: 'block',
-    textAlign: 'left',
+    width: 160,
   },
 };
 


### PR DESCRIPTION
On a project-backed level with a short script name, the sometimes-longer "saved" messages have been causing the layout to jiggle as the central component has been resized by this changing text.   There has also been an issue in which the text has pushed under the progress area.

The simplest solution looks to be fixing the width of the area that contains the dynamic text.

### before

https://github.com/user-attachments/assets/a3f0649b-b2b6-4089-8ea7-619f4a3af54c

### after

https://github.com/user-attachments/assets/12d1f7c0-d58a-4e18-9b71-282cd8b11d0b

