### PR TITLE
[test eyes] Waiting for manage students table to load before the edit action.

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -14,6 +14,7 @@ Feature: Using the manage students tab of the teacher dashboard
     And I wait until element "#uitest-manage-students-table" is visible
 
     # Add a family name for Sally
+    And I wait until element "span:contains('SallyHasAVeryVeryLongFirstName')" is visible
     And I click selector "#uitest-manage-students-table th:contains(Actions) i" once I see it
     And I click selector ".pop-up-menu-item:contains(Edit all)" once I see it
     And I wait until element with css selector "input[name='uitest-family-name']" is enabled


### PR DESCRIPTION
Issue: teacher_dashboard_manage_students_tab_views_eyes test intermittently fails at the step where student's last name is edited, due to the input field not being visible.

Root cause: In some cases the "Edit all" button is pressed before the student table is loaded with data, resulting in the edit button click leading to no-op.

Screen shot of clicking "Edit all" in a failure run
![image](https://github.com/user-attachments/assets/1ddd0ea0-771f-4de7-b3c4-2017951ee047)

Screen shot of clicking "Edit all" in a successful run
![image](https://github.com/user-attachments/assets/f6672e48-3885-4a87-9fcb-85f2842e7a43)

Fix: Waiting for the student table to load before clicking "Edit all"

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1262

## Testing story

- Ran eyes tests through drone, link to test run from this PR branch https://app.saucelabs.com/tests/4c109657a31b45a59117694d69cf9518
- Drone

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
