### PR TITLE
Python Lab: update color of disabled buttons

### DIFF
--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, {useCallback} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
@@ -21,6 +22,7 @@ import {appendSystemMessage} from '../redux/consoleRedux';
 import {sendCodebridgeAnalyticsEvent} from '../utils/analyticsReporterHelper';
 
 import moduleStyles from './console.module.scss';
+import darkModeStyles from '@codebridge/styles/dark-mode.module.scss';
 
 // Control buttons for running and stopping code.
 // Can be extended in the future to include a test button.
@@ -132,7 +134,10 @@ const ControlButtons: React.FunctionComponent = () => {
             iconLeft={{iconStyle: 'solid', iconName: 'play'}}
             size={'xs'}
             color={'white'}
-            className={moduleStyles.controlButton}
+            className={classNames(
+              moduleStyles.controlButton,
+              darkModeStyles.primaryButton
+            )}
           />
         </WithConditionalTooltip>
       )}

--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -112,7 +112,7 @@ const ControlButtons: React.FunctionComponent = () => {
           onClick={handleStop}
           color={'destructive'}
           iconLeft={{iconStyle: 'solid', iconName: 'square'}}
-          size={'s'}
+          size={'xs'}
           className={moduleStyles.controlButton}
         />
       ) : (

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -38,6 +38,7 @@ import ValidationResults from './ValidationResults';
 import ValidationStatusIcon from './ValidationStatusIcon';
 
 import moduleStyles from '@codebridge/InfoPanel/styles/validated-instructions.module.scss';
+import darkModeStyles from '@codebridge/styles/dark-mode.module.scss';
 
 interface InstructionsProps {
   /** Additional callback to fire before navigating to the next level. */
@@ -248,7 +249,10 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
             type={'secondary'}
             disabled={shouldValidateBeDisabled}
             iconLeft={{iconStyle: 'solid', iconName: 'clipboard-check'}}
-            className={moduleStyles.buttonInstruction}
+            className={classNames(
+              darkModeStyles.secondaryButton,
+              moduleStyles.buttonInstruction
+            )}
             color={'white'}
             size={'s'}
           />

--- a/apps/src/codebridge/styles/dark-mode.module.scss
+++ b/apps/src/codebridge/styles/dark-mode.module.scss
@@ -22,6 +22,16 @@
   }
 }
 
+.secondaryButton {
+  // We use important here because the disabled styles used by Button
+  // are more specific than a single class.
+  &:disabled {
+    background-color: $light_black !important;
+    color: $light_gray_800 !important;
+    border: none;
+  }
+}
+
 .dropdownItem {
   display: flex;
   padding: 8px 16px 8px 12px;

--- a/apps/src/codebridge/styles/dark-mode.module.scss
+++ b/apps/src/codebridge/styles/dark-mode.module.scss
@@ -8,7 +8,17 @@
   }
 
   &:disabled {
-    color: $light_gray_200 !important; 
+    color: $light_gray_600 !important; 
+  }
+}
+
+.primaryButton {
+  // We use important here because the disabled styles used by Button
+  // are more specific than a single class.
+  &:disabled {
+    background-color: $light_gray_700 !important;
+    color: $light_gray_900 !important;
+    border: none;
   }
 }
 

--- a/apps/src/lab2/views/components/predict.module.scss
+++ b/apps/src/lab2/views/components/predict.module.scss
@@ -36,4 +36,12 @@
 
 .resetButton {
   width: 212px;
+
+  // We use important here because the disabled styles used by Button
+  // are more specific than a single class.
+  &:disabled {
+    background-color: $light_black !important;
+    color: $light_gray_800 !important;
+    border: none;
+  }
 }

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -81,6 +81,7 @@
   }
 
   &:disabled {
-    color: $light_gray_200 !important;
+    color: $light_gray_600 !important;
+    border: none;
   }
 }


### PR DESCRIPTION
Disabled buttons did not look correct in Python Lab because they weren't designed for dark mode. This updates the buttons that can be disabled (version history, delete predict answer, validate, and run) to the desired disabled styling. I also noticed while testing this that I needed to decrease the stop button size to `xs`, so I did that here (run was already changed in a previous pr).

Ideally we can eventually get rid of these custom styles once we have dark mode DSCO buttons. The downside is you have to remember to add the custom style to new buttons that can be disabled.

### Screenshots
![Screenshot 2024-09-26 at 12 41 12 PM](https://github.com/user-attachments/assets/c464d43b-33a8-4137-91e3-ecbd6d3365a6)

![Screenshot 2024-09-26 at 12 36 22 PM](https://github.com/user-attachments/assets/90bd2d86-a768-4ab4-a7dc-90c3521ad60d)
![Screenshot 2024-09-26 at 12 36 13 PM](https://github.com/user-attachments/assets/cf460edb-6fe8-4ecf-b09b-9752ffd5c164)

![Screenshot 2024-09-26 at 12 36 04 PM](https://github.com/user-attachments/assets/ef013faa-24ec-4016-af51-9a49d23e18a7)

## Links

- jira ticket: [CT-825](https://codedotorg.atlassian.net/browse/CT-825)
- [slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1727215127299829) (includes screenshots of previous state)

## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
