### PR TITLE
Updates Email Validation to new Format for new sign up flow

### DIFF
--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -38,9 +38,8 @@ const LoginTypeSelection: React.FunctionComponent = () => {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [showConfirmPasswordError, setShowConfirmPasswordError] =
     useState(false);
+  const [showEmailError, setShowEmailError] = useState(false);
   const [email, setEmail] = useState('');
-  const [emailIcon, setEmailIcon] = useState(X_ICON);
-  const [emailIconClass, setEmailIconClass] = useState(style.lightGray);
   const [authToken, setAuthToken] = useState('');
   const [createAccountButtonDisabled, setCreateAccountButtonDisabled] =
     useState(true);
@@ -115,19 +114,15 @@ const LoginTypeSelection: React.FunctionComponent = () => {
 
   const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(event.target.value);
-    if (isEmail(event.target.value)) {
-      setEmailIcon(CHECK_ICON);
-      setEmailIconClass(style.teal);
-      sessionStorage.setItem(EMAIL_SESSION_KEY, event.target.value);
-    } else {
-      setEmailIcon(X_ICON);
-      setEmailIconClass(style.lightGray);
-    }
+    sessionStorage.setItem(EMAIL_SESSION_KEY, event.target.value);
   };
 
   const submitLoginType = async () => {
     logUserLoginType('email');
-
+    if (!isEmail(email)) {
+      setShowEmailError(true);
+      return;
+    }
     const submitLoginTypeParams = {
       new_sign_up: true,
       user: {
@@ -298,13 +293,17 @@ const LoginTypeSelection: React.FunctionComponent = () => {
                 onChange={handleEmailChange}
                 name="emailInput"
               />
-              <div className={style.validationMessage}>
-                <FontAwesomeV6Icon
-                  className={emailIconClass}
-                  iconName={emailIcon}
-                />
-                <BodyThreeText>{i18n.censusInvalidEmail()}</BodyThreeText>
-              </div>
+              {showEmailError && (
+                <div className={style.validationMessage}>
+                  <FontAwesomeV6Icon
+                    className={style.red}
+                    iconName={EXCLAMATION_ICON}
+                  />
+                  <BodyThreeText className={style.red}>
+                    {i18n.censusInvalidEmail()}
+                  </BodyThreeText>
+                </div>
+              )}
             </div>
             <div>
               <TextField

--- a/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
+++ b/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
@@ -115,6 +115,39 @@ describe('LoginTypeSelection', () => {
     });
   });
 
+  it('gives email invalid message if given invalid email and create account pressed', async () => {
+    await waitFor(() => {
+      renderDefault();
+    });
+
+    const emailInput = screen.getByLabelText(locale.email_address());
+    await waitFor(() => {
+      fireEvent.change(emailInput, {target: {value: 'invalidEmail'}});
+    });
+    const password = 'password';
+    const passwordInput = screen.getByLabelText(locale.password());
+    const confirmPasswordInput = screen.getByLabelText(
+      locale.confirm_password()
+    );
+    fireEvent.change(passwordInput, {target: {value: password}});
+    fireEvent.change(confirmPasswordInput, {target: {value: password}});
+
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.create_my_account(),
+    }) as HTMLButtonElement;
+    await waitFor(() => {
+      expect(finishSignUpButton).not.toBeDisabled();
+    });
+
+    // Confirm we don't have an error message yet
+    expect(screen.queryByText(i18n.censusInvalidEmail())).toBeNull();
+
+    // Click create account button
+    fireEvent.click(finishSignUpButton);
+    // Confirm we have an error message
+    expect(screen.queryByText(i18n.censusInvalidEmail()));
+  });
+
   it('clicking the create account button triggers fetch call and redirects user', async () => {
     const fetchSpy = sinon.stub(window, 'fetch');
     fetchSpy.returns(Promise.resolve(new Response()));
@@ -150,7 +183,6 @@ describe('LoginTypeSelection', () => {
     fireEvent.change(emailInput, {
       target: {value: email},
     });
-    fireEvent.change(passwordInput, {target: {value: password}});
     fireEvent.change(passwordInput, {target: {value: password}});
     fireEvent.change(confirmPasswordInput, {target: {value: password}});
     await waitFor(() => {
@@ -300,7 +332,7 @@ describe('LoginTypeSelection', () => {
     screen.getByText('Schoology', {selector: 'span'});
   });
 
-  it('valid email is stored in sessionStorage', async () => {
+  it('email is stored in sessionStorage', async () => {
     await waitFor(() => {
       renderDefault();
     });
@@ -310,18 +342,9 @@ describe('LoginTypeSelection', () => {
     // Session storage starts empty
     expect(sessionStorage.getItem(EMAIL_SESSION_KEY)).toBe(null);
 
-    // Session storage doesn't update for an invalid email
     await waitFor(() => {
       fireEvent.change(emailInput, {target: {value: 'invalidEmail'}});
     });
-    expect(sessionStorage.getItem(EMAIL_SESSION_KEY)).toBe(null);
-
-    // Session storage updates for valid email
-    await waitFor(() => {
-      fireEvent.change(emailInput, {target: {value: 'validEmail@email.com'}});
-    });
-    expect(sessionStorage.getItem(EMAIL_SESSION_KEY)).toBe(
-      'validEmail@email.com'
-    );
+    expect(sessionStorage.getItem(EMAIL_SESSION_KEY)).toBe('invalidEmail');
   });
 });


### PR DESCRIPTION
This updates the email validation to be 'after save' instead of before to reduce error messaging overload.

Before:
https://github.com/user-attachments/assets/5e6d0820-82ab-412d-8329-e71f146758e9


After:
https://github.com/user-attachments/assets/9fd7988a-886d-487e-9bfe-57643cbdde3d


## Links

- spec: https://www.figma.com/design/88sbry7xnl1wcyrOgbgFtn/Sign-Up-Flow?node-id=4283-2014&node-type=canvas&t=LxudgidWTxSE0MEJ-0
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2448

## Testing story

I updated the email session storage test and added a new test to ensure email validation only appears after an attempted save with an invalid email.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
