### PR TITLE
Fix the width of the PL action blocks

### DIFF
--- a/apps/src/templates/certificates/certificate_batch.module.scss
+++ b/apps/src/templates/certificates/certificate_batch.module.scss
@@ -245,6 +245,7 @@ a.linkButton {
 
 .professionalLearning .actionBlock {
   border: none;
+  padding: 0;
 }
 
 .professionalLearning .contentFooter {


### PR DESCRIPTION

After:

<img width="1422" alt="Screenshot 2024-10-04 at 9 02 05 AM" src="https://github.com/user-attachments/assets/7246a6d9-a8bb-4658-a252-0074ab72bedd">


Before:

<img width="1427" alt="Screenshot 2024-10-04 at 9 02 58 AM" src="https://github.com/user-attachments/assets/63d2ab81-8529-4360-ad97-bb85a75d30a4">
