### PR TITLE
Music: share updates

### DIFF
--- a/apps/src/lab2/header/lab2HeaderShare.js
+++ b/apps/src/lab2/header/lab2HeaderShare.js
@@ -31,7 +31,7 @@ export function shareLab2Project(id, finishUrl) {
     ReactDOM.render(
       <Provider store={getStore()}>
         <Lab2ShareDialogWrapper
-          id={id}
+          dialogId={id}
           shareUrl={shareUrl}
           finishUrl={finishUrl}
         />

--- a/apps/src/lab2/header/lab2HeaderShare.js
+++ b/apps/src/lab2/header/lab2HeaderShare.js
@@ -13,7 +13,7 @@ const PROJECT_SHARE_DIALOG_ID = 'project-share-dialog';
 /**
  * Save, then show the share dialog for a Lab2 project.
  */
-export function shareLab2Project(finishUrl) {
+export function shareLab2Project(id, finishUrl) {
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   if (!projectManager) {
     return null;
@@ -30,7 +30,11 @@ export function shareLab2Project(finishUrl) {
     }
     ReactDOM.render(
       <Provider store={getStore()}>
-        <Lab2ShareDialogWrapper shareUrl={shareUrl} finishUrl={finishUrl} />
+        <Lab2ShareDialogWrapper
+          id={id}
+          shareUrl={shareUrl}
+          finishUrl={finishUrl}
+        />
       </Provider>,
       dialogDom
     );

--- a/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
+++ b/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
@@ -15,7 +15,7 @@ import ShareDialog from './dialogs/ShareDialog';
  */
 const Lab2ShareDialogWrapper: React.FunctionComponent<
   Lab2ShareDialogWrapperProps
-> = ({id, shareUrl, finishUrl}) => {
+> = ({dialogId, shareUrl, finishUrl}) => {
   const isProjectLevel =
     useSelector(
       (state: {lab: LabState}) => state.lab.levelProperties?.isProjectLevel
@@ -62,7 +62,7 @@ const Lab2ShareDialogWrapper: React.FunctionComponent<
 
     return (
       <ShareDialog
-        id={id}
+        dialogId={dialogId}
         shareUrl={shareUrl}
         finishUrl={finishUrl}
         projectType={projectType}
@@ -91,7 +91,7 @@ const Lab2ShareDialogWrapper: React.FunctionComponent<
 };
 
 interface Lab2ShareDialogWrapperProps {
-  id?: string;
+  dialogId?: string;
   shareUrl: string;
   finishUrl?: string;
 }

--- a/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
+++ b/apps/src/lab2/views/Lab2ShareDialogWrapper.tsx
@@ -15,7 +15,7 @@ import ShareDialog from './dialogs/ShareDialog';
  */
 const Lab2ShareDialogWrapper: React.FunctionComponent<
   Lab2ShareDialogWrapperProps
-> = ({shareUrl, finishUrl}) => {
+> = ({id, shareUrl, finishUrl}) => {
   const isProjectLevel =
     useSelector(
       (state: {lab: LabState}) => state.lab.levelProperties?.isProjectLevel
@@ -62,6 +62,7 @@ const Lab2ShareDialogWrapper: React.FunctionComponent<
 
     return (
       <ShareDialog
+        id={id}
         shareUrl={shareUrl}
         finishUrl={finishUrl}
         projectType={projectType}
@@ -90,6 +91,7 @@ const Lab2ShareDialogWrapper: React.FunctionComponent<
 };
 
 interface Lab2ShareDialogWrapperProps {
+  id?: string;
   shareUrl: string;
   finishUrl?: string;
 }

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -206,8 +206,8 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
     }
 
     if (finishUrl) {
-      if (finishDialog === 'hoc2024') {
-        shareLab2Project(finishUrl);
+      if (finishDialog) {
+        shareLab2Project(finishDialog, finishUrl);
       } else {
         window.location.href = finishUrl;
       }

--- a/apps/src/lab2/views/dialogs/ShareDialog.module.scss
+++ b/apps/src/lab2/views/dialogs/ShareDialog.module.scss
@@ -2,9 +2,10 @@
 @import '../common.scss';
 
 %dialog {
-  background-color: $neutral_light;
+  background-color: $light_gray_950;
+  color: $neutral_light;
   border-radius: 5px;
-  padding: 20px 50px;
+  padding: 20px 32px;
   width: 600px;
 }
 
@@ -30,27 +31,49 @@
     flex-direction: column;
     position: relative;
 
-    .itemsContainer {
+    .heading {
+      color: $neutral_light;
+      margin-bottom: 20px;
+    }
+
+    .columns {
       display: flex;
-      justify-content: space-around;
-      align-items: center;
-      gap: 12px;
+      flex-direction: row;
+      gap: 40px;
 
-      .copyToClipboard {
-        @extend %button;
-        background-color: $light_secondary_500;
-        color: $neutral_light;
-
-        &:hover {
-          background-color: $light_secondary_500;
-        }
-
-        &Icon {
-          font-size: 24px;
-          margin-right: 10px;
-          padding-bottom: 3px;
-        }
+      .column {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        gap: 25px;
       }
+    }
+
+    .share {
+      background-color: $white;
+      padding: 20px;
+      border-radius: 10px;
+      color: white;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 20px;
+    }
+
+    .careers {
+      background-color: $neutral_dark80;
+      padding: 20px;
+      border-radius: 10px;
+      color: white;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .doneButton {
+      margin-top: auto;
+      margin-bottom: 20px;
     }
 
     .closeButton {

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -3,7 +3,7 @@ import React, {useCallback, useEffect, useState} from 'react';
 import FocusLock from 'react-focus-lock';
 
 import {hideShareDialog} from '@cdo/apps/code-studio/components/shareDialogRedux';
-import {LinkButton} from '@cdo/apps/componentLibrary/button';
+import {Button, LinkButton} from '@cdo/apps/componentLibrary/button';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import Typography from '@cdo/apps/componentLibrary/typography';
 import {ProjectType} from '@cdo/apps/lab2/types';
@@ -28,18 +28,19 @@ const CopyToClipboardButton: React.FunctionComponent<{
   }, [shareUrl, projectType]);
 
   return (
-    <button
-      type="button"
-      onClick={handleCopyToClipboard}
-      className={moduleStyles.copyToClipboard}
-    >
-      <FontAwesomeV6Icon
-        iconName={copiedToClipboard ? 'clipboard-check' : 'clipboard'}
-        iconStyle="thin"
-        className={moduleStyles.copyToClipboardIcon}
+    <div>
+      <Button
+        iconLeft={{
+          iconName: copiedToClipboard ? 'clipboard-check' : 'clipboard',
+        }}
+        ariaLabel={i18n.copyLinkToProject()}
+        text={i18n.copyLinkToProject()}
+        type="primary"
+        color="black"
+        size="m"
+        onClick={handleCopyToClipboard}
       />
-      {i18n.copyLinkToProject()}
-    </button>
+    </div>
   );
 };
 
@@ -47,15 +48,17 @@ const CopyToClipboardButton: React.FunctionComponent<{
  * A new implementation of the project share dialog for Lab2 labs.  Currently only used
  * by Music Lab and Python Lab, and only supports a minimal subset of functionality.
  */
+
 const ShareDialog: React.FunctionComponent<{
+  id?: string;
   shareUrl: string;
   finishUrl?: string;
   projectType: ProjectType;
-}> = ({shareUrl, finishUrl, projectType}) => {
+}> = ({id, shareUrl, finishUrl, projectType}) => {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    trackEvent('share', 'share_open_dialog', {value: projectType});
+    trackEvent('congrats', 'congrats_open_dialog', {value: projectType});
   });
 
   const handleClose = useCallback(
@@ -63,30 +66,70 @@ const ShareDialog: React.FunctionComponent<{
     [dispatch]
   );
 
+  const careersUrl =
+    'https://www.amazonfutureengineer.com/careertours/careervideos';
+
   return (
     <FocusLock>
       <div className={moduleStyles.dialogContainer}>
         <div id="share-dialog" className={moduleStyles.shareDialog}>
-          <Typography semanticTag="h1" visualAppearance="heading-lg">
-            {i18n.shareTitle()}
+          <Typography
+            semanticTag="h1"
+            visualAppearance="heading-lg"
+            className={moduleStyles.heading}
+          >
+            {id === 'hoc2024' ? i18n.congratulations() : i18n.shareTitle()}
           </Typography>
-          <div className={moduleStyles.itemsContainer}>
-            <CopyToClipboardButton
-              shareUrl={shareUrl}
-              projectType={projectType}
-            />
-            <div id="share-qrcode-container">
-              <QRCode value={shareUrl + '?qr=true'} size={140} />
+          <div className={moduleStyles.columns}>
+            <div className={moduleStyles.column}>
+              <div className={moduleStyles.share}>
+                <div id="share-qrcode-container">
+                  <QRCode value={shareUrl + '?qr=true'} size={140} />
+                </div>
+                <CopyToClipboardButton
+                  shareUrl={shareUrl}
+                  projectType={projectType}
+                />
+              </div>
             </div>
-            {finishUrl && (
-              <LinkButton
-                ariaLabel={i18n.done()}
-                href={finishUrl}
-                text={i18n.done()}
-                type="primary"
-                size="s"
-              />
-            )}
+            <div className={moduleStyles.column}>
+              {id === 'hoc2024' ? (
+                <div className={moduleStyles.careers}>
+                  Learn more about careers in technology and music.
+                  <LinkButton
+                    ariaLabel={i18n.learnMore()}
+                    href={careersUrl}
+                    text={i18n.learnMore()}
+                    type="primary"
+                    color="black"
+                    size="m"
+                    target="_blank"
+                  />
+                </div>
+              ) : (
+                <div>Share your project by using these links.</div>
+              )}
+
+              {finishUrl ? (
+                <LinkButton
+                  ariaLabel={i18n.finish()}
+                  href={finishUrl}
+                  text={i18n.finish()}
+                  type="primary"
+                  size="m"
+                  className={moduleStyles.doneButton}
+                />
+              ) : (
+                <Button
+                  ariaLabel={i18n.done()}
+                  text={i18n.done()}
+                  type="primary"
+                  size="m"
+                  onClick={handleClose}
+                  className={moduleStyles.doneButton}
+                />
+              )}
+            </div>
           </div>
           <button
             type="button"

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -50,15 +50,20 @@ const CopyToClipboardButton: React.FunctionComponent<{
  */
 
 const ShareDialog: React.FunctionComponent<{
-  id?: string;
+  dialogId?: string;
   shareUrl: string;
   finishUrl?: string;
   projectType: ProjectType;
-}> = ({id, shareUrl, finishUrl, projectType}) => {
+}> = ({dialogId, shareUrl, finishUrl, projectType}) => {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    trackEvent('congrats', 'congrats_open_dialog', {value: projectType});
+    trackEvent('share', 'share_open_dialog', {
+      value:
+        dialogId === 'hoc2024'
+          ? 'share_open_dialog_congrats_hoc2024'
+          : projectType,
+    });
   });
 
   const handleClose = useCallback(
@@ -78,7 +83,9 @@ const ShareDialog: React.FunctionComponent<{
             visualAppearance="heading-lg"
             className={moduleStyles.heading}
           >
-            {id === 'hoc2024' ? i18n.congratulations() : i18n.shareTitle()}
+            {dialogId === 'hoc2024'
+              ? i18n.congratulations()
+              : i18n.shareTitle()}
           </Typography>
           <div className={moduleStyles.columns}>
             <div className={moduleStyles.column}>
@@ -93,7 +100,7 @@ const ShareDialog: React.FunctionComponent<{
               </div>
             </div>
             <div className={moduleStyles.column}>
-              {id === 'hoc2024' ? (
+              {dialogId === 'hoc2024' ? (
                 <div className={moduleStyles.careers}>
                   Learn more about careers in technology and music.
                   <LinkButton


### PR DESCRIPTION
This updates the simple share UI started back in #57333.  

The idea is that this UI will serve two purposes:
- a share UI for a Lab2 project;
- a congrats UI for the end of the Music Lab HOC flow.

There is still work to be done on this experience, and obviously a design pass as well.

### Screenshots

#### Share

<img width="701" alt="Screenshot 2024-10-09 at 12 21 08 AM" src="https://github.com/user-attachments/assets/cb730b84-8df5-4ae6-99c5-721e99df0bb8">

#### Music Lab congrats

<img width="701" alt="Screenshot 2024-10-09 at 12 22 30 AM" src="https://github.com/user-attachments/assets/3334eed0-83c0-4080-9dae-eb4c26771407">

