### PR TITLE
Fix Violations of `Style/RedendantParentheses` in HAML

### DIFF
--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -73,7 +73,7 @@
 
       - elsif @script_level
         %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level, @extra_params)).to_s
-    - if (@level.is_a? Blockly) && (!@level.uses_droplet?)
+    - if @level.is_a?(Blockly) && !@level.uses_droplet?
       %button{type: 'button', onclick: 'window.levelbuilder.copySelectedBlockToClipboard()', class: 'btn btn-default btn-sm'}
         Copy selected block
       %button{type: 'button', onclick: 'window.levelbuilder.copyWorkspaceToClipboard()', class: 'btn btn-default btn-sm'}
@@ -84,7 +84,7 @@
       %br
       %button{type: 'button', onclick: 'Blockly.mainBlockSpace.clear()', class: 'btn btn-default btn-sm'}
         Clear workspace
-      - if @level.uses_google_blockly? || (params[:blocklyVersion] == 'google') || (Experiment.enabled?(experiment_name: 'google_blockly', user: current_user))
+      - if @level.uses_google_blockly? || params[:blocklyVersion] == 'google' || Experiment.enabled?(experiment_name: 'google_blockly', user: current_user)
         %button{type: 'button', onclick: 'Blockly.getMainWorkspace().undo(false)', class: 'btn btn-default btn-sm'}
           Undo
       %hr
@@ -163,7 +163,7 @@
         %button{id: "bookmark", class: "btn btn-default btn-sm"}
           Bookmark as a featured project
 
-      #unpublished_warning{'style' => ('display: none; margin-top: 20px; width: 250px;')}
+      #unpublished_warning{'style' => 'display: none; margin-top: 20px; width: 250px;'}
         * This project is currently unpublished. It can still be marked as featured, but it will not show in the gallery until the owner publishes it.
 
     - if current_user.project_validator?

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -1,7 +1,7 @@
 .unplugged.match{id: "level_#{level.id}"}
   = render partial: 'levels/content', locals: {app: 'match', data: level.properties, content_class: level.question_content_class, source_level: level, hide_header: !standalone}
 
-  - if standalone && !(level.properties['options'].try(:[], 'hide_submit'))
+  - if standalone && !level.properties['options'].try(:[], 'hide_submit')
     .buttons
       %a.btn.btn-large.btn-primary.next-lesson.submitButton
         =t('submit')

--- a/dashboard/app/views/levels/editors/fields/_aichat_settings.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_aichat_settings.html.haml
@@ -5,4 +5,4 @@
 
 - content_for :body_scripts do
   %script{src: webpack_asset_path('js/levels/editors/fields/_aichat_settings.js'),
-        data: {aichatsettings: (@level.properties["aichat_settings"]).to_json}}
+        data: {aichatsettings: @level.properties["aichat_settings"].to_json}}

--- a/dashboard/app/views/levels/editors/fields/_blockly.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_blockly.html.haml
@@ -26,7 +26,7 @@
   .aligned-input-group
     = f.check_box :disable_param_editing, {}, 'false', 'true'
     = f.label :disable_param_editing, 'Enable param editing in function blocks'
-  - if (@level.instance_of?(GamelabJr))
+  - if @level.instance_of?(GamelabJr)
     .aligned-input-group
       = f.check_box :mini_toolbox, {}, 'true', 'false'
       = f.label :mini_toolbox, 'Enable mini toolbox for event blocks'

--- a/dashboard/app/views/levels/editors/fields/_code_area.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_code_area.html.haml
@@ -3,7 +3,7 @@
 
 #code_area.in.collapse
   = render partial: 'levels/editors/fields/droplet', locals: {f: f} if @level.uses_droplet?
-  = render partial: 'levels/editors/fields/blockly', locals: {f: f} if !(@level.uses_droplet?) && @level.is_a?(Blockly)
+  = render partial: 'levels/editors/fields/blockly', locals: {f: f} if !@level.uses_droplet? && @level.is_a?(Blockly)
   = render partial: 'levels/editors/fields/weblab_code_area', locals: {f: f} if @level.is_a?(Weblab)
   = render partial: 'levels/editors/fields/blockly_variables', locals: {f: f} if @level.is_a?(GamelabJr)
   = render partial: 'levels/editors/fields/block_pools', locals: {f: f} if @level.is_a?(GamelabJr) || @level.is_a?(Dancelab)

--- a/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
@@ -33,7 +33,7 @@
 
 #dsl_editor.in.collapse
   .script_text
-    = text_area_tag('level[dsl_text]', @level.dsl_text || (@level.dsl_default))
+    = text_area_tag('level[dsl_text]', @level.dsl_text || @level.dsl_default)
 
     - if @level.is_a?(External)
       %p< If you want to embed blocks in this level, you can do so by adding associated_blocks 'block type' to the DSL field. Available block types are: #{External.possible_associated_blocks.join(', ')}

