### PR TITLE
Update x button styling on BaseDialog to not overlap in RTL 

### DIFF
--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -155,7 +155,7 @@ export default class BaseDialog extends React.Component {
     xCloseStyle = {
       position: 'absolute',
       top: 0,
-      right: 0,
+      insetInlineEnd: 0,
       padding: 0,
       color: color.neutral_dark30,
       cursor: 'pointer',


### PR DESCRIPTION
Similar to https://github.com/code-dot-org/code-dot-org/pull/61081
[P20-1152](https://codedotorg.atlassian.net/browse/P20-1152)

In RTL languages the X button on the `BaseDialog` component overlapped other elements. I made a small adjustment to the styles of the dialog to fix the issue. Shown below in the context of a Minecraft level. 

**BEFORE** 

![Screenshot 2024-09-18 at 10 34 51 AM](https://github.com/user-attachments/assets/3bf73a81-40bd-4ba0-bc3f-df5fae524798)


**AFTER** 

![Screenshot 2024-09-18 at 10 33 06 AM](https://github.com/user-attachments/assets/7856caeb-cc31-4684-aec3-10525aaa2fbe)
