### PR TITLE
Fix Violations of and Configure `Style/InverseMethods`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,6 +94,11 @@ Style/EmptyMethod:
 Style/FormatStringToken:
   EnforcedStyle: template
 
+Style/InverseMethods:
+  InverseBlocks:
+    :select: null
+    :select!: null
+
 Style/NumericLiterals:
   MinDigits: 7
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -212,12 +212,6 @@ Style/GlobalVars:
 Style/HashLikeCase:
   Enabled: false
 
-# Offense count: 21
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: InverseMethods, InverseBlocks.
-Style/InverseMethods:
-  Enabled: false
-
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 Style/KeywordParametersOrder:

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -88,7 +88,7 @@ class CoursesController < ApplicationController
     raise ActiveRecord::ReadOnlyRecord if @unit_group.try(:plc_course)
     @unit_group_data = {
       course_summary: @unit_group.summarize(@current_user, for_edit: true),
-      script_names: Unit.all.select {|unit| unit.is_course? == false && !unit.unit_groups.any?}.map(&:name),
+      script_names: Unit.all.select {|unit| unit.is_course? == false && unit.unit_groups.none?}.map(&:name),
       course_families: UnitGroup.family_names,
       version_year_options: UnitGroup.get_version_year_options,
       missing_required_device_compatibilities: @unit_group&.course_version&.course_offering&.missing_required_device_compatibility?

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -256,7 +256,7 @@ class Level < ApplicationRecord
       end
     end
 
-    !(current_parent&.type == "LevelGroup")
+    current_parent&.type != "LevelGroup"
   end
 
   def to_xml(options = {})

--- a/dashboard/app/models/programming_method.rb
+++ b/dashboard/app/models/programming_method.rb
@@ -69,7 +69,7 @@ class ProgrammingMethod < ApplicationRecord
       examples: parsed_examples,
       syntax: syntax,
       externalLink: external_link,
-      canHaveOverload: !programming_class.programming_methods.any? {|m| m.overload_of == key},
+      canHaveOverload: programming_class.programming_methods.none? {|m| m.overload_of == key},
       overloadOf: overload_of
     }
   end

--- a/dashboard/app/serializers/api/v1/pd/application_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/application_serializer.rb
@@ -156,7 +156,7 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
   # update emails are sent by the system if there is no regional partner or if the regional partner
   # has not set the decision email flag to SENT_BY_PARTNER
   def update_emails_sent_by_system
-    !(object&.regional_partner&.applications_decision_emails == RegionalPartner::SENT_BY_PARTNER)
+    object&.regional_partner&.applications_decision_emails != RegionalPartner::SENT_BY_PARTNER
   end
 
   def meets_scholarship_criteria

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -326,7 +326,7 @@ Devise.setup do |config|
       end
     # Students younger than 13 shouldn't see App Lab and Game Lab unless they
     # are in a teacher's section for privacy reasons.
-    limit_project_types = user.under_13? && !user.sections_as_student.any?
+    limit_project_types = user.under_13? && user.sections_as_student.none?
     auth.cookies[environment_specific_cookie_name("_limit_project_types")] = {value: limit_project_types, domain: :all, httponly: true}
     auth.cookies[environment_specific_cookie_name("_user_type")] = {value: user_type, domain: :all, httponly: true}
     auth.cookies[environment_specific_cookie_name("_shortName")] = {value: user.short_name, domain: :all}

--- a/lib/cdo/rack/process_html.rb
+++ b/lib/cdo/rack/process_html.rb
@@ -77,7 +77,7 @@ module Rack
 
       # Skip if :include is provided and evaluates to false
       if @include &&
-          !(@include == env['PATH_INFO'])
+          @include != env['PATH_INFO']
         return false
       end
 


### PR DESCRIPTION
Alternative to https://github.com/code-dot-org/code-dot-org/pull/59666

By far the largest category of existing violations for this rule in our codebase are `select` vs `reject` statements. These block statements and the sometimes-complex filtering logic they contain can be difficult to reason about; by configuring the rule to ignore those methods, we can benefit from some amount of protection while also giving engineers flexibility to write code that reflects how they would prefer to think about the operation.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
