### PR TITLE
Bump `unf_ext` from 0.0.7.2 to 0.0.7.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -275,8 +275,8 @@ gem 'oj', '~> 3.10'
 gem 'rest-client', '~> 2.0.1'
 
 # A rest-client dependency
-# This is the latest version that's installing successfully
-gem 'unf_ext', '0.0.7.2'
+# Needs to be at least this version to install successfully on some ARM processors.
+gem 'unf_ext', '0.0.7.4'
 
 # Generate SSL certificates.
 gem 'acmesmith', '~> 2.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -878,7 +878,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     unicode-display_width (2.4.2)
     unicode_utils (1.4.0)
     uri (0.13.0)
@@ -1095,7 +1095,7 @@ DEPENDENCIES
   timecop
   twilio-ruby (< 6.0)
   uglifier (>= 1.3.0)
-  unf_ext (= 0.0.7.2)
+  unf_ext (= 0.0.7.4)
   user_agent_parser
   validate_url (~> 1.0.15)
   validates_email_format_of


### PR DESCRIPTION
Ran into issues installing this gem in Docker. Found some notes suggesting there were some issues related to ARM chips that were resolved in 0.0.7.4.

https://github.com/knu/ruby-unf_ext/issues/26

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/36c29537-d05c-480c-9ed9-3a75ff68a9a7">

## Links

- [Slack discussion](https://codedotorg.slack.com/archives/C07LFGRN422/p1726860339972829)
- [Changelog](https://github.com/knu/ruby-unf_ext/blob/70b77aaf38cffaa092214405c3c2c3e7172a1302/CHANGELOG.md)
- [version diff](https://github.com/knu/ruby-unf_ext/compare/v0.0.7.2...v0.0.7.4)