### PR TITLE
stop translating resource url in teacher resources dropdown

### DIFF
--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -126,7 +126,7 @@ class Resource < ApplicationRecord
       key: key,
       markdownKey: Services::GloballyUniqueIdentifiers.build_resource_key(self),
       name: get_localized_property(:name),
-      url: get_localized_property(:url)
+      url: url
     }
   end
 

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -150,7 +150,7 @@ class ResourceTest < ActiveSupport::TestCase
     assert_equal existing_resource, copied_resource
   end
 
-  test "summarize retrives translations" do
+  test "summarize retrieves translations" do
     resource = create(:resource, name: "English name")
     test_locale = :'te-ST'
     custom_i18n = {
@@ -166,6 +166,28 @@ class ResourceTest < ActiveSupport::TestCase
     assert_equal("English name", resource.summarize_for_lesson_plan[:name])
     I18n.locale = test_locale
     assert_equal("Translated name", resource.summarize_for_lesson_plan[:name])
+    I18n.locale = I18n.default_locale
+  end
+
+  test "summarize_for_resources_dropdown retrieves translations" do
+    resource = create(:resource, name: "English name", url: "original-url")
+    test_locale = :'te-ST'
+    custom_i18n = {
+      "data" => {
+        "resources" => {
+          Services::GloballyUniqueIdentifiers.build_resource_key(resource) => {
+            "name" => "Translated name",
+            "url" => "translated-url"
+          }
+        }
+      }
+    }
+    I18n.backend.store_translations(test_locale, custom_i18n)
+    assert_equal("English name", resource.summarize_for_resources_dropdown[:name])
+    assert_equal("original-url", resource.summarize_for_resources_dropdown[:url])
+    I18n.locale = test_locale
+    assert_equal("Translated name", resource.summarize_for_resources_dropdown[:name])
+    assert_equal("original-url", resource.summarize_for_resources_dropdown[:url])
     I18n.locale = I18n.default_locale
   end
 end


### PR DESCRIPTION
finishes https://codedotorg.atlassian.net/browse/AITT-822

### screenshots
after setting `load_locales: true` in locals.yml and opening the page incognito, i'm able to see that the page is translated into es-ES but the resource url is not:
![Screenshot 2024-10-07 at 12 08 34 PM](https://github.com/user-attachments/assets/a25ba27c-bdc0-4f77-a6a3-71ae0d1ec5b0)

## Testing story

* new unit test
