### PR TITLE
Codebridge: hide tabs that should be hidden

### DIFF
--- a/apps/src/codebridge/utils/getOpenFiles.ts
+++ b/apps/src/codebridge/utils/getOpenFiles.ts
@@ -5,7 +5,9 @@ import {sortFilesByName} from './sortFilesByName';
 
 export const getOpenFiles = (project: ProjectType) => {
   if (project.openFiles) {
-    return project.openFiles.map(fileId => project.files[fileId]);
+    return project.openFiles
+      .filter(f => shouldShowFile(project.files[f]))
+      .map(fileId => project.files[fileId]);
   } else {
     return sortFilesByName(project.files, {mustBeOpen: true}).filter(f =>
       shouldShowFile(f)


### PR DESCRIPTION
We hide support and validation files from students. However, if those files were open when the start code was saved, we were showing tabs for those files, which were not clickable. This correctly hides those tabs.

## Before
![Screenshot 2024-09-20 at 4 01 25 PM](https://github.com/user-attachments/assets/226dd39c-8e84-4407-940c-8f59c44cd789)

## After
![Screenshot 2024-09-20 at 4 02 00 PM](https://github.com/user-attachments/assets/84db169d-9b02-4a4e-bb48-bf5bfc5c53a6)

## Links

- jira ticket: [CT-748](https://codedotorg.atlassian.net/browse/CT-748)


## Testing story
Tested locally. All file types still show up in start mode (the helper method I used checks for start mode).


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
