### PR TITLE
Allow selecting text from the ai-diff container

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -175,6 +175,7 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
 
   return (
     <Draggable
+      handle=".ai_diff_handle"
       defaultPosition={{x: positionX, y: positionY}}
       onStop={onStopHandler}
     >
@@ -183,7 +184,7 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
           [style.hiddenAiDiffPanel]: !open,
         })}
       >
-        <div className={style.aiDiffHeader}>
+        <div className={classnames(style.aiDiffHeader, 'ai_diff_handle')}>
           <div className={style.aiDiffHeaderLeftSide}>
             <img
               src={aiBotOutlineIcon}

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -244,6 +244,7 @@ export default function RubricContainer({
       defaultPosition={{x: positionX, y: positionY}}
       onStart={onStartHandler}
       onStop={onStopHandler}
+      handle=".ai-rubric-handle"
     >
       <div
         data-testid="draggable-test-id"
@@ -272,7 +273,10 @@ export default function RubricContainer({
             showStepNumbers: true,
           }}
         />
-        <div className={style.rubricHeaderRedesign}>
+        <div
+          className={classnames(style.rubricHeaderRedesign, 'ai-rubric-handle')}
+          data-testid="ai-rubric-handle-test-id"
+        >
           <div className={style.rubricHeaderLeftSide}>
             <img
               src={aiBotOutlineIcon}

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -828,14 +828,15 @@ describe('RubricContainer', () => {
 
     await wait();
 
+    const handle_element = getByTestId('ai-rubric-handle-test-id');
     const element = getByTestId('draggable-test-id');
 
     const initialPosition = element.style.transform;
 
     // simulate dragging
-    fireEvent.mouseDown(element, {clientX: 0, clientY: 0});
-    fireEvent.mouseMove(element, {clientX: 100, clientY: 100});
-    fireEvent.mouseUp(element);
+    fireEvent.mouseDown(handle_element, {clientX: 0, clientY: 0});
+    fireEvent.mouseMove(handle_element, {clientX: 100, clientY: 100});
+    fireEvent.mouseUp(handle_element);
 
     const newPosition = element.style.transform;
 
@@ -864,7 +865,7 @@ describe('RubricContainer', () => {
 
     await wait();
 
-    const element = getByTestId('draggable-test-id');
+    const element = getByTestId('ai-rubric-handle-test-id');
 
     // simulate dragging
     fireEvent.mouseDown(element, {clientX: 0, clientY: 0});


### PR DESCRIPTION
This adds a handle to the draggable element of the aiDiff container so it can only be dragged by clicking the header. This allows selecting text inside the container body for copy/paste

https://github.com/user-attachments/assets/87d4a3be-8743-4a35-8238-d33ca0ac7ca9

Based on Tess and Molly's go-ahead, also making this change for the AI Rubrics container.

## Links

https://codedotorg.atlassian.net/browse/AITT-812
https://codedotorg.atlassian.net/browse/AITT-807

## Testing story

Updated the rubrics container test to drag by the header handle. 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
