### PR TITLE
Music: rename kit property to instrument

### DIFF
--- a/apps/src/music/blockly/FieldPattern.js
+++ b/apps/src/music/blockly/FieldPattern.js
@@ -31,6 +31,10 @@ class FieldPattern extends GoogleBlockly.Field {
   }
 
   loadState(state) {
+    if (state.kit) {
+      state.instrument = state.kit;
+      delete state.kit;
+    }
     this.setValue(state);
   }
 

--- a/apps/src/music/blockly/FieldPatternAi.js
+++ b/apps/src/music/blockly/FieldPatternAi.js
@@ -31,6 +31,10 @@ class FieldPatternAi extends GoogleBlockly.Field {
   }
 
   loadState(state) {
+    if (state.kit) {
+      state.instrument = state.kit;
+      delete state.kit;
+    }
     this.setValue(state);
   }
 

--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -1,4 +1,6 @@
 import {Effects} from './player/interfaces/Effects';
+import {PatternEventValue} from './player/interfaces/PatternEvent';
+import {TuneEventValue} from './player/interfaces/TuneEvent';
 import {Key} from './utils/Notes';
 
 export const baseAssetUrl = 'https://curriculum.code.org/media/musiclab/';
@@ -43,20 +45,16 @@ export const BlockMode = {
   ADVANCED: 'Advanced',
 } as const;
 
