### PR TITLE
[JIMT][CT-797] - use value in prompt

### DIFF
--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -544,7 +544,7 @@ export const FileBrowser = React.memo(() => {
       const results = await dialogControl?.showDialog({
         type: DialogType.GenericPrompt,
         title: codebridgeI18n.renameFile(),
-        placeholder: file.name,
+        value: file.name,
         validateInput: (newName: string) => {
           if (!newName.length) {
             return;
@@ -591,7 +591,7 @@ export const FileBrowser = React.memo(() => {
       const results = await dialogControl?.showDialog({
         type: DialogType.GenericPrompt,
         title: codebridgeI18n.renameFolder(),
-        placeholder: folder.name,
+        value: folder.name,
         validateInput: (newName: string) => {
           if (!newName.length) {
             return;

--- a/apps/src/lab2/views/dialogs/GenericPrompt.tsx
+++ b/apps/src/lab2/views/dialogs/GenericPrompt.tsx
@@ -52,7 +52,7 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
   validateInput = () => undefined,
 }) => {
   const {promiseArgs, setPromiseArgs} = useDialogControl();
-  const prompt = (promiseArgs || value || '') as string;
+  const prompt = (promiseArgs ?? (value || '')) as string;
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
     undefined
   );

--- a/apps/src/lab2/views/dialogs/GenericPrompt.tsx
+++ b/apps/src/lab2/views/dialogs/GenericPrompt.tsx
@@ -9,6 +9,7 @@ export type GenericPromptProps = Required<Pick<GenericDialogProps, 'title'>> & {
   handleConfirm?: (prompt: string) => void;
   handleCancel?: () => void;
   placeholder?: string;
+  value?: string;
   validateInput?: (prompt: string) => string | undefined;
 };
 
@@ -47,10 +48,11 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
   handleConfirm,
   handleCancel,
   placeholder,
+  value,
   validateInput = () => undefined,
 }) => {
   const {promiseArgs, setPromiseArgs} = useDialogControl();
-  const prompt = (promiseArgs || '') as string;
+  const prompt = (promiseArgs || value || '') as string;
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
     undefined
   );


### PR DESCRIPTION
Changes the rename file/folder prompts to use values in the dialogs, instead of placeholders.

Old:
![Screenshot 2024-09-23 at 12 51 18 PM](https://github.com/user-attachments/assets/fd157dda-a783-414e-bce1-f04d9782ee15)

New:

![Screenshot 2024-09-23 at 12 50 48 PM](https://github.com/user-attachments/assets/ae261f29-30f5-41da-ba99-69a49ccf1077)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [https://codedotorg.atlassian.net/browse/CT-797](CT-797)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
