### PR TITLE
Adds Statsig events to Section Join Student Creation Form

### DIFF
--- a/apps/src/sites/studio/pages/followers/student_user_new.js
+++ b/apps/src/sites/studio/pages/followers/student_user_new.js
@@ -1,0 +1,22 @@
+import $ from 'jquery';
+
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+
+$(document).ready(() => {
+  analyticsReporter.sendEvent(
+    EVENTS.SIGN_UP_STARTED_EVENT,
+    {sectionCodeSignUpForm: true},
+    PLATFORMS.STATSIG
+  );
+
+  document
+    .getElementById('create_and_register')
+    .addEventListener('click', () => {
+      analyticsReporter.sendEvent(
+        EVENTS.SIGN_UP_FINISHED_EVENT,
+        {sectionCodeSignUpForm: true},
+        PLATFORMS.STATSIG
+      );
+    });
+});

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -63,6 +63,7 @@ const CODE_STUDIO_ENTRIES = {
   'devise/registrations/_finish_sign_up': './src/sites/studio/pages/devise/registrations/_finish_sign_up.js',
   'devise/registrations/edit': './src/sites/studio/pages/devise/registrations/edit.js',
   'devise/registrations/account_type': './src/sites/studio/pages/devise/registrations/account_type.js',
+  'followers/student_user_new': './src/sites/studio/pages/followers/student_user_new.js',
   'essential': './src/sites/studio/pages/essential.js',
   'home/_homepage': './src/sites/studio/pages/home/_homepage.js',
   'layouts/_parent_email_banner': './src/sites/studio/pages/layouts/_parent_email_banner.js',

--- a/dashboard/app/views/followers/student_user_new.html.haml
+++ b/dashboard/app/views/followers/student_user_new.html.haml
@@ -7,6 +7,8 @@
 - content_for(:head) do
   %meta{name: "robots", content: "noindex"}/
 
+%script{src: webpack_asset_path('js/followers/student_user_new.js')}
+
 - if current_user || !@section
   %h2= t('join_section.code.title')
   %p= t('join_section.code.instructions')
@@ -92,7 +94,7 @@
                   = f.label :gender_student_input, t('signup_form.gender')
                   = f.text_field :gender_student_input, maxlength: 50
                 %br/
-            = submit_tag 'Register', class: 'btn btn-primary'
+            = submit_tag 'Register', class: 'btn btn-primary', id: 'create_and_register'
 
         #student-terms
           != t('signup_form.student_terms_markdown', markdown: true)


### PR DESCRIPTION
Adds a 'sign up started' and 'sign up finished' event to the loading of the section join code form and the final register button. 

<img width="464" alt="Screenshot 2024-10-09 at 2 28 30 PM" src="https://github.com/user-attachments/assets/5a9ad8ed-6df7-4d0f-86a7-d2c073b0cdc1">

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2473

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
