### PR TITLE
[Aichat] increase max-width/fix padding of workspace tabs

### DIFF
--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -25,6 +25,11 @@ $default-spacing: 16px;
 
 .tabsContainer {
   background-color: #eaebeb;
+  ul {
+    li > button[role="tab"] {
+      max-width: 300px;  
+    }
+  }
 }
 
 .tabPanelsContainer {

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -2,6 +2,7 @@
 @import './aichat-common.module.scss';
 
 $default-spacing: 16px;
+$tabs-default-spacing: 4px;
 
 .chatWorkspace {
   @extend %panel-section;
@@ -25,6 +26,7 @@ $default-spacing: 16px;
 
 .tabsContainer {
   background-color: #eaebeb;
+  padding: $tabs-default-spacing $tabs-default-spacing 0 $tabs-default-spacing;
   ul {
     li > button[role="tab"] {
       max-width: 300px;  


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR increases the `max-width` of the chat workspace tabs displayed in teacher view to `300px`. This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/61624.
It also updates the padding around the tabs so that the blue outline when in focus is displayed all around the tab.

Note that this is a re-do of https://github.com/code-dot-org/code-dot-org/pull/61628 (approved) which was merged to a DSCO update PR - so reverted since we want to keep DSCO updates isolated.

## Before update
![Screenshot 2024-10-08 at 4 32 05 PM](https://github.com/user-attachments/assets/60deff62-8bcd-4afd-869a-28a99c111578)



## After update
Without overflown text:
![Screenshot 2024-10-08 at 4 40 02 PM](https://github.com/user-attachments/assets/d8664c46-68dd-4506-a417-c996fc8c3dac)


With overflown text:
![Screenshot 2024-10-08 at 4 40 16 PM](https://github.com/user-attachments/assets/606d0620-fa37-470a-bf2a-b3d2fdd0675b)



## Before update

![Screenshot 2024-10-08 at 4 44 17 PM](https://github.com/user-attachments/assets/e596f901-bf09-473f-8654-f35cbfa71809)


## After update

Screencast video if key-board navigation - blue outline of focus is now shown all around the tab (updated padding):

https://github.com/user-attachments/assets/71f45777-0340-47e2-a21c-8093772a7e57






## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1029)
[jira](https://codedotorg.atlassian.net/browse/LABS-1087)


<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally in aichat levels.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
