### PR TITLE
[Music] Add advanced level to allthethings

### DIFF
--- a/dashboard/config/levels/custom/music/Advanced Music Level 1.level
+++ b/dashboard/config/levels/custom/music/Advanced Music Level 1.level
@@ -1,0 +1,51 @@
+<Music>
+  <config><![CDATA[{
+  "published": true,
+  "game_id": 70,
+  "created_at": "2024-09-18T23:27:29.000Z",
+  "level_num": "custom",
+  "user_id": 1,
+  "properties": {
+    "encrypted": "false",
+    "instructions_important": "false",
+    "hide_share_and_remix": "false",
+    "level_data": {
+      "blockMode": "Advanced",
+      "toolbox": {
+        "type": "category"
+      },
+      "startSources": {
+        "blocks": {
+          "languageVersion": 0,
+          "blocks": [
+            {
+              "type": "when_run",
+              "x": 30,
+              "y": 30
+            },
+            {
+              "type": "triggered_at",
+              "x": 425,
+              "y": 30,
+              "fields": {
+                "trigger": "trigger1"
+              }
+            }
+          ]
+        },
+        "variables": [
+          {
+            "name": "currentTime"
+          },
+          {
+            "name": "i"
+          }
+        ]
+      }
+    },
+    "preload_asset_list": null
+  },
+  "audit_log": "[{\"changed_at\":\"2024-09-18T15:27:29.312-04:00\",\"changed\":[\"cloned from \\\"local music\\\"\"],\"cloned_from\":\"local music\"},{\"changed_at\":\"2024-09-18 15:30:48 -0400\",\"changed\":[\"level_data\"],\"changed_by_id\":1,\"changed_by_email\":\"mike@code.org\"}]"
+}]]></config>
+  <blocks/>
+</Music>

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2024-08-21 19:46:40 UTC",
+    "serialized_at": "2024-09-18 19:31:24 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2694,6 +2694,9 @@
       "activity_section_position": 6,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "2-3 Bee Functions 2"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -6263,6 +6266,27 @@
     },
     {
       "chapter": 169,
+      "position": 5,
+      "activity_section_position": 5,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Advanced Music Level 1"
+        ],
+        "lesson.key": "lesson-49",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a"
+      },
+      "level_keys": [
+        "Advanced Music Level 1"
+      ]
+    },
+    {
+      "chapter": 170,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6286,7 +6310,7 @@
       ]
     },
     {
-      "chapter": 170,
+      "chapter": 171,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6310,7 +6334,7 @@
       ]
     },
     {
-      "chapter": 171,
+      "chapter": 172,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6334,7 +6358,7 @@
       ]
     },
     {
-      "chapter": 172,
+      "chapter": 173,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6358,7 +6382,7 @@
       ]
     },
     {
-      "chapter": 173,
+      "chapter": 174,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6382,7 +6406,7 @@
       ]
     },
     {
-      "chapter": 174,
+      "chapter": 175,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6406,7 +6430,7 @@
       ]
     },
     {
-      "chapter": 175,
+      "chapter": 176,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -6430,7 +6454,7 @@
       ]
     },
     {
-      "chapter": 176,
+      "chapter": 177,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6454,7 +6478,7 @@
       ]
     },
     {
-      "chapter": 177,
+      "chapter": 178,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6478,7 +6502,7 @@
       ]
     },
     {
-      "chapter": 178,
+      "chapter": 179,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6502,7 +6526,7 @@
       ]
     },
     {
-      "chapter": 179,
+      "chapter": 180,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6526,7 +6550,7 @@
       ]
     },
     {
-      "chapter": 180,
+      "chapter": 181,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6550,7 +6574,7 @@
       ]
     },
     {
-      "chapter": 181,
+      "chapter": 182,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6574,7 +6598,7 @@
       ]
     },
     {
-      "chapter": 182,
+      "chapter": 183,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6598,7 +6622,7 @@
       ]
     },
     {
-      "chapter": 183,
+      "chapter": 184,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6622,7 +6646,7 @@
       ]
     },
     {
-      "chapter": 184,
+      "chapter": 185,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -6646,7 +6670,7 @@
       ]
     },
     {
-      "chapter": 185,
+      "chapter": 186,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6670,7 +6694,7 @@
       ]
     },
     {
-      "chapter": 186,
+      "chapter": 187,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6694,7 +6718,7 @@
       ]
     },
     {
-      "chapter": 187,
+      "chapter": 188,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -6718,7 +6742,7 @@
       ]
     },
     {
-      "chapter": 188,
+      "chapter": 189,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -6742,7 +6766,7 @@
       ]
     },
     {
-      "chapter": 189,
+      "chapter": 190,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -6766,7 +6790,7 @@
       ]
     },
     {
-      "chapter": 190,
+      "chapter": 191,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -6790,7 +6814,7 @@
       ]
     },
     {
-      "chapter": 191,
+      "chapter": 192,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -6814,7 +6838,7 @@
       ]
     },
     {
-      "chapter": 192,
+      "chapter": 193,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -6838,7 +6862,7 @@
       ]
     },
     {
-      "chapter": 193,
+      "chapter": 194,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -6862,7 +6886,7 @@
       ]
     },
     {
-      "chapter": 194,
+      "chapter": 195,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -6886,11 +6910,14 @@
       ]
     },
     {
-      "chapter": 194,
+      "chapter": 196,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "test-levelgroup-activityguide"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -9043,6 +9070,18 @@
         "level.key": "Music Level 3",
         "script_level.level_keys": [
           "Music Level 3"
+        ],
+        "lesson.key": "lesson-49",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Advanced Music Level 1",
+        "script_level.level_keys": [
+          "Advanced Music Level 1"
         ],
         "lesson.key": "lesson-49",
         "lesson_group.key": "",


### PR DESCRIPTION
This adds a new Music Lab level to allthethings which is configured to use the Advanced block mode.

![image](https://github.com/user-attachments/assets/73a513c3-4376-4e7e-b6f2-81d3f179bf08)

This will result in Eyes diffs for any test that looks at lesson 46 of allthethings.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
