### PR TITLE
Update pages with Gen AI cards

### DIFF
--- a/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_curricula_middle_high.haml
+++ b/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_curricula_middle_high.haml
@@ -7,7 +7,7 @@
       desc: hoc_s("gen_ai_middle_high_carousel_card.desc"),
       duration: hoc_s("gen_ai_middle_high_carousel_card.duration"),
       url: "/curriculum/generative-ai",
-      aria_label: hoc_s("gen_ai_middle_high_carousel_card.title"),
+      aria_label: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
       button_label: hoc_s(:call_to_action_explore_course),
       new: true,
     },

--- a/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_curricula_middle_high.haml
+++ b/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_curricula_middle_high.haml
@@ -1,6 +1,17 @@
 :ruby
   block_items = [
     {
+      overline: hoc_s("gen_ai_middle_high_carousel_card.overline"),
+      title: hoc_s("gen_ai_middle_high_carousel_card.title"),
+      img: "/images/ai/explore-gen-ai-bot-wizard.png",
+      desc: hoc_s("gen_ai_middle_high_carousel_card.desc"),
+      duration: hoc_s("gen_ai_middle_high_carousel_card.duration"),
+      url: "/curriculum/generative-ai",
+      aria_label: hoc_s("gen_ai_middle_high_carousel_card.title"),
+      button_label: hoc_s(:call_to_action_explore_course),
+      new: true,
+    },
+    {
       overline: hoc_s("ai_page.curricula.tile.humanities.overline"),
       title: hoc_s("ai_page.curricula.tile.humanities.title"),
       img: "/images/action-blocks/action-block-ai-humanities.png",
@@ -9,7 +20,6 @@
       url: CDO.studio_url("/s/gen-ai-humanities"),
       aria_label: hoc_s("ai_page.curricula.tile.humanities.aria_label"),
       button_label: hoc_s("ai_page.curricula.tile.humanities.button"),
-      new: true,
     },
     {
       overline: hoc_s(:module_grade_6_12),

--- a/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_curricula_middle_high.haml
+++ b/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_curricula_middle_high.haml
@@ -1,16 +1,6 @@
 :ruby
+  gen_ai_launched = !!DCDO.get('gen-ai-launch', false)
   block_items = [
-    {
-      overline: hoc_s("gen_ai_middle_high_carousel_card.overline"),
-      title: hoc_s("gen_ai_middle_high_carousel_card.title"),
-      img: "/images/ai/explore-gen-ai-bot-wizard.png",
-      desc: hoc_s("gen_ai_middle_high_carousel_card.desc"),
-      duration: hoc_s("gen_ai_middle_high_carousel_card.duration"),
-      url: "/curriculum/generative-ai",
-      aria_label: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
-      button_label: hoc_s(:call_to_action_explore_course),
-      new: true,
-    },
     {
       overline: hoc_s("ai_page.curricula.tile.humanities.overline"),
       title: hoc_s("ai_page.curricula.tile.humanities.title"),
@@ -20,6 +10,7 @@
       url: CDO.studio_url("/s/gen-ai-humanities"),
       aria_label: hoc_s("ai_page.curricula.tile.humanities.aria_label"),
       button_label: hoc_s("ai_page.curricula.tile.humanities.button"),
+      new: !gen_ai_launched,
     },
     {
       overline: hoc_s(:module_grade_6_12),
@@ -102,6 +93,19 @@
       button_label: hoc_s(:call_to_action_try_activity),
     },
   ]
+  if gen_ai_launched
+    block_items.unshift({
+      overline: hoc_s("gen_ai_middle_high_carousel_card.overline"),
+      title: hoc_s("gen_ai_middle_high_carousel_card.title"),
+      img: "/images/ai/explore-gen-ai-bot-wizard.png",
+      desc: hoc_s("gen_ai_middle_high_carousel_card.desc"),
+      duration: hoc_s("gen_ai_middle_high_carousel_card.duration"),
+      url: "/curriculum/generative-ai",
+      aria_label: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
+      button_label: hoc_s(:call_to_action_explore_course),
+      new: true,
+    })
+  end
 
 .carousel-wrapper
   %swiper-container.swiper-middle-high{navigation: "true", "navigation-next-el": ".nav-next-middle-high", "navigation-prev-el": ".nav-prev-middle-high", pagination: "true", init: "false"}

--- a/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_pl.haml
+++ b/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_pl.haml
@@ -1,6 +1,21 @@
 :ruby
   block_items = [
      {
+      overline: hoc_s("gen_ai_pl_carousel_card.overline"),
+      title: hoc_s("gen_ai_pl_carousel_card.title"),
+      img: "/images/ai/explore-gen-ai-bot-wizard.png",
+      curriculum: hoc_s("gen_ai_pl_carousel_card.curriculum"),
+      duration: hoc_s("gen_ai_pl_carousel_card.duration"),
+      prerequisites: hoc_s("gen_ai_pl_carousel_card.prerequisites"),
+      url: CDO.studio_url("/courses/self-paced-exploring-gen-ai-2024"),
+      aria_label: hoc_s("gen_ai_pl_carousel_card.aria_label"),
+      button_label: hoc_s(:call_to_action_start_pl),
+      secondary_url: "/curriculum/generative-ai",
+      secondary_aria_label: hoc_s("gen_ai_pl_carousel_card.title"),
+      secondary_button_label: hoc_s(:call_to_action_explore_curriculum),
+      new: true,
+     },
+     {
       overline: hoc_s(:module_label_self_paced),
       title: hoc_s(:ai_pl_101_title),
       img: "/images/self-paced-pl-tile-ai-101.jpg",
@@ -9,7 +24,6 @@
       url: CDO.studio_url("/courses/self-paced-pl-ai-101"),
       aria_label: hoc_s("ai_page.pl.tile.ai_101.aria_label"),
       button_label: hoc_s(:call_to_action_start_module),
-      new: true,
     },
     {
       overline: hoc_s("ai_page.pl.tile.decisions.overline"),
@@ -84,15 +98,29 @@
             %h3
               = block_item[:title]
             %img{src: block_item[:img], alt: ""}
-            %p
-              = block_item[:desc]
+            - if block_item[:desc]
+              %p
+                = block_item[:desc]
+            - if block_item[:curriculum]
+              %p
+                %strong
+                  =hoc_s(:module_label_curriculum)
+                = block_item[:curriculum]
             %p
               %strong
                 =hoc_s(:module_label_duration)
               = block_item[:duration]
+            - if block_item[:prerequisites]
+              %p
+                %strong
+                  =hoc_s(:module_label_prerequisites)
+                = block_item[:prerequisites]
           .content-footer
             %a.link-button{href: block_item[:url], aria:{label: block_item[:aria_label]}}
               = block_item[:button_label]
+            - if block_item[:secondary_url]
+              %a.link-button.secondary{href: block_item[:secondary_url], aria: {label: block_item[:secondary_aria_label]}}
+                = block_item[:secondary_button_label]
 
   %button.swiper-nav-prev.nav-prev-pl
   %button.swiper-nav-next.nav-next-pl

--- a/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_pl.haml
+++ b/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_pl.haml
@@ -1,20 +1,6 @@
 :ruby
+  gen_ai_launched = !!DCDO.get('gen-ai-launch', false)
   block_items = [
-     {
-      overline: hoc_s("gen_ai_pl_carousel_card.overline"),
-      title: hoc_s("gen_ai_pl_carousel_card.title"),
-      img: "/images/ai/explore-gen-ai-bot-wizard.png",
-      curriculum: hoc_s("gen_ai_pl_carousel_card.curriculum"),
-      duration: hoc_s("gen_ai_pl_carousel_card.duration"),
-      prerequisites: hoc_s("gen_ai_pl_carousel_card.prerequisites"),
-      url: CDO.studio_url("/courses/self-paced-exploring-gen-ai-2024"),
-      aria_label: hoc_s("gen_ai_pl_carousel_card.aria_label"),
-      button_label: hoc_s(:call_to_action_start_pl),
-      secondary_url: "/curriculum/generative-ai",
-      secondary_aria_label: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
-      secondary_button_label: hoc_s(:call_to_action_explore_curriculum),
-      new: true,
-     },
      {
       overline: hoc_s(:module_label_self_paced),
       title: hoc_s(:ai_pl_101_title),
@@ -24,6 +10,7 @@
       url: CDO.studio_url("/courses/self-paced-pl-ai-101"),
       aria_label: hoc_s("ai_page.pl.tile.ai_101.aria_label"),
       button_label: hoc_s(:call_to_action_start_module),
+      new: !gen_ai_launched,
     },
     {
       overline: hoc_s("ai_page.pl.tile.decisions.overline"),
@@ -34,7 +21,7 @@
       url: CDO.studio_url("/courses/elementaryai-2024"),
       aria_label: hoc_s("ai_page.pl.tile.decisions.aria_label"),
       button_label: hoc_s("ai_page.pl.tile.decisions.button"),
-      new: true,
+      new: !gen_ai_launched,
     },
     {
       overline: hoc_s("ai_page.pl.tile.coding_with_ai.overline"),
@@ -45,7 +32,7 @@
       url: CDO.studio_url("/courses/self-paced-pl-coding-with-ai-2024"),
       aria_label: hoc_s("ai_page.pl.tile.coding_with_ai.aria_label"),
       button_label: hoc_s("ai_page.pl.tile.coding_with_ai.button"),
-      new: true,
+      new: !gen_ai_launched,
     },
     {
       overline: hoc_s("ai_page.pl.tile.computer_vision.overline"),
@@ -56,7 +43,7 @@
       url: CDO.studio_url("/courses/self-paced-pl-computer-vision-2024"),
       aria_label: hoc_s("ai_page.pl.tile.computer_vision.aria_label"),
       button_label: hoc_s("ai_page.pl.tile.computer_vision.button"),
-      new: true,
+      new: !gen_ai_launched,
     },
     {
       overline: hoc_s(:module_label_video_series),
@@ -79,6 +66,23 @@
       button_label: hoc_s(:call_to_action_start_module),
     },
   ]
+  if gen_ai_launched
+    block_items.unshift({
+      overline: hoc_s("gen_ai_pl_carousel_card.overline"),
+      title: hoc_s("gen_ai_pl_carousel_card.title"),
+      img: "/images/ai/explore-gen-ai-bot-wizard.png",
+      curriculum: hoc_s("gen_ai_pl_carousel_card.curriculum"),
+      duration: hoc_s("gen_ai_pl_carousel_card.duration"),
+      prerequisites: hoc_s("gen_ai_pl_carousel_card.prerequisites"),
+      url: CDO.studio_url("/courses/self-paced-exploring-gen-ai-2024"),
+      aria_label: hoc_s("gen_ai_pl_carousel_card.aria_label"),
+      button_label: hoc_s(:call_to_action_start_pl),
+      secondary_url: "/curriculum/generative-ai",
+      secondary_aria_label: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
+      secondary_button_label: hoc_s(:call_to_action_explore_curriculum),
+      new: true,
+     })
+  end
 
 .carousel-wrapper
   %swiper-container.swiper-pl{navigation: "true", "navigation-next-el": ".nav-next-pl", "navigation-prev-el": ".nav-prev-pl", pagination: "true", init: "false"}

--- a/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_pl.haml
+++ b/pegasus/sites.v3/code.org/views/ai_landing_page/ai_carousel_pl.haml
@@ -11,7 +11,7 @@
       aria_label: hoc_s("gen_ai_pl_carousel_card.aria_label"),
       button_label: hoc_s(:call_to_action_start_pl),
       secondary_url: "/curriculum/generative-ai",
-      secondary_aria_label: hoc_s("gen_ai_pl_carousel_card.title"),
+      secondary_aria_label: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
       secondary_button_label: hoc_s(:call_to_action_explore_curriculum),
       new: true,
      },

--- a/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_high.haml
+++ b/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_high.haml
@@ -1,6 +1,19 @@
 :ruby
   block_items = [
     {
+      overline: hoc_s("gen_ai_pl_carousel_card.overline"),
+      title: hoc_s("gen_ai_pl_carousel_card.title"),
+      image: "/images/ai/explore-gen-ai-bot-wizard.png",
+      curriculum: hoc_s("gen_ai_pl_carousel_card.curriculum"),
+      duration: hoc_s("gen_ai_pl_carousel_card.duration"),
+      prerequisites: hoc_s("gen_ai_pl_carousel_card.prerequisites"),
+      url_primary: CDO.studio_url("/courses/self-paced-exploring-gen-ai-2024"),
+      url_secondary: "/curriculum/generative-ai",
+      aria_label_primary: hoc_s("gen_ai_pl_carousel_card.aria_label"),
+      aria_label_secondary: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
+      new: true
+    },
+    {
       overline: hoc_s(:module_grade_k_12_teachers),
       title: hoc_s(:module_label_ai_101_self_paced_pl),
       image: '/images/self-paced-pl-tile-ai-101.jpg',
@@ -11,7 +24,6 @@
       url_secondary: '/ai#ai-curricula',
       aria_label_primary: hoc_s(:aria_label_call_to_action_ai_101),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_ai_101),
-      new: true,
     },
     {
       overline: hoc_s(:module_grade_6_12_teachers),
@@ -24,7 +36,6 @@
       url_secondary: '/curriculum/coding-with-ai',
       aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_coding_with_ai),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_coding_with_ai),
-      new: true,
     },
     {
       overline: hoc_s(:module_grade_9_12_teachers),
@@ -37,7 +48,6 @@
       url_secondary: '/curriculum/computer-vision',
       aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_computer_vision),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_computer_vision),
