### PR TITLE
Music: better preview cancel

### DIFF
--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -42,7 +42,7 @@ class ToneJSPlayer implements AudioPlayer {
   private activePlayers: Source<SourceOptions>[];
   private currentPreview: {
     url: string;
-    player: Source<SourceOptions>;
+    player?: Source<SourceOptions>;
   } | null;
   private effectBusses: {[key: string]: ToneAudioNode};
   private registeredCallbacks: {
@@ -160,11 +160,20 @@ class ToneJSPlayer implements AudioPlayer {
     await this.startContextIfNeeded();
     this.cancelPreviews();
 
+    this.currentPreview = {url: sample.sampleUrl};
+
     const buffer = await this.soundCache.loadSound(sample.sampleUrl);
     if (!buffer) {
       this.metricsReporter.logWarning(
         'Could not load sound which should have been in cache: ' +
           sample.sampleUrl
+      );
+      return;
+    }
+
+    if (this.currentPreview?.url !== sample.sampleUrl) {
+      console.log(
+        `Sample preview ${sample.sampleUrl} playback canceled after load but before play.`
       );
       return;
     }
@@ -190,7 +199,7 @@ class ToneJSPlayer implements AudioPlayer {
     };
 
     player.start();
-    this.currentPreview = {url: sample.sampleUrl, player};
+    this.currentPreview.player = player;
   }
 
   async playSamplesImmediately() {
@@ -240,9 +249,7 @@ class ToneJSPlayer implements AudioPlayer {
   }
 
   cancelPreviews() {
-    if (this.currentPreview) {
-      this.currentPreview.player.stop();
-    }
+    this.currentPreview?.player?.stop();
 
     if (this.currentSequencePreviewTimer) {
       clearInterval(this.currentSequencePreviewTimer);


### PR DESCRIPTION
Before this change, previewing a sample could only be canceled by a subsequent preview if the first sample had already been loaded and started playing.

After this change, a preview completes the load and other async operations, and then checks to see that a different preview has not been initiated in the interim, before it actually starts playing.

This avoids the issue of having multiple previews playing at the same time with some rapid clicking.
