### PR TITLE
Lab2: Handle unsupported TTS event on old browsers

### DIFF
--- a/apps/src/util/BrowserTextToSpeech.ts
+++ b/apps/src/util/BrowserTextToSpeech.ts
@@ -6,17 +6,17 @@ import currentLocale from './currentLocale';
  * Manages native Browser Text to Speech functionality.
  */
 
-let ttsAvailable = false;
+let ttsAvailable = speechSynthesis.getVoices().length > 0;
 
-speechSynthesis.addEventListener('voiceschanged', () => {
-  ttsAvailable = speechSynthesis.getVoices().length > 0;
-});
+// Add a listener to update the ttsAvailable flag when voices are loaded.
+onTtsAvailable(isAvailable => (ttsAvailable = isAvailable));
 
 function onTtsAvailable(callback: (isAvailable: boolean) => void) {
   if (ttsAvailable) {
     callback(true);
   } else {
-    speechSynthesis.addEventListener('voiceschanged', () => {
+    // On some old browsers (e.g. Safari <16), the voiceschanged event is not implemented.
+    speechSynthesis.addEventListener?.('voiceschanged', () => {
       callback(speechSynthesis.getVoices().length > 0);
     });
   }


### PR DESCRIPTION
Fix for https://codedotorg.slack.com/archives/C0T0PNTM3/p1728667674530439. The issue was that the `voiceschanged` speech synthesis is only supported in Safari 16 and newer, while we run UI tests on Safari 14. Fix here is just to optionally add the listener if available, but also check `getVoices().length` up front so we can enable TTS if available on page load. Using the SauceLabs live mode, I was able to confirm that this seem to work on Safari 14 (voices are available on page load even though there's no callback support).

## Testing story

Ran the failing UI tests in SauceLabs with Safari and confirmed that all pass:

https://app.saucelabs.com/tests/e35508cd907a408d9d8d245dee8cdd1f
https://app.saucelabs.com/tests/a28db443955244b69f39c91f9e1db46e
https://app.saucelabs.com/tests/c5ebac453b94468881a1a8f0bd8839d9#91
https://app.saucelabs.com/tests/af4ef2d17418430f88fe78edf652a7e3
https://app.saucelabs.com/tests/8e42f1ce15cf44f580c999ef69fc1bf9