### PR TITLE
Adding Korean Online Coding Party certificates

### DIFF
--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -65,9 +65,9 @@ export default function Congrats(props) {
    * @returns {Object} extraLinkUrl, extraLinkText
    */
   const getExtraLinkData = (language, tutorial, currentDate) => {
-    // https://codedotorg.atlassian.net/browse/P20-948
-    const codingPartyStart = new Date('2024-06-17T00:00:00+09:00');
-    const codingPartyEnd = new Date('2024-07-28T00:00:00+09:00');
+    // https://codedotorg.atlassian.net/browse/P20-1144
+    const codingPartyStart = new Date('2024-10-07:00:00+09:00');
+    const codingPartyEnd = new Date('2024-11-17:00:00+09:00');
     const codingPartyActive =
       codingPartyStart <= currentDate && currentDate < codingPartyEnd;
     if (language === 'ko' && codingPartyActive) {
@@ -75,12 +75,17 @@ export default function Congrats(props) {
         '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
       if (/oceans/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2024-1-oceans.png'),
+          extraLinkUrl: pegasus('/files/online-coding-party-2024-2-oceans.png'),
           extraLinkText: extraLinkText,
         };
       } else if (/hero/.test(tutorial)) {
         return {
-          extraLinkUrl: pegasus('/files/online-coding-party-2024-1-hero.png'),
+          extraLinkUrl: pegasus('/files/online-coding-party-2024-2-hero.png'),
+          extraLinkText: extraLinkText,
+        };
+      } else if (/dance/.test(tutorial)) {
+        return {
+          extraLinkUrl: pegasus('/files/online-coding-party-2024-2-dance.png'),
           extraLinkText: extraLinkText,
         };
       }

--- a/dashboard/config/locales/panels.ko-KR.json
+++ b/dashboard/config/locales/panels.ko-KR.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:642dc941f6e2c2e0ae9b188a4dae909e696064f5310e8ca15b67d9a3f0ea4939
-size 5933
+oid sha256:fd37d2bbc3a6ddbb8c1a24a8dcf8dc6aff5d3222a77d3133c88e4bd5a2bc13f0
+size 5934


### PR DESCRIPTION
> Our Korean partners would like us to show a custom certificate for Korean students. This PR adds a link to a certificate provided by our partner when the language is in Korean. The links will be removed once their HoC promotion is over.

Certificates uploaded on Dropbox: Below are the uploaded certificate file names. The Korean-linked text will remain the same.
* /files/online-coding-party-2024-2-oceans.png 
* /files/online-coding-party-2024-2-dance.png 
* /files/online-coding-party-2024-2-hero.png 
* /files/online-coding-party-2024-2-music.png 

Campaign Start and End Dates 
Campaign Start date: Monday, October 7, 2024, Korea Time (UTC/GMT +9) 
Campaign End Date: Sunday, November 17, 2024, Korea Time (UTC/GMT +9)

Work done in this PR
* Special certificate link campaigns updated with new dates and files.
* Crowdin string for Music lab also update in the JSON file and on Crowdin.

## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1144)

## Testing story
* Manually tested on localhost.
  * On the /congrats page, you can use the query string param `currentDate=2024-11-01` to preview a future date.