### PR TITLE
Add Gen AI videos to /videos page

### DIFF
--- a/apps/src/sites/code.org/pages/views/swiper_page_videos.js
+++ b/apps/src/sites/code.org/pages/views/swiper_page_videos.js
@@ -10,6 +10,7 @@ register();
 
 const swipers = [
   document.querySelector('swiper-container.how-ai-works'),
+  document.querySelector('swiper-container.explore-gen-ai'),
   document.querySelector('swiper-container.how-computers-work'),
   document.querySelector('swiper-container.how-internet-works'),
   document.querySelector('swiper-container.not-hacked'),

--- a/pegasus/sites.v3/code.org/public/educate/resources/videos.haml
+++ b/pegasus/sites.v3/code.org/public/educate/resources/videos.haml
@@ -4,9 +4,9 @@ theme: responsive_full_width
 video_player: true
 ---
 
-- video_page_index = 7
-- video_page_section_title = [hoc_s(:video_library_page_title_ai_works), hoc_s(:video_library_page_title_computers_work), hoc_s(:video_library_page_title_internet_works), hoc_s(:video_library_page_title_not_hacked), hoc_s(:video_library_page_title_blockchain), hoc_s(:video_library_page_title_inspirational), hoc_s(:video_library_page_title_careers)]
-- video_page_section_desc = [hoc_s(:video_library_page_description_ai_works), hoc_s(:video_library_page_description_computers_work), hoc_s(:video_library_page_description_internet_works), hoc_s(:video_library_page_description_not_hacked), hoc_s(:video_library_page_description_blockchain), hoc_s(:video_library_page_description_inspirational), hoc_s(:video_library_page_description_careers)]
+- video_page_index = 8
+- video_page_section_title = [hoc_s(:video_library_page_title_ai_works), hoc_s(:video_library_page_title_gen_ai), hoc_s(:video_library_page_title_computers_work), hoc_s(:video_library_page_title_internet_works), hoc_s(:video_library_page_title_not_hacked), hoc_s(:video_library_page_title_blockchain), hoc_s(:video_library_page_title_inspirational), hoc_s(:video_library_page_title_careers)]
+- video_page_section_desc = [hoc_s(:video_library_page_description_ai_works), hoc_s(:video_library_page_description_gen_ai), hoc_s(:video_library_page_description_computers_work), hoc_s(:video_library_page_description_internet_works), hoc_s(:video_library_page_description_not_hacked), hoc_s(:video_library_page_description_blockchain), hoc_s(:video_library_page_description_inspirational), hoc_s(:video_library_page_description_careers)]
 
 %link{href: "/css/generated/design-system-pegasus.css", rel: "stylesheet"}
 %link{href: "/css/generated/page/video-page-styles.css", rel: "stylesheet"}
@@ -32,16 +32,18 @@ video_player: true
       - if index === 0
         = view :carousel_how_ai_works_video
       - if index === 1
-        = view :carousel_computer_works_video
+        = view :carousel_explore_gen_ai_video
       - if index === 2
-        = view :carousel_internet_video
+        = view :carousel_computer_works_video
       - if index === 3
-        = view :carousel_not_hacked_video
+        = view :carousel_internet_video
       - if index === 4
-        = view :carousel_blockchain_video
+        = view :carousel_not_hacked_video
       - if index === 5
-        = view :carousel_inspirational_video
+        = view :carousel_blockchain_video
       - if index === 6
+        = view :carousel_inspirational_video
+      - if index === 7
         = view :carousel_careers_in_cs_video
   = view :section_divider_line
 

--- a/pegasus/sites.v3/code.org/views/carousel_explore_gen_ai_video.haml
+++ b/pegasus/sites.v3/code.org/views/carousel_explore_gen_ai_video.haml
@@ -1,13 +1,13 @@
 - video_ai_index = 5
 
-- video_download_path = ["//videos.code.org/ai_series/ai-01-intro-to-ai.mp4", "//videos.code.org/ai_series/ai-02-machine-learning.mp4", "//videos.code.org/ai_series/ai-03-training-data.mp4", "//videos.code.org/ai_series/ai-04-neural-networks.mp4", "//videos.code.org/ai_series/ai-05-computer-vision.mp4", "//videos.code.org/ai_series/HowAIWorks_LLM_SM_CoBrand.mp4", "//videos.code.org/ai_series/HowAIWorks_Creativity_SM_CoBrand.mp4", "//videos.code.org/ai_series/ai-06-ai-ethics-access-bias.mp4", "//videos.code.org/ai_series/ai-07-ai-ethics-privacy-work.mp4"]
+- video_download_path = ["//videos.code.org/levelbuilder/gen_ai_input_pretraining_compressed-mp4.mp4", "//videos.code.org/levelbuilder/gen_ai_storage_embeddings_compressed-mp4.mp4", "//videos.code.org/levelbuilder/gen_ai_processing_neuralnets_compressed-mp4.mp4", "//videos.code.org/levelbuilder/gen_ai_attention_compressed-mp4.mp4", "//videos.code.org/levelbuilder/gen_ai_output_probabilities_compressed-mp4.mp4"]
 
-- video_caption = [hoc_s(:ai_vid_intro_caption), hoc_s(:ai_vid_mlintro_caption), hoc_s(:ai_vid_trainingdata_caption), hoc_s(:ai_vid_neuralnetworks_caption), hoc_s(:ai_vid_computervision_caption), hoc_s(:ai_vid_chatbots_caption), hoc_s(:ai_vid_creativity_caption), hoc_s(:ai_vid_ethics1_caption), hoc_s(:ai_vid_ethics2_caption)]
+- video_caption = [hoc_s(:gen_ai_vid_input_caption), hoc_s(:gen_ai_vid_storage_caption), hoc_s(:gen_ai_vid_processing_caption), hoc_s(:gen_ai_vid_attention_caption), hoc_s(:gen_ai_vid_output_caption)]
 
-- video_code = ["Ok-xpKjKp2g", "OeU5m6vRyCk", "x2mRoFNm22g", "JrXazCEACVo", "2hXG8v8p0KM", "X-AWdfSFCHQ", "X994dDnmRmY", "tJQSyzBUAew", "zNxw5gJtHLc"]
+- video_code = ["JO9MgO1Zp3E", "s1fhxAVpYx8", "Z7Mes_Ej69Y", "2RdK6k45koY", "gGK7b7j4BiQ"]
 
 .carousel-wrapper.video-carousel
-  %swiper-container.explore-gen-ai{navigation: "true", "navigation-next-el": ".nav-next-how-ai-works", "navigation-prev-el": ".nav-prev-how-ai-works", pagination: "true", init: "false", "allow-touch-move": "false"}
+  %swiper-container.explore-gen-ai{navigation: "true", "navigation-next-el": ".nav-next-explore-gen-ai", "navigation-prev-el": ".nav-prev-explore-gen-ai", pagination: "true", init: "false", "allow-touch-move": "false"}
     - video_ai_index.times do |index|
       %swiper-slide
         %figure
@@ -15,5 +15,5 @@
           %figcaption.no-margin-bottom
             = video_caption[index]
 
-  %button.swiper-nav-prev.nav-prev-how-ai-works
-  %button.swiper-nav-next.nav-next-how-ai-works
+  %button.swiper-nav-prev.nav-prev-explore-gen-ai
+  %button.swiper-nav-next.nav-next-explore-gen-ai

--- a/pegasus/sites.v3/code.org/views/carousel_explore_gen_ai_video.haml
+++ b/pegasus/sites.v3/code.org/views/carousel_explore_gen_ai_video.haml
@@ -1,0 +1,19 @@
+- video_ai_index = 5
+
+- video_download_path = ["//videos.code.org/ai_series/ai-01-intro-to-ai.mp4", "//videos.code.org/ai_series/ai-02-machine-learning.mp4", "//videos.code.org/ai_series/ai-03-training-data.mp4", "//videos.code.org/ai_series/ai-04-neural-networks.mp4", "//videos.code.org/ai_series/ai-05-computer-vision.mp4", "//videos.code.org/ai_series/HowAIWorks_LLM_SM_CoBrand.mp4", "//videos.code.org/ai_series/HowAIWorks_Creativity_SM_CoBrand.mp4", "//videos.code.org/ai_series/ai-06-ai-ethics-access-bias.mp4", "//videos.code.org/ai_series/ai-07-ai-ethics-privacy-work.mp4"]
+
+- video_caption = [hoc_s(:ai_vid_intro_caption), hoc_s(:ai_vid_mlintro_caption), hoc_s(:ai_vid_trainingdata_caption), hoc_s(:ai_vid_neuralnetworks_caption), hoc_s(:ai_vid_computervision_caption), hoc_s(:ai_vid_chatbots_caption), hoc_s(:ai_vid_creativity_caption), hoc_s(:ai_vid_ethics1_caption), hoc_s(:ai_vid_ethics2_caption)]
+
+- video_code = ["Ok-xpKjKp2g", "OeU5m6vRyCk", "x2mRoFNm22g", "JrXazCEACVo", "2hXG8v8p0KM", "X-AWdfSFCHQ", "X994dDnmRmY", "tJQSyzBUAew", "zNxw5gJtHLc"]
+
+.carousel-wrapper.video-carousel
+  %swiper-container.explore-gen-ai{navigation: "true", "navigation-next-el": ".nav-next-how-ai-works", "navigation-prev-el": ".nav-prev-how-ai-works", pagination: "true", init: "false", "allow-touch-move": "false"}
+    - video_ai_index.times do |index|
+      %swiper-slide
+        %figure
+          = view :video_with_fallback, video_code: video_code[index], download_path: video_download_path[index]
+          %figcaption.no-margin-bottom
+            = video_caption[index]
+
+  %button.swiper-nav-prev.nav-prev-how-ai-works
+  %button.swiper-nav-next.nav-next-how-ai-works

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -12017,6 +12017,8 @@
   video_library_page_hero_description: "Code.org's growing library of educational videos is available for re-use by educators worldwide, online or in classrooms. Our goal is to amplify our efforts beyond our own curriculum's reach."
   video_library_page_title_ai_works: "How AI Works"
   video_library_page_description_ai_works: "This series of short videos will introduce you to how artificial intelligence works and why it matters. Learn about neural networks, or how AI learns, and delve into issues like algorithmic bias and the ethics of AI decision-making."
+  video_library_page_title_gen_ai: "Exploring Generative AI"
+  video_library_page_description_gen_ai: "Generative AI may seem magical and mysterious, but it’s a lot easier to understand when you break it down to four core components: input, storage, processing, and output. Learn How Generative AI Works in this video series!"
   video_library_page_title_computers_work: "How Computers Work"
   video_library_page_description_computers_work: "Explains what makes a computer a computer, how digital information is represented in 1s and 0s, how computer circuits work to manipulate digital information, and how a central processing unit (CPU) and operating system control the inputs, outputs, memory, and hardware of a computer."
   video_library_page_title_internet_works: "How the Internet Works"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1468,6 +1468,12 @@
   ai_vid_ethics1_caption: "Ethics & AI: Equal Access and Algorithmic Bias"
   ai_vid_ethics2_caption: "Ethics & AI: Privacy and the Future of Work"
 
+  gen_ai_vid_input_caption: "Generative AI: Input & Pre-training"
+  gen_ai_vid_storage_caption: "Generative AI: Storage & Embeddings"
+  gen_ai_vid_processing_caption: "Generative AI: Processing & Neural Networks"
+  gen_ai_vid_attention_caption: "Generative AI: Attention"
+  gen_ai_vid_output_caption: "Generative AI: Output & Probabilities"
+
   admins_page_top_heading: "Expand computer science in your district"
   admins_page_top_subhead: "Unlock the future of education with Code.org's comprehensive computer science (CS) programs."
   admins_page_top_desc: "Join a visionary network of over 2 million educators dedicated to shaping innovative leaders, critical thinkers, and engaged digital citizens. Code.org partners with administrators to seamlessly integrate CS into schools, offering extensive resources, tailored professional development, and continual support for systemic success."


### PR DESCRIPTION
Adds the videos in [this playlist of Generative AI videos](https://www.youtube.com/playlist?list=PLzdnOPI1iJNfJLo5nNGPHo0xCd9Xw5lSs) to the [/videos](https://code.org/educate/resources/videos) page under the "How AI Works" section.

https://github.com/user-attachments/assets/40a3a840-7064-45c3-bc25-492bff394023

Fallback videos:
![explore gen ai fallback](https://github.com/user-attachments/assets/db7ead46-f306-42ef-a648-6a746467f957)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2383)
Slack discussion of its content: [here](https://codedotorg.slack.com/archives/C05PP07KC1L/p1725635682539699)

## Testing story
Local testing.
