### PR TITLE
fix proptype for setIsOpen in RubricErrorContainer

### DIFF
--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -59,7 +59,7 @@ export const RubricErrorContainer = ({isOpen, setIsOpen}) => (
 
 RubricErrorContainer.propTypes = {
   isOpen: PropTypes.bool,
-  setIsOpen: PropTypes.function,
+  setIsOpen: PropTypes.func,
 };
 
 function RubricFloatingActionButton({


### PR DESCRIPTION
fixes this warning:
![Screenshot 2024-09-16 at 3 49 17 PM](https://github.com/user-attachments/assets/4cbe29c5-4cdb-434e-a364-bb238550be7c)

## Testing story

existing test coverage