### PR TITLE
[JIMT][CT-843][CT-855] - pre-prime the promiseArgs and errorMessage

### DIFF
--- a/apps/src/lab2/views/dialogs/GenericPrompt.tsx
+++ b/apps/src/lab2/views/dialogs/GenericPrompt.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
 import TextField from '@cdo/apps/componentLibrary/textField';
 import {BodyTwoText} from '@cdo/apps/componentLibrary/typography';
@@ -74,6 +74,10 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
     },
     [validateInput, setPromiseArgs, setErrorMessage]
   );
+
+  // fire the handleInputChange callback once upon loading. This'll populate the given prompt into the promiseArgs
+  // as well as calling validateInput on it to confirm it's acceptable.'
+  useEffect(() => handleInputChange(prompt), []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <GenericDialog


### PR DESCRIPTION
Two different bugs had the same root cause - there were cases where the prompt could open in a pre-primed valid state - for example, if input was not required (as is the case with the `moveFile` prompt, which could move to an empty string (which is the project root)), or if the input was pre-populated (as is the case with the `renameFile` prompt, which would pre-populate the input with the existing name of the file.

What we needed to do was pre-prime both the `promiseArgs` (to fix CT-855) _and_ run the validation (to fix CT-843). So this just adds an effect that runs once upon load to assume input was changed to whatever the starting prompt is.

**OF NOTE** When CT-855, it'd destroy a project because it'd end up setting the file's name to `undefined`, and then the undefineds would later cause errors. This code does _not_ fix those errors - if you have a damaged project, it'll stay damaged.

To fix it, you can do one of the following:
- manually add in a file name to the damaged file in the json file.
- Go into `PythlonLabView.tsx` and add the following code right before the return (currently on line 158):
```
  if (source) {
    const fixedSource = {...source};
    let needsFix = false;
    Object.values(fixedSource.files).forEach(f => {
      console.log('LOOKS AT : ', f.id, f.name);
      if (f.name === undefined) {
        fixedSource.files = {
          ...source.files,
          [f.id]: {...source.files[f.id], name: 'UHOH.txt'},
        };
        needsFix = true;
      }
    });
    if (needsFix) {
      setSource(fixedSource);
    }
  }
```

That'll look for any files w/o names and re-name them to `UHOH.txt`. You'll then need to manually rename the file as desired. You can delete the code once it's patched.

Since this is a pre-release error, I don't think we need to keep the repair code live in the codebase because the only affected projects should be internal.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- jira ticket: [CT-843](https://codedotorg.atlassian.net/issues/CT-843)
- jira ticket: [CT-855](https://codedotorg.atlassian.net/issues/CT-855)


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
