### PR TITLE
Aichat: fix React list keys warning

### DIFF
--- a/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
+++ b/apps/src/aichat/views/modelCustomization/PublishNotes.tsx
@@ -68,47 +68,46 @@ const PublishNotes: React.FunctionComponent = () => {
           const {property, label, editTooltip} = data;
           const InputTag = getInputTag(property);
 
+          if (property === 'exampleTopics') {
+            return (
+              <ExampleTopicsInputs
+                key={property}
+                fieldLabel={label}
+                fieldId={property}
+                tooltipText={editTooltip}
+                topics={modelCardInfo.exampleTopics}
+                readOnly={isReadOnly}
+                visibility={visibility}
+              />
+            );
+          }
           return (
-            <>
-              {property === 'exampleTopics' && (
-                <ExampleTopicsInputs
-                  fieldLabel={label}
-                  fieldId={property}
-                  tooltipText={editTooltip}
-                  topics={modelCardInfo.exampleTopics}
-                  readOnly={isReadOnly}
-                  visibility={visibility}
+            <div
+              className={modelCustomizationStyles.inputContainer}
+              key={property}
+            >
+              <FieldLabel
+                label={label}
+                id={property}
+                tooltipText={editTooltip}
+              />
+              {property !== 'isPublished' && (
+                <InputTag
+                  id={property}
+                  type="text"
+                  disabled={isReadOnly}
+                  value={modelCardInfo[property]}
+                  onChange={event =>
+                    dispatch(
+                      setModelCardProperty({
+                        property: property,
+                        value: event.target.value,
+                      })
+                    )
+                  }
                 />
               )}
-              {property !== 'exampleTopics' && (
-                <div
-                  className={modelCustomizationStyles.inputContainer}
-                  key={property}
-                >
-                  <FieldLabel
-                    label={label}
-                    id={property}
-                    tooltipText={editTooltip}
-                  />
-                  {property !== 'isPublished' && (
-                    <InputTag
-                      id={property}
-                      type="text"
-                      disabled={isReadOnly}
-                      value={modelCardInfo[property]}
-                      onChange={event =>
-                        dispatch(
-                          setModelCardProperty({
-                            property: property,
-                            value: event.target.value,
-                          })
-                        )
-                      }
-                    />
-                  )}
-                </div>
-              )}
-            </>
+            </div>
           );
         })}
       </div>


### PR DESCRIPTION
Fix a React "Each child in a list should have a unique "key" prop" warning that was getting thrown by the `PublishNotes` component. Added keys and converted a fragment to a conditional that only returns one component.

Warning (no longer appears with change):
<img width="845" alt="Screenshot 2024-09-19 at 11 57 30 AM" src="https://github.com/user-attachments/assets/67dfb6eb-b86e-4d30-97b2-90c0804cdb0f">
