### PR TITLE
Codebridge instructions: move validation button and smarter scrolling

### DIFF
--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -311,16 +311,13 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
           vertical && moduleStyles.itemVertical
         )}
       >
-        {instructionsText && (
-          <div
-            key={instructionsText}
-            id="instructions-text"
-            className={classNames(
-              moduleStyles['bubble-' + theme],
-              moduleStyles.scrollingBubble
-            )}
-          >
-            <div className={moduleStyles.scrollingContent}>
+        <div className={moduleStyles.scrollingContent}>
+          {instructionsText && (
+            <div
+              key={instructionsText}
+              id="instructions-text"
+              className={classNames(moduleStyles['bubble-' + theme])}
+            >
               <div className={moduleStyles.mainInstructions}>
                 <ValidationStatusIcon
                   status={showPassedIcon ? 'passed' : 'pending'}
@@ -343,34 +340,24 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
               />
               {renderValidationButton()}
             </div>
-          </div>
-        )}
+          )}
 
-        {validationResults && (
-          <>
-            <div ref={validationScrollRef} />
-            <div
-              className={classNames(
-                moduleStyles['bubble-' + theme],
-                moduleStyles.scrollingBubble
-              )}
-            >
-              <ValidationResults className={moduleStyles.scrollingContent} />
-            </div>
-          </>
-        )}
-        {predictSettings?.isPredictLevel && (
-          <InstructorsOnly>
-            <div
-              className={classNames(
-                moduleStyles['bubble-' + theme],
-                moduleStyles.scrollingBubble
-              )}
-            >
-              <PredictSummary className={moduleStyles.scrollingContent} />
-            </div>
-          </InstructorsOnly>
-        )}
+          {validationResults && (
+            <>
+              <div ref={validationScrollRef} />
+              <div className={classNames(moduleStyles['bubble-' + theme])}>
+                <ValidationResults />
+              </div>
+            </>
+          )}
+          {predictSettings?.isPredictLevel && (
+            <InstructorsOnly>
+              <div className={classNames(moduleStyles['bubble-' + theme])}>
+                <PredictSummary />
+              </div>
+            </InstructorsOnly>
+          )}
+        </div>
         {showNavigation && (
           <div
             id="instructions-navigation"

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -315,9 +315,12 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
           <div
             key={instructionsText}
             id="instructions-text"
-            className={classNames(moduleStyles['bubble-' + theme])}
+            className={classNames(
+              moduleStyles['bubble-' + theme],
+              moduleStyles.scrollingBubble
+            )}
           >
-            <div className={moduleStyles.instructionsContent}>
+            <div className={moduleStyles.scrollingContent}>
               <div className={moduleStyles.mainInstructions}>
                 <ValidationStatusIcon
                   status={showPassedIcon ? 'passed' : 'pending'}
@@ -346,15 +349,25 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
         {validationResults && (
           <>
             <div ref={validationScrollRef} />
-            <div className={moduleStyles['bubble-' + theme]}>
-              <ValidationResults className={moduleStyles.instructionsContent} />
+            <div
+              className={classNames(
+                moduleStyles['bubble-' + theme],
+                moduleStyles.scrollingBubble
+              )}
+            >
+              <ValidationResults className={moduleStyles.scrollingContent} />
             </div>
           </>
         )}
         {predictSettings?.isPredictLevel && (
           <InstructorsOnly>
-            <div className={moduleStyles['bubble-' + theme]}>
-              <PredictSummary />
+            <div
+              className={classNames(
+                moduleStyles['bubble-' + theme],
+                moduleStyles.scrollingBubble
+              )}
+            >
+              <PredictSummary className={moduleStyles.scrollingContent} />
             </div>
           </InstructorsOnly>
         )}

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -317,32 +317,40 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
             id="instructions-text"
             className={classNames(moduleStyles['bubble-' + theme])}
           >
-            <div className={moduleStyles.mainInstructions}>
-              <ValidationStatusIcon
-                status={showPassedIcon ? 'passed' : 'pending'}
-                className={moduleStyles.validationIcon}
+            <div className={moduleStyles.instructionsContent}>
+              <div className={moduleStyles.mainInstructions}>
+                <ValidationStatusIcon
+                  status={showPassedIcon ? 'passed' : 'pending'}
+                  className={moduleStyles.validationIcon}
+                />
+                <EnhancedSafeMarkdown
+                  markdown={instructionsText}
+                  className={moduleStyles.markdownText}
+                  handleInstructionsTextClick={handleInstructionsTextClick}
+                />
+              </div>
+              <PredictQuestion
+                predictSettings={predictSettings}
+                predictResponse={predictResponse}
+                setPredictResponse={response =>
+                  dispatch(setPredictResponse(response))
+                }
+                predictAnswerLocked={predictAnswerLocked}
+                className={moduleStyles.predictQuestion}
               />
-              <EnhancedSafeMarkdown
-                markdown={instructionsText}
-                className={moduleStyles.markdownText}
-                handleInstructionsTextClick={handleInstructionsTextClick}
-              />
+              {renderValidationButton()}
             </div>
-            <PredictQuestion
-              predictSettings={predictSettings}
-              predictResponse={predictResponse}
-              setPredictResponse={response =>
-                dispatch(setPredictResponse(response))
-              }
-              predictAnswerLocked={predictAnswerLocked}
-              className={moduleStyles.predictQuestion}
-            />
-            {renderValidationButton()}
           </div>
         )}
 
