### PR TITLE
[Music] Add default pack option to levelbuilder

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -6,7 +6,11 @@ import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
 import {installFunctionBlocks} from '@cdo/apps/music/blockly/blockUtils';
 import {setUpBlocklyForMusicLab} from '@cdo/apps/music/blockly/setup';
-import {BlockMode, DEFAULT_LIBRARY} from '@cdo/apps/music/constants';
+import {
+  BlockMode,
+  DEFAULT_LIBRARY,
+  DEFAULT_PACK,
+} from '@cdo/apps/music/constants';
 import MusicRegistry from '@cdo/apps/music/MusicRegistry';
 import MusicLibrary from '@cdo/apps/music/player/MusicLibrary';
 import MusicPlayer from '@cdo/apps/music/player/MusicPlayer';
@@ -121,7 +125,11 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
                 labelText="Selected Artist Pack"
                 name="packId"
                 size="s"
-                items={[{value: 'none', text: '(none)'}, ...restrictedPacks]}
+                items={[
+                  {value: 'none', text: '(none)'},
+                  {value: DEFAULT_PACK, text: 'Code.org (Default)'},
+                  ...restrictedPacks,
+                ]}
                 selectedValue={levelData.packId}
                 onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
                   const packId =


### PR DESCRIPTION
The curriculum team needs to be able to configure levels to skip the song-selection modal without also setting a featured pack for the level. This adds a "Code.org (Default)" option to the pack dropdown.

<img width="531" alt="image" src="https://github.com/user-attachments/assets/b16179fd-d055-4c56-96fe-bce5fed8d23c">

Selecting this option results in a level with Code.org sounds already selected for the project, and only those samples available:
<img width="341" alt="image" src="https://github.com/user-attachments/assets/53888e71-39d8-4beb-8faf-cb222841de76">
<img width="635" alt="image" src="https://github.com/user-attachments/assets/90240e23-0735-47c2-a60a-0b1fd4ac4ed0">

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
