### PR TITLE
Farsi site - Show Hour of Code hamburger link on small desktop

### DIFF
--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -660,7 +660,8 @@ nav.main #hamburger #hamburger-contents {
   with appropriate links hidden */
 @media (min-width: 1024px) and (max-width: 1268px) {
   nav.main .left ul li:nth-child(n + 4),
-  nav.main #hamburger-contents > div:nth-child(-n + 5) {
+  nav.main #hamburger-contents:not(.farsi) > div:nth-child(-n + 5),
+  nav.main #hamburger-contents.farsi > div:nth-child(-n + 4) {
     display: none !important;
   }
 }

--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -4,7 +4,7 @@
   contents = request.path.include?('/global/fa')? Hamburger.get_farsi_hamburger_contents(options): Hamburger.get_hamburger_contents(options)
 
 #hamburger{class: contents[:visibility], tabindex: "0", 'aria-label': I18n.t('header_screen_reader_hamburger')}
-  #hamburger-contents.hide-responsive-menu
+  #hamburger-contents.hide-responsive-menu{class: request.path.include?('/global/fa') ? "farsi" : ""}
     -# Show the Sign in and Create account buttons if the user is not signed in
     - unless user_type
       #hamburger-sign-up-buttons


### PR DESCRIPTION
Fixes an issue found [here](https://github.com/code-dot-org/code-dot-org/pull/61222#discussion_r1768882696) where the Hour of Code hamburger link was not showing in the hamburger for small desktop for the https://code.org/global/fa site. 

The issue arose because the hamburger items are being hidden with CSS on code.org (not on the Ruby backend like studio.code.org) so I needed to add a class to select the Farsi-specific hamburger and could then hide the appropriate amount of links.

## Links
Jira ticket: [ACQ-2432](https://codedotorg.atlassian.net/browse/ACQ-2432)

## Testing story
Tested locally to make sure the right hamburger links are showing up on both the https://code.org/global/fa and https://code.org sites.

----


https://github.com/user-attachments/assets/55a64fde-79f7-4e6b-af8d-df85a3f6c60b

