### PR TITLE
Added self-paced-pl-k5-2024 Units and recategorized translatable pl-pd units

### DIFF
--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -243,6 +243,14 @@ module ScriptConstants
     CSC_MAPPINGLANDMARKS_2023_NAME = 'csc-mappinglandmarks-2023'.freeze,
   ].freeze
 
+  TRANSLATABLE_PD_PL_UNITS = [
+    K5_ONLINEPD_2019 = 'k5-onlinepd-2019'.freeze,
+    K5_ONLINEPD = 'K5-OnlinePD'.freeze,
+    KODEA_PD_2021 = 'kodea-pd-2021'.freeze,
+    SELF_PACED_PL_K5_2024_1 = 'self-paced-pl-k5-2024-1'.freeze,
+    SELF_PACED_PL_K5_2024_2 = 'self-paced-pl-k5-2024-2'.freeze,
+  ].freeze
+
   ADDITIONAL_I18N_UNITS = [
     APPLAB_1HOUR = 'applab-1hour'.freeze,
     APPLAB_2HOUR = 'applab-2hour'.freeze,
@@ -265,10 +273,6 @@ module ScriptConstants
     POEM_ART = 'poem-art'.freeze,
     POETRY_HOC3 = 'poetry-hoc3'.freeze,
     VIGENERE = 'vigenere'.freeze,
-    K5_ONLINEPD_2019 = 'k5-onlinepd-2019'.freeze,
-    CS_BASICS_K5_TEACHERS = 'self-paced-pl-k5-2024'.freeze,
-    K5_ONLINEPD = 'K5-OnlinePD'.freeze,
-    KODEA_PD_2021 = 'kodea-pd-2021'.freeze,
     ALLTHETHINGS = 'allthethings'.freeze,
     COMPUTER_VISION = 'computer-vision'.freeze,
     CSD2_2024 = 'csd2-2024'.freeze,
@@ -329,8 +333,10 @@ module ScriptConstants
 
     *CATEGORIES[:hoc],
     *CATEGORIES[:twenty_hour],
+    *CATEGORIES[:twenty_hour],
     *ADDITIONAL_I18N_UNITS,
     *TRANSLATEABLE_CSC_UNITS,
+    *TRANSLATABLE_PD_PL_UNITS,
     JIGSAW_NAME,
   ].freeze
 

--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -333,7 +333,6 @@ module ScriptConstants
 
     *CATEGORIES[:hoc],
     *CATEGORIES[:twenty_hour],
-    *CATEGORIES[:twenty_hour],
     *ADDITIONAL_I18N_UNITS,
     *TRANSLATEABLE_CSC_UNITS,
     *TRANSLATABLE_PD_PL_UNITS,


### PR DESCRIPTION
We added a few weeks ago `self-paced-pl-k5-2024` to translatable Units, however, `self-paced-pl-k5-2024` is a Course, not a Script, and no content was being translated.

### This PR:
- Creates a PD-PL category that groups all translatable PD and PL units.
- Adds `self-paced-pl-k5-2024-1` and `self-paced-pl-k5-2024-2` to translatable units.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
