### PR TITLE
Update code.org/about/supporters and add Amazon Donor Spotlight page

### DIFF
--- a/pegasus/sites.v3/code.org/public/about/supporters.haml
+++ b/pegasus/sites.v3/code.org/public/about/supporters.haml
@@ -60,7 +60,7 @@ theme: responsive
   %figure
     %p Anonymous
   %figure
-    %p Alfred and Rebecca Lin
+    %p Rebecca and Alfred Lin
   %figure
     %p Travis Kalanick
 

--- a/pegasus/sites.v3/code.org/public/about/supporters.haml
+++ b/pegasus/sites.v3/code.org/public/about/supporters.haml
@@ -6,44 +6,94 @@ theme: responsive
 
 -# Import gsheet data
 - supporters_data = DB[:cdo_supporters].all
+- year = "2024"
 
 %link{rel: "stylesheet", href:"/css/donors.css"}
 
 %h1 Supporters
 
-%p Code.org is sincerely grateful for our vibrant community of corporate, institutional, and individual donors. We acknowledge the following supporters who have made generous commitments of $1,000 and above to support our 2023 fiscal year (January 1, 2023 - December 31, 2023).
-
-%p For further details or to explore partnership opportunities with Code.org, please contact our Office of Development at <a href="mailto:giving@code.org">giving@code.org</a>.
+%p Code.org is sincerely grateful for our vibrant community of corporate, institutional, and individual donors. We extend special thanks to Amazon for its partnership and generous support, which has been instrumental in our efforts to expand computer science education.
 
 %p Code.org® believes that every student in every school should have the opportunity to learn computer science. Thanks to the support listed below, we are able to increase access to computer science education globally.
+
+%p For further details or to explore partnership opportunities with Code.org, please contact our Office of Development at <a href="mailto:giving@code.org">giving@code.org</a>.
 
 %p Code.org is a 501(c)(3) nonprofit organization and our Federal Tax ID is 46-0858543.
 
 %a.link-button{href: "/donate"} Please consider a donation
 
-%h2 Platinum Supporters ($3,000,000+)
-%section.grid-container
-  %img{src: "/images/avatars/amazon.png", alt: "Amazon logo"}
-  %img{src: "/images/avatars/google.png", alt: "Google logo"}
-  %img{src: "/images/avatars/microsoft.png", alt: "Microsoft logo"}
-  %img{src: "/images/avatars/ballmer_group.png", alt: "Ballmer Group logo"}
-  %p Kenneth C. Griffin
+%h2 Lifetime Supporters
+%p We recognize Lifetime Supporters for their generous cumulative contributions of $5,000,000 and above as champions in transforming computer science education.
 
-%h2 Gold Supporters ($1,000,000+)
-%section.grid-container
-  %img{src: "/images/avatars/bill_and_melinda_gates_foundation.png", alt: "Bill and Melinda Gates Foundation logo", style: "width: 170px"}
-  %p Musk Foundation
-  %img{src: "/images/avatars/schmidt-futures.png", alt: "Schmidt Futures logo", style: "width: 200px"}
-  %p Alfred and Rebecca Lin
-  %p Charlie Lee and Aileen Tang
-  %p Bret and Karen Taylor
-  %p The Iranian American Community
-  %p Anonymous
+%h3 $30 Million+
+%section.grid-container.col-2
+  %figure.tall
+    %img{src: "/images/avatars/amazon.png", alt: "Amazon logo", style: "width: 145px"}
+  %figure.tall
+    %img{src: "/images/avatars/microsoft.png", alt: "Microsoft logo", style: "width: 185px"}
 
+%h3 $10 Million+
+%section.grid-container.col-4
+  %figure
+    %img{src: "/images/avatars/google.png", alt: "Google logo", style: "width: 110px"}
+  %figure
+    %img{src: "/images/avatars/facebook_circle.png", alt: "Facebook logo", style: "width: 50px"}
+  %figure
+    %img{src: "/images/avatars/ballmer_group.png", alt: "Ballmer Group logo", style: "width: 105px"}
+  %figure
+    %img{src: "/images/avatars/infosys_foundation_usa.png", alt: "Infosys Foundation USA logo", style: "width: 50px"}
+
+%h3 $5 Million+
+%section.grid-container.col-3
+  %figure
+    %img{src: "/images/avatars/aws_web_services.png", alt: "Amazon Web Services logo", style: "width: 140px"}
+  %figure
+    %img{src: "/images/avatars/vista_equity_partners.png", alt: "Vista Equity Partners logo", style: "width: 160px"}
+  %figure
+    %img{src: "/images/avatars/bill_and_melinda_gates_foundation.png", alt: "Bill and Melinda Gates Foundation logo", style: "width: 160px"}
+  %figure
+    %img{src: "/images/avatars/omidyar_network.png", alt: "Omidyar Network logo", style: "width: 160px"}
+  %figure
+    %p Kenneth C. Griffin
+  %figure
+    %p Charlie Lee
+  %figure
+    %p Anonymous
+  %figure
+    %p Alfred and Rebecca Lin
+  %figure
+    %p Travis Kalanick
+
+%h2 Annual Supporters
+%p We extend gratitude to the following supporters who have made significant commitments of $1,000-$4,999,999 to support our #{year} fiscal year (January 1, #{year} - December 31, #{year}).
 %section.lists.no-flex.no-padding
   %section.flex-container.no-padding.mobile-hide
     %h3.heading-sm Institutional Supporters
     %h3.heading-sm Individual Supporters
