### PR TITLE
Revert "Removing cookie banner from embedded projects"

### DIFF
--- a/dashboard/test/ui/features/platform/one_trust.feature
+++ b/dashboard/test/ui/features/platform/one_trust.feature
@@ -29,7 +29,7 @@ Feature: OneTrust integration
     Given I am in Europe
     Given I am on "http://studio.code.org/home?otreset=true&otgeo=es"
     And I wait until element "#onetrust-banner-sdk" is visible
-
+  
   Scenario: The pages load the self hosted OneTrust libraries.
     Given I am on "http://studio.code.org/users/sign_in"
     Then element "script[src$='onetrust/cdo/scripttemplates/otSDKStub.js']" does exist
@@ -60,7 +60,7 @@ Feature: OneTrust integration
     Then element "script[src$='977d/OtAutoBlock.js']" does exist
     Then element "script[src$='977d-test/OtAutoBlock.js']" does not exist
     Then element "script[src$='onetrust/scripttemplates/otSDKStub.js']" does not exist
-
+    
     Given I am on "http://hourofcode.com/us"
     And I use a cookie to mock the DCDO key "onetrust_cookie_scripts" as "prod"
     Given I am on "http://hourofcode.com/us"
@@ -109,28 +109,9 @@ Feature: OneTrust integration
     Then element "script[src*='/common_locale']" is not categorized by OneTrust
     Then element "script[src*='js/code-studio-common']" is not categorized by OneTrust
     Then element "script[src*='js/code-studio']" is not categorized by OneTrust
-  Examples:
+
+    Examples:
     | url                                                                     |
     | http://code.org/index                                                   |
     | http://hourofcode.com/us                                                |
     | http://studio.code.org/users/sign_in                                    |
-
-  @as_student
-  Scenario Outline: Embedded projects do not display the OneTrust banner
-    Given I am in Europe
-    Given I am on "<url>"
-    Then I switch to the embedded view of current project
-    Then I append "?otreset=true&otgeo=es" to the URL
-    Then element "script[src$='otSDKStub.js']" does not exist
-    Then element "script[src$='OtAutoBlock.js']" does not exist
-  Examples:
-    | url                                                                    |
-    | http://studio.code.org/projects/music/new                              |
-    | http://studio.code.org/projects/spritelab/new                          |
-    | http://studio.code.org/projects/artist/new                             |
-    | http://studio.code.org/projects/gamelab/new                            |
-    | http://studio.code.org/projects/dance/new                              |
-    | http://studio.code.org/projects/applab/new                             |
-    | http://studio.code.org/projects/poetry/new                             |
-    | http://studio.code.org/projects/flappy/new                             |
-    | http://studio.code.org/projects/frozen/new                             |

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1334,11 +1334,6 @@ Then /^I append "([^"]*)" to the URL$/ do |append|
   @browser.navigate.to url
 end
 
-Then /^I switch to the embedded view of current project$/ do
-  embed_url = @browser.current_url.sub('/edit', '/embed')
-  @browser.navigate.to embed_url
-end
-
 Then /^selector "([^"]*)" has class "(.*?)"$/ do |selector, class_name|
   item = @browser.find_element(:css, selector)
   classes = item.attribute("class")

--- a/shared/haml/onetrust_cookie_scripts.haml
+++ b/shared/haml/onetrust_cookie_scripts.haml
@@ -1,11 +1,5 @@
 - require deploy_dir('shared/middleware/helpers/experiments')
 
--# When student projects are embedded in other websites, the URL ends with
--# /embed. When Code.org is rendered in an iframe on another website, we are not
--# responsible for getting user consent for Cookies and Tracking Technologies,
--# therefore, we don't need to display the OneTrust banner requesting consent.
-- return if request&.path&.ends_with?('/embed')
-
 -# OneTrust Cookies Consent Notice scripts for code.org
 -# default to loading the prod OneTrust configuration.
 - onetrust_version = experiment_value('onetrust_cookie_scripts', request) || 'self_hosted'


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#60902

The new test scenario was failing repeatedly on the test server (maybe it never passed? I might have gotten confused). Out of caution I'm reverting.

Here's a cucumber log of the test failing which might help: https://cucumber-logs.s3.amazonaws.com/test/test/iPhone_platform_one_trust_output.html?versionId=832raeofmxTTvmiEQdBDTrOfgtcXV43T