### PR TITLE
NAV - minor changes to calendar

### DIFF
--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -15,7 +15,7 @@ const UnitCalendar: React.FC = () => {
   const lessons = useSelector(state => getCurrentUnitData(state)?.lessons);
   const [isLoading, setIsLoading] = useState(true);
   const [weeklyInstructionalMinutes, setWeeklyInstructionalMinutes] =
-    useState<number>(WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS[0]);
+    useState<number>(WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS[4]);
 
   useEffect(() => {
     if (lessons) {
@@ -37,8 +37,7 @@ const UnitCalendar: React.FC = () => {
   };
 
   return (
-    <div>
-      <h2>{i18n.weeklyLessonLayout()}</h2>
+    <div style={styles.contentContainer}>
       <div style={styles.minutesPerWeekWrapper}>
         <div style={styles.minutesPerWeekDescription}>
           {i18n.instructionalMinutesPerWeek()}
@@ -89,5 +88,8 @@ const styles = {
   minutesPerWeekDescription: {
     fontWeight: 'bold' as const,
     marginRight: 10,
+  },
+  contentContainer: {
+    width: 'fit-content',
   },
 };


### PR DESCRIPTION
Made some minor change to the NAV calendar, including:

- Made the default minutes-per-week 225 (which is 45 minutes a day)
- Made the content fit inside the calendar box
- Removed headline

BEFORE:
<img width="1188" alt="image" src="https://github.com/user-attachments/assets/2f0b8799-2913-490b-a152-0a9b2da658d0">


AFTER:
<img width="989" alt="image" src="https://github.com/user-attachments/assets/942b1bff-7133-4948-a682-4f2022017fd9">

VIDEO:

https://github.com/user-attachments/assets/90579cf3-01a1-4d35-ba8c-c489e5fc6652



## Links

[Figma](https://www.figma.com/design/5ILfiJkPQpjskBwksMDeZl/Teacher-Dashboard?node-id=3107-4711&node-type=rounded_rectangle&m=dev)
[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65/backlog?selectedIssue=TEACH-1299&text=Calendar)?  Note that this ticket talks about "Responsive" width, @MollyPeredo to confirm that this video is OK.