### PR TITLE
Store All Session Data in Redis

### DIFF
--- a/dashboard/config/initializers/session_store.rb
+++ b/dashboard/config/initializers/session_store.rb
@@ -6,4 +6,4 @@ Dashboard::Application.config.session_store :redis_store,
   servers: [CDO.session_store_server || 'redis://localhost:6379/0/session'],
   secure: !CDO.no_https_store && (!Rails.env.development? || CDO.https_development),
   domain: :all,
-  expire_after: 200.days # don't expire in the same school year
+  expire_after: 40.days # users who interact with the site at least once a month will remain logged in


### PR DESCRIPTION
Our current strategy for maintaining the Redis Session Storage cluster has not been working well. Our intent was to maintain the database at max capacity, allowing automatic eviction of least-recently-used sessions to expire sessions that are less than 200 days old but relying on monitoring of that eviction rate to maintain a minimum session duration of at least 60 days. This monitoring turns out to be significantly more difficult than expected, as the eviction rate is in practice erratic. This is also a rather tenuous position to try to maintain; in the long run, we want something more stable.

Fortunately, it turns out we probably don't need to worry about keeping sessions alive for as long as we thought we did. Session expiration actually gets updated every time the user interacts with the site, so rather than expiration representing the maximum amount of time before a user is forced to reauthenticate, it actually represents the amount of time a user can go without interacting with the site in any way before being forced to reauthenticate.

With that in mind, this PR proposes we reduce the expiration time down to just 40 days. This is a significant reduction from our theoretical maximum of 200 days, but it's only a slightly reduction from our in-practice maximum of approximately 60 days. It also facilitates a much more predictable and maintainable session store, and users who interact with the site at least once a month will continue to have the same experience they currently do.

As an alternative, if we wanted users to be able to remain logged in despite not interacting with the site for the entirety of summer vacation (which we do not expect they would currently be able to do), we could attempt to upsize the cluster to be able to store 100 days worth of sessions, which the next instance type up should be able to do. See https://github.com/code-dot-org/code-dot-org/pull/61322

## Follow-up work

40 days after this PR is deployed, we should start to see a reduction in total number of sessions in the store. Once we stop regularly evicting sessions, we can update the current eviction alarm to notify us if we see any number of evictions. Once our usage stabilizes, we can add an alarm or two on database capacity, which should be a much more stable metric for us to monitor.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
