### PR TITLE
[Aichat] Update scrolling for compare models dialog

### DIFF
--- a/apps/src/aichat/views/modelCustomization/ModelDescriptionPanel.tsx
+++ b/apps/src/aichat/views/modelCustomization/ModelDescriptionPanel.tsx
@@ -1,6 +1,5 @@
-import React, {useEffect, useState, useRef} from 'react';
+import React, {useState} from 'react';
 
-import Button from '@cdo/apps/componentLibrary/button/Button';
 import SimpleDropdown from '@cdo/apps/componentLibrary/dropdown/simpleDropdown';
 import {BodyThreeText, StrongText} from '@cdo/apps/componentLibrary/typography';
 
@@ -22,30 +21,13 @@ const ModelDescriptionPanel: React.FunctionComponent<{
   const [selectedModel, setSelectedModel] = useState<ModelDescription>(
     getModelFromId(initialSelectedModelId)
   );
-  const [userWantsScroll, setUserWantsScroll] = useState<boolean>(false);
-  const [contentNeedsScroll, setContentNeedsScroll] = useState<boolean>(false);
-
-  const descriptionsContainerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (
-      descriptionsContainerRef.current &&
-      descriptionsContainerRef.current.scrollHeight >
-        descriptionsContainerRef.current.clientHeight
-    ) {
-      setContentNeedsScroll(true);
-    }
-  }, [setContentNeedsScroll, descriptionsContainerRef]);
-
-  const showViewMoreButton = !userWantsScroll && contentNeedsScroll;
-  const shouldScroll = userWantsScroll && contentNeedsScroll;
 
   const onDropdownChange = (value: string) => {
     setSelectedModel(getModelFromId(value));
   };
 
   return (
-    <div className={styles.modelDescriptionContainer}>
+    <div className={styles.modelDescriptionPanelContainer}>
       <SimpleDropdown
         labelText="Choose a model"
         isLabelVisible={false}
@@ -59,12 +41,7 @@ const ModelDescriptionPanel: React.FunctionComponent<{
         className={styles.fullWidth}
       />
       <br />
-      <div
-        ref={descriptionsContainerRef}
-        className={
-          shouldScroll ? styles.overflowYScroll : styles.overflowYHidden
-        }
-      >
+      <div className={styles.modelDescriptionContainer}>
         <StrongText>Overview</StrongText>
         <div className={styles.textContainer}>
           <BodyThreeText>{selectedModel.overview}</BodyThreeText>
@@ -75,18 +52,6 @@ const ModelDescriptionPanel: React.FunctionComponent<{
           <BodyThreeText>{selectedModel.trainingData}</BodyThreeText>
         </div>
       </div>
-      {showViewMoreButton && (
-        <div className={styles.rightAlign}>
-          <Button
-            size="xs"
-            type="secondary"
-            onClick={() => setUserWantsScroll(true)}
-            text="view more"
-            iconRight={{iconName: 'chevron-down'}}
-            className={styles.viewMoreButton}
-          />
-        </div>
-      )}
     </div>
   );
 };

--- a/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
+++ b/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
@@ -39,7 +39,7 @@ div.modelComparisonDialog {
 }
 
 .modelDescriptionContainer {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .fullWidth {

--- a/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
+++ b/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
@@ -6,7 +6,7 @@
   padding: 2px 0;
 }
 
-.modelDescriptionContainer {
+.modelDescriptionPanelContainer {
   flex: 1;
   padding: 5px 10px;
   display: flex;
@@ -38,11 +38,7 @@ div.modelComparisonDialog {
   justify-content: flex-end;
 }
 
-.overflowYHidden {
-  overflow-y: hidden;
-}
-
-.overflowYScroll {
+.modelDescriptionContainer {
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the scrolling for the compare models dialog in `aichat` levels and removes the 'view more' buttons. This bug was reported during the bug bash. 

Before the update, users can scroll on shorter screens if the user sets the window size and then opens the compare models dialog. The user views the compare info, and can click on the ‘view more’ buttons and then can scroll down.
However, if the user has the models dialog open and then changes the window size. then the ‘view more’ buttons are not displayed. 

After consulting with @samantha-code and @markabarrett [Slack thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1726589963946079), this PR updates the the model descriptions dialog so that the descriptions are always scrollable and the 'view more' buttons have been removed.

## Before update

https://github.com/user-attachments/assets/ecd64973-9668-483d-877f-8cd3fcfa4819

## After update


https://github.com/user-attachments/assets/a01232e2-c86e-411f-b250-9968b1f5cbaa




## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1017)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally on an `aichat` level.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Noticed that the initial safe chatting dialog is not scrollable. So will make it scrollable for short window heights.

<img width="1397" alt="Screenshot 2024-09-17 at 1 47 11 PM" src="https://github.com/user-attachments/assets/52f9b4f1-e581-43e3-a12a-b2f49cb37f18">

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
