### PR TITLE
Panels: center text

### DIFF
--- a/apps/src/lab2/levelEditors/panels/EditPanels.tsx
+++ b/apps/src/lab2/levelEditors/panels/EditPanels.tsx
@@ -222,8 +222,10 @@ const EditPanel: React.FunctionComponent<EditPanelProps> = ({
           selectedValue={panel.layout || 'text-top-right'}
           items={[
             {value: 'text-top-left', text: 'Top Left'},
+            {value: 'text-top-center', text: 'Top Center'},
             {value: 'text-top-right', text: 'Top Right'},
             {value: 'text-bottom-left', text: 'Bottom Left'},
+            {value: 'text-bottom-center', text: 'Bottom Center'},
             {value: 'text-bottom-right', text: 'Bottom Right'},
           ]}
         />

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -98,18 +98,19 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
   }
 
   const showSmallText = height < 300;
-  const textLayoutClass =
-    panel.layout === 'text-top-left'
-      ? styles.markdownTextTopLeft
-      : panel.layout === 'text-top-center'
-      ? styles.markdownTextTopCenter
-      : panel.layout === 'text-bottom-left'
-      ? styles.markdownTextBottomLeft
-      : panel.layout === 'text-bottom-center'
-      ? styles.markdownTextBottomCenter
-      : panel.layout === 'text-bottom-right'
-      ? styles.markdownTextBottomRight
-      : styles.markdownTextTopRight;
+
+  const layoutClassMap = {
+    'text-top-left': styles.markdownTextTopLeft,
+    'text-top-center': styles.markdownTextTopCenter,
+    'text-bottom-left': styles.markdownTextBottomLeft,
+    'text-bottom-center': styles.markdownTextBottomCenter,
+    'text-bottom-right': styles.markdownTextBottomRight,
+    'text-top-right': styles.markdownTextTopRight,
+  };
+
+  const textLayoutClass = panel.layout
+    ? layoutClassMap[panel.layout]
+    : styles.markdownTextTopRight;
 
   return (
     <div

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -101,8 +101,12 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
   const textLayoutClass =
     panel.layout === 'text-top-left'
       ? styles.markdownTextTopLeft
+      : panel.layout === 'text-top-center'
+      ? styles.markdownTextTopCenter
       : panel.layout === 'text-bottom-left'
       ? styles.markdownTextBottomLeft
+      : panel.layout === 'text-bottom-center'
+      ? styles.markdownTextBottomCenter
       : panel.layout === 'text-bottom-right'
       ? styles.markdownTextBottomRight
       : styles.markdownTextTopRight;

--- a/apps/src/panels/panelsView.module.scss
+++ b/apps/src/panels/panelsView.module.scss
@@ -79,6 +79,12 @@
         left: -20px;
       }
 
+      &TopCenter {
+        top: 40px;
+        left: 50%;
+        transform: translateX(-50%);
+      }
+
       &TopRight {
         top: 40px;
         right: -20px;
@@ -89,6 +95,11 @@
         left: -20px;
       }
 
+      &BottomCenter {
+        bottom: 40px;
+        left: 50%;
+        transform: translateX(-50%);
+      }
 
       &BottomRight {
         bottom: 40px;

--- a/apps/src/panels/types.ts
+++ b/apps/src/panels/types.ts
@@ -6,8 +6,10 @@ export interface PanelsLevelProperties extends LevelProperties {
 
 export type PanelLayout =
   | 'text-top-left'
+  | 'text-top-center'
   | 'text-top-right'
   | 'text-bottom-left'
+  | 'text-bottom-center'
   | 'text-bottom-right';
 
 export interface Panel {


### PR DESCRIPTION
This adds two new options to position panels text: top center & bottom center.

### Editor

<img width="986" alt="Screenshot 2024-10-07 at 10 14 50 PM" src="https://github.com/user-attachments/assets/6af1c7b8-36eb-4ba6-8ebb-563b4cdc770c">
