### PR TITLE
Updates to the Farsi MVP

### DIFF
--- a/i18n/locales/source/pegasus/mobile.json
+++ b/i18n/locales/source/pegasus/mobile.json
@@ -798,7 +798,7 @@
   "header_about_us": "About Us",
   "header_course_catalog": "Course Catalog",
   "header_courses": "Courses",
-  "header_csf": "CS Fundamentals",
+  "header_csf": "CSF",
   "header_districts": "Districts",
   "header_documentation": "Documentation",
   "header_donate": "Donate",

--- a/i18n/locales/source/pegasus/mobile.json
+++ b/i18n/locales/source/pegasus/mobile.json
@@ -798,7 +798,7 @@
   "header_about_us": "About Us",
   "header_course_catalog": "Course Catalog",
   "header_courses": "Courses",
-  "header_csf": "CSF",
+  "header_csf": "CS Fundamentals",
   "header_districts": "Districts",
   "header_documentation": "Documentation",
   "header_donate": "Donate",

--- a/lib/cdo/hamburger.rb
+++ b/lib/cdo/hamburger.rb
@@ -310,4 +310,117 @@ class Hamburger
 
     signed_out_links
   end
+
+  def self.get_farsi_hamburger_contents(options)
+    loc_prefix = options[:loc_prefix]
+    is_teacher_or_student = options[:user_type] == "teacher" || options[:user_type] == "student"
+    is_level = options[:level]
+    hide_small_desktop = is_teacher_or_student || is_level
+
+    # Teacher-specific hamburger dropdown links.
+    teacher_entries = [
+      {title: "my_dashboard", url: CDO.studio_url("/home")},
+      {title: "course_catalog", url: CDO.studio_url("/catalog")},
+      {title: "project_gallery", url: CDO.studio_url("/projects")},
+      {title: "professional_learning", url: CDO.studio_url("/my-professional-learning")},
+      {title: "incubator", url: CDO.studio_url("/incubator")}
+    ].each do |entry|
+      entry[:title] = I18n.t("#{loc_prefix}#{entry[:title]}")
+    end
+
+    # Student-specific hamburger dropdown links.
+    student_entries = [
+      {title: "my_dashboard", url: CDO.studio_url("/home"), id: "hamburger-student-home"},
+      {title: "course_catalog", url: CDO.code_org_url("/students")},
+      {title: "project_gallery", url: CDO.studio_url("/projects"), id: "hamburger-student-projects"},
+      {title: "incubator", url: CDO.studio_url("/incubator")}
+    ].each do |entry|
+      entry[:title] = I18n.t("#{loc_prefix}#{entry[:title]}")
+    end
+
+    # Privacy & Legal hamburger dropdown links.
+    legal_entries = [
+      {title: "legal_privacy", url: "https://code-org.translate.goog/privacy?_x_tr_sl=auto&_x_tr_tl=fa&_x_tr_hl=en&_x_tr_pto=wapp"},
+      {title: "legal_cookie_notice", url: CDO.code_org_url("/cookies")},
+      {title: "legal_tos", url: "https://code-org.translate.goog/tos?_x_tr_sl=auto&_x_tr_tl=fa&_x_tr_hl=en&_x_tr_pto=wapp"},
+    ].each do |entry|
+      entry[:title] = I18n.t("#{loc_prefix}#{entry[:title]}")
+    end.freeze
+
+    # Get visibility CSS.
+    visibility_options = {level: options[:level], language: options[:language], user_type: options[:user_type]}
+    visibility = Hamburger.get_visibility(visibility_options)
+
+    # Generate the list of entries.
+    entries = []
+
+    # user_type-specific.
+    case options[:user_type]
+    when 'teacher'
+      entries = entries.concat(teacher_entries.each {|e| e[:class] = visibility[:show_teacher_options]})
+      entries << {type: "divider", class: get_divider_visibility(visibility[:show_teacher_options], visibility[:show_help_options]), id: "after-teacher"}
+    when 'student'
+      entries = entries.concat(student_entries.each {|e| e[:class] = visibility[:show_student_options]})
+      entries << {type: "divider", class: get_divider_visibility(visibility[:show_student_options], visibility[:show_help_options]), id: "after-student"}
+    end
+
+    # Show help links before Pegasus links for signed in users.
+    help_contents = HelpHeader.get_help_contents(options)
+    if is_teacher_or_student
+      entries.concat(help_contents.each {|e| e[:class] = visibility[:show_help_options]})
+      entries << {type: "divider", class: get_divider_visibility(visibility[:show_help_options], visibility[:show_pegasus_options]), id: "after-help"}
+    end
+
+    # Pegasus links.
+    entries << {
+      title: I18n.t("#{loc_prefix}teach"),
+      url: CDO.code_org_url("/global/fa/teacher"),
+      class: visibility[:show_pegasus_options] + (hide_small_desktop ? "" : " hide-small-desktop"),
+      id: "header-teach"
+    }
+
+    entries << {
+      title: I18n.t("#{loc_prefix}about"),
+      url: CDO.code_org_url("/global/fa/about"),
+      id: "header-about",
+      class: visibility[:show_pegasus_options] + (hide_small_desktop ? "" : " hide-small-desktop")
+    }
+
+    entries << {
+      title: I18n.t("#{loc_prefix}csf"),
+      url: CDO.code_org_url("/global/fa/csf"),
+      id: "header-csf",
+      class: visibility[:show_pegasus_options] + (hide_small_desktop ? "" : " hide-small-desktop")
+    }
+
+    entries << {
+      title: I18n.t("#{loc_prefix}hour_of_code"),
+      url: CDO.code_org_url("/global/fa/hourofcode"),
+      id: "header-hoc",
+      class: visibility[:show_pegasus_options]
+    }
+
+    entries << {
+      title: I18n.t("#{loc_prefix}videos"),
+      url: CDO.code_org_url("/global/fa/videos"),
+      id: "header-videos",
+      class: visibility[:show_pegasus_options]
+    }
+
+    entries << {
+      type: "expander",
+      title: I18n.t("#{loc_prefix}legal"),
+      id: "legal_entries",
+      subentries: legal_entries.each {|e| e[:class] = visibility[:show_pegasus_options]},
+      class: visibility[:show_pegasus_options]
+    }
+
+    # Show help links at the bottom of the list for signed out users.
+    unless is_teacher_or_student
+      entries << {type: "divider", class: get_divider_visibility(visibility[:show_help_options], visibility[:show_pegasus_options]) + (is_level ? "  hide-large-desktop" : ""), id: "before-help"}
+      entries.concat(help_contents.each {|e| e[:class] = visibility[:show_help_options]})
+    end
+
+    {entries: entries, visibility: visibility[:hamburger_class]}
+  end
 end

