### PR TITLE
Ceara/aitt 774 ai diff logging

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -8,6 +8,8 @@ import Button from '@cdo/apps/componentLibrary/button';
 import {AiInteractionStatus as Status} from '@cdo/generated-scripts/sharedConstants';
 import aiBotOutlineIcon from '@cdo/static/ai-bot-outline.png';
 
+import {EVENTS, PLATFORMS} from '../metrics/AnalyticsConstants';
+import analyticsReporter from '../metrics/AnalyticsReporter';
 import HttpClient from '../util/HttpClient';
 
 import AiDiffChatFooter from './AiDiffChatFooter';
@@ -20,6 +22,7 @@ interface AiDiffContainerProps {
   closeTutor?: () => void;
   open: boolean;
   lessonId: number;
+  lessonName: string;
   unitDisplayName: string;
 }
 
@@ -27,12 +30,19 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
   closeTutor,
   open,
   lessonId,
+  lessonName,
   unitDisplayName,
 }) => {
   // TODO: Update to support i18n
   const aiDiffHeaderText = 'AI Teaching Assistant';
 
   const aiDiffChatMessageEndpoint = '/ai_diff/chat_completion';
+
+  const reportingData = {
+    lessonId: lessonId,
+    lessonName: lessonName,
+    unitName: unitDisplayName,
+  };
 
   const [positionX, setPositionX] = useState(0);
   const [positionY, setPositionY] = useState(0);
@@ -85,15 +95,39 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
     };
 
     setMessageHistory(prevMessages => [...prevMessages, newUserMessage]);
-    getAIResponse(message);
+    getAIResponse(message, false);
   };
 
   const onPromptSelect = (prompt: ChatPrompt) => {
-    getAIResponse(prompt.prompt);
+    getAIResponse(prompt.prompt, true);
   };
 
-  const getAIResponse = (prompt: string) => {
+  const sendChatEvent = (
+    role: string,
+    prompt: string,
+    preset: boolean,
+    session: string
+  ) => {
+    const responseEventData = {
+      ...reportingData,
+      role: role,
+      isPreset: preset,
+      text: prompt,
+      sessionId: session,
+    };
+    analyticsReporter.sendEvent(
+      EVENTS.AI_DIFF_CHAT_EVENT,
+      responseEventData,
+      PLATFORMS.STATSIG
+    );
+  };
+
+  const getAIResponse = (prompt: string, isPreset: boolean) => {
     setIsWaitingForResponse(true);
+
+    if (sessionId !== null) {
+      sendChatEvent(Role.USER, prompt, isPreset, sessionId);
+    }
 
     const body = JSON.stringify({
       inputText: prompt,
@@ -111,6 +145,19 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
           chatMessageText: json.chat_message_text,
           status: json.status,
         };
+
+        // logging here because on the first user message the sessionId is null
+        // we only get a sessionID initialized in the response
+        if (sessionId === null) {
+          sendChatEvent(Role.USER, prompt, isPreset, json.session_id);
+        }
+
+        sendChatEvent(
+          Role.ASSISTANT,
+          json.chat_message_text,
+          isPreset,
+          json.session_id
+        );
         setSessionId(json.session_id);
         setMessageHistory(prevMessages => [...prevMessages, newAiMessage]);
       })

--- a/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
+++ b/apps/src/aiDifferentiation/AiDiffFloatingActionButton.tsx
@@ -2,6 +2,9 @@ import React, {useState} from 'react';
 
 import aiFabIcon from '@cdo/static/ai-fab-background.png';
 
+import {EVENTS, PLATFORMS} from '../metrics/AnalyticsConstants';
+import analyticsReporter from '../metrics/AnalyticsReporter';
+
 import AiDiffContainer from './AiDiffContainer';
 
 import style from './ai-differentiation.module.scss';
@@ -13,15 +16,27 @@ import style from './ai-differentiation.module.scss';
 
 interface AiDiffFloatingActionButtonProps {
   lessonId: number;
+  lessonName: string;
   unitDisplayName: string;
 }
 
 const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
   lessonId,
+  lessonName,
   unitDisplayName,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+
   const handleClick = () => {
+    const eventData = {
+      lessonId: lessonId,
+      lessonName: lessonName,
+      unitName: unitDisplayName,
+    };
+    const eventName = isOpen
+      ? EVENTS.TA_RUBRIC_CLOSED_FROM_FAB_EVENT
+      : EVENTS.TA_RUBRIC_OPENED_FROM_FAB_EVENT;
+    analyticsReporter.sendEvent(eventName, eventData, PLATFORMS.STATSIG);
     setIsOpen(!isOpen);
   };
 
@@ -39,6 +54,7 @@ const AiDiffFloatingActionButton: React.FC<AiDiffFloatingActionButtonProps> = ({
         open={isOpen}
         closeTutor={handleClick}
         lessonId={lessonId}
+        lessonName={lessonName}
         unitDisplayName={unitDisplayName}
       />
     </div>

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -241,6 +241,11 @@ const EVENTS = {
   TA_RUBRIC_ANNOUNCEMENT_CLICKED: 'TA Rubric Announcement Clicked',
   TA_RUBRIC_ANNOUNCEMENT_DISMISSED: 'TA Rubric Announcement Dismissed',
 
+  //AI Differentiation
+  AI_DIFF_CHAT_OPENED: 'AI Differentiation Chat Opened',
+  AI_DIFF_CHAT_CLOSED: 'AI Differentiation Chat Closed',
+  AI_DIFF_CHAT_EVENT: 'AI Differentiation Message Event',
+
   // AI Tutor
   AI_TUTOR_PANEL_OPENED: 'AI Tutor Panel Opened',
   AI_TUTOR_PANEL_CLOSED: 'AI Tutor Panel Closed',

--- a/apps/src/sites/studio/pages/lessons/show.js
+++ b/apps/src/sites/studio/pages/lessons/show.js
@@ -147,11 +147,13 @@ function displayDifferentiationChat() {
   );
   const lessonData = getScriptData('lesson');
   const lessonId = lessonData['id'];
+  const lessonName = lessonData['displayName'];
 
   if (aiDiffFabMountPoint && experiments.isEnabled('ai-differentiation')) {
     ReactDOM.render(
       <AiDiffFloatingActionButton
         lessonId={lessonId}
+        lessonName={lessonName}
         unitDisplayName={lessonData['unit']['displayName']}
       />,
       aiDiffFabMountPoint


### PR DESCRIPTION
Adding statsig logging to AI Differentiation to log chat open/close and chat message events. The chat message event records the role (i.e. user or the AI assistant), the text, lesson, course, sessionID, and I believe that statsig automatically records the userID of the signed in user. 

Some of the content of the chat message event is temporary until the data model is implemented.

<img width="1356" alt="Screenshot 2024-09-18 at 3 38 13 PM" src="https://github.com/user-attachments/assets/dda09a55-8c17-47c8-b237-f58cd5eb369a">

## Links

Jira: https://codedotorg.atlassian.net/browse/AITT-774


## Testing story

No testing changes currently

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
