### PR TITLE
HoC 2024 - Update default_hoc_mode to soon-hoc

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -448,7 +448,7 @@ levelbuilder_mode:
 # make it easier to tell the difference
 use_local_header_color:
 
-default_hoc_mode: false  # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode: soon-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''      # overridden by 'hoc_launch' DCDO param, except in :test
 
 # teacher_application_mode values: 'open', 'closing-soon', 'closed'


### PR DESCRIPTION
Updates `default_hoc_mode` to `soon-hoc` on the test environment. See last year's PR: https://github.com/code-dot-org/code-dot-org/pull/54035

## Links
Jira ticket: [ACQ-2453](https://codedotorg.atlassian.net/browse/ACQ-2453)
Spec: [here](https://docs.google.com/document/d/1npRdcuOhOPGghHXkBZain_7ZvRrqvizAbwT1gwlAaK8/edit)