### PR TITLE
BE changes to include new fields for curriculum content categorization.

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -331,10 +331,12 @@ class ScriptsController < ApplicationController
       :include_student_lesson_plans,
       :use_legacy_lesson_plans,
       :lesson_groups,
+      :content_area,
       resourceIds: [],
       studentResourceIds: [],
       project_widget_types: [],
       supported_locales: [],
+      topic_tags: []
     ).to_h
     h[:peer_reviews_to_complete] = h[:peer_reviews_to_complete].to_i > 0 ? h[:peer_reviews_to_complete].to_i : nil
     h[:announcements] = JSON.parse(h[:announcements]) if h[:announcements]

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -336,7 +336,7 @@ class ScriptsController < ApplicationController
       studentResourceIds: [],
       project_widget_types: [],
       supported_locales: [],
-      topic_tags: []
+      topic_tags: [],
     ).to_h
     h[:peer_reviews_to_complete] = h[:peer_reviews_to_complete].to_i > 0 ? h[:peer_reviews_to_complete].to_i : nil
     h[:announcements] = JSON.parse(h[:announcements]) if h[:announcements]

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1859,6 +1859,8 @@ class Unit < ApplicationRecord
       :use_legacy_lesson_plans
     ]
 
+    puts unit_data.inspect
+
     result = {}
     # If a non-boolean prop was missing from the input, it'll get populated in the result hash as nil.
     nonboolean_keys.each {|k| result[k] = unit_data[k]}

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1859,8 +1859,6 @@ class Unit < ApplicationRecord
       :use_legacy_lesson_plans
     ]
 
-    puts unit_data.inspect
-
     result = {}
     # If a non-boolean prop was missing from the input, it'll get populated in the result hash as nil.
     nonboolean_keys.each {|k| result[k] = unit_data[k]}

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -292,6 +292,10 @@ class Unit < ApplicationRecord
   #   all /s, /lessons and /levels page in that unit to our "This course is deprecated" page.
   #   We don't use published_state here because some courses in the deprecated published state
   #   are not ready to be redirected. In the future we should unify these two states.
+  # content_area - field to categorize the bigger curriculum umbrella to which this unit belongs
+  #   for example, k-5, 6-12, pl, etc.
+  # topic_tags - a collection of tags that help classify the unit based on the content. A unit can
+  #   have multiple topic tags associated with it. For example, AI, Maker
   serialized_attrs %w(
     hideable_lessons
     professional_learning_course
@@ -320,6 +324,8 @@ class Unit < ApplicationRecord
     seeded_from
     use_legacy_lesson_plans
     is_deprecated
+    content_area
+    topic_tags
   )
 
   def self.twenty_hour_unit
@@ -1581,6 +1587,8 @@ class Unit < ApplicationRecord
         updated_at: updated_at.to_s,
         isPlCourse: pl_course?,
         showAiAssessmentsAnnouncement: show_ai_assessments_announcement?(user),
+        content_area: content_area,
+        topic_tags: topic_tags,
       }
 
       #TODO: lessons should be summarized through lesson groups in the future
@@ -1837,6 +1845,8 @@ class Unit < ApplicationRecord
       :editor_experiment,
       :curriculum_umbrella,
       :weekly_instructional_minutes,
+      :content_area,
+      :topic_tags
     ]
     boolean_keys = [
       :has_verified_resources,

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -954,8 +954,6 @@ class ScriptsControllerTest < ActionController::TestCase
     }
     unit.reload
 
-    puts unit.inspect
-
     assert unit.project_sharing
     assert_equal 'CSF', unit.curriculum_umbrella
     assert_equal '6-12', unit.content_area

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -935,6 +935,8 @@ class ScriptsControllerTest < ActionController::TestCase
 
     assert_nil unit.project_sharing
     assert_nil unit.curriculum_umbrella
+    assert_nil unit.content_area
+    assert_nil unit.topic_tags
     assert_nil unit.family_name
     assert_nil unit.version_year
 
@@ -945,15 +947,21 @@ class ScriptsControllerTest < ActionController::TestCase
       lesson_groups: '[]',
       project_sharing: 'on',
       curriculum_umbrella: 'CSF',
+      content_area: '6-12',
       family_name: 'my-fam',
