### PR TITLE
[Music] default start measure 1

### DIFF
--- a/apps/src/music/blockly/toolbox/toolboxBlocks.ts
+++ b/apps/src/music/blockly/toolbox/toolboxBlocks.ts
@@ -290,6 +290,9 @@ const toolboxBlocks: {[blockType in BlockTypes | string]: BlockInfoWithText} = {
     levelbuilderText: 'Number',
     kind: 'block',
     type: 'math_number',
+    fields: {
+      NUM: 1,
+    },
   },
   ['math_round']: {
     levelbuilderText: 'Round',

--- a/apps/src/music/player/sequencer/AdvancedSequencer.ts
+++ b/apps/src/music/player/sequencer/AdvancedSequencer.ts
@@ -9,6 +9,8 @@ import MusicLibrary from '../MusicLibrary';
 
 import Sequencer from './Sequencer';
 
+const DEFAULT_START_MEASURE = 1;
+
 /**
  * A {@link Sequencer} used in the Advanced (programming with variables) block mode.
  */
@@ -38,7 +40,7 @@ export default class AdvancedSequencer extends Sequencer {
       soundType: soundData.type,
       blockId,
       triggered: false,
-      when: measure,
+      when: measure ?? DEFAULT_START_MEASURE,
       effects: {...this.effects},
     } as PlaybackEvent);
   }
@@ -56,7 +58,7 @@ export default class AdvancedSequencer extends Sequencer {
       length: length,
       blockId,
       triggered: false,
-      when: measure,
+      when: measure ?? DEFAULT_START_MEASURE,
       value,
       effects: {...this.effects},
     } as PlaybackEvent);
@@ -73,7 +75,7 @@ export default class AdvancedSequencer extends Sequencer {
       length: DEFAULT_CHORD_LENGTH,
       blockId,
       triggered: false,
-      when: measure,
+      when: measure ?? DEFAULT_START_MEASURE,
       value,
       effects: {...this.effects},
     } as PlaybackEvent);


### PR DESCRIPTION
In advanced mode, Music Lab's various `play` block require a starting measure. If an unexpected value, such as an undefined variable is used, we can't schedule the event because it ends up as `NaN`:

<img width="282" alt="image" src="https://github.com/user-attachments/assets/be8b89e5-0e88-4596-b0e3-42e4bcde980e"><img width="376" alt="image" src="https://github.com/user-attachments/assets/f439a3de-cbbc-4022-be6d-d903018e54cb">
<img width="561" alt="image" src="https://github.com/user-attachments/assets/190d9f8e-1880-4c2a-b171-c2983dbc60a8">

To avoid this problem, we can provide a default start measure in case the student code attempts to use something like undefined.  This is done here using the nullish coalescing `??` [operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) which returns its right-hand operand if the left side is `null` or `undefined`.

Now the unexpected value doesn't prevent us from playing the sample at a good start position and the song can be executed without error:
<img width="320" alt="image" src="https://github.com/user-attachments/assets/cb502092-5891-4b25-9a10-e5543a5a0c55"><img width="357" alt="image" src="https://github.com/user-attachments/assets/a8ce350f-e9dc-416c-b426-6c1bb8464f1a">


Additionally, since `1` is the most commonly expected starting measure, and because `play` blocks are the primary blocks with number inputs, it makes sense to reinforce that within the math toolbox.
<img width="45%" alt="image" src="https://github.com/user-attachments/assets/46590360-b6d4-4b21-a579-8f1c84d8ab6a"><img width="45%" alt="image" src="https://github.com/user-attachments/assets/c60aac7a-3d4b-43b2-94b0-be8ccd7fa684">

This branch also updates the default field value of the standalone number block in the toolbox from 0 to 1. This doesn't prevent a user from entering an unexpected value (e.g. negative, zero, or very high start measures), but it does reinforce the default values we give in the shadow blocks.

<img width="431" alt="image" src="https://github.com/user-attachments/assets/7acc3afb-0dca-41a8-9b73-11dc1ecd598d"><img width="280" alt="image" src="https://github.com/user-attachments/assets/21c33c69-af42-49ab-853c-3297f6c602e2">


