### PR TITLE
Use new school info flow in census banner and turn it on

### DIFF
--- a/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
+++ b/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
@@ -62,6 +62,13 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
   const [schoolName, setSchoolName] = useState(detectedSchoolName);
   const [schoolsList, setSchoolsList] = useState<SchoolDropdownOption[]>([]);
 
+  const reset = () => {
+    setCountry(detectedCountry);
+    setSchoolId(detectedSchoolId);
+    setSchoolZip(detectedZip);
+    setSchoolName(detectedSchoolName);
+  };
+
   // Memoized fetchSchools function using useCallback
   const fetchSchools = useCallback(
     (
@@ -170,5 +177,6 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     setCountry,
     setSchoolName,
     setSchoolZip,
+    reset,
   };
 }

--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -100,7 +100,7 @@ function showHomepage() {
             topPlCourse={homepageData.topPlCourse}
             queryStringOpen={query['open']}
             canViewAdvancedTools={homepageData.canViewAdvancedTools}
-            ncesSchoolId={homepageData.ncesSchoolId}
+            existingSchoolInfo={homepageData.existingSchoolInfo}
             censusQuestion={homepageData.censusQuestion}
             showCensusBanner={homepageData.showCensusBanner}
             showNpsSurvey={homepageData.showNpsSurvey}

--- a/apps/src/templates/SchoolDataInputs.jsx
+++ b/apps/src/templates/SchoolDataInputs.jsx
@@ -87,9 +87,11 @@ export default function SchoolDataInputs({
   const handleSchoolChange = id => {
     setSchoolId(id);
 
-    const schoolName = schoolsList.find(school => school.value === id).text;
-    if (schoolName) {
-      setSchoolName(schoolName);
+    if (!Object.values(NonSchoolOptions).includes(id)) {
+      const schoolName = schoolsList.find(school => school.value === id)?.text;
+      if (schoolName) {
+        setSchoolName(schoolName);
+      }
     }
   };
 

--- a/apps/src/templates/SchoolDataInputs.jsx
+++ b/apps/src/templates/SchoolDataInputs.jsx
@@ -86,6 +86,11 @@ export default function SchoolDataInputs({
 
   const handleSchoolChange = id => {
     setSchoolId(id);
+
+    const schoolName = schoolsList.find(school => school.value === id).text;
+    if (schoolName) {
+      setSchoolName(schoolName);
+    }
   };
 
   return (

--- a/apps/src/templates/census/CensusTeacherBanner.jsx
+++ b/apps/src/templates/census/CensusTeacherBanner.jsx
@@ -162,7 +162,6 @@ export default function CensusTeacherBanner({
     return (
       <div>
         <div style={styles.header}>
-          <h2>Update your school information</h2>
           {showSchoolInfoUnknownError && (
             <p style={styles.error}>
               We encountered an error with your submission. Please try again.
@@ -172,7 +171,7 @@ export default function CensusTeacherBanner({
         <div style={styles.message}>
           <SchoolDataInputs {...schoolInfo} />
         </div>
-        <div style={styles.buttonDiv}>
+        <div style={{...styles.buttonDiv, ...styles.updateSchoolButtonDiv}}>
           <Button
             __useDeprecatedTag
             onClick={dismissSchoolInfoForm}
@@ -411,6 +410,9 @@ const styles = {
   },
   buttonDiv: {
     textAlign: 'center',
+  },
+  updateSchoolButtonDiv: {
+    marginRight: 190,
   },
   clear: {
     clear: 'both',

--- a/apps/src/templates/census/CensusTeacherBanner.jsx
+++ b/apps/src/templates/census/CensusTeacherBanner.jsx
@@ -43,8 +43,6 @@ export default function CensusTeacherBanner({
     schoolType: existingSchoolInfo.type,
   });
 
-  console.log(schoolInfo);
-
   const hideSchoolInfoForm = () => {
     setShowSchoolInfoForm(false);
   };
@@ -296,7 +294,7 @@ export default function CensusTeacherBanner({
                 onChange={onTeachesChange}
                 checked={teaches === true}
               />
-              Yes, we’ve done {numHours} hours.
+              Yes, we've done {numHours} hours.
             </label>
             <label>
               <input

--- a/apps/src/templates/census/CensusTeacherBanner.jsx
+++ b/apps/src/templates/census/CensusTeacherBanner.jsx
@@ -5,6 +5,7 @@ import fontConstants from '@cdo/apps/fontConstants';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import {useSchoolInfo} from '@cdo/apps/schoolInfo/hooks/useSchoolInfo';
+import {schoolInfoInvalid} from '@cdo/apps/schoolInfo/utils/schoolInfoInvalid';
 import {updateSchoolInfo} from '@cdo/apps/schoolInfo/utils/updateSchoolInfo';
 import color from '@cdo/apps/util/color';
 import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
@@ -157,8 +158,7 @@ export default function CensusTeacherBanner({
   };
 
   const renderSchoolInfoForm = () => {
-    const submitDisabled =
-      schoolInfo.schoolId === NonSchoolOptions.SELECT_A_SCHOOL;
+    const submitDisabled = schoolInfoInvalid(schoolInfo);
     return (
       <div>
         <div style={styles.header}>

--- a/apps/src/templates/census/CensusTeacherBanner.jsx
+++ b/apps/src/templates/census/CensusTeacherBanner.jsx
@@ -54,6 +54,7 @@ export default function CensusTeacherBanner({
     // may have been partial state about the school changed. We do not want
     // to use that partial state in the census submission so we need to reset
     // to the previous values.
+    schoolInfo.reset();
     setShowSchoolInfoForm(false);
     setShowSchoolInfoUnknownError(false);
   };

--- a/apps/src/templates/census/CensusTeacherBanner.story.js
+++ b/apps/src/templates/census/CensusTeacherBanner.story.js
@@ -9,20 +9,21 @@ export default {
 export const BasicCensus = () => (
   <CensusTeacherBanner
     schoolYear={2024}
-    onSubmit={() => {}}
+    onSubmitSuccess={() => {}}
     onDismiss={() => {}}
     onPostpone={() => {}}
     onTeachesChange={() => {}}
     onInClassChange={() => {}}
-    ncesSchoolId={'-1'}
+    existingSchoolInfo={{
+      id: 'ABCD',
+      name: 'NCES School',
+      country: 'US',
+      zip: '12345',
+    }}
     question={'how_many_10_hours'}
     teaches={true}
     inClass={true}
-    teacherId={1111111}
     teacherName={'BlakeSmith'}
     teacherEmail={'BlakeSmith@gmail.com'}
-    showInvalidError={false}
-    showUnknownError={false}
-    submittedSuccessfully={true}
   />
 );

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -39,7 +39,7 @@ export const UnconnectedTeacherHomepage = ({
   afeEligible,
   joinedStudentSections,
   joinedPlSections,
-  ncesSchoolId,
+  existingSchoolInfo,
   queryStringOpen,
   schoolYear,
   showCensusBanner,
@@ -214,7 +214,7 @@ export const UnconnectedTeacherHomepage = ({
           <div>
             <CensusTeacherBanner
               schoolYear={schoolYear}
-              initialNcesSchoolId={ncesSchoolId}
+              existingSchoolInfo={existingSchoolInfo}
               question={censusQuestion}
               teaches={censusBannerTeachesSelection}
               inClass={censusBannerInClassSelection}
@@ -284,7 +284,13 @@ UnconnectedTeacherHomepage.propTypes = {
   hocLaunch: PropTypes.string,
   joinedStudentSections: shapes.sections,
   joinedPlSections: shapes.sections,
-  ncesSchoolId: PropTypes.string,
+  existingSchoolInfo: PropTypes.shape({
+    country: PropTypes.string,
+    id: PropTypes.string,
+    name: PropTypes.string,
+    zip: PropTypes.string,
+    type: PropTypes.string,
+  }),
   queryStringOpen: PropTypes.string,
   schoolYear: PropTypes.number,
   showCensusBanner: PropTypes.bool.isRequired,

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -57,19 +57,18 @@ export const UnconnectedTeacherHomepage = ({
   showIncubatorBanner,
   currentUserId,
 }) => {
-  const censusBanner = useRef(null);
   const teacherReminders = useRef(null);
   const flashes = useRef(null);
 
   /*
    * Determines whether the AFE banner will take premium space on the Teacher Homepage
    */
-  const shouldShowAFEBanner = true;
+  const shouldShowAFEBanner = false;
 
   /*
    * Set to true to hide the census banner
    */
-  const forceHideCensusBanner = true;
+  const forceHideCensusBanner = false;
 
   /* We are hiding the PL application banner to free up space on the Teacher Homepage (May 2023)
    * when we want to show the PL banner again set this to true
@@ -79,14 +78,10 @@ export const UnconnectedTeacherHomepage = ({
   const [displayCensusBanner, setDisplayCensusBanner] = useState(
     showCensusBanner && !forceHideCensusBanner
   );
-  const [censusSubmittedSuccessfully, setCensusSubmittedSuccessfully] =
-    useState(null);
   const [censusBannerTeachesSelection, setCensusBannerTeachesSelection] =
     useState(null);
   const [censusBannerInClassSelection, setCensusBannerInClassSelection] =
     useState(null);
-  const [showCensusUnknownError, setShowCensusUnknownError] = useState(false);
-  const [showCensusInvalidError, setShowCensusInvalidError] = useState(false);
 
   useEffect(() => {
     // The component used here is implemented in legacy HAML/CSS rather than React.
@@ -104,26 +99,6 @@ export const UnconnectedTeacherHomepage = ({
   useEffect(() => {
     analyticsReporter.sendEvent(EVENTS.TEACHER_HOMEPAGE_VISITED);
   }, []);
-
-  const handleCensusBannerSubmit = () => {
-    if (censusBanner.current.isValid()) {
-      $.ajax({
-        url: '/dashboardapi/v1/census/CensusTeacherBannerV1',
-        type: 'post',
-        dataType: 'json',
-        data: censusBanner.current.getData(),
-      })
-        .done(() => {
-          setCensusSubmittedSuccessfully(true);
-          dismissCensusBanner(null, null);
-        })
-        .fail(() => {
-          setShowCensusUnknownError(true);
-        });
-    } else {
-      setShowCensusInvalidError(true);
-    }
-  };
 
   const dismissCensusBanner = (onSuccess, onFailure) => {
     $.ajax({
@@ -238,19 +213,15 @@ export const UnconnectedTeacherHomepage = ({
         {displayCensusBanner && (
           <div>
             <CensusTeacherBanner
-              ref={censusBanner}
               schoolYear={schoolYear}
-              ncesSchoolId={ncesSchoolId}
+              initialNcesSchoolId={ncesSchoolId}
               question={censusQuestion}
               teaches={censusBannerTeachesSelection}
               inClass={censusBannerInClassSelection}
               teacherId={teacherId}
               teacherName={teacherName}
               teacherEmail={teacherEmail}
-              showInvalidError={showCensusInvalidError}
-              showUnknownError={showCensusUnknownError}
-              submittedSuccessfully={censusSubmittedSuccessfully}
-              onSubmit={() => handleCensusBannerSubmit()}
+              onSubmitSuccess={() => dismissCensusBanner(null, null)}
               onDismiss={() => dismissAndHideCensusBanner()}
               onPostpone={() => postponeCensusBanner()}
               onTeachesChange={event =>

--- a/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
+++ b/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
@@ -311,6 +311,26 @@ describe('useSchoolInfo', () => {
         expect(schoolNameSessionStorageCalls[1][1]).toBe('Super Cool School');
       });
     });
+
+    it('should reset school info to initial state if passed', async () => {
+      await act(async () => {
+        hook.current.setSchoolZip('90210');
+      });
+      expect(hook.current.schoolZip).toBe('90210');
+      act(async () => {
+        hook.current.setSchoolId(NonSchoolOptions.CLICK_TO_ADD);
+        hook.current.setSchoolName('Fake School');
+      });
+      expect(hook.current.schoolId).toBe(NonSchoolOptions.CLICK_TO_ADD);
+      expect(hook.current.schoolName).toBe('Fake School');
+      act(async () => {
+        hook.current.reset();
+      });
+      expect(hook.current.schoolZip).toBe(initialState.schoolZip);
+      expect(hook.current.schoolName).toBe(initialState.schoolName);
+      expect(hook.current.schoolId).toBe(initialState.schoolId);
+      expect(hook.current.country).toBe(initialState.country);
+    });
   });
 
   describe('fetchSchools', () => {

--- a/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
+++ b/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
@@ -110,6 +110,26 @@ describe('useSchoolInfo', () => {
       await waitForNextUpdate(); // Wait for initial render
     });
 
+    it('should reset school info to initial state if passed', async () => {
+      await act(async () => {
+        hook.current.setSchoolZip('90210');
+      });
+      expect(hook.current.schoolZip).toBe('90210');
+      await act(async () => {
+        hook.current.setSchoolId(NonSchoolOptions.CLICK_TO_ADD);
+        hook.current.setSchoolName('Fake School');
+      });
+      expect(hook.current.schoolId).toBe(NonSchoolOptions.CLICK_TO_ADD);
+      expect(hook.current.schoolName).toBe('Fake School');
+      await act(async () => {
+        hook.current.reset();
+      });
+      expect(hook.current.schoolZip).toBe(initialState.schoolZip);
+      expect(hook.current.schoolName).toBe(initialState.schoolName);
+      expect(hook.current.schoolId).toBe(initialState.schoolId);
+      expect(hook.current.country).toBe(initialState.country);
+    });
+
     describe('country updates', () => {
       it('should update sessionStorage', () => {
         act(() => {
@@ -218,32 +238,32 @@ describe('useSchoolInfo', () => {
           {value: '2', text: 'Other School'},
         ]);
       });
-    });
 
-    it('should send an analytics event', async () => {
-      await act(async () => {
-        hook.current.setSchoolZip('90210');
+      it('should send an analytics event', async () => {
+        await act(async () => {
+          hook.current.setSchoolZip('90210');
+        });
+
+        expect(sendAnalyticsEventSpy).toHaveBeenCalledWith(
+          EVENTS.ZIP_CODE_ENTERED,
+          {zip: '90210'},
+          PLATFORMS.BOTH
+        );
       });
 
-      expect(sendAnalyticsEventSpy).toHaveBeenCalledWith(
-        EVENTS.ZIP_CODE_ENTERED,
-        {zip: '90210'},
-        PLATFORMS.BOTH
-      );
-    });
+      it('should fetch schools', async () => {
+        await act(async () => {
+          hook.current.setSchoolZip('90210');
+        });
 
-    it('should fetch schools', async () => {
-      await act(async () => {
-        hook.current.setSchoolZip('90210');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(mockFetch.mock.calls[0][0]).toEqual(
+          expect.stringMatching(initialState.schoolZip)
+        );
+        expect(mockFetch.mock.calls[1][0]).toEqual(
+          expect.stringMatching('90210')
+        );
       });
-
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(mockFetch.mock.calls[0][0]).toEqual(
-        expect.stringMatching(initialState.schoolZip)
-      );
-      expect(mockFetch.mock.calls[1][0]).toEqual(
-        expect.stringMatching('90210')
-      );
     });
 
     describe('schoolId updates', () => {
@@ -310,26 +330,6 @@ describe('useSchoolInfo', () => {
         );
         expect(schoolNameSessionStorageCalls[1][1]).toBe('Super Cool School');
       });
-    });
-
-    it('should reset school info to initial state if passed', async () => {
-      await act(async () => {
-        hook.current.setSchoolZip('90210');
-      });
-      expect(hook.current.schoolZip).toBe('90210');
-      act(async () => {
-        hook.current.setSchoolId(NonSchoolOptions.CLICK_TO_ADD);
-        hook.current.setSchoolName('Fake School');
-      });
-      expect(hook.current.schoolId).toBe(NonSchoolOptions.CLICK_TO_ADD);
-      expect(hook.current.schoolName).toBe('Fake School');
-      act(async () => {
-        hook.current.reset();
-      });
-      expect(hook.current.schoolZip).toBe(initialState.schoolZip);
-      expect(hook.current.schoolName).toBe(initialState.schoolName);
-      expect(hook.current.schoolId).toBe(initialState.schoolId);
-      expect(hook.current.country).toBe(initialState.country);
     });
   });
 

--- a/apps/test/unit/templates/census/CensusTeacherBannerTest.jsx
+++ b/apps/test/unit/templates/census/CensusTeacherBannerTest.jsx
@@ -1,0 +1,96 @@
+import '@testing-library/jest-dom';
+import {act, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import CensusTeacherBanner from '@cdo/apps/templates/census/CensusTeacherBanner';
+
+jest.mock('@cdo/apps/schoolInfo/utils/fetchSchools');
+
+describe('CensusTeacherBannerTest', () => {
+  const defaultExistingSchoolInfo = {
+    id: 'ABCDEF123',
+    country: 'US',
+    name: 'Test School',
+    zip: '12345',
+  };
+
+  const defaultProps = {
+    onDismiss: jest.fn(),
+    onPostpone: jest.fn(),
+    onTeachesChange: jest.fn(),
+    onInClassChange: jest.fn(),
+    existingSchoolInfo: defaultExistingSchoolInfo,
+
+    question: 'how_many_20_hours',
+    teaches: true,
+    inClass: true,
+    teacherName: 'Test Teacher',
+    teacherEmail: 'test@test.com',
+    onSubmitSuccess: jest.fn(),
+    schoolYear: 2024,
+  };
+
+  beforeEach(() => {
+    //jest.clearAllMocks();
+    //window.fetch = jest.fn();
+  });
+
+  function renderDefault(propOverrides = {}) {
+    render(<CensusTeacherBanner {...defaultProps} {...propOverrides} />);
+  }
+
+  it('displays the school name and census question by default', async () => {
+    renderDefault();
+    //screen.debug();
+    await screen.findByText('Add Test School to our map!');
+
+    await screen.findByText(
+      'It looks like you teach computer science. Have your students already done 20 hours of programming content this year (not including HTML/CSS)?'
+    );
+  });
+
+  it('shows school update form when update is clicked', async () => {
+    renderDefault();
+    act(() => {
+      screen.getByText('Update here').click();
+    });
+    await screen.findByText('Tell us about your school');
+  });
+
+  it('returns to census question when school update flow is dismissed', async () => {
+    renderDefault();
+    act(() => {
+      screen.getByText('Update here').click();
+    });
+    await screen.findByText('Tell us about your school');
+
+    act(() => {
+      screen.getByText('Dismiss').click();
+    });
+    await screen.findByText('Add Test School to our map!');
+  });
+
+  it('renders thank you after submitting census question', async () => {
+    renderDefault();
+
+    const ajaxStub = jest
+      .spyOn($, 'ajax')
+      .mockClear()
+      .mockReturnValue({
+        done: successCallback => {
+          successCallback();
+          return {fail: () => {}};
+        },
+      });
+
+    act(() => {
+      //screen.getByRole('radio', {value: 'SOME'}).click();
+      //screen.getByRole('radio', {value: 'inclass'}).click();
+      screen.getByLabelText("Yes, we've done 20 hours.").click();
+      screen.getByLabelText('In a classroom').click();
+      screen.getByText('Add my school to the map!').click();
+    });
+    await screen.findByText('Thanks for adding your school to the map!');
+    ajaxStub.mockRestore();
+  });
+});

--- a/apps/test/unit/templates/census/CensusTeacherBannerTest.jsx
+++ b/apps/test/unit/templates/census/CensusTeacherBannerTest.jsx
@@ -30,18 +30,12 @@ describe('CensusTeacherBannerTest', () => {
     schoolYear: 2024,
   };
 
-  beforeEach(() => {
-    //jest.clearAllMocks();
-    //window.fetch = jest.fn();
-  });
-
   function renderDefault(propOverrides = {}) {
     render(<CensusTeacherBanner {...defaultProps} {...propOverrides} />);
   }
 
   it('displays the school name and census question by default', async () => {
     renderDefault();
-    //screen.debug();
     await screen.findByText('Add Test School to our map!');
 
     await screen.findByText(
@@ -84,8 +78,6 @@ describe('CensusTeacherBannerTest', () => {
       });
 
     act(() => {
-      //screen.getByRole('radio', {value: 'SOME'}).click();
-      //screen.getByRole('radio', {value: 'inclass'}).click();
       screen.getByLabelText("Yes, we've done 20 hours.").click();
       screen.getByLabelText('In a classroom').click();
       screen.getByText('Add my school to the map!').click();

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -138,7 +138,7 @@ describe('TeacherHomepage', () => {
    */
   it('renders CensusTeacherBanner if showCensusBanner is true and forceHide is false', () => {
     const wrapper = setUp({showCensusBanner: true});
-    assert(!wrapper.find('CensusTeacherBanner').exists());
+    assert(wrapper.find('CensusTeacherBanner').exists());
   });
 
   /*
@@ -147,7 +147,7 @@ describe('TeacherHomepage', () => {
    */
   it('renders a DonorTeacherBanner only if afeEligible is true and shouldShowAFEBanner', () => {
     const wrapper = setUp({afeEligible: true});
-    assert(wrapper.find('DonorTeacherBanner').exists());
+    assert(!wrapper.find('DonorTeacherBanner').exists());
   });
 
   it('renders a TeacherSections component', () => {

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -198,6 +198,13 @@ class HomeController < ApplicationController
 
         @homepage_data[:censusQuestion] = school_stats.try(:has_high_school_grades?) ? "how_many_20_hours" : "how_many_10_hours"
         @homepage_data[:currentSchoolYear] = current_census_year
+        @homepage_data[:existingSchoolInfo] = {
+          id: teachers_school.id,
+          name: teachers_school.name,
+          country: 'US',
+          zip: teachers_school.zip,
+          type: teachers_school.school_type,
+        }
         @homepage_data[:ncesSchoolId] = teachers_school.id
         @homepage_data[:teacherName] = current_user.name
         @homepage_data[:teacherId] = current_user.id

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2469,6 +2469,8 @@ class User < ApplicationRecord
   def show_census_teacher_banner?
     # Must have an NCES school to show the banner
     users_school = try(:school_info).try(:school)
+    puts users_school.inspect
+    puts next_census_display.inspect
     teacher? && users_school && (next_census_display.nil? || Time.zone.today >= next_census_display.to_date)
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2469,8 +2469,6 @@ class User < ApplicationRecord
   def show_census_teacher_banner?
     # Must have an NCES school to show the banner
     users_school = try(:school_info).try(:school)
-    puts users_school.inspect
-    puts next_census_display.inspect
     teacher? && users_school && (next_census_display.nil? || Time.zone.today >= next_census_display.to_date)
   end
 


### PR DESCRIPTION
This PR does a few things:
- Turns on the `CensusTeacherBanner `and turns off the AFE banner
- Refactors `CensusTeacherBanner` into a functional component
- Moves state that belonged in `CensusTeacherBanner` into that component and out of `TeacherHomepage`
- Uses the new school info flow for the `CensusTeacherBanner`
- Adds a few tests as there weren't any previously

That felt like a lot for one PR, so there are a few cleanups I didn't do:
- `CensusTeacherBanner` still uses inline styles instead of a SCSS module
- `CensusTeacherBanner` still uses deprecated components, such as buttons, instead of our component library ones
- All of this is in vanilla JS instead of Typescript


Unfortunately, I don't think there's a way around needing a pass for the whole changeset, but it may be easier to take a peek at a couple of individual commits first:
- 2bcbe6657c8a0c86607aa4216a58305e765b3e6c refactors `CensusTeacherBanner` into a function component, without updating school info
- a1f2967f46cf6191feefbdd2cb9c0ee3e3ace603 uses the new school info component and hook


Video of flow of updating school and submitting the census:


https://github.com/user-attachments/assets/62548875-1985-4204-b120-f1d68b65d4d2


