### PR TITLE
Scroll to bottom of chat window when new message comes in

### DIFF
--- a/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
+++ b/apps/src/aiComponentLibrary/userMessageEditor/UserMessageEditor.tsx
@@ -34,6 +34,7 @@ const UserMessageEditor: React.FunctionComponent<UserMessageEditorProps> = ({
 
   const handleKeyPress = (e: React.KeyboardEvent, userMessage: string) => {
     if (e.key === 'Enter' && userMessage.trim() !== '') {
+      e.preventDefault(); // Prevent the text box from having just a blank line.
       handleSubmit(userMessage);
     }
   };

--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, {useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import Draggable, {DraggableEventHandler} from 'react-draggable';
 
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatMessage/ChatMessage';
@@ -120,6 +120,12 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
       });
   };
 
+  // Scroll to bottom of content when a new message comes in
+  const chatWindowRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    chatWindowRef.current?.lastElementChild?.scrollIntoView();
+  }, [messageHistory]);
+
   return (
     <Draggable
       defaultPosition={{x: positionX, y: positionY}}
@@ -152,7 +158,7 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
         </div>
 
         <div className={style.fabBackground}>
-          <div className={style.chatContent}>
+          <div className={style.chatContent} ref={chatWindowRef}>
             {messageHistory.map((item: ChatItem, id: number) =>
               Array.isArray(item) ? (
                 <AiDiffSuggestedPrompts

--- a/apps/test/unit/aiDifferentiation/AiDiffFloatingActionButtonTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffFloatingActionButtonTest.jsx
@@ -6,6 +6,10 @@ import AiDiffFloatingActionButton from '@cdo/apps/aiDifferentiation/AiDiffFloati
 import {expect} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 
 describe('AIDiffFloatingActionButton', () => {
+  beforeEach(() => {
+    window.HTMLElement.prototype.scrollIntoView = () => {};
+  });
+
   it('begins closed', () => {
     render(<AiDiffFloatingActionButton />);
     expect(screen.getByText('AI Teaching Assistant')).not.be.visible;


### PR DESCRIPTION
Two small UI improvements for AI differentiation chat:
1. New messages added to the bottom of the chat window will now cause the window to scroll to the bottom to show these messages, rather than having them show up invisibly and requiring the user to scroll manually.
2. Previously when submitting a chat message with the Enter key on the keyboard the text box would clear out the old message except for the final newline generated by the Enter key. Now that newline is suppressed as well.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
