### PR TITLE
HoC 2024 - Change "October" to "September" on hourofcode.com/events

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10936,8 +10936,7 @@
 
   hoc_events:
     heading: "Register to host an Hour of Code"
-    desc: "Hour of Code is available year-round, but every year in December your class can join millions of students around the world celebrating Computer Science Education Week with the Hour of Code. Registration for the annual celebration starts each year in October."
-    desc_sept: "Hour of Code is available year-round, but every year in December your class can join millions of students around the world celebrating Computer Science Education Week with the Hour of Code. Registration for the annual celebration starts each year in September."
+    desc: "Hour of Code is available year-round, but every year in December your class can join millions of students around the world celebrating Computer Science Education Week with the Hour of Code. Registration for the annual celebration starts each year in September."
     button: "Register my event"
     register:
       heading: "Register your event"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -10937,6 +10937,7 @@
   hoc_events:
     heading: "Register to host an Hour of Code"
     desc: "Hour of Code is available year-round, but every year in December your class can join millions of students around the world celebrating Computer Science Education Week with the Hour of Code. Registration for the annual celebration starts each year in October."
+    desc_sept: "Hour of Code is available year-round, but every year in December your class can join millions of students around the world celebrating Computer Science Education Week with the Hour of Code. Registration for the annual celebration starts each year in September."
     button: "Register my event"
     register:
       heading: "Register your event"

--- a/pegasus/sites.v3/hourofcode.com/public/events.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events.haml
@@ -29,7 +29,7 @@ layout: wide_index
         %h1.no-margin-top
           =hoc_s("hoc_events.heading")
         %p.body-two
-          =hoc_s("hoc_events.desc_sept")
+          =hoc_s("hoc_events.desc")
         %a.link-button{href: "#form"}
           =hoc_s("hoc_events.button")
       %figure.flex-1

--- a/pegasus/sites.v3/hourofcode.com/public/events.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events.haml
@@ -28,8 +28,9 @@ layout: wide_index
       .text-wrapper.flex-1
         %h1.no-margin-top
           =hoc_s("hoc_events.heading")
+        -# TODO - Update this to use .desc_sept for all languages once translation comes in
         %p.body-two
-          =hoc_s("hoc_events.desc_sept")
+          =hoc_s(@language == 'en' ? "hoc_events.desc_sept" : "hoc_events.desc")
         %a.link-button{href: "#form"}
           =hoc_s("hoc_events.button")
       %figure.flex-1

--- a/pegasus/sites.v3/hourofcode.com/public/events.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events.haml
@@ -28,9 +28,8 @@ layout: wide_index
       .text-wrapper.flex-1
         %h1.no-margin-top
           =hoc_s("hoc_events.heading")
-        -# TODO - Update this to use .desc_sept for all languages once translation comes in
         %p.body-two
-          =hoc_s(@language == 'en' ? "hoc_events.desc_sept" : "hoc_events.desc")
+          =hoc_s("hoc_events.desc_sept")
         %a.link-button{href: "#form"}
           =hoc_s("hoc_events.button")
       %figure.flex-1

--- a/pegasus/sites.v3/hourofcode.com/public/events.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events.haml
@@ -29,7 +29,7 @@ layout: wide_index
         %h1.no-margin-top
           =hoc_s("hoc_events.heading")
         %p.body-two
-          =hoc_s("hoc_events.desc")
+          =hoc_s("hoc_events.desc_sept")
         %a.link-button{href: "#form"}
           =hoc_s("hoc_events.button")
       %figure.flex-1


### PR DESCRIPTION
Updates https://hourofcode.com/events to say registrations begin in September instead of October.

## Links
Jira ticket: [ACQ-2419](https://codedotorg.atlassian.net/browse/ACQ-2419)
Slack convo: [here](https://codedotorg.slack.com/archives/C5V9YCXTR/p1726705817853109?thread_ts=1726663730.305159&cid=C5V9YCXTR)

----

<img width="1283" alt="Screenshot 2024-09-19 at 11 53 36 AM" src="https://github.com/user-attachments/assets/229712cc-7690-4627-b74e-5447965717ed">
