### PR TITLE
[Music] Use redux state for playback events during validation

### DIFF
--- a/apps/src/music/player/sequencer/AdvancedSequencer.ts
+++ b/apps/src/music/player/sequencer/AdvancedSequencer.ts
@@ -99,8 +99,10 @@ export default class AdvancedSequencer extends Sequencer {
     return this.playbackEvents;
   }
 
-  clear(): void {
-    this.playbackEvents = [];
+  clear(preserveEvents?: boolean): void {
+    if (!preserveEvents) {
+      this.playbackEvents = [];
+    }
     this.effects = {};
   }
 

--- a/apps/src/music/player/sequencer/AdvancedSequencer.ts
+++ b/apps/src/music/player/sequencer/AdvancedSequencer.ts
@@ -99,10 +99,8 @@ export default class AdvancedSequencer extends Sequencer {
     return this.playbackEvents;
   }
 
-  clear(preserveEvents?: boolean): void {
-    if (!preserveEvents) {
-      this.playbackEvents = [];
-    }
+  clear(): void {
+    this.playbackEvents = [];
     this.effects = {};
   }
 

--- a/apps/src/music/player/sequencer/Simple2Sequencer.ts
+++ b/apps/src/music/player/sequencer/Simple2Sequencer.ts
@@ -62,11 +62,9 @@ export default class Simple2Sequencer extends Sequencer {
   /**
    * Resets to the default new sequence and clears all sequenced events
    */
-  clear(preserveEvents?: boolean) {
+  clear() {
     this.newSequence();
-    if (!preserveEvents) {
-      this.functionMap = {};
-    }
+    this.functionMap = {};
   }
 
   getLastMeasure(): number {

--- a/apps/src/music/player/sequencer/Simple2Sequencer.ts
+++ b/apps/src/music/player/sequencer/Simple2Sequencer.ts
@@ -62,9 +62,11 @@ export default class Simple2Sequencer extends Sequencer {
   /**
    * Resets to the default new sequence and clears all sequenced events
    */
-  clear() {
+  clear(preserveEvents?: boolean) {
     this.newSequence();
-    this.functionMap = {};
+    if (!preserveEvents) {
+      this.functionMap = {};
+    }
   }
 
   getLastMeasure(): number {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -502,7 +502,7 @@ class UnconnectedMusicView extends React.Component {
       return;
     }
 
-    this.sequencer.clear();
+    this.sequencer.clear(true /* Do not clear events */);
     this.musicBlocklyWorkspace.executeTrigger(id, triggerStartPosition);
     const playbackEvents = this.sequencer.getPlaybackEvents();
     this.props.addPlaybackEvents({

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -108,6 +108,7 @@ class UnconnectedMusicView extends React.Component {
     clearCallout: PropTypes.func,
     isPlayView: PropTypes.bool,
     blockMode: PropTypes.string,
+    playbackEvents: PropTypes.array,
   };
 
   constructor(props) {
@@ -382,7 +383,7 @@ class UnconnectedMusicView extends React.Component {
   };
 
   getPlaybackEvents = () => {
-    return this.sequencer.getPlaybackEvents();
+    return this.props.playbackEvents;
   };
 
   getCurrentPlayheadPosition = () => {
@@ -502,7 +503,7 @@ class UnconnectedMusicView extends React.Component {
       return;
     }
 
-    this.sequencer.clear(true /* Do not clear events */);
+    this.sequencer.clear();
     this.musicBlocklyWorkspace.executeTrigger(id, triggerStartPosition);
     const playbackEvents = this.sequencer.getPlaybackEvents();
     this.props.addPlaybackEvents({
@@ -719,6 +720,7 @@ const MusicView = connect(
     isReadOnlyWorkspace: isReadOnlyWorkspace(state),
     startingPlayheadPosition: state.music.startingPlayheadPosition,
     isPlayView: state.lab.isShareView,
+    playbackEvents: state.music.playbackEvents,
   }),
   dispatch => ({
     setPackId: packId => dispatch(setPackId(packId)),


### PR DESCRIPTION
I found an interesting bug where we lose count of playedNumberSounds if there’s a trigger. this level should pass as soon as three sounds play, but it only does if you don’t press a trigger button:

https://github.com/user-attachments/assets/465a2d26-f4ed-417d-ae58-0b21fd3d7b0e

Interestingly, you can pass if the trigger results in three sounds being played, but we’re still ignoring the “when run” sounds:


https://github.com/user-attachments/assets/91756efd-51b8-452c-ad9c-edbd0db8e839



~~When `playTrigger` is called (by clicking on the beat-pad buttons), it calls `this.sequencer.clear();` `Simple2Sequencer.clear` wipes `this.functionMap` (Simple2) or `this.playbackEvents` (Advanced). (`Simple2Sequencer.getPlaybackEvents` looks at the ordered functions to determine where to look for playback events.)~~

~~This fixes the problem _with the assumption that there isn't a need to clear the function map or list of playback events when the sequencer is cleared for a trigger_.~~

After discussing with @sanchitmalhotra126, we agreed that the right fix for this is to update the way we get playback events during validation. Specifically, we should use Redux as the source of truth.

Now, triggered playback events are counted and we don't lose track of the playback events for the "when run" context:

https://github.com/user-attachments/assets/cfd0e2b6-2781-4d64-85da-50081b00661e


Note: This work also unblocks [another PR](https://github.com/code-dot-org/code-dot-org/pull/61491) which adds a condition for detecting multiple triggered sounds (by pressing a beat pad button repeatedly). Each press was wiping the playback events so we could never count more than 1.

