### PR TITLE
Python Lab: Fix folder name moving to the right when expanded

### DIFF
--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -82,6 +82,10 @@ div.row:hover .button-kebab {
   margin: 2px 8px 2px 8px;
   font-size: 13px;
   line-height: 125%;
+
+  // prevents caret-down icon from pushing
+  // text to the right when toggling folders
+  min-width: 9px;
 }
 
 .acceptingDrop {


### PR DESCRIPTION
My folder don't jiggle jiggle,
it stays. 
Don't like to see it wiggle wiggle,
no way.

before:

https://github.com/user-attachments/assets/31d786e9-cba5-49dc-b71a-bae70db54fb0

after:

https://github.com/user-attachments/assets/30145296-a006-4e1c-8027-b89ec372c3ea


## Links

- figma: 
![image](https://github.com/user-attachments/assets/5245c03b-19ea-47cd-8674-bd081f2687dd)


## Testing story

Tested locally. See videos.

