### PR TITLE
Music: validation callout

### DIFF
--- a/apps/src/lab2/levelEditors/validations/EditValidation.tsx
+++ b/apps/src/lab2/levelEditors/validations/EditValidation.tsx
@@ -95,6 +95,22 @@ const EditValidation: React.FunctionComponent<EditValidationProps> = ({
         />
       </div>
       <div className={moduleStyles.row}>
+        <label htmlFor="callout" className={moduleStyles.label}>
+          Callout (optional):
+        </label>
+        <textarea
+          id="callout"
+          name="callout"
+          rows={1}
+          className={moduleStyles.callout}
+          value={validation.callout}
+          onChange={e => {
+            validation.callout = e.target.value;
+            onValidationChange(validation);
+          }}
+        />
+      </div>
+      <div className={moduleStyles.row}>
         <label htmlFor="next" className={moduleStyles.label}>
           Passes Level?
         </label>

--- a/apps/src/lab2/levelEditors/validations/EditValidation.tsx
+++ b/apps/src/lab2/levelEditors/validations/EditValidation.tsx
@@ -98,10 +98,10 @@ const EditValidation: React.FunctionComponent<EditValidationProps> = ({
         <label htmlFor="callout" className={moduleStyles.label}>
           Callout (optional):
         </label>
-        <textarea
-          id="callout"
+        <input
+          type="text"
+          id="edit-validation-callout"
           name="callout"
-          rows={1}
           className={moduleStyles.callout}
           value={validation.callout}
           onChange={e => {

--- a/apps/src/lab2/levelEditors/validations/edit-validations.module.scss
+++ b/apps/src/lab2/levelEditors/validations/edit-validations.module.scss
@@ -25,6 +25,9 @@
   width: 90%;
 }
 
+.callout {
+  width: 70%;
+}
 
 .label {
   padding-right: 10px;

--- a/apps/src/lab2/progress/ProgressManager.ts
+++ b/apps/src/lab2/progress/ProgressManager.ts
@@ -19,6 +19,7 @@ export interface ValidationState {
   hasConditions: boolean;
   satisfied: boolean;
   message: string | null;
+  callout?: string;
   index: number;
   validationResults?: ValidationResult[];
 }
@@ -41,6 +42,7 @@ export const getInitialValidationState: () => ValidationState = () => ({
   hasConditions: false,
   satisfied: false,
   message: null,
+  callout: undefined,
   index: 0,
 });
 
@@ -107,6 +109,7 @@ export default class ProgressManager {
           if (!this.currentValidationState.satisfied) {
             this.currentValidationState.satisfied = validation.next;
             this.currentValidationState.message = validation.message;
+            this.currentValidationState.callout = validation.callout;
             this.onProgressChange();
           }
           return;
@@ -132,6 +135,7 @@ export default class ProgressManager {
       hasConditions,
       satisfied: false,
       message: null,
+      callout: undefined,
       // Ensure that the validation feedback UI is rendered fresh.  This index is
       // used as part of the key for that React component; having a unique value
       // ensures that the UI is rendered fresh, and any apperance animation is

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -300,6 +300,7 @@ export interface ConditionType {
 export interface Validation {
   conditions: Condition[];
   message: string;
+  callout?: string;
   next: boolean;
   key: string;
 }

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -87,12 +87,16 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     state => state.lab.levelProperties?.levelData
   );
   const isPlayView = useAppSelector(state => state.lab.isShareView);
+  const validationStateCallout = useAppSelector(
+    state => state.lab.validationState.callout
+  );
 
   const progressManager = useContext(ProgressManagerContext);
 
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const projectTemplateLevel = useAppSelector(isProjectTemplateLevel);
   const blockMode = useSelector(getBlockMode);
+
   // Pass music validator to Progress Manager
   useEffect(() => {
     if (progressManager && appName === 'music') {
@@ -140,6 +144,12 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     },
     [dispatch]
   );
+
+  useEffect(() => {
+    if (validationStateCallout) {
+      dispatch(showCallout(validationStateCallout));
+    }
+  }, [dispatch, validationStateCallout]);
 
   const renderInstructions = useCallback(
     (position: InstructionsPosition) => {


### PR DESCRIPTION
This allows a validation to specify a callout to be shown at the same time as the validation appears in the instructions panel.

### Screen recording

https://github.com/user-attachments/assets/a11400ed-8605-4210-a418-ad56f246cd5c

### Levelbuilder

<img width="772" alt="Screenshot 2024-09-27 at 11 02 17 PM" src="https://github.com/user-attachments/assets/6f678fbb-8727-4fc2-9af5-15c55f80062e">