-        {validationResults && <div ref={validationScrollRef} />}
-        <ValidationResults className={moduleStyles['bubble-' + theme]} />
+        {validationResults && (
+          <>
+            <div ref={validationScrollRef} />
+            <div className={moduleStyles['bubble-' + theme]}>
+              <ValidationResults className={moduleStyles.instructionsContent} />
+            </div>
+          </>
+        )}
         {predictSettings?.isPredictLevel && (
           <InstructorsOnly>
             <div className={moduleStyles['bubble-' + theme]}>
@@ -355,8 +363,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
             id="instructions-navigation"
             className={classNames(
               moduleStyles['bubble-' + theme],
-              moduleStyles.button,
-              moduleStyles.navigationButton
+              moduleStyles.button
             )}
             ref={navigationScrollRef}
           >

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -345,7 +345,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
           )}
           {predictSettings?.isPredictLevel && (
             <InstructorsOnly>
-              <div className={classNames(moduleStyles['bubble-' + theme])}>
+              <div className={moduleStyles['bubble-' + theme]}>
                 <PredictSummary />
               </div>
             </InstructorsOnly>

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -355,7 +355,8 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
             id="instructions-navigation"
             className={classNames(
               moduleStyles['bubble-' + theme],
-              moduleStyles.button
+              moduleStyles.button,
+              moduleStyles.navigationButton
             )}
             ref={navigationScrollRef}
           >

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -267,25 +267,18 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
   const {showNavigation, navigationText, navigationIcon, handleNavigation} =
     getNavigationButtonProps();
 
-  const navigationScrollRef = useRef<HTMLDivElement>(null);
   const validationScrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    let refToScrollTo;
-    if (showNavigation) {
-      refToScrollTo = navigationScrollRef;
-    } else if (validationResults) {
-      refToScrollTo = validationScrollRef;
-    }
-    if (refToScrollTo) {
+    if (validationResults) {
       // We must at least set a timeout with a wait of 0 to ensure the scroll happens at all,
       // because the DOM needs to update before we can scroll to the new element.
       setTimeout(
-        () => refToScrollTo.current?.scrollIntoView({behavior: 'smooth'}),
+        () => validationScrollRef.current?.scrollIntoView({behavior: 'smooth'}),
         0
       );
     }
-  }, [showNavigation, validationResults]);
+  }, [validationResults]);
 
   const showPassedIcon = hasMetValidation || hasSubmitted;
 
@@ -365,7 +358,6 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
               moduleStyles['bubble-' + theme],
               moduleStyles.button
             )}
-            ref={navigationScrollRef}
           >
             <Button
               text={navigationText}

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -238,33 +238,29 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
     if (!hasConditions) {
       return null;
     }
