### PR TITLE
[Music] Only check conditions included in validations

### DIFF
--- a/apps/src/lab2/progress/ProgressManager.ts
+++ b/apps/src/lab2/progress/ProgressManager.ts
@@ -8,7 +8,7 @@ import {Condition, Validation} from '@cdo/apps/lab2/types';
 export abstract class Validator {
   abstract shouldCheckConditions(): boolean;
   abstract shouldCheckNextConditionsOnly(): boolean;
-  abstract checkConditions(): void;
+  abstract checkConditions(validations: Validation[]): void;
   abstract conditionsMet(conditions: Condition[]): boolean;
   abstract clear(): void;
   abstract getValidationResults(): ValidationResult[] | undefined;
@@ -88,7 +88,7 @@ export default class ProgressManager {
     // Give the lab-specific code a chance to check conditions.  We do
     // it once each update in case it's expensive, and since conditions
     // can be used by multiple validations.
-    this.validator.checkConditions();
+    this.validator.checkConditions(this.currentValidations);
 
     // Go through each validation to see if we have a match.
     for (const validation of this.currentValidations) {

--- a/apps/src/pythonlab/progress/PythonValidator.ts
+++ b/apps/src/pythonlab/progress/PythonValidator.ts
@@ -1,5 +1,5 @@
 import {Validator} from '@cdo/apps/lab2/progress/ProgressManager';
-import {Condition} from '@cdo/apps/lab2/types';
+import {Condition, Validation} from '@cdo/apps/lab2/types';
 
 import PythonValidationTracker from './PythonValidationTracker';
 
@@ -24,7 +24,7 @@ export default class PythonValidator extends Validator {
   }
 
   // No-op, conditions are reported to pythonValidationTracker.
-  checkConditions(): void {}
+  checkConditions(validations: Validation[]): void {}
 
   conditionsMet(conditions: Condition[]): boolean {
     for (const condition of conditions) {


### PR DESCRIPTION
The MusicValidator's `checkConditions` method that potentially adds many satisfied conditions to the Lab2 ConditionsChecker. All possible conditions are evaluated each time we update progress, whether we care about them in that particular level or not. For example, we will always check that a sound was played with a function context, even if the level is only about chords.

With these changes, we will now check if any relevant conditions (for sounds, patterns, or chords, etc.) exist before performing further calculations.

There are probably other steps we could take to further simplify some of this work, but this should get us to place that is less expensive than what we have now.

## Links

Some additional discussion about this issue can be found here: https://github.com/code-dot-org/code-dot-org/pull/61104#discussion_r1761630310

## Testing story

I manually tested that a few levels are still passing/failing the user as expected. I add some (uncommitted) extra logging to confirm that this drastically cuts down on the number of unnecessary satisfied conditions that are added.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
