### PR TITLE
Manage students loads students for new sections

### DIFF
--- a/apps/src/templates/manageStudents/ManageStudents.jsx
+++ b/apps/src/templates/manageStudents/ManageStudents.jsx
@@ -8,46 +8,52 @@ import {loadSectionStudentData} from '@cdo/apps/templates/manageStudents/manageS
 
 import ManageStudentsTable from './ManageStudentsTable';
 
-class ManageStudents extends React.Component {
-  static propTypes = {
-    studioUrlPrefix: PropTypes.string,
+function ManageStudents({
+  studioUrlPrefix,
+  sectionId,
+  isLoadingStudents,
+  loadSectionStudentData,
+  isLoadingSectionData,
+}) {
+  React.useEffect(() => {
+    if (!isLoadingSectionData) {
+      loadSectionStudentData(sectionId);
+    }
+  }, [sectionId, isLoadingSectionData, loadSectionStudentData]);
 
-    // Provided by redux
-    sectionId: PropTypes.number,
-    isLoadingStudents: PropTypes.bool.isRequired,
-    loadSectionStudentData: PropTypes.func.isRequired,
-  };
-
-  componentDidMount() {
-    this.props.loadSectionStudentData(this.props.sectionId);
-  }
-
-  render() {
-    const {sectionId, studioUrlPrefix, isLoadingStudents} = this.props;
-
-    return (
-      <div data-testid={'manage-students-tab'}>
-        {isLoadingStudents && <Spinner />}
-        {!isLoadingStudents && (
-          <div>
-            <SyncOmniAuthSectionControl
-              sectionId={sectionId}
-              studioUrlPrefix={studioUrlPrefix}
-            />
-            <ManageStudentsTable studioUrlPrefix={studioUrlPrefix} />
-          </div>
-        )}
-      </div>
-    );
-  }
+  return (
+    <div data-testid={'manage-students-tab'}>
+      {isLoadingStudents && <Spinner />}
+      {!isLoadingStudents && (
+        <div>
+          <SyncOmniAuthSectionControl
+            sectionId={sectionId}
+            studioUrlPrefix={studioUrlPrefix}
+          />
+          <ManageStudentsTable studioUrlPrefix={studioUrlPrefix} />
+        </div>
+      )}
+    </div>
+  );
 }
 
 export const UnconnectedManageStudents = ManageStudents;
+
+ManageStudents.propTypes = {
+  studioUrlPrefix: PropTypes.string,
+
+  // Provided by redux
+  sectionId: PropTypes.number,
+  isLoadingStudents: PropTypes.bool.isRequired,
+  loadSectionStudentData: PropTypes.func.isRequired,
+  isLoadingSectionData: PropTypes.bool.isRequired,
+};
 
 export default connect(
   state => ({
     sectionId: state.teacherSections.selectedSectionId,
     isLoadingStudents: state.manageStudents.isLoadingStudents,
+    isLoadingSectionData: state.teacherSections.isLoadingSectionData,
   }),
   dispatch => ({
     loadSectionStudentData(sectionId) {

--- a/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
+++ b/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
@@ -66,5 +66,6 @@ export const asyncLoadSelectedSection = async (sectionId: string) => {
     getStore().dispatch(updateSelectedSection(selectedSection));
 
     getStore().dispatch(finishLoadingSectionData());
+    console.log('Finished loading section data');
   });
 };

--- a/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
+++ b/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
@@ -66,6 +66,5 @@ export const asyncLoadSelectedSection = async (sectionId: string) => {
     getStore().dispatch(updateSelectedSection(selectedSection));
 
     getStore().dispatch(finishLoadingSectionData());
-    console.log('Finished loading section data');
   });
 };


### PR DESCRIPTION
The manage_students tab was not loading students when the selected section changes. This was not a problem because the selected section did not change on this page without a full page reload. Now that we have introduced the navigation sidebar, the selected section may change without a page reload. This PR:
* Refactors `<ManageStudents>` to a function component
* Loads student data in a `React.useEffect` so that it loads whenever the selectedSectionId changes

## Links
https://codedotorg.atlassian.net/browse/TEACH-1372
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
