### PR TITLE
NAV - add in standards and vocab to lesson materials page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2984,6 +2984,8 @@
   "unassignedStudents": "Unassigned Students",
   "uncompletedLessons": "Lesson not completed",
   "unit": "Unit",
+  "unitStandards": "Unit {unitNumber} Standards",
+  "unitVocabulary": "Unit {unitNumber} Vocabulary",
   "unitedStates": "United States",
   "unsubmit": "Unsubmit",
   "unsubmitAssessment": "Unsubmit your assessment",

--- a/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
@@ -17,12 +17,14 @@ type Lesson = {
   id: number;
   position: number;
   lessonPlanHtmlUrl: string;
+  standardsUrl: string;
+  vocabularyUrl: string;
   resources: {
     Teacher: {
       key: string;
       name: string;
       url: string;
-      downloadUrl: string | null;
+      downloadUrl?: string;
       audience: string;
       type: string;
     }[];
@@ -30,7 +32,7 @@ type Lesson = {
       key: string;
       name: string;
       url: string;
-      downloadUrl: string | null;
+      downloadUrl?: string;
       audience: string;
       type: string;
     }[];
@@ -125,6 +127,8 @@ const LessonMaterialsContainer: React.FC = () => {
         unitNumber={unitNumber}
         lessonNumber={selectedLesson.position}
         resources={selectedLesson.resources.Teacher}
+        standardsUrl={selectedLesson.standardsUrl}
+        vocabularyUrl={selectedLesson.vocabularyUrl}
         lessonPlanUrl={selectedLesson.lessonPlanHtmlUrl}
         lessonName={selectedLesson.name}
       />
@@ -141,6 +145,8 @@ const LessonMaterialsContainer: React.FC = () => {
         unitNumber={unitNumber}
         lessonNumber={selectedLesson.position}
         resources={selectedLesson.resources.Student}
+        standardsUrl={null}
+        vocabularyUrl={null}
         lessonPlanUrl={null}
         lessonName={null}
       />

--- a/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
@@ -145,10 +145,6 @@ const LessonMaterialsContainer: React.FC = () => {
         unitNumber={unitNumber}
         lessonNumber={selectedLesson.position}
         resources={selectedLesson.resources.Student}
-        standardsUrl={null}
-        vocabularyUrl={null}
-        lessonPlanUrl={null}
-        lessonName={null}
       />
     );
   };

--- a/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/LessonMaterialsContainer.tsx
@@ -118,7 +118,7 @@ const LessonMaterialsContainer: React.FC = () => {
   );
 
   const renderTeacherResources = () => {
-    if (!selectedLesson || !selectedLesson.resources.Teacher) {
+    if (!selectedLesson) {
       return null;
     }
 
@@ -126,7 +126,7 @@ const LessonMaterialsContainer: React.FC = () => {
       <LessonResources
         unitNumber={unitNumber}
         lessonNumber={selectedLesson.position}
-        resources={selectedLesson.resources.Teacher}
+        resources={selectedLesson.resources.Teacher || []}
         standardsUrl={selectedLesson.standardsUrl}
         vocabularyUrl={selectedLesson.vocabularyUrl}
         lessonPlanUrl={selectedLesson.lessonPlanHtmlUrl}
@@ -136,7 +136,7 @@ const LessonMaterialsContainer: React.FC = () => {
   };
 
   const renderStudentResources = () => {
-    if (!selectedLesson || !selectedLesson.resources.Student) {
+    if (!selectedLesson) {
       return null;
     }
 
@@ -144,7 +144,7 @@ const LessonMaterialsContainer: React.FC = () => {
       <LessonResources
         unitNumber={unitNumber}
         lessonNumber={selectedLesson.position}
-        resources={selectedLesson.resources.Student}
+        resources={selectedLesson.resources.Student || []}
       />
     );
   };

--- a/apps/src/templates/teacherNavigation/LessonResources.tsx
+++ b/apps/src/templates/teacherNavigation/LessonResources.tsx
@@ -7,13 +7,14 @@ import ResourceRow from './ResourceRow';
 
 import styles from './lesson-materials.module.scss';
 
+// lesson plans, standards, and vocabulary are only needed for teacher resources
 type LessonResourcesProps = {
   unitNumber: number;
   lessonNumber: number;
-  lessonPlanUrl: string | null;
-  standardsUrl: string | null;
-  vocabularyUrl: string | null;
-  lessonName: string | null;
+  lessonPlanUrl?: string;
+  standardsUrl?: string;
+  vocabularyUrl?: string;
+  lessonName?: string;
   resources: {
     key: string;
     name: string;
@@ -40,7 +41,7 @@ const LessonResources: React.FC<LessonResourcesProps> = ({
     : i18n.studentResources();
 
   const renderStandardsRow = () => {
-    if (!standardsUrl || !lessonPlanUrl) return null;
+    if (!standardsUrl) return null;
 
     return (
       <ResourceRow
@@ -58,7 +59,7 @@ const LessonResources: React.FC<LessonResourcesProps> = ({
   };
 
   const renderVocabularyRow = () => {
-    if (!vocabularyUrl || !lessonPlanUrl) return null;
+    if (!vocabularyUrl) return null;
 
     return (
       <ResourceRow

--- a/apps/src/templates/teacherNavigation/LessonResources.tsx
+++ b/apps/src/templates/teacherNavigation/LessonResources.tsx
@@ -40,7 +40,7 @@ const LessonResources: React.FC<LessonResourcesProps> = ({
     : i18n.studentResources();
 
   const renderStandardsRow = () => {
-    if (!standardsUrl) return null;
+    if (!standardsUrl || !lessonPlanUrl) return null;
 
     return (
       <ResourceRow
@@ -58,7 +58,7 @@ const LessonResources: React.FC<LessonResourcesProps> = ({
   };
 
   const renderVocabularyRow = () => {
-    if (!vocabularyUrl) return null;
+    if (!vocabularyUrl || !lessonPlanUrl) return null;
 
     return (
       <ResourceRow

--- a/apps/src/templates/teacherNavigation/LessonResources.tsx
+++ b/apps/src/templates/teacherNavigation/LessonResources.tsx
@@ -11,12 +11,14 @@ type LessonResourcesProps = {
   unitNumber: number;
   lessonNumber: number;
   lessonPlanUrl: string | null;
+  standardsUrl: string | null;
+  vocabularyUrl: string | null;
   lessonName: string | null;
   resources: {
     key: string;
     name: string;
     url: string;
-    downloadUrl: string | null;
+    downloadUrl?: string;
     audience: string;
     type: string;
   }[];
@@ -28,12 +30,50 @@ const LessonResources: React.FC<LessonResourcesProps> = ({
   lessonNumber,
   lessonPlanUrl,
   lessonName,
+  standardsUrl,
+  vocabularyUrl,
 }) => {
   // Note that lessonPlanUrl is not needed for student resources
   // and should be null for student resoruces section
   const sectionHeaderText = lessonPlanUrl
     ? i18n.teacherResourcesforLessonMaterials()
     : i18n.studentResources();
+
+  const renderStandardsRow = () => {
+    if (!standardsUrl) return null;
+
+    return (
+      <ResourceRow
+        key={`standards-${lessonNumber}`}
+        unitNumber={unitNumber}
+        resource={{
+          key: 'standardsKey',
+          name: i18n.standards(),
+          url: standardsUrl,
+          audience: 'Teacher',
+          type: 'Standards',
+        }}
+      />
+    );
+  };
+
+  const renderVocabularyRow = () => {
+    if (!vocabularyUrl) return null;
+
+    return (
+      <ResourceRow
+        key={`vocabulary-${lessonNumber}`}
+        unitNumber={unitNumber}
+        resource={{
+          key: 'vocabularyKey',
+          name: i18n.vocabulary(),
+          url: vocabularyUrl,
+          audience: 'Teacher',
+          type: 'Vocabulary',
+        }}
+      />
+    );
+  };
 
   const renderLessonPlanRow = () => {
     if (!lessonPlanUrl) return null;
@@ -47,7 +87,6 @@ const LessonResources: React.FC<LessonResourcesProps> = ({
           key: 'lessonPlanKey',
           name: lessonName || '',
           url: lessonPlanUrl,
-          downloadUrl: null,
           audience: 'Teacher',
           type: 'Lesson Plan',
         }}
@@ -69,6 +108,8 @@ const LessonResources: React.FC<LessonResourcesProps> = ({
           resource={resource}
         />
       ))}
+      {renderStandardsRow()}
+      {renderVocabularyRow()}
     </div>
   );
 };

--- a/apps/src/templates/teacherNavigation/LessonResources.tsx
+++ b/apps/src/templates/teacherNavigation/LessonResources.tsx
@@ -108,8 +108,8 @@ const LessonResources: React.FC<LessonResourcesProps> = ({
           resource={resource}
         />
       ))}
-      {renderStandardsRow()}
       {renderVocabularyRow()}
+      {renderStandardsRow()}
     </div>
   );
 };

--- a/apps/src/templates/teacherNavigation/ResourceIcon.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceIcon.tsx
@@ -28,6 +28,10 @@ const ResourceIcon: React.FC<ResourceIconProps> = ({
       return RESOURCE_TYPE.VIDEO;
     } else if (resourceType === 'Lesson Plan') {
       return RESOURCE_TYPE.LESSON_PLAN;
+    } else if (resourceType === 'Standards') {
+      return RESOURCE_TYPE.STANDARDS;
+    } else if (resourceType === 'Vocabulary') {
+      return RESOURCE_TYPE.VOCABULARY;
     } else {
       return RESOURCE_TYPE.LINK;
     }

--- a/apps/src/templates/teacherNavigation/ResourceIconType.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceIconType.tsx
@@ -16,4 +16,6 @@ export const RESOURCE_TYPE = Object.freeze({
   LINK: makeObjectType('link-simple', styles.link),
   GOOGLE_DOC: makeObjectType('files', styles.files),
   VIDEO: makeObjectType('video', styles.video),
+  STANDARDS: makeObjectType('files', styles.files),
+  VOCABULARY: makeObjectType('files', styles.files),
 } as const);

--- a/apps/src/templates/teacherNavigation/ResourceRow.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {BodyTwoText, StrongText} from '@cdo/apps/componentLibrary/typography';
+import i18n from '@cdo/locale';
 
 import ResourceIcon from './ResourceIcon';
 import ResourceViewOptionsDropdown from './ResourceViewOptionsDropdown';
@@ -8,13 +9,13 @@ import ResourceViewOptionsDropdown from './ResourceViewOptionsDropdown';
 import styles from './lesson-materials.module.scss';
 
 type ResourceRowProps = {
-  lessonNumber: number;
+  lessonNumber?: number;
   unitNumber: number;
   resource: {
     key: string;
     name: string;
     url: string;
-    downloadUrl: string | null;
+    downloadUrl?: string;
     audience: string;
     type: string;
   };
@@ -25,19 +26,30 @@ const ResourceRow: React.FC<ResourceRowProps> = ({
   unitNumber,
   resource,
 }) => {
-  const resourcePositionLabel = (
-    <strong>{unitNumber + '.' + lessonNumber + ' '}</strong>
-  );
+  const resourceDisplayText = () => {
+    if (!resource.type) {
+      return resource.name;
+    } else if (resource.type === 'Standards') {
+      return `${i18n.unit()} ${unitNumber} ${i18n.standards()}`;
+    } else if (resource.type === 'Vocabulary') {
+      return `${i18n.unit()} ${unitNumber} ${i18n.vocabulary()}`;
+    } else {
+      return `${resource.type}: ${resource.name}`;
+    }
+  };
 
-  const resourceDisplayText = () =>
-    resource.type ? `${resource.type}: ${resource.name}` : resource.name;
+  const resourceNumberingText = lessonNumber ? (
+    <StrongText>
+      <strong>{`${unitNumber}.${lessonNumber} `}</strong>
+    </StrongText>
+  ) : null;
 
   return (
     <div className={styles.rowContainer}>
       <div className={styles.iconAndName}>
         <ResourceIcon resourceType={resource.type} resourceUrl={resource.url} />
         <BodyTwoText className={styles.resourceLabel}>
-          <StrongText>{resourcePositionLabel}</StrongText>
+          {resourceNumberingText}
           {resourceDisplayText()}
         </BodyTwoText>
       </div>

--- a/apps/src/templates/teacherNavigation/ResourceRow.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceRow.tsx
@@ -30,9 +30,9 @@ const ResourceRow: React.FC<ResourceRowProps> = ({
     if (!resource.type) {
       return resource.name;
     } else if (resource.type === 'Standards') {
-      return `${i18n.unit()} ${unitNumber} ${i18n.standards()}`;
+      return i18n.unitStandards({unitNumber: unitNumber});
     } else if (resource.type === 'Vocabulary') {
-      return `${i18n.unit()} ${unitNumber} ${i18n.vocabulary()}`;
+      return i18n.unitVocabulary({unitNumber: unitNumber});
     } else {
       return `${resource.type}: ${resource.name}`;
     }

--- a/apps/src/templates/teacherNavigation/ResourceViewOptionsDropdown.tsx
+++ b/apps/src/templates/teacherNavigation/ResourceViewOptionsDropdown.tsx
@@ -5,7 +5,7 @@ import {ActionDropdown} from '@cdo/apps/componentLibrary/dropdown';
 type ResourceViewOptionsDropdownProps = {
   resource: {
     url: string;
-    downloadUrl: string | null;
+    downloadUrl?: string;
     type: string;
   };
 };

--- a/apps/test/unit/templates/teacherNavigation/LessonMaterialsContainerTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/LessonMaterialsContainerTest.tsx
@@ -21,6 +21,8 @@ describe('LessonMaterialsContainer', () => {
         id: 1,
         position: 1,
         lessonPlanHtmlUrl: 'studio.code.org/lesson1',
+        standardsUrl: 'studio.code.org/standards',
+        vocabularyUrl: 'studio.code.org/vocab',
         resources: {
           Teacher: [
             {
@@ -97,12 +99,15 @@ describe('LessonMaterialsContainer', () => {
   it('renders the student and teacher resources for the first lesson on render', () => {
     render(<LessonMaterialsContainer />);
 
-    // Teacher resources, including lesson plan
+    // Teacher resources, including lesson plan, unit vocab and unit standards
     screen.getByText('Teacher Resources');
     screen.getByTestId('resource-icon-' + RESOURCE_TYPE.SLIDES.icon);
     screen.getByText('Slides: my slides');
     screen.getByTestId('resource-icon-' + RESOURCE_TYPE.LESSON_PLAN.icon);
     screen.getByText('Lesson Plan: First lesson');
+    // checks that standards and vocab are rendered only once and not rendred in the "student resoruces section"
+    screen.getByText('Unit 3 Standards');
+    screen.getByText('Unit 3 Vocabulary');
 
     // Student resources
     screen.getByText('Student Resources');

--- a/apps/test/unit/templates/teacherNavigation/ResourceRowTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/ResourceRowTest.tsx
@@ -9,7 +9,6 @@ describe('ResourceRow', () => {
     key: 'resourceKey1',
     name: 'Handout for teacher',
     url: 'code.org',
-    downloadUrl: null,
     audience: 'Teacher',
     type: 'Handout',
   };

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -267,14 +267,6 @@ class Lesson < ApplicationRecord
     CDO.code_org_url "/curriculum/#{script.name}/#{relative_position}"
   end
 
-  def unit_standards_url
-    CDO.code_org_url "/s/#{script.name}/standards"
-  end
-
-  def unit_vocabulary_url
-    CDO.code_org_url "/s/#{script.name}/vocab"
-  end
-
   def course_version_standards_url
     script.get_course_version&.all_standards_url
   end
@@ -503,8 +495,8 @@ class Lesson < ApplicationRecord
       lessonPlanPdfUrl: lesson_plan_pdf_url,
       lessonPlanHtmlUrl: lesson_plan_html_url,
       scriptResourcesPdfUrl: script.get_unit_resources_pdf_url,
-      standardsUrl: unit_standards_url,
-      vocabularyUrl: unit_vocabulary_url,
+      standardsUrl: standards_script_path(script),
+      vocabularyUrl: vocab_script_path(script),
     }
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -267,6 +267,14 @@ class Lesson < ApplicationRecord
     CDO.code_org_url "/curriculum/#{script.name}/#{relative_position}"
   end
 
+  def unit_standards_url
+    CDO.code_org_url "/s/#{script.name}/standards"
+  end
+
+  def unit_vocabulary_url
+    CDO.code_org_url "/s/#{script.name}/vocabulary"
+  end
+
   def course_version_standards_url
     script.get_course_version&.all_standards_url
   end
@@ -494,7 +502,9 @@ class Lesson < ApplicationRecord
       resources: resources_for_lesson_plan(user&.verified_instructor?),
       lessonPlanPdfUrl: lesson_plan_pdf_url,
       lessonPlanHtmlUrl: lesson_plan_html_url,
-      scriptResourcesPdfUrl: script.get_unit_resources_pdf_url
+      scriptResourcesPdfUrl: script.get_unit_resources_pdf_url,
+      standardsUrl: unit_standards_url,
+      vocabularyUrl: unit_vocabulary_url,
     }
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -272,7 +272,7 @@ class Lesson < ApplicationRecord
   end
 
   def unit_vocabulary_url
-    CDO.code_org_url "/s/#{script.name}/vocabulary"
+    CDO.code_org_url "/s/#{script.name}/vocab"
   end
 
   def course_version_standards_url


### PR DESCRIPTION

Adds in vocab and standards rows with accurate links in data for english pages.  Open question noted in PR about handling this for other languages... 

Video of it working:



https://github.com/user-attachments/assets/a495753e-e3ce-4913-8aab-1d2ab74e013a




Screenshot from figma:

<img width="861" alt="image" src="https://github.com/user-attachments/assets/84fd8919-bf5c-4b72-b012-5359c2bf3655">



## Links

-  [Figma](https://www.figma.com/design/5ILfiJkPQpjskBwksMDeZl/Teacher-Dashboard?node-id=3148-1445&node-type=frame&m=dev)
- [Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1322)
- [Thread about how we are displaying these names here](https://codedotorg.slack.com/archives/C045UAX4WKH/p1727197144803619)

## Testing story

- Added to existing tests