### PR TITLE
Python Lab validation: fix small start mode bug

### DIFF
--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -7,7 +7,7 @@ import {LanguageSupport} from '@codemirror/language';
 import React, {useContext, useEffect, useState} from 'react';
 
 import {sendPredictLevelReport} from '@cdo/apps/code-studio/progressRedux';
-import {MAIN_PYTHON_FILE} from '@cdo/apps/lab2/constants';
+import {MAIN_PYTHON_FILE, START_SOURCES} from '@cdo/apps/lab2/constants';
 import {ProgressManagerContext} from '@cdo/apps/lab2/progress/ProgressContainer';
 import {isPredictAnswerLocked} from '@cdo/apps/lab2/redux/predictLevelRedux';
 import {MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
@@ -15,6 +15,7 @@ import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import {AppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import useLifecycleNotifier from '../lab2/hooks/useLifecycleNotifier';
+import {getAppOptionsEditBlocks} from '../lab2/projects/utils';
 
 import PythonValidationTracker from './progress/PythonValidationTracker';
 import PythonValidator from './progress/PythonValidator';
@@ -108,6 +109,7 @@ const PythonlabView: React.FunctionComponent = () => {
   const predictAnswerLocked = useAppSelector(isPredictAnswerLocked);
   const progressManager = useContext(ProgressManagerContext);
   const appName = useAppSelector(state => state.lab.levelProperties?.appName);
+  const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
 
   useEffect(() => {
     if (progressManager && appName === 'pythonlab') {
@@ -128,12 +130,14 @@ const PythonlabView: React.FunctionComponent = () => {
     dispatch: AppDispatch,
     source: MultiFileSource | undefined
   ) => {
+    // We don't send the validation file to the runner if we are in start mode,
+    // as we want to use the validation from the sources instead.
     await handleRunClick(
       runTests,
       dispatch,
       source,
       progressManager,
-      validationFile
+      isStartMode ? undefined : validationFile
     );
     // Only send a predict level report if this is a predict level and the predict
     // answer was not locked.


### PR DESCRIPTION
Bug fix from #61463. If you loaded a level with validation in start mode, then changed the validation, we would still run the validation from the level rather than the validation from the updated start code. This fixes that bug.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
