### PR TITLE
Music: add analytics for AI panel

### DIFF
--- a/apps/src/music/MusicRegistry.ts
+++ b/apps/src/music/MusicRegistry.ts
@@ -1,3 +1,4 @@
+import AnalyticsReporter from './analytics/AnalyticsReporter';
 import MusicPlayer from './player/MusicPlayer';
 
 /**
@@ -7,6 +8,7 @@ import MusicPlayer from './player/MusicPlayer';
  */
 class MusicRegistry {
   private playerRef: MusicPlayer | null = null;
+  private analyticsReporterRef: AnalyticsReporter | null = null;
 
   public showSoundFilters: boolean = false;
   public hideAiTemperature: boolean = false;
@@ -20,6 +22,17 @@ class MusicRegistry {
 
   public set player(player: MusicPlayer) {
     this.playerRef = player;
+  }
+
+  public get analyticsReporter(): AnalyticsReporter {
+    if (!this.analyticsReporterRef) {
+      throw new Error('AnalyticsReporter not set in MusicRegistry');
+    }
+    return this.analyticsReporterRef;
+  }
+
+  public set analyticsReporter(analyticsReporter: AnalyticsReporter) {
+    this.analyticsReporterRef = analyticsReporter;
   }
 }
 

--- a/apps/src/music/ai/patternAi.ts
+++ b/apps/src/music/ai/patternAi.ts
@@ -1,6 +1,7 @@
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 
+import MusicRegistry from '../MusicRegistry';
 import {InstrumentTickEvent} from '../player/interfaces/InstrumentEvent';
 
 import {Message} from './types';
@@ -21,8 +22,10 @@ export function generatePattern(
   onError: (error: Error) => void
 ) {
   const reporter = Lab2Registry.getInstance().getMetricsReporter();
+  const analyticsReporter = MusicRegistry.analyticsReporter;
   // Report attempt
   reporter.incrementCounter('MusicAI.GeneratePatternAttempt');
+  analyticsReporter.onGenerateAiPatternStart();
 
   worker.postMessage([
     Message.GeneratePattern,
@@ -40,6 +43,10 @@ export function generatePattern(
         reportGeneratePatternTime(reporter, e.data[1], isInitialGenerate);
         break;
       case Message.Result:
+        analyticsReporter.onGenerateAiPatternEnd(
+          e.data[2] / 1000,
+          isInitialGenerate
+        );
         onComplete(e.data[1]);
         // Flip the flag after the first successful generate.
         isInitialGenerate = false;

--- a/apps/src/music/ai/patternAiWorker.ts
+++ b/apps/src/music/ai/patternAiWorker.ts
@@ -89,13 +89,14 @@ const reverseMidiMapping = new Map([
 onmessage = async e => {
   if (e.data[0] === Message.GeneratePattern) {
     try {
+      const startTime = Date.now();
       const result = await generatePattern(
         e.data[1],
         e.data[2],
         e.data[3],
         e.data[4]
       );
-      postMessage([Message.Result, result]);
+      postMessage([Message.Result, result, Date.now() - startTime]);
     } catch (e) {
       // Using setTimeout to ensure the error is handled by the onerror callback.
       setTimeout(() => {

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -216,7 +216,22 @@ export default class AnalyticsReporter {
     this.trackUIEvent('Validation attempt', {passed, message});
   }
 
-  private trackUIEvent(eventType: string, payload: object) {
+  onOpenPatternAiPanel() {
+    this.trackUIEvent('Pattern AI panel opened');
+  }
+
+  onGenerateAiPatternStart() {
+    this.trackUIEvent('Generate AI pattern start');
+  }
+
+  onGenerateAiPatternEnd(timeSeconds: number, isInitialGenerate: boolean) {
+    this.trackUIEvent('Generate AI pattern end', {
+      timeSeconds,
+      isInitialGenerate,
+    });
+  }
+
+  private trackUIEvent(eventType: string, payload: object = {}) {
     const logMessage = `${eventType}. Payload: ${JSON.stringify(payload)}`;
 
     if (!this.session) {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -126,7 +126,6 @@ class UnconnectedMusicView extends React.Component {
       key && Key[key.toUpperCase()],
       this.analyticsReporter
     );
-    MusicRegistry.player = this.player;
     this.musicBlocklyWorkspace = new MusicBlocklyWorkspace();
     this.soundUploader = new SoundUploader(this.player);
     this.playingTriggers = [];
@@ -137,6 +136,11 @@ class UnconnectedMusicView extends React.Component {
       this.player,
       this.getPlayingTriggers
     );
+
+    // Set shared shared objects in the MusicRegistry so views outside of this
+    // React tree (i.e. Blockly fields) can access them.
+    MusicRegistry.player = this.player;
+    MusicRegistry.analyticsReporter = this.analyticsReporter;
 
     // Set default for instructions position.
     const defaultInstructionsPos = AppConfig.getValue(

--- a/apps/src/music/views/PatternAiPanel.tsx
+++ b/apps/src/music/views/PatternAiPanel.tsx
@@ -142,6 +142,11 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
     onChange(currentValue);
   }, [onChange, currentValue]);
 
+  // Report analytics when the panel first opens.
+  useEffect(() => {
+    MusicRegistry.analyticsReporter.onOpenPatternAiPanel();
+  }, []);
+
   useEffect(() => {
     if (!MusicRegistry.player.isInstrumentLoaded(currentValue.instrument)) {
       setIsLoading(true);


### PR DESCRIPTION
This adds three new analytics events to amplitude for the Music AI pattern panel.

- **Pattern AI panel opened** any time the panel is opened
- **Generate AI pattern start** when the Generate button is clicked
- **Generate AI pattern end** when generation completes. This also includes the properties
  - `isInitialGenerate` (true/false) whether this was the first generate of the page load or subsequent (we've seen much higher wait times on the initial generate)
  - `timeSeconds` how long it took to generate

@dju90 let me know if there's any other info we want to track!

Screenshots:
<img width="819" alt="Screenshot 2024-10-14 at 12 24 25 PM" src="https://github.com/user-attachments/assets/452c941b-23f2-4e35-bac6-1a320c83870c">
<img width="829" alt="Screenshot 2024-10-14 at 12 24 34 PM" src="https://github.com/user-attachments/assets/2b4f5e05-1bf8-435a-9dde-161c1c61c915">
<img width="811" alt="Screenshot 2024-10-14 at 12 24 42 PM" src="https://github.com/user-attachments/assets/a82ca78d-8f57-4ced-824e-30b870b859f8">


## Links

https://codedotorg.atlassian.net/browse/LABS-1067

## Testing story

Tested locally with Amplitude