-      new: true,
     },
     {
       overline: hoc_s(:module_grade_9_12_teachers),

--- a/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_high.haml
+++ b/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_high.haml
@@ -1,18 +1,6 @@
 :ruby
+  gen_ai_launched = !!DCDO.get('gen-ai-launch', false)
   block_items = [
-    {
-      overline: hoc_s("gen_ai_pl_carousel_card.overline"),
-      title: hoc_s("gen_ai_pl_carousel_card.title"),
-      image: "/images/ai/explore-gen-ai-bot-wizard.png",
-      curriculum: hoc_s("gen_ai_pl_carousel_card.curriculum"),
-      duration: hoc_s("gen_ai_pl_carousel_card.duration"),
-      prerequisites: hoc_s("gen_ai_pl_carousel_card.prerequisites"),
-      url_primary: CDO.studio_url("/courses/self-paced-exploring-gen-ai-2024"),
-      url_secondary: "/curriculum/generative-ai",
-      aria_label_primary: hoc_s("gen_ai_pl_carousel_card.aria_label"),
-      aria_label_secondary: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
-      new: true
-    },
     {
       overline: hoc_s(:module_grade_k_12_teachers),
       title: hoc_s(:module_label_ai_101_self_paced_pl),
@@ -24,6 +12,7 @@
       url_secondary: '/ai#ai-curricula',
       aria_label_primary: hoc_s(:aria_label_call_to_action_ai_101),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_ai_101),
+      new: !gen_ai_launched,
     },
     {
       overline: hoc_s(:module_grade_6_12_teachers),
@@ -36,6 +25,7 @@
       url_secondary: '/curriculum/coding-with-ai',
       aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_coding_with_ai),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_coding_with_ai),
