### PR TITLE
Codebridge: delete relevant open files when deleting a folder

### DIFF
--- a/apps/src/codebridge/codebridgeContext/codebridgeContextProjectReducer.ts
+++ b/apps/src/codebridge/codebridgeContext/codebridgeContextProjectReducer.ts
@@ -302,6 +302,12 @@ export const projectReducer = (
         Object.values(newProject.files)
           .filter(f => files.has(f.id))
           .forEach(f => delete newProject.files[f.id]);
+        if (newProject.openFiles) {
+          // Delete files from the list of open files.
+          newProject.openFiles = newProject.openFiles.filter(
+            fileId => !files.has(fileId)
+          );
+        }
       }
 
       return newProject;


### PR DESCRIPTION
I noticed a bug in codebridge where if you delete a folder with open files, it crashes the project. This is because we weren't deleting the files from the list of open files. This bug is effectively fixed by these lines in [PR 61463](https://github.com/code-dot-org/code-dot-org/pull/61463/files#diff-e71a88902a21f9a6c599372c75330656d612123403f04bf7ac4b03dacc3f4520R7-R11), because we ignore undefined files when trying to open them, but this fix is good to do too so we don't keep irrelevant info in the open files list.

## Links

- jira ticket: [CT-834](https://codedotorg.atlassian.net/browse/CT-834)


## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
