### PR TITLE
A couple of small updates to the district page

### DIFF
--- a/pegasus/sites.v3/code.org/public/districts.haml
+++ b/pegasus/sites.v3/code.org/public/districts.haml
@@ -63,7 +63,7 @@ theme: responsive_full_width
         %div
           %i{class: "#{icon_laptop_file}"}
         .text-wrapper
-          %h3 Turnkey K-12 computer science curriculum
+          %h3 Turnkey K-12 computer science and AI curriculum
           %p Get a complete, free <a href="/teach" target="_blank" rel="noopener noreferrer">open source K-12 program</a> and learning platform to introduce computer science at any grade.
       %li
         %div

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -12090,7 +12090,7 @@
   about_page_donors_link_1: "Make a donations"
   about_page_donors_link_2: "[see our list of donors](%{donors_url})"
 
-  districts_skinny_banner_title: "Over 100+ Districts have joined our District Program! [See district partners](%{district_partners_url})"
+  districts_skinny_banner_title: "Over 500+ Districts have joined our District Program! [See district partners](%{district_partners_url})"
 
   teach_ai_title: "Real-world Examples. Practical Resources."
   teach_ai_description: "The AI Guidance for Schools Toolkit is a resource for policymakers, school leaders, and staff to develop initial guidance on AI in their schools."


### PR DESCRIPTION
A couple of small improvements to the district page, as requested in [ACQ-2405](https://codedotorg.atlassian.net/browse/ACQ-2405):
- Change 100 to 500 on the top skinny banner
- Change "K-12 computer science curriculum" to "K-12 computer science and AI curriculum"

Update for the slightly longer string:

<img width="496" alt="Screenshot 2024-09-18 at 5 54 37 PM" src="https://github.com/user-attachments/assets/581da463-ef79-4595-ad17-487b94573bab">

I didn't screenshot the 100->500 change as it didn't affect spacing.