--- a/pegasus/cache/i18n/en-US.json
+++ b/pegasus/cache/i18n/en-US.json
@@ -1480,7 +1480,7 @@
     "header_schools": "Schools",
     "header_districts": "Districts",
     "header_screen_reader_help": "Help Menu",
-    "header_csf": "CSF",
+    "header_csf": "CS Fundamentals",
     "header_videos": "Videos",
     "header_hour_of_code": "Hour of Code",
     "app_lab_documentation": "App Lab Documentation",

--- a/pegasus/sites.v3/code.org/public/global/fa/about.haml
+++ b/pegasus/sites.v3/code.org/public/global/fa/about.haml
@@ -104,6 +104,31 @@ theme: responsive_full_width
 // Want to always be in English
 %section
   .wrapper
+    %h2="Code.org in Farsi is about children, not politics"
+    %p
+      ="Code.org is an education nonprofit and NGO dedicated to the vision that every student in every school has the opportunity to learn computer science and artificial intelligence as part of their core education. Because of our global impact, we often collaborate with regional governments to advance this goal. However, for Code.org in Farsi, we operate independently from any government influence due to geopolitical sensitivities. This project is designed to enable global access to our free educational resources, and is unrestricted by US sanctions. Code.org’s purpose is to support educational opportunities for Farsi-speaking children, with no stance on any other political or controversial topics."
+    %details
+      %summary="What countries is Code.org in?"
+      %p="The Code.org website and learning platform is used in over 50 languages, by students and classrooms in EVERY country in the world. Although headquartered in the USA, Code.org's curriculum is designed for global reach, localized to different languages and cultures, with targeted campaigns to reach students in Latin America, Asia, the Middle East, and Africa."
+    %details
+      %summary="Is Code.org collaborating with the government of _____?"
+      %p="Code.org often collaborates with local governments to ensure that education systems teach computer science. When we work with governments, it is to work with national ministries or local departments of education, to create opportunities for children in local schools. In the case of Code.org in Farsi, Code.org is not collaborating with, for, or against any government. Code.org’s founder and CEO (Hadi Partovi) is Iranian-born, and he sees this as a project to support Farsi speaking children all around the globe."
+    %details
+      %summary="What is Code.org’s stance on the government of Iran?"
+      %p="Code.org has no stance on any government or political issue other than our one organizing focus: that every student in every school should have the opportunity to learn computer science. You can read more about Code.org’s apolitical, inclusive, and unifying stance."
+    %details
+      %summary="What is Code.org’s stance on the hijab laws in Iran? Do Code.org videos abide by hijab laws?"
+      %p="Code.org takes no stance on political issues in any country. We believe that every student should have equal access to a high quality computer science education, regardless of their birthplace, language, gender, skin color, or religion. To enable universal access to our courses, we design our content with a global audience in mind. And to localize our curriculum for Middle Eastern students, we are re-recording some of our educational videos with Iranian (or Arabic) speakers, so that Middle Eastern students may see computer science role models who showcase the customs of their region. In some of these videos, female speakers wear hijab, and in others they do not — both situations reflect their personal preference or custom, and not a position or stance of Code.org."
+    %details
+      %summary="Is Code.org in Farsi compliant with US sanctions on Iran?"
+      %p="As a U.S. nonprofit, Code.org is subject to laws regarding sanctions with Iran. After consulting with U.S. legal counsel experienced in the Iranian Sanctions and Translations Regulations (ITSR), Code.org believes that it may fund, prepare, and distribute the Farsi translations of its computer science curriculum globally via its website, to audiences in every country including Iran. The ITSR provides an exemption for “information and informational materials” (the IIM Exemption) and Code.org believes that this exemption will fully shield its funding, preparation, and distribution of the Farsi translations and thus enable its Farsi translations effort to proceed in full compliance with U.S. economic sanctions requirements. Code.org does not have any financial relationship or legal contracts with any Iran-based entities."
+    %details
+      %summary="Who funds Code.org in Farsi, and what are their objectives?"
+      %p="Code.org in Farsi is funded by donors who believe that every Farsi-speaking student should have the opportunity to learn computer science, with the same access as students who speak English, Spanish, Arabic, or other language. Code.org’s unifying mission attracts a diverse group of supporters, but their only relationship with Code.org is to support our student-focused mission. Any other efforts or goals of our funders have absolutely no bearing on the work or intentions of Code.org."
+
+// Want to always be in English
+%section.bg-neutral-light
+  .wrapper
     %h2.heading-sm
       ="Compliance In Support Of Farsi Translations"
     %p.body-three

