### PR TITLE
NAV - make unit number work

### DIFF
--- a/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
@@ -71,7 +71,7 @@ const createDisplayName = (lessonName: string, lessonPosition: number) => {
 const LessonMaterialsContainer: React.FC = () => {
   const loadedData = useLoaderData() as LessonMaterialsData | null;
   const lessons = useMemo(() => loadedData?.lessons || [], [loadedData]);
-  const unitNumber = useMemo(() => loadedData?.unitNumber || 0, [loadedData]);
+  const unitNumber = useMemo(() => loadedData?.unitNumber || 1, [loadedData]);
 
   const getLessonFromId = (lessonId: number): Lesson | null => {
     return lessons.find(lesson => lesson.id === lessonId) || null;

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1760,10 +1760,6 @@ class Unit < ApplicationRecord
   end
 
   def unit_number
-    has_prefix = unit_group&.has_numbered_units
-
-    return nil unless has_prefix
-
     unit_group_units&.first&.position
   end
 


### PR DESCRIPTION
There was an issue with this prematurely returning null.  After some investigation with Hannah, we saw that the prefix was not necessary for the work we were doing.  

This will set the correct "unitNumber" for a unit - example below for "Unit 5"
<img width="321" alt="image" src="https://github.com/user-attachments/assets/50712555-8623-484c-b8ed-b37e36391691">


Note: This may need to be modified once we get the stand alone courses working. 

