### PR TITLE
Header: fix button shift

### DIFF
--- a/apps/src/code-studio/components/header/header-popup.module.scss
+++ b/apps/src/code-studio/components/header/header-popup.module.scss
@@ -5,7 +5,7 @@
   cursor: pointer;
   background-color: transparent;
   padding: 2px 0 2px 0;
-  border: none;
+  border: solid 1px rgba(0 0 0 / 0);
   color: color.$orange;
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
Clicking on the `MORE` button in the header causes it to shift a little since it only has a border in its `:active` psuedo-class.  This change simply adds a corresponding, but invisible, border all the time so that there is no longer a shift.  

### before

https://github.com/user-attachments/assets/45329304-4ea8-48f2-8943-8d6ca3d6fbf5

### after

https://github.com/user-attachments/assets/c6b8f43a-00b9-4a02-be0f-71cda420b506
