### PR TITLE
Fix Violations of and Reenable `Style/RedundantInitialize`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -262,12 +262,6 @@ Style/RedundantAssignment:
 Style/RedundantCondition:
   Enabled: false
 
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowComments.
-Style/RedundantInitialize:
-  Enabled: false
-
 # Offense count: 26
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantRegexpCharacterClass:

--- a/dashboard/test/lib/purged_account_log_test.rb
+++ b/dashboard/test/lib/purged_account_log_test.rb
@@ -95,9 +95,6 @@ class PurgedAccountLogTest < ActiveSupport::TestCase
     log_obj.purged_at = purge_time
 
     class StubUploader
-      def initialize(_bucket = '', _prefix = '')
-      end
-
       def upload_log(_name, _body)
       end
     end

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -539,9 +539,6 @@ module Poste2
       partner@code.org
     ]
 
-    def initialize(settings = nil)
-    end
-
     def deliver!(mail)
       attachments = nil
 


### PR DESCRIPTION
This one's pretty straightforward:

> Checks for `initialize` methods that are redundant.

We only have two violations, and both seem straightforward; both simple classes that neither inherit from nor are inherited by any other classes, and I could not find any evidence of us trying to do anything clever with initialization.

I think all `Style/` Cops are optional, but this one seems like an easy win. Please let me know if you disagree; happy to accommodate!

## Links

- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantInitialize
- https://docs.rubocop.org/rubocop/cops_style.html#styleredundantinitialize

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
