### PR TITLE
Add join route to CAP lockout exceptions

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -362,6 +362,9 @@ class ApplicationController < ActionController::Base
       policy_compliance_child_account_consent_path,
       # The age interstitial when the age isn't known will block the lockout page
       users_set_student_information_path,
+      # Allow students to join sections while locked out
+      student_user_new_path,
+      student_register_path,
     ].include?(request.path)
 
     redirect_to lockout_path

--- a/dashboard/test/controllers/application_controller_test.rb
+++ b/dashboard/test/controllers/application_controller_test.rb
@@ -67,6 +67,16 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
       refute_redirect_to lockout_path
     end
 
+    it 'allows student to visit the join page' do
+      get student_user_new_path
+      refute_redirect_to lockout_path
+    end
+
+    it 'allows student to join a section' do
+      post student_register_path
+      refute_redirect_to lockout_path
+    end
+
     context 'when user is not sign in' do
       before do
         sign_out user


### PR DESCRIPTION
School-owned Google and Microsoft accounts will soon be exempt from CAP lockouts. Part of this work was to allow these accounts to join sections even when they're locked out, since being part of a section implies school ownership of the account. To simplify this work, product decided it is acceptable to unlock `/join` for all locked-out users, since no harm is really done by allowing a user to join a section while they are locked out from the rest of the app.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1228)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
