### PR TITLE
[Design2-161-1] DSCO - CloseButton - add support of `xs` and `s` sizes, `id` prop

### DIFF
--- a/apps/src/componentLibrary/closeButton/CHANGELOG.md
+++ b/apps/src/componentLibrary/closeButton/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/61581)
+
+* added `id` prop to `CloseButton` component
+* added `xs` and `s` sizes to `CloseButton` component
+
 ## [0.1.0](https://github.com/code-dot-org/code-dot-org/pull/59242)
 
 * implemented component

--- a/apps/src/componentLibrary/closeButton/CloseButton.story.tsx
+++ b/apps/src/componentLibrary/closeButton/CloseButton.story.tsx
@@ -49,6 +49,8 @@ GroupOfColorsOfCloseButton.args = {
 export const GroupOfSizesOfCloseButton = MultipleTemplate.bind({});
 GroupOfSizesOfCloseButton.args = {
   components: [
+    {onClick: () => null, size: 'xs', 'aria-label': 'Close xs'},
+    {onClick: () => null, size: 's', 'aria-label': 'Close s'},
     {onClick: () => null, size: 'm', 'aria-label': 'Close m'},
     {onClick: () => null, size: 'l', 'aria-label': 'Close l'},
   ],

--- a/apps/src/componentLibrary/closeButton/CloseButton.tsx
+++ b/apps/src/componentLibrary/closeButton/CloseButton.tsx
@@ -11,11 +11,13 @@ export interface CloseButtonProps extends AriaAttributes {
   /** Close Button onClick */
   onClick: () => void;
   /** Close Button size */
-  size?: Exclude<ComponentSizeXSToL, 's' | 'xs'>;
+  size?: ComponentSizeXSToL;
   /** Close Button Color*/
   color?: 'light' | 'dark';
   /** Close Button Custom class name */
   className?: string;
+  /** Close Button id */
+  id?: string;
   /** Close Button an accessible label indicating invisible label for the Close Button */
   'aria-label': string;
 }
@@ -39,6 +41,7 @@ const CloseButton: React.FunctionComponent<CloseButtonProps> = ({
   size = 'm',
   'aria-label': ariaLabel,
   color = 'dark',
+  id,
   className,
   ...rest
 }) => {
@@ -47,7 +50,7 @@ const CloseButton: React.FunctionComponent<CloseButtonProps> = ({
   return (
     <button
       type="button"
-      id="ui-close-dialog"
+      id={id}
       aria-label={ariaLabel}
       className={classNames(
         moduleStyles.closeButton,

--- a/apps/src/componentLibrary/closeButton/closeButton.module.scss
+++ b/apps/src/componentLibrary/closeButton/closeButton.module.scss
@@ -86,3 +86,25 @@
     width: 1.25rem;
   }
 }
+
+.closeButton-s {
+  width: 1.125rem;
+  height: 1.125rem;
+
+  i {
+    font-size: 0.75rem;
+    line-height: 125%;
+    width: 1.125rem;
+  }
+}
+
+.closeButton-xs {
+  width: 0.8125rem;
+  height: 0.8125rem;
+
+  i {
+    font-size: 0.625rem;
+    line-height: 125%;
+    width: 0.8125rem;
+  }
+}

--- a/apps/src/sharedComponents/AccessibleDialog.jsx
+++ b/apps/src/sharedComponents/AccessibleDialog.jsx
@@ -49,6 +49,7 @@ function AccessibleDialog({
             role="dialog"
           >
             <CloseButton
+              id="ui-close-dialog"
               className={closeIconStyle}
               aria-label={i18n.closeDialog()}
               onClick={xIconOnClick}


### PR DESCRIPTION
### [Design2-161-1] DSCO - CloseButton - add support of `xs` and `s` sizes, `id` prop


* added `xs` and `s` size support
* added `id` prop support

Before:
<img width="470" alt="Знімок екрана 2024-10-07 о 13 30 25" src="https://github.com/user-attachments/assets/a0ffe04b-25be-42e7-bda1-7c755af164b6">

After:
<img width="470" alt="Знімок екрана 2024-10-07 о 13 29 49" src="https://github.com/user-attachments/assets/ebb903fb-2619-4904-9002-6564fac3f51f">


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: [Design2-161](https://codedotorg.atlassian.net/browse/DESIGN2-161)
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
