### PR TITLE
[Aichat] Change focus to chat message input after update/submit

### DIFF
--- a/apps/src/aichat/views/UserChatMessageEditor.tsx
+++ b/apps/src/aichat/views/UserChatMessageEditor.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useEffect} from 'react';
 
 import UserMessageEditor from '@cdo/apps/aiComponentLibrary/userMessageEditor/UserMessageEditor';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -29,6 +29,12 @@ const UserChatMessageEditor: React.FunctionComponent<{
   );
 
   const disabled = isWaitingForChatResponse || saveInProgress;
+
+  useEffect(() => {
+    if (!disabled) {
+      document.getElementById('uitest-chat-textarea')?.focus();
+    }
+  }, [disabled]);
 
   return (
     <UserMessageEditor


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR changes the focus to the user chat message input box after:
- the user submits a chat message and then the model response is displayed,
- model customizations are updated by the user.

The jira ticket requested that the focus change to the user message input box after chat message submission, but checked with product/curriculum [Slack thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1726762352487559), and they appreciated that the focus now changes to the same input box after a model update as well.

An `onEffect` was added with dependency `disabled` which is assigned `isWaitingForChatResponse || saveInProgress`.

## Before update

https://github.com/user-attachments/assets/8a1749d8-5817-43b9-be12-0743d2819907


## After update



https://github.com/user-attachments/assets/ba6ea7c9-59bb-4ef9-8a23-70c91b1e07c7







## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1027)
[Slack thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1726762352487559)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally on `aichat` levels. 
- Toggled between 'Edit' and 'User View'
- Checked as a teacher user viewing student work and testing student model.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
