### PR TITLE
[Design] DSCO - Tabs component - add native tooltip when tab label overflows

### DIFF
--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -2,6 +2,7 @@
 @import './aichat-common.module.scss';
 
 $default-spacing: 16px;
+$tabs-default-spacing: 4px;
 
 .chatWorkspace {
   @extend %panel-section;
@@ -25,6 +26,12 @@ $default-spacing: 16px;
 
 .tabsContainer {
   background-color: #eaebeb;
+  padding: $tabs-default-spacing $tabs-default-spacing 0 $tabs-default-spacing;
+  ul {
+    li > button[role="tab"] {
+      max-width: 300px;  
+    }
+  }
 }
 
 .tabPanelsContainer {

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -2,7 +2,6 @@
 @import './aichat-common.module.scss';
 
 $default-spacing: 16px;
-$tabs-default-spacing: 4px;
 
 .chatWorkspace {
   @extend %panel-section;
@@ -26,12 +25,6 @@ $tabs-default-spacing: 4px;
 
 .tabsContainer {
   background-color: #eaebeb;
-  padding: $tabs-default-spacing $tabs-default-spacing 0 $tabs-default-spacing;
-  ul {
-    li > button[role="tab"] {
-      max-width: 300px;  
-    }
-  }
 }
 
 .tabPanelsContainer {

--- a/apps/src/componentLibrary/tabs/CHANGELOG.md
+++ b/apps/src/componentLibrary/tabs/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.2]()
+## [0.3.2](https://github.com/code-dot-org/code-dot-org/pull/61624)
 
-* add native tooltip for `_Tab` component when tab has overflown text(label)
+* add native tooltip for `_Tab` component when tab has overflown text(label) and no tooltip prop
 
 ## [0.3.1](https://github.com/code-dot-org/code-dot-org/pull/61120)
 

--- a/apps/src/componentLibrary/tabs/CHANGELOG.md
+++ b/apps/src/componentLibrary/tabs/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.1]()
+## [0.3.2]()
+
+* add native tooltip for `_Tab` component when tab has overflown text(label)
+
+## [0.3.1](https://github.com/code-dot-org/code-dot-org/pull/61120)
 
 * set max-width for `_Tab` component
 * overflown text in `_Tab` component is now ellipsized

--- a/apps/src/componentLibrary/tabs/Tabs.story.tsx
+++ b/apps/src/componentLibrary/tabs/Tabs.story.tsx
@@ -49,6 +49,25 @@ DefaultTabs.args = {
   onChange: () => null,
 };
 
+export const DefaultTabsOverflownLabel = SingleTemplate.bind({});
+DefaultTabsOverflownLabel.args = {
+  name: 'default_tabs_with_overflown_label',
+  tabs: [
+    {
+      value: 'tab1',
+      text: 'Tab 1 with very long label name',
+      tabContent: <div>Tab 1 Content</div>,
+    },
+    {
+      value: 'tab2',
+      text: 'Tab 2 with very long label name',
+      tabContent: <div>Tab 2 Content</div>,
+    },
+  ],
+  defaultSelectedTabValue: 'tab1',
+  onChange: () => null,
+};
+
 export const DefaultTabsWithDisabledTab = SingleTemplate.bind({});
 DefaultTabsWithDisabledTab.args = {
   name: 'default_tabs_with_disabled_tab',

--- a/apps/src/componentLibrary/tabs/_Tab.tsx
+++ b/apps/src/componentLibrary/tabs/_Tab.tsx
@@ -88,13 +88,13 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
   isIconOnly = false,
 }) => {
   const handleClick = useCallback(() => onClick(value), [onClick, value]);
-  const handleTooltip = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleNativeTooltip = (e: React.MouseEvent<HTMLButtonElement>) => {
     const target = e.currentTarget;
     // Locate the element that contains the text (if nested inside spans or other elements).
     const textElement = target.querySelector('span') || target;
 
-    if (textElement.scrollWidth > textElement.clientWidth) {
-      // Set the tooltip text if overflow occurs.
+    if (textElement.scrollWidth > textElement.clientWidth && !tooltip) {
+      // Set the tooltip text if overflow occurs if the tooltip prop is not passed.
       target.title = textElement.textContent || '';
     } else {
       // Clear tooltip if no overflow.
@@ -124,7 +124,7 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
         isIconOnly && moduleStyles.iconOnlyTab
       )}
       onClick={handleClick}
-      onMouseOver={handleTooltip}
+      onMouseOver={handleNativeTooltip}
       disabled={disabled}
     >
       {buttonContent}

--- a/apps/src/componentLibrary/tabs/_Tab.tsx
+++ b/apps/src/componentLibrary/tabs/_Tab.tsx
@@ -90,14 +90,14 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
   const handleClick = useCallback(() => onClick(value), [onClick, value]);
   const handleTooltip = (e: React.MouseEvent<HTMLButtonElement>) => {
     const target = e.currentTarget;
-    // Locate the element that contains the text (if nested inside spans or other elements)
+    // Locate the element that contains the text (if nested inside spans or other elements).
     const textElement = target.querySelector('span') || target;
 
     if (textElement.scrollWidth > textElement.clientWidth) {
-      // Set the tooltip text if overflow occurs
+      // Set the tooltip text if overflow occurs.
       target.title = textElement.textContent || '';
     } else {
-      // Clear tooltip if no overflow
+      // Clear tooltip if no overflow.
       target.title = '';
     }
   };

--- a/apps/src/componentLibrary/tabs/_Tab.tsx
+++ b/apps/src/componentLibrary/tabs/_Tab.tsx
@@ -88,6 +88,20 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
   isIconOnly = false,
 }) => {
   const handleClick = useCallback(() => onClick(value), [onClick, value]);
+  const handleTooltip = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const target = e.currentTarget;
+    // Locate the element that contains the text (if nested inside spans or other elements)
+    const textElement = target.querySelector('span') || target;
+
+    if (textElement.scrollWidth > textElement.clientWidth) {
+      // Set the tooltip text if overflow occurs
+      target.title = textElement.textContent || '';
+    } else {
+      // Clear tooltip if no overflow
+      target.title = '';
+    }
+  };
+
   checkTabForErrors(isIconOnly, icon, text);
 
   const buttonContent = renderTabButtonContent(
@@ -110,6 +124,7 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
         isIconOnly && moduleStyles.iconOnlyTab
       )}
       onClick={handleClick}
+      onMouseOver={handleTooltip}
       disabled={disabled}
     >
       {buttonContent}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the DSCO `Tabs` component so that when the Tab label text overflows, a tooltip is displayed on hover.
I consulted with @levadadenys and he recommended setting the `title` attribute when the label text overflows. 7bbf26e2797e39d5bc7decf5049d28f0b8357b26

I added a Storybook example of tabs with overflown label text - on hover you can view tooltip.



https://github.com/user-attachments/assets/1ed88e8e-759e-47cd-a4c8-2ceef959e15d



This was needed in `aichat` levels for the workspace tabs which are shown when a teacher user views student chat history and tests the student-customized chatbot.


https://github.com/user-attachments/assets/e6574907-5f95-49b8-b1d0-049c0d9ed65a






## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1029)
[Slack thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1728320508551979)


<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally in an `aichat` level and also ran storybook locally and confirmed tooltip is displayed for `Tabs` example added.


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
