### PR TITLE
[Music] Use dialog control for Blockly alerts

### DIFF
--- a/apps/src/lab2/views/dialogs/GenericAlertDialog.tsx
+++ b/apps/src/lab2/views/dialogs/GenericAlertDialog.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 
 import GenericDialog, {GenericDialogProps} from './GenericDialog';
 
-export type GenericAlertDialogProps = Required<
-  Pick<GenericDialogProps, 'title'>
-> &
+export type GenericAlertDialogProps = Pick<GenericDialogProps, 'title'> &
   Pick<GenericDialogProps, 'message'>;
 
 const GenericAlertDialog: React.FunctionComponent<GenericAlertDialogProps> = ({

--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -142,7 +142,14 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
     },
     [dialogControl]
   );
+  const showGenericAlert = useCallback(
+    (message: string) => {
+      dialogControl.showDialog({type: DialogType.GenericAlert, message});
+    },
+    [dialogControl]
+  );
   Blockly.dialog.setPrompt(showGenericPrompt);
+  Blockly.dialog.setAlert(showGenericAlert);
 
   useEffect(() => {
     installFunctionBlocks(blockMode);


### PR DESCRIPTION
Similar to:
- https://github.com/code-dot-org/code-dot-org/pull/61432


This allows our Lab2 `GenericAlert` component to be used for Blockly alerts. For example, we will now see this alert when when attempting to create a variable that already exists:

<img width="744" alt="image" src="https://github.com/user-attachments/assets/6fc37e5e-4942-4f9e-94cc-a4adbc555c50">


## Follow-up work

I considered whether we should also do this for confirmation dialogs. However, the only two times that Blockly would create a confirm dialog are not currently enabled on our platform.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