+      new: !gen_ai_launched,
     },
     {
       overline: hoc_s(:module_grade_9_12_teachers),
@@ -48,6 +38,7 @@
       url_secondary: '/curriculum/computer-vision',
       aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_computer_vision),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_computer_vision),
+      new: !gen_ai_launched,
     },
     {
       overline: hoc_s(:module_grade_9_12_teachers),
@@ -158,6 +149,21 @@
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_design_process),
     },
   ]
+  if gen_ai_launched
+    block_items.unshift({
+      overline: hoc_s("gen_ai_pl_carousel_card.overline"),
+      title: hoc_s("gen_ai_pl_carousel_card.title"),
+      image: "/images/ai/explore-gen-ai-bot-wizard.png",
+      curriculum: hoc_s("gen_ai_pl_carousel_card.curriculum"),
+      duration: hoc_s("gen_ai_pl_carousel_card.duration"),
+      prerequisites: hoc_s("gen_ai_pl_carousel_card.prerequisites"),
+      url_primary: CDO.studio_url("/courses/self-paced-exploring-gen-ai-2024"),
+      url_secondary: "/curriculum/generative-ai",
+      aria_label_primary: hoc_s("gen_ai_pl_carousel_card.aria_label"),
+      aria_label_secondary: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
+      new: true
+    })
+  end
 
 .carousel-wrapper
   %swiper-container.swiper-high{navigation: "true", "navigation-next-el": ".nav-next-high", "navigation-prev-el": ".nav-prev-high", pagination: "true", init: "false"}