--- a/dashboard/app/views/levels/editors/fields/_instructions_area.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_instructions_area.html.haml
@@ -5,5 +5,5 @@
   = render partial: 'levels/editors/fields/instructions', locals: {f: f} unless @level.is_a?(DSLDefined) || @level.is_a?(Unplugged)
   = render partial: 'levels/editors/fields/ailab_dynamic_instructions', locals: {f: f} if @level.is_a?(Ailab)
   = render partial: 'levels/editors/fields/help_and_tips', locals: {f: f} if @level.show_help_and_tips_in_level_editor?
-  = render partial: 'levels/editors/fields/mini_rubric', locals: {f: f} if (@level.uses_droplet?) || @level.is_a?(Weblab) || @level.is_a?(Javalab)
-  = render partial: 'levels/editors/fields/authored_hints', locals: {f: f} if !(@level.uses_droplet?) && @level.is_a?(Blockly) && !@level.is_a?(NetSim)
+  = render partial: 'levels/editors/fields/mini_rubric', locals: {f: f} if @level.uses_droplet? || @level.is_a?(Weblab) || @level.is_a?(Javalab)
+  = render partial: 'levels/editors/fields/authored_hints', locals: {f: f} if !@level.uses_droplet? && @level.is_a?(Blockly) && !@level.is_a?(NetSim)

--- a/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
@@ -28,4 +28,4 @@
       \/
       %a.select_none{href: '#'} no
       (shift-click or cmd-click to select multiple).
-    = f.select :available_poems, (@level.class.poems_for_standalone_app(@level.standalone_app_name)), {}, {multiple: true}
+    = f.select :available_poems, @level.class.poems_for_standalone_app(@level.standalone_app_name), {}, {multiple: true}

--- a/dashboard/app/views/levels/editors/fields/_predict_settings.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_predict_settings.html.haml
@@ -5,4 +5,4 @@
 
 - content_for :body_scripts do
   %script{src: webpack_asset_path('js/levels/editors/fields/_predict_settings.js'),
-        data: {predictsettings: (@level.properties["predict_settings"]).to_json}}
+        data: {predictsettings: @level.properties["predict_settings"].to_json}}

--- a/dashboard/app/views/levels/editors/fields/_sharing.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_sharing.html.haml
@@ -6,6 +6,6 @@
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :disable_sharing, description: "Disable sharing"}
     %p If set, this level cannot be shared or saved to galleries even if it's free play.
 
-  = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :hide_share_and_remix, description: "Hide Share and Remix buttons in header"} if (@level.uses_droplet?) || @level.is_a?(Blockly) || @level.is_a?(Weblab) || @level.is_a?(Javalab) || @level.uses_lab2?
+  = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :hide_share_and_remix, description: "Hide Share and Remix buttons in header"} if @level.uses_droplet? || @level.is_a?(Blockly) || @level.is_a?(Weblab) || @level.is_a?(Javalab) || @level.uses_lab2?
 
   = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :shareable, description: "Make Shareable?"}  if @level.is_a?(Flappy)

--- a/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
@@ -7,7 +7,7 @@
 
 #validation.in.collapse
   -# Deprecated for Sprite Lab and Dance not used in Gamelab, Weblab or Applab
-  - if (!(@level.is_a?(Gamelab) || @level.is_a?(Applab) || @level.is_a?(Weblab)) && (@level.is_a?(Blockly)))
+  - if (!(@level.is_a?(Gamelab) || @level.is_a?(Applab) || @level.is_a?(Weblab)) && @level.is_a?(Blockly))
     .field
       = f.label :failure_message_override, 'Failure Message Override'
       %p If specified this error message will be used to replace ALL error

--- a/dashboard/app/views/levels/editors/fields/_video.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_video.html.haml
@@ -16,5 +16,5 @@
   = f.select :video_key, options_for_select(video_key_choices, @level.video_key), {include_blank: true}, {class: 'video-dropdown'}
   .video-preview{style: 'display: block'}
 
-  - if (@level.uses_droplet?) || @level.is_a?(Blockly)
+  - if @level.uses_droplet? || @level.is_a?(Blockly)
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :never_autoplay_video, description: "Never autoplay video"}

--- a/dashboard/app/views/pd/application/teacher_application_mailer/_questions_concerns.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/_questions_concerns.html.haml
@@ -1,4 +1,4 @@
-- if !(@application.regional_partner)
+- if !@application.regional_partner
   %p
     Please direct all questions or concerns to
     = mail_to('teacher@code.org') + '.'

--- a/dashboard/app/views/pd/workshop_enrollment/_enroll_form.html.haml
+++ b/dashboard/app/views/pd/workshop_enrollment/_enroll_form.html.haml
@@ -58,7 +58,7 @@
       %span.form-required-field
         *
     -# Manually wrap an error highlight around the entire district dropdown.
