### PR TITLE
Redirect users to new sign up if they end up in wrong flow but are in experiment

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_sign_up.js
@@ -2,9 +2,21 @@ import $ from 'jquery';
 
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import statsigReporter from '@cdo/apps/metrics/StatsigReporter';
 
 $(document).ready(() => {
   analyticsReporter.sendEvent(EVENTS.SIGN_UP_STARTED_EVENT, {}, PLATFORMS.BOTH);
+
+  const isInSignupExperiment = statsigReporter.getIsInExperiment(
+    'new_sign_up_v1',
+    'showNewFlow',
+    false
+  );
+
+  if (isInSignupExperiment) {
+    window.location.href =
+      'https://studio.code.org/users/new_sign_up/account_type';
+  }
 
   document
     .getElementById('signup_form_submit')


### PR DESCRIPTION
I was able to test this locally by overriding local_mode in the statsigReporter, opening an incognito window until I got put in the test group, and then trying to go to the old flow (via url) to ensure it would query my experiment group there and redirect me back into the new flow. Video below:

https://github.com/user-attachments/assets/89cf36ce-0dda-49d2-b96b-b0fba24b588f



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2388

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
