### PR TITLE
Music: library partials

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -75,11 +75,11 @@ export async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
     // Second, retrieve any partial library files.  These contain
     // additional content that will be merged into the library.
     const partialsPromises: Promise<GetResponse<LibraryJson>>[] | undefined =
-      libraryJson.partials?.map(merge => {
+      libraryJson.partials?.map(partial => {
         return HttpClient.fetchJson<LibraryJson>(
           getBaseAssetUrl() +
             'v2/partials/' +
-            merge +
+            partial +
             '.json' +
             (requestVersion ? `?version=${requestVersion}` : ''),
           {},

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -93,8 +93,8 @@ export async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
       partialsResponses = await Promise.allSettled(partialsPromises);
     }
 
-    libraryJson.kits ??= [];
     libraryJson.instruments ??= [];
+    libraryJson.kits ??= [];
     libraryJson.packs ??= [];
 
     partialsResponses.forEach(partialsResponse => {
@@ -102,11 +102,11 @@ export async function loadLibrary(libraryName: string): Promise<MusicLibrary> {
         throw new Error('Error loading a library partial.');
       }
       const src = partialsResponse.value.value;
-      if (src.kits) {
-        libraryJson.kits.push(...src.kits);
-      }
       if (src.instruments) {
         libraryJson.instruments.push(...src.instruments);
+      }
+      if (src.kits) {
+        libraryJson.kits.push(...src.kits);
       }
       if (src.packs) {
         libraryJson.packs.push(...src.packs);


### PR DESCRIPTION
This change proposes that the music library can be sourced from multiple "partial" library files.

The curriculum team is interested in teaching with a smaller set of specialised sounds, while also giving access to the restricted packs available in the current `launch2024` library.  At first, I thought of adding another kind of filtering to the existing library, so that a levelbuilder could specify the use of a non-restricted pack and a restricted pack at the same time.  But then I realised this scenario was already possible with our existing support for different libraries, with the only complication being a desire to avoid duplicating metadata for restricted packs, and indeed instruments and kits as well.

Therefore, this change revisits an idea we've had for a while, which is to support assembling the library from mutiple JSON files.  It allows us to avoid duplication of metadata, while building a variety of specialised libraries.

At load time, we continue to load the main library file and the translations (if not `en`) simultaneously.  Then, if there are partials to load, they are all loaded simultaneously.  

Partials are currently intended to contain the `instruments`, `kits`, and `packs` arrays.  As each partial is processed, entries are added to the end of the appropriate arrays, maintaining declaration order.

With this change, the existing `intro2024` library continues without any changes.  The `launch2024`library has a new file structure, like this:

```
music-library-launch2024.json
partials/
  music-library-launch2024-instruments.json
  music-library-launch2024-kits.json
  music-library-launch2024-packs-codeorg.json
  music-library-launch2024-packs-restricted.json
```
And `music-library-launch2024.json` is much smaller, looking like this:
```
{
  "id": "launch2024-prep",
  "path": "library-launch2024",
  "bpm": 120,
  "key": 0,
  "partials": [
    "music-library-launch2024-instruments",
    "music-library-launch2024-kits",
    "music-library-launch2024-packs-restricted",
    "music-library-launch2024-packs-codeorg"
  ]
}
```

All of this is placed in a `/v2/` directory on S3, so that when this PR goes live, we don't need to change anything on S3 at the same time.  
