### PR TITLE
[JIMT] wider-startmode - moves start mode banner

### DIFF
--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -54,6 +54,7 @@ const Workspace = () => {
       <div
         className={classnames(moduleStyles.workspaceWorkarea, {
           [moduleStyles.withFileBrowser]: config.showFileBrowser,
+          [moduleStyles.withStartMode]: isStartMode,
         })}
       >
         <div

--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -66,16 +66,7 @@ const Workspace = () => {
         <div>
           <FileTabs />
         </div>
-        {isStartMode && (
-          <div
-            id="startSourcesWarningBanner"
-            className={moduleStyles.warningBanner}
-          >
-            {projectTemplateLevel
-              ? WARNING_BANNER_MESSAGES.TEMPLATE
-              : WARNING_BANNER_MESSAGES.STANDARD}
-          </div>
-        )}
+
         {config.showFileBrowser && <FileBrowser />}
 
         <div
@@ -83,6 +74,16 @@ const Workspace = () => {
             [moduleStyles.withFileBrowser]: config.showFileBrowser,
           })}
         >
+          {isStartMode && (
+            <div
+              id="startSourcesWarningBanner"
+              className={moduleStyles.warningBanner}
+            >
+              {projectTemplateLevel
+                ? WARNING_BANNER_MESSAGES.TEMPLATE
+                : WARNING_BANNER_MESSAGES.STANDARD}
+            </div>
+          )}
           <Editor
             langMapping={config.languageMapping}
             editableFileTypes={config.editableFileTypes}

--- a/apps/src/codebridge/Workspace/index.tsx
+++ b/apps/src/codebridge/Workspace/index.tsx
@@ -54,7 +54,6 @@ const Workspace = () => {
       <div
         className={classnames(moduleStyles.workspaceWorkarea, {
           [moduleStyles.withFileBrowser]: config.showFileBrowser,
-          [moduleStyles.withStartMode]: isStartMode,
         })}
       >
         <div

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -53,10 +53,6 @@
   flex: 1;
 }
 
-.workspaceWorkarea.withStartMode {
-  grid-auto-rows: auto auto 1fr auto;
-}
-
 .workspaceWorkarea.withFileBrowser {
   grid-template-columns: 200px auto;
 }

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -53,6 +53,10 @@
   flex: 1;
 }
 
+.workspaceWorkarea.withStartMode {
+  grid-auto-rows: auto auto 1fr auto;
+}
+
 .workspaceWorkarea.withFileBrowser {
   grid-template-columns: 200px auto;
 }

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -21,7 +21,6 @@
   padding: 5px;
   width: 100%;
   color: $black;
-  grid-column: span 2;
 }
 
 .workspaceToggleButtonContainer {

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -21,6 +21,7 @@
   padding: 5px;
   width: 100%;
   color: $black;
+  grid-column: span 2;
 }
 
 .workspaceToggleButtonContainer {


### PR DESCRIPTION
just moves the start mode banner inside the workspaceeditorarea so it shows up above it.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
