### PR TITLE
Fix Unexpected Application Error due to courseVersionName

### DIFF
--- a/apps/src/templates/teacherNavigation/SidebarOption.tsx
+++ b/apps/src/templates/teacherNavigation/SidebarOption.tsx
@@ -12,7 +12,7 @@ import styles from './teacher-navigation.module.scss';
 interface SidebarOptionProps {
   isSelected: boolean;
   sectionId: number;
-  courseVersionName: string;
+  courseVersionName: string | null;
   pathKey: keyof typeof LABELED_TEACHER_NAVIGATION_PATHS;
   onClick: () => void;
 }

--- a/apps/src/templates/teacherNavigation/TeacherNavigationPaths.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationPaths.tsx
@@ -17,7 +17,7 @@ export const TEACHER_NAVIGATION_PATHS = {
   aiTutorChatMessages: 'ai_tutor',
   lessonMaterials: 'materials',
   calendar: 'calendar',
-  courseOverview: 'courses/:courseVersionName',
+  courseOverview: 'courses/:courseVersionName?',
   unitOverview: 'unit/:unitName?',
   settings: 'settings',
 };


### PR DESCRIPTION
Fixes a bug where when there is no course assigned to a section, teacher dashboard would throw an unrecoverable error.

![image](https://github.com/user-attachments/assets/481ce25c-8be1-4847-b0b0-d31cf03cfa37)


This was caused because the URL for the course page that includes the course name did not mark the `:courseVersionName` as optional.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Manually tested that pages loaded
