### PR TITLE
[Music] Validation Condition: Played sound in any function

### DIFF
--- a/apps/src/music/progress/MusicConditions.ts
+++ b/apps/src/music/progress/MusicConditions.ts
@@ -29,6 +29,11 @@ export const MusicConditions: ConditionNames = {
     description:
       'Successful when a sound is playing in a given function. Simple2 only. Ex. Value: chorus',
   },
+  PLAYED_SOUND_IN_ANY_FUNCTION: {
+    name: 'played_sound_in_any_function',
+    description:
+      'Successful when a sound is playing in any function. Simple2 only.',
+  },
   PLAYED_SOUNDS: {
     name: 'played_sounds',
     valueType: 'number',

--- a/apps/src/music/progress/MusicValidator.ts
+++ b/apps/src/music/progress/MusicValidator.ts
@@ -104,6 +104,9 @@ export default class MusicValidator extends Validator {
 
           if (eventData.functionContext) {
             this.conditionsChecker.addSatisfiedCondition({
+              name: MusicConditions.PLAYED_SOUND_IN_ANY_FUNCTION.name,
+            });
+            this.conditionsChecker.addSatisfiedCondition({
               name: MusicConditions.PLAYED_SOUND_IN_FUNCTION.name,
               value: eventData.functionContext.name,
             });


### PR DESCRIPTION
This adds a new `PLAYED_SOUND_IN_ANY_FUNCTION` validation condition. This is an alternative to the stricter `PLAYED_SOUND_IN_FUNCTION` which expects a specific a function name.

With this condition, levels can expect students to use a function to play a sound, without caring about what that function is named. This is required for the K5 module which will teach students to define their own functions.

https://github.com/user-attachments/assets/fed916af-4ec2-400b-8f9b-bf19b15ab5f9

