### PR TITLE
Add Classy pixel for tracking on code.org/donate

### DIFF
--- a/pegasus/sites.v3/code.org/public/donate/index.haml
+++ b/pegasus/sites.v3/code.org/public/donate/index.haml
@@ -14,7 +14,7 @@ theme: responsive_full_width
   var DDCONF = { API_KEY: "#{CDO.ddconf_api_key}" };
 %script{src: "https://doublethedonation.com/api/js/ddplugin.js"}
 
--# Adds Classy tracking pixel to code.org/donate
+-# Adds Classy tracking pixel
 = view :classy_tracking_pixel
 
 -# Classy donation form

--- a/pegasus/sites.v3/code.org/public/donate/index.haml
+++ b/pegasus/sites.v3/code.org/public/donate/index.haml
@@ -14,6 +14,9 @@ theme: responsive_full_width
   var DDCONF = { API_KEY: "#{CDO.ddconf_api_key}" };
 %script{src: "https://doublethedonation.com/api/js/ddplugin.js"}
 
+-# Adds Classy tracking pixel to code.org/donate
+= view :classy_tracking_pixel
+
 -# Classy donation form
 = view :classy_embed_form
 

--- a/pegasus/sites.v3/code.org/views/classy_tracking_pixel.haml
+++ b/pegasus/sites.v3/code.org/views/classy_tracking_pixel.haml
@@ -1,0 +1,1 @@
+%img{src: "https://connect.blockboardtech.com/track/t?e=Impression&vr=1&d=eJwzNDcyNzQwNzQzMrWw1DExMTHVMTIxtTDVMTYwtDDXMbU0BvGNdAx0QvOy8_LL84AsVAhC6AJgCioMMsJAJy0xpzhVxxAAGf8XlA--&m=1&op5=[VALUE-1]&op6=[VALUE-2]&op7=[VALUE-3]&op8=[VALUE-4]&op9=[VALUE-5]&op10=[VALUE-6]", width: "1", height: "1", border: "0"}


### PR DESCRIPTION
Adds a tracking pixel for Classy on https://code.org/donate. The instructions say to add this in the `<head>` of the document but this doesn't seem possible (see linked Slack convo below) so I added it in the `<body>` section.

## Links
Jira ticket: [ACQ-2515](https://codedotorg.atlassian.net/browse/ACQ-2515)
Slack convo w/ question about implementation: [here](https://codedotorg.slack.com/archives/C046G4TRLEN/p1728584097331999)

----

## Network call
<img width="750" alt="Screenshot 2024-10-10 at 11 37 03 AM" src="https://github.com/user-attachments/assets/06fa0708-7820-42e9-a342-6c2952e651d3">