--- a/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_middle.haml
+++ b/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_middle.haml
@@ -1,6 +1,19 @@
 :ruby
   block_items = [
     {
+      overline: hoc_s("gen_ai_pl_carousel_card.overline"),
+      title: hoc_s("gen_ai_pl_carousel_card.title"),
+      image: "/images/ai/explore-gen-ai-bot-wizard.png",
+      curriculum: hoc_s("gen_ai_pl_carousel_card.curriculum"),
+      duration: hoc_s("gen_ai_pl_carousel_card.duration"),
+      prerequisites: hoc_s("gen_ai_pl_carousel_card.prerequisites"),
+      url_primary: CDO.studio_url("/courses/self-paced-exploring-gen-ai-2024"),
+      url_secondary: "/curriculum/generative-ai",
+      aria_label_primary: hoc_s("gen_ai_pl_carousel_card.aria_label"),
+      aria_label_secondary: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
+      new: true
+    },
+    {
       overline: hoc_s(:module_grade_k_12_teachers),
       title: hoc_s(:module_label_ai_101_self_paced_pl),
       image: '/images/self-paced-pl-tile-ai-101.jpg',
@@ -11,7 +24,6 @@
       url_secondary: '/ai#ai-curricula',
       aria_label_primary: hoc_s(:aria_label_call_to_action_ai_101),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_ai_101),
-      new: true
     },
     {
       overline: hoc_s(:module_grade_6_12_teachers),
@@ -24,7 +36,6 @@
       url_secondary: '/curriculum/coding-with-ai',
       aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_coding_with_ai),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_coding_with_ai),
