### PR TITLE
Improve account linking blocked error message

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -163,7 +163,7 @@ en:
     disconnect_successful: "Success! We have disconnected the external account from your Code.org account."
     already_in_use: "Your %{provider} account is already connected to another Code.org account."
     already_linked: "Your %{provider} account is already linked to your Code.org account."
-    parental_permission_required: "Uh oh! You must obtain parental permission before creating a linked account."
+    parental_permission_required: "Uh oh! You must obtain parental permission before creating a linked account. Please log in to the account you are trying to link and obtain parental consent."
     existing_account:
       account_exists: "Good news! You already have a Code.org account that uses %{email}"
       sign_in: "Please sign in to your existing account. Then you will be able to link your %{provider} profile from your Account Settings page."

--- a/dashboard/test/helpers/users_helper_test.rb
+++ b/dashboard/test/helpers/users_helper_test.rb
@@ -535,7 +535,7 @@ class UsersHelperTest < ActionView::TestCase
       let(:user_cap_compliant?) {false}
 
       it 'returns lock reason message' do
-        _(account_linking_lock_reason(user)).must_equal 'Uh oh! You must obtain parental permission before creating a linked account.'
+        _(account_linking_lock_reason(user)).must_equal 'Uh oh! You must obtain parental permission before creating a linked account. Please log in to the account you are trying to link and obtain parental consent.'
       end
     end
 
@@ -543,7 +543,7 @@ class UsersHelperTest < ActionView::TestCase
       let(:user_in_grace_period?) {true}
 
       it 'returns lock reason message' do
-        _(account_linking_lock_reason(user)).must_equal 'Uh oh! You must obtain parental permission before creating a linked account.'
+        _(account_linking_lock_reason(user)).must_equal 'Uh oh! You must obtain parental permission before creating a linked account. Please log in to the account you are trying to link and obtain parental consent.'
       end
     end
   end


### PR DESCRIPTION
Adds a second sentence to the error message when account linking is blocked based on CAP status.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
