### PR TITLE
New rotation pattern for unison.log copying to S3 (Try 2)

### DIFF
--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -37,8 +37,7 @@ FOLDERS = {
 INTERVAL_SECONDS = 5
 TOTAL_SECONDS = 55 - INTERVAL_SECONDS
 
-LOG_DIR = '/home/ubuntu/staging/log'.freeze
-FileUtils.mkdir_p(LOG_DIR) # This directory should always exist, but just in case
+LOG_DIR = '/home/ubuntu'.freeze
 
 logger = HighFrequencyReporter.new(Slack, 'sync-dropbox-staging', File.join(LOG_DIR, 'dropbox_sync_error_log.csv'))
 logger.load # load errors from most recent sync

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -47,23 +47,11 @@ end
 apt_package 'enscript'
 
 # Install dependencies required to sync content between our Code.org shared
-# Dropbox folder and our git repository. Also check whether the tool that
-# performs the sync is installed, and display instructions for how to do so if
-# it isn't. Ideally, we would be able to install the tool with this code, but
-# the process is sufficiently interactive and we have to do it sufficiently
-# rarely that we think documentation will suffice for now.
+# Dropbox folder and our git repository only on the staging server. In the long
+# run, we'd like to have this happen in a separate environment independent of
+# any of our build pipeline servers; but for now, we default to staging.
 if node.chef_environment == 'staging'
-  apt_package 'unison'
-  dropbox_daemon_file = File.join(node[:home], '.dropbox-dist/dropboxd')
-  unless File.exist?(dropbox_daemon_file)
-    environment_name = node.chef_environment.inspect
-    Chef.event_handler do
-      on :run_completed do
-        Chef::Log.warn("Chef environment #{environment_name} expects the Dropbox Daemon to be configured.")
-        Chef::Log.warn('Follow the instructions at https://www.dropbox.com/install-linux to do so')
-      end
-    end
-  end
+  include_recipe 'cdo-apps::dropbox_sync'
 end
 
 include_recipe 'cdo-python'

--- a/cookbooks/cdo-apps/recipes/dropbox_sync.rb
+++ b/cookbooks/cdo-apps/recipes/dropbox_sync.rb
@@ -1,0 +1,40 @@
+# Install the tool that syncs content between the Dropbox directory and the git
+# repository. Also configure rotation for the tool's fairly verbose logs,
+# including logic to back them up to S3.
+apt_package 'unison'
+file '/etc/logrotate.d/unison' do
+  content <<~LOGROTATE
+    #{File.join(node[:home], 'unison.log')} {
+      daily
+      rotate 15
+      dateext
+      compress
+      missingok
+      notifempty
+      copytruncate
+      prerotate
+        INSTANCE_ID="`wget -q -O - http://instance-data/latest/meta-data/instance-id`"
+        /usr/local/bin/aws s3 cp $1 "s3://cdo-logs/#{node.chef_environment}-misc-logs/${INSTANCE_ID}/$(date +%F)$1"
+      endscript
+    }
+  LOGROTATE
+  mode '0644'
+  owner 'root'
+  group 'root'
+end
+
+# Check whether the tool that syncs content between Dropbox's servers and our
+# local Dropbox directory is installed, and display instructions for how to do
+# so if it isn't. Ideally, we would be able to install the tool with this code,
+# but the process is sufficiently interactive and we have to do it sufficiently
+# rarely that we think documentation will suffice for now.
+dropbox_daemon_file = File.join(node[:home], '.dropbox-dist/dropboxd')
+unless File.exist?(dropbox_daemon_file)
+  environment_name = node.chef_environment.inspect
+  Chef.event_handler do
+    on :run_completed do
+      Chef::Log.warn("Chef environment #{environment_name} expects the Dropbox Daemon to be configured.")
+      Chef::Log.warn('Follow the instructions at https://www.dropbox.com/install-linux to do so')
+    end
+  end
+end


### PR DESCRIPTION
Bringing back https://github.com/code-dot-org/code-dot-org/pull/59880
With many thanks to Elijah!

We return the `unison.log` file to its original location in the home directory, and configure logrotation for just that file. We also include logic to upload the last day's worth of logs to S3 before rotating, to a path unique to that server and that day, so the logs can be preserved even after rotation has deleted them from the local filesystem.

Also extract our existing Chef code related to the dropbox sync to its own recipe, since it was starting to get a little long.

## Links

[Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1720468091032489)

## Testing story

Trusting the manual test Elijah did here.  I'm using the script verbatim that he used there.

## Deployment plan

These are legacy files needing adjustment:
- Before the PR merge: the original 85G log file in `/home/ubuntu/unison.log` still exists:
   - Gzip/chunk and move to S3 [DONE, file is [here](https://us-east-1.console.aws.amazon.com/s3/object/cdo-logs?region=us-east-1&bucketType=general&prefix=staging-misc-logs/i-05db0499224ca06de/2024-09-25_legacy_unison.log.gz.tgz), compressed 85GB down to 22 MB!!]
- After the PR deploys: clean up the logs that have been rotating under `/home/ubuntu/staging/logs/unison.log*`
   - move them (the ones that have not been rotate/deleted) to S3

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [X] Code is well-commented