-// For reference, events look like this:
-// events: [{src: 'sound_1', tick: 3}]
-export const DEFAULT_PATTERN = {
-  kit: 'drums',
+export const DEFAULT_PATTERN: PatternEventValue = {
+  instrument: 'drums',
   events: [],
   ai: false,
 };
 
 export const DEFAULT_PATTERN_LENGTH = 1;
 
-// For reference, events look like this:
-// events: [{src: 'sound_1', tick: 3}]
-export const DEFAULT_PATTERN_AI = {
-  kit: 'drums',
+export const DEFAULT_PATTERN_AI: PatternEventValue = {
+  instrument: 'drums',
   length: 2,
   events: [],
   ai: true,
@@ -73,9 +71,7 @@ export const DEFAULT_CHORD = {
 
 export const DEFAULT_CHORD_LENGTH = 1;
 
-// For reference, events look like this:
-// events: [{note: 60, tick: 3}]
-export const DEFAULT_TUNE = {
+export const DEFAULT_TUNE: TuneEventValue = {
   instrument: 'piano',
   events: [],
 };

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -12,11 +12,11 @@ import {
 } from '../constants';
 import {LoadFinishedCallback, UpdateLoadProgressCallback} from '../types';
 import {generateNotesFromChord, ChordNote} from '../utils/Chords';
-//import {generateNotesFromTune, TuneNote} from '../utils/Tunes';
 import {getPitchName, getTranposedNote, Key} from '../utils/Notes';
 
 import {ChordEvent, ChordEventValue} from './interfaces/ChordEvent';
 import {Effects} from './interfaces/Effects';
+import {hasInstrument} from './interfaces/Instruments';
 import {PatternEvent, PatternEventValue} from './interfaces/PatternEvent';
 import {PlaybackEvent} from './interfaces/PlaybackEvent';
 import {SoundEvent} from './interfaces/SoundEvent';
@@ -140,12 +140,8 @@ export default class MusicPlayer {
     if (this.audioPlayer.supportsSamplers()) {
       const instrumentNames = new Set(
         events
-          .filter(event => event.type !== 'sound')
-          .map(event =>
-            event.type === 'chord'
-              ? (event as ChordEvent).value.instrument
-              : (event as PatternEvent).value.kit
-          )
+          .filter(event => hasInstrument(event))
+          .map(event => event.value.instrument)
       );
       for (const instrumentName of instrumentNames) {
         const sampleMap = this.generateSampleMap(instrumentName);
@@ -427,7 +423,7 @@ export default class MusicPlayer {
 
       const results: SampleEvent[] = [];
 
-      const kit = patternEvent.value.kit;
+      const kit = patternEvent.value.instrument;
 
       const folder: SoundFolder | null = library.getFolderForFolderId(kit);
 
@@ -611,7 +607,7 @@ export default class MusicPlayer {
       return null;
     }
 
-    const kit = patternEvent.value.kit;
+    const kit = patternEvent.value.instrument;
     const folder = library.getFolderForFolderId(kit);
     if (folder === null) {
       this.metricsReporter.logWarning(`No instrument ${kit}`);

--- a/apps/src/music/player/interfaces/Instruments.ts
+++ b/apps/src/music/player/interfaces/Instruments.ts
@@ -6,5 +6,7 @@ import {TuneEvent} from './TuneEvent';
 export function hasInstrument(
   event: PlaybackEvent
 ): event is ChordEvent | TuneEvent | PatternEvent {
-  return 'instrument' in event;
+  return (
+    event.type === 'chord' || event.type === 'tune' || event.type === 'pattern'
+  );
 }

--- a/apps/src/music/player/interfaces/Instruments.ts
+++ b/apps/src/music/player/interfaces/Instruments.ts
@@ -1,0 +1,10 @@
+import {ChordEvent} from './ChordEvent';
+import {PatternEvent} from './PatternEvent';
+import {PlaybackEvent} from './PlaybackEvent';
+import {TuneEvent} from './TuneEvent';
+
+export function hasInstrument(
+  event: PlaybackEvent
+): event is ChordEvent | TuneEvent | PatternEvent {
+  return 'instrument' in event;
+}

--- a/apps/src/music/player/interfaces/PatternEvent.ts
+++ b/apps/src/music/player/interfaces/PatternEvent.ts
@@ -9,7 +9,7 @@ export interface PatternEvent extends PlaybackEvent {
 }
 
 export interface PatternEventValue {
-  kit: string;
+  instrument: string;
   length?: 1 | 2;
   events: PatternTickEvent[];
   ai?: boolean;

--- a/apps/src/music/utils/Patterns.ts
+++ b/apps/src/music/utils/Patterns.ts
@@ -43,7 +43,7 @@ export function generateGraphDataFromPattern({
   const useHeight = height - 2 * padding - noteHeight;
 
   const currentFolder = MusicLibrary.getInstance()?.getFolderForFolderId(
-    patternEventValue.kit
+    patternEventValue.instrument
   );
   if (!currentFolder) {
     return [];

--- a/apps/src/music/views/PatternAiPanel.tsx
+++ b/apps/src/music/views/PatternAiPanel.tsx
@@ -73,9 +73,10 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
   const currentFolder = useMemo(() => {
     // Default to the first available kit if the current kit is not found in this library.
     return (
-      availableKits.find(kit => kit.id === currentValue.kit) || availableKits[0]
+      availableKits.find(kit => kit.id === currentValue.instrument) ||
+      availableKits[0]
     );
-  }, [availableKits, currentValue.kit]);
+  }, [availableKits, currentValue.instrument]);
   const [currentPreviewTick, setCurrentPreviewTick] = useState(0);
 
   const toggleEvent = useCallback(
@@ -89,7 +90,7 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
       } else {
         // Not found, so add.
         currentValue.events.push({tick, note});
-        MusicRegistry.player.previewNote(note, currentValue.kit);
+        MusicRegistry.player.previewNote(note, currentValue.instrument);
       }
 
       onChange(currentValue);
@@ -105,7 +106,7 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
   };
 
   const handleFolderChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    currentValue.kit = event.target.value;
+    currentValue.instrument = event.target.value;
     onChange(currentValue);
   };
 
@@ -140,23 +141,23 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
   }, [onChange, currentValue]);
 
   useEffect(() => {
-    if (!MusicRegistry.player.isInstrumentLoaded(currentValue.kit)) {
+    if (!MusicRegistry.player.isInstrumentLoaded(currentValue.instrument)) {
       setIsLoading(true);
-      if (MusicRegistry.player.isInstrumentLoading(currentValue.kit)) {
+      if (MusicRegistry.player.isInstrumentLoading(currentValue.instrument)) {
         // If the instrument is already loading, register a callback and wait for it to finish.
         MusicRegistry.player.registerCallback('InstrumentLoaded', kit => {
-          if (kit === currentValue.kit) {
+          if (kit === currentValue.instrument) {
             setIsLoading(false);
           }
         });
       } else {
         // Otherwise, initiate the load.
-        MusicRegistry.player.setupSampler(currentValue.kit, () =>
+        MusicRegistry.player.setupSampler(currentValue.instrument, () =>
           setIsLoading(false)
         );
       }
     }
-  }, [currentValue.kit, setIsLoading]);
+  }, [currentValue.instrument, setIsLoading]);
 
   // Tracks the tasks completed by the user.
   useEffect(() => {
@@ -242,7 +243,7 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
 
   return (
     <div className={styles.patternPanel}>
-      <select value={currentValue.kit} onChange={handleFolderChange}>
+      <select value={currentValue.instrument} onChange={handleFolderChange}>
         {availableKits.map(folder => (
           <option key={folder.id} value={folder.id}>
             {folder.name}
@@ -333,7 +334,7 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
                     onClick={() =>
                       MusicRegistry.player.previewNote(
                         note || index,
-                        currentValue.kit
+                        currentValue.instrument
                       )
                     }
                   >

--- a/apps/src/music/views/PatternPanel.tsx
+++ b/apps/src/music/views/PatternPanel.tsx
@@ -45,10 +45,10 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
   const currentFolder = useMemo(() => {
     // Default to the first available kit if the current kit is not found in this library.
     return (
-      availableKits?.find(kit => kit.id === currentValue.kit) ||
+      availableKits?.find(kit => kit.id === currentValue.instrument) ||
       availableKits?.[0]
     );
-  }, [availableKits, currentValue.kit]);
+  }, [availableKits, currentValue.instrument]);
   const [currentPreviewTick, setCurrentPreviewTick] = useState(0);
 
   const toggleEvent = useCallback(
@@ -62,7 +62,7 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
       } else {
         // Not found, so add.
         currentValue.events.push({tick, note});
-        MusicRegistry.player.previewNote(note, currentValue.kit);
+        MusicRegistry.player.previewNote(note, currentValue.instrument);
       }
 
       onChange(currentValue);
@@ -78,7 +78,7 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
   };
 
   const handleFolderChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    currentValue.kit = event.target.value;
+    currentValue.instrument = event.target.value;
     onChange(currentValue);
   };
 
@@ -112,27 +112,27 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
   }, [setCurrentPreviewTick]);
 
   useEffect(() => {
-    if (!MusicRegistry.player.isInstrumentLoaded(currentValue.kit)) {
+    if (!MusicRegistry.player.isInstrumentLoaded(currentValue.instrument)) {
       setIsLoading(true);
-      if (MusicRegistry.player.isInstrumentLoading(currentValue.kit)) {
+      if (MusicRegistry.player.isInstrumentLoading(currentValue.instrument)) {
         // If the instrument is already loading, register a callback and wait for it to finish.
         MusicRegistry.player.registerCallback('InstrumentLoaded', kit => {
-          if (kit === currentValue.kit) {
+          if (kit === currentValue.instrument) {
             setIsLoading(false);
           }
         });
       } else {
         // Otherwise, initiate the load.
-        MusicRegistry.player.setupSampler(currentValue.kit, () =>
+        MusicRegistry.player.setupSampler(currentValue.instrument, () =>
           setIsLoading(false)
         );
       }
     }
-  }, [currentValue.kit, setIsLoading]);
+  }, [currentValue.instrument, setIsLoading]);
 
   return (
     <div className={styles.patternPanel}>
-      <select value={currentValue.kit} onChange={handleFolderChange}>
+      <select value={currentValue.instrument} onChange={handleFolderChange}>
         {availableKits.map(folder => (
           <option key={folder.id} value={folder.id}>
             {folder.name}
@@ -149,7 +149,7 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
                 onClick={() =>
                   MusicRegistry.player.previewNote(
                     note || index,
-                    currentValue.kit
+                    currentValue.instrument
                   )
                 }
               >

--- a/apps/test/unit/music/player/sequencer/Simple2SequencerTest.ts
+++ b/apps/test/unit/music/player/sequencer/Simple2SequencerTest.ts
@@ -79,7 +79,7 @@ describe('Simple2Sequencer', () => {
 
   it('adds a pattern event', () => {
     const patternValue: PatternEventValue = {
-      kit: 'machine',
+      instrument: 'machine',
       events: [],
     };
 


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/61547. This renames the `kit` property on the Pattern interfaces to `instrument`, to further align it with the existing Tune interface. The next step here will be to replace the Pattern and Tune interfaces with a single shared interface, so naming the keys similarly will help that transition.

I chose 'instrument' since it felt a little more general than 'kit' and the Tune interface was already using it, but we do have slightly different meanings of instrument depending on where in the code it's referenced. For example in MusicPlayer and now PlaybackEvent code, 'instrument' refers to anything played on a sampler that uses an array of individual samples mapped to note values. However in the music library, instrument specifically refers to melodic instruments, while kit refers to percussion/drum instruments. I'm definitely open to renaming if there are any other ideas!

## Testing story

Tested with all instruments/kits with the pattern, pattern AI, notes, and tunes blocks. I tested creating a project with all these blocks before applying this change, and then confirmed that no data was lost once this change was applied.
