### PR TITLE
Codebridge: Polish file tabs

### DIFF
--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -7,6 +7,7 @@
   "cannotRun": "We don't know how to run your code. Please contact support.",
   "cannotStop": "We don't know how to stop your code. Please contact support.",
   "cannotTest": "We don't know how to run your tests. Please contact support.",
+  "closeFile": "close file",
   "defaultLayout": "Default layout",
   "delete": "Delete",
   "deleteFile": "Delete file",

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -21,9 +21,9 @@ const FileTab = ({file}: FileTabProps) => {
   const {iconName, iconStyle, isBrand} = getFileIconNameAndStyle(file);
   const iconClassName = isBrand ? 'fa-brands' : undefined;
   const isActive = file.active || file === activeFile;
-  const className = isActive
-    ? classNames(moduleStyles.fileTab, moduleStyles.active)
-    : moduleStyles.fileTab;
+  const className = classNames(moduleStyles.fileTab, {
+    [moduleStyles.active]: isActive,
+  });
 
   return (
     <div className={className} key={file.id}>
@@ -39,11 +39,10 @@ const FileTab = ({file}: FileTabProps) => {
         onClick={() => closeFile(file.id)}
         color={'light'}
         aria-label={codebridgeI18n.closeFile()}
-        className={
-          isActive
-            ? classNames(moduleStyles.active, moduleStyles.closeButton)
-            : classNames(moduleStyles.closeButton, moduleStyles.inactive)
-        }
+        className={classNames(moduleStyles.closeButton, {
+          [moduleStyles.active]: isActive,
+          [moduleStyles.inactive]: !isActive,
+        })}
       />
     </div>
   );

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -1,8 +1,11 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {ProjectFile} from '@codebridge/types';
 import {getFileIconNameAndStyle} from '@codebridge/utils';
+import classNames from 'classnames';
 import React from 'react';
 
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import CloseButton from '@cdo/apps/componentLibrary/closeButton/CloseButton';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import {getActiveFileForProject} from '@cdo/apps/lab2/projects/utils';
 
@@ -17,30 +20,31 @@ const FileTab = ({file}: FileTabProps) => {
   const activeFile = getActiveFileForProject(project);
   const {iconName, iconStyle, isBrand} = getFileIconNameAndStyle(file);
   const iconClassName = isBrand ? 'fa-brands' : undefined;
+  const isActive = file.active || file === activeFile;
+  const className = isActive
+    ? classNames(moduleStyles.fileTab, moduleStyles.active)
+    : moduleStyles.fileTab;
 
   return (
-    <div
-      className={`${moduleStyles.fileTab} ${
-        file.active || file === activeFile ? moduleStyles.active : ''
-      }`}
-      key={file.id}
-    >
+    <div className={className} key={file.id}>
       <span onClick={() => setActiveFile(file.id)}>
         <FontAwesomeV6Icon
           iconName={iconName}
           iconStyle={iconStyle}
           className={iconClassName}
         />
-        &nbsp;
-        {file.name}
+        <span>{file.name}</span>
       </span>
-      <button
-        type="button"
-        className={moduleStyles.inlineButton}
+      <CloseButton
         onClick={() => closeFile(file.id)}
-      >
-        <i className="fa-solid fa-x" />
-      </button>
+        color={'light'}
+        aria-label={codebridgeI18n.closeFile()}
+        className={
+          isActive
+            ? classNames(moduleStyles.active, moduleStyles.closeButton)
+            : classNames(moduleStyles.closeButton, moduleStyles.inactive)
+        }
+      />
     </div>
   );
 };

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -8,41 +8,41 @@
   overflow-x: scroll;
   max-width: 100%;
   background-color: $charcoal;
-  color: $white;
   scrollbar-width: none;
   grid-area: file-tabs;
-  min-height: 30px;
+  min-height: 32px;
+  font-size: 14px;
+  font-weight: 600;
+  color: $neutral_dark20;
 }
 
 .fileTab {
-  padding: 0;
   display: flex;
   cursor: pointer;
   white-space: nowrap;
   justify-content: space-between;
   gap: 10px;
-  padding-left: 2px;
-  padding-right: 2px;
+  padding: 0 6px;
+  height: 28px;
   background-color: $dark_charcoal;
+  border-radius: 4px 4px 0 0;
 }
 
 .fileTab > span {
   display: flex;
   align-items: center;
-}
-
-.inlineButton {
-  border: none;
-  background: none;
-  color: inherit;
-  padding: 0;
-  font: inherit;
-  cursor: pointer;
-  outline: inherit;
-  white-space: nowrap;
+  gap: 10px;
 }
 
 .active {
-  font-weight: bold;
   background-color: #292f36;
+  color: $white;
+}
+
+.inactive {
+  color: $neutral_dark20;
+}
+
+.closeButton {
+  margin-top: 4px;
 }

--- a/apps/src/codebridge/utils/fileUtils.ts
+++ b/apps/src/codebridge/utils/fileUtils.ts
@@ -24,7 +24,7 @@ export function getFileIconNameAndStyle(file: ProjectFile): {
     if (file.name.endsWith('.py')) {
       return {iconName: 'python', iconStyle: 'regular', isBrand: true};
     }
-    return {iconName: 'file', iconStyle: 'solid'};
+    return {iconName: 'file', iconStyle: 'regular'};
   }
   if (file.type === ProjectFileType.VALIDATION) {
     return {iconName: 'flask', iconStyle: 'solid'};


### PR DESCRIPTION
Polish file tabs to align with [figma](https://www.figma.com/design/vcNGOFsIks0HhRk6GEOfZf/Upper-Lab?node-id=4454-95376&node-type=instance&m=dev). I also switched to using the DSCO close button component.

### Before
![Screenshot 2024-09-25 at 1 58 20 PM](https://github.com/user-attachments/assets/2771f61d-ae6e-4010-8c93-e3c985bee25b)

Before, the close button would not change color when hovered.

### After
#### Close button not hovered
<img width="517" alt="Screenshot 2024-09-25 at 1 58 33 PM" src="https://github.com/user-attachments/assets/8ea15560-64ca-4795-b20a-813346444fb2">


#### Close button hovered
In this screenshot, subfile1.py's close button is being hovered over. 
![Screenshot 2024-09-25 at 2 03 46 PM](https://github.com/user-attachments/assets/9f5ab415-5c8e-4126-8455-a90237128f8f)

## Links
- jira ticket: [CT-811](https://codedotorg.atlassian.net/browse/CT-811)


## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