--- a/pegasus/sites.v3/code.org/public/global/fa/about.haml
+++ b/pegasus/sites.v3/code.org/public/global/fa/about.haml
@@ -133,4 +133,3 @@ theme: responsive_full_width
       ="Compliance In Support Of Farsi Translations"
     %p.body-three
       ="As a U.S. nonprofit, Code.org is subject to laws regarding sanctions with Iran. After consulting with U.S. legal counsel experienced in the Iranian Sanctions and Translations Regulations (ITSR), Code.org believes that it may fund, prepare, and distribute the Farsi Translations of CS Curriculum in the United States and elsewhere around the world, including within Iran. The ITSR provides an exemption for “information and informational materials” (the IIM Exemption) and Code.org believes that this exemption will fully shield its funding, preparation, and distribution of the Farsi Translations and thus enable its Farsi Translations effort to proceed in full compliance with U.S. economic sanctions requirements."
-"

--- a/pegasus/sites.v3/code.org/public/global/fa/teacher.haml
+++ b/pegasus/sites.v3/code.org/public/global/fa/teacher.haml
@@ -23,8 +23,7 @@ theme: responsive_full_width
 
 %section.bg-neutral-light
   .wrapper.centered
-    %h2=hoc_s("game_design_page.why.heading")
-    %p=hoc_s("game_design_page.why.desc")
+    %h2=hoc_s(:teach_page_why_teach_cs_heading)
     = view :"global/fa/farsi_why_list"
     .button-wrapper.centered
       %a.link-button{href: "#curriculum-offerings"}

