### PR TITLE
P20-1198: Change CPA reminder emails to only fire once a week and does not fire for archived sections

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -126,8 +126,8 @@
       cronjob at:'0 4 * * *', do:deploy_dir('bin', 'cron', 'delete_old_ai_chat_data')
 
       # Send warning emails to teachers about their sections with CAP affected students
-      # every Monday and Wednesday at 12:00 AM EST (04:00 AM UTC)
-      cronjob at:'0 4 * * 1,3', do:"#{deploy_dir('bin', 'cron', 'perform_job')} CAP::TeacherSectionsWarningJob"
+      # every Wednesday at 12:00 AM EST (04:00 AM UTC)
+      cronjob at:'0 4 * * 3', do:"#{deploy_dir('bin', 'cron', 'perform_job')} CAP::TeacherSectionsWarningJob"
 
       # RDS backup window is 05:17-05:47 UTC, so by 11:50 backups should definitely be ready
       cronjob at:'50 11 * * *', do:deploy_dir('bin', 'cron', 'push_latest_aurora_backup_to_secondary_account')

--- a/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
+++ b/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
@@ -45,15 +45,7 @@ module CAP
     end
 
     private def teachers
-      return @teachers if defined? @teachers
-
-      available_emails = DCDO.get('cap_teacher_section_warning_emails', [])
-      return @teachers = User.none if available_emails.blank?
-
-      @teachers = User.where(id: cap_affected_sections.select(:user_id))
-      return @teachers if available_emails.include?('all')
-
-      @teachers = @teachers.where(email: available_emails)
+      @teachers ||= User.where(id: cap_affected_sections.select(:user_id))
     end
   end
 end

--- a/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
+++ b/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
@@ -40,6 +40,7 @@ module CAP
 
     private def cap_affected_sections
       @cap_affected_sections ||= Queries::Section.cap_affected(
+        scope: ::Section.visible,
         period: Policies::ChildAccount::TEACHER_WARNING_PERIOD.ago..
       )
     end

--- a/dashboard/app/jobs/concerns/active_job_reporting.rb
+++ b/dashboard/app/jobs/concerns/active_job_reporting.rb
@@ -5,7 +5,7 @@ require 'cdo/honeybadger'
 module ActiveJobReporting
   extend ActiveSupport::Concern
 
-  protected def report_exception(exception)
+  def report_exception(exception)
     Honeybadger.notify(
       exception,
       error_message: "[#{self.class}] Runtime error",

--- a/dashboard/app/jobs/mailjet_delivery_job.rb
+++ b/dashboard/app/jobs/mailjet_delivery_job.rb
@@ -4,9 +4,17 @@ require 'cdo/mailjet'
 
 # This class is an ActiveJob wrapper for scheduling MailJet email sending.
 class MailjetDeliveryJob < ApplicationJob
+  ATTEMPTS_ON_RATE_LIMIT = 5
+
   queue_as CDO.active_job_queues[:mailjet]
 
   rescue_from StandardError, with: :report_exception
+
+  # Retry on any reported rate limit (429 status). With 3 attempts, 'exponentially_longer' waits 3s, then 18s.
+  retry_on RestClient::TooManyRequests, wait: :exponentially_longer, attempts: ATTEMPTS_ON_RATE_LIMIT do |job, error|
+    job.report_exception(error)
+    raise error
+  end
 
   # @see MailJet.send_email
   def perform(...)

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -106,6 +106,8 @@ class Section < ApplicationRecord
 
   before_validation :strip_emoji_from_name
 
+  scope :visible, -> {where(hidden: false)}
+
   # PL courses which are run with adults should be set up with teacher accounts so they must use
   # email logins
   def pl_sections_must_use_email_logins

--- a/dashboard/test/jobs/cap/teacher_sections_warning_job_test.rb
+++ b/dashboard/test/jobs/cap/teacher_sections_warning_job_test.rb
@@ -1,3 +1,4 @@
+test/jobs/cap/teacher_sections_warning_job_test.rb
 # frozen_string_literal: true
 
 require 'test_helper'
@@ -5,8 +6,6 @@ require 'test_helper'
 class CAP::TeacherSectionsWarningJobTest < ActiveJob::TestCase
   describe '.perform_later' do
     subject(:perform_later) {described_class.perform_later}
-
-    let(:cap_teacher_section_warning_emails) {['all']}
 
     let(:student_aga_gate_start_date) {30.days.ago}
     let(:teacher_email) {Faker::Internet.unique.email}
@@ -51,8 +50,6 @@ class CAP::TeacherSectionsWarningJobTest < ActiveJob::TestCase
     before do
       MailjetDeliveryJob.stubs(:perform_later)
       Metrics::Events.stubs(:log_event)
-
-      DCDO.stubs(:get).with('cap_teacher_section_warning_emails', []).returns(cap_teacher_section_warning_emails)
     end
 
     it 'enqueues job to "default" queue' do
@@ -107,30 +104,6 @@ class CAP::TeacherSectionsWarningJobTest < ActiveJob::TestCase
       it 'does not warn teacher' do
         expect_teacher_warning_to_be_sent.never
         expect_event_logging.never
-
-        perform_enqueued_jobs {perform_later}
-        assert_performed_jobs 1
-      end
-    end
-
-    context 'when emails whitelist is empty' do
-      let(:cap_teacher_section_warning_emails) {[]}
-
-      it 'does not warn teacher' do
-        expect_teacher_warning_to_be_sent.never
-        expect_event_logging.never
-
-        perform_enqueued_jobs {perform_later}
-        assert_performed_jobs 1
-      end
-    end
-
-    context 'when teacher email is in whitelist' do
-      let(:cap_teacher_section_warning_emails) {[teacher_email]}
-
-      it 'schedules teacher warning email' do
-        expect_teacher_warning_to_be_sent.once
-        expect_event_logging.once
 
         perform_enqueued_jobs {perform_later}
         assert_performed_jobs 1

--- a/dashboard/test/jobs/concerns/active_job_reporting_test.rb
+++ b/dashboard/test/jobs/concerns/active_job_reporting_test.rb
@@ -22,7 +22,7 @@ class ActiveJobReportingTest < ActiveJob::TestCase
   end
 
   describe '#report_exception' do
-    subject(:report_exception) {decribed_instance.send(:report_exception, exception)}
+    subject(:report_exception) {decribed_instance.report_exception(exception)}
 
     let(:exception) {StandardError.new('expected_error')}
 


### PR DESCRIPTION
## Links
- Jira ticket: [P20-1198](https://codedotorg.atlassian.net/browse/P20-1198)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/60645