### PR TITLE
Teacher dashboard replace unit links in course overview

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
@@ -210,7 +210,9 @@ class UnitOverviewHeader extends Component {
               />
             )}
           </div>
-          <ProtectedStatefulDiv ref={element => (this.protected = element)} />
+          {!location.pathname.includes('teacher_dashboard') && (
+            <ProtectedStatefulDiv ref={element => (this.protected = element)} />
+          )}
         </div>
       </div>
     );

--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -92,6 +92,9 @@ class CourseScript extends Component {
       showAssignButton,
     } = this.props;
 
+    //DEBUG
+    console.log(location.pathname.includes('teacher_dashboard'));
+
     const isHidden = isScriptHiddenForSection(
       hiddenLessonState,
       selectedSectionId,
@@ -131,7 +134,11 @@ class CourseScript extends Component {
             <Button
               __useDeprecatedTag
               text={i18n.goToUnit()}
-              href={`/s/${name}${location.search}`}
+              href={
+                location.pathname.includes('teacher_dashboard')
+                  ? `/teacher_dashboard/sections/${selectedSectionId}/unit/${name}`
+                  : `/s/${name}${location.search}`
+              }
               color={Button.ButtonColor.gray}
               className="uitest-go-to-unit-button"
             />

--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -92,9 +92,6 @@ class CourseScript extends Component {
       showAssignButton,
     } = this.props;
 
-    //DEBUG
-    console.log(location.pathname.includes('teacher_dashboard'));
-
     const isHidden = isScriptHiddenForSection(
       hiddenLessonState,
       selectedSectionId,


### PR DESCRIPTION
Updates Go to Unit button in CourseScript to redirect to teacher dashboard unit overview if the user is on the teacher dashboard.

## Links
[TEACH-1337](https://codedotorg.atlassian.net/browse/TEACH-1337)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

CourseScript does not have a unit test file. Since this update was minimal, it was tested manually. It might be good to add unit tests for this component in a future task.

## Deployment strategy

## Follow-up work

See testing story

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
