### PR TITLE
Python Lab: small polish items

### DIFF
--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -27,7 +27,7 @@
   background-color: $light_gray_900;
   display: flex;
   align-items: center;
-  justify-content: center;
+  padding-left: 4px;
 }
 
 .workspaceToggleButtonContainer.withFileBrowser {
@@ -46,7 +46,7 @@
 
 .workspaceWorkarea {
   display: grid;
-  grid-template-columns: 30px auto;
+  grid-template-columns: 34px auto;
   grid-auto-rows: 32px 1fr auto;
   overflow: hidden;
   flex: 1;

--- a/apps/src/codebridge/components/ToggleFileBrowserButton.tsx
+++ b/apps/src/codebridge/components/ToggleFileBrowserButton.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import React, {useCallback} from 'react';
 
 import codebridgeI18n from '@cdo/apps/codebridge/locale';
@@ -8,7 +7,6 @@ import WithTooltip from '@cdo/apps/componentLibrary/tooltip/WithTooltip';
 
 import {useCodebridgeContext} from '../codebridgeContext';
 
-import moduleStyles from './toggle-file-browser-button.module.scss';
 import darkModeStyles from '@codebridge/styles/dark-mode.module.scss';
 
 /*
@@ -52,10 +50,7 @@ const ToggleFileBrowserButton: React.FunctionComponent = () => {
           ariaLabel={codebridgeI18n.toggleFileBrowser()}
           size={'xs'}
           type={'tertiary'}
-          className={classNames(
-            darkModeStyles.iconOnlyTertiaryButton,
-            moduleStyles.button
-          )}
+          className={darkModeStyles.iconOnlyTertiaryButton}
         />
       </WithTooltip>
     </span>

--- a/apps/src/codebridge/components/toggle-file-browser-button.module.scss
+++ b/apps/src/codebridge/components/toggle-file-browser-button.module.scss
@@ -1,3 +1,0 @@
-.button {
-  margin: 4px 8px;
-}

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -294,6 +294,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
                     },
                   ]}
                   className={moduleStyles.latestTag}
+                  size="s"
                 />
               )}
             </RadioButton>

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -32,7 +32,7 @@
 
 .versionHistoryList {
   max-height: 300px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .versionHistoryRow {


### PR DESCRIPTION
A couple small polish items from the recent [figma](https://www.figma.com/design/vcNGOFsIks0HhRk6GEOfZf/Upper-Lab?node-id=4387-84845&node-type=instance&m=dev) requests:

- Use the smallest tag in version history to mark the current version
- Make it so the file browser button is always in the same place whether open or closed
- Change version history dropdown overflow from `scroll` to `auto`; this gets rid of the placeholder space for a scrollbar when the component is smaller than the max size.

### Before
<img width="398" alt="Screenshot 2024-10-03 at 2 58 01 PM" src="https://github.com/user-attachments/assets/a7958426-0fdd-45c1-9fc8-c42c0aa1e896">

<img width="411" alt="Screenshot 2024-10-03 at 2 49 02 PM" src="https://github.com/user-attachments/assets/d7ad4fb5-674f-4519-b19a-5a0b9bd8bfc8">
<img width="283" alt="Screenshot 2024-10-03 at 2 49 09 PM" src="https://github.com/user-attachments/assets/9eba5f33-958c-4647-8848-06a4d9b3edca">

### After
<img width="398" alt="Screenshot 2024-10-03 at 2 58 08 PM" src="https://github.com/user-attachments/assets/037d006b-d3d6-41e6-8a52-dc844a06d5db">

<img width="281" alt="Screenshot 2024-10-03 at 2 49 22 PM" src="https://github.com/user-attachments/assets/907a1414-ac1d-4349-8748-6a7bfbd65028">

<img width="199" alt="Screenshot 2024-10-03 at 2 49 16 PM" src="https://github.com/user-attachments/assets/6d1bf377-32a4-45f2-97ae-61d7a173c671">



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
