### PR TITLE
Make School Dropdown Options a shared constant

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -110,6 +110,7 @@ def main
       CAP_LINKS
       LMS_LINKS
       USER_TYPES
+      NON_SCHOOL_OPTIONS
       US_STATES
     ), 
     file_type: 'ts'

--- a/apps/src/schoolInfo/SchoolInfoInterstitial.jsx
+++ b/apps/src/schoolInfo/SchoolInfoInterstitial.jsx
@@ -6,13 +6,10 @@ import Button from '@cdo/apps/legacySharedComponents/Button';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
-  CLICK_TO_ADD,
-  NO_SCHOOL_SETTING,
-  NON_SCHOOL_OPTIONS_ARRAY,
-  SELECT_A_SCHOOL,
   SELECT_COUNTRY,
   US_COUNTRY_CODE,
 } from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 import BaseDialog from '../templates/BaseDialog';
@@ -69,15 +66,15 @@ export default function SchoolInfoInterstitial({
       return true;
     }
     // disable true if school is not selected
-    if (schoolInfo.schoolId === SELECT_A_SCHOOL) {
+    if (schoolInfo.schoolId === NonSchoolOptions.SELECT_A_SCHOOL) {
       return true;
     }
     // for non school settings, don't disable
-    if (schoolInfo.schoolId === NO_SCHOOL_SETTING) {
+    if (schoolInfo.schoolId === NonSchoolOptions.NO_SCHOOL_SETTING) {
       return false;
     }
     // if school not in list, disable true if no name
-    if (schoolInfo.schoolId === CLICK_TO_ADD) {
+    if (schoolInfo.schoolId === NonSchoolOptions.CLICK_TO_ADD) {
       return !schoolInfo.schoolName;
     }
 
@@ -101,7 +98,7 @@ export default function SchoolInfoInterstitial({
   const handleSchoolInfoSubmit = async () => {
     const hasNcesId =
       schoolInfo.schoolId &&
-      !NON_SCHOOL_OPTIONS_ARRAY.includes(schoolInfo.schoolId);
+      !Object.values(NonSchoolOptions).includes(schoolInfo.schoolId);
     analyticsReporter.sendEvent(
       EVENTS.SCHOOL_INTERSTITIAL_SUBMIT,
       {

--- a/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
+++ b/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
@@ -3,17 +3,15 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
-  CLICK_TO_ADD,
-  NO_SCHOOL_SETTING,
   SCHOOL_COUNTRY_SESSION_KEY,
   SCHOOL_ID_SESSION_KEY,
   SCHOOL_NAME_SESSION_KEY,
   SCHOOL_ZIP_SESSION_KEY,
-  SELECT_A_SCHOOL,
   SELECT_COUNTRY,
   US_COUNTRY_CODE,
   ZIP_REGEX,
 } from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 
 import {SchoolDropdownOption, SchoolInfoInitialState} from '../types';
 import {constructSchoolOption} from '../utils/constructSchoolOption';
@@ -33,11 +31,11 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
 
   const detectedSchoolId = useMemo(
     () =>
-      initialState.schoolType === NO_SCHOOL_SETTING
-        ? NO_SCHOOL_SETTING
+      initialState.schoolType === NonSchoolOptions.NO_SCHOOL_SETTING
+        ? NonSchoolOptions.NO_SCHOOL_SETTING
         : initialState.schoolId ||
           sessionStorage.getItem(SCHOOL_ID_SESSION_KEY) ||
-          SELECT_A_SCHOOL,
+          NonSchoolOptions.SELECT_A_SCHOOL,
     [initialState.schoolId, initialState.schoolType]
   );
 
@@ -125,13 +123,13 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     sessionStorage.setItem(SCHOOL_ID_SESSION_KEY, schoolId);
     if (!mounted.current) return;
 
-    if (schoolId === NO_SCHOOL_SETTING) {
+    if (schoolId === NonSchoolOptions.NO_SCHOOL_SETTING) {
       analyticsReporter.sendEvent(
         EVENTS.DO_NOT_TEACH_AT_SCHOOL_CLICKED,
         {},
         PLATFORMS.BOTH
       );
-    } else if (schoolId === CLICK_TO_ADD) {
+    } else if (schoolId === NonSchoolOptions.CLICK_TO_ADD) {
       analyticsReporter.sendEvent(
         EVENTS.ADD_MANUALLY_CLICKED,
         {},

--- a/apps/src/schoolInfo/utils/buildSchoolData.ts
+++ b/apps/src/schoolInfo/utils/buildSchoolData.ts
@@ -1,9 +1,8 @@
 import {
-  NO_SCHOOL_SETTING,
-  NON_SCHOOL_OPTIONS_ARRAY,
   SELECT_COUNTRY,
   US_COUNTRY_CODE,
 } from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 
 import {SchoolInfoRequest} from '../types';
 
@@ -23,7 +22,7 @@ export function buildSchoolData({
   if (
     country === US_COUNTRY_CODE &&
     schoolId &&
-    !NON_SCHOOL_OPTIONS_ARRAY.includes(schoolId)
+    !Object.values(NonSchoolOptions).some(option => schoolId === option)
   ) {
     return {
       user: {
@@ -34,12 +33,15 @@ export function buildSchoolData({
     };
   }
 
-  if (country === US_COUNTRY_CODE && schoolId === NO_SCHOOL_SETTING) {
+  if (
+    country === US_COUNTRY_CODE &&
+    schoolId === NonSchoolOptions.NO_SCHOOL_SETTING
+  ) {
     return {
       user: {
         school_info_attributes: {
           country,
-          school_type: NO_SCHOOL_SETTING,
+          school_type: NonSchoolOptions.NO_SCHOOL_SETTING,
         },
       },
     };

--- a/apps/src/signUpFlow/signUpFlowConstants.tsx
+++ b/apps/src/signUpFlow/signUpFlowConstants.tsx
@@ -17,13 +17,5 @@ export const EMAIL_SESSION_KEY = 'email';
 // school association
 export const US_COUNTRY_CODE = 'US';
 export const ZIP_REGEX = new RegExp(/(^\d{5}$)/);
-export const SELECT_A_SCHOOL = 'selectASchool';
 export const SELECT_COUNTRY = 'selectCountry';
-export const CLICK_TO_ADD = 'clickToAdd';
-export const NO_SCHOOL_SETTING = 'noSchoolSetting';
 export const SCHOOL_ZIP_SEARCH_URL = '/dashboardapi/v1/schoolzipsearch/';
-export const NON_SCHOOL_OPTIONS_ARRAY = [
-  NO_SCHOOL_SETTING,
-  CLICK_TO_ADD,
-  SELECT_A_SCHOOL,
-];

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -5,13 +5,11 @@ import ReactDOM from 'react-dom';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import firehoseClient from '@cdo/apps/metrics/firehose';
-import {
-  NON_SCHOOL_OPTIONS_ARRAY,
-  SELECT_COUNTRY,
-} from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {SELECT_COUNTRY} from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import {SchoolDataInputsContainer} from '@cdo/apps/templates/SchoolDataInputsContainer';
 import experiments from '@cdo/apps/util/experiments';
 import getScriptData from '@cdo/apps/util/getScriptData';
+import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 
 const TEACHER_ONLY_FIELDS = [
   '#teacher-name-label',
@@ -108,7 +106,7 @@ $(document).ready(() => {
     const newSchoolIdEl = $(
       'select[name="user[school_info_attributes][school_id]"]'
     );
-    if (NON_SCHOOL_OPTIONS_ARRAY.includes(newSchoolIdEl.val())) {
+    if (Object.values(NonSchoolOptions).includes(newSchoolIdEl.val())) {
       newSchoolIdEl.val('');
       $('input[name="user[school_info_attributes][school_zip]"]').val('');
     }

--- a/apps/src/templates/SchoolDataInputs.jsx
+++ b/apps/src/templates/SchoolDataInputs.jsx
@@ -5,15 +5,13 @@ import {Button} from '@cdo/apps/componentLibrary/button';
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
 import {BodyTwoText, Heading2} from '@cdo/apps/componentLibrary/typography';
 import {
-  CLICK_TO_ADD,
-  NO_SCHOOL_SETTING,
-  SELECT_A_SCHOOL,
   SELECT_COUNTRY,
   US_COUNTRY_CODE,
   ZIP_REGEX,
 } from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import SchoolNameInput from '@cdo/apps/templates/SchoolNameInput';
 import SchoolZipSearch from '@cdo/apps/templates/SchoolZipSearch';
+import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 import {getCountriesUsFirst} from '../schoolInfo/utils/getCountriesUsFirst';
@@ -21,8 +19,8 @@ import {getCountriesUsFirst} from '../schoolInfo/utils/getCountriesUsFirst';
 import style from './school-association.module.scss';
 
 const SEARCH_DEFAULTS = [
-  {value: CLICK_TO_ADD, text: i18n.schoolClickToAdd()},
-  {value: NO_SCHOOL_SETTING, text: i18n.noSchoolSetting()},
+  {value: NonSchoolOptions.CLICK_TO_ADD, text: i18n.schoolClickToAdd()},
+  {value: NonSchoolOptions.NO_SCHOOL_SETTING, text: i18n.noSchoolSetting()},
 ];
 
 const COUNTRIES_US_FIRST = getCountriesUsFirst();
@@ -56,10 +54,13 @@ export default function SchoolDataInputs({
     [country, usIp]
   );
 
-  const inputManually = useMemo(() => schoolId === CLICK_TO_ADD, [schoolId]);
+  const inputManually = useMemo(
+    () => schoolId === NonSchoolOptions.CLICK_TO_ADD,
+    [schoolId]
+  );
 
   const showNoSchoolSettingButton = useMemo(
-    () => schoolId !== NO_SCHOOL_SETTING,
+    () => schoolId !== NonSchoolOptions.NO_SCHOOL_SETTING,
     [schoolId]
   );
 
@@ -70,7 +71,7 @@ export default function SchoolDataInputs({
 
   const schoolSelectOptions = useMemo(
     () => [
-      {value: SELECT_A_SCHOOL, text: i18n.selectASchool()},
+      {value: NonSchoolOptions.SELECT_A_SCHOOL, text: i18n.selectASchool()},
       ...schoolsList,
     ],
     [schoolsList]
@@ -160,7 +161,7 @@ export default function SchoolDataInputs({
                 size={'xs'}
                 onClick={e => {
                   e.preventDefault();
-                  handleSchoolChange(NO_SCHOOL_SETTING);
+                  handleSchoolChange(NonSchoolOptions.NO_SCHOOL_SETTING);
                 }}
               />
             )}
@@ -179,7 +180,7 @@ export default function SchoolDataInputs({
               type={'tertiary'}
               size={'xs'}
               onClick={() => {
-                handleSchoolChange(SELECT_A_SCHOOL);
+                handleSchoolChange(NonSchoolOptions.SELECT_A_SCHOOL);
               }}
             />
           </div>
@@ -188,12 +189,12 @@ export default function SchoolDataInputs({
       {/* hidden fields are needed when form is submitted in _finish_sign_up.js 
       in order to pass the default schoolType when the user does 
       not teach in a school setting */}
-      {schoolId === NO_SCHOOL_SETTING && (
+      {schoolId === NonSchoolOptions.NO_SCHOOL_SETTING && (
         <input
           hidden
           readOnly
           name={fieldNames.schoolType}
-          value={NO_SCHOOL_SETTING}
+          value={NonSchoolOptions.NO_SCHOOL_SETTING}
         />
       )}
     </div>

--- a/apps/test/unit/schoolInfo/SchoolInfoInterstitialTest.jsx
+++ b/apps/test/unit/schoolInfo/SchoolInfoInterstitialTest.jsx
@@ -7,12 +7,10 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import SchoolInfoInterstitial from '@cdo/apps/schoolInfo/SchoolInfoInterstitial';
 import {updateSchoolInfo} from '@cdo/apps/schoolInfo/utils/updateSchoolInfo';
 import {
-  CLICK_TO_ADD,
-  NO_SCHOOL_SETTING,
-  SELECT_A_SCHOOL,
   SELECT_COUNTRY,
   US_COUNTRY_CODE,
 } from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 // Mock the dependencies
@@ -212,7 +210,7 @@ describe('SchoolInfoInterstitial', () => {
             ...defaultProps.scriptData,
             existingSchoolInfo: {
               country: SELECT_COUNTRY,
-              school_id: SELECT_A_SCHOOL,
+              school_id: NonSchoolOptions.SELECT_A_SCHOOL,
               school_name: '',
               school_zip: '',
             },
@@ -252,7 +250,7 @@ describe('SchoolInfoInterstitial', () => {
             ...defaultProps.scriptData,
             existingSchoolInfo: {
               country: US_COUNTRY_CODE,
-              school_id: SELECT_A_SCHOOL,
+              school_id: NonSchoolOptions.SELECT_A_SCHOOL,
               school_name: '',
               school_zip: '12345',
             },
@@ -271,7 +269,7 @@ describe('SchoolInfoInterstitial', () => {
             ...defaultProps.scriptData,
             existingSchoolInfo: {
               country: US_COUNTRY_CODE,
-              school_id: NO_SCHOOL_SETTING,
+              school_id: NonSchoolOptions.NO_SCHOOL_SETTING,
               school_name: '',
               school_zip: '12345',
             },
@@ -317,7 +315,7 @@ describe('SchoolInfoInterstitial', () => {
             ...defaultProps.scriptData,
             existingSchoolInfo: {
               country: 'US',
-              school_id: CLICK_TO_ADD,
+              school_id: NonSchoolOptions.CLICK_TO_ADD,
               school_name: 'Cool School',
               school_zip: '12345',
             },
@@ -342,7 +340,7 @@ describe('SchoolInfoInterstitial', () => {
             ...defaultProps.scriptData,
             existingSchoolInfo: {
               country: 'UK',
-              school_id: SELECT_A_SCHOOL,
+              school_id: NonSchoolOptions.SELECT_A_SCHOOL,
               school_name: '',
               school_zip: '',
             },
@@ -361,7 +359,7 @@ describe('SchoolInfoInterstitial', () => {
             ...defaultProps.scriptData,
             existingSchoolInfo: {
               country: 'UK',
-              school_id: SELECT_A_SCHOOL,
+              school_id: NonSchoolOptions.SELECT_A_SCHOOL,
               school_name: 'UK School',
               school_zip: '',
             },

--- a/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
+++ b/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
@@ -3,15 +3,13 @@ import {act, renderHook} from '@testing-library/react-hooks';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useSchoolInfo} from '@cdo/apps/schoolInfo/hooks/useSchoolInfo';
 import {
-  CLICK_TO_ADD,
-  NO_SCHOOL_SETTING,
   SCHOOL_COUNTRY_SESSION_KEY,
   SCHOOL_ID_SESSION_KEY,
   SCHOOL_NAME_SESSION_KEY,
   SCHOOL_ZIP_SESSION_KEY,
-  SELECT_A_SCHOOL,
   US_COUNTRY_CODE,
 } from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 
 jest.mock('@cdo/apps/metrics/AnalyticsReporter');
 jest.mock('@cdo/apps/util/AuthenticityTokenStore');
@@ -95,7 +93,7 @@ describe('useSchoolInfo', () => {
     // sessionStorage state does not have a valid zip code, so no need to await anything
 
     expect(result.current.country).toBe('CA');
-    expect(result.current.schoolId).toBe(SELECT_A_SCHOOL);
+    expect(result.current.schoolId).toBe(NonSchoolOptions.SELECT_A_SCHOOL);
     expect(result.current.schoolName).toBe('Stored School');
     expect(result.current.schoolZip).toBe('');
   });
@@ -265,7 +263,7 @@ describe('useSchoolInfo', () => {
 
       it('should send analytics events', () => {
         act(() => {
-          hook.current.setSchoolId(NO_SCHOOL_SETTING);
+          hook.current.setSchoolId(NonSchoolOptions.NO_SCHOOL_SETTING);
         });
 
         expect(sendAnalyticsEventSpy).toHaveBeenCalledWith(
@@ -275,7 +273,7 @@ describe('useSchoolInfo', () => {
         );
 
         act(() => {
-          hook.current.setSchoolId(CLICK_TO_ADD);
+          hook.current.setSchoolId(NonSchoolOptions.CLICK_TO_ADD);
         });
 
         expect(sendAnalyticsEventSpy).toHaveBeenCalledWith(

--- a/apps/test/unit/schoolInfo/utils/buildSchoolDataTest.js
+++ b/apps/test/unit/schoolInfo/utils/buildSchoolDataTest.js
@@ -1,10 +1,6 @@
 import {buildSchoolData} from '@cdo/apps/schoolInfo/utils/buildSchoolData';
-import {
-  CLICK_TO_ADD,
-  NO_SCHOOL_SETTING,
-  SELECT_A_SCHOOL,
-  US_COUNTRY_CODE,
-} from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {US_COUNTRY_CODE} from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 
 describe('buildSchoolData', () => {
   describe('country is US', () => {
@@ -45,7 +41,7 @@ describe('buildSchoolData', () => {
 
     it('should return school info with country and school_name when schoolId is CLICK_TO_ADD', () => {
       const result = buildSchoolData({
-        schoolId: CLICK_TO_ADD,
+        schoolId: NonSchoolOptions.CLICK_TO_ADD,
         country: US_COUNTRY_CODE,
         schoolName: 'Test School',
         schoolZip: '54321',
@@ -63,7 +59,7 @@ describe('buildSchoolData', () => {
 
     it('should return school info with country and school_name when schoolId is SELECT_A_SCHOOL', () => {
       const result = buildSchoolData({
-        schoolId: SELECT_A_SCHOOL,
+        schoolId: NonSchoolOptions.SELECT_A_SCHOOL,
         country: US_COUNTRY_CODE,
         schoolName: 'Test School',
         schoolZip: '54321',
@@ -81,7 +77,7 @@ describe('buildSchoolData', () => {
 
     it('should return school info with country and school_type when schoolId is NO_SCHOOL_SETTING', () => {
       const result = buildSchoolData({
-        schoolId: NO_SCHOOL_SETTING,
+        schoolId: NonSchoolOptions.NO_SCHOOL_SETTING,
         country: 'US',
         schoolName: 'Test School',
         schoolZip: '54321',
@@ -91,7 +87,7 @@ describe('buildSchoolData', () => {
         user: {
           school_info_attributes: {
             country: 'US',
-            school_type: NO_SCHOOL_SETTING,
+            school_type: NonSchoolOptions.NO_SCHOOL_SETTING,
           },
         },
       });
@@ -122,7 +118,7 @@ describe('buildSchoolData', () => {
       // changing country would not clear schoolId due to persisting form state
       // non-us country should override existence of schoolId = NO_SCHOOL_SETTING
       const result = buildSchoolData({
-        schoolId: NO_SCHOOL_SETTING,
+        schoolId: NonSchoolOptions.NO_SCHOOL_SETTING,
         country: 'CA',
         schoolName: 'Cool School',
         schoolZip: '54321',

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -8,11 +8,13 @@ import {
   SCHOOL_ID_SESSION_KEY,
   SCHOOL_NAME_SESSION_KEY,
   SCHOOL_ZIP_SESSION_KEY,
-  SELECT_A_SCHOOL,
 } from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import {navigateToHref} from '@cdo/apps/utils';
-import {UserTypes} from '@cdo/generated-scripts/sharedConstants';
+import {
+  UserTypes,
+  NonSchoolOptions,
+} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 jest.mock('@cdo/apps/schoolInfo/utils/fetchSchools');
@@ -84,7 +86,6 @@ describe('FinishTeacherAccount', () => {
   it('school info is tracked in sessionStorage', () => {
     renderDefault();
     const zipCode = '98122';
-    const clickToAddSchool = 'clickToAdd';
     const schoolName = 'Seattle Academy';
 
     // Fill out zip code and add school by name
@@ -92,14 +93,14 @@ describe('FinishTeacherAccount', () => {
       target: {value: zipCode},
     });
     fireEvent.change(screen.getAllByRole('combobox')[1], {
-      target: {value: clickToAddSchool},
+      target: {value: NonSchoolOptions.CLICK_TO_ADD},
     });
     fireEvent.change(screen.getAllByRole('textbox')[2], {
       target: {value: schoolName},
     });
 
     expect(sessionStorage.getItem(SCHOOL_ID_SESSION_KEY)).toBe(
-      clickToAddSchool
+      NonSchoolOptions.CLICK_TO_ADD
     );
     expect(sessionStorage.getItem(SCHOOL_ZIP_SESSION_KEY)).toBe(zipCode);
     expect(sessionStorage.getItem(SCHOOL_NAME_SESSION_KEY)).toBe(schoolName);
@@ -188,8 +189,8 @@ describe('FinishTeacherAccount', () => {
         email: email,
         name: name,
         email_preference_opt_in: true,
-        school: SELECT_A_SCHOOL,
-        school_id: SELECT_A_SCHOOL,
+        school: NonSchoolOptions.SELECT_A_SCHOOL,
+        school_id: NonSchoolOptions.SELECT_A_SCHOOL,
         school_zip: '',
         school_name: '',
         school_country: 'US',

--- a/apps/test/unit/templates/SchoolDataInputsTest.jsx
+++ b/apps/test/unit/templates/SchoolDataInputsTest.jsx
@@ -2,11 +2,8 @@ import '@testing-library/jest-dom';
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 
-import {
-  CLICK_TO_ADD,
-  SELECT_A_SCHOOL,
-} from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import SchoolDataInputs from '@cdo/apps/templates/SchoolDataInputs';
+import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 describe('SchoolDataInputs', () => {
@@ -99,7 +96,7 @@ describe('SchoolDataInputs', () => {
   });
 
   it('dropdown switches to input box if user clicks to add', () => {
-    renderDefault({country: 'US', schoolId: CLICK_TO_ADD});
+    renderDefault({country: 'US', schoolId: NonSchoolOptions.CLICK_TO_ADD});
     expect(
       screen.getByText(i18n.schoolOrganizationQuestion())
     ).toBeInTheDocument();
@@ -108,7 +105,7 @@ describe('SchoolDataInputs', () => {
   it('goes back to dropdown if user clicks return to results list', () => {
     renderDefault({
       country: 'US',
-      schoolId: SELECT_A_SCHOOL,
+      schoolId: NonSchoolOptions.SELECT_A_SCHOOL,
     });
     expect(screen.getByText(i18n.selectYourSchool())).toBeInTheDocument();
   });

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -750,6 +750,12 @@ module SharedConstants
     TEACHER: 'teacher',
   ).freeze
 
+  NON_SCHOOL_OPTIONS = OpenStruct.new(
+    SELECT_A_SCHOOL: 'selectASchool',
+    CLICK_TO_ADD: 'clickToAdd',
+    NO_SCHOOL_SETTING: 'noSchoolSetting'
+  ).freeze
+
   AI_REQUEST_EXECUTION_STATUS = {
     # The request has been created but has not yet been processed.
     NOT_STARTED: 0,


### PR DESCRIPTION
Currently, the additional school dropdown options (`selectASchool`, `clickToAdd`, `noSchoolSetting`) are defined in an `apps` constant file here. I'm currently working on making sure our new user signup flow can properly set up `SchoolInfo` and `UserSchoolInfo` entries when needed, so I'll need to access those constants on the backend. This PR moves those constants so they're shared across backend and frontend.

Note: I did have to make [one change here](https://github.com/code-dot-org/code-dot-org/pull/61498/files#diff-f3d1024c24577475f3e3f77000cc5c164d1856b24a68d54bf3a4ad94c9d563edR25) because of the following TypeScript error I was seeing:
![previousIncludes](https://github.com/user-attachments/assets/6074a10f-d54f-450e-8002-6acf68b1c509)

## Testing story
Successfully locally ran all test files of files touched by this change.
