### PR TITLE
Python Lab: Add hover state for file tabs

### DIFF
--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -26,6 +26,10 @@
   height: 28px;
   background-color: $light_gray_950;
   border-radius: 4px 4px 0 0;
+
+  &:hover:not(.active) {
+    background-color: $light_gray_800;
+  }
 }
 
 .fileTab > span {


### PR DESCRIPTION
Add hover state for file tabs when they are not the active tab.

https://github.com/user-attachments/assets/73d4718a-9510-4e25-a75b-0b44672ab6ed


## Links

- jira ticket: [CT-844 [Nice to have] Add a hover state for file tabs](https://codedotorg.atlassian.net/browse/CT-844)
- [figma](https://www.figma.com/design/vcNGOFsIks0HhRk6GEOfZf/Upper-Lab?node-id=4705-9146&node-type=frame&t=TcutV6BqvXaWdjbM-0)

## Testing story

Tested locally