### PR TITLE
Music: remove src from PatternEventValue

### DIFF
--- a/apps/src/music/ai/patternAiWorker.ts
+++ b/apps/src/music/ai/patternAiWorker.ts
@@ -181,7 +181,6 @@ function fromNoteSequence(
         res.push({
           note: reverseMidiMapping.get(pitch) || 0,
           tick: 8 + quantizedStartStep + 1, // 4 + quantizedStartStep * 2 + 1,
-          src: 'sound_' + ((reverseMidiMapping.get(pitch) || 0) + 1),
         });
       }
     }

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -120,6 +120,14 @@ export default class MusicLibrary {
     this.libraryJson = libraryJson;
     this.allowedSounds = null;
 
+    // Add notes for drum kits based on index if they don't already have them.
+    for (const kit of libraryJson.kits) {
+      kit.sounds = kit.sounds.map((sound, i) => ({
+        ...sound,
+        note: i,
+      }));
+    }
+
     // Combine the JSON-specified folders into one flat list of folders.
     this.folders = [
       ...libraryJson.packs,

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -440,22 +440,18 @@ export default class MusicPlayer {
       }
 
       for (const event of patternEvent.value.events) {
-        const soundData = library.getSoundForId(`${folder.id}/${event.src}`);
-        if (soundData === null) {
+        const sampleUrl = this.getSampleForNote(event.note, kit);
+        if (sampleUrl === null) {
           return [];
         }
 
-        const resultEvent = {
-          id: `${folder.id}/${event.src}`,
-          sampleUrl: library.generateSoundUrl(folder, soundData),
+        results.push({
+          sampleUrl,
           playbackPosition: patternEvent.when + (event.tick - 1) / eventsLength,
-          triggered: patternEvent.triggered,
-          effects: patternEvent.effects,
           originalBpm: this.bpm,
           pitchShift: 0,
-        };
-
-        results.push(resultEvent);
+          ...patternEvent,
+        });
       }
 
       return results;

--- a/apps/src/music/player/interfaces/PatternEvent.ts
+++ b/apps/src/music/player/interfaces/PatternEvent.ts
@@ -17,6 +17,5 @@ export interface PatternEventValue {
 
 export interface PatternTickEvent {
   tick: number;
-  src: string;
   note: number;
 }

--- a/apps/src/music/utils/Patterns.ts
+++ b/apps/src/music/utils/Patterns.ts
@@ -52,12 +52,9 @@ export function generateGraphDataFromPattern({
   const numSounds = currentFolder.sounds.length;
 
   return patternEventValue.events.map((event: PatternTickEvent) => {
-    const soundIndex = currentFolder.sounds.findIndex(
-      sound => sound.src === event.src
-    );
     return {
       x: 1 + ((event.tick - 1) * useWidth) / (eventsLength - 1) + padding,
-      y: 1 + padding + (soundIndex * useHeight) / (numSounds - 1),
+      y: 1 + padding + (event.note * useHeight) / (numSounds - 1),
       width: noteWidth,
       height: noteHeight,
       tick: event.tick,

--- a/apps/src/music/views/PatternPanel.tsx
+++ b/apps/src/music/views/PatternPanel.tsx
@@ -9,7 +9,7 @@ import React, {
 
 import MusicRegistry from '../MusicRegistry';
 import {PatternEventValue} from '../player/interfaces/PatternEvent';
-import MusicLibrary, {SoundData} from '../player/MusicLibrary';
+import MusicLibrary from '../player/MusicLibrary';
 
 import LoadingOverlay from './LoadingOverlay';
 import PreviewControls from './PreviewControls';
@@ -52,17 +52,17 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
   const [currentPreviewTick, setCurrentPreviewTick] = useState(0);
 
   const toggleEvent = useCallback(
-    (sound: SoundData, tick: number, note: number) => {
+    (tick: number, note: number) => {
       const index = currentValue.events.findIndex(
-        event => event.src === sound.src && event.tick === tick
+        event => event.note === note && event.tick === tick
       );
       if (index !== -1) {
         // If found, delete.
         currentValue.events.splice(index, 1);
       } else {
         // Not found, so add.
-        currentValue.events.push({src: sound.src, tick, note});
-        MusicRegistry.player.previewSound(`${currentValue.kit}/${sound.src}`);
+        currentValue.events.push({tick, note});
+        MusicRegistry.player.previewNote(note, currentValue.kit);
       }
 
       onChange(currentValue);
@@ -70,9 +70,9 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
     [onChange, currentValue]
   );
 
-  const hasEvent = (sound: SoundData, tick: number) => {
+  const hasEvent = (note: number, tick: number) => {
     const element = currentValue.events.find(
-      event => event.src === sound.src && event.tick === tick
+      event => event.note === note && event.tick === tick
     );
     return !!element;
   };
@@ -82,8 +82,8 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
     onChange(currentValue);
   };
 
-  const getCellClasses = (sound: SoundData, tick: number) => {
-    const isSet = hasEvent(sound, tick);
+  const getCellClasses = (note: number, tick: number) => {
+    const isSet = hasEvent(note, tick);
     const isHighlighted = !isSet && (tick - 1) % 4 === 0;
 
     return classNames(
@@ -140,19 +140,20 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
         ))}
       </select>
       <LoadingOverlay show={isLoading} />
-      {currentFolder.sounds.map((sound, index) => {
+      {currentFolder.sounds.map(({name, note}, index) => {
         return (
-          <div className={styles.row} key={sound.src}>
+          <div className={styles.row} key={note}>
             <div className={styles.nameContainer}>
               <span
                 className={styles.name}
                 onClick={() =>
-                  MusicRegistry.player.previewSound(
-                    `${currentValue.kit}/${sound.src}`
+                  MusicRegistry.player.previewNote(
+                    note || index,
+                    currentValue.kit
                   )
                 }
               >
-                {sound.name}
+                {name}
               </span>
             </div>
             {arrayOfTicks.map(tick => {
@@ -162,10 +163,10 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
                     styles.outerCell,
                     tick === currentPreviewTick && styles.outerCellPlaying
                   )}
-                  onClick={() => toggleEvent(sound, tick, index)}
+                  onClick={() => toggleEvent(tick, note || index)}
                   key={tick}
                 >
-                  <div className={getCellClasses(sound, tick)} />
+                  <div className={getCellClasses(note || index, tick)} />
                 </div>
               );
             })}


### PR DESCRIPTION
Some minor interface cleanup, with the eventual goal of unifying the pattern, pattern AI, and tune interfaces since they're all essentially the same thing (a series of notes played on an instrument). This is also to help clean up code in https://github.com/code-dot-org/code-dot-org/pull/61412 which uses a common instrument grid editor with a single interface.

As a first step, this PR just removes references to the `src` field on the `PatternTickEvent` interface, instead referencing individual sounds by their `note` value, which matches how we eventually play the sound at the ToneJSPlayer level. No functional changes otherwise.
