### PR TITLE
Unit page links to teacher dashboard if appropriate

### DIFF
--- a/apps/src/code-studio/components/progress/TeacherUnitOverview.tsx
+++ b/apps/src/code-studio/components/progress/TeacherUnitOverview.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {useSelector} from 'react-redux';
-import {useNavigate, useParams} from 'react-router-dom';
+import {generatePath, useNavigate, useParams} from 'react-router-dom';
 
 import {initializeHiddenScripts} from '@cdo/apps/code-studio/hiddenLessonRedux';
 import plcHeaderReducer, {
@@ -18,6 +18,7 @@ import {
   setPageType,
   pageTypes,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {TEACHER_NAVIGATION_PATHS} from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
 import {PeerReviewLessonInfo} from '@cdo/apps/types/progressTypes';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import experiments from '@cdo/apps/util/experiments';
@@ -332,7 +333,13 @@ const TeacherUnitOverview: React.FC<TeacherUnitOverviewProps> = props => {
       courseOfferingId={selectedSection.courseOfferingId}
       courseVersionId={selectedSection.courseVersionId}
       courseTitle={unitSummaryResponse.unitData.course_title}
-      courseLink={unitSummaryResponse.unitData.course_link}
+      courseLink={
+        unitSummaryResponse.unitData.course_name
+          ? generatePath('../' + TEACHER_NAVIGATION_PATHS.courseOverview, {
+              courseVersionName: unitSummaryResponse.unitData.course_name,
+            })
+          : null
+      }
       excludeCsfColumnInLegend={!unitSummaryResponse.unitData.csf}
       teacherResources={unitSummaryResponse.unitData.teacher_resources}
       studentResources={unitSummaryResponse.unitData.student_resources || []}

--- a/apps/src/sharedComponents/Spinner.jsx
+++ b/apps/src/sharedComponents/Spinner.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
+import i18n from '@cdo/locale';
 
 export default class Spinner extends React.Component {
   static propTypes = {
@@ -22,6 +23,7 @@ export default class Spinner extends React.Component {
         style={style}
         icon="spinner"
         className={`fa-pulse ${displaySize}`}
+        title={i18n.loading()}
       />
     );
   }

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -6,6 +6,7 @@ import {BrowserRouter} from 'react-router-dom';
 
 import announcementReducer from '@cdo/apps/code-studio/announcementsRedux';
 import hiddenLesson from '@cdo/apps/code-studio/hiddenLessonRedux';
+import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import progressRedux from '@cdo/apps/code-studio/progressRedux';
 import verifiedInstructor from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import viewAs from '@cdo/apps/code-studio/viewAsRedux';
@@ -64,6 +65,7 @@ $(document).ready(function () {
     verifiedInstructor,
     announcementReducer,
     progressRedux,
+    isRtl,
   });
 
   const store = getStore();

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -6,6 +6,7 @@ import {BrowserRouter} from 'react-router-dom';
 
 import announcementReducer from '@cdo/apps/code-studio/announcementsRedux';
 import hiddenLesson from '@cdo/apps/code-studio/hiddenLessonRedux';
+import progressRedux from '@cdo/apps/code-studio/progressRedux';
 import verifiedInstructor from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import viewAs from '@cdo/apps/code-studio/viewAsRedux';
 import DCDO from '@cdo/apps/dcdo';
@@ -62,6 +63,7 @@ $(document).ready(function () {
     hiddenLesson,
     verifiedInstructor,
     announcementReducer,
+    progressRedux,
   });
 
   const store = getStore();

--- a/apps/src/templates/courseOverview/TeacherCourseOverview.tsx
+++ b/apps/src/templates/courseOverview/TeacherCourseOverview.tsx
@@ -136,9 +136,11 @@ const TeacherCourseOverview: React.FC = () => {
 
   React.useEffect(() => {
     if (!selectedSection || !selectedSection?.courseVersionName) {
+      console.log('lfm early return');
       return;
     }
     if (!selectedSection.courseId && selectedSection.unitName) {
+      console.log('lfm unit');
       navigate(
         generatePath('../' + TEACHER_NAVIGATION_PATHS.unitOverview, {
           unitName: selectedSection.unitName,
@@ -149,6 +151,7 @@ const TeacherCourseOverview: React.FC = () => {
     }
 
     if (selectedSection.courseVersionName !== params.courseVersionName) {
+      console.log('lfm course');
       navigate(
         generatePath('../' + TEACHER_NAVIGATION_PATHS.courseOverview, {
           courseVersionName: selectedSection.courseVersionName,
@@ -160,6 +163,7 @@ const TeacherCourseOverview: React.FC = () => {
 
     courseSummaryCachedLoader(selectedSection.courseVersionName).then(
       response => {
+        console.log('lfm set');
         if (response) {
           setCourseSummary(response.unit_group as CourseSummary);
           setIsVerifiedInstructor(response.is_verified_instructor);

--- a/apps/src/templates/courseOverview/TeacherCourseOverview.tsx
+++ b/apps/src/templates/courseOverview/TeacherCourseOverview.tsx
@@ -136,11 +136,9 @@ const TeacherCourseOverview: React.FC = () => {
 
   React.useEffect(() => {
     if (!selectedSection || !selectedSection?.courseVersionName) {
-      console.log('lfm early return');
       return;
     }
     if (!selectedSection.courseId && selectedSection.unitName) {
-      console.log('lfm unit');
       navigate(
         generatePath('../' + TEACHER_NAVIGATION_PATHS.unitOverview, {
           unitName: selectedSection.unitName,
@@ -151,7 +149,6 @@ const TeacherCourseOverview: React.FC = () => {
     }
 
     if (selectedSection.courseVersionName !== params.courseVersionName) {
-      console.log('lfm course');
       navigate(
         generatePath('../' + TEACHER_NAVIGATION_PATHS.courseOverview, {
           courseVersionName: selectedSection.courseVersionName,
@@ -163,7 +160,6 @@ const TeacherCourseOverview: React.FC = () => {
 
     courseSummaryCachedLoader(selectedSection.courseVersionName).then(
       response => {
-        console.log('lfm set');
         if (response) {
           setCourseSummary(response.unit_group as CourseSummary);
           setIsVerifiedInstructor(response.is_verified_instructor);

--- a/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
+++ b/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
@@ -69,7 +69,6 @@ const ElementOrEmptyPage: React.FC<ElementOrEmptyPageProps> = ({
     } else if (showNoCurriculumAssigned) {
       return <LinkButton href="/catalog" text={i18n.browseCurriculum()} />;
     } else {
-      // TODO: change to href
       return (
         <Button onClick={navigateToCoursePage} text={i18n.assignAUnit()} />
       );

--- a/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
+++ b/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
@@ -69,6 +69,7 @@ const ElementOrEmptyPage: React.FC<ElementOrEmptyPageProps> = ({
     } else if (showNoCurriculumAssigned) {
       return <LinkButton href="/catalog" text={i18n.browseCurriculum()} />;
     } else {
+      // TODO: change to href
       return (
         <Button onClick={navigateToCoursePage} text={i18n.assignAUnit()} />
       );

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -112,6 +112,7 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
   const navigateToDifferentPage = (
     page: keyof typeof LABELED_TEACHER_NAVIGATION_PATHS
   ) => {
+    console.log('lfm', {section: sections[selectedSectionId]});
     if (LABELED_TEACHER_NAVIGATION_PATHS[page]) {
       navigate(
         generatePath(LABELED_TEACHER_NAVIGATION_PATHS[page].absoluteUrl, {

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -112,7 +112,6 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
   const navigateToDifferentPage = (
     page: keyof typeof LABELED_TEACHER_NAVIGATION_PATHS
   ) => {
-    console.log('lfm', {section: sections[selectedSectionId]});
     if (LABELED_TEACHER_NAVIGATION_PATHS[page]) {
       navigate(
         generatePath(LABELED_TEACHER_NAVIGATION_PATHS[page].absoluteUrl, {

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -11,9 +11,7 @@ import {
 import TutorTab from '@cdo/apps/aiTutor/views/teacherDashboard/TutorTab';
 import TeacherUnitOverview from '@cdo/apps/code-studio/components/progress/TeacherUnitOverview';
 
-import TeacherCourseOverview, {
-  teacherCourseOverviewLoader,
-} from '../courseOverview/TeacherCourseOverview';
+import TeacherCourseOverview from '../courseOverview/TeacherCourseOverview';
 import ManageStudents from '../manageStudents/ManageStudents';
 import SectionProjectsListWithData from '../projects/SectionProjectsListWithData';
 import SectionAssessments from '../sectionAssessments/SectionAssessments';
@@ -57,6 +55,7 @@ export interface Section {
   courseOfferingId: number;
   unitId: number;
   courseDisplayName: string;
+  courseId: number;
 }
 
 const applyV1TeacherDashboardWidth = (children: React.ReactNode) => {
@@ -256,7 +255,6 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
           />
           <Route
             path={TEACHER_NAVIGATION_PATHS.courseOverview}
-            loader={teacherCourseOverviewLoader}
             element={
               <ElementOrEmptyPage
                 showNoStudents={false}

--- a/apps/test/unit/templates/courseOverview/TeacherCourseOverviewTest.tsx
+++ b/apps/test/unit/templates/courseOverview/TeacherCourseOverviewTest.tsx
@@ -1,0 +1,189 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+import {Provider} from 'react-redux';
+import {
+  createMemoryRouter,
+  createRoutesFromElements,
+  Route,
+  RouterProvider,
+} from 'react-router-dom';
+
+import announcements from '@cdo/apps/code-studio/announcementsRedux';
+import hiddenLesson from '@cdo/apps/code-studio/hiddenLessonRedux';
+import progress from '@cdo/apps/code-studio/progressRedux';
+import verifiedInstructor from '@cdo/apps/code-studio/verifiedInstructorRedux';
+import viewAs from '@cdo/apps/code-studio/viewAsRedux';
+import {getStore, registerReducers} from '@cdo/apps/redux';
+import TeacherCourseOverview from '@cdo/apps/templates/courseOverview/TeacherCourseOverview';
+import currentUser, {
+  setInitialData,
+} from '@cdo/apps/templates/currentUserRedux';
+import teacherSections, {
+  selectSection,
+  setSections,
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {LABELED_TEACHER_NAVIGATION_PATHS} from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
+import HttpClient from '@cdo/apps/util/HttpClient';
+
+jest.mock('@cdo/apps/util/AuthenticityTokenStore', () => ({
+  getAuthenticityToken: jest.fn().mockReturnValue(Promise.resolve('authToken')),
+}));
+
+jest.mock('@cdo/apps/code-studio/initSigninState', () => ({
+  getUserSignedInFromCookieAndDom: jest.fn().mockReturnValue({
+    signedIn: true,
+    userType: 'teacher',
+  }),
+}));
+
+const COURSE_SUMMARY = {
+  name: 'csp',
+  title: 'Computer Science Principles 2017',
+  assignment_family_title: 'Computer Science Principles',
+  id: 30,
+  course_offering_id: 1,
+  course_version_id: 1,
+  description_student:
+    '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
+  description_teacher:
+    '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
+  teacher_resources: [],
+  student_resources: [],
+  scripts: [
+    {
+      course_id: 30,
+      id: 112,
+      title: 'CSP Unit 1',
+      name: 'csp1',
+      description: 'desc',
+    },
+    {
+      course_id: 30,
+      id: 113,
+      title: 'CSP Unit 2',
+      name: 'csp2',
+      description: 'desc',
+    },
+  ],
+  show_assign_button: true,
+  participant_audience: 'Student',
+  course_versions: {},
+  announcements: [],
+  has_verified_resources: false,
+};
+
+// const fakeTeacherAnnouncement = {
+//   notice: 'Notice - Teacher',
+//   details: 'Teachers are the best',
+//   link: '/foo/bar/teacher',
+//   type: NotificationType.information,
+//   visibility: VisibilityType.teacher,
+// };
+// const fakeStudentAnnouncement = {
+//   notice: 'Notice - Student',
+//   details: 'Students are the best',
+//   link: '/foo/bar/student',
+//   type: NotificationType.information,
+//   visibility: VisibilityType.student,
+// };
+// const fakeTeacherAndStudentAnnouncement = {
+//   notice: 'Notice - Teacher And Student',
+//   details: 'More detail here',
+//   link: '/foo/bar/teacherAndStudent',
+//   type: NotificationType.information,
+//   visibility: VisibilityType.teacherAndStudent,
+// };
+
+const sections = [
+  {
+    id: 11,
+    name: 'Period 1',
+    course_id: 30,
+    unitName: 'csd1-2024',
+    courseVersionName: 'csd-2024',
+    scriptId: 1,
+  },
+  {
+    id: 12,
+    name: 'Period 2',
+    course_id: 30,
+    unitName: 'csd1-2024',
+    courseVersionName: 'csd-2024',
+    scriptId: 1,
+  },
+  {
+    id: 13,
+    name: 'Period 3',
+    course_id: 30,
+    unitName: null,
+    courseVersionName: 'csd-2024',
+    scriptId: null,
+  },
+];
+
+describe('TeacherCourseOverview', () => {
+  beforeEach(() => {
+    const store = getStore();
+
+    registerReducers({
+      teacherSections,
+      currentUser,
+      verifiedInstructor,
+      announcements,
+      viewAs,
+      hiddenLesson,
+      progress,
+    });
+
+    store.dispatch(setInitialData({id: 1}));
+
+    store.dispatch(setSections(sections));
+    store.dispatch(selectSection(12));
+
+    // jest.spyOn(globalAny, 'fetch').mockImplementation(
+    //   jest.fn(() =>
+    //     Promise.resolve({
+    //       json: () =>
+    //         Promise.resolve({
+    //
+    //         }),
+    //     })
+    //   ) as jest.Mock
+    // );
+    HttpClient.fetchJson = jest.fn().mockResolvedValue({
+      value: {
+        unit_group: COURSE_SUMMARY,
+        is_verified_instructor: true,
+        hidden_scripts: [],
+      },
+      response: new Response(),
+    });
+  });
+
+  function renderDefault(initialRoute = '/sections/12/courses/csd-2024') {
+    render(
+      <Provider store={getStore()}>
+        <RouterProvider
+          router={createMemoryRouter(
+            createRoutesFromElements([
+              <Route
+                path={
+                  LABELED_TEACHER_NAVIGATION_PATHS.courseOverview.absoluteUrl
+                }
+                element={<TeacherCourseOverview />}
+              />,
+            ]),
+            {initialEntries: [initialRoute]}
+          )}
+        />
+      </Provider>
+    );
+  }
+
+  it('renders course overview', async () => {
+    renderDefault();
+
+    await screen.findByText('Computer Science Principles');
+    screen.getByText('Teacher description');
+  });
+});

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -35,6 +35,8 @@ class CoursesController < ApplicationController
       return
     end
 
+    puts 'lfm1', @unit_group.name
+
     # Attempt to redirect user if we think they ended up on the wrong course overview page.
     override_redirect = VersionRedirectOverrider.override_course_redirect?(session, @unit_group)
     if !override_redirect && redirect_unit_group = redirect_unit_group(@unit_group)

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -35,8 +35,6 @@ class CoursesController < ApplicationController
       return
     end
 
-    puts 'lfm1', @unit_group.name
-
     # Attempt to redirect user if we think they ended up on the wrong course overview page.
     override_redirect = VersionRedirectOverrider.override_course_redirect?(session, @unit_group)
     if !override_redirect && redirect_unit_group = redirect_unit_group(@unit_group)


### PR DESCRIPTION
Adds the following redirects:
* Redirect to the unit page if the assigned course is actually a standalone unit
* Redirect to the correct course URL (including :courseVersionName) if the course name is absent or different than what is assigned
* Make the link to the course page from the unit page link to the teacher dashboard version

## Links
https://codedotorg.atlassian.net/browse/TEACH-1290
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Added unit tests for the TeacherCourseOverview

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
