### PR TITLE
P20 1156/farsi mvp footer components for regional rendering

### DIFF
--- a/config/global_editions/en.yml
+++ b/config/global_editions/en.yml
@@ -339,6 +339,34 @@ header:
       url: https://forum.code.org
       id: teacher-community
 
+# The navigation region found at the bottom of each page
+footer:
+  # Remove these links to support pages
+  links:
+    - title: privacy_updated
+      url: /privacy
+      domain: code.org
+      style: 'color: #ffa400;'
+    - title: privacy
+      url: /privacy
+      domain: code.org
+      style: 'color: #ffa400;'
+    - title: cookie_notice
+      url: /cookies
+      domain: code.org
+    - title: translate
+      url: /translate
+      domain: code.org
+    - title: help_support
+      url: https://support.code.org
+      target: _blank
+      id: support
+    - title: store
+      url: https://store.code.org
+    - title: tos_short
+      url: /tos'
+      domain: code.org
+
 # These override specially wrapped components in particular pages.
 #
 # When we navigate to such a page that matches /global/:region<your mask>

--- a/config/global_editions/en.yml
+++ b/config/global_editions/en.yml
@@ -341,31 +341,76 @@ header:
 
 # The navigation region found at the bottom of each page
 footer:
-  # Remove these links to support pages
   links:
-    - title: privacy_updated
-      url: /privacy
-      domain: code.org
-      style: 'color: #ffa400;'
-    - title: privacy
-      url: /privacy
-      domain: code.org
-      style: 'color: #ffa400;'
-    - title: cookie_notice
-      url: /cookies
-      domain: code.org
-    - title: translate
-      url: /translate
-      domain: code.org
-    - title: help_support
-      url: https://support.code.org
-      target: _blank
-      id: support
-    - title: store
-      url: https://store.code.org
-    - title: tos_short
-      url: /tos'
-      domain: code.org
+    studio:
+      - title: privacy
+        url: /privacy
+        domain: code.org
+        style: 'color: #ffa400;'
+      - title: cookie_notice
+        url: /cookies
+        domain: code.org
+      - title: translate
+        url: /translate
+        domain: code.org
+      - title: help_support
+        url: https://support.code.org
+        target: _blank
+        loc_prefix: landing.
+        id: support
+      - title: store
+        url: https://store.code.org
+      - title: tos_short
+        url: /tos
+        domain: code.org
+    code_org:
+      - title: privacy_policy
+        url: /privacy
+        domain: code.org
+        style: 'color: #ffa400;'
+      - title: cookie_notice
+        url: /cookies
+        domain: code.org
+      - title: about
+        url: /about
+        domain: code.org
+      - title: partners
+        url: /partners
+        domain: code.org
+      - title: blog
+        url: https://medium.com/@codeorg
+        target: _blank
+      - title: donate
+        url: /donate
+        domain: code.org
+      - title: store
+        url: shop
+        domain: code.org
+      - title: support
+        url: http://support.code.org/
+        target: _blank
+      - title: terms
+        url: /tos
+        domain: code.org
+    hour_of_code:
+      - title: contact
+        url: http://support.code.org/hc/en-us/requests/new
+        target: _blank
+      - title: support
+        url: http://support.code.org
+        target: _blank
+      - title: terms
+        url: /tos
+        domain: code.org
+        target: _blank
+      - title: privacy
+        url: /privacy
+        domain: code.org
+        target: _blank
+      - title: cookie
+        domain: hourofcode.com
+        url: /cookies
+        target: _blank
 
 # These override specially wrapped components in particular pages.
 #

--- a/config/global_editions/fa.yml
+++ b/config/global_editions/fa.yml
@@ -127,9 +127,11 @@ footer:
     url: /tos'
     domain: code.org
 
-locale_options:
-  - ['English', 'en-US']
-  - ['فارسی', 'fa-IR']
+# A subset of locales can be specified with the following structure
+#locale_options:
+#  - ['English', 'en-US']
+#  - ['فارسی', 'fa-IR']
+
 
 # Route matching to influence properties of components
 #pages:

--- a/config/global_editions/fa.yml
+++ b/config/global_editions/fa.yml
@@ -112,10 +112,6 @@ header:
 footer:
   links:
     studio:
-      - title: privacy_updated
-        url: /privacy
-        domain: code.org
-        style: 'color: #ffa400;'
       - title: privacy
         url: /privacy
         domain: code.org
@@ -124,14 +120,14 @@ footer:
         url: /cookies
         domain: code.org
       - title: tos_short
-        url: /tos'
+        url: /tos
         domain: code.org
     code_org:
       - title: privacy_policy
-        url: /privacy
+        url: https://code-org.translate.goog/privacy?_x_tr_sl=auto&_x_tr_tl=fa&_x_tr_hl=en&_x_tr_pto=wapp
         domain: code.org
       - title: terms
-        url: /tos
+        url: https://code-org.translate.goog/tos?_x_tr_sl=auto&_x_tr_tl=fa&_x_tr_hl=en&_x_tr_pto=wapp
         domain: code.org
     hour_of_code:
       - title: terms
@@ -145,11 +141,6 @@ footer:
       - title: cookie
         url: /cookies
         target: _blank
-# A subset of locales can be specified with the following structure
-#locale_options:
-#  - ['English', 'en-US']
-#  - ['فارسی', 'fa-IR']
-
 
 # Route matching to influence properties of components
 #pages:

--- a/config/global_editions/fa.yml
+++ b/config/global_editions/fa.yml
@@ -111,22 +111,40 @@ header:
 # The navigation region found at the bottom of each page
 footer:
   links:
