### PR TITLE
Revert "Header: adjust saved layout"

### DIFF
--- a/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
+++ b/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
@@ -15,7 +15,6 @@ class ProjectUpdatedAt extends React.Component {
     status: PropTypes.oneOf(Object.values(statuses)),
     updatedAt: PropTypes.string,
     onContentUpdated: PropTypes.func,
-    floatRight: PropTypes.bool,
   };
 
   componentDidMount() {
@@ -64,13 +63,7 @@ class ProjectUpdatedAt extends React.Component {
 
   render() {
     return (
-      <div
-        className="project_updated_at header_text"
-        style={{
-          ...styles.container,
-          ...(this.props.floatRight && styles.floatRight),
-        }}
-      >
+      <div className="project_updated_at header_text" style={styles.container}>
         {this.renderText()}
         <RetryProjectSaveDialog onTryAgain={() => project.save()} />
       </div>
@@ -82,9 +75,6 @@ const styles = {
   container: {
     display: 'block',
     width: 160,
-  },
-  floatRight: {
-    float: 'right',
   },
 };
 

--- a/apps/src/code-studio/components/header/ScriptName.jsx
+++ b/apps/src/code-studio/components/header/ScriptName.jsx
@@ -103,18 +103,11 @@ class ScriptName extends React.Component {
           ref="scriptName"
           style={{...styles.headerInner, height: 40}}
         >
-          <div
-            style={
-              this.props.isRtl
-                ? styles.outerContainerRtl
-                : styles.outerContainer
-            }
-          >
+          <div style={styles.outerContainer}>
             <div style={styles.containerWithUpdatedAt}>
               {this.renderScriptLink()}
               <ProjectUpdatedAt
                 onContentUpdated={this.onProjectUpdatedAtContentUpdated}
-                floatRight={!this.props.isRtl}
               />
             </div>
           </div>
@@ -130,7 +123,6 @@ const styles = {
     position: 'relative',
     overflow: 'hidden',
     height: 40,
-    top: 3,
   },
   headerInner: {
     position: 'absolute',
@@ -140,9 +132,6 @@ const styles = {
   },
   outerContainer: {
     textAlign: 'right',
-  },
-  outerContainerRtl: {
-    textAlign: 'left',
   },
   containerWithUpdatedAt: {
     verticalAlign: 'bottom',


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#61137

Will revisit this with an improved layout for levels that show a script name but not a "saved" message below it. 