### PR TITLE
Set up test /yourschoolteststaging page for Access Report Mapbox testing

### DIFF
--- a/apps/src/sites/code.org/pages/public/yourschoolteststaging.js
+++ b/apps/src/sites/code.org/pages/public/yourschoolteststaging.js
@@ -1,0 +1,54 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Provider} from 'react-redux';
+
+import isRtl from '@cdo/apps/code-studio/isRtlRedux';
+import initResponsive from '@cdo/apps/code-studio/responsive';
+import responsive from '@cdo/apps/code-studio/responsiveRedux';
+import {getStore, registerReducers} from '@cdo/apps/redux';
+import YourSchool from '@cdo/apps/templates/census/YourSchool';
+
+registerReducers({isRtl, responsive});
+
+$(document).ready(initYourSchool);
+
+function showYourSchool() {
+  const rawSchoolId = $('#your-school').data('parameters-schoolId');
+  const rawSchoolZip = $('#your-school').data('parameters-schoolZip');
+  const yourschoolElement = $('#your-school');
+  const prefillData = {
+    userName: yourschoolElement.data('parameters-user-name'),
+    userEmail: yourschoolElement.data('parameters-user-email'),
+    isTeacher: yourschoolElement.data('parameters-is-teacher'),
+    schoolCountry: yourschoolElement.data('parameters-school-country'),
+    schoolId: rawSchoolId ? rawSchoolId.toString() : undefined,
+    schoolType: yourschoolElement.data('parameters-school-type'),
+    schoolName: yourschoolElement.data('parameters-school-name'),
+    schoolState: yourschoolElement.data('parameters-school-state'),
+    schoolZip: rawSchoolZip ? rawSchoolZip.toString() : undefined,
+  };
+
+  ReactDOM.render(
+    <Provider store={getStore()}>
+      <YourSchool
+        alertHeading={yourschoolElement.data('parameters-alert-heading')}
+        alertText={yourschoolElement.data('parameters-alert-text')}
+        alertUrl={yourschoolElement.data('parameters-alert-url')}
+        hideMap={yourschoolElement.data('parameters-hide-map')}
+        prefillData={prefillData}
+        currentCensusYear={yourschoolElement.data('parameters-school-year')}
+        teacherApplicationMode={yourschoolElement.data(
+          'parameters-teacher-application-mode'
+        )}
+        tileset={yourschoolElement.data('parameters-tileset')}
+      />
+    </Provider>,
+    yourschoolElement[0]
+  );
+}
+
+function initYourSchool() {
+  initResponsive();
+  showYourSchool();
+}

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -197,6 +197,7 @@ const PEGASUS_ENTRIES = {
   'code.org/public/transformersone': './src/sites/code.org/pages/public/transformersone.js',
   'code.org/public/teacher-dashboard/index': './src/sites/code.org/pages/public/teacher-dashboard/index.js',
   'code.org/public/yourschool': './src/sites/code.org/pages/public/yourschool.js',
+  'code.org/public/yourschoolteststaging': './src/sites/code.org/pages/public/yourschoolteststaging.js',
   'code.org/public/yourschool/thankyou': './src/sites/code.org/pages/public/yourschool/thankyou.js',
   'code.org/views/admins_email_signup_form': './src/sites/code.org/pages/views/admins_email_signup_form.js',
   'code.org/views/share_privacy': './src/sites/code.org/pages/views/share_privacy.js',

--- a/bin/test_staging_update_census_mapbox
+++ b/bin/test_staging_update_census_mapbox
@@ -63,7 +63,7 @@ def main
     CDO.log.info "Census summaries loading: done processing #{filename}.\n"
 
     file = Tempfile.new(['census', 'geojson'])
-    tiles = Tempfile.new(['censustiles-test-staging', 'mbtiles'])
+    tiles = Tempfile.new(['censustiles-dev', 'mbtiles'])
     file.write(JSON.pretty_generate(geojson))
     _stdout, stderr, tippecanoe_status = Open3.capture3(
       # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
@@ -74,7 +74,7 @@ def main
     )
     upload_successful = false
     if tippecanoe_status.success?
-      upload_successful = upload_maptiles(tiles.path, 'censustiles-test-staging')
+      upload_successful = upload_maptiles(tiles.path, 'censustiles-dev')
     end
     unless tippecanoe_status.success? && upload_successful
       CDO.log.info "Error in uploading"

--- a/bin/test_staging_update_census_mapbox
+++ b/bin/test_staging_update_census_mapbox
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+
+# The map on code.org/yourschool is run off of Mapbox.
+# This script updates the data on Mapbox by querying all rows from
+# census_summaries table for the appropriate school year,
+# creating maptiles with Mapbox's command line tool, Tippecanoe,
+# and uploading them to Mapbox's server.
+
+require_relative '../dashboard/config/environment'
+require_relative '../pegasus/helpers/properties'
+
+require_relative './cron/upload_to_mapbox'
+
+raise "CDO.mapbox_upload_token is not defined" unless CDO.mapbox_upload_token
+
+CSV_IMPORT_OPTIONS = {col_sep: ",", headers: true, encoding: 'bom|utf-8'}.freeze
+
+def make_location(lat, long)
+  return nil if lat.nil? || long.nil?
+
+  "#{format('%.6f', lat)}, #{format('%.6f', long)}"
+end
+
+def main
+  CDO.log.info "Loading census summary data."
+  AWS::S3.seed_from_file('cdo-census', "access-report-data-files-2024/final-csv/final_csv_2024_09_30.csv") do |filename|
+    year = '2024'
+    geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
+    entries_skipped = 0
+
+    CSV.read(filename, **CSV_IMPORT_OPTIONS).each do |row|
+      # Parse or skip row data
+      parsed = row.to_hash.symbolize_keys
+      school = School.find_by_id(parsed[:school_id])
+
+      if school.nil?
+        entries_skipped += 1
+        next
+      end
+
+      teaches_cs = parsed[:teaches_cs] == 'unknown' ? 'U' : parsed[:teaches_cs]
+
+      # Add parsed row to map
+      geojson["features"] <<
+        {
+          geometry: {
+            coordinates: [school.longitude.to_f, school.latitude.to_f],
+            type: "Point"
+          },
+          properties: {
+            school_id: school.id,
+            year: year,
+            school_name: school.name.titleize,
+            school_city: school.city.titleize,
+            school_state: school.state,
+            teaches_cs: teaches_cs
+          },
+          type: "Feature"
+        }
+    end
+
+    CDO.log.info "#{entries_skipped} census summaries skipped due to no school_id match in database."
+    CDO.log.info "Census summaries loading: done processing #{filename}.\n"
+
+    file = Tempfile.new(['census', 'geojson'])
+    tiles = Tempfile.new(['censustiles-test-staging', 'mbtiles'])
+    file.write(JSON.pretty_generate(geojson))
+    _stdout, stderr, tippecanoe_status = Open3.capture3(
+      # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
+      # clusters points that are approximately 2 pixels apart, and drops points to make them fit if they can't.
+      # The layer is called "census". DO NOT change the layer name without changing the map
+      # in the Mapbox UI.
+      "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"census\" --force #{file.path}"
+    )
+    upload_successful = false
+    if tippecanoe_status.success?
+      upload_successful = upload_maptiles(tiles.path, 'censustiles-test-staging')
+    end
+    unless tippecanoe_status.success? && upload_successful
+      CDO.log.info "Error in uploading"
+      CDO.log.info `Success state: #{tippecanoe_status.success?}`
+      CDO.log.info `Upload successful: #{upload_successful}`
+      Honeybadger.notify(
+        error_message: "Updating Census map on Mapbox failed",
+        error_class: "Census Map Update Failure",
+        context: {
+          tippecanoe_status: stderr,
+          upload_status: upload_successful
+        }
+      )
+    end
+  end
+end
+
+main

--- a/pegasus/sites.v3/code.org/public/yourschoolteststaging.haml
+++ b/pegasus/sites.v3/code.org/public/yourschoolteststaging.haml
@@ -27,7 +27,7 @@ social:
 - census_announcement['locale'] = request.locale
 - teacher_application_mode  = DCDO.get("teacher_application_mode", CDO.default_teacher_application_mode)
 - census_announcement['teacher_application_mode'] = teacher_application_mode
-- census_announcement['tileset'] = 'censustiles-test-staging'
+- census_announcement['tileset'] = 'censustiles-dev'
 
 = inline_css 'trophy_announcement_sparkle.css'
 

--- a/pegasus/sites.v3/code.org/public/yourschoolteststaging.haml
+++ b/pegasus/sites.v3/code.org/public/yourschoolteststaging.haml
@@ -1,0 +1,67 @@
+---
+title: Test staging yourschool
+theme: responsive
+social:
+  "og:title": "Does your school teach computer science?"
+  "og:description": "Expand computer science at your school or district. Join the thousands of schools who have already incorporated high quality computer science education into their curriculum and provide opportunities for the students in your local area."
+---
+
+%link{:rel=>'stylesheet', :type=>'text/css', :href=>'/css/yourschool.css'}
+
+- require 'country_codes'
+- require 'state_abbr'
+- require 'census_helper'
+
+- census_announcement = DCDO.get('census_announcement', nil)
+- census_announcement ||= {}
+- census_announcement['user_name'] = request.params["name"] if request.params["name"]
+- census_announcement['user_email'] = request.params["email"] if request.params["email"]
+- census_announcement['is_teacher'] = 'true' if request.params["isTeacher"] == 'true'
+- census_announcement['school_country'] = request.params["country"] if request.params["country"]
+- census_announcement['school_id'] = request.params["schoolId"] if request.params["schoolId"]
+- census_announcement['school_type'] = request.params["schoolType"].capitalize if request.params["schoolType"]
+- census_announcement['school_name'] = request.params["schoolName"] if request.params["schoolName"]
+- census_announcement['school_state'] = request.params["state"] if request.params["state"]
+- census_announcement['school_zip'] = request.params["zip"] if request.params["zip"]
+- census_announcement['school_year'] = current_census_year
+- census_announcement['locale'] = request.locale
+- teacher_application_mode  = DCDO.get("teacher_application_mode", CDO.default_teacher_application_mode)
+- census_announcement['teacher_application_mode'] = teacher_application_mode
+- census_announcement['tileset'] = 'censustiles-test-staging'
+
+= inline_css 'trophy_announcement_sparkle.css'
+
+- js_locale = request.locale.to_s.downcase.tr('-', '_')
+%script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
+%link{rel: "stylesheet", type: "text/css", href: "/css/selectize.bootstrap3.css"}
+%script{type: "text/javascript", src: "/shared/js/helpers.js"}
+%link{rel: "stylesheet", href: "https://api.tiles.mapbox.com/mapbox-gl-js/v1.1.1/mapbox-gl.css"}
+%script{type: "text/javascript", src: "https://api.tiles.mapbox.com/mapbox-gl-js/v1.1.1/mapbox-gl.js"}
+:javascript
+  mapboxgl.accessToken = "#{CDO.mapbox_access_token}";
+%script{src: webpack_asset_path('js/code.org/public/yourschoolteststaging.js')}
+%link{rel: "stylesheet", type: "text/css", href: "/css/census-map.css"}
+
+%script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
+
+%br/
+
+#your-school{'data-parameters' => census_announcement}
+
+#partners
+  %hr
+  %center
+    %p{style: 'margin: 40px 0 50px 0; font-size: 16px;'}
+      Your pledge and information about your school helps expand computer science education across the United States. See K-12 Computer Science Access Report data on an
+      = " "
+      %a{href: CDO.code_org_url("/yourschool/accessreport"), target: "_blank"}> interactive data visualization
+      = " "
+      and in the
+      = " "
+      %a{href: "https://advocacy.code.org/stateofcs/", target: "_blank"}> annual State of Computer Science Education
+      , published each fall.
+    %span{style: "font-family: var(--main-font); font-weight: var(--bold-font-weight); font-size: 20px; margin: 0 25px 0 25px;"} In partnership with
+    %img{src: '/images/fit-200/avatars/computer_science_teachers_association.png'}
+
+%br
+%br


### PR DESCRIPTION
As part of the annual access report work, I was trying to set up an adhoc that could display the new data on the [code.org/yourschool](https://code.org/yourschool) map but ran into webpack issues on pegasus (also seen by Bethany in [this thread](https://codedotorg.slack.com/archives/C03CK49G9/p1727722207177409)) and trouble getting `tippecanoe` to work (`tippecanoe` is also not set up locally). If we had time, it would probably be best to try and debug the adhoc setup to get this working, but the Access Report is starting to become more urgent so this is a temporary workaround.

The current /yourschool page renders the `censustiles` tileset in the map. This PR sets up a mirrored /yourschool page (/yourschoolteststaging) that renders the arbitrarily-named `censustiles-dev` tileset. I've also created a script similar to `update_census_mapbox` that populates the `census-test-staging` tileset. Normally, `CensusSummary.seed_all` seeds the `CensusSummary` data table, then `update_census_mapbox` creates a mapbox point for each entry of the current census year in the `CensusSummary` table. To avoid having to touch any of our data tables, I made a similar script, `test_staging_update_census_mapbox`, which reads the 2024 data and immediately builds the `censustiles-dev` tileset without storing anything in our database.

While this is not a perfect solution, I believe it is safe to merge given that nowhere on our site will point to this new page, it is super similar to other already-live pages, and it does not touch our database other than queries to the `Schools` data table. After merging, the plan would be to:
- Wait for staging to rebuild
- Run `./bin/test_staging_update_census_mapbox` on staging
- Check that [staging.code.org/yourschoolteststaging](https://staging.code.org/yourschoolteststaging) is showing the new data

If we're able to go through those steps, I believe that will give us enough confidence that if we use the new census year (2024) and the new data filename (access-report-data-files-2024/final-csv/final_csv_2024_09_30.csv) constants, it will not break anything on production when we merge [the PR](https://github.com/code-dot-org/code-dot-org/pull/61454) to update them.

Reviewing note: Since there's a lot of copy/pasted code, I've labeled what I've changed and what I've copied from where in each file.

## Links
Census summaries spec: [here](https://docs.google.com/document/d/1ZcvnXAUfOwnmWdS8Z8JwwYDdHWTF6CrCWCmpgiKlw4U/edit#heading=h.rizng6chl91e)
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1623)

## Testing story
While my testing was super limited given that I cannot fully run `update_census_mapbox` locally or on adhoc at the moment, I did check that if I supply the `main` function with a dummy set of rows with real `school_id`'s and each of the different `teaches_cs` values that it properly skips the rows with `school_id`s that don't match any in our database and adds all others to the `geojson` features array.

Can also confirm that the /yourschoolteststaging page renders:
![rendersmapwithstaging](https://github.com/user-attachments/assets/7a1b2015-581e-4c56-83dc-5108c1bd4d65)

## Follow-up work
After merging [the PR that updates the new census year and data filename constants](https://github.com/code-dot-org/code-dot-org/pull/61454), cleanup would just be deleting everything from this PR.
