### PR TITLE
Lab2: Cancel TTS on level change and page switch

### DIFF
--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -6,6 +6,7 @@ import TextToSpeech from '@cdo/apps/lab2/views/components/TextToSpeech';
 import FontAwesome from '../legacySharedComponents/FontAwesome';
 import EnhancedSafeMarkdown from '../templates/EnhancedSafeMarkdown';
 import {commonI18n} from '../types/locale';
+import {cancelSpeech} from '../util/BrowserTextToSpeech';
 
 import {Panel} from './types';
 
@@ -91,6 +92,13 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
       setCurrentPanel(Math.max(panels.length - 1, 0));
     }
   }, [currentPanel, panels]);
+
+  // Cancel any in-progress text-to-speech when the panel changes.
+  useEffect(() => {
+    if (offerTts) {
+      cancelSpeech();
+    }
+  }, [currentPanel, offerTts]);
 
   const panel = panels[currentPanel];
   if (!panel) {

--- a/apps/src/util/BrowserTextToSpeech.ts
+++ b/apps/src/util/BrowserTextToSpeech.ts
@@ -11,6 +11,9 @@ let ttsAvailable = speechSynthesis.getVoices().length > 0;
 // Add a listener to update the ttsAvailable flag when voices are loaded.
 onTtsAvailable(isAvailable => (ttsAvailable = isAvailable));
 
+// Stop any speech when the page is changed or refreshed.
+addEventListener('beforeunload', () => speechSynthesis.cancel());
+
 function onTtsAvailable(callback: (isAvailable: boolean) => void) {
   if (ttsAvailable) {
     callback(true);
@@ -39,4 +42,8 @@ function speak(text: string) {
   speechSynthesis.speak(utterance);
 }
 
-export {onTtsAvailable, isTtsAvailable, speak};
+function cancelSpeech() {
+  speechSynthesis.cancel();
+}
+
+export {onTtsAvailable, isTtsAvailable, speak, cancelSpeech};


### PR DESCRIPTION
TTS updates to cancel any in-progress text-to-speech when the level changes or is reloaded (due to view-as user switch), or when the user refreshes or navigates away. Also on Panels levels, cancels speech when the panel changes.

Screencast with audio:

https://github.com/user-attachments/assets/8c971a71-b65e-4463-baf8-d50cb21c04dd

## Testing story

Tested locally on Chrome with TTS flag enabled. Also double checked browser compatibility (though this change does not introduce any new speech synthesis API calls).