### PR TITLE
Add Google Tag Manager to code.org

### DIFF
--- a/apps/src/sites/code.org/pages/views/theme_google_analytics.js
+++ b/apps/src/sites/code.org/pages/views/theme_google_analytics.js
@@ -1,1 +1,15 @@
 import '@cdo/apps/metrics/GoogleAnalyticsReporter';
+
+// Google Tag Manager
+(function (w, d, s, l, i) {
+  w[l] = w[l] || [];
+  w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+  var f = d.getElementsByTagName(s)[0],
+    j = d.createElement(s),
+    // eslint-disable-next-line eqeqeq
+    dl = l != 'dataLayer' ? '&l=' + l : '';
+  j.async = true;
+  j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+  f.parentNode.insertBefore(j, f);
+})(window, document, 'script', 'dataLayer', 'GTM-TZZBRK5');
+// End Google Tag Manager

--- a/pegasus/sites.v3/code.org/themes/default.haml
+++ b/pegasus/sites.v3/code.org/themes/default.haml
@@ -10,5 +10,6 @@
 
     =view :theme_common_head_after
   %body
+    =view :theme_common_google_tag_manager
     =body
     =view :theme_common_body_after

--- a/pegasus/sites.v3/code.org/themes/responsive.haml
+++ b/pegasus/sites.v3/code.org/themes/responsive.haml
@@ -21,5 +21,6 @@
 
     =view :theme_common_head_after
   %body
+    =view :theme_common_google_tag_manager
     =body
     =view :theme_common_body_after

--- a/pegasus/sites.v3/code.org/themes/responsive_full_width.haml
+++ b/pegasus/sites.v3/code.org/themes/responsive_full_width.haml
@@ -22,5 +22,6 @@
 
     =view :theme_common_head_after
   %body
+    =view :theme_common_google_tag_manager
     =body
     =view :theme_common_body_after

--- a/pegasus/sites.v3/code.org/themes/responsive_wide.haml
+++ b/pegasus/sites.v3/code.org/themes/responsive_wide.haml
@@ -16,5 +16,6 @@
 
     =view :theme_common_head_after
   %body
+    =view :theme_common_google_tag_manager
     =body
     =view :theme_common_body_after

--- a/pegasus/sites.v3/code.org/views/theme_common_google_tag_manager.haml
+++ b/pegasus/sites.v3/code.org/views/theme_common_google_tag_manager.haml
@@ -1,0 +1,4 @@
+/ Google Tag Manager (noscript)
+%noscript
+  %iframe{height: "0", src: "https://www.googletagmanager.com/ns.html?id=GTM-TZZBRK5", style: "display:none;visibility:hidden", width: "0"}
+/ End Google Tag Manager (noscript)


### PR DESCRIPTION
Adds Google Tag Manager to the code.org site. We **do not** want it to be added to hourofcode.com and studio.code.org at this time. This was recently removed in this PR https://github.com/code-dot-org/code-dot-org/pull/60145, but the marketing and development teams want it back.

## Links
Jira ticket: [ACQ-2513](https://codedotorg.atlassian.net/browse/ACQ-2513)
Slack convo: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1727903588792459)

## Testing story
Tested locally to make sure the scripts are showing up in the `<head>` and right under the opening `<body>` tag according to the directions (see screenshot below). I will need to check [here](https://tagmanager.google.com/#/container/accounts/2475316723/containers/8381446/workspaces/61) that this is working properly once this goes live.

---- 

### I followed the instructions [here](https://tagmanager.google.com/#/container/accounts/2475316723/containers/8381446/workspaces/61):

Click this:
<img width="1637" alt="Screenshot 2024-10-08 at 3 20 57 PM" src="https://github.com/user-attachments/assets/5cdf4234-8e09-4cc5-aece-6f7f6802509e">

Opens this popup:
<img width="732" alt="Screenshot 2024-10-08 at 3 11 42 PM" src="https://github.com/user-attachments/assets/81d38e01-f995-4f62-9a98-cc072bec1068">

<img width="1639" alt="Screenshot 2024-10-08 at 3 04 36 PM" src="https://github.com/user-attachments/assets/2c118674-8906-4597-9033-1d6883dd8fe2">

<img width="1638" alt="Screenshot 2024-10-08 at 3 09 42 PM" src="https://github.com/user-attachments/assets/4e0eb82f-6832-46ad-86a6-9b3e26193045">
