### PR TITLE
[JIMT][CT-822 (partial)] moveFolderPrompt -> openMoveFolderPrompt

### DIFF
--- a/apps/i18n/codebridge/en_us.json
+++ b/apps/i18n/codebridge/en_us.json
@@ -34,6 +34,8 @@
   "moveFolder": "Move",
   "moveFilePrompt": "Please enter your destination folder",
   "moveFolderPrompt": "Please enter your destination folder",
+  "moveFolderErrorSelf": "Cannot move a folder into itself",
+  "moveFolderErrorChild": "Cannot move a folder into a child folder",
   "newFile": "New File",
   "newFilePrompt": "Please name your new file",
   "newFolder": "New Folder",

--- a/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
@@ -3,6 +3,7 @@ import {
   openNewFolderPrompt as globalOpenNewFolderPrompt,
   openNewFilePrompt as globalOpenNewFilePrompt,
   openMoveFilePrompt as globalOpenMoveFilePrompt,
+  openMoveFolderPrompt as globalOpenMoveFolderPrompt,
 } from '@codebridge/FileBrowser/prompts';
 import {sendCodebridgeAnalyticsEvent as globalSendCodebridgeAnalyticsEvent} from '@codebridge/utils';
 import {useCallback, useMemo} from 'react';
@@ -18,6 +19,7 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
  *
  * @returns An object containing the following functions:
  *   - **openMoveFilePrompt:** Opens a prompt for moving a file within the project.
+ *   - **openMoveFolderPrompt:** Opens a prompt for moving a folder within the project.
  *   - **openNewFilePrompt:** Opens a prompt for creating a new file within the project.
  *   - **openNewFolderPrompt:** Opens a prompt for creating a new folder within the project.
  */
@@ -29,7 +31,8 @@ export const usePrompts = () => {
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const dialogControl = useDialogControl();
 
-  const {project, moveFile, newFolder, newFile} = useCodebridgeContext();
+  const {project, moveFile, moveFolder, newFolder, newFile} =
+    useCodebridgeContext();
 
   const sendCodebridgeAnalyticsEvent = useCallback(
     (event: string) => globalSendCodebridgeAnalyticsEvent(event, appName),
@@ -65,8 +68,26 @@ export const usePrompts = () => {
     validationFile,
   } satisfies PAFunctionArgs<typeof globalOpenMoveFilePrompt>);
 
+  const openMoveFolderPrompt = usePartialApply(globalOpenMoveFolderPrompt, {
+    appName,
+    dialogControl,
+    moveFolder,
+    projectFolders: project.folders,
+    sendCodebridgeAnalyticsEvent,
+  } satisfies PAFunctionArgs<typeof globalOpenMoveFolderPrompt>);
+
   return useMemo(
-    () => ({openNewFilePrompt, openNewFolderPrompt, openMoveFilePrompt}),
-    [openNewFilePrompt, openNewFolderPrompt, openMoveFilePrompt]
+    () => ({
+      openNewFilePrompt,
+      openNewFolderPrompt,
+      openMoveFilePrompt,
+      openMoveFolderPrompt,
+    }),
+    [
+      openNewFilePrompt,
+      openNewFolderPrompt,
+      openMoveFilePrompt,
+      openMoveFolderPrompt,
+    ]
   );
 };

--- a/apps/src/codebridge/FileBrowser/prompts/index.ts
+++ b/apps/src/codebridge/FileBrowser/prompts/index.ts
@@ -1,3 +1,4 @@
 export * from './openMoveFilePrompt';
+export * from './openMoveFolderPrompt';
 export * from './openNewFilePrompt';
 export * from './openNewFolderPrompt';

--- a/apps/src/codebridge/FileBrowser/prompts/openMoveFolderPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openMoveFolderPrompt.tsx
@@ -3,6 +3,7 @@ import {ProjectType, FolderId} from '@codebridge/types';
 import {
   findFolder,
   getErrorMessage,
+  getFolderLineage,
   validateFolderName,
 } from '@codebridge/utils';
 
@@ -48,6 +49,19 @@ export const openMoveFolderPrompt = async ({
           folders: Object.values(projectFolders),
           required: true,
         });
