### PR TITLE
HoC 2024 - Show banner on teacher homepage

### DIFF
--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -1,6 +1,6 @@
 {
   "pages": {
-    "/home": "transformers-sept-2024",
+    "/home": "hoc-2024",
     "/student-home": "transformers-sept-2024"
   },
   "banners": {


### PR DESCRIPTION
Shows the 2024 Hour of Code banner on https://studio.code.org/home for Teachers. I'm going to merge this on Friday 9/20 so it will go out with Monday's (9/23) deploy.

## Links
Jira: [ACQ-2368](https://codedotorg.atlassian.net/browse/ACQ-2368)
Related PR: https://github.com/code-dot-org/code-dot-org/pull/60857

## Testing story
Tested locally

----

| Before | After |
| ---- | ---- |
| ![Before](https://github.com/user-attachments/assets/365c30e6-3aec-4982-b11a-f01e4490f3b2) | ![After](https://github.com/user-attachments/assets/c978bb8e-1003-46eb-815b-4ab5bfbf8248) |

