### PR TITLE
Music: sound panel height

### DIFF
--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -3,7 +3,7 @@
 .soundsPanel {
   user-select: none;
   width: 600px;
-  height: 340px;
+  height: 290px;
   display: flex;
   flex-direction: column;
   gap: 5px;

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -6,12 +6,11 @@
   height: 290px;
   display: flex;
   flex-direction: column;
-  gap: 5px;
 
   &Top {
     display: flex;
     justify-content: space-between;
-    margin: 5px 0;
+    margin-bottom: 5px;
 
     .segmentedButtons {
       span {
@@ -60,9 +59,6 @@
 
     &:first-child {
       margin-top: 1px;
-    }
-    &:not(:first-child) {
-      margin-top: 14px;
     }
 
     &Left {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -914,10 +914,6 @@ $small-footer-standard-width: 400px;
       color: $neutral_light;
     }
   }
-
-  .blocklyDropDownContent {
-    max-height: initial;
-  }
 }
 
 .header_separator {


### PR DESCRIPTION
In https://github.com/code-dot-org/code-dot-org/pull/58275, there was a change to make the sounds panel `350px` high, beyond Blockly's usual maximum of `300px`.

Recent playtests have not always used this increased height because not every new level has had the required `"background": "music-black"` entry which allowed this increased height. 

This change removes the increased height.  A lot of users have limited vertical space, so it feels safer to keep the original vertical constraint in place, especially since we haven't always playtested with it.

It also tidies up the layout of the sounds panel a tiny bit.  Notably, gaps should be more consistent, and the pack list is tightened a bit so that users will get a peek at the fourth so it's more clear that it's scrollable.

### before

<img width="647" alt="Screenshot 2024-09-26 at 8 13 28 PM" src="https://github.com/user-attachments/assets/11e0ca65-586b-4fb6-af0a-e66fcf6b10c7">

### after

<img width="647" alt="Screenshot 2024-09-26 at 8 09 33 PM" src="https://github.com/user-attachments/assets/cbc8d9e7-2c6c-4bc9-8347-be1fa018150e">

