### PR TITLE
Skipping teachers who don't have a plaintext email

### DIFF
--- a/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
+++ b/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
@@ -8,6 +8,8 @@ module CAP
 
     def perform
       teachers.find_each do |teacher|
+        next if teacher.email.blank?
+
         cap_section_ids = []
         email_cap_sections = []
 

--- a/dashboard/test/jobs/cap/teacher_sections_warning_job_test.rb
+++ b/dashboard/test/jobs/cap/teacher_sections_warning_job_test.rb
@@ -106,5 +106,16 @@ class CAP::TeacherSectionsWarningJobTest < ActiveJob::TestCase
         perform_enqueued_jobs {perform_later}
       end
     end
+
+    # We have legacy teacher accounts which don't have a plaintext email
+    context 'teacher email is blank' do
+      let(:teacher) {create(:teacher, :without_email, name: teacher_name)}
+
+      it 'does not warn teacher' do
+        expect_teacher_warning_to_be_sent.never
+        expect_event_logging.never
+        perform_enqueued_jobs {perform_later}
+      end
+    end
   end
 end


### PR DESCRIPTION
CAP teacher reminder emails should not try to email teachers with no email address.

## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1197)

## Testing story
* Unit tests
