### PR TITLE
Add back oceans-overview image

### DIFF
--- a/pegasus/sites.v3/code.org/public/images/oceans/oceans-overview.png
+++ b/pegasus/sites.v3/code.org/public/images/oceans/oceans-overview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad5c13cc223b2ffb426adb2b2b3126e86470edf10a9124ffaca3fa209060aa62
+size 141664


### PR DESCRIPTION
When I deleted images in https://github.com/code-dot-org/code-dot-org/pull/60979, I only checked for `/images/oceans/`, not for `/images/fill-484x234/oceans/`. 

I searched `images/fill.*/oceans` and only found `oceans-overview` (except in an unused view, which I'm removing in #61360). 

