### PR TITLE
[JIMT][CT-835] - added keyboard traps to dialogs

### DIFF
--- a/apps/src/lab2/hooks/index.ts
+++ b/apps/src/lab2/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useKeyboardTrap';
+export * from './useLifecycleNotifier';

--- a/apps/src/lab2/hooks/useKeyboardTrap.ts
+++ b/apps/src/lab2/hooks/useKeyboardTrap.ts
@@ -1,0 +1,34 @@
+import {useEffect} from 'react';
+
+/* useful to trap keypresses on the document. Give it a string + a callback function, and whenever that key is typed,
+   the callback is called.
+
+   Most useful with helper Enter / Escape hooks for dialogs.
+
+   Note that your callback will -not- receive the keyboard event.
+*/
+
+type keyboardTrapCallback = () => void;
+
+export const useKeyboardTrap = (
+  key: string,
+  callback: keyboardTrapCallback
+) => {
+  useEffect(() => {
+    const callbackRelay = (e: KeyboardEvent) => {
+      if (e.key === key) {
+        callback();
+      }
+    };
+
+    document.addEventListener('keydown', callbackRelay);
+
+    return () => document.removeEventListener('keydown', callbackRelay);
+  }, [key, callback]);
+};
+
+export const useEscapeKeyboardTrap = (callback: keyboardTrapCallback) =>
+  useKeyboardTrap('Escape', callback);
+
+export const useEnterKeyboardTrap = (callback: keyboardTrapCallback) =>
+  useKeyboardTrap('Enter', callback);

--- a/apps/src/lab2/views/dialogs/GenericDialog.tsx
+++ b/apps/src/lab2/views/dialogs/GenericDialog.tsx
@@ -1,8 +1,12 @@
 import FocusTrap from 'focus-trap-react';
-import React from 'react';
+import React, {useCallback} from 'react';
 
 import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
 import {BodyTwoText, Heading3} from '@cdo/apps/componentLibrary/typography';
+import {
+  useEnterKeyboardTrap,
+  useEscapeKeyboardTrap,
+} from '@cdo/apps/lab2/hooks';
 import commonI18n from '@cdo/locale';
 
 import {useDialogControl} from './DialogControlContext';
@@ -59,16 +63,21 @@ import moduleStyles from './generic-dialog.module.scss';
  * If no confirm button text is provided, the default text is "OK" (translatable).
  */
 
-const closingCallback =
-  (
-    closeDialog: DialogCloseFunctionType,
-    closeType: DialogCloseActionType,
-    callback: dialogCallback | undefined
-  ) =>
-  () => {
+type UseClosingCallbackArgs = {
+  closeDialog: DialogCloseFunctionType;
+  closeType: DialogCloseActionType;
+  callback: dialogCallback | undefined;
+};
+
+const useClosingCallback = ({
+  closeDialog,
+  closeType,
+  callback,
+}: UseClosingCallbackArgs) =>
+  useCallback(() => {
     closeDialog(closeType);
     callback && callback();
-  };
+  }, [closeDialog, closeType, callback]);
 
 const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
   buttons,
