### PR TITLE
Update script_constants.rb to include Teaching CSF and Foundations Gen AI

### DIFF
--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -245,6 +245,7 @@ module ScriptConstants
 
   TRANSLATABLE_PD_PL_UNITS = [
     K5_ONLINEPD_2019 = 'k5-onlinepd-2019'.freeze,
+    K5_ONLINEPD_2023 = 'k5-onlinepd-2023'.freeze,
     K5_ONLINEPD = 'K5-OnlinePD'.freeze,
     KODEA_PD_2021 = 'kodea-pd-2021'.freeze,
     SELF_PACED_PL_K5_2024_1 = 'self-paced-pl-k5-2024-1'.freeze,
@@ -275,6 +276,7 @@ module ScriptConstants
     VIGENERE = 'vigenere'.freeze,
     ALLTHETHINGS = 'allthethings'.freeze,
     COMPUTER_VISION = 'computer-vision'.freeze,
+    FOUNDATIONS_GEN_AI = 'foundations-gen-ai-2024'.freeze,
     CSD2_2024 = 'csd2-2024'.freeze,
     K5_UNPLUGGED = 'k5-unplugged'.freeze
   ]


### PR DESCRIPTION
Added scripts to the i18n constants.

This PR:
- Adds k5-onlinepd-2023 and foundations-gen-ai-2024 to the translatable units

Purpose:
- Enable translation of more online PD courses so more teachers have access to these learning materials.
- Test translatability of the Foundations of Gen AI module.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
