### PR TITLE
feat: skip dependabot assignment if PR is already assigned

### DIFF
--- a/.github/actions/assign-dependabot-reviewer/assign-reviewers.mjs
+++ b/.github/actions/assign-dependabot-reviewer/assign-reviewers.mjs
@@ -41,14 +41,6 @@ function getPRTitle() {
  * @param teamReviewers The teams to assign to
  */
 async function assignReviewers(dependencyName, teamReviewers) {
-
-    console.log(`request`,
-        {owner: REPO_OWNER,
-        repo: REPO,
-        pull_number: getPRNumber(),
-        team_reviewers: teamReviewers
-})
-
     // Assign reviewer to PR
     await octokit.rest.pulls.requestReviewers({
         owner: REPO_OWNER,
@@ -67,6 +59,21 @@ async function assignReviewers(dependencyName, teamReviewers) {
         
         This pull request is open to anyone (including the public) to work on. If you have any questions, please feel free to contact **${teamReviewers.join(',')}**`
     });
+}
+
+/**
+ * Gets the current team reviewers for a given PR
+ */
+async function getCurrentTeamReviewers() {
+    const response = await octokit.rest.pulls.listRequestedReviewers(
+        {
+            owner: REPO_OWNER,
+            repo: REPO,
+            pull_number: getPRNumber()
+        }
+    );
+
+    return response.data.teams;
 }
 
 /**
@@ -97,6 +104,13 @@ function extractDependencyName(str) {
 async function main() {
     try {
         const prTitle = getPRTitle();
+        const currentReviewers = await getCurrentTeamReviewers();
+
+        if (currentReviewers.length > 0) {
+            console.log(`Team reviewers are already assigned to this PR, skipping...`)
+            return;
+        }
+
         // Determine the dependency using the title of the PR
 
         const reviewers = [];


### PR DESCRIPTION
Previously, the dependabot assignment script would run anytime a dependabot PR is synchronized (rebased for example). This is a bit noisy because it will cause the script to leave a comment each time it runs. This PR adds a reviewers check to not perform actions if a team reviewer is already assigned.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested on [test repo](https://github.com/code-dot-org/stephen-dependabot-autoassign-testing/actions/runs/10892798939)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
