### PR TITLE
Music: update color

### DIFF
--- a/apps/src/blockly/themes/cdoDark.js
+++ b/apps/src/blockly/themes/cdoDark.js
@@ -14,8 +14,8 @@ export default GoogleBlockly.Theme.defineTheme(Themes.DARK, {
   blockStyles: cdoBlockStyles,
   componentStyles: {
     workspaceBackgroundColour: color.neutral_dark,
-    blackBackground: color.neutral_dark90,
-    flyoutBackgroundColour: color.neutral_dark90,
+    blackBackground: color.light_gray_950,
+    flyoutBackgroundColour: color.light_gray_950,
     flyoutOpacity: 0.8,
   },
   fontStyle: {

--- a/apps/src/music/views/controls.module.scss
+++ b/apps/src/music/views/controls.module.scss
@@ -5,7 +5,7 @@
 
 .controlsContainer {
   display: flex;
-  background-color: $neutral_dark90;
+  background-color: $light_gray_950;
   z-index: 70;
   border-radius: $default-border-radius;
   position: relative;

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -24,7 +24,7 @@
   }
 
   .measuresBackground {
-    background-color: $neutral_dark90;
+    background-color: $light_gray_950;
     height: 24px;
     border-bottom: solid $default-spacing $dark_black;
 


### PR DESCRIPTION
Following up on the change in panel header color in https://github.com/code-dot-org/code-dot-org/pull/61479, this change adjusts the color inside each panel so that there is a difference again.

### After

![localhost-studio code org_9000_s_music-intro-2024_lessons_1_levels_8](https://github.com/user-attachments/assets/4c0df966-cd6a-4e41-a0bf-f16dc1221240)
