### PR TITLE
Log namespace on PutMetricData failures to more easily tune permissions

### DIFF
--- a/lib/cdo/aws/metrics.rb
+++ b/lib/cdo/aws/metrics.rb
@@ -49,7 +49,7 @@ module Cdo
         )
       rescue => exception
         Honeybadger.notify(exception)
-        puts "Error sending metrics: #{exception.full_message}" if rack_env?(:development)
+        puts "Error sending metrics to namespace #{@namespace}: #{exception.full_message}" if rack_env?(:development)
       end
 
       def size(events)


### PR DESCRIPTION
Slack Threads:
* https://codedotorg.slack.com/archives/C046G4TRLEN/p1728923285565519?thread_ts=1728922038.220509&cid=C046G4TRLEN
* https://codedotorg.slack.com/archives/C046G4TRLEN/p1728408972758089?thread_ts=1728408972.758089&cid=C046G4TRLEN

Some IAM Roles lack permissions for PutMetricData. This updates the `puts` in local development to state what namespace we're attempting to log to, and failing. This will make it easier to tune permissions for local development.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

The better solution is to not try to put metrics to AWS when we don't have permission and are in development or local testing modes, instead writing to a local log file or other location.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
