### PR TITLE
Add sendProgressReport for lab2 and implement in Aichat

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -8,7 +8,7 @@ import {
 } from '@reduxjs/toolkit';
 
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
-import {sendInProgressReport} from '@cdo/apps/code-studio/progressRedux';
+import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
 import {
   getCurrentScriptLevelId,
   getCurrentLevel,
@@ -296,7 +296,7 @@ export const onSaveComplete =
     dispatch(endSave());
     // Send a report that user has started the aichat level after a successful save.
     // A teacher will view that the level is now in progress.
-    dispatch(sendInProgressReport('aichat', TestResults.LEVEL_STARTED));
+    dispatch(sendProgressReport('aichat', TestResults.LEVEL_STARTED));
     // Go to the presentation page if we just finished publishing the model card.
     if (currentSaveType === 'publishModelCard') {
       dispatch(setViewMode(ViewMode.PRESENTATION));
@@ -465,7 +465,7 @@ export const submitChatContents = createAsyncThunk(
     // Send a report that the user has started the aichat level after successfully sending
     // a chat message and then receiving a response from the chatbot.
     // A teacher will view that the level is now in progress.
-    dispatch(sendInProgressReport('aichat', TestResults.LEVEL_STARTED));
+    dispatch(sendProgressReport('aichat', TestResults.LEVEL_STARTED));
     chatApiResponse.messages.forEach(message => {
       dispatch(addChatEvent({...message, timestamp: Date.now()}));
     });

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -294,7 +294,8 @@ export const onSaveComplete =
     dispatch(setSavedAiCustomizations(currentAiCustomizations));
     // Notify the UI that the save is complete.
     dispatch(endSave());
-    // Send a report that user has started the aichat level - a teacher will view that level is now in progress.
+    // Send a report that user has started the aichat level after a successful save.
+    // A teacher will view that the level is now in progress.
     dispatch(sendInProgressReport('aichat', TestResults.LEVEL_STARTED));
     // Go to the presentation page if we just finished publishing the model card.
     if (currentSaveType === 'publishModelCard') {
@@ -461,7 +462,9 @@ export const submitChatContents = createAsyncThunk(
     }
 
     thunkAPI.dispatch(clearChatMessagePending());
-    // Send a report that user has started the aichat level - a teacher will view that level is now in progress.
+    // Send a report that the user has started the aichat level after successfully sending
+    // a chat message and then receiving a response from the chatbot.
+    // A teacher will view that the level is now in progress.
     dispatch(sendInProgressReport('aichat', TestResults.LEVEL_STARTED));
     chatApiResponse.messages.forEach(message => {
       dispatch(addChatEvent({...message, timestamp: Date.now()}));

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -8,6 +8,7 @@ import {
 } from '@reduxjs/toolkit';
 
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
+import {sendInProgressReport} from '@cdo/apps/code-studio/progressRedux';
 import {
   getCurrentScriptLevelId,
   getCurrentLevel,
@@ -292,6 +293,7 @@ export const onSaveComplete =
     dispatch(setSavedAiCustomizations(currentAiCustomizations));
     // Notify the UI that the save is complete.
     dispatch(endSave());
+    dispatch(sendInProgressReport('aichat'));
     // Go to the presentation page if we just finished publishing the model card.
     if (currentSaveType === 'publishModelCard') {
       dispatch(setViewMode(ViewMode.PRESENTATION));
@@ -457,6 +459,7 @@ export const submitChatContents = createAsyncThunk(
     }
 
     thunkAPI.dispatch(clearChatMessagePending());
+    dispatch(sendInProgressReport('aichat'));
     chatApiResponse.messages.forEach(message => {
       dispatch(addChatEvent({...message, timestamp: Date.now()}));
     });

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -294,6 +294,7 @@ export const onSaveComplete =
     dispatch(setSavedAiCustomizations(currentAiCustomizations));
     // Notify the UI that the save is complete.
     dispatch(endSave());
+    // Send a report that user has started the aichat level - a teacher will view that level is now in progress.
     dispatch(sendInProgressReport('aichat', TestResults.LEVEL_STARTED));
     // Go to the presentation page if we just finished publishing the model card.
     if (currentSaveType === 'publishModelCard') {
@@ -460,6 +461,7 @@ export const submitChatContents = createAsyncThunk(
     }
 
     thunkAPI.dispatch(clearChatMessagePending());
+    // Send a report that user has started the aichat level - a teacher will view that level is now in progress.
     dispatch(sendInProgressReport('aichat', TestResults.LEVEL_STARTED));
     chatApiResponse.messages.forEach(message => {
       dispatch(addChatEvent({...message, timestamp: Date.now()}));

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -13,6 +13,7 @@ import {
   getCurrentScriptLevelId,
   getCurrentLevel,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
+import {TestResults} from '@cdo/apps/constants';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -293,7 +294,7 @@ export const onSaveComplete =
     dispatch(setSavedAiCustomizations(currentAiCustomizations));
     // Notify the UI that the save is complete.
     dispatch(endSave());
-    dispatch(sendInProgressReport('aichat'));
+    dispatch(sendInProgressReport('aichat', TestResults.LEVEL_STARTED));
     // Go to the presentation page if we just finished publishing the model card.
     if (currentSaveType === 'publishModelCard') {
       dispatch(setViewMode(ViewMode.PRESENTATION));
@@ -459,7 +460,7 @@ export const submitChatContents = createAsyncThunk(
     }
 
     thunkAPI.dispatch(clearChatMessagePending());
-    dispatch(sendInProgressReport('aichat'));
+    dispatch(sendInProgressReport('aichat', TestResults.LEVEL_STARTED));
     chatApiResponse.messages.forEach(message => {
       dispatch(addChatEvent({...message, timestamp: Date.now()}));
     });

--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -353,6 +353,18 @@ export function sendSuccessReport(appType: string): ProgressThunkAction {
   };
 }
 
+// The user has attempted the level (as defined by the app type). Currently only used by Lab2 labs.
+export function sendInProgressReport(appType: string): ProgressThunkAction {
+  return (dispatch, getState) => {
+    sendReportHelper(
+      appType,
+      TestResults.LEVEL_INCOMPLETE_FAIL,
+      dispatch,
+      getState
+    );
+  };
+}
+
 export const sendPredictLevelReport = createAsyncThunk<
   void,
   {appType: string; predictResponse: string},

--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -354,14 +354,12 @@ export function sendSuccessReport(appType: string): ProgressThunkAction {
 }
 
 // The user has attempted the level (as defined by the app type). Currently only used by Lab2 labs.
-export function sendInProgressReport(appType: string): ProgressThunkAction {
+export function sendInProgressReport(
+  appType: string,
+  result: TestResults
+): ProgressThunkAction {
   return (dispatch, getState) => {
-    sendReportHelper(
-      appType,
-      TestResults.LEVEL_INCOMPLETE_FAIL,
-      dispatch,
-      getState
-    );
+    sendReportHelper(appType, result, dispatch, getState);
   };
 }
 

--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -353,8 +353,9 @@ export function sendSuccessReport(appType: string): ProgressThunkAction {
   };
 }
 
-// The user has attempted the level (as defined by the app type). Currently only used by Lab2 labs.
-export function sendInProgressReport(
+// Send a report of user progress (e.g., TestResults.LEVEL_ATTEMPTED) on an appType level.
+// Currently only used by Lab2 labs.
+export function sendProgressReport(
   appType: string,
   result: TestResults
 ): ProgressThunkAction {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds `sendProgressReport` to `progressRedux` that can be used by Lab2 labs to report a `TestResult` to `Milestone` on a level. If a user completes a level, then `sendSuccessReport` is called. The definitions of a particular `TestResult` and success are defined by the lab type.

Currently in `aichat` levels, a user completes a level if they click on 'Continue' or 'Finish' button in the `Instructions` panel. A user is 'in progress' if they did NOT click on the 'Continue'/'Finish' button and they either
- saved a model customization or model card info field successfully,
- submitted a chat message and received a chatbot response.

Adding the in progress state will allow teachers to view via the teacher dashboard or panel whether a student has interacted with a particular `aichat` level or not - the progress bubble will be outlined with green. (Success is a solid green progress bubble.)

## After update:

Screencast video: a user updates a model customization / submits chat message, and progress bubble then changes so it is outlined in green. Once the user clicks on 'Continue'/'Finish', the progress bubble turns solid green. The second part of the video includes a user on a level with sublevels. Note that when the user attempts a level, both the sublevel and the parent level progress bubble change so that they have the green outline.


https://github.com/user-attachments/assets/c079b448-927e-470c-9b36-7ce6c947d3c1



Screencast video: a teacher user can view a student's progress via teacher panel.


https://github.com/user-attachments/assets/9e4c1816-e5aa-4ae5-8d1d-e9a406a4483e



Screenshot of teacher dashboard - a section in which a student has both completed and in progress `aichat` levels.

<img width="1023" alt="Screenshot 2024-10-02 at 9 41 44 AM" src="https://github.com/user-attachments/assets/3e751f84-9f87-45df-b291-c5cdc31b5582">



## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1050)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally in `aichat` levels in both 'allthethings' and 'gen-ai-staging'. I used both a teacher and student account with the student being in the teacher section. I also confirmed the expected behavior in both `aichat` levels and sublevels.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
