### PR TITLE
[JIMT][CT-822 (partial)][CT-617 (partial)] open move file prompt

### DIFF
--- a/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
@@ -2,6 +2,7 @@ import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {
   openNewFolderPrompt as globalOpenNewFolderPrompt,
   openNewFilePrompt as globalOpenNewFilePrompt,
+  openMoveFilePrompt as globalOpenMoveFilePrompt,
 } from '@codebridge/FileBrowser/prompts';
 import {sendCodebridgeAnalyticsEvent as globalSendCodebridgeAnalyticsEvent} from '@codebridge/utils';
 import {useCallback, useMemo} from 'react';
@@ -16,6 +17,7 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
  * Provides functions to open new file or folder prompts within the application.
  *
  * @returns An object containing the following functions:
+ *   - **openMoveFilePrompt:** Opens a prompt for moving a file within the project.
  *   - **openNewFilePrompt:** Opens a prompt for creating a new file within the project.
  *   - **openNewFolderPrompt:** Opens a prompt for creating a new folder within the project.
  */
@@ -27,7 +29,7 @@ export const usePrompts = () => {
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const dialogControl = useDialogControl();
 
-  const {project, newFolder, newFile} = useCodebridgeContext();
+  const {project, moveFile, newFolder, newFile} = useCodebridgeContext();
 
   const sendCodebridgeAnalyticsEvent = useCallback(
     (event: string) => globalSendCodebridgeAnalyticsEvent(event, appName),
@@ -52,8 +54,19 @@ export const usePrompts = () => {
     validationFile,
   } satisfies PAFunctionArgs<typeof globalOpenNewFilePrompt>);
 
+  const openMoveFilePrompt = usePartialApply(globalOpenMoveFilePrompt, {
+    appName,
+    dialogControl,
+    moveFile,
+    projectFiles: project.files,
+    projectFolders: project.folders,
+    sendCodebridgeAnalyticsEvent,
+    isStartMode,
+    validationFile,
+  } satisfies PAFunctionArgs<typeof globalOpenMoveFilePrompt>);
+
   return useMemo(
-    () => ({openNewFilePrompt, openNewFolderPrompt}),
-    [openNewFilePrompt, openNewFolderPrompt]
+    () => ({openNewFilePrompt, openNewFolderPrompt, openMoveFilePrompt}),
+    [openNewFilePrompt, openNewFolderPrompt, openMoveFilePrompt]
   );
 };

--- a/apps/src/codebridge/FileBrowser/prompts/index.ts
+++ b/apps/src/codebridge/FileBrowser/prompts/index.ts
@@ -1,2 +1,3 @@
+export * from './openMoveFilePrompt';
 export * from './openNewFilePrompt';
 export * from './openNewFolderPrompt';

--- a/apps/src/codebridge/FileBrowser/prompts/openMoveFilePrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openMoveFilePrompt.tsx
@@ -1,0 +1,81 @@
+import {MoveFileFunction} from '@codebridge/codebridgeContext/types';
+import {ProjectFile, ProjectType, FileId} from '@codebridge/types';
+import {findFolder, getErrorMessage, validateFileName} from '@codebridge/utils';
+
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import {
+  DialogType,
+  DialogControlInterface,
+  extractUserInput,
+} from '@cdo/apps/lab2/views/dialogs';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+
+type OpenMoveFilePromptArgsType = {
+  fileId: FileId;
+  projectFiles: ProjectType['files'];
+  projectFolders: ProjectType['folders'];
+  dialogControl: Pick<DialogControlInterface, 'showDialog'>;
+  appName: string;
+  moveFile: MoveFileFunction;
+  isStartMode: boolean;
+  validationFile: ProjectFile | undefined;
+  sendCodebridgeAnalyticsEvent: (eventName: string) => unknown;
+};
+
+export const openMoveFilePrompt = async ({
+  fileId,
+  projectFiles,
+  projectFolders,
+  dialogControl,
+  appName,
+  moveFile,
+  isStartMode,
+  validationFile,
+  sendCodebridgeAnalyticsEvent,
+}: OpenMoveFilePromptArgsType) => {
+  const file = projectFiles[fileId];
+  const results = await dialogControl?.showDialog({
+    type: DialogType.GenericPrompt,
+    title: codebridgeI18n.moveFilePrompt(),
+    placeholder: codebridgeI18n.rootFolder(),
+    requiresPrompt: false,
+
+    validateInput: (destinationFolderName: string) => {
+      try {
+        const folderId = findFolder(destinationFolderName.split('/'), {
+          folders: Object.values(projectFolders),
+          required: true,
+        });
+
+        return validateFileName({
+          fileName: file.name,
+          folderId,
+          projectFiles,
+          isStartMode,
+          validationFile,
+        });
+      } catch (e) {
+        return getErrorMessage(e);
+      }
+    },
+  });
+
+  if (results.type !== 'confirm') {
+    return;
+  }
+
+  const destinationFolderName = extractUserInput(results) || '';
+  try {
+    const folderId = findFolder(destinationFolderName.split('/'), {
+      folders: Object.values(projectFolders),
+      required: true,
+    });
+    moveFile(fileId, folderId);
+  } catch (e) {
+    dialogControl?.showDialog({
+      type: DialogType.GenericAlert,
+      title: getErrorMessage(e),
+    });
+  }
+  sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_MOVE_FILE);
+};

