### PR TITLE
[JIMT][CT-868] - delayed error reporting

### DIFF
--- a/apps/src/lab2/views/dialogs/GenericDialog.tsx
+++ b/apps/src/lab2/views/dialogs/GenericDialog.tsx
@@ -1,5 +1,5 @@
 import FocusTrap from 'focus-trap-react';
-import React, {useCallback} from 'react';
+import React, {useMemo} from 'react';
 
 import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
 import {BodyTwoText, Heading3} from '@cdo/apps/componentLibrary/typography';
@@ -46,6 +46,7 @@ export type GenericDialogProps = GenericDialogTitleProps &
         destructive?: boolean;
       };
     };
+    getButtonCallback?: typeof defaultGetButtonCallback;
   };
 
 import moduleStyles from './generic-dialog.module.scss';
@@ -64,25 +65,35 @@ import moduleStyles from './generic-dialog.module.scss';
  * If no confirm button text is provided, the default text is "OK" (translatable).
  */
 
-type UseClosingCallbackArgs = {
+export type GetButtonCallbackArgs = {
   closeDialog: DialogCloseFunctionType;
   closeType: DialogCloseActionType;
   callback: dialogCallback | undefined;
   disabled: boolean | undefined;
 };
 
-const useClosingCallback = ({
-  closeDialog,
-  closeType,
-  callback,
-  disabled,
-}: UseClosingCallbackArgs) =>
-  useCallback(() => {
+export const defaultGetButtonCallback =
+  ({closeDialog, closeType, callback, disabled}: GetButtonCallbackArgs) =>
+  () => {
     if (!disabled) {
       closeDialog(closeType);
       callback && callback();
     }
-  }, [closeDialog, closeType, callback, disabled]);
+  };
+
+const useButtonCallback = ({
+  closeDialog,
+  closeType,
+  callback,
+  disabled,
+  getButtonCallback,
+}: GetButtonCallbackArgs & {
+  getButtonCallback: typeof defaultGetButtonCallback;
+}) =>
+  useMemo(
+    () => getButtonCallback({closeDialog, closeType, callback, disabled}),
+    [closeDialog, closeType, callback, disabled, getButtonCallback]
+  );
 
 const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
   buttons,
@@ -90,28 +101,32 @@ const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
   titleComponent,
   message,
   bodyComponent,
+  getButtonCallback = defaultGetButtonCallback,
 }) => {
   const dialogControl = useDialogControl();
 
-  const cancelCallback = useClosingCallback({
+  const cancelCallback = useButtonCallback({
     closeDialog: dialogControl.closeDialog,
     closeType: 'cancel',
     callback: buttons?.cancel?.callback,
     disabled: buttons?.cancel?.disabled,
+    getButtonCallback,
   });
 
-  const neutralCallback = useClosingCallback({
+  const neutralCallback = useButtonCallback({
     closeDialog: dialogControl.closeDialog,
     closeType: 'neutral',
     callback: buttons?.neutral?.callback,
     disabled: buttons?.neutral?.disabled,
+    getButtonCallback,
   });
 
-  const confirmCallback = useClosingCallback({
+  const confirmCallback = useButtonCallback({
     closeDialog: dialogControl.closeDialog,
     closeType: 'confirm',
     callback: buttons?.confirm?.callback,
     disabled: buttons?.confirm?.disabled,
+    getButtonCallback,
   });
 
   useEscapeKeyboardTrap(cancelCallback);

--- a/apps/src/lab2/views/dialogs/GenericPrompt.tsx
+++ b/apps/src/lab2/views/dialogs/GenericPrompt.tsx
@@ -83,6 +83,12 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
   const handleInputChange = useCallback(
     (newInput: string) => {
       setPromiseArgs(newInput);
+      // if the user has typed something in and we do not currently have an error,
+      // then use the debounced handler with the delay.
+      //
+      //That'll prevent the error from popping up immediately and giving a chance to type.
+      // Otherwise, if there is no input or the user already has an error, then we want to
+      // validate immediately (in an attempt to clear the error), so use the non-debounced version.
       if (newInput.length && !errorMessage?.length) {
         debouncedErrorHandler(newInput);
       } else {
@@ -102,7 +108,7 @@ const GenericPrompt: React.FunctionComponent<GenericPromptProps> = ({
   // as well as calling validateInput on it to confirm it's acceptable.'
   useEffect(() => handleInputChange(prompt), []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // we're going to hande in a custom buttonCallback getter to the generic dialog. We don't need to worry about memoizing this,
+  // we're going to hand in a custom buttonCallback getter to the generic dialog. We don't need to worry about memoizing this,
   // since it'll get memoized up in the parent component. When the user clicks the confirm button, we're just going to re-validate
   // the prompt. If if produces a validation error, display it and bow out. Otherwise, just proceed with the default handler.
   //


### PR DESCRIPTION
CT-868 suggested delaying reporting of errors - for example, when the new file prompt is opened, the user _immediately_ gets an error message as soon as they start typing, because they haven't typed the extension yet.

Here's how it currently works:

https://github.com/user-attachments/assets/dcb60a11-80dc-4e0b-99e5-b21f07b3acc2

So this PR introduces some modifications to the `GenericPrompt`.

- validation now happens on a 300ms debounced delay, giving the user a reasonable amount of time to type. 300ms seemed like a good delay to me, but we can adjust up or down. Maybe a longer delay is better with kids that are less experienced typists?
- If the user _deletes_ everything in the prompt, it will validate immediately. This way there isn't a delay while the error persists if the user tries to start over.
- If the user _has_ an error, then there will be no delay. This way, the error will clear immediately once it's corrected (e.g., once the file extension is typed in). After the error is gone, it will go back to the debounced delay.
- The prompt will re-validate once the `confirm` button is clicked. The current behavior is that the button would remain disabled until it was validated. However, the user could quickly type `foo.txt` and still need to wait for a moment for the debounce to catch up and unlock the button, which was bad UX. If the button remained active initially, then the user could quickly type an invalid entry and hit enter before the validation catches up and disables the button. This way, we can have the error delay slightly to give the user time to type + have it respond immediately when the button is clicked.

Here's the new behavior:

https://github.com/user-attachments/assets/3174c04a-cfab-4d90-a8b1-a2c4702734e2



## Links




<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CT-868](https://codedotorg.atlassian.net/browse/CT-261)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
