### PR TITLE
Mark rural schools as AFE eligible

### DIFF
--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -60,14 +60,15 @@ class School < ApplicationRecord
   # Determines if school meets Amazon Future Engineer criteria.
   # Eligible if the school is any of the following:
   # a) title I school,
-  # b) >40% URM students,
-  # or c) >40% of students eligible for free and reduced meals.
+  # b) rural school,
+  # c) >40% URM students,
+  # or d) >40% of students eligible for free and reduced meals.
   def afe_high_needs?
     stats = most_recent_school_stats
+    # Return false if we don't have all data for a given school.
     return false if stats.nil?
 
-    # Return false if we don't have all data for a given school.
-    stats.title_i_eligible? || (stats.urm_percent || 0) >= 40 || (stats.frl_eligible_percent || 0) >= 40
+    stats.title_i_eligible? || stats.rural_school? || (stats.urm_percent || 0) >= 40 || (stats.frl_eligible_percent || 0) >= 40
   end
 
   # Public school ids from NCES are always 12 digits, possibly with

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -61,14 +61,14 @@ class School < ApplicationRecord
   # Eligible if the school is any of the following:
   # a) title I school,
   # b) rural school,
-  # c) >40% URM students,
+  # c) >30% URM students,
   # or d) >40% of students eligible for free and reduced meals.
   def afe_high_needs?
     stats = most_recent_school_stats
     # Return false if we don't have all data for a given school.
     return false if stats.nil?
 
-    stats.title_i_eligible? || stats.rural_school? || (stats.urm_percent || 0) >= 40 || (stats.frl_eligible_percent || 0) >= 40
+    stats.title_i_eligible? || stats.rural_school? || (stats.urm_percent || 0) >= 30 || (stats.frl_eligible_percent || 0) >= 40
   end
 
   # Public school ids from NCES are always 12 digits, possibly with

--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -93,7 +93,7 @@ class SchoolTest < ActiveSupport::TestCase
     assert school.afe_high_needs?
   end
 
-  test 'AFE high needs true when urm percent above 40 percent of students' do
+  test 'AFE high needs true when urm percent above 30 percent of students' do
     school = create :school
     school.school_stats_by_year << SchoolStatsByYear.new(
       {
@@ -107,7 +107,7 @@ class SchoolTest < ActiveSupport::TestCase
     assert school.afe_high_needs?
   end
 
-  test 'AFE high needs false when urm percent below 40 percent of students' do
+  test 'AFE high needs false when urm percent below 30 percent of students' do
     school = create :school
     school.school_stats_by_year << SchoolStatsByYear.new(
       {

--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -134,6 +134,19 @@ class SchoolTest < ActiveSupport::TestCase
     assert school.afe_high_needs?
   end
 
+  test 'AFE high needs true when school is rural' do
+    school = create :school
+    school.school_stats_by_year << SchoolStatsByYear.new(
+      {
+        school_id: school.id,
+        school_year: '1998-1999',
+        community_type: 'rural_distant'
+      }
+    )
+    school.save!
+    assert school.afe_high_needs?
+  end
+
   test 'AFE high needs false when no criteria are met' do
     school = create :school
     school.school_stats_by_year << SchoolStatsByYear.new(


### PR DESCRIPTION
In [this thread](https://codedotorg.slack.com/archives/C039SAH84/p1727100992497509), Andrew and Natalia found that [a school that should be AFE eligible](https://nces.ed.gov/ccd/schoolsearch/school_detail.asp?Search=1&Zip=99029&Miles=5&ID=530721003809) (due to being a rural school) was not being approved. It turns out our logic only showed eligibility based on Title I status, free and reduced lunch percentage, and under represented group percentage. This PR now incorporates if the schools is rural to determine eligibility as well.

Note: we already have a [method](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/school_stats_by_year.rb#L119-L127) that determines if a school is rural based on its `community_type`.

## Links
Slack thread: [here](https://codedotorg.slack.com/archives/C039SAH84/p1727100992497509)
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2441)

## Testing story
Adding a unit test.
