### PR TITLE
Fixes pegasus link to videos within the Farsi Global Edition

### DIFF
--- a/pegasus/sites.v3/code.org/public/global/fa/index.haml
+++ b/pegasus/sites.v3/code.org/public/global/fa/index.haml
@@ -46,5 +46,5 @@ theme: responsive_full_width
           =hoc_s(:"farsi_site.farsi_homepage_video_card_title")
         %p.heading-sm
           =hoc_s(:"farsi_site.farsi_homepage_video_card_description")
-        %a.link-button{href: "https://hourofcode.com/learn"}
+        %a.link-button{href: "/global/fa/videos"}
           =hoc_s(:"farsi_site.farsi_homepage_video_card_cta")


### PR DESCRIPTION
Just fixes a link that should go to the Farsi Edition videos page.

Reported in Slack: https://codedotorg.slack.com/archives/C07GC122TPH/p1727210366942339

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
