### PR TITLE
Music: even better preview cancel

### DIFF
--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -256,6 +256,8 @@ class ToneJSPlayer implements AudioPlayer {
       this.currentSequencePreviewTimer = null;
     }
 
+    this.currentPreview = null;
+
     this.stopAllSamplers();
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/61231.  

In that change, starting a new preview would do a better job of canceling an existing preview, in particular one that was still loading.  

With this change, canceling all previews also does a better job of canceling an existing preview, again in particular one that is still loading.