### PR TITLE
HoC 2024 - Add OpenGraph image and tags

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/styles/060-hoc-specific.css
+++ b/pegasus/sites.v3/hourofcode.com/styles/060-hoc-specific.css
@@ -35,7 +35,7 @@
 }
 #hoc-nav ul {
   list-style: none;
-  margin: .2em 0;
+  margin: 1px 0;
   padding: 0;
 }
 #hoc-nav ul li {
@@ -178,6 +178,7 @@ iframe {
   }
   #hoc-nav-hamburger {
     display: inline-block;
+    margin-top: -8px;
   }
   #hoc-nav-hamburger:hover,
   #hoc-nav-hamburger:active {

--- a/pegasus/src/social_metadata.rb
+++ b/pegasus/src/social_metadata.rb
@@ -5,7 +5,6 @@
 #   code.org/dance
 #   code.org/minecraft
 #   code.org/hourofcode/overview
-#   code.org/learn
 #   code.org/hourofcode2022
 #   code.org/maker
 #   code.org/blockchain
@@ -59,6 +58,7 @@ def get_social_metadata_for_page(request)
     ai_101: {path: "/shared/images/social-media/ai-101-social.png", width: 1200, height: 630},
     ai_how_ai_works: {path: "/shared/images/social-media/ai-how-ai-works-social.png", width: 1200, height: 630},
     hoc_2023_social: {path: "/shared/images/social-media/hoc2023_social.png", width: 1200, height: 630},
+    hoc_2024_social: {path: "/shared/images/social-media/hoc2024_social.png", width: 1200, height: 630},
     videos_page: {path: "/shared/images/social-media/videos-page.png", width: 1200, height: 630},
     ten_years: {path: "/shared/images/social-media/10years-social.png", width: 1200, height: 630},
     young_women_in_cs: {path: "/shared/images/social-media/young-women-social.png", width: 1200, height: 630},
@@ -81,9 +81,9 @@ def get_social_metadata_for_page(request)
     },
     "hourofcode.com" => {
       "default" => {
-        title: hoc_s(:hoc2023_social_creativity_with_ai_title),
-        description: hoc_s(:hoc2023_social_creativity_with_ai_desc),
-        image: images[:hoc_2023_social]
+        title: hoc_s("hoc_2024.social.title"),
+        description: hoc_s("hoc_2024.social.desc"),
+        image: images[:hoc_2024_social]
       }
     },
     "challenge" => {
@@ -134,23 +134,16 @@ def get_social_metadata_for_page(request)
     },
     "learn" => {
       "default" => {
-        title: hoc_s(:hoc2023_social_creativity_with_ai_title),
-        description: hoc_s(:hoc2023_social_creativity_with_ai_desc),
-        image: images[:hoc_2023_social]
+        title: hoc_s("hoc_2024.social.title"),
+        description: hoc_s("hoc_2024.social.desc"),
+        image: images[:hoc_2024_social]
       }
     },
     "hoc-overview" => {
       "default" => {
-        title: hoc_s(:social_hoc_anybody),
-        description: hoc_s(:hoc2023_social_creativity_with_ai_desc),
-        image: images[:hoc_2023_social]
-      }
-    },
-    "learn-cdo" => {
-      "default" => {
-        title: hoc_s(:social_hoc_anybody),
-        description: hoc_s(:social_hoc2022_explore_play_create),
-        image: images[:hoc_2022_social]
+        title: hoc_s("hoc_2024.social.title"),
+        description: hoc_s("hoc_2024.social.desc"),
+        image: images[:hoc_2024_social]
       }
     },
     "maker" => {
@@ -237,8 +230,6 @@ def get_social_metadata_for_page(request)
     page = "learn"
   elsif request.path == "/hourofcode" && request.site == "code.org"
     page = "hoc-overview"
-  elsif request.path == "/learn" && request.site == "code.org"
-    page = "learn-cdo"
   elsif request.path == "/maker" && request.site == "code.org"
     page = "maker"
   elsif request.path == "/blockchain" && request.site == "code.org"

--- a/shared/images/social-media/hoc2024_social.png
+++ b/shared/images/social-media/hoc2024_social.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68fb39428fa4e05c65cea3ae8d814b6b084f7621292e6789fdc7a808d1f40a43
+size 175344


### PR DESCRIPTION
Updates the OpenGraph image and tags for the following pages for Hour of Code 2024.
- https://hourofcode.com homepage
- https://hourofcode.com/learn 
- https://code.org/hourofcode

I also removed the code.org hoc-overview OG stuff since that page no longer exists and fixed the spacing on the nav and hamburger spacing.

## Links
Jira ticket: [ACQ-2370](https://codedotorg.atlassian.net/browse/ACQ-2370)

## Testing story
Tested locally