### PR TITLE
Making the manage student table selection step more resilient in UI tests.

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -15,7 +15,7 @@ Feature: Using the manage students tab of the teacher dashboard
 
     # Add a family name for Sally
     And I click selector "#uitest-manage-students-table th:contains(Actions) i" once I see it
-    And I click selector ".pop-up-menu-item:contains(Edit all)"
+    And I click selector ".pop-up-menu-item:contains(Edit all)" once I see it
     And I wait until element with css selector "input[name='uitest-family-name']" is enabled
     And I press keys "SallyAlsoHasAVeryVeryLongLastName" for element "input[name='uitest-family-name']"
     And I wait until element "input[value='SallyAlsoHasAVeryVeryLongLastName']" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -15,7 +15,7 @@ Feature: Using the manage students tab of the teacher dashboard
 
     # Add a family name for Sally
     And I click selector "#uitest-manage-students-table th:contains(Actions) i" once I see it
-    And I press the child number 0 of class ".pop-up-menu-item"
+    And I click selector ".pop-up-menu-item:contains(Edit all)"
     And I wait until element with css selector "input[name='uitest-family-name']" is enabled
     And I press keys "SallyAlsoHasAVeryVeryLongLastName" for element "input[name='uitest-family-name']"
     And I wait until element "input[value='SallyAlsoHasAVeryVeryLongLastName']" is visible


### PR DESCRIPTION
Issue: The manage student table eyes test intermittently fails at the step to input student's family name. This happens because the click event on the "Edit all" pop up menu item is registered before the pop-up menu is visible, resulting in the actual family name field never getting to editable state. 

Example failure https://app.saucelabs.com/tests/0a163c738901424ba26ac2ae74cb538b#82

Fix: 
- Include a step to ensure the pop up menu is visible
- Additionally, update the selection criteria in the pop-up menu to be more specific (as there is a new pop up menu with state column in that table)

## Links

JIRA https://codedotorg.atlassian.net/browse/TEACH-1262

## Testing story

- Drone
- Additionally ran eyes tests in drone to cover this change

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Regular DTP

## Follow-up work

Continue monitoring failure rate for this test to ensure fixes are helping

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
