### PR TITLE
Removing upper righthand buttons for new sign up flow

### DIFF
--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -9,6 +9,9 @@
   elsif local_assigns[:level]
     # Only show the create menu on project levels (and not on levels in units)
     show_create_menu = local_assigns[:level].try(:is_project_level)
+  elsif request.path_info.start_with?('/users/new_sign_up')
+    # Do not show create menu within sign up flow
+    show_create_menu = false
   else
     # Show the create menu on non-level pages
     show_create_menu = true
@@ -94,7 +97,7 @@
     .header_button.header_user#header_user_signin
       %span= I18n.t("#{loc_prefix}signin")
   -# Hides the Create account button on the sign up page
-  - if request.path_info != '/users/sign_up'
+  - if request.path_info != '/users/sign_up' && !request.path_info.start_with?('/users/new_sign_up')
     %a.linktag{href: CDO.studio_url('users/sign_up'), class: 'button-create-account desktop', id: 'create_account_button'}
       .header_button.header_user#header_user_create_account
         %span= I18n.t("#{loc_prefix}create_account_low_cap")


### PR DESCRIPTION
Removes the project and create account buttons in the header for the new sign up flow. 

<img width="1060" alt="Screenshot 2024-09-25 at 1 00 21 PM" src="https://github.com/user-attachments/assets/a72788b0-75cb-499c-ba2d-824bfc63a9a9">
<img width="1058" alt="Screenshot 2024-09-25 at 1 00 32 PM" src="https://github.com/user-attachments/assets/d3951eb8-2cc8-4a86-8225-dd0490fef09a">
<img width="1060" alt="Screenshot 2024-09-25 at 1 00 41 PM" src="https://github.com/user-attachments/assets/6cc6d01b-89d2-466b-a5b1-488f6a3dc8a2">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2389

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
