### PR TITLE
Remove the teacher panel from the unit overview page

### DIFF
--- a/apps/src/code-studio/components/progress/TeacherUnitOverview.tsx
+++ b/apps/src/code-studio/components/progress/TeacherUnitOverview.tsx
@@ -246,7 +246,7 @@ const initializeRedux = (
   dispatch(initializeHiddenScripts(unitData.section_hidden_unit_info));
   dispatch(setPageType(pageTypes.scriptOverview));
 
-  progress.initCourseProgress(unitData);
+  progress.initCourseProgress(unitData, false);
 
   const mountPoint = document.createElement('div');
   $('.user-stats-block').prepend(mountPoint);

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -238,10 +238,13 @@ function extractLevelResults(userProgressResponse) {
  * @param {boolean} scriptData.age_13_required
  * Fetch and store progress for the course overview page.
  */
-progress.initCourseProgress = function (scriptData) {
+progress.initCourseProgress = function (
+  scriptData,
+  shouldRenderTeacherPanel = true
+) {
   const store = getStore();
   initializeStoreWithProgress(store, scriptData, null, true);
-  queryUserProgress(store, scriptData, null);
+  queryUserProgress(store, scriptData, null, shouldRenderTeacherPanel);
 };
 
 /* Set our initial view type (Participant or Instructor) from current user's user_type
@@ -285,7 +288,12 @@ progress.retrieveProgress = function (scriptName, scriptData, currentLevelId) {
  * as appropriate. If the user is not signed in, level progress data is populated
  * from session storage.
  */
-function queryUserProgress(store, scriptData, currentLevelId) {
+function queryUserProgress(
+  store,
+  scriptData,
+  currentLevelId,
+  shouldRenderTeacherPanel = true
+) {
   const userId = clientState.queryParams('user_id');
   store.dispatch(reduxQueryUserProgress(userId)).then(data => {
     const onOverviewPage = !currentLevelId;
@@ -312,11 +320,12 @@ function queryUserProgress(store, scriptData, currentLevelId) {
       (data.isInstructor || data.teacherViewingStudent) &&
       !data.deeperLearningCourse
     ) {
-      const pageType = currentLevelId
-        ? pageTypes.level
-        : pageTypes.scriptOverview;
-
-      renderTeacherPanel(store, scriptData.id, scriptData.name, pageType);
+      if (shouldRenderTeacherPanel) {
+        const pageType = currentLevelId
+          ? pageTypes.level
+          : pageTypes.scriptOverview;
+        renderTeacherPanel(store, scriptData.id, scriptData.name, pageType);
+      }
     }
   });
 }

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -19,7 +19,7 @@ import {
   setVerified,
   setVerifiedResources,
 } from '@cdo/apps/code-studio/verifiedInstructorRedux';
-import {DCDO} from '@cdo/apps/dcdo';
+import DCDO from '@cdo/apps/dcdo';
 import {registerReducers} from '@cdo/apps/redux';
 import ParentalPermissionBanner from '@cdo/apps/templates/policy_compliance/ParentalPermissionBanner';
 import googlePlatformApi, {

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -19,6 +19,7 @@ import {
   setVerified,
   setVerifiedResources,
 } from '@cdo/apps/code-studio/verifiedInstructorRedux';
+import {DCDO} from '@cdo/apps/dcdo';
 import {registerReducers} from '@cdo/apps/redux';
 import ParentalPermissionBanner from '@cdo/apps/templates/policy_compliance/ParentalPermissionBanner';
 import googlePlatformApi, {
@@ -30,6 +31,7 @@ import {
   setPageType,
   pageTypes,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import experiments from '@cdo/apps/util/experiments';
 import {tooltipifyVocabulary} from '@cdo/apps/utils';
 
 import locales, {setLocaleCode} from '../../../../redux/localesRedux';
@@ -87,7 +89,12 @@ function initPage() {
   store.dispatch(initializeHiddenScripts(scriptData.section_hidden_unit_info));
   store.dispatch(setPageType(pageTypes.scriptOverview));
 
-  initCourseProgress(scriptData);
+  const v2TeacherDashboardEnabled =
+    DCDO.get('teacher-local-nav-v2', false) ||
+    experiments.isEnabled('teacher-local-nav-v2');
+
+  // Don't show the teacher panel if v2 dashboard is enabled
+  initCourseProgress(scriptData, !v2TeacherDashboardEnabled);
 
   const mountPoint = document.createElement('div');
   $('.user-stats-block').prepend(mountPoint);

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -33,6 +33,7 @@
     #stats
       .user-stats-block
 
+      -# TODO(lfm): need to move this to react
     %div{style: 'clear: both;'}
     %br/
     %br/


### PR DESCRIPTION
We are removing the teacher panel from the unit overview page because all it's functions will be taken care of by the new sidebar or adding elements to the page itself. Removed from both the teacher dashboard and unassigned unit overview pages. Only removed behind the feature flag
![image](https://github.com/user-attachments/assets/792b3d52-9c7f-480e-bca2-9e613f5ff79d)

![image](https://github.com/user-attachments/assets/2c501e67-54d5-49d3-b523-61486683fbda)

With flag turned off: 
![image](https://github.com/user-attachments/assets/e33b4f60-8bf8-4454-b2c7-536ead5179c3)


## Links
[Tech spec](https://docs.google.com/document/d/1o_7Ii02DxzV9D9HvL3-XAs0tJAZUCce2zsJy8AhIQUk/edit#heading=h.4schd43y1qoc)


## Testing story
Manual testing
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
