### PR TITLE
Music: AI drums tweak

### DIFF
--- a/apps/src/music/views/PatternAiPanel.tsx
+++ b/apps/src/music/views/PatternAiPanel.tsx
@@ -372,6 +372,7 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
           <div
             className={classNames(
               styles.botArea,
+              MusicRegistry.hideAiTemperature && styles.botAreaGap,
               ['drawnDrums', 'generated'].includes(userCompletedTask) &&
                 styles.botAreaVisible
             )}
@@ -386,15 +387,6 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
               )}
               alt=""
               draggable={false}
-            />
-            <Button
-              ariaLabel={musicI18n.generate()}
-              text={musicI18n.generate()}
-              onClick={handleAiClick}
-              disabled={generateState === 'generating'}
-              type="primary"
-              size="s"
-              className={styles.button}
             />
             {!MusicRegistry.hideAiTemperature && (
               <div>
@@ -434,6 +426,15 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
                 </div>
               </div>
             )}
+            <Button
+              ariaLabel={musicI18n.generate()}
+              text={musicI18n.generate()}
+              onClick={handleAiClick}
+              disabled={generateState === 'generating'}
+              type="primary"
+              size="s"
+              className={styles.button}
+            />
           </div>
         </div>
       </div>

--- a/apps/src/music/views/patternAiPanel.module.scss
+++ b/apps/src/music/views/patternAiPanel.module.scss
@@ -80,6 +80,12 @@
   align-items: center;
   opacity: 0;
   transition: 0.1s ease-in-out;
+  justify-content: flex-end;
+  height: 100%;
+
+  &Gap {
+    gap: 30px;
+  }
 
   &Visible {
     opacity: 1;
@@ -200,7 +206,7 @@
   }
 
   &Generate {
-    top: 143px;
+    top: 172px;
     right: 196px;
 
     &Error {
@@ -224,7 +230,7 @@
 
   &Generate {
     right: 177px;
-    top: 152px;
+    top: 201px;
   }
 }
 


### PR DESCRIPTION
A small tweak to the AI drums UI which moves the temperature slider above the `Generate` button.

This is a more natural arrangement, since a user would adjust the slider first, and then move down to the button.

### After

<img width="321" alt="Screenshot 2024-10-07 at 9 47 29 PM" src="https://github.com/user-attachments/assets/6447fa15-f2e5-4efb-98ae-d7e634548c2a">
