### PR TITLE
Header: adjust saved layout

### DIFF
--- a/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
+++ b/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
@@ -15,6 +15,7 @@ class ProjectUpdatedAt extends React.Component {
     status: PropTypes.oneOf(Object.values(statuses)),
     updatedAt: PropTypes.string,
     onContentUpdated: PropTypes.func,
+    floatRight: PropTypes.bool,
   };
 
   componentDidMount() {
@@ -63,7 +64,13 @@ class ProjectUpdatedAt extends React.Component {
 
   render() {
     return (
-      <div className="project_updated_at header_text" style={styles.container}>
+      <div
+        className="project_updated_at header_text"
+        style={{
+          ...styles.container,
+          ...(this.props.floatRight && styles.floatRight),
+        }}
+      >
         {this.renderText()}
         <RetryProjectSaveDialog onTryAgain={() => project.save()} />
       </div>
@@ -75,6 +82,9 @@ const styles = {
   container: {
     display: 'block',
     width: 160,
+  },
+  floatRight: {
+    float: 'right',
   },
 };
 

--- a/apps/src/code-studio/components/header/ScriptName.jsx
+++ b/apps/src/code-studio/components/header/ScriptName.jsx
@@ -103,12 +103,18 @@ class ScriptName extends React.Component {
           ref="scriptName"
           style={{...styles.headerInner, height: 40}}
         >
-          <div style={styles.outerContainer}>
+          <div
+            style={
+              this.props.isRtl
+                ? styles.outerContainerRtl
+                : styles.outerContainer
+            }
+          >
             <div style={styles.containerWithUpdatedAt}>
               {this.renderScriptLink()}
               <ProjectUpdatedAt
                 onContentUpdated={this.onProjectUpdatedAtContentUpdated}
-                floatRight={true}
+                floatRight={!this.props.isRtl}
               />
             </div>
           </div>
@@ -124,6 +130,7 @@ const styles = {
     position: 'relative',
     overflow: 'hidden',
     height: 40,
+    top: 3,
   },
   headerInner: {
     position: 'absolute',
@@ -133,6 +140,9 @@ const styles = {
   },
   outerContainer: {
     textAlign: 'right',
+  },
+  outerContainerRtl: {
+    textAlign: 'left',
   },
   containerWithUpdatedAt: {
     verticalAlign: 'bottom',

--- a/apps/src/code-studio/components/header/ScriptName.jsx
+++ b/apps/src/code-studio/components/header/ScriptName.jsx
@@ -108,6 +108,7 @@ class ScriptName extends React.Component {
               {this.renderScriptLink()}
               <ProjectUpdatedAt
                 onContentUpdated={this.onProjectUpdatedAtContentUpdated}
+                floatRight={true}
               />
             </div>
           </div>


### PR DESCRIPTION
A small follow-up to https://github.com/code-dot-org/code-dot-org/pull/61107.

### LTR

It was intended that when the "saved" message was shown under the script name in a project-backed level, both would be right-aligned.  However, this wasn't always the case for the second line.  With this change, it is now explicitly right-aligned.

#### before

<img width="372" alt="Screenshot 2024-09-17 at 11 08 54 AM" src="https://github.com/user-attachments/assets/ac1ed78c-e7f7-423a-8aa6-a8a564e4b4cd">


#### after

<img width="372" alt="Screenshot 2024-09-17 at 11 08 35 AM" src="https://github.com/user-attachments/assets/1e84f432-a20a-4674-9ec6-992a0467501b">

### RTL

This also tidies up the RTL layout.

#### before

<img width="346" src="https://github.com/user-attachments/assets/1765fc34-81e3-4df0-9fb5-aa7fa19edfd2">

#### after

<img width="346" src="https://github.com/user-attachments/assets/6d7a711e-b4e1-4e1f-83bd-60af16692bef">

### Also

The keen-eyed will also notice that the text is now 3 pixels lower.  I've been meaning to address this ever since https://github.com/code-dot-org/code-dot-org/pull/34551.  