### PR TITLE
Lab2/Python Lab: Smarter project clean up/autosave

### DIFF
--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -11,6 +11,8 @@ import _ from 'lodash';
 
 import {setVerified} from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import {TestResults} from '@cdo/apps/constants';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import notifyLevelChange from '@cdo/apps/lab2/utils/notifyLevelChange';
 import {
   processServerStudentProgress,
   getLevelResult,
@@ -29,7 +31,6 @@ import {
 } from '@cdo/apps/types/progressTypes';
 import {RootState} from '@cdo/apps/types/redux';
 
-import notifyLevelChange from '../lab2/utils/notifyLevelChange';
 import {getBubbleUrl} from '../templates/progress/BubbleFactory';
 import {AppDispatch} from '../util/reduxHooks';
 import {navigateToHref} from '../utils';
@@ -310,7 +311,7 @@ export const queryUserProgress =
 // so we should update the browser and also set this as the new
 // current level.
 export function navigateToLevelId(levelId: string): ProgressThunkAction {
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     const state = getState().progress;
     if (!state.currentLessonId || !state.currentLevelId) {
       return;
@@ -328,6 +329,12 @@ export function navigateToLevelId(levelId: string): ProgressThunkAction {
       notifyLevelChange(currentLevel.id, levelId);
       dispatch(setCurrentLevelId(levelId));
     } else {
+      if (currentLevel?.usesLab2) {
+        // If we are switching from a lab2 level but can't change the level without reloading,
+        // we clean up the project manager (if it exists) to avoid a confusing pop-up to users
+        // if their most recent code has not saved.
+        await Lab2Registry.getInstance().getProjectManager()?.cleanUp();
+      }
       const url = getBubbleUrl(newLevel.path, undefined, undefined, true);
       navigateToHref(url);
     }

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -8,15 +8,14 @@ import React, {useContext, useEffect, useState} from 'react';
 
 import {sendPredictLevelReport} from '@cdo/apps/code-studio/progressRedux';
 import {MAIN_PYTHON_FILE, START_SOURCES} from '@cdo/apps/lab2/constants';
+import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {ProgressManagerContext} from '@cdo/apps/lab2/progress/ProgressContainer';
+import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {isPredictAnswerLocked} from '@cdo/apps/lab2/redux/predictLevelRedux';
 import {MultiFileSource, ProjectSources} from '@cdo/apps/lab2/types';
 import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import {AppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
-
-import useLifecycleNotifier from '../lab2/hooks/useLifecycleNotifier';
-import Lab2Registry from '../lab2/Lab2Registry';
-import {getAppOptionsEditBlocks} from '../lab2/projects/utils';
 
 import PythonValidationTracker from './progress/PythonValidationTracker';
 import PythonValidator from './progress/PythonValidator';

--- a/apps/src/pythonlab/PythonlabView.tsx
+++ b/apps/src/pythonlab/PythonlabView.tsx
@@ -15,6 +15,7 @@ import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import {AppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import useLifecycleNotifier from '../lab2/hooks/useLifecycleNotifier';
+import Lab2Registry from '../lab2/Lab2Registry';
 import {getAppOptionsEditBlocks} from '../lab2/projects/utils';
 
 import PythonValidationTracker from './progress/PythonValidationTracker';
@@ -130,6 +131,10 @@ const PythonlabView: React.FunctionComponent = () => {
     dispatch: AppDispatch,
     source: MultiFileSource | undefined
   ) => {
+    // Flush any pending saves if we have a project manager on run. The user will likely
+    // run their code before navigating away from the page, so switching pages
+    // will be faster if we flush save now.
+    Lab2Registry.getInstance().getProjectManager()?.flushSave();
     // We don't send the validation file to the runner if we are in start mode,
     // as we want to use the validation from the sources instead.
     await handleRunClick(


### PR DESCRIPTION
A couple changes to decrease the chances of getting an ugly "you have unsaved changes" pop-up on Python Lab when navigating away from the level. We could see this in two main situations:
- When switching from a lab2 level to a non-lab2 level (ex. bubble choice) and your code hadn't saved yet.
- When closing the tab when your code hadn't saved yet.
This was noted in the bug bash by a few people.

Previously, in Python Lab, we request saves on each code change, and the Project Manager throttles the saves to happen every 30 seconds. The first save will wait 30 seconds to occur (this is generic lab2 behavior). When we switch between lab2 levels, we clean up the project manager and flush saves before going to the next level, and the user is none the wiser. However, when we go from a lab2 to a non lab2 level, we hit this [beforeunload event](https://github.com/code-dot-org/code-dot-org/blob/a6b3a56d5778f0d5c191b8f7fec371c8ed5dbcae/apps/src/lab2/projects/ProjectContainer.tsx#L106), which will pop up the browser default "are you sure" message. There's no way to customize this message (this is the Firefox version):
![Screenshot 2024-10-08 at 2 50 32 PM](https://github.com/user-attachments/assets/121a0a82-3a5a-4cff-9d34-79b5ae3c71ef)

When switching from a lab2 level to a non-lab2 level, we can avoid this completely. I updated the `navigateToLevelId` function such that if we are in this case, we call `cleanUp` on the project manager before navigating to the next level. For the case of closing a tab, we can make it less likely by forcing a save every time the user runs. Users are likely to edit code, then run their code. This won't get rid of all cases, but will decrease the frequency of seeing it. I think closing the tab is also a case where that pop-up is a little more acceptable.

## Links

- jira ticket: [CT-854](https://codedotorg.atlassian.net/browse/CT-854)


## Testing story
Tested on multiple lab2 labs (AI Chat, Python Lab, Music Lab). This change won't impact non-lab2 labs because `navigateToLevelId` is only used by lab2 labs.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