+
+        if (folderId === parentId) {
+          return codebridgeI18n.moveFolderErrorSelf();
+        }
+
+        const destinationLineage = new Set(
+          getFolderLineage(parentId, Object.values(projectFolders))
+        );
+
+        if (destinationLineage.has(folderId)) {
+          return codebridgeI18n.moveFolderErrorChild();
+        }
+
         return validateFolderName({
           folderName: folder.name,
           parentId,

--- a/apps/src/codebridge/FileBrowser/prompts/openMoveFolderPrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openMoveFolderPrompt.tsx
@@ -1,0 +1,80 @@
+import {MoveFolderFunction} from '@codebridge/codebridgeContext/types';
+import {ProjectType, FolderId} from '@codebridge/types';
+import {
+  findFolder,
+  getErrorMessage,
+  validateFolderName,
+} from '@codebridge/utils';
+
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import {
+  DialogType,
+  DialogControlInterface,
+  extractUserInput,
+} from '@cdo/apps/lab2/views/dialogs';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+
+type OpenMoveFolderPromptArgsType = {
+  folderId: FolderId;
+  projectFolders: ProjectType['folders'];
+  dialogControl: Pick<DialogControlInterface, 'showDialog'>;
+  appName: string;
+  moveFolder: MoveFolderFunction;
+  sendCodebridgeAnalyticsEvent: (eventName: string) => unknown;
+};
+
+export const openMoveFolderPrompt = async ({
+  folderId,
+  projectFolders,
+  dialogControl,
+  appName,
+  moveFolder,
+  sendCodebridgeAnalyticsEvent,
+}: OpenMoveFolderPromptArgsType) => {
+  const folder = projectFolders[folderId];
+  const results = await dialogControl?.showDialog({
+    type: DialogType.GenericPrompt,
+    title: codebridgeI18n.moveFolderPrompt(),
+    placeholder: codebridgeI18n.rootFolder(),
+    requiresPrompt: false,
+
+    // in this case, the destinationFolderName is where we want to move the folder -to-, not what we are
+    // renaming the folder to.
+    // i.e., if we have folder 'foo' and the user types in '/bar/baz', then we want to place folder `foo` into `bar/baz`,
+    // not rename it as `bar/baz`
+    validateInput: (destinationFolderName: string) => {
+      try {
+        const parentId = findFolder(destinationFolderName.split('/'), {
+          folders: Object.values(projectFolders),
+          required: true,
+        });
+        return validateFolderName({
+          folderName: folder.name,
+          parentId,
+          projectFolders,
+        });
+      } catch (e) {
+        return getErrorMessage(e);
+      }
+    },
+  });
+
+  if (results.type !== 'confirm') {
+    return;
+  }
+
+  const destinationFolderName = extractUserInput(results) || '';
+  try {
+    const parentId = findFolder(destinationFolderName.split('/'), {
+      folders: Object.values(projectFolders),
+      required: true,
+    });
+    moveFolder(folderId, parentId);
+  } catch (e) {
+    dialogControl?.showDialog({
+      type: DialogType.GenericAlert,
+      title: getErrorMessage(e),
+    });
+  }
+  sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_MOVE_FOLDER);
+};

--- a/apps/src/codebridge/utils/getFolderLineage.ts
+++ b/apps/src/codebridge/utils/getFolderLineage.ts
@@ -1,0 +1,38 @@
+import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
+import {FolderId, ProjectFolder} from '@codebridge/types';
+
+/**
+ * Gets the full path of a folder within a project, given its ID and a list of all project folders.
+ *
+ * This function traverses the folder hierarchy by recursively searching for parent folders using their IDs.
+ * If the specified folder is not found or has no parent folders, an empty string is returned.
+ *
+ * @param folderId - The unique identifier of the target folder.
+ * @param projectFolders - An array containing all folders within the project, including the target folder.
+ * @returns - An array of all parent folder ids + the original folder id, in order from most distant to the folder id
+ */
+export const getFolderLineage = (
+  folderId: FolderId,
+  projectFolders: ProjectFolder[]
+) => {
+  // if we're given the DEFAULT_FOLDER_ID, then wrap and return it
+  if (folderId === DEFAULT_FOLDER_ID) {
+    return [DEFAULT_FOLDER_ID];
+  }
+
+  let folder = projectFolders.find(f => f.id === folderId);
+
+  if (!folder) {
+    return [];
+  }
+  const parents = [];
+
+  while (folder) {
+    parents.unshift(folder.id);
+    folder = projectFolders.find(f => f.id === folder?.parentId);
+  }
+
+  parents.unshift(DEFAULT_FOLDER_ID); // and the first element should always be the project root
+
+  return parents;
+};

--- a/apps/src/codebridge/utils/getFolderPath.ts
+++ b/apps/src/codebridge/utils/getFolderPath.ts
@@ -1,0 +1,29 @@
+import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
+import {FolderId, ProjectType} from '@codebridge/types';
+
+import {getFolderLineage} from './getFolderLineage';
+
+/**
+ * Gets the full path of a folder within a project, given its ID and a list of all project folders.
+ *
+ * This function traverses the folder hierarchy by recursively searching for parent folders using their IDs.
+ * If the specified folder is not found or has no parent folders, an empty string is returned.
+ *
+ * @param folderId - The unique identifier of the target folder.
+ * @param projectFolders - An array containing all folders within the project, including the target folder.
+ * @returns - The full path of the target folder, or an empty string if not found.
+ */
+export const getFolderPath = (
+  folderId: FolderId,
+  projectFolders: ProjectType['folders']
+) => {
+  if (folderId === DEFAULT_FOLDER_ID) {
+    return '/';
+  }
+
+  const fullPath = getFolderLineage(folderId, Object.values(projectFolders));
+
+  return fullPath
+    .map(id => (id === DEFAULT_FOLDER_ID ? '' : projectFolders[id].name))
+    .join('/');
+};

--- a/apps/src/codebridge/utils/index.ts
+++ b/apps/src/codebridge/utils/index.ts
@@ -8,6 +8,8 @@ export * from './fileUtils';
 export * from './findFolder';
 export * from './getEmptyProject';
 export * from './getErrorMessage';
+export * from './getFolderLineage';
+export * from './getFolderPath';
 export * from './getOpenFiles';
 export * from './previewFileType';
 export * from './sortFilesByName';

--- a/apps/test/unit/codebridge/FileBrowser/prompts/openMoveFilePromptTest.ts
+++ b/apps/test/unit/codebridge/FileBrowser/prompts/openMoveFilePromptTest.ts
@@ -1,6 +1,7 @@
 import {MoveFileFunction} from '@codebridge/codebridgeContext/types';
 import {openMoveFilePrompt} from '@codebridge/FileBrowser/prompts/openMoveFilePrompt';
 import {ProjectFile} from '@codebridge/types';
+import {getFolderPath} from '@codebridge/utils';
 
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 
@@ -24,7 +25,10 @@ describe('openMoveFilePrompt', function () {
     const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
     const fileId = '4';
     const destinationFolderId = '1';
-    const destinationFolderName = testProject.folders[destinationFolderId].name;
+    const destinationFolderName = getFolderPath(
+      destinationFolderId,
+      testProject.folders
+    );
 
     const [moveFileData, moveFileDataMock] = getMoveFileMock();
 
@@ -73,7 +77,10 @@ describe('openMoveFilePrompt', function () {
     const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
     const fileId = '1';
     const destinationFolderId = '1';
-    const destinationFolderName = testProject.folders[destinationFolderId].name;
+    const destinationFolderName = getFolderPath(
+      destinationFolderId,
+      testProject.folders
+    );
 
     const [moveFileData, moveFileDataMock] = getMoveFileMock();
 

--- a/apps/test/unit/codebridge/FileBrowser/prompts/openMoveFolderPromptTest.ts
+++ b/apps/test/unit/codebridge/FileBrowser/prompts/openMoveFolderPromptTest.ts
@@ -1,0 +1,141 @@
+import {MoveFolderFunction} from '@codebridge/codebridgeContext/types';
+import {openMoveFolderPrompt} from '@codebridge/FileBrowser/prompts/openMoveFolderPrompt';
+import {ProjectFolder} from '@codebridge/types';
+import {getFolderPath} from '@codebridge/utils';
+
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+
+import {testProject} from '../../test-files/';
+import {getDialogControlMock, getAnalyticsMock} from '../../test_utils';
+
+const getMoveFolderMock = (): [ProjectFolder, MoveFolderFunction] => {
+  const MoveFolderData = {} as ProjectFolder;
+  const mock: MoveFolderFunction = (folderId, parentId) => {
+    MoveFolderData.id = folderId;
+    MoveFolderData.parentId = parentId;
+  };
+
+  return [MoveFolderData, mock];
+};
+
+const appName = 'Codebridge Unit Test';
+
+describe('openMoveFolderPrompt', function () {
+  it('can successfully move a folder', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const folderId = '1';
+    const destinationFolderId = '3';
+    const destinationFolderName = getFolderPath(
+      destinationFolderId,
+      testProject.folders
+    );
+
+    const [MoveFolderData, MoveFolderDataMock] = getMoveFolderMock();
+
+    await openMoveFolderPrompt({
+      folderId,
+      projectFolders: testProject.folders,
+      dialogControl: getDialogControlMock(destinationFolderName),
+      appName,
+      moveFolder: MoveFolderDataMock,
+      sendCodebridgeAnalyticsEvent,
+    });
+
+    expect(MoveFolderData.id).toEqual(folderId);
+    expect(MoveFolderData.parentId).toEqual(destinationFolderId);
+
+    expect(analyticsData.event).toEqual(EVENTS.CODEBRIDGE_MOVE_FOLDER);
+  });
+
+  it('can refuse to move a folder to a non-existent folder', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const folderId = '4';
+    const destinationFolderName = 'fake-folder';
+
+    const [MoveFolderData, MoveFolderDataMock] = getMoveFolderMock();
+
+    await openMoveFolderPrompt({
+      folderId,
+      projectFolders: testProject.folders,
+      dialogControl: getDialogControlMock(destinationFolderName),
+      appName,
+      moveFolder: MoveFolderDataMock,
+      sendCodebridgeAnalyticsEvent,
+    });
+
+    expect(Object.keys(MoveFolderData).length).toEqual(0);
+    expect(Object.keys(analyticsData).length).toEqual(0);
+  });
+
+  it('can refuse to move a folder to a directory which has an identically named folder', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const folderId = '2';
+    const destinationFolderId = '0';
+    const destinationFolderName = getFolderPath(
+      destinationFolderId,
+      testProject.folders
+    );
+
+    const [MoveFolderData, MoveFolderDataMock] = getMoveFolderMock();
+
+    await openMoveFolderPrompt({
+      folderId,
+      projectFolders: testProject.folders,
+      dialogControl: getDialogControlMock(destinationFolderName),
+      appName,
+      moveFolder: MoveFolderDataMock,
+      sendCodebridgeAnalyticsEvent,
+    });
+
+    expect(Object.keys(MoveFolderData).length).toEqual(0);
+    expect(Object.keys(analyticsData).length).toEqual(0);
+  });
+
+  it('can refuse to move a folder to a itself', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const folderId = '2';
+    const destinationFolderId = '2';
+    const destinationFolderName = getFolderPath(
+      destinationFolderId,
+      testProject.folders
+    );
+
+    const [MoveFolderData, MoveFolderDataMock] = getMoveFolderMock();
+
+    await openMoveFolderPrompt({
+      folderId,
+      projectFolders: testProject.folders,
+      dialogControl: getDialogControlMock(destinationFolderName),
+      appName,
+      moveFolder: MoveFolderDataMock,
+      sendCodebridgeAnalyticsEvent,
+    });
+
+    expect(Object.keys(MoveFolderData).length).toEqual(0);
+    expect(Object.keys(analyticsData).length).toEqual(0);
+  });
+
+  it('can refuse to move a folder to a child folder', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const folderId = '1';
+    const destinationFolderId = '2';
+    const destinationFolderName = getFolderPath(
+      destinationFolderId,
+      testProject.folders
+    );
+
+    const [MoveFolderData, MoveFolderDataMock] = getMoveFolderMock();
+
+    await openMoveFolderPrompt({
+      folderId,
+      projectFolders: testProject.folders,
+      dialogControl: getDialogControlMock(destinationFolderName),
+      appName,
+      moveFolder: MoveFolderDataMock,
+      sendCodebridgeAnalyticsEvent,
+    });
+
+    expect(Object.keys(MoveFolderData).length).toEqual(0);
+    expect(Object.keys(analyticsData).length).toEqual(0);
+  });
+});

