### PR TITLE
Removed bible-api.com from the list of APIs

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -24,12 +24,7 @@ class XhrProxyController < ApplicationController
       text/plain
     )
   ).freeze
-
-  # bible-api.com has been replaced with the more official api.scripture.api.bible. However, since
-  # bible-api.com is still working, we'll leave it up during a transition period. If today's date is
-  # later than June 1, 2024 and you are reading this, go ahead and remove bible-api.com as well as
-  # this comment.
-
+  
   # 'code.org' is included so applab apps can access the tables and properties of other applab apps.
   ALLOWED_HOSTNAME_SUFFIXES = %w(
     api.amadeus.com
@@ -72,7 +67,6 @@ class XhrProxyController < ApplicationController
     api.weatherapi.com
     api.wolframalpha.com
     api.zippopotam.us
-    bible-api.com
     bnefoodtrucks.com.au
     ch.tetr.io
     code.org


### PR DESCRIPTION
I was going through the startWebRequest() documentation and I was directed to this repo with all the websites allowed for a web request. There was a comment that said if the date was past June 1, 2024, to remove the bible-api.com and the respective comment. It is past that date so I went ahead and removed it.

## Links

https://forum.code.org/t/weather-api-used-in-app-lab/25704

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I didn't test this because it was simply removing a line of code to end support for an outdated api

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately
- [X] Follow-up work items (including potential tech debt) are tracked and linked