-    return (
-      <div className={moduleStyles['bubble-' + theme]}>
-        {isValidating ? (
-          <Button
-            text={codebridgeI18n.stopValidation()}
-            onClick={handleStop}
-            color={'destructive'}
-            iconLeft={{iconStyle: 'solid', iconName: 'square'}}
-            className={moduleStyles.buttonInstruction}
-            size={'s'}
-          />
-        ) : (
-          <Button
-            text={codebridgeI18n.validate()}
-            onClick={() => handleValidate()}
-            type={'secondary'}
-            disabled={shouldValidateBeDisabled}
-            iconLeft={{iconStyle: 'solid', iconName: 'clipboard-check'}}
-            className={classNames(
-              darkModeStyles.secondaryButton,
-              moduleStyles.buttonInstruction
-            )}
-            color={'white'}
-            size={'s'}
-          />
+    return isValidating ? (
+      <Button
+        text={codebridgeI18n.stopValidation()}
+        onClick={handleStop}
+        color={'destructive'}
+        iconLeft={{iconStyle: 'solid', iconName: 'square'}}
+        className={moduleStyles.buttonInstruction}
+        size={'s'}
+      />
+    ) : (
+      <Button
+        text={codebridgeI18n.validate()}
+        onClick={() => handleValidate()}
+        type={'secondary'}
+        disabled={shouldValidateBeDisabled}
+        iconLeft={{iconStyle: 'solid', iconName: 'clipboard-check'}}
+        className={classNames(
+          darkModeStyles.secondaryButton,
+          moduleStyles.buttonInstruction
         )}
-      </div>
+        color={'white'}
+        size={'s'}
+      />
     );
   };
 
@@ -341,9 +337,12 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
               predictAnswerLocked={predictAnswerLocked}
               className={moduleStyles.predictQuestion}
             />
+            {renderValidationButton()}
           </div>
         )}
 
+        {validationResults && <div ref={validationScrollRef} />}
+        <ValidationResults className={moduleStyles['bubble-' + theme]} />
         {predictSettings?.isPredictLevel && (
           <InstructorsOnly>
             <div className={moduleStyles['bubble-' + theme]}>
@@ -351,9 +350,6 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
             </div>
           </InstructorsOnly>
         )}
