### PR TITLE
HoC 2024 - Embed global Pardot forms on /events

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/events/event_registration_form.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/events/event_registration_form.haml
@@ -14,9 +14,29 @@
     }
   }
 
+:ruby
+  language_urls = {
+    "ar" => "https://go.pardot.com/l/153401/2024-09-13/pr5bw1",
+    "zh" => "https://go.pardot.com/l/153401/2024-09-13/pr5bw7",
+    "fa" => "https://go.pardot.com/l/153401/2024-09-13/pr5bwb",
+    "ph" => "http://go.pardot.com/l/153401/2024-09-13/pr5bwt",
+    "fr" => "https://go.pardot.com/l/153401/2024-09-13/pr5bwx",
+    "de" => "https://go.pardot.com/l/153401/2024-09-13/pr5bx1",
+    "es" => "https://go.pardot.com/l/153401/2024-09-13/pr5bx4",
+    "hi" => "http://go.pardot.com/l/153401/2024-09-13/pr5bx7",
+    "id" => "https://go.pardot.com/l/153401/2024-09-13/pr5bxb",
+    "ja" => "https://go.pardot.com/l/153401/2024-09-13/pr5bxf",
+    "it" => "https://go.pardot.com/l/153401/2024-09-13/pr5bxj",
+    "ko" => "http://go.pardot.com/l/153401/2024-09-13/pr5bxm",
+    "pt" => "https://go.pardot.com/l/153401/2024-09-13/pr5bxq",
+    "tr" => "https://go.pardot.com/l/153401/2024-09-13/pr5bxt"
+  }
+
+  url = language_urls[@language] || "https://go.pardot.com/l/153401/2024-08-26/pr46fc"
+
 %div.event-registration-form.flex-container.flex-direction-column-tablet-reverse.align-items-center.gap-2
   %figure.rounded-corners.flex-1
-    %iframe{allowtransparency: "true", frameborder: "0", height: "425px", src: "https://go.pardot.com/l/153401/2024-08-26/pr46fc", style: "border: 0", type: "text/html", width: "100%"}
+    %iframe{allowtransparency: "true", frameborder: "0", height: "425px", src: url, style: "border: 0", type: "text/html", width: "100%"}
   .text-wrapper.flex-1
     %h2.no-margin-top
       =hoc_s("hoc_events.register.heading")

--- a/pegasus/sites.v3/hourofcode.com/views/events/event_registration_form.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/events/event_registration_form.haml
@@ -23,6 +23,7 @@
     "fr" => "https://go.pardot.com/l/153401/2024-09-13/pr5bwx",
     "de" => "https://go.pardot.com/l/153401/2024-09-13/pr5bx1",
     "es" => "https://go.pardot.com/l/153401/2024-09-13/pr5bx4",
+    "la" => "https://go.pardot.com/l/153401/2024-09-13/pr5bx4",
     "hi" => "http://go.pardot.com/l/153401/2024-09-13/pr5bx7",
     "id" => "https://go.pardot.com/l/153401/2024-09-13/pr5bxb",
     "ja" => "https://go.pardot.com/l/153401/2024-09-13/pr5bxf",
@@ -36,7 +37,7 @@
 
 %div.event-registration-form.flex-container.flex-direction-column-tablet-reverse.align-items-center.gap-2
   %figure.rounded-corners.flex-1
-    %iframe{allowtransparency: "true", frameborder: "0", height: "425px", src: url, style: "border: 0", type: "text/html", width: "100%"}
+    %iframe{allowtransparency: "true", frameborder: "0", height: "450px", src: url, style: "border: 0", type: "text/html", width: "100%"}
   .text-wrapper.flex-1
     %h2.no-margin-top
       =hoc_s("hoc_events.register.heading")


### PR DESCRIPTION
Adds support for translated Pardot event registration forms on https://hourofcode.com/events in the following languages:
- Arabic: `ar`
- Chinese Traditional: `zh`
- Farsi: `fa`
- Filipino: `ph`
- French: `fr`
- German: `de`
- Spanish (Latam + ES): `la`, `es`
- Hindi: `hi`
- Indonesian: `id`
- Japanese: `ja`
- Italian: `it`
- Korean: `ko`
- Portuguese-BR: `pt`
- Turkish: `tr`

## Links
Jira ticket: [ACQ-2298](https://codedotorg.atlassian.net/browse/ACQ-2298)
Gsheet: [here](https://docs.google.com/spreadsheets/d/1CBRlq2waVfjSImJi_u4sbWJHA-kGbnk3KJ1g9H28C2A/edit?gid=0#gid=0&range=26:26)

## Testing story
Tested locally

----

## Spanish example
<img width="1168" alt="Spanish" src="https://github.com/user-attachments/assets/0de8540a-1ff2-45f8-8e34-cf2c7578c59a">

## French example
<img width="1168" alt="Screenshot 2024-09-24 at 11 29 48 AM" src="https://github.com/user-attachments/assets/cfe02aaa-5a08-4a18-966f-773a66b012e0">

## Japanese example
<img width="1168" alt="Japanese" src="https://github.com/user-attachments/assets/e9b7bd10-96ab-41f3-a677-dabdd959ca47">
