### PR TITLE
Accept more data values for /yourschool to properly show new data

### DIFF
--- a/apps/src/templates/census/CensusMap.jsx
+++ b/apps/src/templates/census/CensusMap.jsx
@@ -21,21 +21,21 @@ class CensusMapInfoWindow extends Component {
     let color = '';
 
     switch (this.props.teachesCs) {
-      case 'YES':
+      case ('YES', 'Y'):
         censusMessage = 'We believe this school offers Computer Science.';
         color = 'green';
         break;
-      case 'NO':
+      case ('NO', 'N'):
         censusMessage =
           'We believe this school offers no Computer Science opportunities.';
         color = 'blue';
         break;
-      case 'HISTORICAL_YES':
+      case ('HISTORICAL_YES', 'HY'):
         censusMessage =
           'We believe this school historically offered Computer Science.';
         color = 'green';
         break;
-      case 'HISTORICAL_NO':
+      case ('HISTORICAL_NO', 'HN'):
         censusMessage =
           'We believe this school historically offered no Computer Science opportunities.';
         color = 'blue';
@@ -202,7 +202,7 @@ export default class CensusMap extends Component {
           'circle-color': [
             'match',
             ['get', 'teaches_cs'],
-            ['NO', 'HISTORICAL_NO'],
+            ['NO', 'N', 'HISTORICAL_NO', 'HN'],
             '#989CF8',
             'white',
           ],
@@ -212,7 +212,9 @@ export default class CensusMap extends Component {
         filter: [
           'all',
           ['!=', 'teaches_cs', 'YES'],
+          ['!=', 'teaches_cs', 'Y'],
           ['!=', 'teaches_cs', 'HISTORICAL_YES'],
+          ['!=', 'teaches_cs', 'HY'],
           ['!=', 'teaches_cs', 'EXCLUDED'],
         ],
       });
@@ -230,7 +232,9 @@ export default class CensusMap extends Component {
         filter: [
           'any',
           ['==', 'teaches_cs', 'YES'],
+          ['==', 'teaches_cs', 'Y'],
           ['==', 'teaches_cs', 'HISTORICAL_YES'],
+          ['==', 'teaches_cs', 'HY'],
         ],
       });
 


### PR DESCRIPTION
As part of this year's access report, I had to [set up a test map](https://github.com/code-dot-org/code-dot-org/pull/61466) (can be viewed at [staging.code.org/yourschoolteststaging](https://staging.code.org/yourschoolteststaging)) to display the new data so we had confidence that the new data wouldn't break the /yourschool map. However, once the `bin/test_staging_update_census_mapbox` script (parallel of the `update_census_mapbox` script that doesn't touch the `CensusSummary` data table) was run, it was only able to plot points for each school but did not correctly display whether it taught CS through the color code:
![staging not working](https://github.com/user-attachments/assets/d2bce4c2-79de-4440-9bda-8aefa61f5dff)

After diving in with Bethany, we found that the `teaches_cs` values get swapped between shorthand and written-out which was the cause of the issue. This PR updates the `YourSchool` component to accept the shorthand values of `teaches_cs` as well to ensure that the data will be displayed correctly either way. The written-out to shorthand key is:
- Yes = Y
- No = N
- Historical Yes = HY
- Historical No = HN
- Unknown = U

## Links
Live test map showing the blank school data points: [here](https://staging.code.org/yourschoolteststaging)

## Testing story
Pointed `localhost` to the test tileset that [staging.code.org/yourschoolteststaging](https://staging.code.org/yourschoolteststaging) used (`censustiles-dev`) and checked that each possible `teaches_cs` value was properly color-coded:

#### YES / Y
![YES](https://github.com/user-attachments/assets/e960058d-3c31-4b16-93de-ec4820ccb904)

#### NO / N
![NO](https://github.com/user-attachments/assets/007197c3-12a0-402f-83c4-8c0e2e550cac)

#### HISTORICAL YES / Y
![HY](https://github.com/user-attachments/assets/9bc04a64-9b81-40ae-8684-793c7ed2f04a)

#### HISTORICAL NO / HN
![HN](https://github.com/user-attachments/assets/1b51a663-819a-45a8-bf91-a8c865e95c37)

#### UNKNOWN / U
![U](https://github.com/user-attachments/assets/76fa120d-f375-46d6-abeb-d0cf4a612537)

### New school year data
I also double checked that the map was displaying this year's data rather than last year's by finding a school that changed `teaches_cs` values between the two years. I found that West Ouachita High School in Louisiana changed from "NO" to "YES":

Currently on [/yourschool](https://code.org/yourschool) (2023 data):
![old_no](https://github.com/user-attachments/assets/7c9d9ac3-75f6-4894-bf48-1a3afbc17c59)

With this change and the new data:
![new_yes](https://github.com/user-attachments/assets/8bdc1c9d-84f8-4f99-b475-3e1abb505b50)

## Follow-up work
Seeing the new data with the correct color-coding gives us confidence that the new data is good to go so we will be able to merge [the PR that updates the census year and census_summary data file constants for 2024](https://github.com/code-dot-org/code-dot-org/pull/61454) shortly.
