### PR TITLE
[Music] Support dynamic functions in flyout

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -184,6 +184,7 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
         <EditMusicToolbox
           toolbox={levelData.toolbox}
           blockMode={levelData.blockMode || BlockMode.SIMPLE2}
+          addFunctionDefinition={levelData.toolbox?.addFunctionDefinition}
           addFunctionCalls={levelData.toolbox?.addFunctionCalls}
           onChange={toolbox => setLevelData({...levelData, toolbox})}
           onBlockModeChange={blockMode => {
@@ -198,7 +199,21 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
               toolbox: {
                 ...levelData.toolbox,
                 blocks: undefined,
+                addFunctionDefinition: undefined,
                 addFunctionCalls: undefined,
+              },
+            });
+          }}
+          onAddFunctionDefinitionChange={(addFunctionDefinition: boolean) => {
+            setLevelData({
+              ...levelData,
+              toolbox: {
+                ...levelData.toolbox,
+                addFunctionDefinition,
+                // Call blocks are required if definitions are included.
+                addFunctionCalls: addFunctionDefinition
+                  ? true
+                  : levelData.toolbox?.addFunctionCalls,
               },
             });
           }}
@@ -207,6 +222,10 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
               ...levelData,
               toolbox: {
                 ...levelData.toolbox,
+                // Definitions are prohibited unless call blocks are included.
+                addFunctionDefinition: !addFunctionCalls
+                  ? false
+                  : levelData.toolbox?.addFunctionDefinition,
                 addFunctionCalls,
               },
             });

--- a/apps/src/lab2/levelEditors/levelData/EditMusicToolbox.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicToolbox.tsx
@@ -23,9 +23,11 @@ import styles from './edit-music-level-data.module.scss';
 interface EditMusicToolboxProps {
   toolbox?: ToolboxData;
   blockMode: ValueOf<typeof BlockMode>;
+  addFunctionDefinition?: boolean;
   addFunctionCalls?: boolean;
   onChange: (toolbox: ToolboxData) => void;
   onBlockModeChange: (blockMode: ValueOf<typeof BlockMode>) => void;
+  onAddFunctionDefinitionChange: (addDefinitionCalls: boolean) => void;
   onAddFunctionCallsChange: (addFunctionCalls: boolean) => void;
 }
 
