### PR TITLE
use only unix status when deciding to report cronjob errors

### DIFF
--- a/bin/cron/hoc_student_name_cleanup
+++ b/bin/cron/hoc_student_name_cleanup
@@ -124,7 +124,7 @@ if options[:start_date].nil?
   last_processed_date = Properties.get(LAST_PROCESSED_DATE_PROPERTY)
   if last_processed_date.nil?
     CDO.log.error "--start-date is required on first run of the script"
-    return
+    exit 1
   end
   options[:start_date] = Date.parse(last_processed_date) + 1
 end

--- a/bin/test/cron/test_cronjob.rb
+++ b/bin/test/cron/test_cronjob.rb
@@ -1,0 +1,46 @@
+require_relative '../test_helper'
+
+BIN_DIR = File.expand_path('../../', __dir__)
+BIN_CRONJOB = File.join(BIN_DIR, 'cronjob')
+
+describe 'bin/cronjob' do
+  it 'can run the true command' do
+    success = system("#{BIN_CRONJOB} true")
+    assert success, 'Expected `bin/cronjob true` to return 0'
+  end
+
+  it 'notifies honeybadger if cronjob returns status 1' do
+    Honeybadger.expects(:notify).with(has_entry(:error_class, 'cronjob exit 1 returned 1')).once
+    bin_cronjob(command: 'exit 1')
+  end
+
+  it 'does not notify honeybadger if cronjob returns status 0' do
+    Honeybadger.expects(:notify).never
+    bin_cronjob(command: 'exit 0')
+  end
+
+  it 'does not notify honeybadger if cronjob just prints to stderr' do
+    Honeybadger.expects(:notify).never
+    bin_cronjob(command: '>&2 echo hello_badger')
+  end
+
+  it 'passes stderr to honeybadger if cronjob fails' do
+    Honeybadger.expects(:notify).with(has_entry(:error_message, "hello_badger\n")).once
+    bin_cronjob(command: '>&2 echo hello_badger && exit 1')
+  end
+
+  before do
+    @original_argv = ARGV.dup
+  end
+
+  after do
+    ARGV.replace(@original_argv)
+  end
+
+  # We use load('bin/cronjob'), as opposed to system('bin/cronjob'), to run cronjob in-process.
+  # This allows us to stub Honeybadger.notify and thereby simulate behavior.
+  private def bin_cronjob(command:)
+    ARGV.replace([command])
+    load BIN_CRONJOB
+  end
+end

--- a/bin/test/cron/test_cronjob.rb
+++ b/bin/test/cron/test_cronjob.rb
@@ -1,11 +1,11 @@
 require_relative '../test_helper'
 
 BIN_DIR = File.expand_path('../../', __dir__)
-BIN_CRONJOB = File.join(BIN_DIR, 'cronjob')
+BIN_CRONJOB_PATH = File.join(BIN_DIR, 'cronjob')
 
 describe 'bin/cronjob' do
   it 'can run the true command' do
-    success = system("#{BIN_CRONJOB} true")
+    success = system("#{BIN_CRONJOB_PATH} true")
     assert success, 'Expected `bin/cronjob true` to return 0'
   end
 
@@ -41,6 +41,6 @@ describe 'bin/cronjob' do
   # This allows us to stub Honeybadger.notify and thereby verify its called/not-called.
   private def bin_cronjob(command:)
     ARGV.replace([command])
-    load BIN_CRONJOB
+    load BIN_CRONJOB_PATH
   end
 end

--- a/bin/test/cron/test_cronjob.rb
+++ b/bin/test/cron/test_cronjob.rb
@@ -38,7 +38,7 @@ describe 'bin/cronjob' do
   end
 
   # We use load('bin/cronjob'), as opposed to system('bin/cronjob'), to run cronjob in-process.
-  # This allows us to stub Honeybadger.notify and thereby simulate behavior.
+  # This allows us to stub Honeybadger.notify and thereby verify its called/not-called.
   private def bin_cronjob(command:)
     ARGV.replace([command])
     load BIN_CRONJOB

--- a/lib/cdo/honeybadger.rb
+++ b/lib/cdo/honeybadger.rb
@@ -34,12 +34,7 @@ module Honeybadger
   # stdout - captured stdout from the command
   # stderr - captured stderr from the command
   def self.notify_command_error(command, status, stdout, stderr)
-    return if stderr.to_s.empty? && status == 0
-
-    # Temporarily ignore this high-volume deprecation warning, until we can
-    # implement alternatives to the deprecated functionality.
-    # TODO: eliminate this warning, and remove this exception
-    return if stderr.start_with?("WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.")
+    return if status == 0
 
     error_message, backtrace = parse_exception_dump stderr
 


### PR DESCRIPTION
it looks like we could be failing to log HB errors when cronjobs fail, any time that cronjob emits a certain common MYSQL warning. EDIT: also, it looks like we have many HB errors that are false positives, i.e. the cronjob completes but we log a HB error.

this is because we are trying to fail cronjobs when they log to STDERR, even if they have exit status 0. this is sloppy -- cronjobs should return nonzero exit status in order to indicate failure.

after testing steps below, the solution is to look only at exit status to decide whether the cronjob succeeded.

see [slack](https://codedotorg.slack.com/archives/C03CK49G9/p1728083559818039?thread_ts=1728079272.893629&cid=C03CK49G9) for full details.

## Testing story

* Dave audited cronjob code for obvious signs of relying on STDERR logging to kill the job. found one possible reliance on the old behavior, fixed in this PR
* Seth audited recent honeybadger error history for signs of HB errors with status code 0. there is lots of noise in HB with status 0 due to non-empty STDERR. all the examples we could easily check appear to have completed successfully, therefore, no need to log to honeybadger.