### PR TITLE
Defaulting to test wide timeout for reset progress for flaky test multiple_choice_contained_levels.feature

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
@@ -66,7 +66,7 @@ Scenario: Teacher can reset progress on multiple choice contained level
   And I am on "http://studio.code.org/s/allthethings/lessons/41/levels/2"
   And I wait for the lab page to fully load
   Then I press "unchecked_0"
-  And I wait until element "#checked_0" is visible
+  And I wait up to 5 seconds for element "#checked_0" to be visible
   Then I press "runButton"
   And I verify progress in the header of the current page is "perfect" for level 2
   Then I press "resetButton"
@@ -75,7 +75,7 @@ Scenario: Teacher can reset progress on multiple choice contained level
   And I wait for 5 seconds
   And I verify progress in the header of the current page is "not_tried" for level 2
   Then I press "unchecked_1"
-  And I wait until element "#checked_1" is visible
+  And I wait up to 5 seconds for element "#checked_1" to be visible
   Then I press "runButton"
   Then I press "resetButton"
   And I verify progress in the header of the current page is "perfect" for level 2
@@ -85,16 +85,16 @@ Scenario: Student can retry multiple choice contained level that allows multiple
   And I rotate to landscape
   And I wait for the lab page to fully load
   Then I press "unchecked_0"
-  And I wait until element "#checked_0" is visible
+  And I wait up to 5 seconds for element "#checked_0" to be visible
   Then I press "runButton"
   Then I press "resetButton"
   And I verify progress in the header of the current page is "perfect" for level 10
   Then I press "unchecked_1"
-  And I wait until element "#checked_1" is visible
+  And I wait up to 5 seconds for element "#checked_1" to be visible
   Then I press "runButton"
   Then I press "resetButton"
   And I verify progress in the header of the current page is "perfect" for level 10
   Then I am on "http://studio.code.org/s/allthethings/lessons/41/levels/10"
   And I rotate to landscape
   And I wait for the lab page to fully load
-  And I wait until element "#checked_1" is visible
+  And I wait up to 5 seconds for element "#checked_1" to be visible

--- a/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/multiple_choice_contained_levels.feature
@@ -66,16 +66,16 @@ Scenario: Teacher can reset progress on multiple choice contained level
   And I am on "http://studio.code.org/s/allthethings/lessons/41/levels/2"
   And I wait for the lab page to fully load
   Then I press "unchecked_0"
-  And I wait up to 5 seconds for element "#checked_0" to be visible
+  And I wait until element "#checked_0" is visible
   Then I press "runButton"
   And I verify progress in the header of the current page is "perfect" for level 2
   Then I press "resetButton"
   Then I click selector "button:contains('Delete Answer')"
-  And I wait up to 5 seconds for element "#unchecked_0" to be visible
+  And I wait until element "#unchecked_0" is visible
   And I wait for 5 seconds
   And I verify progress in the header of the current page is "not_tried" for level 2
   Then I press "unchecked_1"
-  And I wait up to 5 seconds for element "#checked_1" to be visible
+  And I wait until element "#checked_1" is visible
   Then I press "runButton"
   Then I press "resetButton"
   And I verify progress in the header of the current page is "perfect" for level 2
@@ -85,16 +85,16 @@ Scenario: Student can retry multiple choice contained level that allows multiple
   And I rotate to landscape
   And I wait for the lab page to fully load
   Then I press "unchecked_0"
-  And I wait up to 5 seconds for element "#checked_0" to be visible
+  And I wait until element "#checked_0" is visible
   Then I press "runButton"
   Then I press "resetButton"
   And I verify progress in the header of the current page is "perfect" for level 10
   Then I press "unchecked_1"
-  And I wait up to 5 seconds for element "#checked_1" to be visible
+  And I wait until element "#checked_1" is visible
   Then I press "runButton"
   Then I press "resetButton"
   And I verify progress in the header of the current page is "perfect" for level 10
   Then I am on "http://studio.code.org/s/allthethings/lessons/41/levels/10"
   And I rotate to landscape
   And I wait for the lab page to fully load
-  And I wait up to 5 seconds for element "#checked_1" to be visible
+  And I wait until element "#checked_1" is visible


### PR DESCRIPTION
There are two root causes for flakiness in multiple_choice_contained_levels.feature,

1. There is no progress bar in the header
2. The choice continues to be checked after user clicks "Delete Answer"

This PR focuses on #2 above. When looking at a few different test runs, the API call to `POST /delete_predict_level_progress` [takes under 100 ms in successful cases](https://app.saucelabs.com/tests/f2557765fbb14f6396b321fa1ce5336e#71), while in case of failures, [the call takes over 2 seconds](https://app.saucelabs.com/tests/8cdc1ee137c54d15a3d9efae0c50bdf6#99) and in some cases the[ test exists before the call completes](https://app.saucelabs.com/tests/05ffcc7181984814b8471a41d695fa0d#87). 

While trying this scenario manually, I noticed a fairly long delay performing this action on test. 

Fix: The test currently has an upper limit of 5 seconds for the action to complete and UI reflect the change.  This change would remove the upper limit and have this step also fall back to the test wide timeout. 

There is a follow up here worth pursuing if this helps but results in a large latency. Added that in this https://codedotorg.atlassian.net/browse/TEACH-1383 to track.

## Links

JIRA https://codedotorg.atlassian.net/browse/TEACH-1383

## Testing story

Drone

## Deployment strategy

Regular DTP

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
