### PR TITLE
[Music] always use full toolbox in start mode

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -3,7 +3,6 @@ import {Abstract} from 'blockly/core/events/events_abstract';
 
 import {Renderers} from '@cdo/apps/blockly/constants';
 import CdoDarkTheme from '@cdo/apps/blockly/themes/cdoDark';
-import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
@@ -87,12 +86,8 @@ export default class MusicBlocklyWorkspace {
     }
 
     this.container = container;
-    const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
-    const toolboxBlocks = getToolbox(
-      blockMode,
-      // In start mode, we always show the full toolbox for the given block mode.
-      isStartMode ? undefined : toolbox
-    );
+
+    const toolboxBlocks = getToolbox(blockMode, toolbox);
 
     // This dialog is used for naming variables, which are only present in advanced mode.
     // Other Blockly labs use FeedbackUtils.prototype.showSimpleDialog to create a prettier dialog.

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -3,6 +3,7 @@ import {Abstract} from 'blockly/core/events/events_abstract';
 
 import {Renderers} from '@cdo/apps/blockly/constants';
 import CdoDarkTheme from '@cdo/apps/blockly/themes/cdoDark';
+import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
@@ -86,8 +87,12 @@ export default class MusicBlocklyWorkspace {
     }
 
     this.container = container;
-
-    const toolboxBlocks = getToolbox(blockMode, toolbox);
+    const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
+    const toolboxBlocks = getToolbox(
+      blockMode,
+      // In start mode, we always show the full toolbox for the given block mode.
+      isStartMode ? undefined : toolbox
+    );
 
     // This dialog is used for naming variables, which are only present in advanced mode.
     // Other Blockly labs use FeedbackUtils.prototype.showSimpleDialog to create a prettier dialog.

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -5,12 +5,14 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 import DCDO from '@cdo/apps/dcdo';
+import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {
   isReadOnlyWorkspace,
   setIsLoading,
   setPageError,
 } from '@cdo/apps/lab2/lab2Redux';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import AnalyticsReporter from '@cdo/apps/music/analytics/AnalyticsReporter';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 
@@ -233,6 +235,11 @@ class UnconnectedMusicView extends React.Component {
     if (libraryName === LEGACY_DEFAULT_LIBRARY) {
       libraryName = DEFAULT_LIBRARY;
     }
+
+    // In start mode, we always show the full toolbox for the given block mode.
+    const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
+    const toolboxData = isStartMode ? undefined : levelData?.toolbox;
+
     await this.loadAndInitializePlayer(libraryName || DEFAULT_LIBRARY);
 
     if (this.getBlockMode() === BlockMode.SIMPLE2) {
@@ -249,7 +256,7 @@ class UnconnectedMusicView extends React.Component {
           document.getElementById(BLOCKLY_DIV_ID),
           this.onBlockSpaceChange,
           this.props.isReadOnlyWorkspace,
-          levelData?.toolbox,
+          toolboxData,
           this.props.isRtl,
           this.getBlockMode()
         );


### PR DESCRIPTION
Katie Frank asked and made the following request:
> Are you aware that the full toolbox isn’t available in the start block setup page? You only have what was setup in the toolbox on the editor page. Not sure if that’s expected but it has been a snag for me several times. I can adjust my flow. But let us know if it might be able to be fixed

At the time that we would get the toolbox for the level, it's easily determined if we're in start mode. If we are, we can withhold the toolbox definition for that level so that the start mode always has the full toolbox available:

| Regular Level | Start Mode |
|-|-|
|![image](https://github.com/user-attachments/assets/68a2ae57-0fbb-43ae-91f6-23e9ff621580)|![image](https://github.com/user-attachments/assets/cca50147-ac6e-4b53-9bae-d73a420df3f7)|



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