--- a/pegasus/sites.v3/code.org/public/global/fa/teacher.haml
+++ b/pegasus/sites.v3/code.org/public/global/fa/teacher.haml
@@ -59,7 +59,7 @@ theme: responsive_full_width
           =hoc_s(:"farsi_site.farsi_homepage_video_card_title")
         %p.heading-sm
           =hoc_s(:"farsi_site.farsi_homepage_video_card_description")
-        %a.link-button{href: "https://hourofcode.com/learn"}
+        %a.link-button{href: "/global/fa/videos"}
           =hoc_s(:"farsi_site.farsi_homepage_video_card_cta")
 
 %section#professional-learning.bg-neutral-light

--- a/pegasus/sites.v3/code.org/public/global/fa/videos.haml
+++ b/pegasus/sites.v3/code.org/public/global/fa/videos.haml
@@ -32,11 +32,11 @@ video_player: true
       %p
         = video_page_section_desc[index]
       - if index === 0
-        = view :carousel_how_ai_works_video
+        = view :"global/fa/carousel_farsi_how_ai_works_video"
       - if index === 1
-        = view :carousel_computer_works_video
+        = view :"global/fa/carousel_farsi_computer_works_video"
       - if index === 2
-        = view :carousel_internet_video
+        = view :"global/fa/carousel_farsi_internet_video"
   = view :section_divider_line
 
 %section.centered

--- a/pegasus/sites.v3/code.org/public/global/fa/videos.haml
+++ b/pegasus/sites.v3/code.org/public/global/fa/videos.haml
@@ -32,11 +32,11 @@ video_player: true
       %p
         = video_page_section_desc[index]
       - if index === 0
-        = view :"global/fa/carousel_farsi_how_ai_works_video"
+        = view :"global/fa/carousel_farsi_how_ai_works_videos"
       - if index === 1
-        = view :"global/fa/carousel_farsi_computer_works_video"
+        = view :"global/fa/carousel_farsi_computer_works_videos"
       - if index === 2
-        = view :"global/fa/carousel_farsi_internet_video"
+        = view :"global/fa/carousel_farsi_internet_videos"
   = view :section_divider_line
 
 %section.centered

--- a/pegasus/sites.v3/code.org/public/images/global/fa/farsi-lesson-plan.gif
+++ b/pegasus/sites.v3/code.org/public/images/global/fa/farsi-lesson-plan.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dfdf95ca8038310ca6fe0baf3390be3b7e8fb643468aef6446ef983f8f803ec
+size 3853091

--- a/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_computer_works_videos.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_computer_works_videos.haml
@@ -1,0 +1,19 @@
+- video_computer_index = 6
+
+- video_computer_caption = [hoc_s(:video_library_page_computer_work_video_title_1), hoc_s(:video_library_page_computer_work_video_title_4), hoc_s(:video_library_page_computer_work_video_title_2), hoc_s(:video_library_page_computer_work_video_title_5), hoc_s(:video_library_page_computer_work_video_title_3), hoc_s(:video_library_page_computer_work_video_title_6)]
+
+- video_download_path = ["//videos.code.org/farsi/ai-01-intro-to-ai.mp4", "//videos.code.org/farsi/ai-02-machine-learning.mp4"]
+
+- video_computer = ["p7f8HZqPsPk", "sNbdsmVRp6Y", "Me9o7DuFvXg", "ZSiVLP15zEM", "s_g-c9uWpFI", "ylO1ba84_7w"]
+
+.carousel-wrapper.video-carousel
+  %swiper-container.how-computers-work{navigation: "true", "navigation-next-el": ".nav-next-how-computers-work", "navigation-prev-el": ".nav-prev-how-computers-work", pagination: "true", init: "false", "allow-touch-move": "false"}
+    - video_computer_index.times do |index|
+      %swiper-slide
+        %figure
+          = view :video_with_fallback, video_code: video_computer[index], download_path: video_download_path[index]
+          %figcaption.no-margin-bottom
+            = video_computer_caption[index]
+
+  %button.swiper-nav-prev.nav-prev-how-computers-work
+  %button.swiper-nav-next.nav-next-how-computers-work

