### PR TITLE
Lab2: HOC finish update

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -29,8 +29,6 @@ require 'cdo/shared_constants'
 class Level < ApplicationRecord
   include SharedConstants
   include Levels::LevelsWithinLevels
-  include ScriptLevelsHelper
-  include Rails.application.routes.url_helpers
 
   belongs_to :game, optional: true
   has_and_belongs_to_many :concepts

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -847,7 +847,7 @@ class Level < ApplicationRecord
     properties_camelized[:appName] = game&.app
     properties_camelized[:useRestrictedSongs] = game.use_restricted_songs?
     properties_camelized[:usesProjects] = try(:is_project_level) || channel_backed?
-    properties_camelized[:finishUrl] = script_completion_redirect(current_user, script) if script
+    properties_camelized[:finishUrl] = script_level.next_level_or_redirect_path_for_user(current_user) if script_level
 
     if try(:project_template_level).try(:start_sources)
       properties_camelized['templateSources'] = try(:project_template_level).try(:start_sources)


### PR DESCRIPTION
This small follow-up to https://github.com/code-dot-org/code-dot-org/pull/61294 changes the API used on the server to determine the next URL after the final level of a Lab2 lesson.  Before this change, the student was being taken to a course certificate even if there was another lesson after the current one.  After this change, the student is taken to the first level of the next lesson, if there is one.  

If it's the final level in a script, the user continues to be taken to the certificate if the script has a `marketing_initiative` of `"HOC"`, and the script landing page otherwise.