### PR TITLE
Codebridge: auto scroll instructions to validation/continue button

### DIFF
--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -267,15 +267,11 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
       refToScrollTo = validationScrollRef;
     }
     if (refToScrollTo) {
-      // We do a 30 ms timeout before scrolling to avoid a flicker. When a new
-      // "bubble" (validation results or continue button) appears, we do an animation
-      // for it to appear. If we scroll immediately, it looks like the instructions are
-      // jumping.
       // We must at least set a timeout with a wait of 0 to ensure the scroll happens at all,
       // because the DOM needs to update before we can scroll to the new element.
       setTimeout(
         () => refToScrollTo.current?.scrollIntoView({behavior: 'smooth'}),
-        30
+        0
       );
     }
   }, [showNavigation, validationResults]);

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, {useCallback, useContext} from 'react';
+import React, {useCallback, useContext, useEffect, useRef} from 'react';
 import {useSelector} from 'react-redux';
 
 import InstructorsOnly from '@cdo/apps/code-studio/components/InstructorsOnly';
@@ -74,7 +74,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
     state => state.lab.levelProperties?.longInstructions
   );
   const hasNextLevel = useSelector(state => nextLevelId(state) !== undefined);
-  const {hasConditions, satisfied} = useAppSelector(
+  const {hasConditions, validationResults, satisfied} = useAppSelector(
     state => state.lab.validationState
   );
   const predictSettings = useAppSelector(
@@ -256,6 +256,30 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
   const {showNavigation, navigationText, navigationIcon, handleNavigation} =
     getNavigationButtonProps();
 
+  const navigationScrollRef = useRef<HTMLDivElement>(null);
+  const validationScrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let refToScrollTo;
+    if (showNavigation) {
+      refToScrollTo = navigationScrollRef;
+    } else if (validationResults) {
+      refToScrollTo = validationScrollRef;
+    }
+    if (refToScrollTo) {
+      // We do a 30 ms timeout before scrolling to avoid a flicker. When a new
+      // "bubble" (validation results or continue button) appears, we do an animation
+      // for it to appear. If we scroll immediately, it looks like the instructions are
+      // jumping.
+      // We must at least set a timeout with a wait of 0 to ensure the scroll happens at all,
+      // because the DOM needs to update before we can scroll to the new element.
+      setTimeout(
+        () => refToScrollTo.current?.scrollIntoView({behavior: 'smooth'}),
+        30
+      );
+    }
+  }, [showNavigation, validationResults]);
+
   const validationIcon =
     hasMetValidation || hasSubmitted
       ? 'fa-solid fa-circle-check'
@@ -322,11 +346,13 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
           </InstructorsOnly>
         )}
         {renderValidationButton()}
+        {validationResults && <div ref={validationScrollRef} />}
         <ValidationResults className={moduleStyles['bubble-' + theme]} />
         {showNavigation && (
           <div
             id="instructions-navigation"
             className={moduleStyles['bubble-' + theme]}
+            ref={navigationScrollRef}
           >
             <Button
               text={navigationText}


### PR DESCRIPTION
It's somewhat likely for the continue button or validation results to extend past the visible area in the instructions panel, since we plan to have longer instructions. When we get new validation results or are showing the navigation button for the first time, scroll the instructions panel to the new content. If we get both validation results and a continue button simultaneously, scroll to the continue button.

## Before
https://github.com/user-attachments/assets/f4bd0bd3-5ffa-412e-a735-e0a2e757375e


## After
Passing validation
https://github.com/user-attachments/assets/d6b8cf78-d1b6-4dc0-964d-aaf5dba40139


Failing validation
https://github.com/user-attachments/assets/3ac1516e-3479-40fc-a33b-ff3bf76e928e


## Links

- jira ticket: [CT-773](https://codedotorg.atlassian.net/browse/CT-773)

## Testing story
Tested locally


## Follow-up work
The extra links box can overlap with the Instructions output. Since this is an internal tool I'm not worrying too much about it, but we can see if it becomes a problem for folks.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