--- a/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_computer_works_videos.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_computer_works_videos.haml
@@ -2,7 +2,7 @@
 
 - video_computer_caption = [hoc_s(:video_library_page_computer_work_video_title_1), hoc_s(:video_library_page_computer_work_video_title_4), hoc_s(:video_library_page_computer_work_video_title_2), hoc_s(:video_library_page_computer_work_video_title_5), hoc_s(:video_library_page_computer_work_video_title_3), hoc_s(:video_library_page_computer_work_video_title_6)]
 
-- video_download_path = ["//videos.code.org/farsi/ai-01-intro-to-ai.mp4", "//videos.code.org/farsi/ai-02-machine-learning.mp4"]
+- video_download_path = ["//videos.code.org/farsi/how-computers-work/01_HowComputersWork_Farsi_V1.mp4", "//videos.code.org/farsi/how-computers-work/02 WhatMakesAComputer_Farsi_V1.mp4", "//videos.code.org/farsi/how-computers-work/03_BinaryData_Farsi_V1.mp4", "//videos.code.org/farsi/how-computers-work/04_CircuitsLogic_Farsi_V1.mp4", "//videos.code.org/farsi/how-computers-work/05_CPUMemoryIO_Farsi_V1.mp4", "//videos.code.org/farsi/how-computers-work/06_HardwareSoftware_Farsi_V1.mp4"]
 
 - video_computer = ["p7f8HZqPsPk", "sNbdsmVRp6Y", "Me9o7DuFvXg", "ZSiVLP15zEM", "s_g-c9uWpFI", "ylO1ba84_7w"]
 

--- a/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_how_ai_works_videos.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_how_ai_works_videos.haml
@@ -1,0 +1,22 @@
+// Should be 9 when done
+- video_ai_index = 2
+
+- video_download_path = ["//videos.code.org/farsi/ai-01-intro-to-ai.mp4", "//videos.code.org/farsi/ai-02-machine-learning.mp4"]
+
+// this is the full list which will be helpful when we add the needed videos
+//- video_caption = [hoc_s(:ai_vid_intro_caption), hoc_s(:ai_vid_mlintro_caption), hoc_s(:ai_vid_trainingdata_caption), hoc_s(:ai_vid_neuralnetworks_caption), hoc_s(:ai_vid_computervision_caption), hoc_s(:ai_vid_chatbots_caption), hoc_s(:ai_vid_creativity_caption), hoc_s(:ai_vid_ethics1_caption), hoc_s(:ai_vid_ethics2_caption)]
+- video_caption = [hoc_s(:ai_vid_mlintro_caption), hoc_s(:ai_vid_trainingdata_caption)]
+
+- video_code = ["2V6zog8MPQo", "p7f8HZqPsPk"]
+
+.carousel-wrapper.video-carousel
+  %swiper-container.how-ai-works{navigation: "true", "navigation-next-el": ".nav-next-how-ai-works", "navigation-prev-el": ".nav-prev-how-ai-works", pagination: "true", init: "false", "allow-touch-move": "false"}
+    - video_ai_index.times do |index|
+      %swiper-slide
+        %figure
+          = view :video_with_fallback, video_code: video_code[index], download_path: video_download_path[index]
+          %figcaption.no-margin-bottom
+            = video_caption[index]
+
+  %button.swiper-nav-prev.nav-prev-how-ai-works
+  %button.swiper-nav-next.nav-next-how-ai-works

--- a/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_how_ai_works_videos.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_how_ai_works_videos.haml
@@ -1,7 +1,7 @@
 // Should be 9 when done
 - video_ai_index = 2
 
-- video_download_path = ["//videos.code.org/farsi/ai-01-intro-to-ai.mp4", "//videos.code.org/farsi/ai-02-machine-learning.mp4"]
+- video_download_path = ["//videos.code.org/farsi/how-ai-works/ai-training-data-bias.mp4", "//videos.code.org/farsi/how-ai-works/ai-what-machine-learning.mp4"]
 
 // this is the full list which will be helpful when we add the needed videos
 //- video_caption = [hoc_s(:ai_vid_intro_caption), hoc_s(:ai_vid_mlintro_caption), hoc_s(:ai_vid_trainingdata_caption), hoc_s(:ai_vid_neuralnetworks_caption), hoc_s(:ai_vid_computervision_caption), hoc_s(:ai_vid_chatbots_caption), hoc_s(:ai_vid_creativity_caption), hoc_s(:ai_vid_ethics1_caption), hoc_s(:ai_vid_ethics2_caption)]

