### PR TITLE
[Aichat] Update compare models dialog UI

### DIFF
--- a/apps/src/aichat/views/modelCustomization/ModelDescriptionPanel.tsx
+++ b/apps/src/aichat/views/modelCustomization/ModelDescriptionPanel.tsx
@@ -44,12 +44,16 @@ const ModelDescriptionPanel: React.FunctionComponent<{
       <div className={styles.modelDescriptionContainer}>
         <StrongText>Overview</StrongText>
         <div className={styles.textContainer}>
-          <BodyThreeText>{selectedModel.overview}</BodyThreeText>
+          <BodyThreeText className={styles.modelText}>
+            {selectedModel.overview}
+          </BodyThreeText>
         </div>
         <br />
         <StrongText>Training Data</StrongText>
         <div className={styles.textContainer}>
-          <BodyThreeText>{selectedModel.trainingData}</BodyThreeText>
+          <BodyThreeText className={styles.modelText}>
+            {selectedModel.trainingData}
+          </BodyThreeText>
         </div>
       </div>
     </div>

--- a/apps/src/aichat/views/modelCustomization/ModelDescriptionPanel.tsx
+++ b/apps/src/aichat/views/modelCustomization/ModelDescriptionPanel.tsx
@@ -38,7 +38,7 @@ const ModelDescriptionPanel: React.FunctionComponent<{
         selectedValue={selectedModel.id}
         name={dropdownName}
         size="s"
-        className={styles.fullWidth}
+        className={styles.compareModelsDropdown}
       />
       <br />
       <div className={styles.modelDescriptionContainer}>

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -132,7 +132,7 @@ const SetupCustomization: React.FunctionComponent = () => {
       <div className={styles.customizationContainer}>
         {isVisible(selectedModelId) && renderChooseAndCompareModels()}
         {isVisible(temperature) && (
-          <div>
+          <>
             <div className={styles.horizontalFlexContainer}>
               <FieldLabel
                 id="temperature"
@@ -157,10 +157,10 @@ const SetupCustomization: React.FunctionComponent = () => {
                 )
               }
             />
-          </div>
+          </>
         )}
         {isVisible(systemPrompt) && (
-          <div>
+          <>
             <FieldLabel
               id="system-prompt"
               label="System Prompt"
@@ -180,7 +180,7 @@ const SetupCustomization: React.FunctionComponent = () => {
                 )
               }
             />
-          </div>
+          </>
         )}
       </div>
       <div className={styles.footerButtonContainer}>

--- a/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
+++ b/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
@@ -42,8 +42,9 @@ div.modelComparisonDialog {
   overflow-y: auto;
 }
 
-.fullWidth {
+.compareModelsDropdown {
   width: 100%;
+  display: inline-block;
 }
 
 .headerContainer {

--- a/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
+++ b/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
@@ -3,7 +3,13 @@
 .textContainer {
   background-color: $light_gray_50;
   border-radius: 4px;
-  padding: 2px 0;
+}
+
+.modelText {
+  padding-left: 10px;
+  padding-right: 5px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .modelDescriptionPanelContainer {

--- a/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
+++ b/apps/src/aichat/views/modelCustomization/compare-models-dialog.module.scss
@@ -1,5 +1,10 @@
 @import 'color';
 
+hr {
+  margin: 1rem 0;
+  border-color: $light_gray_200;
+}
+
 .textContainer {
   background-color: $light_gray_50;
   border-radius: 4px;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the `aichat` compare models dialog and includes:
- a fix to a regression in the width of the dropdowns,
- updating the padding for the model description text,
- updating the color of the divider from teal to gray.

## Before update
<img width="864" alt="Screenshot 2024-10-10 at 1 38 37 PM" src="https://github.com/user-attachments/assets/ea1cceae-12a5-45d0-a105-8d061f7de773">


## After update
<img width="857" alt="Screenshot 2024-10-10 at 1 37 56 PM" src="https://github.com/user-attachments/assets/6a590ede-709c-4555-a6a5-b9e2cdaef4fb">




## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1091)
[Slack thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1728513202942979)


<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