@@ -78,6 +87,27 @@ const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
   bodyComponent,
 }) => {
   const dialogControl = useDialogControl();
+
+  const cancelCallback = useClosingCallback({
+    closeDialog: dialogControl.closeDialog,
+    closeType: 'cancel',
+    callback: buttons?.cancel?.callback,
+  });
+
+  const neutralCallback = useClosingCallback({
+    closeDialog: dialogControl.closeDialog,
+    closeType: 'neutral',
+    callback: buttons?.neutral?.callback,
+  });
+
+  const confirmCallback = useClosingCallback({
+    closeDialog: dialogControl.closeDialog,
+    closeType: 'confirm',
+    callback: buttons?.confirm?.callback,
+  });
+
+  useEscapeKeyboardTrap(cancelCallback);
+  useEnterKeyboardTrap(confirmCallback);
 
   return (
     <FocusTrap>
@@ -93,11 +123,7 @@ const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
           <div className={moduleStyles.outerButtonContainer}>
             {buttons?.cancel ? (
               <Button
-                onClick={closingCallback(
-                  dialogControl.closeDialog,
-                  'cancel',
-                  buttons.cancel.callback
-                )}
+                onClick={cancelCallback}
                 className={moduleStyles.cancel}
                 type="secondary"
                 disabled={buttons.cancel.disabled}
@@ -110,11 +136,7 @@ const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
             <div className={moduleStyles.innerButtonContainer}>
               {buttons?.neutral && (
                 <Button
-                  onClick={closingCallback(
-                    dialogControl.closeDialog,
-                    'neutral',
-                    buttons.neutral.callback
-                  )}
+                  onClick={neutralCallback}
                   type="secondary"
                   disabled={buttons.neutral.disabled}
                   color={buttonColors.gray}
@@ -122,11 +144,7 @@ const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
                 />
               )}
               <Button
-                onClick={closingCallback(
-                  dialogControl.closeDialog,
-                  'confirm',
-                  buttons?.confirm?.callback
-                )}
+                onClick={confirmCallback}
                 disabled={buttons?.confirm?.disabled}
                 type="primary"
                 color={

--- a/apps/src/lab2/views/dialogs/GenericDialog.tsx
+++ b/apps/src/lab2/views/dialogs/GenericDialog.tsx
@@ -67,17 +67,21 @@ type UseClosingCallbackArgs = {
   closeDialog: DialogCloseFunctionType;
   closeType: DialogCloseActionType;
   callback: dialogCallback | undefined;
+  disabled: boolean | undefined;
 };
 
 const useClosingCallback = ({
   closeDialog,
   closeType,
   callback,
+  disabled,
 }: UseClosingCallbackArgs) =>
   useCallback(() => {
-    closeDialog(closeType);
-    callback && callback();
-  }, [closeDialog, closeType, callback]);
+    if (!disabled) {
+      closeDialog(closeType);
+      callback && callback();
+    }
+  }, [closeDialog, closeType, callback, disabled]);
 
 const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
   buttons,
@@ -92,18 +96,21 @@ const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
     closeDialog: dialogControl.closeDialog,
     closeType: 'cancel',
     callback: buttons?.cancel?.callback,
+    disabled: buttons?.cancel?.disabled,
   });
 
   const neutralCallback = useClosingCallback({
     closeDialog: dialogControl.closeDialog,
     closeType: 'neutral',
     callback: buttons?.neutral?.callback,
+    disabled: buttons?.neutral?.disabled,
   });
 
   const confirmCallback = useClosingCallback({
     closeDialog: dialogControl.closeDialog,
     closeType: 'confirm',
     callback: buttons?.confirm?.callback,
+    disabled: buttons?.confirm?.disabled,
   });
 
   useEscapeKeyboardTrap(cancelCallback);

--- a/apps/src/lab2/views/dialogs/GenericPrompt.tsx
+++ b/apps/src/lab2/views/dialogs/GenericPrompt.tsx
@@ -91,8 +91,8 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
         confirm: {
           callback: () => handleConfirm?.(prompt),
           disabled:
-            requiresPrompt !== false &&
-            (Boolean(errorMessage) || !prompt.length),
+            Boolean(errorMessage) ||
+            (requiresPrompt === true && !prompt.length),
         },
         cancel: {callback: () => handleCancel?.()},
       }}

--- a/apps/src/lab2/views/dialogs/GenericPrompt.tsx
+++ b/apps/src/lab2/views/dialogs/GenericPrompt.tsx
@@ -90,9 +90,7 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
       buttons={{
         confirm: {
           callback: () => handleConfirm?.(prompt),
-          disabled:
-            Boolean(errorMessage) ||
-            (requiresPrompt === true && !prompt.length),
+          disabled: Boolean(errorMessage) || (requiresPrompt && !prompt.length),
         },
         cancel: {callback: () => handleCancel?.()},
       }}


### PR DESCRIPTION
Our dialogs from lab2's dialogControl were keyboard accessible with tabs, but wouldn't automatically respond to `Enter` (for the command button) or `Escape` (for the cancel button).

Extends the dialogs with a simple keyboard trap to respond to those keypresses when the dialogs are open.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CT-835](https://codedotorg.atlassian.net/browse/CT-835)


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
