### PR TITLE
Music: callouts by ID

### DIFF
--- a/apps/src/music/views/Callouts.tsx
+++ b/apps/src/music/views/Callouts.tsx
@@ -13,7 +13,7 @@ const arrowImage = require(`@cdo/static/music/music-callout-arrow.png`);
 type DirectionString = 'up' | 'left';
 
 interface AvailableCallout {
-  selector: string;
+  selector?: string;
   openToolboxCategory?: number;
   direction?: DirectionString;
 }
@@ -100,15 +100,30 @@ const Callouts: React.FunctionComponent = () => {
 
   const calloutIds = callout?.id?.split('---');
 
-  const validCallouts: AvailableCallout[] | undefined = calloutIds?.map(
-    calloutId => availableCallouts[calloutId]
-  );
+  const validCallouts: AvailableCallout[] = [];
+
+  calloutIds?.forEach(calloutId => {
+    const splitId = calloutId.split(':');
+    if (splitId.length === 2) {
+      const dataId = splitId[1];
+      validCallouts.push({
+        selector: `.blocklyWorkspace g[data-id="${dataId}"] path`,
+        direction: splitId[0] === 'id-left' ? 'left' : 'up',
+      });
+    } else if (availableCallouts[calloutId]) {
+      validCallouts.push({
+        selector: availableCallouts[calloutId].selector,
+        direction: availableCallouts[calloutId].direction,
+        openToolboxCategory: availableCallouts[calloutId].openToolboxCategory,
+      });
+    }
+  });
 
   const targets: Target[] = [];
   let calloutClassName;
 
-  validCallouts?.forEach(validCallout => {
-    const element = document.querySelector(validCallout.selector);
+  validCallouts.forEach(validCallout => {
+    const element = document.querySelector(validCallout.selector || '');
     const elementRect = element?.getBoundingClientRect();
     if (elementRect && elementRect.width > 0) {
       let target: Target;
@@ -132,7 +147,7 @@ const Callouts: React.FunctionComponent = () => {
   });
 
   const openToolboxCategory =
-    validCallouts && validCallouts[0].openToolboxCategory;
+    validCallouts && validCallouts[0]?.openToolboxCategory;
 
   const calloutIndex = callout.index;
 

--- a/apps/src/music/views/callouts.module.scss
+++ b/apps/src/music/views/callouts.module.scss
@@ -37,6 +37,7 @@
   width: 32px;
   height: 32px;
   animation: fade-in-out 2.5s;
+  pointer-events: none;
 
   &Up {
     transform: translateX(-50%);
@@ -61,6 +62,7 @@
   transform: translateX(-50%);
   animation: moving-fade-in-out 3.5s;
   transition-duration: 2.5s;
+  pointer-events: none;
 
   .arrow {
     position: absolute;


### PR DESCRIPTION
This adds the ability for a callout to specify the ID of a block in the workspace.  

The ID must be prefixed with `id:`, or `id-left:` if it's a non-moving callout that should point to the left.

This is intended for cases where the levelbuilder has to add an ID to a block in the start sources anyway, as encountered in https://github.com/code-dot-org/code-dot-org/pull/61577.

### Video

The video demonstrates three examples:

- `play-sound-block---id:when_run_simple2`: a callout that moves between the `play sound` block and `when run`.
- `id:when_run_simple2`: a callout that points up at `when run`.
- `id-left:when_run_simple2`: a callout that points left at `when run`.

https://github.com/user-attachments/assets/592db62f-ef98-49a6-b0fa-dfc11a38f59a
