### PR TITLE
Update case switching for /yourschool map

### DIFF
--- a/apps/src/templates/census/CensusMap.jsx
+++ b/apps/src/templates/census/CensusMap.jsx
@@ -21,21 +21,25 @@ class CensusMapInfoWindow extends Component {
     let color = '';
 
     switch (this.props.teachesCs) {
-      case ('YES', 'Y'):
+      case 'YES':
+      case 'Y':
         censusMessage = 'We believe this school offers Computer Science.';
         color = 'green';
         break;
-      case ('NO', 'N'):
+      case 'NO':
+      case 'N':
         censusMessage =
           'We believe this school offers no Computer Science opportunities.';
         color = 'blue';
         break;
-      case ('HISTORICAL_YES', 'HY'):
+      case 'HISTORICAL_YES':
+      case 'HY':
         censusMessage =
           'We believe this school historically offered Computer Science.';
         color = 'green';
         break;
-      case ('HISTORICAL_NO', 'HN'):
+      case 'HISTORICAL_NO':
+      case 'HN':
         censusMessage =
           'We believe this school historically offered no Computer Science opportunities.';
         color = 'blue';


### PR DESCRIPTION
After running the `./bin/update_census_mapbox` script on production to update the [code.org/yourschool](https://code.org/yourschool) map, we saw that the points were color-coded to last year's data and labeled as 'unknown'. After checking on the production database, it looked like the right data was present in the `CensusSummary` data table.

Bethany then helped me narrow down that the issue was how the `case`/`switch` was being handled in the `CensusMap.jsx` file. It turns out `('YES', 'Y')` just returns `'Y'` rather than checking for either option. After adjusting how the different cases are handled, it now shows the right colors with the right data.

### How it looks now on /yourschool:
Wrong data color on the point (purple = "NO"/"N") and labeled as having no data.
![BROKEN](https://github.com/user-attachments/assets/228b6499-187c-48bb-a5e8-e2b9e2f0caff)

### How it looks with the fix locally:
Correct data color on point and correct label as having data.
![FIXED](https://github.com/user-attachments/assets/d3251687-fb1f-441c-a89b-757eaabf5f7e)

## Testing story
Local testing.
