### PR TITLE
Music: sound icons

### DIFF
--- a/apps/src/music/views/SoundStyle.module.scss
+++ b/apps/src/music/views/SoundStyle.module.scss
@@ -3,10 +3,7 @@
 @mixin sound-type-style($type, $color, $fill, $background, $border) {
   &#{$type} {
     &Color { color: $color }
-    &Fill {
-      fill: $fill;
-      font-weight: 600;
-    }
+    &Fill { fill: $fill }
     &Background { background: $background }
     &Border { border-color: $border }
   }

--- a/apps/src/music/views/SoundStyle.module.scss
+++ b/apps/src/music/views/SoundStyle.module.scss
@@ -3,7 +3,10 @@
 @mixin sound-type-style($type, $color, $fill, $background, $border) {
   &#{$type} {
     &Color { color: $color }
-    &Fill { fill: $fill }
+    &Fill {
+      fill: $fill;
+      font-weight: 600;
+    }
     &Background { background: $background }
     &Border { border-color: $border }
   }

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -189,6 +189,7 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
             styles.typeIcon,
             SoundStyle[sound.type]?.classNameColor
           )}
+          iconStyle="regular"
         />
         <div
           className={classNames(


### PR DESCRIPTION
@katiejofr noticed that the sound icons in the sounds panel were not the regular variant used in the block's custom field. Now they match.

### Before

<img width="453" alt="Screenshot 2024-10-09 at 2 36 15 PM" src="https://github.com/user-attachments/assets/cb4bd503-ecc6-4f78-9ece-e6e87bf91091">

### After

<img width="453" alt="Screenshot 2024-10-09 at 2 33 13 PM" src="https://github.com/user-attachments/assets/b208e1b0-d711-4424-96b6-d078c47d94b9">


