### PR TITLE
Fix Project Template Workspace Icon bug 

### DIFF
--- a/apps/src/templates/ProjectTemplateWorkspaceIcon.jsx
+++ b/apps/src/templates/ProjectTemplateWorkspaceIcon.jsx
@@ -29,7 +29,8 @@ export default class ProjectTemplateWorkspaceIcon extends React.Component {
           data-tip
           data-for={this.tooltipId}
           aria-describedby={this.tooltipId}
-          data-event="mouseenter mouseleave click"
+          data-event="mouseenter focusin"
+          data-event-off="mouseleave focusout"
           className={moduleStyles.projectTemplateButton}
         >
           <img


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR fixes a bug involving the project template workspace icon tooltip. It was reported during the aichat bug bash, but it isn't specific to `aichat` levels. On any level that is project template-backed, this icon is displayed in the header and when the user hovers over the icon, a message is displayed in the tooltip.

The bug is that if a user clicks on the icon, the tooltip toggles to being hidden. So that when the user hovers off the icon, the tooltip is displayed and when the user hovers on the icon, the tooltip is hidden. If the user clicks on the icon again, then hovering on will display the tooltip again. See following screencast video:

## Before update - user clicking and hovering on icon


https://github.com/user-attachments/assets/cf843fb1-5a77-445f-9ec8-7f3585ae62ad



The reason that `click` was added to the `button`'s  `data-event` is that when a user keyboard-navigates to the icon, the tooltip is displayed when a user clicks on the icon.

## Before update - user keyboard-navigates to icon and then clicks


https://github.com/user-attachments/assets/30ea5337-0288-4ad8-91de-0b7070433642


This PR updates the `button`'s `data-event` and adds `data-event-off`. This removes the bug, but it also improves keyboard navigation in that the tooltip is now automatically displayed when the user nevigates to the icon.

## Ater update - user clicking and hovering on icon

https://github.com/user-attachments/assets/6aa1338b-a556-45b8-bf88-5145dd509135



## After update - user keyboard-navigates to icon and then clicks

https://github.com/user-attachments/assets/07b4f234-211e-4d57-99fb-d125c9b3ee31


Just wanted to note that I did consider using the DSCO `Tooltip` that is being used for `aichat`'s `InfoTooltipIcon`. However, this project template workspace icon is used across both legacy and lab2 labs so didn't want create any unexpected impacts from refactoring `ProjectTemplateWorkspaceIcon`.


~~In addition, an image is used for the 'icon' and not a FA icon and currently `WithTooltip` props include an optional icon, but not an image.~~ Updated - in the future, we could use `WithTooltip` and wrap it around the image.


## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1021)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I also check on an App lab level that is project-template backed: 's/allthethings/lessons/18/levels/11' and the expected behavior was displayed after the update.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work


<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
