### PR TITLE
Panels: delay button

### DIFF
--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -9,7 +9,7 @@ import {commonI18n} from '../types/locale';
 
 import {Panel} from './types';
 
-import styles from './panels.module.scss';
+import styles from './panelsView.module.scss';
 
 // Leave a margin to the left and the right of the panels, to the edges
 // of the screen.

--- a/apps/src/panels/panelsView.module.scss
+++ b/apps/src/panels/panelsView.module.scss
@@ -11,6 +11,15 @@
   }
 }
 
+@keyframes delay-pointer-events {
+  0%, 49% {
+    pointer-events: none;
+  }
+  50%, 100% {
+    pointer-events: initial;
+  }
+}
+
 .panelsContainer {
   position: absolute;
   display: flex;
@@ -105,7 +114,7 @@
       margin: 0;
       position: absolute;
       right: 0;
-      animation: fade-in 3s;
+      animation: fade-in 3s, delay-pointer-events 3s;
     }
 
     .bubble {


### PR DESCRIPTION
This change prevents clicks from working on the Next/Continue button until after it starts fading in.
