### PR TITLE
HoC 2024 - Add translated page titles

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -11049,6 +11049,9 @@
         body_04: "No use of \"Hour of Code\" or \"Hora del Código\" in app names."
 
   hoc_how_to:
+    page_title:
+      teachers: "How-to guide for Teachers"
+      events: "How-to guide for Events"
     heading: "Your go-to guide starts here!"
     desc: "Choose the right guide for you:"
     label:

--- a/pegasus/sites.v3/hourofcode.com/public/cookies.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/cookies.haml
@@ -1,7 +1,9 @@
 ---
-title: Code.org Cookie Notice
 layout: wide
 ---
+
+:ruby
+  @header["title"] = hoc_s(:footer_menu_cookie)
 
 %link{ :href => "/css/cookies.css", :rel => "stylesheet" }
 

--- a/pegasus/sites.v3/hourofcode.com/public/how-to/events.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/how-to/events.haml
@@ -1,8 +1,10 @@
 ---
-title: How-to Guide for Events | Hour of Code
 layout: wide_index
 theme: how_to_guide
 ---
+
+:ruby
+  @header["title"] = hoc_s("hoc_how_to.page_title.events")
 
 -# Hero banner
 = view :"how-to/how_to_banner"

--- a/pegasus/sites.v3/hourofcode.com/public/how-to/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/how-to/index.haml
@@ -1,8 +1,10 @@
 ---
-title: How-to Guide for Teachers | Hour of Code
 layout: wide_index
 theme: how_to_guide
 ---
+
+:ruby
+  @header["title"] = hoc_s("hoc_how_to.page_title.teachers")
 
 -# TODO remove this logic after soon-hoc launch
 -# Get the default HOC mode

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -1,5 +1,4 @@
 ---
-title: Learn
 layout: wide_index
 social:
   twitter:card: photo
@@ -7,6 +6,9 @@ social:
   og:image:width: '1200'
   og:image:height: '630'
 ---
+
+:ruby
+  @header["title"] = hoc_s("hoc_activities.heading")
 
 %link{href: "/css/generated/hoc-banner.css", rel: "stylesheet", type: "text/css"}
 


### PR DESCRIPTION
Adds translated page titles to the following pages on hourofcode.com:
- https://hourofcode.com/us/learn
  - Used an existing string
- https://hourofcode.com/us/how-to
  - Added new string  
- https://hourofcode.com/us/how-to/events
  - Added new string
- https://hourofcode.com/us/cookies
  - Used an existing string

## Links
Jira ticket: [ACQ-2395](https://codedotorg.atlassian.net/browse/ACQ-2395)

## Testing story
Tested locally