### PR TITLE
Python Lab: Catch possible exception when trying to send run_complete message

### DIFF
--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -93,7 +93,14 @@ onmessage = async event => {
   // Documentation on this method:
   // https://pyodide.org/en/stable/usage/api/js-api.html#pyodide.ffi.PyProxy.toJs
   const resultsObject = results?.toJs();
-  postMessage({type: 'run_complete', message: resultsObject, id});
+  try {
+    postMessage({type: 'run_complete', message: resultsObject, id});
+  } catch (e) {
+    // Likely we hit a DataCloneError trying to send the resultsObject.
+    // In this case, don't try to send the results object, as if it can't be
+    // sent, it wasn't going to be parsed by us anyway.
+    postMessage({type: 'run_complete', id});
+  }
 };
 
 // Run code owned by us (not the user). If there is an error, post a


### PR DESCRIPTION
I was playing around with the new Python Lab levels and noticed [this level](https://studio.code.org/s/data-science-with-python-2024/lessons/4/levels/4) fails to finish its run with an error `DataCloneError: Proxy object could not be cloned.` in the console. The cause of this error is when we send the `run_complete` method we try to send over the returned result from [runPython](https://pyodide.org/en/stable/usage/api/js-api.html#pyodide.runPython), which is either the return value or whatever the value of the last expression in the method was. The only time we actually use this result is when parsing validation results, which can be cloned.

To fix this, we now catch the error and re-send without the results object. 

## Links
- jira ticket: [CT-798](https://codedotorg.atlassian.net/browse/CT-798)

## Testing story
Tested locally, with this change the above level can run successfully. We also can still parse validation results.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
