### PR TITLE
[JIMT][CT-817] - fix hovers

### DIFF
--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -58,7 +58,7 @@ li .button-kebab {
   height: 13px;
 }
 
-li :hover .button-kebab {
+div.row:hover .button-kebab {
   display: inherit;
 }
 


### PR DESCRIPTION
Just needed a super tiny CSS tweak to bind the `:hover` to the `div.row` instead of the entire container `li`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CT-817](https://codedotorg.atlassian.net/browse/CT-817)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