-        {renderValidationButton()}
-        {validationResults && <div ref={validationScrollRef} />}
-        <ValidationResults className={moduleStyles['bubble-' + theme]} />
         {showNavigation && (
           <div
             id="instructions-navigation"

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -135,16 +135,9 @@
 
 .button {
   padding: 12px;
-  //margin-top: 10px;
-}
-
-// Wrap scrollingContent in a scrollingBubble
-// to get a scrolling bubble.
-.scrollingBubble {
-  overflow: hidden;
 }
 
 .scrollingContent {
   overflow-y: auto;
-  box-sizing: border-box;
+  //box-sizing: border-box;
 }

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -22,7 +22,7 @@
   font-size: 14px;
   line-height: 1.5;
   display: flex;
-  overflow: scroll;
+  overflow: hidden;
 
   &.vertical {
     flex-direction: column;
@@ -74,6 +74,7 @@
   border-radius: 4px;
   margin-bottom: 10px;
   animation: slidein 0.5s;
+  overflow: scroll;
 }
 
 .bubble-dark {
@@ -144,4 +145,8 @@
 
 .button {
   padding: 12px;
+}
+
+.navigationButton {
+  overflow: visible;
 }

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -65,7 +65,6 @@
   border-radius: 4px;
   margin-bottom: 10px;
   animation: slidein 0.5s;
-  overflow: hidden;
 }
 
 .bubble-dark {
@@ -138,7 +137,13 @@
   padding: 12px;
 }
 
-.instructionsContent {
+// Wrap scrollingContent in a scrollingBubble
+// to get a scrolling bubble.
+.scrollingBubble {
+  overflow: hidden;
+}
+
+.scrollingContent {
   height: 100%;
   overflow-y: auto;
   box-sizing: border-box;

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -139,5 +139,4 @@
 
 .scrollingContent {
   overflow-y: auto;
-  //box-sizing: border-box;
 }

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -23,6 +23,7 @@
   line-height: 1.5;
   display: flex;
   overflow: hidden;
+  margin-bottom: 45px; // space for copyright footer
 
   &.vertical {
     flex-direction: column;
@@ -44,20 +45,10 @@
   pointer-events: auto;
   flex: 1;
   opacity: 1;
+  height: 100%;
 
   &.itemVertical {
     flex-direction: column;
-  }
-}
-
-.itemTitle {
-  font-size: 18px;
-  text-align: left;
-  overflow-wrap: break-word;
-  padding: 5px;
-
-  &Horizontal {
-    max-width: 140px;
   }
 }
 
@@ -74,7 +65,7 @@
   border-radius: 4px;
   margin-bottom: 10px;
   animation: slidein 0.5s;
-  overflow: scroll;
+  overflow: hidden;
 }
 
 .bubble-dark {
@@ -147,6 +138,8 @@
   padding: 12px;
 }
 
-.navigationButton {
-  overflow: visible;
+.instructionsContent {
+  height: 100%;
+  overflow-y: auto;
+  box-sizing: border-box;
 }

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -16,7 +16,7 @@
   width: 100%;
   height: 100%;
   background-size: 100% 200%;
-  padding: 10px;
+  padding: 0 10px 10px 10px;
   box-sizing: border-box;
   position: relative;
   font-size: 14px;
@@ -63,7 +63,7 @@
 %bubble {
   padding: 8px;
   border-radius: 4px;
-  margin-bottom: 10px;
+  margin-top: 10px;
   animation: slidein 0.5s;
 }
 
@@ -135,6 +135,7 @@
 
 .button {
   padding: 12px;
+  //margin-top: 10px;
 }
 
 // Wrap scrollingContent in a scrollingBubble
@@ -144,7 +145,6 @@
 }
 
 .scrollingContent {
-  height: 100%;
   overflow-y: auto;
   box-sizing: border-box;
 }

--- a/apps/src/lab2/views/components/PredictSummary.tsx
+++ b/apps/src/lab2/views/components/PredictSummary.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import React, {useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 
@@ -12,13 +11,7 @@ import moduleStyles from './predict-summary.module.scss';
 
 const SUMMARY_PATH = '/summary';
 
-interface PredictSummaryProps {
-  className?: string;
-}
-
-const PredictSummary: React.FunctionComponent<PredictSummaryProps> = ({
-  className,
-}) => {
+const PredictSummary: React.FunctionComponent = () => {
   // If viewing the page as Participant, be sure to rewrite the link URL
   // to view as Instructor, so we don't just get redirected back.
   const params = document.location.search.replace(
@@ -59,9 +52,7 @@ const PredictSummary: React.FunctionComponent<PredictSummaryProps> = ({
   };
 
   return (
-    <div
-      className={classNames(moduleStyles.predictSummaryContainer, className)}
-    >
+    <div className={moduleStyles.predictSummaryContainer}>
       {responseCount !== null && numStudents !== null && (
         <div className={moduleStyles.responses}>
           <div className={moduleStyles.responseIcon}>

--- a/apps/src/lab2/views/components/PredictSummary.tsx
+++ b/apps/src/lab2/views/components/PredictSummary.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, {useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 
@@ -11,7 +12,13 @@ import moduleStyles from './predict-summary.module.scss';
 
 const SUMMARY_PATH = '/summary';
 
-const PredictSummary: React.FunctionComponent = () => {
+interface PredictSummaryProps {
+  className?: string;
+}
+
+const PredictSummary: React.FunctionComponent<PredictSummaryProps> = ({
+  className,
+}) => {
   // If viewing the page as Participant, be sure to rewrite the link URL
   // to view as Instructor, so we don't just get redirected back.
   const params = document.location.search.replace(
@@ -52,7 +59,9 @@ const PredictSummary: React.FunctionComponent = () => {
   };
 
   return (
-    <div className={moduleStyles.predictSummaryContainer}>
+    <div
+      className={classNames(moduleStyles.predictSummaryContainer, className)}
+    >
       {responseCount !== null && numStudents !== null && (
         <div className={moduleStyles.responses}>
           <div className={moduleStyles.responseIcon}>


### PR DESCRIPTION
This PR has a couple improvements to validated instructions:
- Move the validate button inside the instructions bubble rather than having it be its own bubble.
- When we have too much content, scroll everything but the continue button. This allows us to "pin" the continue button so it is always visible, similar to Music Lab. If space is limited, we will still auto-scroll to the validation results when they first appear.
- Add a margin at the bottom to account for the copyright/language footer

## Screen recordings
### Resizing
https://github.com/user-attachments/assets/330bea9a-207c-4b4c-9517-c561b6052d1b


### Validation appearing on small window
https://github.com/user-attachments/assets/d83312be-89ac-49f4-b35f-26d788560ca7


## Links
- jira tickets: [CT-809](https://codedotorg.atlassian.net/browse/CT-809), [CT-799](https://codedotorg.atlassian.net/browse/CT-799)

## Testing story
Tested locally on multiple levels


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
