### PR TITLE
Improve error messaging for LTI NRPS errors

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1724,6 +1724,8 @@
   "ltiSectionSyncDialogDescription": "New to Code.org? A [section]({aboutSectionsUrl}) is used to manage your classroom and assign curricula. We've identified the following sections & students associated with your course.\n\nNot seeing all of your sections? Make sure you are enrolled as a teacher in each section you want to sync. Learn more [about syncing here]({aboutSyncingUrl}).",
   "ltiSectionSyncDialogDescriptionNoChange": "You're all set! Your sections & students are already up to date.\n\nYou can re-sync your sections at any time. Learn more [about syncing here]({aboutSyncingUrl})",
   "ltiSectionSyncDialogError": "We encountered an error when trying to sync with your LMS.",
+  "ltiSectionSyncDialogErrorCodeLabel": "Error Code",
+  "ltiSectionSyncDialogErrorNoCourseFound": "We couldn't find your course. Please try launching Code.org from your LMS again.",
   "ltiSectionSyncDialogErrorNoIntegration": "LTI Integration not found",
   "ltiSectionSyncDialogErrorNoSectionFound": "We couldn't find the given section.",
   "ltiSectionSyncDialogErrorWrongContext": "Sorry, looks like you are attempting to sync a course or section from the wrong place. Please launch the Code.org Integration from inside the course or section you would like to sync. Read more about supported placements [here]({url}).",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1724,7 +1724,7 @@
   "ltiSectionSyncDialogDescription": "New to Code.org? A [section]({aboutSectionsUrl}) is used to manage your classroom and assign curricula. We've identified the following sections & students associated with your course.\n\nNot seeing all of your sections? Make sure you are enrolled as a teacher in each section you want to sync. Learn more [about syncing here]({aboutSyncingUrl}).",
   "ltiSectionSyncDialogDescriptionNoChange": "You're all set! Your sections & students are already up to date.\n\nYou can re-sync your sections at any time. Learn more [about syncing here]({aboutSyncingUrl})",
   "ltiSectionSyncDialogError": "We encountered an error when trying to sync with your LMS.",
-  "ltiSectionSyncDialogErrorCodeLabel": "Error Code",
+  "ltiSectionSyncDialogErrorCode": "Error Code: {code}",
   "ltiSectionSyncDialogErrorNoCourseFound": "We couldn't find your course. Please try launching Code.org from your LMS again.",
   "ltiSectionSyncDialogErrorNoIntegration": "LTI Integration not found",
   "ltiSectionSyncDialogErrorNoSectionFound": "We couldn't find the given section.",

--- a/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.story.tsx
+++ b/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.story.tsx
@@ -100,5 +100,6 @@ Error.args = {
   isOpen: true,
   syncResult: {
     error: 'no_integration',
+    honeybadger_id: 'some-honeybadger-id',
   },
 };

--- a/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, {CSSProperties, useState} from 'react';
 
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
+import Typography from '@cdo/apps/componentLibrary/typography/Typography';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import {PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -82,6 +83,13 @@ export default function LtiSectionSyncDialog({
             markdown={errorMessage}
           />
         ))}
+        {syncResult.honeybadger_id && (
+          <Typography semanticTag="p" visualAppearance="body-four">
+            {`${i18n.ltiSectionSyncDialogErrorCodeLabel()}: ${
+              syncResult.honeybadger_id
+            }`}
+          </Typography>
+        )}
       </div>
     );
   };

--- a/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, {CSSProperties, useState} from 'react';
 
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
-import Typography from '@cdo/apps/componentLibrary/typography/Typography';
+import {BodyFourText} from '@cdo/apps/componentLibrary/typography';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import {PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -84,11 +84,11 @@ export default function LtiSectionSyncDialog({
           />
         ))}
         {syncResult.honeybadger_id && (
-          <Typography semanticTag="p" visualAppearance="body-four">
-            {`${i18n.ltiSectionSyncDialogErrorCodeLabel()}: ${
-              syncResult.honeybadger_id
-            }`}
-          </Typography>
+          <BodyFourText>
+            {i18n.ltiSectionSyncDialogErrorCode({
+              code: syncResult.honeybadger_id,
+            })}
+          </BodyFourText>
         )}
       </div>
     );

--- a/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialogHelpers.tsx
+++ b/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialogHelpers.tsx
@@ -11,6 +11,8 @@ export const getRosterSyncErrorMessage = (syncResult: LtiSectionSyncResult) => {
       return i18n.ltiSectionSyncDialogErrorNoIntegration();
     case 'no_section':
       return i18n.ltiSectionSyncDialogErrorNoSectionFound();
+    case 'nrps_error':
+      return i18n.ltiSectionSyncDialogErrorNoCourseFound();
     default:
       return syncResult.message
         ? syncResult.message

--- a/apps/src/simpleSignUp/lti/sync/types.ts
+++ b/apps/src/simpleSignUp/lti/sync/types.ts
@@ -20,6 +20,7 @@ export interface LtiSectionSyncResult {
   error?: string;
   message?: string;
   course_name?: string;
+  honeybadger_id?: string;
 }
 
 export interface LtiSectionSyncDialogProps {


### PR DESCRIPTION
Honeybadger notifies return an ID. This PR adds the ID to the payload that gets sent to the frontend after an LTI sync error. Users can then include the ID in reports, which will help us look up the corresponding log in Honeybadger.

Also adds a specific error message around the NRPS call in the sync_course route.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
