### PR TITLE
Print metrics exception to console on dev

### DIFF
--- a/lib/cdo/aws/metrics.rb
+++ b/lib/cdo/aws/metrics.rb
@@ -49,6 +49,7 @@ module Cdo
         )
       rescue => exception
         Honeybadger.notify(exception)
+        puts "Error sending metrics: #{exception.full_message}" if rack_env?(:development)
       end
 
       def size(events)


### PR DESCRIPTION
Print exception details to the console if we receive an exception trying to send Cloudwatch metrics on development, for developer visibility. 

Recent motivation: @fisher-alice was working on a change in AI Chat to add some metrics reporting and trying to debug why metrics were not appearing in Cloudwatch. She eventually discovered that there was an issue in the payload format, but this took a long period of debugging that could have been mitigated if we were able to see the exception details in the console.

## Testing story

Tested locally; able to see errors when the buffer is flushed.