### PR TITLE
Migrate users during LTI account linking

### DIFF
--- a/dashboard/lib/services/lti/account_linker.rb
+++ b/dashboard/lib/services/lti/account_linker.rb
@@ -19,6 +19,7 @@ module Services
           user.lti_roster_sync_enabled = true if user.teacher?
           user.lms_landing_opted_out = true
           user.verify_teacher! if Policies::Lti.unverified_teacher?(user)
+          user.provider = ::User::PROVIDER_MIGRATED unless user.migrated?
           user.save!
           ::PartialRegistration.delete(session)
           unless rehydrated_user.id


### PR DESCRIPTION
This makes sure that any users who link their accounts are considered migrated, since after linking their LTI login they will by definition be "multi-auth."

Note this intentionally avoids calling the `migrate_to_multiauth` helper to avoid any unexpected side effects, such as creating email auth options. After linking accounts, we should be able to consider the account migrated.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1214)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
