### PR TITLE
Codebridge: Always start at the beginning of the file in the editor

### DIFF
--- a/apps/src/lab2/views/components/editor/CodeEditor.tsx
+++ b/apps/src/lab2/views/components/editor/CodeEditor.tsx
@@ -72,6 +72,11 @@ const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({
           extensions: editorExtensions,
         }),
         parent: editorRef.current,
+        // Always start on the first line.
+        // TODO: Determine if we should track line position and scroll to
+        // a saved position instead.
+        // https://codedotorg.atlassian.net/browse/CT-870
+        scrollTo: EditorView.scrollIntoView(0),
       })
     );
     setDidInit(true);


### PR DESCRIPTION
I'm not sure why, but when a long file was loaded into the editor in codebridge it would start at a point partway through the document instead of the beginning, even though the selected line was always the first line. This change just explicitly sets that when we load a file, we start at the top.

## Links

- jira ticket: [CT-859](https://codedotorg.atlassian.net/browse/CT-859)


## Testing story
Tested locally

## Follow-up work
This change is objectively better than we had before; we weren't tracking location and a 1000 line csv would open at line 250 or so. However, we could start tracking last position and scroll to that location on start instead. I filed [CT-870](https://codedotorg.atlassian.net/browse/CT-870) to look into this.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
