### PR TITLE
Do not error out if EditorAnnotator.getCode would be falsy

### DIFF
--- a/apps/src/EditorAnnotator.js
+++ b/apps/src/EditorAnnotator.js
@@ -830,7 +830,7 @@ export default class EditorAnnotator {
       return EditorAnnotator.code_;
     }
 
-    let code = EditorAnnotator.annotator()?.getCode() || '';
+    let code = EditorAnnotator.annotator()?.getCode();
     EditorAnnotator.code_ = code;
 
     if (options.stripComments && code) {
@@ -852,12 +852,12 @@ export default class EditorAnnotator {
       }
 
       EditorAnnotator.strippedLines_ =
-        EditorAnnotator.getCode(options).split('\n');
+        EditorAnnotator.getCode(options)?.split('\n');
     } else if (EditorAnnotator.lines_) {
       return EditorAnnotator.lines_;
     }
 
-    EditorAnnotator.lines_ = EditorAnnotator.getCode(options).split('\n');
+    EditorAnnotator.lines_ = EditorAnnotator.getCode(options)?.split('\n');
     return EditorAnnotator.lines_;
   }
 
@@ -890,6 +890,10 @@ export default class EditorAnnotator {
     // Get the code
     let code = EditorAnnotator.getCode(options);
     let lines = EditorAnnotator.getLines(options);
+    if (!code && !lines) {
+      // In case there are no lines (the editor is not loaded)
+      return ret;
+    }
 
     // Attempt to just find the code in the full code listing
     let index = code.indexOf(snippet);

--- a/apps/src/EditorAnnotator.js
+++ b/apps/src/EditorAnnotator.js
@@ -830,7 +830,7 @@ export default class EditorAnnotator {
       return EditorAnnotator.code_;
     }
 
-    let code = EditorAnnotator.annotator()?.getCode();
+    let code = EditorAnnotator.annotator()?.getCode() || '';
     EditorAnnotator.code_ = code;
 
     if (options.stripComments && code) {

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -12,7 +12,7 @@ import EditorAnnotator from '@cdo/apps/EditorAnnotator';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {singleton as StudioApp} from '@cdo/apps/StudioApp';
+import {singleton as studioApp} from '@cdo/apps/StudioApp';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {ai_rubric_cyan} from '@cdo/apps/util/color';
 import HttpClient from '@cdo/apps/util/HttpClient';
@@ -537,13 +537,13 @@ export default function LearningGoals({
   };
 
   // Remember whether no not the code editor is loaded
-  const studioApp = StudioApp();
-  const [editorLoaded, setEditorLoaded] = useState(!!studioApp.editor);
+  const studio = studioApp();
+  const [editorLoaded, setEditorLoaded] = useState(!!studio.editor);
   useMemo(() => {
-    studioApp.on('afterInit', () => {
+    studio.on('afterInit', () => {
       setEditorLoaded(true);
     });
-  }, [studioApp]);
+  }, [studio]);
 
   const aiEvidence = useMemo(() => {
     if (!editorLoaded) {

--- a/apps/src/templates/rubrics/LearningGoals.jsx
+++ b/apps/src/templates/rubrics/LearningGoals.jsx
@@ -12,6 +12,7 @@ import EditorAnnotator from '@cdo/apps/EditorAnnotator';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {singleton as StudioApp} from '@cdo/apps/StudioApp';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {ai_rubric_cyan} from '@cdo/apps/util/color';
 import HttpClient from '@cdo/apps/util/HttpClient';
@@ -535,7 +536,20 @@ export default function LearningGoals({
     );
   };
 
+  // Remember whether no not the code editor is loaded
+  const studioApp = StudioApp();
+  const [editorLoaded, setEditorLoaded] = useState(!!studioApp.editor);
+  useMemo(() => {
+    studioApp.on('afterInit', () => {
+      setEditorLoaded(true);
+    });
+  }, [studioApp]);
+
   const aiEvidence = useMemo(() => {
+    if (!editorLoaded) {
+      return;
+    }
+
     const onEvidenceTooltipOpened = () => {
       // When the tooltip is opened, we will record that this happened alongside
       // information about the learning goal.
@@ -575,6 +589,7 @@ export default function LearningGoals({
     return [];
   }, [
     aiEvalInfo,
+    editorLoaded,
     productTour,
     currentLearningGoal,
     learningGoals,

--- a/apps/test/unit/EditorAnnotatorTest.js
+++ b/apps/test/unit/EditorAnnotatorTest.js
@@ -210,6 +210,16 @@ describe('EditorAnnotator', () => {
       dropletStub.getValue = sinon.stub().returns(code);
     });
 
+    it('returns undefined if the annotator is not yet available', () => {
+      EditorAnnotator.reset();
+      restoreDroplet();
+
+      let snippet = 'var y = 6;';
+      const result = EditorAnnotator.findCodeRegion(snippet);
+      expect(result.firstLine).to.be.undefined;
+      expect(result.lastLine).to.be.undefined;
+    });
+
     it('returns undefined for both lines when the snippet is not found', () => {
       let snippet = 'var a = 0;';
       const result = EditorAnnotator.findCodeRegion(snippet);


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/TEACH-1404

## Testing story

I pushed a commit that adds some reasonable bails when the editor is not loaded.

I first added a test that purposefully unloads the editor stubs and it indeed failed:

```
  ● EditorAnnotator › findCodeRegion › returns undefined if the annotator is not yet available

    TypeError: Cannot read properties of undefined (reading 'split')

      858 |     }
      859 |
    > 860 |     EditorAnnotator.lines_ = EditorAnnotator.getCode(options).split('\n');
          |                                                              ^
      861 |     return EditorAnnotator.lines_;
      862 |   }
      863 |
```

Then I added the committed code and it passes.

**Note**: This will get rid of the error but our rubric component has no reason to reload the evidence when the editor loads. It does not know when the editor loads if it happens to render before Droplet exists in the background.

### Editor Detection

Our `StudioApp` loads the editor via its initialization and triggers an event called `afterInit`. So, I have added to the component the ability to know when the editor is loaded via a `useMemo` that wraps that event trigger and sets some state. Then, the evidence only tries to render when `StudioApp.editor` exists, essentially.

There are updated tests to reflect this.