--- a/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_internet_videos.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_internet_videos.haml
@@ -2,7 +2,7 @@
 
 - internet_video_caption = [hoc_s(:video_library_page_internet_work_video_title_1), hoc_s(:video_library_page_internet_work_video_title_5), hoc_s(:video_library_page_internet_work_video_title_2), hoc_s(:video_library_page_internet_work_video_title_6) , hoc_s(:video_library_page_internet_work_video_title_3), hoc_s(:video_library_page_internet_work_video_title_7), hoc_s(:video_library_page_internet_work_video_title_4), hoc_s(:video_library_page_internet_work_video_title_8)]
 
-- video_download_path = ["//videos.code.org/farsi/ai-01-intro-to-ai.mp4", "//videos.code.org/farsi/ai-02-machine-learning.mp4"]
+- video_download_path = ["//videos.code.org/farsi/how-internet-works/what-is-internet.mp4", "//videos.code.org/farsi/how-internet-works/internet-wire-cables.mp4", "//videos.code.org/farsi/how-internet-works/internet-ip.mp4", "//videos.code.org/farsi/how-internet-works/internet-packets.mp4", "//videos.code.org/farsi/how-internet-works/internet-http-html.mp4", "//videos.code.org/farsi/how-internet-works/internet-encryption.mp4", "//videos.code.org/farsi/how-internet-works/internet-cybersecurity.mp4", "//videos.code.org/farsi/how-internet-works/internet-search.mp4"]
 
 - video_internet = ["zHJ1E-qAxiA", "QPWb53_wM6Q", "Gy5Qe75Gy1w", "WLc3kCKgbtw", "cold1Glav6o", "itX9NUDYhis", "vY269KmgXi8", "mkLKkCJ1Z4Y"]
 

--- a/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_internet_videos.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_internet_videos.haml
@@ -1,0 +1,19 @@
+- video_internet_index = 8
+
+- internet_video_caption = [hoc_s(:video_library_page_internet_work_video_title_1), hoc_s(:video_library_page_internet_work_video_title_5), hoc_s(:video_library_page_internet_work_video_title_2), hoc_s(:video_library_page_internet_work_video_title_6) , hoc_s(:video_library_page_internet_work_video_title_3), hoc_s(:video_library_page_internet_work_video_title_7), hoc_s(:video_library_page_internet_work_video_title_4), hoc_s(:video_library_page_internet_work_video_title_8)]
+
+- video_download_path = ["//videos.code.org/farsi/ai-01-intro-to-ai.mp4", "//videos.code.org/farsi/ai-02-machine-learning.mp4"]
+
+- video_internet = ["zHJ1E-qAxiA", "QPWb53_wM6Q", "Gy5Qe75Gy1w", "WLc3kCKgbtw", "cold1Glav6o", "itX9NUDYhis", "vY269KmgXi8", "mkLKkCJ1Z4Y"]
+
+.carousel-wrapper.video-carousel
+  %swiper-container.how-internet-works{navigation: "true", "navigation-next-el": ".nav-next-how-internet-works", "navigation-prev-el": ".nav-prev-how-internet-works", pagination: "true", init: "false", "allow-touch-move": "false"}
+    - video_internet_index.times do |index|
+      %swiper-slide
+        %figure
+          = view :video_with_fallback, video_code: video_internet[index], download_path: video_download_path[index]
+          %figcaption.no-margin-bottom
+            = internet_video_caption[index]
+
+  %button.swiper-nav-prev.nav-prev-how-internet-works
+  %button.swiper-nav-next.nav-next-how-internet-works

--- a/pegasus/sites.v3/code.org/views/global/fa/farsi_curriculum.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/farsi_curriculum.haml
@@ -24,5 +24,5 @@
       %img{src: "/images/global/fa/hour-of-code-2023.png", alt: ""}
       %p=hoc_s(:"farsi_site.farsi_homepage_curriculum_description_1")
     .content-footer
-      %a.link-button{href: "/global/fa/hoc"}
+      %a.link-button{href: "/global/fa/hourofcode"}
         =hoc_s(:call_to_action_explore_hoc_short)

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_assessments.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_assessments.haml
@@ -8,5 +8,5 @@
         =hoc_s(:resources_tabs_assessments_subhead)
     %p.body-three
       =hoc_s(:resources_tabs_assessments_desc)