--- a/apps/test/unit/codebridge/FileBrowser/prompts/openMoveFilePromptTest.ts
+++ b/apps/test/unit/codebridge/FileBrowser/prompts/openMoveFilePromptTest.ts
@@ -1,0 +1,95 @@
+import {MoveFileFunction} from '@codebridge/codebridgeContext/types';
+import {openMoveFilePrompt} from '@codebridge/FileBrowser/prompts/openMoveFilePrompt';
+import {ProjectFile} from '@codebridge/types';
+
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+
+import {testProject} from '../../test-files/';
+import {getDialogControlMock, getAnalyticsMock} from '../../test_utils';
+
+const getMoveFileMock = (): [ProjectFile, MoveFileFunction] => {
+  const moveFileData = {} as ProjectFile;
+  const mock: MoveFileFunction = (fileId, folderId) => {
+    moveFileData.id = fileId;
+    moveFileData.folderId = folderId;
+  };
+
+  return [moveFileData, mock];
+};
+
+const appName = 'Codebridge Unit Test';
+
+describe('openMoveFilePrompt', function () {
+  it('can successfully move a file', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '4';
+    const destinationFolderId = '1';
+    const destinationFolderName = testProject.folders[destinationFolderId].name;
+
+    const [moveFileData, moveFileDataMock] = getMoveFileMock();
+
+    await openMoveFilePrompt({
+      fileId,
+      projectFiles: testProject.files,
+      projectFolders: testProject.folders,
+      dialogControl: getDialogControlMock(destinationFolderName),
+      appName,
+      moveFile: moveFileDataMock,
+      isStartMode: false,
+      validationFile: undefined,
+      sendCodebridgeAnalyticsEvent,
+    });
+
+    expect(moveFileData.id).toEqual(fileId);
+    expect(moveFileData.folderId).toEqual(destinationFolderId);
+
+    expect(analyticsData.event).toEqual(EVENTS.CODEBRIDGE_MOVE_FILE);
+  });
+
+  it('can refuse to move a file to a non-existent folder', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '4';
+    const destinationFolderName = 'fake-folder';
+
+    const [moveFileData, moveFileDataMock] = getMoveFileMock();
+
+    await openMoveFilePrompt({
+      fileId,
+      projectFiles: testProject.files,
+      projectFolders: testProject.folders,
+      dialogControl: getDialogControlMock(destinationFolderName),
+      appName,
+      moveFile: moveFileDataMock,
+      isStartMode: false,
+      validationFile: undefined,
+      sendCodebridgeAnalyticsEvent,
+    });
+
+    expect(Object.keys(moveFileData).length).toEqual(0);
+    expect(Object.keys(analyticsData).length).toEqual(0);
+  });
+
+  it('can refuse to move a file to a directory which has an identically named file', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '1';
+    const destinationFolderId = '1';
+    const destinationFolderName = testProject.folders[destinationFolderId].name;
+
+    const [moveFileData, moveFileDataMock] = getMoveFileMock();
+
+    await openMoveFilePrompt({
+      fileId,
+      projectFiles: testProject.files,
+      projectFolders: testProject.folders,
+      dialogControl: getDialogControlMock(destinationFolderName),
+      appName,
+      moveFile: moveFileDataMock,
+      isStartMode: false,
+      validationFile: undefined,
+      sendCodebridgeAnalyticsEvent,
+    });
+
+    expect(Object.keys(moveFileData).length).toEqual(0);
+    expect(Object.keys(analyticsData).length).toEqual(0);
+  });
+});

