### PR TITLE
Music: add error handling and latency reporting for AI block

### DIFF
--- a/apps/src/music/ai/types.ts
+++ b/apps/src/music/ai/types.ts
@@ -1,0 +1,6 @@
+export enum Message {
+  GeneratePattern = 'generatePattern',
+  ModelCreated = 'modelCreated',
+  GenerateFinished = 'generateFinished',
+  Result = 'result',
+}

--- a/apps/src/music/views/PatternAiPanel.tsx
+++ b/apps/src/music/views/PatternAiPanel.tsx
@@ -45,7 +45,7 @@ interface PatternAiPanelProps {
 }
 
 type UserCompletedTaskType = 'none' | 'generated' | 'drawnDrums';
-type GenerateStateType = 'none' | 'generating';
+type GenerateStateType = 'none' | 'generating' | 'error';
 
 /*
  * Renders a UI for designing a pattern, with AI generation. This is currently
@@ -204,6 +204,10 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
     const seedEvents = currentValue.events.filter(
       event => event.tick <= numSeedEvents
     );
+    const onError = (e: Error) => {
+      console.error(e);
+      setGenerateState('error');
+    };
     generatePattern(
       seedEvents,
       numSeedEvents,
@@ -217,7 +221,8 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
           setGenerateState('none');
           playPreview();
         });
-      }
+      },
+      onError
     );
     setGenerateState('generating');
   }, [currentValue, onChange, aiTemperature, stopPreview, playPreview]);
@@ -273,9 +278,21 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
         )}
         {userCompletedTask === 'drawnDrums' && (
           <div className={styles.helpContainer}>
-            <div className={classNames(styles.help, styles.helpGenerate)}>
+            <div
+              className={classNames(
+                styles.help,
+                styles.helpGenerate,
+                generateState === 'error' && styles.helpGenerateError
+              )}
+            >
               Click this button and A.I. will generate more drums based on what
               you started.
+              {generateState === 'error' && (
+                <div className={styles.errorMessage}>
+                  <br />
+                  Something went wrong. Try again.
+                </div>
+              )}
             </div>
             <div
               className={classNames(
@@ -289,6 +306,19 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
               >
                 <img src={arrowImage} alt="" />
               </div>
+            </div>
+          </div>
+        )}
+        {userCompletedTask === 'generated' && generateState === 'error' && (
+          <div className={styles.helpContainer}>
+            <div
+              className={classNames(
+                styles.help,
+                styles.helpError,
+                styles.errorMessage
+              )}
+            >
+              Something went wrong. Try again.
             </div>
           </div>
         )}

--- a/apps/src/music/views/patternAiPanel.module.scss
+++ b/apps/src/music/views/patternAiPanel.module.scss
@@ -202,6 +202,15 @@
   &Generate {
     top: 143px;
     right: 196px;
+
+    &Error {
+      top: 100px;
+    }
+  }
+
+  &Error {
+    top: 143px;
+    right: 196px;
   }
 }
 
@@ -232,4 +241,8 @@
     transform: rotate(90deg);
     animation: left-right 0.75s infinite;
   }
+}
+
+.errorMessage {
+  color: $product_negative_default;
 }


### PR DESCRIPTION
Adds error handling and some latency/error metrics reporting for the AI generate pattern call. If an error is thrown inside the patternAiWorker, we should now be able to catch it, log and report it. 

Here's an example of how an error log appears in Cloudwatch:

- <img width="1192" alt="Screenshot 2024-10-01 at 12 46 23 PM" src="https://github.com/user-attachments/assets/c5ca77f1-2f49-47b5-a7c0-4cb56b692528">

Additionally, this adds the following metrics to Cloudwatch:
- **MusicAI.GeneratePatternAttempt**: counter metric emitted when generation starts
- **MusicAI.GeneratePatternError**: counter metric emitted if an error occurs during generation
- **MusicAI.CreateModelTime**: timing metric tracking how long the model creation step takes (in ms)
- **MusicAI.GeneratePatternTime**: timing metric tracking how long the generate step takes (in ms)

Sample metrics on a graph. Error rate is computed by dividing MusicAI.GeneratePatternAttempt by MusicAI.GeneratePatternError * 100. (I generated some sample errors by randomly throwing errors in the patternAiWorker).

- <img width="1219" alt="Screenshot 2024-10-01 at 12 51 23 PM" src="https://github.com/user-attachments/assets/28575b36-dbc9-489a-afd7-1640f94bde3b">

If any error occurs during generation, we'll show these error messages to the user (before and after first generation respectively). Didn't spend a whole lot of time polishing these messages as I'm sure we'll do an overall UI polish pass on this panel soon.

- <img width="921" alt="Screenshot 2024-10-01 at 12 47 17 PM" src="https://github.com/user-attachments/assets/207785db-261a-4a7b-96c3-7aef88e73b18">
- <img width="923" alt="Screenshot 2024-10-01 at 12 47 33 PM" src="https://github.com/user-attachments/assets/ad218ecc-f9a7-44b9-90c3-ce1f472f2524">

## Links

https://codedotorg.atlassian.net/browse/LABS-1059
https://codedotorg.atlassian.net/browse/LABS-1060

## Testing story

Tested locally by manually generating errors.