-      new: true,
     },
     {
       overline: hoc_s(:module_grade_6_10_teachers),

--- a/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_middle.haml
+++ b/pegasus/sites.v3/code.org/views/self_paced_pl/self_paced_pl_modules_carousel_middle.haml
@@ -1,18 +1,6 @@
 :ruby
+  gen_ai_launched = !!DCDO.get('gen-ai-launch', false)
   block_items = [
-    {
-      overline: hoc_s("gen_ai_pl_carousel_card.overline"),
-      title: hoc_s("gen_ai_pl_carousel_card.title"),
-      image: "/images/ai/explore-gen-ai-bot-wizard.png",
-      curriculum: hoc_s("gen_ai_pl_carousel_card.curriculum"),
-      duration: hoc_s("gen_ai_pl_carousel_card.duration"),
-      prerequisites: hoc_s("gen_ai_pl_carousel_card.prerequisites"),
-      url_primary: CDO.studio_url("/courses/self-paced-exploring-gen-ai-2024"),
-      url_secondary: "/curriculum/generative-ai",
-      aria_label_primary: hoc_s("gen_ai_pl_carousel_card.aria_label"),
-      aria_label_secondary: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
-      new: true
-    },
     {
       overline: hoc_s(:module_grade_k_12_teachers),
       title: hoc_s(:module_label_ai_101_self_paced_pl),
@@ -24,6 +12,7 @@
       url_secondary: '/ai#ai-curricula',
       aria_label_primary: hoc_s(:aria_label_call_to_action_ai_101),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_ai_101),
+      new: !gen_ai_launched,
     },
     {
       overline: hoc_s(:module_grade_6_12_teachers),
@@ -36,6 +25,7 @@
       url_secondary: '/curriculum/coding-with-ai',
       aria_label_primary: hoc_s(:aria_label_call_to_action_teaching_coding_with_ai),
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_coding_with_ai),
+      new: !gen_ai_launched,
     },
     {
       overline: hoc_s(:module_grade_6_10_teachers),
@@ -146,6 +136,21 @@
       aria_label_secondary: hoc_s(:aria_label_call_to_action_curriculum_web_development),
     }
   ]
