### PR TITLE
Python Lab logging: part 1

### DIFF
--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -13,12 +13,12 @@ import {
 import {MultiFileSource} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {useCodebridgeContext} from '../codebridgeContext';
 import WithConditionalTooltip from '../components/WithConditionalTooltip';
 import {appendSystemMessage} from '../redux/consoleRedux';
+import {sendCodebridgeAnalyticsEvent} from '../utils/analyticsReporterHelper';
 
 import moduleStyles from './console.module.scss';
 
@@ -60,9 +60,7 @@ const ControlButtons: React.FunctionComponent = () => {
   const handleRun = () => {
     if (onRun) {
       dispatch(setIsRunning(true));
-      analyticsReporter.sendEvent(EVENTS.CODEBRIDGE_RUN_CLICK, {
-        labType: labType,
-      });
+      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_RUN_CLICK, labType);
       onRun(/*runTests*/ false, dispatch, source).finally(() =>
         dispatch(setIsRunning(false))
       );

--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -42,7 +42,7 @@ const ControlButtons: React.FunctionComponent = () => {
   );
   const isRunning = useAppSelector(state => state.lab2System.isRunning);
   const isValidating = useAppSelector(state => state.lab2System.isValidating);
-  const labType = useAppSelector(state => state.lab.levelProperties?.appName);
+  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
 
@@ -60,7 +60,7 @@ const ControlButtons: React.FunctionComponent = () => {
   const handleRun = () => {
     if (onRun) {
       dispatch(setIsRunning(true));
-      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_RUN_CLICK, labType);
+      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_RUN_CLICK, appName);
       onRun(/*runTests*/ false, dispatch, source).finally(() =>
         dispatch(setIsRunning(false))
       );

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -8,7 +8,10 @@ import Button, {buttonColors} from '@cdo/apps/componentLibrary/button';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {sendCodebridgeAnalyticsEvent} from '../utils/analyticsReporterHelper';
 
 import ControlButtons from './ControlButtons';
 import GraphModal from './GraphModal';
@@ -29,8 +32,9 @@ const Console: React.FunctionComponent = () => {
 
   const clearOutput = useCallback(() => {
     dispatch(resetOutput());
+    sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_CLEAR_CONSOLE, appName);
     setGraphModalOpen(false);
-  }, [dispatch]);
+  }, [dispatch, appName]);
 
   // Clear console when we change levels.
   useLifecycleNotifier(LifecycleEvent.LevelLoadCompleted, clearOutput);
@@ -42,6 +46,7 @@ const Console: React.FunctionComponent = () => {
   }, [codeOutput]);
 
   const popOutGraph = (index: number) => {
+    sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_POP_OUT_IMAGE, appName);
     setActiveGraphIndex(index);
     setGraphModalOpen(true);
   };

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -24,6 +24,7 @@ import PredictQuestion from '@cdo/apps/lab2/views/components/PredictQuestion';
 import PredictSummary from '@cdo/apps/lab2/views/components/PredictSummary';
 import {DialogType, useDialogControl} from '@cdo/apps/lab2/views/dialogs';
 import {ThemeContext} from '@cdo/apps/lab2/views/ThemeWrapper';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
@@ -31,6 +32,7 @@ import commonI18n from '@cdo/locale';
 
 import {useCodebridgeContext} from '../codebridgeContext';
 import {appendSystemMessage} from '../redux/consoleRedux';
+import {sendCodebridgeAnalyticsEvent} from '../utils/analyticsReporterHelper';
 
 import ValidationResults from './ValidationResults';
 
