### PR TITLE
Fix import error- selectSection is in teacherSectionRedux

### DIFF
--- a/apps/src/code-studio/components/progress/SectionSelector.jsx
+++ b/apps/src/code-studio/components/progress/SectionSelector.jsx
@@ -2,10 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
-import {
-  selectSection,
-  sectionsNameAndId,
-} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+import {selectSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {sectionsNameAndId} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import i18n from '@cdo/locale';
 
 import {reload} from '../../../utils';

--- a/apps/src/templates/rubrics/SectionSelector.jsx
+++ b/apps/src/templates/rubrics/SectionSelector.jsx
@@ -6,10 +6,8 @@ import Select from 'react-select';
 
 import {updateQueryParam} from '@cdo/apps/code-studio/utils';
 import {BodyThreeText, EmText} from '@cdo/apps/componentLibrary/typography';
-import {
-  selectSection,
-  sectionsNameAndId,
-} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+import {selectSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {sectionsNameAndId} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {reload} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 


### PR DESCRIPTION
Fixes `selectSection` imports from teacherSectionRedux. These were incorrectly moved to import from teacherSectionReduxSelectors in https://github.com/code-dot-org/code-dot-org/pull/61150

This should also fix a new bug in the section dropdowns that was reported on zendesk

## Links

jira ticket: https://codedotorg.atlassian.net/browse/TEACH-1373
zendesk ticket: https://codeorg.zendesk.com/agent/tickets/509648

## Testing story

No changes to testing

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