+  %h4.heading-xs $3,000,000+
+  .col-50
+    %h5.mobile-show Institutional Supporters
+    %ul
+      - supporters_data.select { |list| list[:institutional_3m_s].present? }.each do |list|
+        %li=list[:institutional_3m_s]
+  .col-50
+    %h5.mobile-show Individual Supporters
+    %ul
+      - supporters_data.select { |list| list[:individual_3m_s].present? }.each do |list|
+        %li=list[:individual_3m_s]
+  .clearfix
+  %h4.heading-xs $1,000,000+
+  .col-50
+    %h5.mobile-show Institutional Supporters
+    %ul
+      - supporters_data.select { |list| list[:institutional_1m_s].present? }.each do |list|
+        %li=list[:institutional_1m_s]
+  .col-50
+    %h5.mobile-show Individual Supporters
+    %ul
+      - supporters_data.select { |list| list[:individual_1m_s].present? }.each do |list|
+        %li=list[:individual_1m_s]
+  .clearfix
   %h4.heading-xs $500,000+
   .col-50
     %h5.mobile-show Institutional Supporters

--- a/pegasus/sites.v3/code.org/public/about/supporters/amazon.haml
+++ b/pegasus/sites.v3/code.org/public/about/supporters/amazon.haml
@@ -14,6 +14,13 @@ theme: responsive
     align-items: center;
     margin-bottom: 1rem;
 
+    @media (max-width: 768px) {
+      margin-bottom: 2rem;
+      flex-direction: column;
+      align-items: start;
+      gap: 1rem;
+    }
+
     & > h1 {
       margin-top: 1rem
     }

--- a/pegasus/sites.v3/code.org/public/about/supporters/amazon.haml
+++ b/pegasus/sites.v3/code.org/public/about/supporters/amazon.haml
@@ -1,0 +1,42 @@
+---
+title: Amazon Donor Spotlight
+nav: about_nav
+theme: responsive
+---
+
+:css
+  .overline-one {
+    margin-block: 3.5rem 0;
+  }
+
+  .flex-container {
+    display: flex;
+    align-items: center;
+    margin-bottom: 1rem;
+
+    & > h1 {
+      margin-top: 1rem
+    }
+
+    & > img {
+      width: 200px;
+    }
+  }
+
+%p.overline-one
+  Donor spotlight
+
+.flex-container
+  %h1.heading-xl
+    Amazon supports Code.org's mission to bring CS to everyone.
+  %img{src: "/images/avatars/amazon.png", alt: "Amazon logo"}
+
+%p Amazon believes education has the power to transform lives and create boundless opportunities. That's why the company invests heavily in programs to empower learners of all ages to unlock their full potential. Amazon understands that access to quality education opens doors, fuels innovation, and drives positive change in communities worldwide.
+
+%p Amazon's Future Engineer program remains dedicated to supporting Code.org's mission to make computer science accessible to over one million underserved students in the U.S. and worldwide. Together, Amazon and Code.org aim to teach K-12 students computer science and AI fundamentals, equipping the next generation with essential skills for the digital world.
+
+%p The Amazon Future Engineer program also supports curriculum development, teacher training, and student engagement, including the Hour of Code, while providing AWS technology support. Their partnership with Code.org co-creates innovative educational experiences like Dance Party and Dance Party: AI Edition, reaching millions globally.
+
+%p Amazon's commitment to innovation remains steadfast as it develops programs that equip students for future careers. Harnessing Amazon's culture of invention and Code.org's expertise, this collaboration prepares students for future careers in computer science and STEM, nurturing the next generation of innovators.
+
+%p More information on Amazon Future Engineer is <a href="https://www.amazonfutureengineer.com/" target="_blank" rel="nooopener nooreferrer" class="has-external-link">available here</a>.

--- a/pegasus/sites.v3/code.org/public/about/supporters/index.haml
+++ b/pegasus/sites.v3/code.org/public/about/supporters/index.haml
@@ -29,8 +29,11 @@ theme: responsive
 %section.grid-container.col-2
   %figure.tall
     %img{src: "/images/avatars/amazon.png", alt: "Amazon logo", style: "width: 145px"}
+    %a{href: "/about/supporters/amazon"} Learn more
   %figure.tall
     %img{src: "/images/avatars/microsoft.png", alt: "Microsoft logo", style: "width: 185px"}
+    -# TODO show this once Microsoft Donor Spotlight page is added
+    -# %a{href: "/about/supporters/microsoft"} Learn more
 
 %h3 $10 Million+
 %section.grid-container.col-4

