### PR TITLE
Python Lab logging: part 2

### DIFF
--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -279,6 +279,7 @@ const InnerFileBrowser = React.memo(
                       renameFilePrompt={renameFilePrompt}
                       renameFolderPrompt={renameFolderPrompt}
                       setFileType={setFileType}
+                      appName={appName}
                     />
                   </ul>
                 )}
@@ -632,6 +633,7 @@ export const FileBrowser = React.memo(() => {
           renameFilePrompt={renameFilePrompt}
           renameFolderPrompt={renameFolderPrompt}
           setFileType={setFileType}
+          appName={appName}
         />
       </ul>
     </PanelContainer>

--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -417,8 +417,9 @@ export const FileBrowser = React.memo(() => {
     () => fileId => {
       const file = project.files[fileId];
       fileDownload(file.contents, file.name);
+      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_DOWNLOAD_FILE, appName);
     },
-    [project.files]
+    [appName, project.files]
   );
 
   const newFilePrompt: FilesComponentProps['newFilePrompt'] = useMemo(

--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -28,7 +28,10 @@ import {
   DialogType,
   DialogClosePromiseReturnType,
 } from '@cdo/apps/lab2/views/dialogs';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {sendCodebridgeAnalyticsEvent} from '../utils/analyticsReporterHelper';
 
 import {FileBrowserHeaderPopUpButton} from './FileBrowserHeaderPopUpButton';
 import {
@@ -55,6 +58,7 @@ type FilesComponentProps = {
   renameFilePrompt: renameFilePromptType;
   renameFolderPrompt: renameFolderPromptType;
   setFileType: setFileType;
+  appName?: string;
 };
 
 // given a promise returned from DialogManager.showDialog({type : DialogType.GenericPrompt}), will return the input
@@ -84,6 +88,7 @@ const InnerFileBrowser = React.memo(
     renameFilePrompt,
     renameFolderPrompt,
     setFileType,
+    appName,
   }: FilesComponentProps) => {
     const {
       openFile,
@@ -95,17 +100,27 @@ const InnerFileBrowser = React.memo(
     const dialogControl = useDialogControl();
     const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
 
+    const handleConfirmDeleteFile = (fileId: string) => {
+      deleteFile(fileId);
+      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_DELETE_FILE, appName);
+    };
+
     const handleDeleteFile = (fileId: string) => {
       const filename = files[fileId].name;
       const title = codebridgeI18n.areYouSure();
       const message = codebridgeI18n.deleteFileConfirm({filename});
       dialogControl?.showDialog({
         type: DialogType.GenericConfirmation,
-        handleConfirm: () => deleteFile(fileId),
+        handleConfirm: () => handleConfirmDeleteFile(fileId),
         title,
         message,
         confirmText: codebridgeI18n.delete(),
       });
+    };
+
+    const handleConfirmDeleteFolder = (folderId: string) => {
+      deleteFolder(folderId);
+      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_DELETE_FOLDER, appName);
     };
 
     const handleDeleteFolder = (folderId: string) => {
@@ -142,7 +157,7 @@ const InnerFileBrowser = React.memo(
       const message = confirmation + ' ' + additionalWarning;
       dialogControl?.showDialog({
         type: DialogType.GenericConfirmation,
-        handleConfirm: () => deleteFolder(folderId),
+        handleConfirm: () => handleConfirmDeleteFolder(folderId),
         title,
         message,
         confirmText: codebridgeI18n.delete(),
@@ -329,6 +344,7 @@ export const FileBrowser = React.memo(() => {
   } = useCodebridgeContext();
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
   const dialogControl = useDialogControl();
+  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
   // Check if the filename is already in use in the given folder.
   // If it is, alert the user and return true, otherwise return false.
@@ -386,8 +402,14 @@ export const FileBrowser = React.memo(() => {
 
         const folderId = getNextFolderId(Object.values(project.folders));
         newFolder({parentId, folderName, folderId});
+
+        const eventName =
+          parentId === DEFAULT_FOLDER_ID
+            ? EVENTS.CODEBRIDGE_NEW_FOLDER
+            : EVENTS.CODEBRIDGE_NEW_SUBFOLDER;
+        sendCodebridgeAnalyticsEvent(eventName, appName);
       },
-    [dialogControl, newFolder, project.folders]
+    [appName, dialogControl, newFolder, project.folders]
   );
 
   const downloadFile: FilesComponentProps['downloadFile'] = useMemo(
@@ -437,8 +459,10 @@ export const FileBrowser = React.memo(() => {
           fileName,
           folderId,
         });
+
+        sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_NEW_FILE, appName);
       },
-    [dialogControl, checkForDuplicateFilename, newFile, project.files]
+    [dialogControl, project.files, newFile, appName, checkForDuplicateFilename]
   );
 
   const moveFilePrompt: FilesComponentProps['moveFilePrompt'] = useMemo(
@@ -488,13 +512,15 @@ export const FileBrowser = React.memo(() => {
           title: getErrorMessage(e),
         });
       }
+      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_MOVE_FILE, appName);
     },
     [
-      dialogControl,
-      moveFile,
-      checkForDuplicateFilename,
       project.files,
       project.folders,
+      dialogControl,
+      appName,
+      checkForDuplicateFilename,
+      moveFile,
     ]
   );
 
@@ -534,8 +560,15 @@ export const FileBrowser = React.memo(() => {
       }
       const newName = extractInput(results);
       renameFile(fileId, newName);
+      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_RENAME_FILE, appName);
     },
-    [dialogControl, project.files, checkForDuplicateFilename, renameFile]
+    [
+      dialogControl,
+      project.files,
+      checkForDuplicateFilename,
+      renameFile,
+      appName,
+    ]
   );
 
   const renameFolderPrompt: FilesComponentProps['renameFolderPrompt'] = useMemo(
@@ -568,8 +601,9 @@ export const FileBrowser = React.memo(() => {
       }
       const newName = extractInput(results);
       renameFolder(folderId, newName);
+      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_RENAME_FOLDER, appName);
     },
-    [dialogControl, renameFolder, project.folders]
+    [project.folders, dialogControl, renameFolder, appName]
   );
 
   return (

--- a/apps/src/codebridge/InfoPanel/index.tsx
+++ b/apps/src/codebridge/InfoPanel/index.tsx
@@ -3,7 +3,10 @@ import React, {useEffect, useState} from 'react';
 
 import Button from '@cdo/apps/componentLibrary/button';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {sendCodebridgeAnalyticsEvent} from '../utils/analyticsReporterHelper';
 
 import ForTeachersOnly from './ForTeachersOnly';
 import HelpAndTips from './HelpAndTips';
@@ -28,6 +31,12 @@ const panelProps = {
   [Panels.ForTeachersOnly]: {},
 };
 
+const panelEventNames = {
+  [Panels.Instructions]: EVENTS.CODEBRIDGE_INSTRUCTIONS_TOGGLE,
+  [Panels.HelpAndTips]: EVENTS.CODEBRIDGE_HELP_TIPS_TOGGLE,
+  [Panels.ForTeachersOnly]: EVENTS.CODEBRIDGE_FOR_TEACHERS_ONLY_TOGGLE,
+};
+
 export const InfoPanel = React.memo(() => {
   const mapReference = useAppSelector(
     state => state.lab.levelProperties?.mapReference
@@ -47,6 +56,7 @@ export const InfoPanel = React.memo(() => {
   const hasPredictSolution = useAppSelector(
     state => !!state.lab.levelProperties?.predictSettings?.solution
   );
+  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
   useEffect(() => {
     // For now, always include Instructions panel.
@@ -96,7 +106,10 @@ export const InfoPanel = React.memo(() => {
   };
 
   const changePanel = (panel: Panels) => {
-    setCurrentPanel(panel);
+    if (panel !== currentPanel) {
+      setCurrentPanel(panel);
+      sendCodebridgeAnalyticsEvent(panelEventNames[panel], appName);
+    }
     setIsDropdownOpen(false);
   };
 

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -106,7 +106,8 @@ export function getFileByName(
 /**
  * Given a map of {fileId: ProjectFile}, return the first non-hidden, active file.
  * @param project - The folders and files for a given project.
- * @returns The first non-hidden, active file, or undefined if no files are active.
+ * @returns The first non-hidden, active file, the first open file if no files are active,
+ * or undefined if no files are open.
  */
 export function getActiveFileForProject(project: MultiFileSource) {
   const files = Object.values(project.files);
@@ -117,8 +118,9 @@ export function getActiveFileForProject(project: MultiFileSource) {
     f => isStartMode || !f.type || f.type === ProjectFileType.STARTER
   );
 
-  // Get the first active file, or undefined if no files are active.
-  return visibleFiles.find(f => f.active);
+  // Get the first active file, if no active file then the first open file,
+  // or undefined if no files are open.
+  return visibleFiles.find(f => f.active) || visibleFiles.find(f => f.open);
 }
 
 /**

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -389,7 +389,6 @@ const EVENTS = {
   // Codebridge - File broswer-related events
   CODEBRIDGE_DELETE_FILE: 'Delete file on codebridge',
   CODEBRIDGE_DELETE_FOLDER: 'Delete folder on codebridge',
-  CODEBRIDGE_FILE_ADDED_TO_FOLDER: 'Add file to folder on codebridge',
   CODEBRIDGE_MOVE_FILE: 'Move file on codebridge',
   CODEBRIDGE_NEW_FILE: 'Create a new file on codebridge',
   CODEBRIDGE_NEW_FOLDER: 'Create a new folder on codebridge',
@@ -405,6 +404,10 @@ const EVENTS = {
   CODEBRIDGE_VALIDATE_CLICK: 'Validate button clicked on codebridge',
   CODEBRIDGE_VERSION_RESTORED: 'Version restored on codebridge',
   CODEBRIDGE_VERSION_VIEWED: 'Version viewed on codebridge',
+  CODEBRIDGE_FOR_TEACHERS_ONLY_TOGGLE:
+    'Toggled to For Teachers Only on codebridge',
+  CODEBRIDGE_INSTRUCTIONS_TOGGLE: 'Toggled to Instructions on codebridge',
+  CODEBRIDGE_HELP_TIPS_TOGGLE: 'Toggled to Help and Tips on codebridge',
 };
 
 const EVENT_GROUP_NAMES = {

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -395,6 +395,7 @@ const EVENTS = {
   CODEBRIDGE_NEW_SUBFOLDER: 'Create a new subfolder on codebridge',
   CODEBRIDGE_RENAME_FILE: 'Rename file on codebridge',
   CODEBRIDGE_RENAME_FOLDER: 'Rename folder on codebridge',
+  CODEBRIDGE_DOWNLOAD_FILE: 'Download file on codebridge',
 
   // Codebridge - Other events
   CODEBRIDGE_CLEAR_CONSOLE: 'Console cleared on codebridge',


### PR DESCRIPTION
Add the remaining requested logs for python lab, except file upload which hasn't been implemented. This includes all file browser events (delete, rename, move, new, download), as well as toggling between panels in the info panel (instructions, for teachers only, help and tips).

I also found a bug from #61097 where if you delete the active file, but still have other open files, we show the "open a file" message. I fixed this by updating our get active file method to get the first open file if there is no active file.

## Links

- [spec](https://docs.google.com/document/d/1QyuUErb3dArvlbr-XNB8vxsS9hFrcdjd2y2zTmLNLdE/edit)
- jira ticket: [CT-616](https://codedotorg.atlassian.net/browse/CT-616)


## Testing story
Tested locally

## Follow-up work
The only other metric we need is file upload, which isn't implemented yet. I updated [CT-446](https://codedotorg.atlassian.net/browse/CT-446) to indicate we should add a metric when we add this feature.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
