### PR TITLE
Slight simplifications to emulated S3 setup

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -108,7 +108,7 @@ If you want to run the server code natively, but leverage Docker to run the depe
 First, you want to follow the normal [SETUP.md](SETUP.md) instructions for your platform.
 You can skip over many steps that are related to running mysql and redis.
 
-Instead, once you have a working Ruby and Node environment, you can then use this command to spin up the database and redis servers:
+Instead, once you have a working Ruby and Node environment, you can then use this command to spin up the database and redis servers, as well as the S3 emulation service:
 
 ```shell
 docker compose run all-services

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -264,13 +264,11 @@ google_client_secret:
 # Default AWS region for the application.
 aws_region: us-east-1
 
-# Set the AWS endpoint, typically to point to a local instance of
-# an AWS service. For instance, an emulated LocalStack solution.
+# Set the endpoint to point to a local instance of an AWS S3 emulation service (Minio).
 # When the endpoint is set, you can also set the access key, etc.
-aws_endpoint:
-aws_s3_endpoint:
-aws_access_key_id:
-aws_secret_access_key:
+minio_s3_endpoint:
+minio_access_key_id:
+minio_secret_access_key:
 
 # Amazon Future Engineer integration
 afe_pardot_form_handler_url:

--- a/dashboard/legacy/middleware/sound_library_api.rb
+++ b/dashboard/legacy/middleware/sound_library_api.rb
@@ -82,7 +82,7 @@ class SoundLibraryApi < Sinatra::Base
   # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html
   def has_signed_cookie?
     encoded_policy = request.cookies['CloudFront-Policy'].to_s
-    if encoded_policy.blank? && (CDO.aws_emulated? || CDO.aws_s3_emulated?)
+    if encoded_policy.blank? && CDO.aws_s3_emulated?
       encoded_policy = request.cookies['CloudFront-Policy-Emulated'].to_s
     end
     return false unless encoded_policy && !encoded_policy.empty?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         echo 'cloudfront_private_key: localoverride' &&
         echo 'slack_bot_token: localoverride' &&
         echo \"properties_encryption_key: ''\" &&
-        echo 'aws_s3_endpoint: http://localhost:9000' &&
-        echo 'aws_access_key_id: local-development' &&
-        echo 'aws_secret_access_key: allstudents'
+        echo 'minio_s3_endpoint: http://localhost:9000' &&
+        echo 'minio_access_key_id: local-development' &&
+        echo 'minio_secret_access_key: allstudents'
       "

--- a/docker/developers/docker-compose.minio.yml
+++ b/docker/developers/docker-compose.minio.yml
@@ -101,9 +101,9 @@ services:
         echo &&
         echo 'You need to add the following to locals.yml to have your server use these services:' &&
         echo &&
-        echo 'aws_s3_endpoint: http://localhost:9000' &&
-        echo 'aws_access_key_id: local-development' &&
-        echo 'aws_secret_access_key: allstudents'
+        echo 'minio_s3_endpoint: http://localhost:9000' &&
+        echo 'minio_access_key_id: local-development' &&
+        echo 'minio_secret_access_key: allstudents'
       "
 
 volumes:

--- a/docker/developers/docker-compose.minio.yml
+++ b/docker/developers/docker-compose.minio.yml
@@ -48,11 +48,11 @@ services:
       - AWS_ACCESS_KEY_ID=local-development
       - AWS_SECRET_ACCESS_KEY=allstudents
       - AWS_DEFAULT_REGION=us-east-1
-      - AWS_S3_ENDPOINT_URL=http://localhost:9000
+      - MINIO_ENDPOINT_URL=http://localhost:9000
       - WITHIN_DOCKER=1
     volumes:
       - ../..:/app/src
-    command: /bin/bash ./install-s3.sh
+    command: /bin/bash ./install-minio-s3.sh
 
   minio-install:
     <<: *minio-install-base
@@ -66,7 +66,7 @@ services:
       - AWS_ACCESS_KEY_ID=local-development
       - AWS_SECRET_ACCESS_KEY=allstudents
       - AWS_DEFAULT_REGION=us-east-1
-      - AWS_S3_ENDPOINT_URL=http://minio:9000
+      - MINIO_ENDPOINT_URL=http://minio:9000
       - WITHIN_DOCKER=1
     networks:
       cdo_network:

--- a/docker/developers/install-minio-s3.sh
+++ b/docker/developers/install-minio-s3.sh
@@ -12,7 +12,7 @@ fi
 # See: https://stackoverflow.com/questions/57953187/aws-cli-has-no-output
 export AWS_PAGER=
 
-export AWS_ENDPOINT_URL=${AWS_S3_ENDPOINT_URL}
+export AWS_ENDPOINT_URL=${MINIO_ENDPOINT_URL}
 
 # Determine all the buckets that exist in the s3 path and create those buckets
 cd s3

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -287,12 +287,6 @@ module Cdo
       rack_env?(:production) || !!ENV['AWS_PROFILE']&.include?('cdo')
     end
 
-    # The web server in connected to an emulated (non-production) AWS system.
-    def aws_emulated?
-      # This is true when an endpoint is set explicitly
-      !!(CDO.aws_endpoint && (rack_env?(:development) || rack_env?(:test)))
-    end
-
     # The web server is connected to an emulated S3 server local to this server.
     def aws_s3_emulated?
       # This is true when an endpoint is set explicitly

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -290,7 +290,7 @@ module Cdo
     # The web server is connected to an emulated S3 server local to this server.
     def aws_s3_emulated?
       # This is true when an endpoint is set explicitly
-      !!(CDO.aws_s3_endpoint && (rack_env?(:development) || rack_env?(:test)))
+      !!(CDO.minio_s3_endpoint && (rack_env?(:development) || rack_env?(:test)))
     end
 
     def shared_image_url(path)

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -319,8 +319,8 @@ module AWS
         ]
       }.to_json
 
-      # If we are emulating AWS at all, we just return mock cloudfront policy output
-      if CDO.aws_emulated? || CDO.aws_s3_emulated?
+      # If we are emulating S3, we just return mock cloudfront policy output
+      if CDO.aws_s3_emulated?
         return {
           'CloudFront-Policy-Emulated': Base64.encode64(policy).tr('+=/', '-_~')
         }

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -49,9 +49,9 @@ module AWS
     def self.connect_v2!
       self.s3 ||= if CDO.aws_s3_emulated?
                     Aws::S3::Client.new(
-                      endpoint: CDO.aws_s3_endpoint || CDO.aws_endpoint,
-                      access_key_id: CDO.aws_access_key_id,
-                      secret_access_key: CDO.aws_secret_access_key,
+                      endpoint: CDO.minio_s3_endpoint,
+                      access_key_id: CDO.minio_access_key_id,
+                      secret_access_key: CDO.minio_secret_access_key,
                       region: CDO.aws_region,
                       force_path_style: true,
                     )

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -84,28 +84,7 @@ module AWS
       return unless CDO.aws_s3_emulated?
       return if exists_in_bucket(bucket, key)
 
-      # Determine the Populator class that can generate files for this bucket, if it
-      # exists. We allow subdirectories to have their own populators, so this will find
-      # them, in that case, or ascend up the hierarchy instead.
-      path_parts = [bucket, *key.split('/')]
-      class_parts = path_parts.map do |part|
-        part.tr('-', '_').camelize
-      end
-
-      # The 'base' will be the most specific populator found for the path within the
-      # bucket.
-      base = nil
-      relative_path = []
-      until class_parts.empty?
-        begin
-          base = [*class_parts, 'Populate'].join('::').constantize
-          relative_path << path_parts.pop
-          break if base
-        rescue NameError
-          class_parts.pop
-        end
-      end
-
+      base, relative_path = Populator.find_populator(bucket, key)
       base.new.populate(File.join(*relative_path)) if base && relative_path
     end
 


### PR DESCRIPTION
Some small proposed simplifications for the Docker S3 approach:

1. Move logic to find appropriate Populator into Populator module. Based on [this comment](https://github.com/code-dot-org/code-dot-org/pull/60276#discussion_r1775826437).
2. Remove unused `aws_endpoint` and `aws_emulated?`. Based on [this comment](https://github.com/code-dot-org/code-dot-org/pull/60276#discussion_r1775735969).
3. Rename Minio-specific "AWS" config where possible -- in particular, having config values for `aws_access_key_id` and `aws_secret_access_key` in config.yml that are actually only used by Minio seemed potentially confusing for future users. Based on [this comment](https://github.com/code-dot-org/code-dot-org/pull/60276#discussion_r1775666507).