### PR TITLE
TEACH-1364: Introduce new values for existing initiatives field in unit model

### DIFF
--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -61,7 +61,20 @@ module Curriculum
         pd_workshop_activity_csp: 'PD Workshop Activity CSP',
         pd_workshop_activity_csa: 'PD Workshop Activity CSA',
         foundations_of_cs: 'Foundations of CS',
-        foundations_of_programming: 'Foundations of Programming'
+        foundations_of_programming: 'Foundations of Programming',
+        CSC_K_5: 'CSC K-5',
+        CSC_6_8: 'CSC 6-8',
+        CSC_9_12: 'CSC 9-12',
+        special_topics_k_5: 'K-5 Special topics',
+        special_topics_6_8: '6-8 Special topics',
+        special_topics_9_12: '9-12 Special topics',
+        foundations_of_cs_selfpaced_pl: 'Foundations of CS selfpaced pl',
+        ai_for_teachers_selfpaced_pl: 'AI for teachers selfpaced pl',
+        special_topics_curriculum_selfpaced_pl_k_5: 'K-5 Special topics curriculum selfpaced pl',
+        special_topics_curriculum_selfpaced_pl_6_8: '6-8 Special topics curriculum selfpaced pl',
+        special_topics_curriculum_selfpaced_pl_9_12: '9-12 Special topics curriculum selfpaced pl',
+        pedagogy_special_topics_selfpaced_pl: 'Pedagogy special topics selfpaced pl',
+        cs_basics_selfpaced_pl: 'CS Basics selfpaced pl'
       }
     ).freeze
 


### PR DESCRIPTION
The change adds a few new values for the existing initiative field in the unit editor for mapping scripts to different org wide initiatives. 

![image](https://github.com/user-attachments/assets/20662f32-2cbf-4996-843c-279db0fabd60)

More details about the requirement can be found at https://docs.google.com/document/d/1u4kFMpiktoTv7reTBXgWjW0MXbKH3V3stO9s7PWS4ss/edit#heading=h.22p8ihbcb1tv

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1364
Requirements spreadsheet from RED: https://docs.google.com/spreadsheets/d/1piJ86Zt3a5g57wh1-zRe0n3se3S5EaFokKkseY8BVvA/edit?gid=0#gid=0

## Testing story

- Drone
- Validated manually that the new fields show up in level builder unit editor

## Deployment strategy

Regular DTP

## Follow-up work

- [Once this is rolled out, backfill scripts which have initiative field as "CSC" to "CSC K-5" ](https://codedotorg.atlassian.net/browse/TEACH-1365)
- [Remove the value "CSC" from the list ](https://codedotorg.atlassian.net/browse/TEACH-1366)

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