-    - error_class = (@enrollment.errors.include?(:"school_info")) ? "field_with_errors_div" : ""
+    - error_class = @enrollment.errors.include?(:"school_info") ? "field_with_errors_div" : ""
     #school_info.span5{class: error_class, style: "border: solid 1px #bbb; border-radius: 4px; padding: 15px; margin-left: 0px; box-sizing: border-box;"}
       %div.controls
         -# ignore existing info if it was in the old data format, to avoid inclusion of bogus fields.

--- a/dashboard/app/views/shared/_course_wide_block.haml
+++ b/dashboard/app/views/shared/_course_wide_block.haml
@@ -89,7 +89,7 @@
   .courseblock-span6.courseblock-wide-small
     = link_to script_url(id)  do
       .courseblock-span2.imgspan
-        - image = (family_name.nil?) ? "logo_tall_#{id}.jpg" : "logo_tall_#{family_name}.jpg"
+        - image = family_name.nil? ? "logo_tall_#{id}.jpg" : "logo_tall_#{family_name}.jpg"
         %img{src: CDO.code_org_url("/shared/images/courses/fill-150x110/#{image}")}
       .courseblock-span4.heading
         %h3= data_t_suffix('script.name', id, 'title')
@@ -111,7 +111,7 @@
   .courseblock-span6.courseblock-wide-small
     = link_to script_url(id)  do
       .courseblock-span2.imgspan
-        - image = (family_name.nil?) ? "logo_tall_#{id}.jpg" : "logo_tall_#{family_name}.jpg"
+        - image = family_name.nil? ? "logo_tall_#{id}.jpg" : "logo_tall_#{family_name}.jpg"
         %img{src: CDO.code_org_url("/shared/images/courses/fill-150x110/#{image}")}
       .courseblock-span4.heading
         %h3= data_t_suffix('script.name', id, 'title')

--- a/dashboard/app/views/shared/_school_info.html.haml
+++ b/dashboard/app/views/shared/_school_info.html.haml
@@ -89,9 +89,9 @@
 
   $(document).ready(function() {
     var options = #{existing_school_info.to_json};
-    var suppressScrolling = #{!!(local_assigns[:suppress_scrolling])};
+    var suppressScrolling = #{!!local_assigns[:suppress_scrolling]};
     options['suppressScrolling'] = suppressScrolling;
-    options['assumeUsa'] = #{!!(local_assigns[:assume_usa])};
+    options['assumeUsa'] = #{!!local_assigns[:assume_usa]};
 
     // Send through some values that the JavaScript will need.
     window.schoolInfoManager = new SchoolInfoManager(options);

--- a/pegasus/sites.v3/code.org/views/find-on-fb.haml
+++ b/pegasus/sites.v3/code.org/views/find-on-fb.haml
@@ -1,4 +1,4 @@
--if (current_site) == 'code.org'
+-if current_site == 'code.org'
   -fb_acct = 'Code.org'
 -else
   -fb_acct = 'csedweek'

--- a/pegasus/sites/all/views/page.haml
+++ b/pegasus/sites/all/views/page.haml
@@ -9,12 +9,12 @@
       %meta{property: property, content: content}
 
     -if request.site == 'csedweek.org'
-      -title = (header['title'].nil?) ? 'The Hour of Code' : header['title']
-      -tagline = (header['tagline'].nil?) ? 'The Hour of Code' : header['tagline']
+      -title = header['title'].nil? ? 'The Hour of Code' : header['title']
+      -tagline = header['tagline'].nil? ? 'The Hour of Code' : header['tagline']
       -copyright = '&copy; Computer Science Education Week, 2014'
     -else
-      -title = (header['title'].nil?) ? 'Anybody can learn' : header['title']
-      -tagline = (header['tagline'].nil?) ? 'Code.org' : header['tagline']
+      -title = header['title'].nil? ? 'Anybody can learn' : header['title']
+      -tagline = header['tagline'].nil? ? 'Code.org' : header['tagline']
       -copyright = '&copy; Code.org, 2015'
 
     -full_title = (tagline == '' || title == tagline) ? title : title + ' | ' + tagline


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/60779, which reenabled this Cop and tested that all our Rubocop-linted code passed validation, but unfortunately did not take into account that `haml-lint` uses the same config. Because our automated linting in CI and in the pre-commit hook only checks files changes in the PR, we didn't realize this was opening us up to linting errors in HAML until the staging build.

Fortunately, the total number of violations is relatively small; despite being on a version of `haml-lint` that does not support autocorrection, it was straightforward to make the necessary corrections manually (especially with the help of [`surround.vim`](https://github.com/tpope/vim-surround)!)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[Relevant Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1726775618002349)

## Testing story

Verified by running `bundle exec haml-lint` manually that after this change, we no longer have any linting violations.

I don't know to what extent we can rely on unit tests to verify that none of these code changes resulted in any functional changes, and I also don't know how to manually test the majority of the affected pages. Given the extremely simple nature of the code changes, I'm comfortable relying on a manual visual inspection of the diff to convince ourselves that this change is safe. But I'm open to better ideas if anyone has some!

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