+  if gen_ai_launched
+    block_items.unshift({
+      overline: hoc_s("gen_ai_pl_carousel_card.overline"),
+      title: hoc_s("gen_ai_pl_carousel_card.title"),
+      image: "/images/ai/explore-gen-ai-bot-wizard.png",
+      curriculum: hoc_s("gen_ai_pl_carousel_card.curriculum"),
+      duration: hoc_s("gen_ai_pl_carousel_card.duration"),
+      prerequisites: hoc_s("gen_ai_pl_carousel_card.prerequisites"),
+      url_primary: CDO.studio_url("/courses/self-paced-exploring-gen-ai-2024"),
+      url_secondary: "/curriculum/generative-ai",
+      aria_label_primary: hoc_s("gen_ai_pl_carousel_card.aria_label"),
+      aria_label_secondary: hoc_s("gen_ai_middle_high_carousel_card.aria_label"),
+      new: true
+    })
+  end
 
 .carousel-wrapper
   %swiper-container.swiper-middle{navigation: "true", "navigation-next-el": ".nav-next-middle", "navigation-prev-el": ".nav-prev-middle", pagination: "true", init: "false"}

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1366,6 +1366,7 @@
     title: "Exploring Generative AI"
     desc: "Empower students with hands-on projects and ethical insights into generative AI, equipping them to think critically and innovate in an AI-driven world."
     duration: "6 weeks"
+    aria_label: "Explore the Exploring Generative AI course"
 
   gen_ai_pl_carousel_card:
     overline: "8-12 Teachers"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1362,17 +1362,18 @@
     in_partnership: "In partnership with"
 
   gen_ai_middle_high_carousel_card:
-    overline: "Grades: 8-12"
+    overline: "8-12"
     title: "Exploring Generative AI"
     desc: "Empower students with hands-on projects and ethical insights into generative AI, equipping them to think critically and innovate in an AI-driven world."
     duration: "6 weeks"
 
-  gen_ai_pl_carousel_cared:
+  gen_ai_pl_carousel_card:
     overline: "8-12 Teachers"
     title: "Teaching Exploring Generative AI"
     curriculum: "Exploring Generative AI"
     duration: "2.5 hours"
     prerequisites: "Verified teacher account or SSO-login needed to access AI Chat Lab"
+    aria_label: "Start the Teaching Exploring Generative AI professional learning course"
 
   ai_integrations:
     heading: "AI Integrations"


### PR DESCRIPTION
Updates pages to include curriculum cards for Gen AI behind the `gen-ai-launch` DCDO flag.

## Update code.org/ai
### Add tile for curriculum in middle and high school carousel
With flag flipped to true (shows new card):
![middleandhigh TRE](https://github.com/user-attachments/assets/d28d1949-f574-46e2-b2f0-86fe830604c9)

With flag flipped to false (shows old view):
![middleandhigh FALSE](https://github.com/user-attachments/assets/f001648a-8ab5-4685-a3ed-3b6141fda335)

### Add tile for PL in PL section
With flag flipped to true (shows new card):
![pl TRUE](https://github.com/user-attachments/assets/34d451e8-ab12-456e-8b69-4782be689003)
![explore curriculum](https://github.com/user-attachments/assets/df4db160-1a41-4d5d-bb48-91d9422f9f7c)

With flag flipped to false (shows old view):
![pl FALSE](https://github.com/user-attachments/assets/8eb19fa4-6bdd-4cf5-8a22-3064d5171623)

## Update code.org/professional-learning/self-paced
### Middle school carousel
With flag flipped to true (shows new card):
![middle school TRUE](https://github.com/user-attachments/assets/b5e932b6-24c2-44c8-a120-19619035db43)
![self paced explore curr](https://github.com/user-attachments/assets/0e22e965-ffea-4cd6-811c-cffd088192f9)

With flag flipped to false (shows old view):
![middle school FALSE](https://github.com/user-attachments/assets/0c00635a-307e-407a-b972-af63c2190830)

### High school carousel
With flag flipped to true (shows new card):
![high school TRUE](https://github.com/user-attachments/assets/a35dc256-90e0-478c-9ba7-1fa67edcd3f5)
![self paced high school explore curr](https://github.com/user-attachments/assets/f067e04a-f98a-4cc9-a4c8-bef2e677a075)

With flag flipped to false (shows old view):
![high school FALSE](https://github.com/user-attachments/assets/95616de9-fb59-4048-ad50-7185b4d0e915)

## Links
Jira ticket for updates to /ai page: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2202)
Jira ticket for updates to /professional-learning/self-paced page: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2204)
Figma: [here](https://www.figma.com/design/cnqwFBmgKQkMJrDMiADIrW/Exploring-Gen-AI-Launch?node-id=2313-14416&node-type=frame&t=AlZlMxEZmlvwCGXI-0)

## Testing story
Local testing.
