### PR TITLE
Header: button border

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -290,6 +290,9 @@ img.video_thumbnail {
       text-decoration: none;
       background-color: $orange;
     }
+    &:active {
+      border: 2px solid $white !important;
+    }
   }
 
   .user_menu, .create_menu, .help_button {


### PR DESCRIPTION
Before this change, clicking on a header button caused it to shrink due to a smaller (and grey) border.

This is a very targeted fix which simply prevents that border from being shown.  

A more comprehensive fix would involve migrating to a modern button component.

### before

https://github.com/user-attachments/assets/219094a8-f8cb-47e1-a6ac-ff7edfda79ed
