### PR TITLE
[Music] Levelbuilder quick wins

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -20,6 +20,7 @@ import RawJsonEditor from './RawJsonEditor';
 import moduleStyles from './edit-music-level-data.module.scss';
 
 const VALID_LIBRARIES = [DEFAULT_LIBRARY, 'launch2024'];
+const RECOMMENDED_LIBRARY = 'launch2024';
 
 const JSON_FIELDS = [['startSources', 'Start Sources']] as const;
 
@@ -39,6 +40,10 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
   }, []);
 
   const [levelData, setLevelData] = useState(initialLevelData);
+  // Immediately set a level, if needed, so we can populate its allowed sounds.
+  if (!levelData.library) {
+    levelData.library = RECOMMENDED_LIBRARY;
+  }
 
   const blockMode = levelData.blockMode || BlockMode.SIMPLE2;
   useEffect(() => {
@@ -85,6 +90,10 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
       />
       <CollapsibleSection headerContent="Library & Sounds">
         <div className={moduleStyles.section}>
+          <i>
+            Note that currently, all levels within a lesson must use the same
+            library.
+          </i>
           <div>
             <SimpleDropdown
               labelText="Selected Library"

--- a/apps/src/lab2/levelEditors/levelData/EditMusicToolbox.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicToolbox.tsx
@@ -97,11 +97,6 @@ const EditMusicToolbox: React.FunctionComponent<EditMusicToolboxProps> = ({
                 }}
               />
             </div>
-            <i>
-              Note that currently, all levels will use the Simple2 sequencing
-              model by default. The advanced model is only usable by adding
-              '?blocks=advanced' to the URL.
-            </i>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This adds the following changes/improvements to the level edit page for Music Lab levels:

This lower warning has been removed as it is no longer needed or accurate:
**Before:**
![image](https://github.com/user-attachments/assets/5990ac97-8b7d-4099-842e-b66b7cf59e48)
**After:**
<img width="758" alt="image" src="https://github.com/user-attachments/assets/fd872191-bb53-41e9-8ff7-d5d8ba4cd031">


A warning has been added to help clarify limitations around loading libraries with Lab2. Additionally, the dropdown menu will now select the recommended 'launch2024' by default, and populate its allowed sounds list, unless the level has already been configured with a library.

**Before:**
![image](https://github.com/user-attachments/assets/7ef97edd-2133-4f7a-a36e-a75f65393303)
**After:**
<img width="780" alt="image" src="https://github.com/user-attachments/assets/26f45bb1-ac01-4316-ab0b-b98996fcc248">



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