-      version_year: '2017'
+      version_year: '2017',
+      topic_tags: ['ai', 'maker']
     }
     unit.reload
 
+    puts unit.inspect
+
     assert unit.project_sharing
     assert_equal 'CSF', unit.curriculum_umbrella
+    assert_equal '6-12', unit.content_area
     assert_equal 'my-fam', unit.family_name
     assert_equal '2017', unit.version_year
+    assert_equal ['ai', 'maker'], unit.topic_tags
   end
 
   test 'set and unset all general_params' do
@@ -986,8 +994,10 @@ class ScriptsControllerTest < ActionController::TestCase
       pilot_experiment: 'fake-pilot-experiment',
       editor_experiment: 'fake-editor-experiment',
       curriculum_umbrella: 'CSF',
+      content_area: 'k-5',
       supported_locales: ['fake-locale'],
       project_widget_types: ['gamelab', 'weblab'],
+      topic_tags: ['ai', 'maker', 'virutal-pl'],
     }
 
     post :update, params: {
@@ -1019,8 +1029,10 @@ class ScriptsControllerTest < ActionController::TestCase
       pilot_experiment: '',
       editor_experiment: '',
       curriculum_umbrella: '',
+      content_area: '',
       supported_locales: [],
       project_widget_types: [],
+      topic_tags: [],
     }
     assert_response :success
     unit.reload

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -1755,6 +1755,17 @@ class UnitTest < ActiveSupport::TestCase
     assert_equal ['English', 'fr-fr'], unit.supported_locale_names
   end
 
+  test 'initiative mapping fields' do
+    unit_init_fields = create(:script, content_area: 'k-5')
+    assert_equal "k-5", unit_init_fields.content_area
+
+    unit_init_fields.topic_tags = ['ai']
+    assert_equal ['ai'], unit_init_fields.topic_tags
+
+    unit_init_fields.topic_tags += ['maker']
+    assert_equal ['ai', 'maker'], unit_init_fields.topic_tags
+  end
+
   test 'section_hidden_unit_info' do
     teacher = create :teacher
     section1 = create :section, user: teacher
@@ -2163,7 +2174,7 @@ class UnitTest < ActiveSupport::TestCase
       Unit.any_instance.stubs(:write_script_json)
       Unit.stubs(:merge_and_write_i18n)
 
-      @standalone_unit = create :script, is_migrated: true, is_course: true, version_year: '2021', family_name: 'csf', name: 'standalone-2021'
+      @standalone_unit = create :script, is_migrated: true, is_course: true, version_year: '2021', family_name: 'csf', name: 'standalone-2021', content_area: 'k-5', topic_tags: ['ai', 'maker']
       create :course_version, content_root: @standalone_unit
 
       @deeper_learning_unit = create :script, participant_audience: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator, instructor_audience: Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer, professional_learning_course: 'DLP 2021'
@@ -2206,6 +2217,8 @@ class UnitTest < ActiveSupport::TestCase
       assert_equal cloned_unit.instruction_type, @standalone_unit.instruction_type
       assert_equal cloned_unit.instructor_audience, @standalone_unit.instructor_audience
       assert_equal cloned_unit.participant_audience, @standalone_unit.participant_audience
+      assert_equal cloned_unit.content_area, 'k-5'
+      assert_equal cloned_unit.topic_tags, ['ai', 'maker']
     end
 
     test 'can update markdown on clone' do


### PR DESCRIPTION
This change is part of the work addressing requirements captured in [this tech spec](https://docs.google.com/document/d/1d-kWtVF2qsyRoryDROZNQ6LyXXO1zVXqRblNAEB6ozc/edit#heading=h.ps9e6ijhb3cr). The feature involves adding two new fields that would enable RED team to do more granular categorization of curriculum to different initiatives.

This change contains
- Updates in the unit model to add two new fields, content_area, which will be a single string value and topic_tags, which will be a collection of strings to annotate the curriculum unit
- Corresponding changes in the scripts controller to expose these two fields
- Unit tests to validate these changes

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1363, https://codedotorg.atlassian.net/browse/TEACH-1361

## Testing story

- new unit tests to validate changes
- drone

## Deployment strategy

Regular DTP

## Follow-up work

The linked JIRA tickets will continue to track the front-end work needed to expose these fields in level builder UI.

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