--- a/apps/test/unit/codebridge/test-files/project.json
+++ b/apps/test/unit/codebridge/test-files/project.json
@@ -39,6 +39,20 @@
       "folderId": "0",
       "type": "support"
     },
+    "4": {
+      "id": "4",
+      "name": "testFile3.txt",
+      "language": "txt",
+      "contents": "This is test file 3",
+      "folderId": "0"
+    },
+    "5": {
+      "id": "5",
+      "name": "testFile1.txt",
+      "language": "txt",
+      "contents": "This is test file 1, in testfolder1",
+      "folderId": "1"
+    },
     "7": {
       "id": "7",
       "name": "validation_file.vld",

--- a/apps/test/unit/codebridge/test_utils.ts
+++ b/apps/test/unit/codebridge/test_utils.ts
@@ -2,14 +2,14 @@ import {DialogControlInterface} from '@cdo/apps/lab2/views/dialogs';
 import {GenericPromptProps} from '@cdo/apps/lab2/views/dialogs/GenericPrompt';
 
 export const getDialogControlMock = (
-  newFolderName: string
+  dialogInput: string
 ): Pick<DialogControlInterface, 'showDialog'> => ({
   showDialog: ({validateInput}: GenericPromptProps) => {
-    const error = validateInput?.(newFolderName);
+    const error = validateInput?.(dialogInput);
     if (error) {
       return Promise.resolve({type: 'cancel', args: error});
     } else {
-      return Promise.resolve({type: 'confirm', args: newFolderName});
+      return Promise.resolve({type: 'confirm', args: dialogInput});
     }
   },
 });

--- a/apps/test/unit/codebridge/utils/isDuplicateFileNameTest.ts
+++ b/apps/test/unit/codebridge/utils/isDuplicateFileNameTest.ts
@@ -2,47 +2,6 @@ import {isDuplicateFileName, DuplicateFileError} from '@codebridge/utils';
 
 import {supportFile, validationFile, testProject} from '../test-files';
 
-/*
-
-type IsDuplicateFileNameArgs = {
-  fileName: string;
-  folderId: string;
-  projectFiles: Record<string, ProjectFile>;
-  isStartMode: boolean;
-  validationFile?: ProjectFile;
-};*/
-
-/*(
-export const isDuplicateFileName = ({
-  fileName,
-  folderId,
-  projectFiles,
-  isStartMode,
-  validationFile,
-}: IsDuplicateFileNameArgs) => {
-  // The validation file is in the project files in start mode.
-  if (!isStartMode && validationFile?.name === fileName) {
-    return DuplicateFileError.DUPLICATE_SUPPORT_FILE;
-  } else {
-    const existingFile = Object.values(projectFiles).find(
-      f => f.name === fileName && f.folderId === folderId
-    );
-    if (existingFile) {
-      if (
-        existingFile.type === ProjectFileType.SUPPORT ||
-        existingFile.type === ProjectFileType.VALIDATION
-      ) {
-        return DuplicateFileError.DUPLICATE_SUPPORT_FILE;
-      } else {
-        return DuplicateFileError.DUPLICATE_FILE;
-      }
-    }
-  }
-
-  return false;
-};
-) */
-
 describe('isDuplicateFolderName', function () {
   it('can determine isDuplicateFolderName not startMode, no validationFile', function () {
     expect(
@@ -85,7 +44,7 @@ describe('isDuplicateFolderName', function () {
 
     expect(
       isDuplicateFileName({
-        fileName: 'testFile1.txt',
+        fileName: 'testFileNEW.txt',
         folderId: '1',
         projectFiles: testProject.files,
         isStartMode: true,


### PR DESCRIPTION
More CT-822 work, and finally a smaller scale PR w/o additional scaffolding necessary.

This just moves the inlined `moveFilePrompt` function to an external `openMoveFilePrompt` function, as well as adds tests for it.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CT-617](https://codedotorg.atlassian.net/browse/CT-617)
- jira ticket: [CT-822](https://codedotorg.atlassian.net/browse/CT-822)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
