### PR TITLE
Fix lab2 level editors collapse bug

### DIFF
--- a/apps/src/lab2/levelEditors/panels/edit-panels.module.scss
+++ b/apps/src/lab2/levelEditors/panels/edit-panels.module.scss
@@ -1,6 +1,10 @@
 @import '../../../mixins.scss';
 @import 'color.scss';
 
+$scale-factor: 0.5;
+$full-width: 1920px;
+$full-height: 1080px;
+
 .container {
   display: flex;
   flex-direction: column;
@@ -8,16 +12,17 @@
 
 .panelsContainer {
   position: relative;
-  height: 540px;
+  height: $full-height * $scale-factor;
+  width: $full-width * $scale-factor;
   background-color: #121212;
   margin-bottom: 25px;
 }
 
 .fullSizeContainer {
   position: relative;
-  width: 1920px;
-  height: 1080px;
-  transform: scale(0.5) translateX(-50%) translateY(-50%);
+  width: $full-width;
+  height: $full-height;
+  transform: scale($scale-factor) translateX(-50%) translateY(-50%);
 }
 
 .panelEditors {

--- a/apps/src/sites/studio/pages/levels/editors/fields/_aichat_settings.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_aichat_settings.js
@@ -10,6 +10,6 @@ $(document).ready(function () {
 
   ReactDOM.render(
     <EditAichatSettings initialSettings={initialSettings} />,
-    document.getElementById('aichat-settings-container')
+    document.getElementById('aichat-settings-editor')
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_music_level_data.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_music_level_data.js
@@ -9,6 +9,6 @@ $(document).ready(function () {
   const initialLevelData = getScriptData('musicleveldata');
   ReactDOM.render(
     <EditMusicLevelData initialLevelData={initialLevelData} />,
-    document.getElementById('music-level-data-container')
+    document.getElementById('music-level-data-editor')
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_panels.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_panels.js
@@ -12,6 +12,6 @@ $(document).ready(function () {
 
   ReactDOM.render(
     <EditPanels initialPanels={initialPanels} levelName={levelName} />,
-    document.getElementById('panels-container')
+    document.getElementById('panels-editor')
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_predict_settings.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_predict_settings.js
@@ -10,6 +10,6 @@ $(document).ready(function () {
 
   ReactDOM.render(
     <EditPredictSettings initialSettings={initialSettings} />,
-    document.getElementById('predict-settings-container')
+    document.getElementById('predict-settings-editor')
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/fields/_validations.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_validations.js
@@ -18,6 +18,6 @@ $(document).ready(function () {
       levelName={levelName}
       appName={appName}
     />,
-    document.getElementById('validations-container')
+    document.getElementById('validations-editor')
   );
 });

--- a/dashboard/app/views/levels/editors/fields/_aichat_settings.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_aichat_settings.html.haml
@@ -2,6 +2,7 @@
   AI Chat Settings
 
 #aichat-settings-container.in.collapse
+  #aichat-settings-editor
 
 - content_for :body_scripts do
   %script{src: webpack_asset_path('js/levels/editors/fields/_aichat_settings.js'),

--- a/dashboard/app/views/levels/editors/fields/_music_level_data.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_music_level_data.html.haml
@@ -2,6 +2,7 @@
   Music Level Data
 
 #music-level-data-container.in.collapse
+  #music-level-data-editor
 
 - content_for :body_scripts do
   %script{src: webpack_asset_path("js/#{js_locale}/music_locale.js")}

--- a/dashboard/app/views/levels/editors/fields/_panels.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_panels.html.haml
@@ -2,6 +2,7 @@
   Panels
 
 #panels-container.in.collapse
+  #panels-editor
 
 - content_for :body_scripts do
   %script{src: webpack_asset_path('js/levels/editors/fields/_panels.js'),

--- a/dashboard/app/views/levels/editors/fields/_predict_settings.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_predict_settings.html.haml
@@ -2,6 +2,7 @@
   Predict Level Settings
 
 #predict-settings-container.in.collapse
+  #predict-settings-editor
 
 - content_for :body_scripts do
   %script{src: webpack_asset_path('js/levels/editors/fields/_predict_settings.js'),

--- a/dashboard/app/views/levels/editors/fields/_validations.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_validations.html.haml
@@ -2,6 +2,7 @@
   Validations
 
 #validations-container.in.collapse
+  #validations-editor
 
 - content_for :body_scripts do
   %script{src: webpack_asset_path('js/levels/editors/fields/_validations.js'),


### PR DESCRIPTION
Fixes a small bug in all the new lab2 level editors where once the category was collapsed, it couldn't be opened again. Not sure if this was a recent regression or had always been there, but the fix here is just to render the content in a child of the `in.collapse` container, which seems to be the target of the collapse/expand logic.

Also fixed a small styling issue with the panels editor.

Before:

https://github.com/user-attachments/assets/1a49548c-a32f-421f-9087-a7d3a540585c

After:

https://github.com/user-attachments/assets/ebe76a97-65b5-45db-bf40-6715abf0cfdf

Panels before (going off screen):
<img width="1597" alt="Screenshot 2024-09-19 at 12 18 57 PM" src="https://github.com/user-attachments/assets/a9a01e5a-4c59-4a77-bbca-c2fd5a9fb93c">

Panels after:
<img width="1609" alt="Screenshot 2024-09-19 at 12 19 43 PM" src="https://github.com/user-attachments/assets/3cd39274-5083-484d-82f3-c21717ce58e6">
