### PR TITLE
Further Tweak Evictions Alarm

### DIFF
--- a/aws/cloudformation/components/session_store.yml.erb
+++ b/aws/cloudformation/components/session_store.yml.erb
@@ -88,7 +88,7 @@
       DatapointsToAlarm: 3
       # TODO infra: update this threshold and upgrade the alarm to Urgent once
       # we've confirmed that this threshold and implementation are practical.
-      Threshold: 10000
+      Threshold: 20000
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: missing
   SessionStoreNetworkBytesInAlarm:


### PR DESCRIPTION
Evictions continue to be erratic, and this alarm has been noisy.

See https://github.com/code-dot-org/code-dot-org/pull/61320 for the longer-term fix to this problem. Since we expect that fix to take several weeks to start showing an effect once merged, in the shorter term I propose we again double the limit from 10k to 20, which based on [the last week of activity](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~'AWS*2fElastiCache~'Evictions~'CacheClusterId~'ausxf3ubdbzebgu-001~'CacheNodeId~'0001)~(~'...~'ausxf3ubdbzebgu-002~'.~'.)~(~'...~'ausxf3ubdbzebgu-003~'.~'.))~region~'us-east-1~title~'Evictions~stat~'Maximum~view~'timeSeries~start~'-PT168H~end~'P0D~period~300)) should be quieter, if not entirely silent:

![image](https://github.com/user-attachments/assets/334daeaf-1cff-441c-9506-51afcfa9f387)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
