### PR TITLE
Python Lab: Instructions styling tweaks

### DIFF
--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -127,6 +127,10 @@
       line-height: 1.2;
       font-weight: bold;
       margin: 4px 0;
+
+      &:hover {
+        background-color: $light_gray_800;
+      }
     }
   }
 }

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -120,9 +120,14 @@
   p {
     font-size: 14px;
   }
-  
+
   details {
-    line-height: 1.2;
+    line-height: 0;
+    summary {
+      line-height: 1.2;
+      font-weight: bold;
+      margin: 4px 0;
+    }
   }
 }
 

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -33,6 +33,15 @@
 .instructions-dark {
   @extend %instructions;
   background-color: $neutral_dark;
+
+  a {
+    color: $light_white;
+    text-decoration: underline;
+    &:hover {
+      color: $light_gray_100;
+    }
+  }
+
 }
 
 .instructions-light {

--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -38,7 +38,7 @@
     color: $light_white;
     text-decoration: underline;
     &:hover {
-      color: $light_gray_100;
+      color: #e4e6e9;
     }
   }
 


### PR DESCRIPTION
A few tweaks to improve the instructions styling:
- Better spacing, which enables us to have sections open by default without a bunch of extra whitespace. It also adds some breathing room between steps. [Here is a thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1728592462200079) with details on the markdown for default-open sections.
- Change the hover color for summary tags to match our other hover colors, which has better contrast.
- Fix the color of links

## Before
### Hover Color for summary tag
<img width="317" alt="Screenshot 2024-10-10 at 1 40 29 PM" src="https://github.com/user-attachments/assets/545ab41c-74c6-491e-963d-9afcb66a0808">

### Details spacing
<img width="317" alt="Screenshot 2024-10-10 at 1 37 20 PM" src="https://github.com/user-attachments/assets/b3e631d3-602f-4a95-b45b-64b13a819937">
<img width="320" alt="Screenshot 2024-10-10 at 1 37 26 PM" src="https://github.com/user-attachments/assets/71246ea5-5f8e-4040-900f-9549ac54e4a1">
<img width="321" alt="Screenshot 2024-10-10 at 1 37 33 PM" src="https://github.com/user-attachments/assets/102fb1e4-20fd-4987-a017-b9dc6162e570">

### Link colors
First one is hover state
![Screenshot 2024-10-10 at 1 45 24 PM](https://github.com/user-attachments/assets/153aef56-c3e5-4774-bba1-bc028fd693f5)
![Screenshot 2024-10-10 at 1 45 20 PM](https://github.com/user-attachments/assets/4f3e9b1c-7fd6-487b-a6a9-255966156860)


## After
### Hover Color for summary tag
<img width="317" alt="Screenshot 2024-10-10 at 1 40 20 PM" src="https://github.com/user-attachments/assets/dc506523-db18-4131-9c75-e3af34637320">

### Details spacing
<img width="315" alt="Screenshot 2024-10-10 at 1 38 04 PM" src="https://github.com/user-attachments/assets/6200a864-7368-4111-8360-a0d436029644">
<img width="320" alt="Screenshot 2024-10-10 at 1 37 57 PM" src="https://github.com/user-attachments/assets/7fd3ea9c-a9f3-4dab-9592-3dade6505265">
<img width="320" alt="Screenshot 2024-10-10 at 1 37 52 PM" src="https://github.com/user-attachments/assets/7df18c86-a44d-4de8-8a74-ddc4dcc154dc">

### Link colors
[Thread with Mark](https://codedotorg.slack.com/archives/C06JELCAPT9/p1728593165579759). First screenshot is hover state.
<img width="299" alt="Screenshot 2024-10-10 at 2 09 43 PM" src="https://github.com/user-attachments/assets/ed955c66-d7b0-4c94-bc26-16c8fde4f07d">
<img width="299" alt="Screenshot 2024-10-10 at 2 11 40 PM" src="https://github.com/user-attachments/assets/7445390e-b64c-4a0f-b2f9-80a3240aefcb">


## Links

- jira ticket: [CT-861](https://codedotorg.atlassian.net/browse/CT-861), [CT-858](https://codedotorg.atlassian.net/browse/CT-858) Both of these tickets were just css changes to validated instructions, so I opted to combine them.

## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
