### PR TITLE
[Music] Start Sources updates for Advanced Mode

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -64,6 +64,16 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
     });
   }, [levelData.library, loadedLibraries]);
 
+  // Reset the start sources whenever the block mode changes.
+  useEffect(() => {
+    const startSourcesFilename = `startSources${blockMode}`;
+    const startSources = require(`@cdo/static/music/${startSourcesFilename}.json`);
+    setLevelData(prevLevelData => ({
+      ...prevLevelData,
+      startSources,
+    }));
+  }, [blockMode]);
+
   const hasRestrictedSounds = useMemo(
     () =>
       levelData.library &&

--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -64,16 +64,6 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
     });
   }, [levelData.library, loadedLibraries]);
 
-  // Reset the start sources whenever the block mode changes.
-  useEffect(() => {
-    const startSourcesFilename = `startSources${blockMode}`;
-    const startSources = require(`@cdo/static/music/${startSourcesFilename}.json`);
-    setLevelData(prevLevelData => ({
-      ...prevLevelData,
-      startSources,
-    }));
-  }, [blockMode]);
-
   const hasRestrictedSounds = useMemo(
     () =>
       levelData.library &&
@@ -196,18 +186,22 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
           blockMode={levelData.blockMode || BlockMode.SIMPLE2}
           addFunctionCalls={levelData.toolbox?.addFunctionCalls}
           onChange={toolbox => setLevelData({...levelData, toolbox})}
-          onBlockModeChange={blockMode =>
+          onBlockModeChange={blockMode => {
+            const startSourcesFilename = `startSources${blockMode}`;
+            const startSources = require(`@cdo/static/music/${startSourcesFilename}.json`);
+
             // Reset toolbox blocks when changing block mode
             setLevelData({
               ...levelData,
               blockMode,
+              startSources,
               toolbox: {
                 ...levelData.toolbox,
                 blocks: undefined,
                 addFunctionCalls: undefined,
               },
-            })
-          }
+            });
+          }}
           onAddFunctionCallsChange={(addFunctionCalls: boolean) => {
             setLevelData({
               ...levelData,

--- a/apps/src/lab2/levelEditors/levelData/EditMusicToolbox.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicToolbox.tsx
@@ -33,7 +33,7 @@ const ChangeWarning: React.FC = () => (
   <Alert
     type="warning"
     size="xs"
-    text="Changing this setting will reset toolbox blocks."
+    text="Changing this setting will reset toolbox blocks and start sources."
   />
 );
 

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -411,7 +411,16 @@ class UnconnectedMusicView extends React.Component {
       this.library.setCurrentPackId(null);
     }
 
-    this.loadCode(this.getStartSources());
+    // Check if we are in start mode, and if so, load sources from the default JSON.
+    const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
+    if (isStartMode) {
+      const startSourcesFilename = 'startSources' + this.props.blockMode;
+      const defaultSources = require(`@cdo/static/music/${startSourcesFilename}.json`);
+      this.loadCode(defaultSources);
+    } else {
+      // Otherwise, use getStartSources which handles levelData and fallback logic.
+      this.loadCode(this.getStartSources());
+    }
     this.setPlaying(false);
   };
 

--- a/apps/static/music/startSourcesAdvanced.json
+++ b/apps/static/music/startSourcesAdvanced.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:205fd5082d256a48b02ebe7dc0f25e7d57454499f8435ddefbc9055ef0e51f1c
-size 318
+oid sha256:a7563e8c8615683fda7cb7f8bb6c56d7de5f9d4aaa4c2b020028aaf529e13389
+size 233


### PR DESCRIPTION
This branch includes three updates to start sources and level editing that are relevant for creating Advanced Mode levels:

## 1. Starting over will use the default sources in Start Mode
Currently, if you go to start mode and choose start over (`clearCode`), we will load the last-saved sources. There is no way to go back to the actual default sources (e.g. just a `when run` block).

With these changes, pressing start over will load sources from one of our static JSON files. Refreshing the page without saving will still load the last-saved sources.

https://github.com/user-attachments/assets/3ef3a1cb-b595-4529-bd20-568b6ebc328b

## 2. Toggling the block mode will reset the start sources
When editing the toolbox, you can now toggle the block mode. However, doing so doesn't change the start sources. This means it's possible to save configuration suggesting a simple2 toolbox with advanced start sources, or vice versa. Now, if you toggle the block mode, we also reset the start sources.

https://github.com/user-attachments/assets/aa35f248-4aa0-4d63-9787-5bd8342614be

## 3. Update the Advanced default sources.
As shown near the end of the video above, the new start sources will just include a undeletable `when run` block, as many lessons do not require the specific trigger event block that is currently provided.

@onlinecsteacher says:
> We definitely want “when run” but not the event block as the default starter blocks because I could see us having levels (even whole lessons) that don’t use the event triggers




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