@@ -44,9 +46,11 @@ const ChangeWarning: React.FC = () => (
 const EditMusicToolbox: React.FunctionComponent<EditMusicToolboxProps> = ({
   toolbox,
   blockMode,
+  addFunctionDefinition,
   addFunctionCalls,
   onChange,
   onBlockModeChange,
+  onAddFunctionDefinitionChange,
   onAddFunctionCallsChange,
 }) => {
   const defaultBlocks = defaultMaps[blockMode];
@@ -135,14 +139,25 @@ const EditMusicToolbox: React.FunctionComponent<EditMusicToolboxProps> = ({
             toolboxType={toolbox?.type}
           />
           {toolbox?.type === 'flyout' && blockMode === BlockMode.SIMPLE2 && (
-            <Checkbox
-              checked={!!addFunctionCalls}
-              name="addFunctionCalls"
-              label="Add function calls"
-              onChange={event => {
-                onAddFunctionCallsChange(event.target.checked);
-              }}
-            />
+            <div className={styles.checkbox}>
+              <Checkbox
+                checked={!!addFunctionDefinition}
+                name="addFunctionDefinition"
+                label="Add function definition"
+                onChange={event => {
+                  onAddFunctionDefinitionChange(event.target.checked);
+                }}
+              />
+              <Checkbox
+                checked={!!addFunctionCalls}
+                name="addFunctionCalls"
+                label="Add function calls"
+                disabled={!!addFunctionDefinition}
+                onChange={event =>
+                  onAddFunctionCallsChange(event.target.checked)
+                }
+              />
+            </div>
           )}
         </div>
         <div className={styles.verticalLine}>&nbsp;</div>

--- a/apps/src/lab2/levelEditors/levelData/PreviewMusicWorkspace.tsx
+++ b/apps/src/lab2/levelEditors/levelData/PreviewMusicWorkspace.tsx
@@ -66,8 +66,8 @@ const PreviewMusicWorkspace: React.FC<PreviewMusicWorkspaceProps> = ({
         the toolbox. Blocks added to the workspace and changes made
         to field values will not be saved. ` +
           (toolboxData?.type === 'flyout' && blockMode === BlockMode.SIMPLE2
-            ? `Function calls for (non-deletable, non-editable) function definitions in
-        the user workspace will not be shown in this preview`
+            ? `Function blocks are dynamically generated and will not be shown
+            in this preview.`
             : ``)
         }
         type="info"

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -476,10 +476,13 @@ export default class MusicBlocklyWorkspace {
 
     (this.workspace?.getTopBlocks() as ProcedureBlock[])
       .filter(
-        // Disregarding unrendered blocks prevents duplicating call blocks
-        // for a defintion block that was just pulled from the toolbox.
+        // When a block is dragged from the toolbox, an insertion marker is
+        // created with the same type. Insertion markers just provide a
+        // visual indication of where the actual block will go. They should
+        // not be counted here or we could end up with duplicate call blocks.
         block =>
-          block.type === BLOCK_TYPES.procedureDefinition && block.rendered
+          block.type === BLOCK_TYPES.procedureDefinition &&
+          !block.isInsertionMarker()
       )
       .forEach(block => {
         allFunctions.push(

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -3,7 +3,7 @@ import GoogleBlockly from 'blockly/core';
 import {Abstract} from 'blockly/core/events/events_abstract';
 import {ToolboxItemInfo} from 'blockly/core/utils/toolbox';
 
-import {Renderers} from '@cdo/apps/blockly/constants';
+import {BLOCK_TYPES, Renderers} from '@cdo/apps/blockly/constants';
 import CdoDarkTheme from '@cdo/apps/blockly/themes/cdoDark';
 import {ProcedureBlock} from '@cdo/apps/blockly/types';
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
@@ -14,6 +14,7 @@ import {nameComparator} from '@cdo/apps/util/sort';
 
 import CustomMarshalingInterpreter from '../../lib/tools/jsinterpreter/CustomMarshalingInterpreter';
 import {BlockMode, Triggers} from '../constants';
+import musicI18n from '../locale';
 
 import {BlockTypes} from './blockTypes';
 import {
@@ -454,23 +455,32 @@ export default class MusicBlocklyWorkspace {
     const codeCopy = JSON.parse(JSON.stringify(code));
 
     Blockly.serialization.workspaces.load(codeCopy, this.workspace);
-
-    if (
-      this.toolbox?.addFunctionCalls &&
-      this.toolbox?.type === 'flyout' &&
-      this.blockMode === BlockMode.SIMPLE2
-    ) {
-      this.generateFunctionCallBlocks();
-    }
   }
 
   // For each function body in the current workspace, add a function call
-  // block to the toolbox.
-  generateFunctionCallBlocks() {
+  // block to the toolbox. Also add a function defintion block, if required.
+  generateFunctionBlocks() {
+    const blockList: ToolboxItemInfo[] = [];
+
+    if (this.toolbox?.addFunctionDefinition) {
+      blockList.push({
+        kind: 'block',
+        type: BLOCK_TYPES.procedureDefinition,
+        fields: {
+          NAME: musicI18n.blockly_functionNamePlaceholder(),
+        },
+      });
+    }
+
     const allFunctions: GoogleBlockly.serialization.procedures.State[] = [];
 
     (this.workspace?.getTopBlocks() as ProcedureBlock[])
-      .filter(block => block.type === 'procedures_defnoreturn')
+      .filter(
+        // Disregarding unrendered blocks prevents duplicating call blocks
+        // for a defintion block that was just pulled from the toolbox.
+        block =>
+          block.type === BLOCK_TYPES.procedureDefinition && block.rendered
+      )
       .forEach(block => {
         allFunctions.push(
           Blockly.serialization.procedures.saveProcedure(
@@ -479,12 +489,10 @@ export default class MusicBlocklyWorkspace {
         );
       });
 
-    const blockList: ToolboxItemInfo[] = [];
-
     allFunctions.sort(nameComparator).forEach(({name, id, parameters}) => {
       blockList.push({
         kind: 'block',
-        type: 'procedures_callnoreturn',
+        type: BLOCK_TYPES.procedureCall,
         extraState: {
           name,
           id,

--- a/apps/src/music/blockly/toolbox/types.ts
+++ b/apps/src/music/blockly/toolbox/types.ts
@@ -36,5 +36,6 @@ export interface ToolboxData {
   blocks?: CategoryBlocksMap;
   type?: ToolboxType;
   includeAi?: boolean;
+  addFunctionDefinition?: boolean;
   addFunctionCalls?: boolean;
 }

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -1,4 +1,5 @@
 /** @file Top-level view for Music */
+import {ProcedureBase} from '@blockly/block-shareable-procedures';
 import {isEqual} from 'lodash';
 import markdownToTxt from 'markdown-to-txt';
 import PropTypes from 'prop-types';
@@ -456,6 +457,22 @@ class UnconnectedMusicView extends React.Component {
         this.props.setSelectedTriggerId(
           this.musicBlocklyWorkspace.getSelectedTriggerId(e.blockId)
         );
+      }
+    }
+
+    // Procedure events should regenerate function blocks in the (uncategorized) toolbox.
+    // This keeps call blocks in sync when functions are created/deleted/renamed.
+    if (
+      e instanceof ProcedureBase ||
+      e.type === Blockly.Events.FINISHED_LOADING
+    ) {
+      const workspace = this.musicBlocklyWorkspace;
+      if (
+        workspace.toolbox?.addFunctionCalls &&
+        workspace.toolbox?.type === 'flyout' &&
+        workspace.blockMode === BlockMode.SIMPLE2
+      ) {
+        workspace.generateFunctionBlocks();
       }
     }
 


### PR DESCRIPTION
Follow up to:
- https://github.com/code-dot-org/code-dot-org/pull/61232

This removes the restriction that function definitions must be uneditable and undeletable in the start sources. Instead of generate the function blocks only one when the workspace is initialized, now we'll also do it each time there is a procedure-related event (ie. when functions are created/deleted/renamed). This makes it so that the toolbox content stays in sync with the functions on the user's workspace.

![2024-10-09 13-08-40 2024-10-09 13_09_23](https://github.com/user-attachments/assets/bdc551cd-2ff1-47fc-92a3-60cd83ddaf48)

This also adds support for an optional `levelData.toolbox.addFunctionDefinition` property for Music Lab.  When it's `true`, the model is `simple2`, and the toolbox is of type `"flyout"` (that is, with no categories), then an empty function definition block is added to the toolbox. This works smoothly with the above option to include call blocks:

![2024-10-09 13-10-26 2024-10-09 13_11_17](https://github.com/user-attachments/assets/5976902d-baf4-438d-b015-06fcf4db3ee4)

Providing a definition block without call blocks isn't a scenario that makes sense (since then the student inside functions couldn't possibly be run), so we don't want to support it. As such, including definition blocks will require including call blocks. You also won't be able to exclude call blocks unless definition blocks are also excluded.

The updated UI enforces this:

![2024-10-09 13-06-49 2024-10-09 13_07_49](https://github.com/user-attachments/assets/a4b2f73a-4bec-4912-a15d-62ccf52611f2)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
