### PR TITLE
P20-1139/Add timer to iframe buster

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1707,6 +1707,7 @@
   "ltiIframeDescription": "Please click the button below to continue to Code.org",
   "ltiIframeCallToAction": "Continue to Code.org",
   "ltiIframeRefresh": "Code.org was successfully launched in a new tab. Please refresh the page to access Code.org again.",
+  "ltiIframeTimedOut": "Your session has timed out. Please refresh the page to access Code.org.",
   "ltiLinkAccountExistingAccountCardHeaderLabel": "I have an existing Code.org account",
   "ltiLinkAccountExistingAccountCardContent": "You'll need to sign in to connect your existing Code.org account with {providerName}",
   "ltiLinkAccountExistingAccountCardActionLabel": "Sign in with my account",

--- a/apps/src/simpleSignUp/lti/iframe/LtiIframePage.tsx
+++ b/apps/src/simpleSignUp/lti/iframe/LtiIframePage.tsx
@@ -6,6 +6,8 @@ import i18n from '@cdo/locale';
 
 import styles from './styles.module.scss';
 
+const IFRAME_TIMEOUT_MILLISECONDS = 300000; // Time out after 5 minutes
+
 interface LtiIframePageProps {
   logoUrl: string;
   authUrl: string;
@@ -28,7 +30,7 @@ export const LtiIframePage = ({logoUrl, authUrl}: LtiIframePageProps) => {
         setCallToActionDisabled(true);
         setTextContent(i18n.ltiIframeTimedOut());
       }
-    }, 300000); // Time out after 5 minutes
+    }, IFRAME_TIMEOUT_MILLISECONDS);
 
     return () => clearTimeout(timer);
   }, [callToActionDisabled]);

--- a/apps/src/simpleSignUp/lti/iframe/LtiIframePage.tsx
+++ b/apps/src/simpleSignUp/lti/iframe/LtiIframePage.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {Button} from '@cdo/apps/componentLibrary/button';
 import Typography from '@cdo/apps/componentLibrary/typography';
@@ -14,11 +14,24 @@ interface LtiIframePageProps {
 export const LtiIframePage = ({logoUrl, authUrl}: LtiIframePageProps) => {
   const [callToActionDisabled, setCallToActionDisabled] =
     useState<boolean>(false);
+  const [textContent, setTextContent] = useState(i18n.ltiIframeDescription());
 
   const handleCallToAction = () => {
     window.open(authUrl, '_blank');
     setCallToActionDisabled(true);
+    setTextContent(i18n.ltiIframeRefresh());
   };
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (!callToActionDisabled) {
+        setCallToActionDisabled(true);
+        setTextContent(i18n.ltiIframeTimedOut());
+      }
+    }, 300000); // Time out after 5 minutes
+
+    return () => clearTimeout(timer);
+  }, [callToActionDisabled]);
 
   return (
     <main className={styles.mainContentContainer}>
@@ -29,9 +42,7 @@ export const LtiIframePage = ({logoUrl, authUrl}: LtiIframePageProps) => {
           visualAppearance="body-one"
           className={styles.description}
         >
-          {callToActionDisabled
-            ? i18n.ltiIframeRefresh()
-            : i18n.ltiIframeDescription()}
+          {textContent}
         </Typography>
         <div>
           <Button

--- a/apps/src/simpleSignUp/lti/iframe/LtiIframePage.tsx
+++ b/apps/src/simpleSignUp/lti/iframe/LtiIframePage.tsx
@@ -6,7 +6,7 @@ import i18n from '@cdo/locale';
 
 import styles from './styles.module.scss';
 
-const IFRAME_TIMEOUT_MILLISECONDS = 300000; // Time out after 5 minutes
+export const LTI_IFRAME_TIMEOUT_MILLISECONDS = 300_000; // Time out after 5 minutes
 
 interface LtiIframePageProps {
   logoUrl: string;
@@ -30,7 +30,7 @@ export const LtiIframePage = ({logoUrl, authUrl}: LtiIframePageProps) => {
         setCallToActionDisabled(true);
         setTextContent(i18n.ltiIframeTimedOut());
       }
-    }, IFRAME_TIMEOUT_MILLISECONDS);
+    }, LTI_IFRAME_TIMEOUT_MILLISECONDS);
 
     return () => clearTimeout(timer);
   }, [callToActionDisabled]);

