### PR TITLE
Aichat: use -production or -test endpoint names

### DIFF
--- a/dashboard/app/helpers/aichat_sagemaker_helper.rb
+++ b/dashboard/app/helpers/aichat_sagemaker_helper.rb
@@ -53,7 +53,7 @@ module AichatSagemakerHelper
 
   def self.request_sagemaker_chat_completion(inputs, selected_model_id)
     create_sagemaker_client.invoke_endpoint(
-      endpoint_name: selected_model_id, # required
+      endpoint_name: get_endpoint_name(selected_model_id), # required
       body: inputs.to_json, # required
       content_type: "application/json"
     )
@@ -71,6 +71,10 @@ module AichatSagemakerHelper
 
   def self.can_request_aichat_chat_completion?
     DCDO.get("aichat_chat_completion", true)
+  end
+
+  def self.get_endpoint_name(model_id)
+    "#{model_id}-#{rack_env?(:production) ? 'production' : 'test'}"
   end
 end
 


### PR DESCRIPTION
**NOTE:** this change will only be merged in conjunction with performing a stack update using the Gen AI cloudformation template ([deploy script here](https://github.com/code-dot-org/code-dot-org/blob/staging/aws/cloudformation/standalone/gen_ai_curriculum/deploy_gen_ai_curriculum_stack)).

Now that we have a [cloudformation template](https://github.com/code-dot-org/code-dot-org/blob/staging/aws/cloudformation/standalone/gen_ai_curriculum/gen_ai_curriculum.yml.erb) for deploying Gen AI resources, we need to update our sagemaker helper to use the right endpoints. The cloudformation template has the ability to deploy separate -production and -test stacks so we can separate resources between prod and non-prod environments (staging/test/localhost). 

## Links

https://codedotorg.atlassian.net/browse/LABS-1053

## Testing story

Tested with the -test stack which is already deployed; confirmed all endpoints work correctly.

## Deployment strategy

Once this is ready to merge, I will prepare the stack update and try to coordinate it so that this change reaches production as the production stack is ready. Due to resource limitations in our production AWS account there will likely be a short period of downtime where the old endpoints have to be taken down and the change has not fully propagated to production machines, but I'll clear this with the Gen AI team so folks are aware.