### PR TITLE
Music: new callout

### DIFF
--- a/apps/src/music/views/Callouts.tsx
+++ b/apps/src/music/views/Callouts.tsx
@@ -54,6 +54,10 @@ const availableCallouts: {
   'run-button': {selector: '#run-button'},
   'trigger-button-1': {selector: `#${Triggers[0].id}`},
   'toolbox-first-row': {selector: '.blocklyTreeRow'},
+  'flyout-first-block': {
+    selector:
+      '.blocklyFlyout:not([style*="display: none;"]) .blocklyDraggable:nth-of-type(1)',
+  },
   'toolbox-second-block': {
     openToolboxCategory: 0,
     selector:


### PR DESCRIPTION
Adds a new callout, `flyout-first-block`, which points at the first block in a flyout (i.e. non-category) toolbox. 