### PR TITLE
Remove references to unused show_lock_section_field DCDO flag

### DIFF
--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -18,7 +18,6 @@ import {
   setAuthProviders,
   setPageType,
   beginCreatingSection,
-  setShowLockSectionField, // DCDO Flag - show/hide Lock Section field
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import i18n from '@cdo/locale';
 
@@ -39,9 +38,6 @@ function showHomepage() {
   store.dispatch(initializeHiddenScripts(homepageData.hiddenScripts));
   store.dispatch(setPageType(pageTypes.homepage));
   store.dispatch(setLocaleCode(homepageData.localeCode));
-
-  // DCDO Flag - show/hide Lock Section field
-  store.dispatch(setShowLockSectionField(homepageData.showLockSectionField));
 
   if (homepageData.mapboxAccessToken) {
     store.dispatch(setMapboxAccessToken(homepageData.mapboxAccessToken));

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -30,7 +30,6 @@ import teacherSections, {
   setRosterProvider,
   setRosterProviderName,
   setSections,
-  setShowLockSectionField, // DCDO Flag - show/hide Lock Section field
   setStudentsForCurrentSection,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {sectionProviderName} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
@@ -71,9 +70,6 @@ $(document).ready(function () {
   );
   store.dispatch(setSections(sections));
   store.dispatch(setLocaleCode(localeCode));
-
-  // DCDO Flag - show/hide Lock Section field
-  store.dispatch(setShowLockSectionField(scriptData.showLockSectionField));
 
   const showAITutorTab = canViewStudentAIChatMessages;
 

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -69,10 +69,6 @@ const SET_AVAILABLE_PARTICIPANT_TYPES =
 const SET_STUDENT_SECTION = 'teacherDashboard/SET_STUDENT_SECTION';
 const SET_PAGE_TYPE = 'teacherDashboard/SET_PAGE_TYPE';
 
-// DCDO Flag - show/hide Lock Section field
-const SET_SHOW_LOCK_SECTION_FIELD =
-  'teacherDashboard/SET_SHOW_LOCK_SECTION_FIELD';
-
 /** Sets teacher's current authentication providers */
 const SET_AUTH_PROVIDERS = 'teacherDashboard/SET_AUTH_PROVIDERS';
 const SET_SECTIONS = 'teacherDashboard/SET_SECTIONS';
@@ -171,13 +167,6 @@ export const setStudentsForCurrentSection = (sectionId, studentInfo) => ({
 });
 export const setPageType = pageType => ({type: SET_PAGE_TYPE, pageType});
 
-// DCDO Flag - show/hide Lock Section field
-export const setShowLockSectionField = showLockSectionField => {
-  return {
-    type: SET_SHOW_LOCK_SECTION_FIELD,
-    showLockSectionField,
-  };
-};
 export const setSectionCodeReviewExpiresAt = (
   sectionId,
   codeReviewExpiresAt
@@ -698,8 +687,6 @@ const initialState = {
   loadError: null,
   // The page where the action is occurring
   pageType: '',
-  // DCDO Flag - show/hide Lock Section field
-  showLockSectionField: null,
   ltiSyncResult: null,
   isLoadingSectionData: false,
 };
@@ -1259,14 +1246,6 @@ export default function teacherSections(state = initialState, action) {
     return {
       ...state,
       ltiSyncResult: action.results,
-    };
-  }
-
-  // DCDO Flag - show/hide Lock Section field
-  if (action.type === SET_SHOW_LOCK_SECTION_FIELD) {
-    return {
-      ...state,
-      showLockSectionField: action.showLockSectionField,
     };
   }
 

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -114,9 +114,6 @@ class HomeController < ApplicationController
     current_user_permissions = UserPermission.where(user_id: current_user.id).pluck(:permission)
     @homepage_data[:showStudentAsVerifiedTeacherWarning] = current_user.student? && current_user_permissions.include?(UserPermission::AUTHORIZED_TEACHER)
 
-    # DCDO Flag - show/hide Lock Section field - Can/Will be overwritten by DCDO.
-    @homepage_data[:showLockSectionField] = DCDO.get('show_lock_section_field', true)
-
     @force_race_interstitial = params[:forceRaceInterstitial]
     @force_school_info_confirmation_dialog = params[:forceSchoolInfoConfirmationDialog]
     @force_school_info_interstitial = params[:forceSchoolInfoInterstitial]

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -9,7 +9,6 @@
   teacher_dashboard_data[:hasSeenStandardsReportInfo] = @current_user.has_seen_standards_report_info_dialog || false
   teacher_dashboard_data[:userName] = @current_user.short_name
   teacher_dashboard_data[:localeCode] = request.locale
-  teacher_dashboard_data[:showLockSectionField] = DCDO.get('show_lock_section_field', true)
   teacher_dashboard_data[:canViewStudentAIChatMessages] = @current_user.can_view_student_ai_chat_messages?
 
 %script{src: webpack_asset_path('js/teacher_dashboard/show.js'), data: {dashboard: teacher_dashboard_data.to_json}}


### PR DESCRIPTION
This DCDO flag was added about three years ago, is no longer used, and was not cleaned up at the time. Getting rid of it now makes our redux store slightly simpler.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
