### PR TITLE
Added min and max width to localeForm

### DIFF
--- a/apps/src/sharedComponents/footer/I18nDropdown/style.scss
+++ b/apps/src/sharedComponents/footer/I18nDropdown/style.scss
@@ -1,5 +1,10 @@
 @import 'color';
 
+#localeForm {
+  min-width: 6.25rem;
+  max-width: 50%;
+}
+
 .languageSelect {
   > div {
     display: flex;


### PR DESCRIPTION
This PR adds min-width and max-width properties to the i18n-dropdown component.
6.25rem min-width keeps enough language names to make it distinguishable. 
50% max-width fits the longest locale we support.

## Screenshots
Large visualization collum:
![Screenshot 2024-10-01 at 16 17 15](https://github.com/user-attachments/assets/074f31db-8d53-4086-8d6c-bc25e135255f)
Small visualization collum:
![Screenshot 2024-10-01 at 16 17 43](https://github.com/user-attachments/assets/0f7a2457-c280-4589-a36d-4b4037a4d1ec)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
