### PR TITLE
Python Lab: polish around validation results and button

### DIFF
--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -244,7 +244,10 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
         onClick={handleStop}
         color={'destructive'}
         iconLeft={{iconStyle: 'solid', iconName: 'square'}}
-        className={moduleStyles.buttonInstruction}
+        className={classNames(
+          moduleStyles.buttonInstruction,
+          moduleStyles.validationButton
+        )}
         size={'s'}
       />
     ) : (
@@ -256,7 +259,8 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
         iconLeft={{iconStyle: 'solid', iconName: 'clipboard-check'}}
         className={classNames(
           darkModeStyles.secondaryButton,
-          moduleStyles.buttonInstruction
+          moduleStyles.buttonInstruction,
+          moduleStyles.validationButton
         )}
         color={'white'}
         size={'s'}

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -88,6 +88,10 @@
   height: 32px;
 }
 
+.validationButton {
+  margin-top: 8px;
+}
+
 .markdownText {
   line-height: 0;
 

--- a/apps/src/codebridge/InfoPanel/styles/validation-results.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validation-results.module.scss
@@ -5,7 +5,6 @@
 }
 
 .validationResultsTable {
-  table-layout: fixed;
   width: 100%;
   border-collapse: collapse;
   border: 1px solid $light_white;
@@ -17,7 +16,7 @@
 
   td {
     border: 1px solid $light_white;
-    padding: 4px;
+    padding: 4px 6px;
   }
 }
 

--- a/apps/src/codebridge/InfoPanel/styles/validation-results.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validation-results.module.scss
@@ -5,6 +5,7 @@
 }
 
 .validationResultsTable {
+  table-layout: auto;
   width: 100%;
   border-collapse: collapse;
   border: 1px solid $light_white;


### PR DESCRIPTION
Ken noticed that if a validation name had a long word, we were overflowing the table cell. This PR fixes this by changing the table layout from fixed to auto and updated the padding to give a little more breathing room.
While I was fixing this, I noticed if the instructions have a collapsible section at the bottom and it's collapsed, there's no whitespace between the instructions and the validation button. Therefore I added a top margin to the validation button to address this.

## Before
### Collapsible instruction collapsed
<img width="320" alt="Screenshot 2024-10-07 at 11 40 38 AM" src="https://github.com/user-attachments/assets/c09552ea-07f3-4e2a-91f8-feb814e2fc9f">

### Collapsible instruction open
<img width="320" alt="Screenshot 2024-10-07 at 11 40 45 AM" src="https://github.com/user-attachments/assets/b87d7444-bd4e-410a-8e7a-e952843394f4">

### Table with overflowing content
![Screenshot 2024-10-07 at 11 16 04 AM](https://github.com/user-attachments/assets/3a76fbf1-716e-4eb8-8b5e-ae5565a9e25e)

## After
### Collapsible instruction collapsed
<img width="318" alt="Screenshot 2024-10-07 at 11 37 11 AM" src="https://github.com/user-attachments/assets/96d6a2f6-8591-4f56-9bf6-d6413b67fea5">

### Collapsible instruction open
<img width="320" alt="Screenshot 2024-10-07 at 11 37 17 AM" src="https://github.com/user-attachments/assets/26f61b24-2090-4c87-a4f5-de9e6c307bbc">

### Table with overflowing content
<img width="324" alt="Screenshot 2024-10-07 at 11 36 31 AM" src="https://github.com/user-attachments/assets/f4fd93b2-f906-441b-8f5a-e60aeaaed8f6">

## Links
- jira ticket: [CT-850](https://codedotorg.atlassian.net/browse/CT-850)


## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
