### PR TITLE
Python Lab: levelbuilders can add videos that show in Help and Tips 

### DIFF
--- a/apps/src/codebridge/InfoPanel/HelpAndTips.tsx
+++ b/apps/src/codebridge/InfoPanel/HelpAndTips.tsx
@@ -4,14 +4,21 @@ import HelpTabContents from '@cdo/apps/templates/instructions/HelpTabContents';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 const HelpAndTips: React.FunctionComponent = () => {
+  const labState = useAppSelector(state => state.lab);
   const mapReference = useAppSelector(
     state => state.lab.levelProperties?.mapReference
   );
   const referenceLinks = useAppSelector(
     state => state.lab.levelProperties?.referenceLinks
   );
+  const helpVideos = useAppSelector(
+    state => state.lab.levelProperties?.helpVideos
+  );
+  const helpVideo = helpVideos ? helpVideos[0] : null;
+  console.log('state', labState);
   return (
     <HelpTabContents
+      videoData={helpVideo}
       mapReference={mapReference}
       referenceLinks={referenceLinks}
       openReferenceLinksInNewTab

--- a/apps/src/codebridge/InfoPanel/HelpAndTips.tsx
+++ b/apps/src/codebridge/InfoPanel/HelpAndTips.tsx
@@ -4,7 +4,6 @@ import HelpTabContents from '@cdo/apps/templates/instructions/HelpTabContents';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 const HelpAndTips: React.FunctionComponent = () => {
-  const labState = useAppSelector(state => state.lab);
   const mapReference = useAppSelector(
     state => state.lab.levelProperties?.mapReference
   );
@@ -15,7 +14,6 @@ const HelpAndTips: React.FunctionComponent = () => {
     state => state.lab.levelProperties?.helpVideos
   );
   const helpVideo = helpVideos ? helpVideos[0] : null;
-  console.log('state', labState);
   return (
     <HelpTabContents
       videoData={helpVideo}

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -166,6 +166,7 @@ export interface LevelProperties {
   // Help and Tips values
   mapReference?: string;
   referenceLinks?: string[];
+  helpVideos?: VideoData[];
   // Exemplars
   exampleSolutions?: string[];
   exemplarSources?: MultiFileSource;
@@ -187,6 +188,15 @@ export interface VideoLevelData {
   src: string;
   download: string;
   thumbnail: string;
+}
+
+// Addtional fields for videos that are linked as references in the
+// Help & Tips tab of Instructions.
+interface VideoData extends VideoLevelData {
+  name?: string;
+  key?: string;
+  enable_fallback?: boolean;
+  autoplay?: boolean;
 }
 
 export enum OptionsToAvoid {

--- a/apps/src/templates/instructions/HelpTabContents.jsx
+++ b/apps/src/templates/instructions/HelpTabContents.jsx
@@ -15,6 +15,7 @@ export default class HelpTabContents extends Component {
   };
 
   render() {
+    console.log('videoData in HelpTabContents', this.props.videoData);
     return (
       <div style={styles.referenceArea}>
         {this.props.videoData && (

--- a/apps/src/templates/instructions/HelpTabContents.jsx
+++ b/apps/src/templates/instructions/HelpTabContents.jsx
@@ -15,7 +15,6 @@ export default class HelpTabContents extends Component {
   };
 
   render() {
-    console.log('videoData in HelpTabContents', this.props.videoData);
     return (
       <div style={styles.referenceArea}>
         {this.props.videoData && (

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -840,6 +840,7 @@ class Level < ApplicationRecord
     properties_camelized = properties.camelize_keys
     properties_camelized[:id] = id
     properties_camelized[:levelData] = video if video
+    properties_camelized[:helpVideos] = related_videos.map(&:summarize)
     properties_camelized[:type] = type
     properties_camelized[:appName] = game&.app
     properties_camelized[:useRestrictedSongs] = game.use_restricted_songs?

--- a/dashboard/app/views/levels/editors/_pythonlab.html.haml
+++ b/dashboard/app/views/levels/editors/_pythonlab.html.haml
@@ -1,5 +1,6 @@
 = render partial: 'levels/editors/fields/long_instructions', locals: {f: f}
 = render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
+= render partial: 'levels/editors/fields/video', locals: {f: f}
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/help_and_tips', locals: {f: f}
 = render partial: 'levels/editors/fields/pythonlab_fields', locals: {f: f}

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -85,7 +85,7 @@ class LevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"id" => level.id, "levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => [], "usesProjects" => false, "exemplarSources" => nil}, body)
+    assert_equal({"id" => level.id, "levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => [], "usesProjects" => false, "exemplarSources" => nil, "helpVideos" => []}, body)
   end
 
   test "should get filtered levels with just page param" do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -115,7 +115,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal({"id" => level.id, "levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => [], "usesProjects" => false, "exampleSolutions" => []}, body)
+    assert_equal({"id" => level.id, "levelData" => {"hello" => "there"}, "other" => "other", "preloadAssetList" => nil, "type" => "Maze", "appName" => "maze", "useRestrictedSongs" => false, "sharedBlocks" => [], "usesProjects" => false, "exampleSolutions" => [], "helpVideos" => []}, body)
   end
 
   test 'should show script level for csp1-2020 lockable lesson with lesson plan' do


### PR DESCRIPTION
[CT-819](https://codedotorg.atlassian.net/browse/CT-819)

Levelbuilders can now add a video to Python Lab levels that will show in the Help & Tips section of the Instructions panel. 

When editing a level: 

![Screenshot 2024-09-24 at 2 41 06 PM](https://github.com/user-attachments/assets/cae788c6-f881-469e-a0ac-06fc2cc8fb71)


When viewing the level, after a video is added: 
![Screenshot 2024-09-24 at 2 24 10 PM](https://github.com/user-attachments/assets/b54eef73-dca8-4430-bbdf-0afcc683db8c)

* I just picked the first video in the dropdown and didn't check-in the updated level file