--- a/apps/test/unit/codebridge/FileBrowser/prompts/openNewFolderPromptTest.ts
+++ b/apps/test/unit/codebridge/FileBrowser/prompts/openNewFolderPromptTest.ts
@@ -22,7 +22,7 @@ const getNewFolderMock = (
 };
 
 const appName = 'Codebridge Unit Test';
-const EXPECTED_NEXT_FOLDER_ID = '4';
+const EXPECTED_NEXT_FOLDER_ID = '6';
 
 describe('openNewFolderPrompt', function () {
   it('can successfully add a new folder to root', async function () {

--- a/apps/test/unit/codebridge/test-files/project.json
+++ b/apps/test/unit/codebridge/test-files/project.json
@@ -14,6 +14,16 @@
       "id": "3",
       "name": "testfolder2",
       "parentId": "0"
+    },
+    "4": {
+      "id": "4",
+      "name": "testfolder4",
+      "parentId": "2"
+    },
+    "5": {
+      "id": "5",
+      "name": "testfolder5",
+      "parentId": "4"
     }
   },
   "files": {

--- a/apps/test/unit/codebridge/utils/getFolderLineageTest.ts
+++ b/apps/test/unit/codebridge/utils/getFolderLineageTest.ts
@@ -1,0 +1,26 @@
+import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
+import {getFolderLineage} from '@codebridge/utils/getFolderLineage';
+
+import {testProject} from '../test-files/';
+
+const projectFolders = Object.values(testProject.folders);
+
+describe('getFolderLineage', () => {
+  it('should return an empty string for a non-existent folder', () => {
+    expect(getFolderLineage('1492', projectFolders)).toEqual([]);
+  });
+  it('should getFolderLineage on existing folders', () => {
+    expect(getFolderLineage(DEFAULT_FOLDER_ID, projectFolders)).toEqual(['0']);
+    expect(getFolderLineage('1', projectFolders)).toEqual(['0', '1']);
+    expect(getFolderLineage('2', projectFolders)).toEqual(['0', '1', '2']);
+    expect(getFolderLineage('3', projectFolders)).toEqual(['0', '3']);
+    expect(getFolderLineage('4', projectFolders)).toEqual(['0', '1', '2', '4']);
+    expect(getFolderLineage('5', projectFolders)).toEqual([
+      '0',
+      '1',
+      '2',
+      '4',
+      '5',
+    ]);
+  });
+});

--- a/apps/test/unit/codebridge/utils/getFolderPathTest.ts
+++ b/apps/test/unit/codebridge/utils/getFolderPathTest.ts
@@ -1,0 +1,24 @@
+import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
+import {getFolderPath} from '@codebridge/utils/getFolderPath';
+
+import {testProject} from '../test-files/';
+
+describe('getFolderPath', () => {
+  it('should return an empty string for a non-existent folder', () => {
+    expect(getFolderPath('1492', testProject.folders)).toEqual('');
+  });
+  it('should getFolderPath on existing folders', () => {
+    expect(getFolderPath(DEFAULT_FOLDER_ID, testProject.folders)).toEqual('/');
+    expect(getFolderPath('1', testProject.folders)).toEqual('/testfolder1');
+    expect(getFolderPath('2', testProject.folders)).toEqual(
+      '/testfolder1/testfolder2'
+    );
+    expect(getFolderPath('3', testProject.folders)).toEqual('/testfolder2');
+    expect(getFolderPath('4', testProject.folders)).toEqual(
+      '/testfolder1/testfolder2/testfolder4'
+    );
+    expect(getFolderPath('5', testProject.folders)).toEqual(
+      '/testfolder1/testfolder2/testfolder4/testfolder5'
+    );
+  });
+});


### PR DESCRIPTION
More CT-822 work, this just moves the embedded `moveFolderPrompt` to an external `openFolderPrompt` and adds tests.

While I was working on it, I realized that there were two edge cases we weren't handling - moving the folder into itself, and moving the folder into a child folder.

Moving a folder into itself would _technically_ not fail, in that the `moveFolder` function explicitly blocked it. But no error would be reported to the user - they would just attempt to move to itself, and it would "succeed" but be a no-op. Now it'll produce a warning.

More significant was moving a folder into a _child_ folder. i.e., you have folders `test1` and `test1/test2` and you attempted to move `test1` _into_ `test1/test2`. This wouldn't toss an error, but the folders would disappear. This is because they were now part of a loop external to the project root, so they would never appear (`test2`'s parent would be `test1`, whose parent would be `test2`). So this adds extra checks to prevent that from happening.

Both of _those_ changes required a little extra machinery, so I added two new utility functions - `getFolderPath` will print out a `/` separated path to the folder from the root. And `getFolderLineage` will return an array from the root of the project with all parent folders.

`getFolderPath` is used in the tests to ensure that we don't improperly name a folder by just looking to its `name` attribute, and `getFolderLineage` is used in the prompt. Tests are provided for both utilities.

Note that due to how the drag 'n drop functionality was implemented, it was immune from this bug.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CT-617](https://codedotorg.atlassian.net/browse/CT-617)
- jira ticket: [CT-822](https://codedotorg.atlassian.net/browse/CT-822)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
