### PR TITLE
Write name to LtiDeployment

### DIFF
--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -158,9 +158,10 @@ class LtiV1Controller < ApplicationController
       lti_account_type = Policies::Lti.get_account_type(decoded_jwt[Policies::Lti::LTI_ROLES_KEY])
 
       # If deployment name is nil, update it with the name from the JWT. This
-      # could likeyl be removed after a period of time, as we also write the name
-      # for all new deployments in the next block. This block is necessary to backfill
-      # existing deployments that were created before we started writing the name.
+      # could likely be removed after a period of time, as we also write the name
+      # for all new deployments in the next block. This block is necessary to
+      # backfill existing deployments that were created before we started
+      # writing the name.
       if deployment && deployment.name.nil?
         deployment.update(name: deployment_name)
       end

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -159,12 +159,10 @@ class LtiV1Controller < ApplicationController
 
       # If deployment name is nil, update it with the name from the JWT. This
       # could likely be removed after a period of time, as we also write the name
-      # for all new deployments in the next block. This block is necessary to
+      # for all new deployments in the next block. This line is necessary to
       # backfill existing deployments that were created before we started
       # writing the name.
-      if deployment && deployment.name.nil?
-        deployment.update(name: deployment_name)
-      end
+      deployment&.update(name: deployment_name) if deployment&.name.nil?
 
       if deployment.nil?
         deployment = Services::Lti.create_lti_deployment(integration[:id], deployment_id, deployment_name)

--- a/dashboard/app/models/lti_deployment.rb
+++ b/dashboard/app/models/lti_deployment.rb
@@ -7,6 +7,7 @@
 #  lti_integration_id :bigint           not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  name               :string(255)
 #
 # Indexes
 #

--- a/dashboard/lib/policies/lti.rb
+++ b/dashboard/lib/policies/lti.rb
@@ -42,6 +42,7 @@ class Policies::Lti
   LTI_CONTEXT_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/context".freeze
   LTI_RESOURCE_LINK_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/resource_link".freeze
   LTI_DEPLOYMENT_ID_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/deployment_id".freeze
+  LTI_DEPLOYMENT_PLATFORM_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/tool_platform".freeze
   LTI_NRPS_CLAIM = "https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice".freeze
   LTI_PLATFORM_CONFIGURATION = "https://purl.imsglobal.org/spec/lti-platform-configuration".freeze
   CANVAS_ACCOUNT_NAME = "https://canvas.instructure.com/lti/account_name".freeze

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -60,10 +60,11 @@ module Services
       )
     end
 
-    def self.create_lti_deployment(integration_id, deployment_id)
+    def self.create_lti_deployment(integration_id, deployment_id, deployment_name)
       LtiDeployment.create(
         lti_integration_id: integration_id,
         deployment_id: deployment_id,
+        name: deployment_name,
       )
     end
 

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -345,10 +345,12 @@ class Services::LtiTest < ActiveSupport::TestCase
   test 'create_lti_deployment should create an LtiDeloyment when given valid inputs' do
     deployment_id = SecureRandom.uuid
     integration = create :lti_integration
+    deployment_name = 'deployment_name'
 
-    deployment = Services::Lti.create_lti_deployment(integration.id, deployment_id)
+    deployment = Services::Lti.create_lti_deployment(integration.id, deployment_id, deployment_name)
 
     assert deployment
+    assert_equal deployment.name, deployment_name
   end
 
   test 'should create a student user given an LTI NRPS member object' do


### PR DESCRIPTION
This PR updates the logic to write `name` to new LtiDeployments, and update existing LtiDeployments with `name` if empty.

These two cases will handle new deployments, and backfill existing deployments. This work is to further enable better reporting on Schoology installations, as LtiDeployment is used as the unique identifier for Schoology installations.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[Jira](https://codedotorg.atlassian.net/browse/P20-1223)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

```
bundle exec spring testunit ./test/controllers/lti_v1_controller_test.rb
Running via Spring preloader in process 1993
Started with run options --seed 38258

Since there is no EDITOR or BETTER_ERRORS_EDITOR environment variable, using Textmate by default.================================                                             ] 73% Time: 00:00:08,  ETA: 00:00:03
  52/52: [===================================================================================================================================================================] 100% Time: 00:00:11, Time: 00:00:11

Finished in 11.16319s
52 tests, 131 assertions, 0 failures, 0 errors, 0 skips
```
```
bundle exec spring testunit ./test/lib/services/lti_test.rb
Running via Spring preloader in process 3681
Started with run options --seed 28435

  28/28: [===================================================================================================================================================================] 100% Time: 00:00:05, Time: 00:00:05

Finished in 5.18332s
28 tests, 78 assertions, 0 failures, 0 errors, 0 skips
```
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
