### PR TITLE
[JIMT][CT-810] - wraps GenericDialog in FocusTrap

### DIFF
--- a/apps/src/lab2/views/dialogs/GenericDialog.tsx
+++ b/apps/src/lab2/views/dialogs/GenericDialog.tsx
@@ -1,3 +1,4 @@
+import FocusTrap from 'focus-trap-react';
 import React from 'react';
 
 import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
@@ -80,69 +81,71 @@ const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
   const dialogControl = useDialogControl();
 
   return (
-    <div className={moduleStyles.genericDialog}>
-      {titleComponent || (
-        <Typography semanticTag="h1" visualAppearance="heading-lg">
-          {title}
-        </Typography>
-      )}
+    <FocusTrap>
+      <div className={moduleStyles.genericDialog}>
+        {titleComponent || (
+          <Typography semanticTag="h1" visualAppearance="heading-lg">
+            {title}
+          </Typography>
+        )}
 
-      {bodyComponent || (
-        <Typography semanticTag="p" visualAppearance="body-two">
-          {message}
-        </Typography>
-      )}
-      <div className={moduleStyles.buttonContainer}>
-        <div className={moduleStyles.outerButtonContainer}>
-          {buttons?.cancel ? (
-            <Button
-              onClick={closingCallback(
-                dialogControl.closeDialog,
-                'cancel',
-                buttons.cancel.callback
-              )}
-              className={moduleStyles.cancel}
-              type="secondary"
-              disabled={buttons.cancel.disabled}
-              color={buttonColors.gray}
-              text={buttons.cancel.text || commonI18n.cancel()}
-            />
-          ) : (
-            <div />
-          )}
-          <div className={moduleStyles.innerButtonContainer}>
-            {buttons?.neutral && (
+        {bodyComponent || (
+          <Typography semanticTag="p" visualAppearance="body-two">
+            {message}
+          </Typography>
+        )}
+        <div className={moduleStyles.buttonContainer}>
+          <div className={moduleStyles.outerButtonContainer}>
+            {buttons?.cancel ? (
               <Button
                 onClick={closingCallback(
                   dialogControl.closeDialog,
-                  'neutral',
-                  buttons.neutral.callback
+                  'cancel',
+                  buttons.cancel.callback
                 )}
+                className={moduleStyles.cancel}
                 type="secondary"
-                disabled={buttons.neutral.disabled}
+                disabled={buttons.cancel.disabled}
                 color={buttonColors.gray}
-                text={buttons.neutral.text}
+                text={buttons.cancel.text || commonI18n.cancel()}
               />
+            ) : (
+              <div />
             )}
-            <Button
-              onClick={closingCallback(
-                dialogControl.closeDialog,
-                'confirm',
-                buttons?.confirm?.callback
+            <div className={moduleStyles.innerButtonContainer}>
+              {buttons?.neutral && (
+                <Button
+                  onClick={closingCallback(
+                    dialogControl.closeDialog,
+                    'neutral',
+                    buttons.neutral.callback
+                  )}
+                  type="secondary"
+                  disabled={buttons.neutral.disabled}
+                  color={buttonColors.gray}
+                  text={buttons.neutral.text}
+                />
               )}
-              disabled={buttons?.confirm?.disabled}
-              type="primary"
-              color={
-                buttons?.confirm?.destructive
-                  ? buttonColors.destructive
-                  : buttonColors.purple
-              }
-              text={buttons?.confirm?.text || commonI18n.dialogOK()}
-            />
+              <Button
+                onClick={closingCallback(
+                  dialogControl.closeDialog,
+                  'confirm',
+                  buttons?.confirm?.callback
+                )}
+                disabled={buttons?.confirm?.disabled}
+                type="primary"
+                color={
+                  buttons?.confirm?.destructive
+                    ? buttonColors.destructive
+                    : buttonColors.purple
+                }
+                text={buttons?.confirm?.text || commonI18n.dialogOK()}
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </FocusTrap>
   );
 };
 


### PR DESCRIPTION
Just wraps the `GenericDialog` in dialog control into a `FocusTrap` (from react-trap-focus, which we already use).

This also gets us tabbing remaining focused within the dialog for free. but note, we don't get automatic `escape` key presses on the cancel button.

Also, there appears to be a bug in the focus trap where hitting escape can cause tabbing to escape the dialog. Weird. But that's also outside of scope for this mod.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CT-810](https://codedotorg.atlassian.net/browse/CT-810)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
