### PR TITLE
Move old privacy policies onto /privacy/archive

### DIFF
--- a/pegasus/sites.v3/code.org/public/privacy.md
+++ b/pegasus/sites.v3/code.org/public/privacy.md
@@ -6,17 +6,7 @@ theme: responsive
 # Privacy Policy
 Date of Last Revision: April 4, 2024
 
-Previous Privacy Policies:
-* [December 2014](https://code.org/assets/privacy-policies/2014.pdf)
-* [April 2016](https://code.org/assets/privacy-policies/2016.pdf)
-* [April 2018](https://code.org/assets/privacy-policies/april-2018.pdf)
-* [May 2018](https://code.org/assets/privacy-policies/may-2018.pdf)
-* [September 2020](https://code.org/assets/privacy-policies/2020.pdf)
-* [March 2021](https://code.org/assets/privacy-policies/march-2021.pdf)
-* [July 2021](https://code.org/assets/privacy-policies/july-2021.pdf)
-* [November 2021](https://code.org/assets/privacy-policies/nov-2021.pdf)
-* [October 2022](https://code.org/assets/privacy-policies/oct-2022.pdf)
-* [December 2022](https://code.org/assets/privacy-policies/dec-2022.pdf)
+To see previous privacy policies [click here](/privacy/archive).
 
 [<img src="/shared/images/student_privacy_pledge.png" width="120" target="_blank" style="margin-top: 1rem">](http://studentprivacypledge.org/)
 

--- a/pegasus/sites.v3/code.org/public/privacy/archive.md
+++ b/pegasus/sites.v3/code.org/public/privacy/archive.md
@@ -1,0 +1,18 @@
+---
+title: Privacy Policy Archive
+theme: responsive
+---
+
+# Privacy Policy Archive
+
+Previous Privacy Policies:
+* [December 2014](https://code.org/assets/privacy-policies/2014.pdf)
+* [April 2016](https://code.org/assets/privacy-policies/2016.pdf)
+* [April 2018](https://code.org/assets/privacy-policies/april-2018.pdf)
+* [May 2018](https://code.org/assets/privacy-policies/may-2018.pdf)
+* [September 2020](https://code.org/assets/privacy-policies/2020.pdf)
+* [March 2021](https://code.org/assets/privacy-policies/march-2021.pdf)
+* [July 2021](https://code.org/assets/privacy-policies/july-2021.pdf)
+* [November 2021](https://code.org/assets/privacy-policies/nov-2021.pdf)
+* [October 2022](https://code.org/assets/privacy-policies/oct-2022.pdf)
+* [December 2022](https://code.org/assets/privacy-policies/dec-2022.pdf)


### PR DESCRIPTION
Moves old privacy policies onto a new https://code.org/privacy/archive page.

## Links 
Jira ticket: [ACQ-2530](https://codedotorg.atlassian.net/browse/ACQ-2530)

## Testing story
Tested locally

----

| Before | After |
| ---- | ---- |
| ![Before](https://github.com/user-attachments/assets/ac6b00b9-4303-4fa7-a161-37ce82a02dfc) | ![After](https://github.com/user-attachments/assets/6bfbc877-d28b-4bbf-a66e-51c42e303558) |

## code.org/privacy/archive

![localhost code org_3000_privacy_archive(Code org - 1366x768)](https://github.com/user-attachments/assets/837b418d-b7b2-4cc6-989a-3421b6934278)

