### PR TITLE
[Music] Validator for sounds fields

### DIFF
--- a/apps/src/music/blockly/blocks/advanced.js
+++ b/apps/src/music/blockly/blocks/advanced.js
@@ -8,6 +8,7 @@ import {
   FIELD_EFFECTS_VALUE,
   FIELD_PATTERN_NAME,
   FIELD_SOUNDS_NAME,
+  FIELD_SOUNDS_VALIDATOR,
 } from '../constants';
 import {
   fieldChordDefinition,
@@ -35,6 +36,7 @@ export const playSound = {
     nextStatement: null,
     tooltip: musicI18n.blockly_blockPlaySoundAtMeasureTooltip(),
     helpUrl: '',
+    extensions: [FIELD_SOUNDS_VALIDATOR],
   },
   generator: ctx =>
     'Sequencer.playSoundAtMeasureById("' +

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -16,6 +16,7 @@ import {
   TriggerStart,
   FIELD_EFFECTS_EXTENSION,
   FIELD_EFFECT_NAME_OPTIONS,
+  FIELD_SOUNDS_VALIDATOR,
 } from '../constants';
 import {
   fieldSoundsDefinition,
@@ -108,6 +109,7 @@ export const playSoundAtCurrentLocationSimple2 = {
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundTooltip(),
     helpUrl: DOCS_BASE_URL + 'play_sample',
+    extensions: [FIELD_SOUNDS_VALIDATOR],
   },
   generator: block =>
     `Sequencer.playSound("${block.getFieldValue(FIELD_SOUNDS_NAME)}", "${

--- a/apps/src/music/blockly/constants.js
+++ b/apps/src/music/blockly/constants.js
@@ -4,6 +4,7 @@ import musicI18n from '../locale';
 
 export const DEFAULT_TRACK_NAME_EXTENSION = 'default_track_name_extension';
 export const FIELD_EFFECTS_EXTENSION = 'field_effects_extension';
+export const FIELD_SOUNDS_VALIDATOR = 'field_sounds_validator';
 export const PLAY_MULTI_MUTATOR = 'play_multi_mutator';
 
 // Field / Input Names

--- a/apps/src/music/blockly/extensions.js
+++ b/apps/src/music/blockly/extensions.js
@@ -1,3 +1,5 @@
+import MusicLibrary from '../player/MusicLibrary';
+
 import {BlockTypes} from './blockTypes';
 import {
   EXTRA_SOUND_INPUT_PREFIX,
@@ -150,4 +152,14 @@ export const effectsFieldExtension = function () {
 
     baseHandler.call(fieldEffectsName, menu, menuItem);
   };
+};
+
+export const fieldSoundsValidator = function () {
+  this.getField('sound').setValidator(newValue => {
+    if (MusicLibrary.getInstance()?.getSoundForId(newValue)) {
+      return newValue;
+    } else {
+      return MusicLibrary.getInstance()?.getDefaultSound();
+    }
+  });
 };

--- a/apps/src/music/blockly/extensions.js
+++ b/apps/src/music/blockly/extensions.js
@@ -11,6 +11,7 @@ import {
   FIELD_EFFECTS_VALUE,
   FIELD_EFFECTS_VALUE_OPTIONS,
   DEFAULT_EFFECT_VALUE,
+  FIELD_SOUNDS_NAME,
 } from './constants';
 
 export const getDefaultTrackNameExtension = player =>
@@ -155,7 +156,7 @@ export const effectsFieldExtension = function () {
 };
 
 export const fieldSoundsValidator = function () {
-  this.getField('sound').setValidator(newValue => {
+  this.getField(FIELD_SOUNDS_NAME).setValidator(newValue => {
     if (MusicLibrary.getInstance()?.getSoundForId(newValue)) {
       return newValue;
     } else {

--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -10,11 +10,13 @@ import {
   FIELD_SOUNDS_TYPE,
   PLAY_MULTI_MUTATOR,
   FIELD_EFFECTS_EXTENSION,
+  FIELD_SOUNDS_VALIDATOR,
 } from './constants';
 import {
   getDefaultTrackNameExtension,
   playMultiMutator,
   effectsFieldExtension,
+  fieldSoundsValidator,
 } from './extensions';
 import FieldChord from './FieldChord';
 import FieldPattern from './FieldPattern';
@@ -38,6 +40,7 @@ export function setUpBlocklyForMusicLab() {
   );
 
   Blockly.Extensions.register(FIELD_EFFECTS_EXTENSION, effectsFieldExtension);
+  Blockly.Extensions.register(FIELD_SOUNDS_VALIDATOR, fieldSoundsValidator);
   Blockly.Extensions.registerMutator(PLAY_MULTI_MUTATOR, playMultiMutator);
 
   // Needed for TypeScript to recognize the type of the MUSIC_BLOCKS. Remove


### PR DESCRIPTION
If a level with start sources has it's selected library updated, it can invalidate any field values in sound blocks:

<img width="127" alt="image" src="https://github.com/user-attachments/assets/b8b0689d-b42d-44fc-a8a2-c864ca684ce0">
<img width="671" alt="image" src="https://github.com/user-attachments/assets/e1feaf45-a8ca-421c-909f-2475bdcbcfef">

Blockly supports field validators as a means to make sure that fields always end up with a valid value. 
https://developers.google.com/blockly/guides/create-custom-blocks/fields/validators

We can implement a field validator that will check that the sound id can be found in the current MusicLibrary instance. If it's not, the validator can return the default sound (which matches the value we use in the toolbox). 

<img width="198" alt="image" src="https://github.com/user-attachments/assets/613c4783-aedb-418c-afa0-1ae1408cb5ba">

This came up because we realized that a whole bunch of new levels were not using the recommended `launch2024` library yet, and switching it was breaking blocks. 
In practice, a levelbuilder may still need to revise their start sources after changing libraries, but this will prevent invalid values from being passed to the sequencer. The alternative that was considered was that switching libraries could trigger a hard reset of start sources, which feels much more destructive.
