### PR TITLE
[Codebridge] Make files more easily clickable and closeable

### DIFF
--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -66,7 +66,7 @@ li .button-kebab {
   display: none;
   height: 20px;
   width: 20px;
-  margin: 2px;
+  margin: 2px 2px 2px 0;
 }
 
 div.row:hover .button-kebab {
@@ -83,7 +83,8 @@ div.row:hover .button-kebab {
   display: flex;
   justify-content: flex-start;
   overflow: hidden;
-  margin-right: 4px;
+  padding-right: 4px;
+  width: 100%;
 }
 
 .rowIcon {

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -28,8 +28,8 @@ const FileTab = ({file}: FileTabProps) => {
   return (
     <div className={className} key={file.id}>
       <div
-        onClick={() => setActiveFile(file.id)}
         className={moduleStyles.label}
+        onClick={() => setActiveFile(file.id)}
       >
         <FontAwesomeV6Icon
           iconName={iconName}

--- a/apps/src/codebridge/FileTabs/FileTab.tsx
+++ b/apps/src/codebridge/FileTabs/FileTab.tsx
@@ -27,14 +27,17 @@ const FileTab = ({file}: FileTabProps) => {
 
   return (
     <div className={className} key={file.id}>
-      <span onClick={() => setActiveFile(file.id)}>
+      <div
+        onClick={() => setActiveFile(file.id)}
+        className={moduleStyles.label}
+      >
         <FontAwesomeV6Icon
           iconName={iconName}
           iconStyle={iconStyle}
           className={iconClassName}
         />
         <span>{file.name}</span>
-      </span>
+      </div>
       <CloseButton
         onClick={() => closeFile(file.id)}
         color={'light'}

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -21,7 +21,6 @@
   cursor: pointer;
   white-space: nowrap;
   justify-content: space-between;
-  padding: 0 6px;
   height: 28px;
   background-color: $light_gray_950;
   border-radius: 4px 4px 0 0;
@@ -36,7 +35,7 @@
   align-items: center;
   gap: 10px;
   width: 100%;
-  padding-right: 10px;
+  padding: 0 10px;
 }
 
 .active {
@@ -49,5 +48,6 @@
 }
 
 .closeButton {
-  margin-top: 4px;
+  margin: 4px 0;
+  padding-right: 10px;
 }

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -34,7 +34,6 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  width: 100%;
   padding: 0 10px;
 }
 

--- a/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
+++ b/apps/src/codebridge/FileTabs/styles/fileTabs.module.scss
@@ -21,7 +21,6 @@
   cursor: pointer;
   white-space: nowrap;
   justify-content: space-between;
-  gap: 10px;
   padding: 0 6px;
   height: 28px;
   background-color: $light_gray_950;
@@ -32,10 +31,12 @@
   }
 }
 
-.fileTab > span {
+.label {
   display: flex;
   align-items: center;
   gap: 10px;
+  width: 100%;
+  padding-right: 10px;
 }
 
 .active {


### PR DESCRIPTION
A couple changes to make files in the file browser more easily openable and file tabs more easily activated and closed. The crux of the issue here was we had gaps between elements that weren't part of the click targets, so you could click on a tab and it wouldn't open because you weren't clicking on the text of the filename, for example.

## Before
https://github.com/user-attachments/assets/49837dc1-f7e4-49ec-a0ec-11a3c1a3491e


## After
https://github.com/user-attachments/assets/0f6096b7-2ae6-4909-b191-c0911d2aa8f3



## Links
- jira ticket: [CT-856](https://codedotorg.atlassian.net/browse/CT-856) I couldn't reproduce the exact issue in the bug bash, which was even if the 'x' was highlighted the tab wasn't closing. But it may have been due to the small hit box and a small mouse movement after highlighting the x. This is a much better experience overall, and we can keep an eye out and see if folks still see issues closing tabs.

## Testing story
Tested locally



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