@@ -147,6 +149,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
   const handleValidate = () => {
     if (onRun) {
       dispatch(setIsValidating(true));
+      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_VALIDATE_CLICK, appType);
       onRun(true, dispatch, source).finally(() =>
         dispatch(setIsValidating(false))
       );

--- a/apps/src/codebridge/SwapLayoutButton.tsx
+++ b/apps/src/codebridge/SwapLayoutButton.tsx
@@ -2,7 +2,11 @@ import React, {useCallback} from 'react';
 
 import Button from '@cdo/apps/componentLibrary/button';
 
+import {EVENTS} from '../metrics/AnalyticsConstants';
+import {useAppSelector} from '../util/reduxHooks';
+
 import {useCodebridgeContext} from './codebridgeContext';
+import {sendCodebridgeAnalyticsEvent} from './utils/analyticsReporterHelper';
 
 /*
   Please note - this is a fairly brittle component in that it's only allowing toggling between
@@ -19,19 +23,22 @@ import {useCodebridgeContext} from './codebridgeContext';
 
 const SwapLayoutButton: React.FunctionComponent = () => {
   const {config, setConfig} = useCodebridgeContext();
+  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
   const iconName =
     config.activeGridLayout === 'horizontal' ? 'table-columns' : 'table-rows';
 
-  const onClick = useCallback(
-    () =>
-      setConfig({
-        ...config,
-        activeGridLayout:
-          config.activeGridLayout === 'horizontal' ? 'vertical' : 'horizontal',
-      }),
-    [config, setConfig]
-  );
+  const onClick = useCallback(() => {
+    const newLayout =
+      config.activeGridLayout === 'horizontal' ? 'vertical' : 'horizontal';
+    sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_MOVE_CONSOLE, appName, {
+      positionMovedTo: newLayout,
+    });
+    setConfig({
+      ...config,
+      activeGridLayout: newLayout,
+    });
+  }, [appName, config, setConfig]);
 
   if (!config.activeGridLayout || !config.labeledGridLayouts) {
     return null;

--- a/apps/src/codebridge/utils/analyticsReporterHelper.ts
+++ b/apps/src/codebridge/utils/analyticsReporterHelper.ts
@@ -1,0 +1,11 @@
+import {PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+
+export function sendCodebridgeAnalyticsEvent(
+  eventName: string,
+  labType?: string,
+  payload?: Record<string, string>
+) {
+  const fullPayload = payload ? {labType, ...payload} : {labType};
+  analyticsReporter.sendEvent(eventName, fullPayload, PLATFORMS.STATSIG);
+}

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -385,6 +385,24 @@ const EVENTS = {
   SUBMIT_AICHAT_REQUEST_SUCCESS: 'User submits aichat request successfully',
   SUBMIT_AICHAT_REQUEST_UNAUTHORIZED:
     'Unauthorized user attempts to submit aichat request and fails',
+
+  // Codebridge
+  CODEBRIDGE_CLEAR_CONSOLE: 'Console cleared on codebridge',
+  CODEBRIDGE_MOVE_CONSOLE: 'Console moved on codebridge',
+  CODEBRIDGE_DELETE_FILE: 'Delete file on codebridge',
+  CODEBRIDGE_DELETE_FOLDER: 'Delete folder on codebridge',
+  CODEBRIDGE_FILE_ADDED_TO_FOLDER: 'Add file to folder on codebridge',
+  CODEBRIDGE_MOVE_FILE: 'Move file on codebridge',
+  CODEBRIDGE_NEW_FILE: 'Create a new file on codebridge',
+  CODEBRIDGE_NEW_FOLDER: 'Create a new folder on codebridge',
+  CODEBRIDGE_NEW_SUBFOLDER: 'Create a new subfolder on codebridge',
+  CODEBRIDGE_POP_OUT_IMAGE: 'Image popped out of console on codebridge',
+  CODEBRIDGE_RENAME_FILE: 'Rename file on codebridge',
+  CODEBRIDGE_RENAME_FOLDER: 'Rename folder on codebridge',
+  CODEBRIDGE_RUN_CLICK: 'Run button clicked on codebridge',
+  CODEBRIDGE_VALIDATE_CLICK: 'Validate button clicked on codebridge',
+  CODEBRIDGE_VERSION_RESTORED: 'Version restored on codebridge',
+  CODEBRIDGE_VERSION_VIEWED: 'Version viewed on codebridge',
 };
 
 const EVENT_GROUP_NAMES = {

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -386,9 +386,7 @@ const EVENTS = {
   SUBMIT_AICHAT_REQUEST_UNAUTHORIZED:
     'Unauthorized user attempts to submit aichat request and fails',
 
-  // Codebridge
-  CODEBRIDGE_CLEAR_CONSOLE: 'Console cleared on codebridge',
-  CODEBRIDGE_MOVE_CONSOLE: 'Console moved on codebridge',
+  // Codebridge - File broswer-related events
   CODEBRIDGE_DELETE_FILE: 'Delete file on codebridge',
   CODEBRIDGE_DELETE_FOLDER: 'Delete folder on codebridge',
   CODEBRIDGE_FILE_ADDED_TO_FOLDER: 'Add file to folder on codebridge',
@@ -396,9 +394,13 @@ const EVENTS = {
   CODEBRIDGE_NEW_FILE: 'Create a new file on codebridge',
   CODEBRIDGE_NEW_FOLDER: 'Create a new folder on codebridge',
   CODEBRIDGE_NEW_SUBFOLDER: 'Create a new subfolder on codebridge',
-  CODEBRIDGE_POP_OUT_IMAGE: 'Image popped out of console on codebridge',
   CODEBRIDGE_RENAME_FILE: 'Rename file on codebridge',
   CODEBRIDGE_RENAME_FOLDER: 'Rename folder on codebridge',
+
+  // Codebridge - Other events
+  CODEBRIDGE_CLEAR_CONSOLE: 'Console cleared on codebridge',
+  CODEBRIDGE_MOVE_CONSOLE: 'Console moved on codebridge',
+  CODEBRIDGE_POP_OUT_IMAGE: 'Image popped out of console on codebridge',
   CODEBRIDGE_RUN_CLICK: 'Run button clicked on codebridge',
   CODEBRIDGE_VALIDATE_CLICK: 'Validate button clicked on codebridge',
   CODEBRIDGE_VERSION_RESTORED: 'Version restored on codebridge',


### PR DESCRIPTION
Part 1 of adding logging to python lab/codebridge. I added logging for the following events:
- Run button clicked
- Validate button clicked
- Console cleared
- Console moved
- Version viewed
- Version restored
- Graph popped out of console

I also made a helper method for logging events in codebridge that always includes the lab type and only logs to statsig. I also added the event names for the other events we plan to add (see links), which I will add in a follow-up PR (they are all relating to the file browser).

## Links
- [spec](https://docs.google.com/document/d/1QyuUErb3dArvlbr-XNB8vxsS9hFrcdjd2y2zTmLNLdE/edit)
- jira ticket: [CT-616](https://codedotorg.atlassian.net/browse/CT-616)

## Testing story
Tested locally that the events show up in the console as statsig events.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