--- a/pegasus/sites.v3/code.org/public/css/donors.css
+++ b/pegasus/sites.v3/code.org/public/css/donors.css
@@ -165,9 +165,11 @@ section.grid-container {
     display: flex;
     justify-content: center;
     align-items: center;
+    flex-direction: column;
+    gap: 1rem;
 
     &.tall {
-      height: 110px;
+      height: 140px;
     }
 
     & > img {

--- a/pegasus/sites.v3/code.org/public/css/donors.css
+++ b/pegasus/sites.v3/code.org/public/css/donors.css
@@ -134,24 +134,54 @@ section.grid-container {
   padding: 2em 0;
   display: grid;
   align-items: center;
-  grid-gap: 2em;
+  grid-gap: 1.5rem;
 
-  @media (min-width: 768px) {
-    grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(2, 1fr);
+  &.col-2 {
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(2, 1fr);
+      grid-template-rows: repeat(1, 1fr);
+    }
   }
 
-  & > img {
-    width: 120px;
-    margin-inline: auto;
+  &.col-3 {
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(3, 1fr);
+      grid-template-rows: repeat(1, 1fr);
+    }
   }
 
-  & > p {
-    margin: 0;
-    font-size: 16px;
-    text-align: center;
-    font-family: var(--main-font);
-    font-weight: var(--semi-bold-font-weight);
+  &.col-4 {
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(4, 1fr);
+      grid-template-rows: repeat(1, 1fr);
+    }
+  }
+
+  & > figure {
+    width: 100%;
+    height: 90px;
+    border: 1px solid var(--neutral_dark20);
+    border-radius: 4px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    &.tall {
+      height: 110px;
+    }
+
+    & > img {
+      margin-inline: auto;
+    }
+
+    & > p {
+      margin: 0;
+      width: 90%;
+      font-size: 16px;
+      text-align: center;
+      font-family: var(--main-font);
+      font-weight: var(--semi-bold-font-weight);
+    }
   }
 }
 
@@ -166,7 +196,7 @@ section.lists h3 {
   background: #00b2c0;
   color: white;
   padding: .75em;
-  margin: 2em 0 0;
+  margin: 0;
   width: 100%;
 }
   section.lists h4 {

--- a/pegasus/sites.v3/code.org/public/images/avatars/aws_web_services.png
+++ b/pegasus/sites.v3/code.org/public/images/avatars/aws_web_services.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e81849504098bdc04df32b8e18a5d0266cb013905179094b09303e13d174490
+size 6569

--- a/pegasus/sites.v3/code.org/public/images/avatars/facebook_circle.png
+++ b/pegasus/sites.v3/code.org/public/images/avatars/facebook_circle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0643f76cbcfba33473dc7c6256c5dc8f057276bab6468e9410b7d882cdce7467
+size 17496

--- a/pegasus/sites.v3/code.org/public/images/avatars/omidyar_network.png
+++ b/pegasus/sites.v3/code.org/public/images/avatars/omidyar_network.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a638e824745fd57e08c1bfa77fe34363cea1784fbb1107f18a9a0bd677b4b6f4
-size 12348
+oid sha256:8794a872aa6c61dd2b27195bc1b36c4a127771ede6b4f24251b3c523b08b1fcb
+size 16757

--- a/pegasus/sites.v3/code.org/public/images/avatars/vista_equity_partners.png
+++ b/pegasus/sites.v3/code.org/public/images/avatars/vista_equity_partners.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3d134e35d5acb3fa4b1b25cd6c96b69f5c2f53828d7b13eac75afe07f1f49834
-size 10108
+oid sha256:d265c78672a7481d1821b6dfbb4038a62a39466444856d1f1d106375694dd100
+size 49747


### PR DESCRIPTION
Updates https://code.org/about/supporters page and adds a new page for Amazon.
- Updates the copy at the top of the Supporters page
- Adds a Lifetime Supporters section 
- Adds $3M+ and $1M+ rows in the Annual Supporters column 
- Adds a new page for Amazon donor spotlight 

The rest of the Supporters page hasn't changed. These pages don't need to be translated.

## Links
Jira ticket: [ACQ-2122](https://codedotorg.atlassian.net/browse/ACQ-2122)
Figma mock: [here](https://www.figma.com/design/qEFj4WmsjOC5okiMMxLJXq/Amazon-at-Code.org?node-id=1856-554&node-type=frame&m=dev)
Gsheet where the list of Annual Supporters is updated: [here](https://docs.google.com/spreadsheets/d/1Nmd1lt8_MnnHcDLZuKmTeBs68Gq8OAFNl2r2Y_Vj50U/edit?gid=0#gid=0)

## Testing story
Tested locally

----

## code.org/supporters updates


https://github.com/user-attachments/assets/4fbf56e7-862e-48ff-8100-c4604ee24cc5


## code.org/about/supporters/amazon
![localhost code org_3000_about_supporters_amazon](https://github.com/user-attachments/assets/5e1eba37-58ce-4389-a999-33ad1bcb50b5)