--- a/apps/test/unit/simpleSignUp/lti/iframe/IframePageTest.tsx
+++ b/apps/test/unit/simpleSignUp/lti/iframe/IframePageTest.tsx
@@ -4,7 +4,10 @@ import React from 'react';
 import {act} from 'react-dom/test-utils'; // eslint-disable-line no-restricted-imports
 import sinon, {SinonStub} from 'sinon'; // eslint-disable-line no-restricted-imports
 
-import LtiIframePage from '@cdo/apps/simpleSignUp/lti/iframe/LtiIframePage';
+import {
+  LtiIframePage,
+  LTI_IFRAME_TIMEOUT_MILLISECONDS,
+} from '@cdo/apps/simpleSignUp/lti/iframe/LtiIframePage';
 import i18n from '@cdo/locale';
 
 import {expect} from '../../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
@@ -13,8 +16,6 @@ const DEFAULT_PROPS = {
   logoUrl: 'https://code.org/assets/logo.svg',
   authUrl: 'https://code.org/auth',
 };
-
-const IFRAME_TIMEOUT_MILLISECONDS = 300000;
 
 describe('LTI Iframe Page Test', () => {
   beforeEach(() => sinon.stub(window, 'open'));
@@ -46,7 +47,7 @@ describe('LTI Iframe Page Test', () => {
     const message = screen.getByText(i18n.ltiIframeDescription());
 
     act(() => {
-      jest.advanceTimersByTime(IFRAME_TIMEOUT_MILLISECONDS);
+      jest.advanceTimersByTime(LTI_IFRAME_TIMEOUT_MILLISECONDS);
     });
 
     expect(message.textContent).to.equal(i18n.ltiIframeTimedOut());

--- a/apps/test/unit/simpleSignUp/lti/iframe/IframePageTest.tsx
+++ b/apps/test/unit/simpleSignUp/lti/iframe/IframePageTest.tsx
@@ -1,6 +1,7 @@
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import {act} from 'react-dom/test-utils'; // eslint-disable-line no-restricted-imports
 import sinon, {SinonStub} from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import LtiIframePage from '@cdo/apps/simpleSignUp/lti/iframe/LtiIframePage';
@@ -12,6 +13,8 @@ const DEFAULT_PROPS = {
   logoUrl: 'https://code.org/assets/logo.svg',
   authUrl: 'https://code.org/auth',
 };
+
+const IFRAME_TIMEOUT_MILLISECONDS = 300000;
 
 describe('LTI Iframe Page Test', () => {
   beforeEach(() => sinon.stub(window, 'open'));
@@ -30,6 +33,23 @@ describe('LTI Iframe Page Test', () => {
     expect(window.open).to.have.been.calledOnce.and.calledWith(
       DEFAULT_PROPS.authUrl
     );
+    expect(button.getAttribute('disabled')).to.equal('');
+  });
+
+  it('should time out after 5 minutes', async () => {
+    jest.useFakeTimers();
+    render(<LtiIframePage {...DEFAULT_PROPS} />);
+
+    const button = screen.getByRole('button', {
+      name: i18n.ltiIframeCallToAction(),
+    });
+    const message = screen.getByText(i18n.ltiIframeDescription());
+
+    act(() => {
+      jest.advanceTimersByTime(IFRAME_TIMEOUT_MILLISECONDS);
+    });
+
+    expect(message.textContent).to.equal(i18n.ltiIframeTimedOut());
     expect(button.getAttribute('disabled')).to.equal('');
   });
 });


### PR DESCRIPTION
This PR adds a timer to the page which will request the user to refresh the page after 5 minutes to avoid a bad user experience.

Time out screen
![image](https://github.com/user-attachments/assets/497a844a-2645-4656-9076-44fe3c5a3a23)

## Links

Jira: [P20-1139](https://codedotorg.atlassian.net/browse/P20-1139)


## Testing story
Added unit test to `IframePageTest.tsx`