-    %a.link-button{href: CDO.studio_url("/s/csd1-2023/lessons/8"), target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button{href: CDO.studio_url("/s/courseb-2022/lessons/13?lang=fa-IR"), target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_resources_assessments)

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_lesson_plans.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_lesson_plans.haml
@@ -1,6 +1,6 @@
 %div.flex-container.justify-space-between.align-items-center
   %figure.col-50
-    %img.rounded-corners{src: "/images/resources-tabs-lesson-plan.gif", alt: "", style: "position: relative; width: 100%;"}
+    %img.rounded-corners{src: "/images/global/fa/farsi-lesson-plan.gif", alt: "", style: "position: relative; width: 100%;"}
   .text-wrapper.col-45{style: "float: right"}
     %h3=hoc_s(:resources_tabs_tab_label_lesson_plans)
     %p

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_videos.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_videos.haml
@@ -1,6 +1,6 @@
 %div.flex-container.justify-space-between.align-items-center
   %figure.col-50
-    = view :video_with_fallback, video_code: "v=p7f8HZqPsPk", download_path: "//videos.code.org/farsi/ai-01-intro-to-ai.mp4"
+    = view :video_with_fallback, video_code: "p7f8HZqPsPk", download_path: "//videos.code.org/farsi/ai-01-intro-to-ai.mp4"
     %figcaption.no-margin-bottom
       =hoc_s(:ai_vid_intro_caption)
   .text-wrapper.col-45{style: "float: right"}

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_videos.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_videos.haml
@@ -1,6 +1,6 @@
 %div.flex-container.justify-space-between.align-items-center
   %figure.col-50
-    = view :video_with_fallback, video_code: "Ok-xpKjKp2g", download_path: "//videos.code.org/ai_series/ai-01-intro-to-ai.mp4"
+    = view :video_with_fallback, video_code: "v=p7f8HZqPsPk", download_path: "//videos.code.org/farsi/ai-01-intro-to-ai.mp4"
     %figcaption.no-margin-bottom
       =hoc_s(:ai_vid_intro_caption)
   .text-wrapper.col-45{style: "float: right"}
@@ -10,5 +10,5 @@
         =hoc_s(:resources_tabs_videos_subhead)
     %p.body-three
       =hoc_s(:resources_tabs_videos_desc)
-    %a.link-button{href: "https://www.youtube.com/channel/UCJyEBMU1xVP2be1-AoGS1BA", target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button{href: "https://www.youtube.com/watch?v=p7f8HZqPsPk", target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:call_to_action_resources_videos)

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_videos.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_videos.haml
@@ -1,6 +1,6 @@
 %div.flex-container.justify-space-between.align-items-center
   %figure.col-50
-    = view :video_with_fallback, video_code: "p7f8HZqPsPk", download_path: "//videos.code.org/farsi/ai-01-intro-to-ai.mp4"
+    = view :video_with_fallback, video_code: "gp7f8HZqPsPk", download_path: "//videos.code.org/farsi/ai-01-intro-to-ai.mp4"
     %figcaption.no-margin-bottom
       =hoc_s(:ai_vid_intro_caption)
   .text-wrapper.col-45{style: "float: right"}

--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -1,7 +1,7 @@
 :ruby
   options = { level: level, script_level: script_level, language: language, user_type: user_type, loc_prefix: loc_prefix, request: request }
   dashboard ||= false
-  contents = Hamburger.get_hamburger_contents(options)
+  contents = request.path.include?('/global/fa')? Hamburger.get_farsi_hamburger_contents(options): Hamburger.get_hamburger_contents(options)
 
 #hamburger{class: contents[:visibility], tabindex: "0", 'aria-label': I18n.t('header_screen_reader_hamburger')}
   #hamburger-contents.hide-responsive-menu


### PR DESCRIPTION
Update to the Farsi Marketing MVP based on feedback

- Add the FAQ section to /global/fa/about
- Sets up the hamburger menu to not link to any of the english marketing pages
- Fixes the "Why teach" header on /global/teacher
- Fixed broken link in for HOC on curriculum cards
- Add the Farsi specific videos with fallback players
- Spell out CS Fundamentals in header


Figma for reference: https://www.figma.com/design/tWtelJNCHawn5FVacKcusq/Code-in-Farsi?node-id=2307-1601&node-type=section&t=G06IDuPGz8crBvRQ-0
