### PR TITLE
Revert "add new params link and L7 to ai_rubric_config"

### DIFF
--- a/dashboard/app/jobs/concerns/ai_rubric_config.rb
+++ b/dashboard/app/jobs/concerns/ai_rubric_config.rb
@@ -6,13 +6,12 @@ class AiRubricConfig
   #
   # Basic validation of the new AI config is done by UI tests, or can be done locally
   # by running `AiRubricConfig.validate_ai_config` from the rails console.
-  S3_AI_RELEASE_PATH = 'teaching_assistant/releases/2024-09-05-lesson-7-release/'.freeze
+  S3_AI_RELEASE_PATH = 'teaching_assistant/releases/2024-08-14-cfe-release/'.freeze
 
   # 2D Map from unit name and level name, to the name of the lesson files within
   # the release dir in S3 which will be used for AI evaluation.
   UNIT_AND_LEVEL_TO_LESSON_S3_NAME = {
     'csd3-2023' => {
-      'CSD U3 L7 mini project_2023' => 'csd3-2023-L7',
       'CSD U3 Sprites scene challenge_2023' => 'csd3-2023-L11',
       'CSD web project animated review_2023' => 'csd3-2023-L14',
       'CSD U3 Interactive Card Final_2023' => 'csd3-2023-L18',
@@ -21,7 +20,6 @@ class AiRubricConfig
       'CSD games project review_2023' => 'csd3-2023-L28',
     },
     'csd3-2024' => {
-      'CSD U3 L7 mini project_2024' => 'csd3-2023-L7',
       'CSD U3 Sprites scene challenge_2024' => 'csd3-2023-L11',
       'CSD web project animated review_2024' => 'csd3-2023-L14',
       'CSD U3 Interactive Card Final_2024' => 'csd3-2023-L18',


### PR DESCRIPTION
reverting the launch PR for lesson 7 to avoid EvaluateRubricJob errors on that lesson. 

There have been 1700 errors and counting: https://app.honeybadger.io/projects/3240/faults/111488442 while there is no user-visible impact, these errors are making it hard to detect and diagnose other errors.

AI evaluation is not yet fully launched for Lesson 7, because the "ai enabled" checkbox has not been checked for any learning goals in Lesson 7. this means that we run AI evaluation when a student submits work, but we do not yet let the teacher see the result or request ai evaluation. this is why we do not see any teacher-initiated evaluations for lesson 7 yet.

## root cause

it appears that the CFE is returning an empty label. this causes the lookup of the exact match confidence to fail after the call to aiproxy returns to dashboard.

the issue can be reproduced locally as follows:
* set up local aiproxy, and point local dashboard to it 
* login as a student in a verified teacher's section
* go to http://localhost-studio.code.org/s/csd3-2023/lessons/7/levels/2
* drag the "background" block into the workspace, press run, press submit

expected: aiproxy returns success, evaluate rubric job succeeds
actual: aiproxy returns success, evaluate rubric job fails with error shown in honey badger link above

## future work

make sure ai evaluation is working end-to-end on lesson 7 before re-enabling.