-  # Remove these links to support pages
-  - title: privacy_updated
-    url: /privacy
-    domain: code.org
-    style: 'color: #ffa400;'
-  - title: privacy
-    url: /privacy
-    domain: code.org
-    style: 'color: #ffa400;'
-  - title: cookie_notice
-    url: /cookies
-    domain: code.org
-  - title: tos_short
-    url: /tos'
-    domain: code.org
-
+    studio:
+      - title: privacy_updated
+        url: /privacy
+        domain: code.org
+        style: 'color: #ffa400;'
+      - title: privacy
+        url: /privacy
+        domain: code.org
+        style: 'color: #ffa400;'
+      - title: cookie_notice
+        url: /cookies
+        domain: code.org
+      - title: tos_short
+        url: /tos'
+        domain: code.org
+    code_org:
+      - title: privacy_policy
+        url: /privacy
+        domain: code.org
+      - title: terms
+        url: /tos
+        domain: code.org
+    hour_of_code:
+      - title: terms
+        url: /tos
+        domain: code.org
+        target: _blank
+      - title: privacy
+        url: /privacy
+        domain: code.org
+        target: _blank
+      - title: cookie
+        url: /cookies
+        target: _blank
 # A subset of locales can be specified with the following structure
 #locale_options:
 #  - ['English', 'en-US']

--- a/config/global_editions/fa.yml
+++ b/config/global_editions/fa.yml
@@ -110,12 +110,26 @@ header:
 
 # The navigation region found at the bottom of each page
 footer:
+  links:
   # Remove these links to support pages
-  translate: false
-  help_support: false
-  store: false
-  locale_dropdown: false
+  - title: privacy_updated
+    url: /privacy
+    domain: code.org
+    style: 'color: #ffa400;'
+  - title: privacy
+    url: /privacy
+    domain: code.org
+    style: 'color: #ffa400;'
+  - title: cookie_notice
+    url: /cookies
+    domain: code.org
+  - title: tos_short
+    url: /tos'
+    domain: code.org
 
+locale_options:
+  - ['English', 'en-US']
+  - ['فارسی', 'fa-IR']
 
 # Route matching to influence properties of components
 #pages:

--- a/config/global_editions/fa.yml
+++ b/config/global_editions/fa.yml
@@ -111,7 +111,11 @@ header:
 # The navigation region found at the bottom of each page
 footer:
   # Remove these links to support pages
-  bar: false
+  translate: false
+  help_support: false
+  store: false
+  locale_dropdown: false
+
 
 # Route matching to influence properties of components
 #pages:

--- a/config/global_editions/root.yml
+++ b/config/global_editions/root.yml
@@ -338,6 +338,38 @@ header:
       url: https://forum.code.org
       id: teacher-community
 
+# The navigation region found at the bottom of each page
+footer:
+  # Remove these links to support pages
+  links:
+    - title: privacy_updated
+      url: /privacy
+      domain: code.org
+      style: 'color: #ffa400;'
+    - title: privacy
+      url: /privacy
+      domain: code.org
+      style: 'color: #ffa400;'
+    - title: cookie_notice
+      url: /cookies
+      domain: code.org
+    - title: translate
+      url: /translate
+      domain: code.org
+    - title: help_support
+      url: https://support.code.org
+      target: _blank
+      id: support
+    - title: store
+      url: https://store.code.org
+    - title: tos_short
+      url: /tos'
+      domain: code.org
+
+# A subset of locales can be specified with the following structure
+#locale_options:
+#  - ['English', 'en-US']
+
 # These override specially wrapped components in particular pages.
 #
 # When we navigate to such a page that matches /global/:region<your mask>

--- a/config/global_editions/root.yml
+++ b/config/global_editions/root.yml
@@ -411,10 +411,6 @@ footer:
         url: /cookies
         target: _blank
 
-# A subset of locales can be specified with the following structure
-#locale_options:
-#  - ['English', 'en-US']
-
 # These override specially wrapped components in particular pages.
 #
 # When we navigate to such a page that matches /global/:region<your mask>

--- a/config/global_editions/root.yml
+++ b/config/global_editions/root.yml
@@ -342,29 +342,73 @@ header:
 footer:
   # Remove these links to support pages
   links:
-    - title: privacy_updated
-      url: /privacy
-      domain: code.org
-      style: 'color: #ffa400;'
-    - title: privacy
-      url: /privacy
-      domain: code.org
-      style: 'color: #ffa400;'
-    - title: cookie_notice
-      url: /cookies
-      domain: code.org
-    - title: translate
-      url: /translate
-      domain: code.org
-    - title: help_support
-      url: https://support.code.org
-      target: _blank
-      id: support
-    - title: store
-      url: https://store.code.org
-    - title: tos_short
-      url: /tos'
-      domain: code.org
+    studio:
+      - title: privacy
+        url: /privacy
+        domain: code.org
+        style: 'color: #ffa400;'
+      - title: cookie_notice
+        url: /cookies
+        domain: code.org
+      - title: translate
+        url: /translate
+        domain: code.org
+      - title: help_support
+        url: https://support.code.org
+        target: _blank
+        id: support
+      - title: store
+        url: https://store.code.org
+      - title: tos_short
+        url: /tos'
+        domain: code.org
+    code_org:
+      - title: privacy_policy
+        url: /privacy
+        domain: code.org
+        style: 'color: #ffa400;'
+      - title: cookie_notice
+        url: /cookies
+        domain: code.org
+      - title: about
+        url: /about
+        domain: code.org
+      - title: partners
+        url: /partners
+        domain: code.org
+      - title: blog
+        url: https://medium.com/@codeorg
+        target: _blank
+      - title: donate
+        url: /donate
+        domain: code.org
+      - title: store
+        url: shop
+        domain: code.org
+      - title: support
+        url: http://support.code.org/
+        target: _blank
+      - title: terms
+        url: /tos
+        domain: code.org
+    hour_of_code:
+      - title: contact
+        url: http://support.code.org/hc/en-us/requests/new
+        target: _blank
+      - title: support
+        url: http://support.code.org
+        target: _blank
+      - title: terms
+        url: /tos
+        domain: code.org
+        target: _blank
+      - title: privacy
+        url: /privacy
+        domain: code.org
+        target: _blank
+      - title: cookie
+        url: /cookies
+        target: _blank
 
 # A subset of locales can be specified with the following structure
 #locale_options:

--- a/config/global_editions/root.yml
+++ b/config/global_editions/root.yml
@@ -340,7 +340,6 @@ header:
 
 # The navigation region found at the bottom of each page
 footer:
-  # Remove these links to support pages
   links:
     studio:
       - title: privacy

--- a/config/global_editions/root.yml
+++ b/config/global_editions/root.yml
@@ -356,11 +356,12 @@ footer:
       - title: help_support
         url: https://support.code.org
         target: _blank
+        loc_prefix: landing.
         id: support
       - title: store
         url: https://store.code.org
       - title: tos_short
-        url: /tos'
+        url: /tos
         domain: code.org
     code_org:
       - title: privacy_policy
@@ -407,6 +408,7 @@ footer:
         domain: code.org
         target: _blank
       - title: cookie
+        domain: hourofcode.com
         url: /cookies
         target: _blank
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -596,10 +596,6 @@ html, body {
   }
 
   .container {
-    html[dir=rtl] & {
-      float: right;
-    }
-
     .row {
       [class*="span"] {
         html[dir=rtl] & {

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ require 'dynamic_config/gatekeeper'
 require 'dynamic_config/page_mode'
 require 'cdo/shared_constants'
 require 'policies/child_account'
+#require 'cdo/global'
 
 class ApplicationController < ActionController::Base
   include LocaleHelper
@@ -23,6 +24,8 @@ class ApplicationController < ActionController::Base
   before_action :setup_i18n_tracking
 
   around_action :with_locale
+
+  #before_action :set_footer_config
 
   before_action :fix_crawlers_with_bad_accept_headers
 
@@ -416,4 +419,9 @@ class ApplicationController < ActionController::Base
   ensure
     RequestStore.store[:current_user] = nil
   end
+
+  # private def set_footer_config
+  #   ge_region = params[:ge_region]
+  #   @footer_config = Cdo::Global.configuration_for(ge_region)[:footer] || {}
+  # end
 end

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -421,7 +421,8 @@ class ApplicationController < ActionController::Base
   end
 
   private def set_footer_config
-    ge_region = params[:ge_region]
+    ge_region = params[:ge_region] || 'en'
     @footer_config = Cdo::Global.configuration_for(ge_region)[:footer] || {}
+    @locale_options = Cdo::Global.configuration_for(ge_region)[:locale_options] || options_for_locale_select
   end
 end

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ require 'dynamic_config/gatekeeper'
 require 'dynamic_config/page_mode'
 require 'cdo/shared_constants'
 require 'policies/child_account'
-#require 'cdo/global'
+require 'cdo/global'
 
 class ApplicationController < ActionController::Base
   include LocaleHelper
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
 
   around_action :with_locale
 
-  #before_action :set_footer_config
+  before_action :set_footer_config
 
   before_action :fix_crawlers_with_bad_accept_headers
 
@@ -420,8 +420,8 @@ class ApplicationController < ActionController::Base
     RequestStore.store[:current_user] = nil
   end
 
-  # private def set_footer_config
-  #   ge_region = params[:ge_region]
-  #   @footer_config = Cdo::Global.configuration_for(ge_region)[:footer] || {}
-  # end
+  private def set_footer_config
+    ge_region = params[:ge_region]
+    @footer_config = Cdo::Global.configuration_for(ge_region)[:footer] || {}
+  end
 end

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -25,8 +25,6 @@ class ApplicationController < ActionController::Base
 
   around_action :with_locale
 
-  before_action :set_footer_config
-
   before_action :fix_crawlers_with_bad_accept_headers
 
   before_action :clear_sign_up_session_vars
@@ -418,11 +416,5 @@ class ApplicationController < ActionController::Base
     yield
   ensure
     RequestStore.store[:current_user] = nil
-  end
-
-  private def set_footer_config
-    ge_region = params[:ge_region] || 'en'
-    @footer_config = Cdo::Global.configuration_for(ge_region)[:footer] || {}
-    @locale_options = Cdo::Global.configuration_for(ge_region)[:locale_options] || options_for_locale_select
   end
 end

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ require 'dynamic_config/gatekeeper'
 require 'dynamic_config/page_mode'
 require 'cdo/shared_constants'
 require 'policies/child_account'
-require 'cdo/global'
 
 class ApplicationController < ActionController::Base
   include LocaleHelper

--- a/dashboard/app/helpers/footer.rb
+++ b/dashboard/app/helpers/footer.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module Footer
-end

--- a/dashboard/app/helpers/footer.rb
+++ b/dashboard/app/helpers/footer.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Footer
+end

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -9,12 +9,10 @@
       .span9{style: (full_width ? 'max-width: 80%;' : '')}
         - piped_spaces = ' | '
         - privacy_updated = DCDO.get('recent_privacy_policy_update', nil)
-        - links = (footer_contents[:links] || []).map(&:dup)
-        - if privacy_updated
-          - links.reject! { |link| link[:title] == 'privacy' }
-        - else
-          - links.reject! { |link| link[:title] == 'privacy_updated' }
+        - links = (footer_contents[:links][:studio] || []).map(&:dup)
         - links.each_with_index do |link, index|
+          - if privacy_updated && link[:title] == 'privacy'
+            - link[:title] = 'privacy_updated'
           - if link[:domain] == 'studio.code.org'
             - link[:url] = CDO.studio_url(link[:url])
           - elsif link[:domain] == 'code.org'

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -1,5 +1,6 @@
 - full_width = local_assigns[:full_width]
-- is_farsi = I18n.locale == 'fa-IR'.to_sym  # footer_config = @footer_config
+- footer_config = @footer_config
+- puts footer_config
 .navbar-static-top.footer
   .container{ style: 'padding: 10px;' + (full_width ? 'margin: auto' : '') }
     .row
@@ -12,13 +13,13 @@
           = link_to t('footer.privacy'), CDO.code_org_url('/privacy'), style: 'color: #ffa400;'
         .dim!= piped_spaces
         = link_to t('footer.cookie_notice'), CDO.code_org_url('/cookies')
-        - unless is_farsi # unless footer_config[:translate] == false
+        - unless footer_config[:translate] == false
           .dim!= piped_spaces
           = link_to t('footer.translate'), CDO.code_org_url('/translate')
-        - unless is_farsi # unless footer_config[:help_support] == false
+        - unless footer_config[:help_support] == false
           .dim!= piped_spaces
           = link_to t('landing.help_support'), 'https://support.code.org', target: '_blank', id: "support"
-        - unless is_farsi # unless footer_config[:store] == false
+        - unless footer_config[:store] == false
           .dim!= piped_spaces
           = link_to t('footer.store'), 'https://store.code.org'
         .dim!= piped_spaces
@@ -39,7 +40,7 @@
             %img{:src=>"/shared/images/Powered-By_logo-horiz_RGB_REV.png", :alt=>"Powered by AWS Cloud Computing", :style=>"width: 190px"}
 
       .span3{style: 'float: right;' + (full_width ? 'width: 140px; margin-left: 0px' : '')}
-        - unless is_farsi # unless footer_config[:locale_dropdown] == false
+        - unless footer_config[:locale_dropdown] == false
           -# NOTE UTF-8 is not being enforced for this form. Do not modify it to accept
           -# user input or to persist data without also updating it to enforce UTF-8
           = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -1,13 +1,15 @@
+- require 'cdo/footer'
 - full_width = local_assigns[:full_width]
-- footer_config = @footer_config
-- locale_options = @locale_options
+- options = {ge_region: params[:ge_region]}
+- footer_contents = Cdo::Footer.get_footer_contents(options)
+- locale_options = Cdo::Footer.get_locale_options(options)
 .navbar-static-top.footer
   .container{ style: 'padding: 10px;' + (full_width ? 'margin: auto' : '') }
     .row
       .span9{style: (full_width ? 'max-width: 80%;' : '')}
         - piped_spaces = ' | '
         - privacy_updated = DCDO.get('recent_privacy_policy_update', nil)
-        - links = (footer_config[:links] || []).map(&:dup)
+        - links = (footer_contents[:links] || []).map(&:dup)
         - if privacy_updated
           - links.reject! { |link| link[:title] == 'privacy' }
         - else

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -1,29 +1,27 @@
 - full_width = local_assigns[:full_width]
 - footer_config = @footer_config
-- puts footer_config
+- locale_options = @locale_options
 .navbar-static-top.footer
   .container{ style: 'padding: 10px;' + (full_width ? 'margin: auto' : '') }
     .row
       .span9{style: (full_width ? 'max-width: 80%;' : '')}
         - piped_spaces = ' | '
         - privacy_updated = DCDO.get('recent_privacy_policy_update', nil)
+        - links = (footer_config[:links] || []).map(&:dup)
         - if privacy_updated
-          = link_to t('footer.privacy_updated'), CDO.code_org_url('/privacy'), style: 'color: #ffa400;'
+          - links.reject! { |link| link[:title] == 'privacy' }
         - else
-          = link_to t('footer.privacy'), CDO.code_org_url('/privacy'), style: 'color: #ffa400;'
-        .dim!= piped_spaces
-        = link_to t('footer.cookie_notice'), CDO.code_org_url('/cookies')
-        - unless footer_config[:translate] == false
-          .dim!= piped_spaces
-          = link_to t('footer.translate'), CDO.code_org_url('/translate')
-        - unless footer_config[:help_support] == false
-          .dim!= piped_spaces
-          = link_to t('landing.help_support'), 'https://support.code.org', target: '_blank', id: "support"
-        - unless footer_config[:store] == false
-          .dim!= piped_spaces
-          = link_to t('footer.store'), 'https://store.code.org'
-        .dim!= piped_spaces
-        = link_to t('footer.tos_short'), CDO.code_org_url('/tos')
+          - links.reject! { |link| link[:title] == 'privacy_updated' }
+        - links.each_with_index do |link, index|
+          - if link[:domain] == 'studio.code.org'
+            - link[:url] = CDO.studio_url(link[:url])
+          - elsif link[:domain] == 'code.org'
+            - link[:url] = CDO.code_org_url(link[:url])
+          - else
+            - link[:rel] = "noopener noreferrer nofollow"
+          = link_to t("footer.#{link[:title]}"), link[:url], link.except(:title, :url, :domain)
+          - unless index == links.length - 1
+            .dim!= piped_spaces
         %br/
 
         %small.fineprint.dim
@@ -40,11 +38,10 @@
             %img{:src=>"/shared/images/Powered-By_logo-horiz_RGB_REV.png", :alt=>"Powered by AWS Cloud Computing", :style=>"width: 190px"}
 
       .span3{style: 'float: right;' + (full_width ? 'width: 140px; margin-left: 0px' : '')}
-        - unless footer_config[:locale_dropdown] == false
-          -# NOTE UTF-8 is not being enforced for this form. Do not modify it to accept
-          -# user input or to persist data without also updating it to enforce UTF-8
-          = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do
-            = hidden_field_tag :user_return_to, request.url
-            = select_tag :locale, options, { onchange: 'this.form.submit();', 'aria-label':  t('footer.locale_select', default: 'Select language') }
+        -# NOTE UTF-8 is not being enforced for this form. Do not modify it to accept
+        -# user input or to persist data without also updating it to enforce UTF-8
+        = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do
+          = hidden_field_tag :user_return_to, request.url
+          = select_tag :locale, options, { onchange: 'this.form.submit();', 'aria-label':  t('footer.locale_select', default: 'Select language') }
         %small.dim
           !="&copy; Code.org, #{Time.now.year}"

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -1,4 +1,5 @@
 - full_width = local_assigns[:full_width]
+- is_farsi = I18n.locale == 'fa-IR'.to_sym  # footer_config = @footer_config
 .navbar-static-top.footer
   .container{ style: 'padding: 10px;' + (full_width ? 'margin: auto' : '') }
     .row
@@ -11,12 +12,15 @@
           = link_to t('footer.privacy'), CDO.code_org_url('/privacy'), style: 'color: #ffa400;'
         .dim!= piped_spaces
         = link_to t('footer.cookie_notice'), CDO.code_org_url('/cookies')
-        .dim!= piped_spaces
-        = link_to t('footer.translate'), CDO.code_org_url('/translate')
-        .dim!= piped_spaces
-        = link_to t('landing.help_support'), 'https://support.code.org', target: '_blank', id: "support"
-        .dim!= piped_spaces
-        = link_to t('footer.store'), 'https://store.code.org'
+        - unless is_farsi # unless footer_config[:translate] == false
+          .dim!= piped_spaces
+          = link_to t('footer.translate'), CDO.code_org_url('/translate')
+        - unless is_farsi # unless footer_config[:help_support] == false
+          .dim!= piped_spaces
+          = link_to t('landing.help_support'), 'https://support.code.org', target: '_blank', id: "support"
+        - unless is_farsi # unless footer_config[:store] == false
+          .dim!= piped_spaces
+          = link_to t('footer.store'), 'https://store.code.org'
         .dim!= piped_spaces
         = link_to t('footer.tos_short'), CDO.code_org_url('/tos')
         %br/
@@ -35,12 +39,11 @@
             %img{:src=>"/shared/images/Powered-By_logo-horiz_RGB_REV.png", :alt=>"Powered by AWS Cloud Computing", :style=>"width: 190px"}
 
       .span3{style: 'float: right;' + (full_width ? 'width: 140px; margin-left: 0px' : '')}
-
-        -# NOTE UTF-8 is not being enforced for this form. Do not modify it to accept
-        -# user input or to persist data without also updating it to enforce UTF-8
-        = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do
-          = hidden_field_tag :user_return_to, request.url
-          - options = options_for_select(Cdo::I18n.locale_options, locale)
-          = select_tag :locale, options, { onchange: 'this.form.submit();', 'aria-label':  t('footer.locale_select', default: 'Select language') }
+        - unless is_farsi # unless footer_config[:locale_dropdown] == false
+          -# NOTE UTF-8 is not being enforced for this form. Do not modify it to accept
+          -# user input or to persist data without also updating it to enforce UTF-8
+          = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do
+            = hidden_field_tag :user_return_to, request.url
+            = select_tag :locale, options, { onchange: 'this.form.submit();', 'aria-label':  t('footer.locale_select', default: 'Select language') }
         %small.dim
           !="&copy; Code.org, #{Time.now.year}"

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -1,26 +1,20 @@
 - require 'cdo/footer'
+
 - full_width = local_assigns[:full_width]
-- options = {ge_region: params[:ge_region]}
+- options = {}
+- options[:ge_region] = request.ge_region
+- options[:site] = :studio
+- options[:loc_prefix] = "footer."
 - footer_contents = Cdo::Footer.get_footer_contents(options)
-- locale_options = Cdo::Footer.get_locale_options(options)
+
 .navbar-static-top.footer
   .container{ style: 'padding: 10px;' + (full_width ? 'margin: auto' : '') }
     .row
       .span9{style: (full_width ? 'max-width: 80%;' : '')}
         - piped_spaces = ' | '
-        - privacy_updated = DCDO.get('recent_privacy_policy_update', nil)
-        - links = (footer_contents[:links][:studio] || []).map(&:dup)
-        - links.each_with_index do |link, index|
-          - if privacy_updated && link[:title] == 'privacy'
-            - link[:title] = 'privacy_updated'
-          - if link[:domain] == 'studio.code.org'
-            - link[:url] = CDO.studio_url(link[:url])
-          - elsif link[:domain] == 'code.org'
-            - link[:url] = CDO.code_org_url(link[:url])
-          - else
-            - link[:rel] = "noopener noreferrer nofollow"
-          = link_to t("footer.#{link[:title]}"), link[:url], link.except(:title, :url, :domain)
-          - unless index == links.length - 1
+        - footer_contents.each_with_index do |link, index|
+          = link_to link[:title], link[:url], link.except(:title, :url, :domain)
+          - unless index == footer_contents.length - 1
             .dim!= piped_spaces
         %br/
 
@@ -42,6 +36,7 @@
         -# user input or to persist data without also updating it to enforce UTF-8
         = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do
           = hidden_field_tag :user_return_to, request.url
+          - options = options_for_select(Cdo::I18n.locale_options, locale)
           = select_tag :locale, options, { onchange: 'this.form.submit();', 'aria-label':  t('footer.locale_select', default: 'Select language') }
         %small.dim
           !="&copy; Code.org, #{Time.now.year}"

--- a/lib/cdo/footer.rb
+++ b/lib/cdo/footer.rb
@@ -1,0 +1,15 @@
+require 'cdo/global'
+
+module Cdo
+  class Footer
+    def self.get_locale_options(options)
+      ge_region = options[:ge_region] || :root
+      @locale_options = Cdo::Global.locales_for(ge_region)
+    end
+
+    def self.get_footer_contents(options)
+      ge_region = options[:ge_region] || :root
+      @footer_config = Cdo::Global.configuration_for(ge_region)[:footer] || {}
+    end
+  end
+end

--- a/lib/cdo/footer.rb
+++ b/lib/cdo/footer.rb
@@ -1,15 +1,42 @@
-require 'cdo/global'
+require 'cdo/global_edition'
 
 module Cdo
   class Footer
-    def self.get_locale_options(options)
-      ge_region = options[:ge_region] || :root
-      @locale_options = Cdo::Global.locales_for(ge_region)
-    end
-
     def self.get_footer_contents(options)
+      # Get the 'footer' section from the requested region
       ge_region = options[:ge_region] || :root
-      @footer_config = Cdo::Global.configuration_for(ge_region)[:footer] || {}
+      footer_config = Cdo::GlobalEdition.configuration_for(ge_region)[:footer] || {}
+      site = options[:site] || :code_org
+      footer_links = footer_config.dig(:links, site) || []
+
+      # We allow an override of the translation method (defaults to I18n.t)
+      i18n = options[:i18n] || ::I18n.method(:t)
+
+      privacy_updated = DCDO.get('recent_privacy_policy_update', nil)
+
+      footer_links.map do |link|
+        link = link.dup
+
+        # Remember the locale key
+        link[:key] = link[:title]
+        if privacy_updated && link[:title] == 'privacy'
+          link[:title] = 'privacy_updated'
+        end
+
+        if link[:domain] == 'studio.code.org'
+          link[:url] = CDO.studio_url(link[:url])
+        elsif link[:domain] == 'code.org'
+          link[:url] = CDO.code_org_url(link[:url])
+        else
+          # It is an external link, so appropriately mark its follow rules
+          link[:rel] = "noopener noreferrer nofollow"
+        end
+
+        # Localize
+        loc_prefix = link[:loc_prefix] || options[:loc_prefix]
+        link[:title] = i18n.call("#{loc_prefix}#{link[:key]}")
+        link
+      end
     end
   end
 end

--- a/lib/cdo/global_edition.rb
+++ b/lib/cdo/global_edition.rb
@@ -98,25 +98,5 @@ module Cdo
     def self.country_region(country)
       countries_regions[country]
     end
-
-    # Loads all default locale from config/locales.yml
-    def self.load_default_locales
-      root = File.expand_path(File.join('..', '..'), __dir__)
-      unless defined? @@default_locales
-        @@default_locales = YAML.load_file(File.join(root, "dashboard", "config", "locales.yml"))
-        @@default_locales = @@default_locales.filter_map do |locale, data|
-          next nil unless data.is_a? Hash
-          [data['native'], locale].freeze
-        end.freeze
-      end
-      @@default_locales
-    end
-
-    # Returns the available locales specified for a region in the form of an Array of Arrays
-    # containing the native name and the locale key. ['native name', 'locale-key']
-    def self.locales_for(region)
-      config = configuration_for(region)
-      config[:locale_options] || load_default_locales
-    end
   end
 end

--- a/lib/cdo/global_edition.rb
+++ b/lib/cdo/global_edition.rb
@@ -98,5 +98,25 @@ module Cdo
     def self.country_region(country)
       countries_regions[country]
     end
+
+    # Loads all default locale from config/locales.yml
+    def self.load_default_locales
+      root = File.expand_path(File.join('..', '..'), __dir__)
+      unless defined? @@default_locales
+        @@default_locales = YAML.load_file(File.join(root, "dashboard", "config", "locales.yml"))
+        @@default_locales = @@default_locales.filter_map do |locale, data|
+          next nil unless data.is_a? Hash
+          [data['native'], locale].freeze
+        end.freeze
+      end
+      @@default_locales
+    end
+
+    # Returns the available locales specified for a region in the form of an Array of Arrays
+    # containing the native name and the locale key. ['native name', 'locale-key']
+    def self.locales_for(region)
+      config = configuration_for(region)
+      config[:locale_options] || load_default_locales
+    end
   end
 end

--- a/pegasus/sites.v3/code.org/views/footer.haml
+++ b/pegasus/sites.v3/code.org/views/footer.haml
@@ -1,36 +1,26 @@
+- require 'cdo/footer'
+- options = {ge_region: params[:ge_region]}
+- footer_contents = Cdo::Footer.get_footer_contents(options)
 %footer#pagefooter
   .content
     .left{:style=>"float:left; max-width: 80%;"}
-      %a.whitefooterlink{:href=>"/privacy", :style=>"color: #ffa400;"}
-        - @privacy_updated = DCDO.get('recent_privacy_policy_update', nil)
-        - if @privacy_updated
-          !=I18n.t(:footer_privacy_policy_updated)
+      - @privacy_updated = DCDO.get('recent_privacy_policy_update', nil)
+      - links = (footer_contents[:links][:code_org] || []).map(&:dup)
+      - links.each_with_index do |link, index|
+        - if @privacy_updated && link[:title] == 'privacy_policy'
+          - link[:title] = 'privacy_policy_updated'
+        - if link[:domain] == 'studio.code.org'
+          - link[:href] = CDO.studio_url(link[:url])
+        - elsif link[:domain] == 'code.org'
+          - link[:href] = CDO.code_org_url(link[:url])
         - else
-          !=I18n.t(:footer_privacy_policy)
-      .dim &nbsp; | &nbsp;
-      %a.whitefooterlink{:href=>"/cookies"}
-        !=I18n.t(:footer_cookie_notice)
-      .dim &nbsp; | &nbsp;
-      %a.whitefooterlink{:href=>"/about"}
-        !=I18n.t(:footer_about)
-      .dim &nbsp; | &nbsp;
-      %a.whitefooterlink{:href=>"/partners"}
-        !=I18n.t(:footer_partners)
-      .dim &nbsp; | &nbsp;
-      %a.whitefooterlink{:href=>"https://medium.com/@codeorg", :target=>"_blank"}
-        !=I18n.t(:footer_blog)
-      .dim &nbsp; | &nbsp;
-      %a.whitefooterlink{:href=>"/donate"}
-        !=I18n.t(:footer_donate)
-      .dim &nbsp; | &nbsp;
-      %a.whitefooterlink{:href=>"/shop"}
-        !=I18n.t(:footer_store)
-      .dim &nbsp; | &nbsp;
-      %a#support.whitefooterlink{:href=>"http://support.code.org/", :target=>"_blank"}
-        !=I18n.t(:footer_support)
-      .dim &nbsp; | &nbsp;
-      %a.whitefooterlink{:href=>"/tos"}
-        !=I18n.t(:footer_terms)
+          - link[:href] = link[:url]
+          - link[:rel] = "noopener noreferrer nofollow"
+        %a.whitefooterlink{link.except(:title, :url, :domain)}
+          !=I18n.t("footer_#{link[:title]}")
+        - unless index == links.length - 1
+          .dim &nbsp; | &nbsp;
+
       %small.dim
         !=I18n.t(:footer_trademark, current_year: Time.now.year, cs_discoveries: "CS Discoveries&reg;")
         %br

--- a/pegasus/sites.v3/code.org/views/footer.haml
+++ b/pegasus/sites.v3/code.org/views/footer.haml
@@ -1,24 +1,19 @@
 - require 'cdo/footer'
-- options = {ge_region: params[:ge_region]}
+
+- options = {}
+- options[:ge_region] = request.ge_region
+- options[:site] = :code_org
+- options[:loc_prefix] = 'footer_'
 - footer_contents = Cdo::Footer.get_footer_contents(options)
+
 %footer#pagefooter
   .content
     .left{:style=>"float:left; max-width: 80%;"}
-      - @privacy_updated = DCDO.get('recent_privacy_policy_update', nil)
-      - links = (footer_contents[:links][:code_org] || []).map(&:dup)
-      - links.each_with_index do |link, index|
-        - if @privacy_updated && link[:title] == 'privacy_policy'
-          - link[:title] = 'privacy_policy_updated'
-        - if link[:domain] == 'studio.code.org'
-          - link[:href] = CDO.studio_url(link[:url])
-        - elsif link[:domain] == 'code.org'
-          - link[:href] = CDO.code_org_url(link[:url])
-        - else
-          - link[:href] = link[:url]
-          - link[:rel] = "noopener noreferrer nofollow"
+      - footer_contents.each_with_index do |link, index|
+        - link[:href] = link[:url]
         %a.whitefooterlink{link.except(:title, :url, :domain)}
-          !=I18n.t("footer_#{link[:title]}")
-        - unless index == links.length - 1
+          != link[:title]
+        - unless index == footer_contents.length - 1
           .dim &nbsp; | &nbsp;
 
       %small.dim

--- a/pegasus/sites.v3/code.org/views/global/fa/farsifooter.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/farsifooter.haml
@@ -1,16 +1,21 @@
+- require 'cdo/footer'
 - require 'cdo/global_edition'
+
+- options = {}
+- options[:ge_region] = request.ge_region
+- options[:site] = :code_org
+- options[:loc_prefix] = 'footer_'
+- footer_contents = Cdo::Footer.get_footer_contents(options)
 
 %footer#pagefooter
   .content{style: 'max-width: fit-content;'}
     .left{style: 'float:left; width: 70%;'}
-      %a.whitefooterlink{:href=>"https://code-org.translate.goog/privacy?_x_tr_sl=auto&_x_tr_tl=fa&_x_tr_hl=en&_x_tr_pto=wapp", :style=>"color: #ffa400;"}
-        !=I18n.t(:footer_privacy_policy)
-      .dim &nbsp; | &nbsp;
-      %a.whitefooterlink{:href=>"/cookies"}
-        !=I18n.t(:footer_cookie_notice)
-      .dim &nbsp; | &nbsp;
-      %a.whitefooterlink{:href=>"https://code-org.translate.goog/tos?_x_tr_sl=auto&_x_tr_tl=fa&_x_tr_hl=en&_x_tr_pto=wapp"}
-        !=I18n.t(:footer_terms)
+      - footer_contents.each_with_index do |link, index|
+        - link[:href] = link[:url]
+        %a.whitefooterlink{link.except(:title, :url, :domain)}
+          != link[:title]
+        - unless index == footer_contents.length - 1
+          .dim &nbsp; | &nbsp;
       %small.dim
         !=I18n.t(:footer_trademark, current_year: Time.now.year, cs_discoveries: "CS Discoveries&reg;")
         %br

--- a/pegasus/sites.v3/hourofcode.com/views/footer.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/footer.haml
@@ -1,16 +1,22 @@
+- require 'cdo/footer'
+- options = {ge_region: params[:ge_region]}
+- footer_contents = Cdo::Footer.get_footer_contents(options)
 %footer#pagefooter
   #footer-links
     %ul.hide-responsive-footer-menu
-      %li
-        %a{:href=>"http://support.code.org/hc/en-us/requests/new", :target=>"_blank"}= hoc_s(:footer_menu_contact)
-      %li
-        %a{:href=>"http://support.code.org", :target=>"_blank"}= hoc_s(:footer_menu_support)
-      %li
-        %a{:href=>codeorg_url('/tos'), :target=>"_blank"}= hoc_s(:footer_menu_terms)
-      %li
-        %a{:href=>codeorg_url('/privacy'), :target=>"_blank"}= hoc_s(:footer_menu_privacy)
-      %li
-        %a{href:resolve_url('/cookies'), :target=>"_blank"}= hoc_s(:footer_menu_cookie)
+      - links = (footer_contents[:links][:hour_of_code] || []).map(&:dup)
+      - links.each do |link|
+        - if link[:domain] == 'studio.code.org'
+          - link[:href] = CDO.studio_url(link[:url])
+        - elsif link[:domain] == 'code.org'
+          - link[:href] = codeorg_url(link[:url])
+        - elsif link[:title] == 'cookie'
+          - link[:href] = resolve_url(link[:url])
+        - else
+          - link[:href] = link[:url]
+          - link[:rel] = "noopener noreferrer nofollow"
+        %li
+          %a{link.except(:title, :url, :domain)}= hoc_s("footer_menu_#{link[:title]}")
     #footer-toggle
       %a{href: "#"}
         Code.org

--- a/pegasus/sites.v3/hourofcode.com/views/footer.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/footer.haml
@@ -15,7 +15,6 @@
           - link[:href] = resolve_url(link[:url])
         - elsif link[:domain].nil?
           - link[:href] = link[:url]
-          - link[:rel] = "noopener noreferrer nofollow"
         - else
           - link[:href] = link[:url]
         %li

--- a/pegasus/sites.v3/hourofcode.com/views/footer.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/footer.haml
@@ -1,22 +1,25 @@
 - require 'cdo/footer'
-- options = {ge_region: params[:ge_region]}
+
+- options = {}
+- options[:ge_region] = request.ge_region
+- options[:site] = :hour_of_code
+- options[:loc_prefix] = 'footer_menu_'
+- options[:i18n] = method(:hoc_s)
 - footer_contents = Cdo::Footer.get_footer_contents(options)
+
 %footer#pagefooter
   #footer-links
     %ul.hide-responsive-footer-menu
-      - links = (footer_contents[:links][:hour_of_code] || []).map(&:dup)
-      - links.each do |link|
-        - if link[:domain] == 'studio.code.org'
-          - link[:href] = CDO.studio_url(link[:url])
-        - elsif link[:domain] == 'code.org'
-          - link[:href] = codeorg_url(link[:url])
-        - elsif link[:title] == 'cookie'
+      - footer_contents.each do |link|
+        - if link[:domain] == 'hourofcode.com'
           - link[:href] = resolve_url(link[:url])
-        - else
+        - elsif link[:domain].nil?
           - link[:href] = link[:url]
           - link[:rel] = "noopener noreferrer nofollow"
+        - else
+          - link[:href] = link[:url]
         %li
-          %a{link.except(:title, :url, :domain)}= hoc_s("footer_menu_#{link[:title]}")
+          %a{link.except(:title, :url, :domain)}= link[:title]
     #footer-toggle
       %a{href: "#"}
         Code.org


### PR DESCRIPTION
This PR:
- Adds the global configuration for the footer links in Pegasus and Dashboard.
- Allows `global/fa` to have different footer links than the main site

**Note**: There should be no change in the appearance of the footer for the main "root" site, just changes to the `/global/fa` footers.

## Links

- jira ticket: [P20-1156](https://codedotorg.atlassian.net/browse/P20-1156)

## Testing story

Here are screenshots of the rendered headers. The "Production" image on the left is captured from the current deployment as of November 2024.

### Studio (studio.code.org)

* Production: `https://studio.code.org/users/sign_in`

| Production |
| - |
| ![studio code org_users_sign_in](https://github.com/user-attachments/assets/cf299067-baf4-46a6-9b4d-f42677b9a19b) | 

* Main Site: `http://localhost-studio.code.org:3000/users/sign_in?lang=en-US`

| Main Site |
| - |
| ![localhost-studio code org_3000_users_sign_in_lang=en-US](https://github.com/user-attachments/assets/b0eb3d20-07d0-4ee2-bfc8-1b70a3e8f49a) |

* Global Farsi: `http://localhost-studio.code.org:3000/global/fa/users/sign_in?lang=fa-IR`

| Global Farsi |
| - |
| ![localhost-studio code org_3000_global_fa_users_sign_in_lang=fa-IR (1)](https://github.com/user-attachments/assets/02bf7ab8-ab3b-4b49-b1a3-4654df424258) |

### Pegasus (code.org)

* Production: `https://code.org`

| Production |
| - |
| ![code org__ge_region](https://github.com/user-attachments/assets/77ee0362-f9bf-4826-8aff-b22974e15311) | 

* Main Site: `http://localhost.code.org:3000/`

| Main Site |
| - |
| ![localhost code org_3000_](https://github.com/user-attachments/assets/e0148648-1a65-4171-8ef7-9c4b917f5a03) |

* Global Farsi: `http://localhost.code.org:3000/lang/fa-IR/global/fa/about`

| Global Farsi |
| - |
| ![localhost code org_3000_global_fa_about](https://github.com/user-attachments/assets/0ac16b2c-521b-4279-b5bd-75e122281c52) |

### hourofcode.com

For hourofcode.com, we don't really have a "region" lock like we do on the main two sites. For this, we just look at `/us/fa/...` and there is no real good way to represent the "farsi" region. We'll have to discuss what to do about this later.


* Production: `https://hourofcode.com/us`

| Production |
| - |
| ![hourofcode com_us (1)](https://github.com/user-attachments/assets/4d6b0c05-92cb-4514-b7a1-8b980ff5b80b) | 

* Main Site: `http://localhost.hourofcode.com:3000/us`

| Main Site |
| - |
| ![localhost hourofcode com_3000_us](https://github.com/user-attachments/assets/12a44e7d-a415-453c-b41f-179bb4ab9dc6) |

* Global Farsi: `http://localhost.hourofcode.com:3000/us/fa`

| Global Farsi |
| - |
| ![localhost hourofcode com_3000_us_fa](https://github.com/user-attachments/assets/ce2e6c4d-b344-4d77-834a-d8bf6a65eff8) |

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
