### PR TITLE
Lab2: TTS tweaks

### DIFF
--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -77,7 +77,6 @@ export interface LabState {
   // If this lab should presented in a "share" or "play-only" view, which may hide certain UI elements.
   isShareView: boolean | undefined;
   overrideValidations: Validation[] | undefined;
-  textToSpeechHasVoices: boolean;
 }
 
 const initialState: LabState = {
@@ -90,7 +89,6 @@ const initialState: LabState = {
   levelProperties: undefined,
   isShareView: undefined,
   overrideValidations: undefined,
-  textToSpeechHasVoices: false,
 };
 
 // Thunks
@@ -379,9 +377,6 @@ const labSlice = createSlice({
     setIsShareView(state, action: PayloadAction<boolean>) {
       state.isShareView = action.payload;
     },
-    setTextToSpeechHasVoices(state, action: PayloadAction<boolean>) {
-      state.textToSpeechHasVoices = action.payload;
-    },
     setOverrideValidations(
       state,
       action: PayloadAction<Validation[] | undefined>
@@ -593,7 +588,6 @@ export const {
   setValidationState,
   setIsShareView,
   setOverrideValidations,
-  setTextToSpeechHasVoices,
 } = labSlice.actions;
 
 // These should not be set outside of the lab slice.

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -77,6 +77,7 @@ export interface LabState {
   // If this lab should presented in a "share" or "play-only" view, which may hide certain UI elements.
   isShareView: boolean | undefined;
   overrideValidations: Validation[] | undefined;
+  textToSpeechHasVoices: boolean;
 }
 
 const initialState: LabState = {
@@ -89,6 +90,7 @@ const initialState: LabState = {
   levelProperties: undefined,
   isShareView: undefined,
   overrideValidations: undefined,
+  textToSpeechHasVoices: false,
 };
 
 // Thunks
@@ -377,6 +379,9 @@ const labSlice = createSlice({
     setIsShareView(state, action: PayloadAction<boolean>) {
       state.isShareView = action.payload;
     },
+    setTextToSpeechHasVoices(state, action: PayloadAction<boolean>) {
+      state.textToSpeechHasVoices = action.payload;
+    },
     setOverrideValidations(
       state,
       action: PayloadAction<Validation[] | undefined>
@@ -588,6 +593,7 @@ export const {
   setValidationState,
   setIsShareView,
   setOverrideValidations,
+  setTextToSpeechHasVoices,
 } = labSlice.actions;
 
 // These should not be set outside of the lab slice.

--- a/apps/src/lab2/views/Lab2.tsx
+++ b/apps/src/lab2/views/Lab2.tsx
@@ -8,6 +8,7 @@ import {Provider} from 'react-redux';
 
 import {getStandaloneProjectId} from '@cdo/apps/lab2/projects/utils';
 import {getStore} from '@cdo/apps/redux';
+import BrowserTextToSpeechWrapper from '@cdo/apps/sharedComponents/BrowserTextToSpeechWrapper';
 
 import ProjectContainer from '../projects/ProjectContainer';
 
@@ -20,16 +21,18 @@ import ThemeWrapper from './ThemeWrapper';
 const Lab2: React.FunctionComponent = () => {
   return (
     <Provider store={getStore()}>
-      <ThemeWrapper>
-        <Lab2Wrapper>
-          <DialogManager>
-            <MetricsAdapter />
-            <ProjectContainer channelId={getStandaloneProjectId()}>
-              <LabViewsRenderer />
-            </ProjectContainer>
-          </DialogManager>
-        </Lab2Wrapper>
-      </ThemeWrapper>
+      <BrowserTextToSpeechWrapper>
+        <ThemeWrapper>
+          <Lab2Wrapper>
+            <DialogManager>
+              <MetricsAdapter />
+              <ProjectContainer channelId={getStandaloneProjectId()}>
+                <LabViewsRenderer />
+              </ProjectContainer>
+            </DialogManager>
+          </Lab2Wrapper>
+        </ThemeWrapper>
+      </BrowserTextToSpeechWrapper>
     </Provider>
   );
 };

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -19,7 +19,6 @@ import {
   isLabLoading,
   hasPageError,
   setIsShareView,
-  setTextToSpeechHasVoices,
 } from '../lab2Redux';
 import Lab2Registry from '../Lab2Registry';
 import {getAppOptionsLevelId, getIsShareView} from '../projects/utils';
@@ -62,12 +61,6 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
       dispatch(setIsShareView(isShareView));
     }
   }, [isShareView, dispatch]);
-
-  useEffect(() => {
-    window.speechSynthesis.onvoiceschanged = () => {
-      dispatch(setTextToSpeechHasVoices(true));
-    };
-  }, [dispatch]);
 
   return (
     <ErrorBoundary

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -19,6 +19,7 @@ import {
   isLabLoading,
   hasPageError,
   setIsShareView,
+  setTextToSpeechHasVoices,
 } from '../lab2Redux';
 import Lab2Registry from '../Lab2Registry';
 import {getAppOptionsLevelId, getIsShareView} from '../projects/utils';
@@ -61,6 +62,12 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
       dispatch(setIsShareView(isShareView));
     }
   }, [isShareView, dispatch]);
+
+  useEffect(() => {
+    window.speechSynthesis.onvoiceschanged = () => {
+      dispatch(setTextToSpeechHasVoices(true));
+    };
+  }, [dispatch]);
 
   return (
     <ErrorBoundary

--- a/apps/src/lab2/views/components/TextToSpeech.module.scss
+++ b/apps/src/lab2/views/components/TextToSpeech.module.scss
@@ -4,11 +4,11 @@
 .playButton {
   @include remove-button-styles;
   position: absolute;
-  top: 10px;
-  right: 14px;
+  top: 6px;
+  right: 6px;
   width: 22px;
   height: 22px;
-  color: $neutral_dark80;
+  color: $neutral_dark70;
   cursor: pointer;
 }
 
@@ -16,4 +16,5 @@
   position: absolute;
   top: 2px;
   left: 4px;
+  font-size: 15px;
 }

--- a/apps/src/lab2/views/components/TextToSpeech.tsx
+++ b/apps/src/lab2/views/components/TextToSpeech.tsx
@@ -3,6 +3,7 @@ import React, {useCallback} from 'react';
 
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import {getCurrentLocale} from '@cdo/apps/lab2/projects/utils';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import moduleStyles from './TextToSpeech.module.scss';
 
@@ -14,10 +15,15 @@ interface TextToSpeechProps {
  * TextToSpeech play button.
  */
 const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
+  const textToSpeechHasVoices = useAppSelector(
+    state => state.lab.textToSpeechHasVoices
+  );
+
   const playText = useCallback(() => {
     const currentLocale = getCurrentLocale();
     const voices = speechSynthesis.getVoices();
     if (voices.length === 0) {
+      console.log('TextToSpeech: no voices available to play.');
       return;
     }
     const plainText = markdownToTxt(text);
@@ -27,6 +33,10 @@ const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
     speechSynthesis.speak(utterance);
   }, [text]);
 
+  if (!textToSpeechHasVoices) {
+    return null;
+  }
+
   return (
     <button
       className={moduleStyles.playButton}
@@ -34,8 +44,8 @@ const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
       type="button"
     >
       <FontAwesomeV6Icon
-        iconName={'play'}
-        iconStyle="solid"
+        iconName={'waveform-lines'}
+        iconStyle="regular"
         className={moduleStyles.icon}
       />
     </button>

--- a/apps/src/lab2/views/components/TextToSpeech.tsx
+++ b/apps/src/lab2/views/components/TextToSpeech.tsx
@@ -1,9 +1,7 @@
-import {markdownToTxt} from 'markdown-to-txt';
 import React, {useCallback} from 'react';
 
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
-import {getCurrentLocale} from '@cdo/apps/lab2/projects/utils';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useBrowserTextToSpeech} from '@cdo/apps/sharedComponents/BrowserTextToSpeechWrapper';
 
 import moduleStyles from './TextToSpeech.module.scss';
 
@@ -15,33 +13,22 @@ interface TextToSpeechProps {
  * TextToSpeech play button.
  */
 const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
-  const textToSpeechHasVoices = useAppSelector(
-    state => state.lab.textToSpeechHasVoices
-  );
+  const {isTtsAvailable, speak} = useBrowserTextToSpeech();
 
   const playText = useCallback(() => {
-    const currentLocale = getCurrentLocale();
-    const voices = speechSynthesis.getVoices();
-    if (voices.length === 0) {
-      console.log('TextToSpeech: no voices available to play.');
+    if (!isTtsAvailable) {
+      console.log('Browser TextToSpeech unavailable');
       return;
     }
-    const plainText = markdownToTxt(text);
-    const utterance = new SpeechSynthesisUtterance(plainText);
-    utterance.lang = currentLocale;
-    speechSynthesis.cancel();
-    speechSynthesis.speak(utterance);
-  }, [text]);
-
-  if (!textToSpeechHasVoices) {
-    return null;
-  }
+    speak(text);
+  }, [isTtsAvailable, speak, text]);
 
   return (
     <button
       className={moduleStyles.playButton}
       onClick={playText}
       type="button"
+      disabled={!isTtsAvailable} // TODO: Better UI for disabled state
     >
       <FontAwesomeV6Icon
         iconName={'waveform-lines'}

--- a/apps/src/sharedComponents/BrowserTextToSpeechWrapper.tsx
+++ b/apps/src/sharedComponents/BrowserTextToSpeechWrapper.tsx
@@ -1,0 +1,50 @@
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+import {
+  isTtsAvailable,
+  onTtsAvailable,
+  speak,
+} from '../util/BrowserTextToSpeech';
+
+/**
+ * A wrapper component that provides the browser text-to-speech context.
+ * Attaches a listener that updates context when browser text-to-speech is ready.
+ */
+const BrowserTextToSpeechWrapper: React.FC<{children: ReactNode}> = ({
+  children,
+}) => {
+  const [ttsReady, setTtsReady] = useState(isTtsAvailable());
+
+  useEffect(() => {
+    onTtsAvailable(setTtsReady);
+  }, []);
+
+  return (
+    <BrowserTtsContext.Provider value={{isTtsAvailable: ttsReady, speak}}>
+      {children}
+    </BrowserTtsContext.Provider>
+  );
+};
+
+interface BrowserTtsContextType {
+  isTtsAvailable: boolean;
+  speak: (text: string) => void;
+}
+
+const BrowserTtsContext = createContext<BrowserTtsContextType>({
+  isTtsAvailable: isTtsAvailable(),
+  speak,
+});
+
+/** Hook to access the browser text-to-speech context. */
+export function useBrowserTextToSpeech() {
+  return useContext(BrowserTtsContext);
+}
+
+export default BrowserTextToSpeechWrapper;

--- a/apps/src/util/BrowserTextToSpeech.ts
+++ b/apps/src/util/BrowserTextToSpeech.ts
@@ -1,0 +1,43 @@
+import markdownToTxt from 'markdown-to-txt';
+
+import {getCurrentLocale} from '../lab2/projects/utils';
+
+/**
+ * Manages native Browser Text to Speech functionality.
+ */
+
+let ttsAvailable = false;
+
+speechSynthesis.addEventListener('voiceschanged', () => {
+  ttsAvailable = speechSynthesis.getVoices().length > 0;
+});
+
+function onTtsAvailable(callback: (isAvailable: boolean) => void) {
+  if (ttsAvailable) {
+    callback(true);
+  } else {
+    speechSynthesis.addEventListener('voiceschanged', () => {
+      callback(speechSynthesis.getVoices().length > 0);
+    });
+  }
+}
+
+function isTtsAvailable() {
+  return ttsAvailable;
+}
+
+// TODO: Pick the best voice for the current locale.
+function speak(text: string) {
+  if (!ttsAvailable) {
+    console.log('TextToSpeech: not ready or no voices available to play.');
+    return;
+  }
+  const currentLocale = getCurrentLocale();
+  const plainText = markdownToTxt(text);
+  const utterance = new SpeechSynthesisUtterance(plainText);
+  utterance.lang = currentLocale;
+  speechSynthesis.cancel();
+  speechSynthesis.speak(utterance);
+}
+
+export {onTtsAvailable, isTtsAvailable, speak};

--- a/apps/src/util/BrowserTextToSpeech.ts
+++ b/apps/src/util/BrowserTextToSpeech.ts
@@ -1,6 +1,6 @@
 import markdownToTxt from 'markdown-to-txt';
 
-import {getCurrentLocale} from '../lab2/projects/utils';
+import currentLocale from './currentLocale';
 
 /**
  * Manages native Browser Text to Speech functionality.
@@ -32,10 +32,9 @@ function speak(text: string) {
     console.log('TextToSpeech: not ready or no voices available to play.');
     return;
   }
-  const currentLocale = getCurrentLocale();
   const plainText = markdownToTxt(text);
   const utterance = new SpeechSynthesisUtterance(plainText);
-  utterance.lang = currentLocale;
+  utterance.lang = currentLocale();
   speechSynthesis.cancel();
   speechSynthesis.speak(utterance);
 }


### PR DESCRIPTION
This makes a couple tweaks to Lab2 text-to-speech (TTS) support:
- updated icon that shouldn't be mistaken for a Music Lab play button;
- a centralized [`voiceschanged`](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis/voiceschanged_event) listener, so that the icon is only shown after voices become available.

### Screenshot

<img width="514" alt="Screenshot 2024-10-09 at 11 44 09 PM" src="https://github.com/user-attachments/assets/c1b6610a-506b-4be7-bacf-7aa800d46a52">
