### PR TITLE
Music: fix default sound

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -184,12 +184,9 @@ export default class MusicLibrary {
       return this.libraryJson?.defaultSound;
     }
 
-    // The fallback is the first non-instrument/kit folder's first non-preview sound.
+    // The fallback is the first available pack's first available non-preview sound.
     // We will skip restricted folders unless it's the currently selected pack.
-    const firstFolder = this.packs.find(
-      group =>
-        !group.type && (!group.restricted || group.id === this.currentPackId)
-    );
+    const firstFolder = this.getAvailableSounds()[0];
     const firstSound = firstFolder?.sounds.find(
       sound => sound.type !== 'preview'
     );

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -252,6 +252,12 @@ class UnconnectedMusicView extends React.Component {
       this.sequencer = new MusicPlayerStubSequencer();
     }
 
+    this.library.setAllowedSounds(levelData?.sounds);
+
+    let packId = levelData?.packId || initialSources?.labConfig?.music.packId;
+    this.library.setCurrentPackId(packId);
+    this.props.setPackId(packId);
+
     this.props.isPlayView
       ? this.musicBlocklyWorkspace.initHeadless()
       : this.musicBlocklyWorkspace.init(
@@ -264,14 +270,9 @@ class UnconnectedMusicView extends React.Component {
           levelData?.addFunctionCallsToToolbox
         );
 
-    this.library.setAllowedSounds(levelData?.sounds);
     this.props.setShowInstructions(
       !!levelData?.text || !!this.props.longInstructions
     );
-
-    let packId = levelData?.packId || initialSources?.labConfig?.music.packId;
-    this.library.setCurrentPackId(packId);
-    this.props.setPackId(packId);
 
     // Check if the user has already made changes to the code on the project level.
     let codeChangedOnProjectLevel = false;


### PR DESCRIPTION
Two fixes to how the default sound is selected for the `play sound` block shown in the toolbox:
- Initialization order has been changed so that, if the current level specifies a pack, the sound will come from it correctly.  Previously, the sound listed in a flyout (i.e. non-category) toolbox would be from the previous level's pack.
- If the current level specifies allowed sounds, the sound will only come from that list.
