### PR TITLE
Music: TTS update

### DIFF
--- a/apps/src/lab2/levelEditors/panels/EditPanels.tsx
+++ b/apps/src/lab2/levelEditors/panels/EditPanels.tsx
@@ -121,6 +121,7 @@ const EditPanels: React.FunctionComponent<EditPanelsProps> = ({
             onContinue={onContinue}
             targetWidth={1920}
             targetHeight={1080}
+            offerTts={false}
             resetOnChange={false}
           />
         </div>

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -176,6 +176,7 @@ export interface LevelProperties {
   submittable?: boolean;
   finishUrl?: string;
   finishDialog?: string;
+  offerTts?: boolean;
 }
 
 // Level configuration data used by project-backed labs that don't require

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -86,6 +86,9 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
   const levelData = useAppSelector(
     state => state.lab.levelProperties?.levelData
   );
+  const offerTts =
+    useAppSelector(state => state.lab.levelProperties?.offerTts) ||
+    AppConfig.getValue('show-tts') === 'true';
   const isPlayView = useAppSelector(state => state.lab.isShareView);
 
   const progressManager = useContext(ProgressManagerContext);
@@ -165,13 +168,13 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
                   : 'horizontal'
               }
               handleInstructionsTextClick={onInstructionsTextClick}
-              offerTts={AppConfig.getValue('show-tts') === 'true'}
+              offerTts={offerTts}
             />
           </PanelContainer>
         </div>
       );
     },
-    [hideHeaders, onInstructionsTextClick]
+    [hideHeaders, onInstructionsTextClick, offerTts]
   );
 
   const renderPlayArea = useCallback(

--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -12,6 +12,7 @@ import {
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {queryParams} from '../code-studio/utils';
 import useWindowSize from '../util/hooks/useWindowSize';
 
 import PanelsView from './PanelsView';
@@ -30,6 +31,9 @@ const PanelsLabView: React.FunctionComponent = () => {
     state => state.lab.levelProperties?.appName
   );
   const skipUrl = useAppSelector(state => state.lab.levelProperties?.skipUrl);
+  const offerTts =
+    useAppSelector(state => state.lab.levelProperties?.offerTts) ||
+    queryParams('show-tts') === 'true';
 
   const dialogControl = useDialogControl();
 
@@ -73,6 +77,7 @@ const PanelsLabView: React.FunctionComponent = () => {
       onSkip={skipUrl ? onSkip : undefined}
       targetWidth={windowWidth}
       targetHeight={windowHeight}
+      offerTts={offerTts}
     />
   );
 };

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
+import TextToSpeech from '@cdo/apps/lab2/views/components/TextToSpeech';
+
 import FontAwesome from '../legacySharedComponents/FontAwesome';
 import EnhancedSafeMarkdown from '../templates/EnhancedSafeMarkdown';
 import {commonI18n} from '../types/locale';
@@ -27,6 +29,7 @@ interface PanelsProps {
   onSkip?: () => void;
   targetWidth: number;
   targetHeight: number;
+  offerTts: boolean;
   resetOnChange?: boolean;
 }
 
@@ -39,6 +42,7 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
   onSkip,
   targetWidth,
   targetHeight,
+  offerTts,
   resetOnChange = true,
 }) => {
   const [currentPanel, setCurrentPanel] = useState(0);
@@ -116,14 +120,16 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
             backgroundImage: `url("${panel.imageUrl}")`,
           }}
         />
-        <EnhancedSafeMarkdown
-          markdown={panel.text}
+        <div
           className={classNames(
             styles.markdownText,
             showSmallText && styles.markdownTextSmall,
             textLayoutClass
           )}
-        />
+        >
+          {offerTts && <TextToSpeech text={panel.text} />}
+          <EnhancedSafeMarkdown markdown={panel.text} />
+        </div>
       </div>
       <div
         className={styles.childrenArea}


### PR DESCRIPTION
A small update to text-to-speech (TTS) added in https://github.com/code-dot-org/code-dot-org/pull/60896:
- Panels levels now also support this new text-to-speech component.
- Both panels and music levels continue to show this component if the `?show-tts=true` URL parameter is provided.
- Both panels and music levels will now show this component if `"offerTts": "true"` is specified in the level's `properties`.

### Screenshot

TTS in a panels level:

<img width="965" alt="Screenshot 2024-09-27 at 4 34 57 PM" src="https://github.com/user-attachments/assets/be468471-9946-4932-b8cc-b6ae6f3e9318">
