### PR TITLE
Remove OneTrust from embedded project views

### DIFF
--- a/dashboard/test/ui/features/platform/one_trust.feature
+++ b/dashboard/test/ui/features/platform/one_trust.feature
@@ -29,7 +29,7 @@ Feature: OneTrust integration
     Given I am in Europe
     Given I am on "http://studio.code.org/home?otreset=true&otgeo=es"
     And I wait until element "#onetrust-banner-sdk" is visible
-  
+
   Scenario: The pages load the self hosted OneTrust libraries.
     Given I am on "http://studio.code.org/users/sign_in"
     Then element "script[src$='onetrust/cdo/scripttemplates/otSDKStub.js']" does exist
@@ -60,7 +60,7 @@ Feature: OneTrust integration
     Then element "script[src$='977d/OtAutoBlock.js']" does exist
     Then element "script[src$='977d-test/OtAutoBlock.js']" does not exist
     Then element "script[src$='onetrust/scripttemplates/otSDKStub.js']" does not exist
-    
+
     Given I am on "http://hourofcode.com/us"
     And I use a cookie to mock the DCDO key "onetrust_cookie_scripts" as "prod"
     Given I am on "http://hourofcode.com/us"
@@ -109,9 +109,28 @@ Feature: OneTrust integration
     Then element "script[src*='/common_locale']" is not categorized by OneTrust
     Then element "script[src*='js/code-studio-common']" is not categorized by OneTrust
     Then element "script[src*='js/code-studio']" is not categorized by OneTrust
-
-    Examples:
+  Examples:
     | url                                                                     |
     | http://code.org/index                                                   |
     | http://hourofcode.com/us                                                |
     | http://studio.code.org/users/sign_in                                    |
+
+  @as_student
+  Scenario Outline: Embedded projects do not display the OneTrust banner
+    Given I am in Europe
+    Given I am on "<url>"
+    Then I switch to the embedded view of current project
+    Then I append "?otreset=true&otgeo=es" to the URL
+    Then element "script[src$='otSDKStub.js']" does not exist
+    Then element "script[src$='OtAutoBlock.js']" does not exist
+  Examples:
+    | url                                                                    |
+    | http://studio.code.org/projects/music/new                              |
+    | http://studio.code.org/projects/spritelab/new                          |
+    | http://studio.code.org/projects/artist/new                             |
+    | http://studio.code.org/projects/gamelab/new                            |
+    | http://studio.code.org/projects/dance/new                              |
+    | http://studio.code.org/projects/applab/new                             |
+    | http://studio.code.org/projects/poetry/new                             |
+    | http://studio.code.org/projects/flappy/new                             |
+    | http://studio.code.org/projects/frozen/new                             |

--- a/dashboard/test/ui/features/platform/one_trust.feature
+++ b/dashboard/test/ui/features/platform/one_trust.feature
@@ -119,8 +119,7 @@ Feature: OneTrust integration
   Scenario Outline: Embedded projects do not display the OneTrust banner
     Given I am in Europe
     Given I am on "<url>"
-    Then I switch to the embedded view of current project
-    Then I append "?otreset=true&otgeo=es" to the URL
+    Given I switch to the embedded view of current project with query "otreset=true&otgeo=es"
     Then element "script[src$='otSDKStub.js']" does not exist
     Then element "script[src$='OtAutoBlock.js']" does not exist
   Examples:

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1342,6 +1342,11 @@ Then /^I append "([^"]*)" to the URL$/ do |append|
   @browser.navigate.to url
 end
 
+Then /^I switch to the embedded view of current project$/ do
+  embed_url = @browser.current_url.sub('/edit', '/embed')
+  @browser.navigate.to embed_url
+end
+
 Then /^selector "([^"]*)" has class "(.*?)"$/ do |selector, class_name|
   item = @browser.find_element(:css, selector)
   classes = item.attribute("class")

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1339,7 +1339,7 @@ end
 
 Then /^I append "([^"]*)" to the URL$/ do |append|
   url = @browser.current_url + append
-  navigate_to url
+  @browser.navigate.to url
 end
 
 Then /^I switch to the embedded view of current project(?: with query "(.*)")?$/ do |query|

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1339,12 +1339,13 @@ end
 
 Then /^I append "([^"]*)" to the URL$/ do |append|
   url = @browser.current_url + append
-  @browser.navigate.to url
+  navigate_to url
 end
 
-Then /^I switch to the embedded view of current project$/ do
+Then /^I switch to the embedded view of current project(?: with query "(.*)")?$/ do |query|
   embed_url = @browser.current_url.sub('/edit', '/embed')
-  @browser.navigate.to embed_url
+  embed_url = "#{embed_url}?#{query}" if query
+  navigate_to embed_url
 end
 
 Then /^selector "([^"]*)" has class "(.*?)"$/ do |selector, class_name|

--- a/shared/haml/onetrust_cookie_scripts.haml
+++ b/shared/haml/onetrust_cookie_scripts.haml
@@ -1,5 +1,11 @@
 - require deploy_dir('shared/middleware/helpers/experiments')
 
+-# When student projects are embedded in other websites, the URL ends with
+-# /embed. When Code.org is rendered in an iframe on another website, we are not
+-# responsible for getting user consent for Cookies and Tracking Technologies,
+-# therefore, we don't need to display the OneTrust banner requesting consent.
+- return if request&.path&.ends_with?('/embed')
+
 -# OneTrust Cookies Consent Notice scripts for code.org
 -# default to loading the prod OneTrust configuration.
 - onetrust_version = experiment_value('onetrust_cookie_scripts', request) || 'self_hosted'


### PR DESCRIPTION
We tried merging this PR before, but it needed to be reverted because the UI tests were very flaky. After looking at the log, I found that the UI tests were trying to verify the HTML content before the browser had loaded the new URL. Changing from `@browser.navigate.to embed_url` to `navigate_to embed_url` fixes the flakiness of the test because `navigate_to` waits for the browser to load the new page before resuming the test script.
* [Fix for flaky UI test](https://github.com/code-dot-org/code-dot-org/commit/a7fe576e55a0af0250daa00230e243f80e1d4a02)

## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1128)
* [Previous PR](https://github.com/code-dot-org/code-dot-org/pull/60902)
* [Previous Revert](https://github.com/code-dot-org/code-dot-org/pull/61524)
## Testing story
* Ran UI tests using Sauce Labs proxy and iPhone browser.