### PR TITLE
Update carousel_farsi_how_ai_works_videos.haml

### DIFF
--- a/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_how_ai_works_videos.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/carousel_farsi_how_ai_works_videos.haml
@@ -1,13 +1,13 @@
 // Should be 9 when done
 - video_ai_index = 2
 
-- video_download_path = ["//videos.code.org/farsi/how-ai-works/ai-training-data-bias.mp4", "//videos.code.org/farsi/how-ai-works/ai-what-machine-learning.mp4"]
+- video_download_path = ["//videos.code.org/farsi/how-ai-works/ai-what-machine-learning.mp4", "//videos.code.org/farsi/how-ai-works/ai-training-data-bias.mp4"]
 
 // this is the full list which will be helpful when we add the needed videos
 //- video_caption = [hoc_s(:ai_vid_intro_caption), hoc_s(:ai_vid_mlintro_caption), hoc_s(:ai_vid_trainingdata_caption), hoc_s(:ai_vid_neuralnetworks_caption), hoc_s(:ai_vid_computervision_caption), hoc_s(:ai_vid_chatbots_caption), hoc_s(:ai_vid_creativity_caption), hoc_s(:ai_vid_ethics1_caption), hoc_s(:ai_vid_ethics2_caption)]
 - video_caption = [hoc_s(:ai_vid_mlintro_caption), hoc_s(:ai_vid_trainingdata_caption)]
 
-- video_code = ["2V6zog8MPQo", "p7f8HZqPsPk"]
+- video_code = ["2V6zog8MPQo", "_egaRTxlA44"]
 
 .carousel-wrapper.video-carousel
   %swiper-container.how-ai-works{navigation: "true", "navigation-next-el": ".nav-next-how-ai-works", "navigation-prev-el": ".nav-prev-how-ai-works", pagination: "true", init: "false", "allow-touch-move": "false"}


### PR DESCRIPTION
Updates the youtube embed code to point to the new video.

Swaps the fallbacks which were in the wrong order.

You can see the layout where the fallback video is now correctly associated and the desired video is embedded (with the other video untouched):

![image](https://github.com/user-attachments/assets/29ae4b4f-344a-4803-9de8-f62476cd3f53)

Block youtube and the fallback videos look right:

![image](https://github.com/user-attachments/assets/43f808b0-b5f3-460c-b914-80cd13a9da4b)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
