### PR TITLE
Explicit flag to lazy load translations

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -83,11 +83,11 @@ If you have trouble running the tests, see [troubleshooting dashboard tests](#tr
 #### Running a subset of Dashboard tests
 
 If you just want to run a single file of tests
-`bundle exec spring testunit ./path/to/your/test.rb` 
+`LAZY_LOAD_TRANSLATIONS=1 bundle exec spring testunit ./path/to/your/test.rb` 
 (if you get a seemingly unrelated error `Unable to autoload constant..` try running `spring stop` and trying again)
 
 To run a specific unit test
-`bundle exec spring testunit ./path/to/your/test.rb --name your_amazing_test_name`
+`LAZY_LOAD_TRANSLATIONS=1 bundle exec spring testunit ./path/to/your/test.rb --name your_amazing_test_name`
 The test name is `test_` concatenated with the name of the test listed in the test file (convert spaces to underscores). Ex: If the test is called "testing some unit" you would use `--name test_testing_some_unit`.
 
 You can get a local coverage report with

--- a/TESTING.md
+++ b/TESTING.md
@@ -83,11 +83,11 @@ If you have trouble running the tests, see [troubleshooting dashboard tests](#tr
 #### Running a subset of Dashboard tests
 
 If you just want to run a single file of tests
-`LAZY_LOAD_TRANSLATIONS=1 bundle exec spring testunit ./path/to/your/test.rb` 
+`bundle exec spring testunit ./path/to/your/test.rb` 
 (if you get a seemingly unrelated error `Unable to autoload constant..` try running `spring stop` and trying again)
 
 To run a specific unit test
-`LAZY_LOAD_TRANSLATIONS=1 bundle exec spring testunit ./path/to/your/test.rb --name your_amazing_test_name`
+`bundle exec spring testunit ./path/to/your/test.rb --name your_amazing_test_name`
 The test name is `test_` concatenated with the name of the test listed in the test file (convert spaces to underscores). Ex: If the test is called "testing some unit" you would use `--name test_testing_some_unit`.
 
 You can get a local coverage report with

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -384,6 +384,11 @@ optimize_rails_assets: true
 # due to a difference in the language cookie between production and localhost.
 load_locales:
 
+# Avoid loading all i18n files up front, which can significantly slow down initialization.
+# Instead, it only loads i18n files that belong to the current locale.
+# Particularly useful when running subsets of unit tests locally.
+lazy_load_locales:
+
 # Whether to skip the slow `rake seed:all` command during `rake build`.
 # Until you manually run `rake seed:all` or disable this flag, you won't
 # see changes to: videos, concepts, levels, scripts, trophies, prize providers,

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -28,12 +28,6 @@ Dashboard::Application.configure do
   # Disable Rails.cache when running unit tests (also in Drone, not sure if this is strictly desired).
   config.cache_store = :memory_store, {size: 64.megabytes} if ENV['UNIT_TEST'] || is_ci
 
-  # Avoid loading all i18n files up front, which can significantly slow down initialization.
-  # Instead, it only loads i18n files that belong to the current locale.
-  if ENV['LAZY_LOAD_TRANSLATIONS']
-    config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
-  end
-
   config.assets.quiet = true
 
   # Show full error reports and disable caching.

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -19,41 +19,26 @@ Dashboard::Application.configure do
 
   is_ci = !!ENV.fetch('CI', nil)
 
-  # test environment should use precompiled, minified, digested assets like production,
-  # unless it's being used for unit tests.
-  ci_test = !!(ENV['UNIT_TEST'] || is_ci)
-
-  unless ci_test
-    # Compress JavaScripts and CSS.
-    # webpack handles js compression for us
-    # config.assets.js_compressor = :uglifier
-    # config.assets.css_compressor = :sass
-
-    # Version of your assets, change this if you want to expire all your assets.
-    config.assets.version = '1.0'
-
-    # Avoid loading all i18n files up front, which can significantly slow down initialization.
-    # Instead, it only loads i18n files that belong to the current locale.
-    config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
-  end
-
   # In CI environments (ie, Drone), stub relevant AWS services (currently just SageMaker)
   # so we can run UI tests for our AI Chat (ie, Generative AI) lab.
   if is_ci
     config.stub_aichat_aws_services = true
   end
 
+  # Avoid loading all i18n files up front, which can significantly slow down initialization.
+  # Instead, it only loads i18n files that belong to the current locale.
+  if ENV['LAZY_LOAD_TRANSLATIONS']
+    config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
+  end
+
+  # Disable Rails.cache when running unit tests (also in Drone, not sure if this is strictly desired).
+  config.cache_store = :memory_store, {size: 64.megabytes} if ENV['UNIT_TEST'] || is_ci
+
   config.assets.quiet = true
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-
-  # Disable Rails.cache when running unit tests.
-  config.cache_store = :memory_store, {size: 64.megabytes} if ci_test
-
-  # config.action_mailer.raise_delivery_errors = true
-  # config.action_mailer.delivery_method = :smtp
 
   # Show mail previews (rails/mailers).
   # See http://edgeguides.rubyonrails.org/action_mailer_basics.html#previewing-emails

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -25,14 +25,14 @@ Dashboard::Application.configure do
     config.stub_aichat_aws_services = true
   end
 
+  # Disable Rails.cache when running unit tests (also in Drone, not sure if this is strictly desired).
+  config.cache_store = :memory_store, {size: 64.megabytes} if ENV['UNIT_TEST'] || is_ci
+
   # Avoid loading all i18n files up front, which can significantly slow down initialization.
   # Instead, it only loads i18n files that belong to the current locale.
   if ENV['LAZY_LOAD_TRANSLATIONS']
     config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
   end
-
-  # Disable Rails.cache when running unit tests (also in Drone, not sure if this is strictly desired).
-  config.cache_store = :memory_store, {size: 64.megabytes} if ENV['UNIT_TEST'] || is_ci
 
   config.assets.quiet = true
 

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -277,4 +277,6 @@ module Cdo
   end
 end
 
-CDO_I18N_BACKEND = Cdo::I18n::SimpleBackend.new
+CDO_I18N_BACKEND = CDO.lazy_load_locales ?
+  Cdo::I18n::LazyLoadableBackend.new(lazy_load: true) :
+  Cdo::I18n::SimpleBackend.new

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -42,6 +42,10 @@ use_my_apps: true
 # due to a difference in the language cookie between production and localhost.
 #load_locales: true
 
+# Avoid loading all i18n files up front, which can significantly slow down initialization.
+# Instead, it only loads i18n files that belong to the current locale.
+# Particularly useful when running subsets of unit tests locally.
+lazy_load_locales: true
 
 # Whether to skip the slow `rake seed:all` command during `rake build`.
 # Until you manually run `rake seed:all` or disable this flag, you won't


### PR DESCRIPTION
Actually allow developers to benefit from "lazy loading translations in test environments" work [added here](https://github.com/code-dot-org/code-dot-org/pull/57661#pullrequestreview-1969651627). The approach here (suggested by @artem-vavilov and @Hamms) is to allow setting a config value `lazy_load_locales` (default false), which can be set by developers in `locals.yml` and affect their dev environments as well as **local** test setups.

[More discussion in this Slack thread.](https://codedotorg.slack.com/archives/C046G4TRLEN/p1726002872596669?thread_ts=1725999044.328009&cid=C046G4TRLEN)

Also did a bit of other cleanup by getting rid of a the `unless ci_test` block, which, after moving the lazy loading i18n bit, just consisted of this line:

```
# Version of your assets, change this if you want to expire all your assets.
config.assets.version = '1.0'
```

This I believe is Rails boilerplate and already a default configured here (and doesn't appear to be set to anything else in our code base):

https://github.com/code-dot-org/code-dot-org/blob/91d428a4776e194d5a467b214b672f5060065d9a/dashboard/config/initializers/assets.rb#L3-L4