### PR TITLE
Adding Country Code to reapply CPA to student user in new sign up flow

### DIFF
--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -27,8 +27,9 @@ import style from './signUpFlowStyles.module.scss';
 const FinishStudentAccount: React.FunctionComponent<{
   ageOptions: {value: string; text: string}[];
   usIp: boolean;
+  countryCode: string;
   usStateOptions: {value: string; text: string}[];
-}> = ({ageOptions, usIp, usStateOptions}) => {
+}> = ({ageOptions, usIp, countryCode, usStateOptions}) => {
   // Fields
   const [isParent, setIsParent] = useState(false);
   const [parentEmail, setParentEmail] = useState('');
@@ -163,6 +164,7 @@ const FinishStudentAccount: React.FunctionComponent<{
         age: age,
         gender: gender,
         us_state: state,
+        country_code: countryCode,
         parent_email_preference_email: parentEmail,
         parent_email_preference_opt_in: parentEmailOptInChecked,
       },

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -27,7 +27,8 @@ import style from './signUpFlowStyles.module.scss';
 
 const FinishTeacherAccount: React.FunctionComponent<{
   usIp: boolean;
-}> = ({usIp}) => {
+  countryCode: string;
+}> = ({usIp, countryCode}) => {
   const schoolInfo = useSchoolInfo({usIp});
   const [name, setName] = useState('');
   const [showNameError, setShowNameError] = useState(false);
@@ -87,6 +88,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
         name: name,
         email_preference_opt_in: emailOptInChecked,
         school_info_attributes: {...schoolInfo},
+        country_code: countryCode,
       },
     };
     const authToken = await getAuthenticityToken();

--- a/apps/src/sites/studio/pages/devise/registrations/finish_student_account.js
+++ b/apps/src/sites/studio/pages/devise/registrations/finish_student_account.js
@@ -9,11 +9,13 @@ $(document).ready(() => {
   const ageOptions = getScriptData('ageOptions');
   const usIp = getScriptData('usIp');
   const usStateOptions = getScriptData('usStateOptions');
+  const countryCode = getScriptData('countryCode');
 
   ReactDOM.render(
     <FinishStudentAccount
       ageOptions={ageOptions}
       usIp={usIp}
+      countryCode={countryCode}
       usStateOptions={usStateOptions}
     />,
     document.getElementById('finish-student-account-root')

--- a/apps/src/sites/studio/pages/devise/registrations/finish_teacher_account.js
+++ b/apps/src/sites/studio/pages/devise/registrations/finish_teacher_account.js
@@ -7,8 +7,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 
 $(document).ready(() => {
   const usIp = getScriptData('usIp');
+  const countryCode = getScriptData('countryCode');
   ReactDOM.render(
-    <FinishTeacherAccount usIp={usIp} />,
+    <FinishTeacherAccount usIp={usIp} countryCode={countryCode} />,
     document.getElementById('finish-teacher-account-root')
   );
 });

--- a/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
@@ -341,6 +341,7 @@ describe('FinishStudentAccount', () => {
     const age = '6';
     const gender = 'Female';
     const state = 'AZ';
+    const country = 'US';
     const parentEmail = 'parent@email.com';
     const finishSignUpParams = {
       new_sign_up: true,
@@ -351,6 +352,7 @@ describe('FinishStudentAccount', () => {
         age: age,
         gender: gender,
         us_state: state,
+        country_code: country,
         parent_email_preference_email: parentEmail,
         parent_email_preference_opt_in: true,
       },

--- a/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
@@ -54,6 +54,7 @@ describe('FinishStudentAccount', () => {
       <FinishStudentAccount
         ageOptions={ageOptions}
         usIp={usIp}
+        countryCode={'US'}
         usStateOptions={usStateOptions}
       />
     );

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -36,7 +36,7 @@ describe('FinishTeacherAccount', () => {
   });
 
   function renderDefault(usIp: boolean = true) {
-    render(<FinishTeacherAccount usIp={usIp} />);
+    render(<FinishTeacherAccount usIp={usIp} countryCode={'US'} />);
   }
 
   it('renders finish teacher account page with school zip when usIp is true', () => {

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -197,6 +197,7 @@ describe('FinishTeacherAccount', () => {
           schoolsList: [],
           usIp: true,
         },
+        country_code: 'US',
       },
     };
     sessionStorage.setItem('email', email);

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -95,8 +95,9 @@ class RegistrationsController < Devise::RegistrationsController
     @age_options = [{value: '', text: ''}] + User::AGE_DROPDOWN_OPTIONS.map do |age|
       {value: age.to_s, text: age.to_s}
     end
-
-    @us_ip = us_ip?
+    location = Geocoder.search(request.ip).try(:first)
+    @country_code = location&.country_code.to_s.upcase
+    @us_ip = ['US', 'RD'].include?(@country_code)
     @us_state_options = [{value: '', text: ''}] + User.us_state_dropdown_options.map do |code, name|
       {value: code, text: name}
     end
@@ -108,7 +109,9 @@ class RegistrationsController < Devise::RegistrationsController
   # Get /users/new_sign_up/finish_teacher_account
   #
   def finish_teacher_account
-    @us_ip = us_ip?
+    location = Geocoder.search(request.ip).try(:first)
+    @country_code = location&.country_code.to_s.upcase
+    @us_ip = ['US', 'RD'].include?(@country_code)
     render 'finish_teacher_account'
   end
 

--- a/dashboard/app/views/devise/registrations/finish_student_account.haml
+++ b/dashboard/app/views/devise/registrations/finish_student_account.haml
@@ -1,5 +1,5 @@
 = render 'devise/registrations/new_sign_up_locale'
 
-%script{src: webpack_asset_path('js/devise/registrations/finish_student_account.js'), data: {ageOptions: @age_options.to_json, usIp: @us_ip.to_json, usStateOptions: @us_state_options.to_json}}
+%script{src: webpack_asset_path('js/devise/registrations/finish_student_account.js'), data: {ageOptions: @age_options.to_json, usIp: @us_ip.to_json, countryCode: @country_code.to_json, usStateOptions: @us_state_options.to_json}}
 
 #finish-student-account-root

--- a/dashboard/app/views/devise/registrations/finish_teacher_account.haml
+++ b/dashboard/app/views/devise/registrations/finish_teacher_account.haml
@@ -1,5 +1,5 @@
 = render 'devise/registrations/new_sign_up_locale'
 
-%script{src: webpack_asset_path('js/devise/registrations/finish_teacher_account.js'), data: {usIp: @us_ip.to_json}}
+%script{src: webpack_asset_path('js/devise/registrations/finish_teacher_account.js'), data: {usIp: @us_ip.to_json, countryCode: @country_code.to_json}}
 
 #finish-teacher-account-root

--- a/dashboard/lib/services/partial_registration/user_builder.rb
+++ b/dashboard/lib/services/partial_registration/user_builder.rb
@@ -71,6 +71,7 @@ module Services
           :age,
           :gender,
           :us_state,
+          :country_code,
           :parent_email_preference_email,
           :parent_email_preference_opt_in,
           :parent_email_preference_request_ip,


### PR DESCRIPTION
The CPA experience was not happening when we created a new student user on the back end because we were not saving country code. This PR pipes country code through to the user object for both students and teachers.  I followed this idea from a conversation with Carl from platform- [context here](https://codedotorg.slack.com/archives/CFTFD6BPV/p1728939763172929). 

I was able to verify that adding the country code causes me to land on the /lockout screen!

https://github.com/user-attachments/assets/7a30a112-9b15-4a77-8d0a-4ede4e7821de


I ended up refactoring the us_ip call a bit in the registrations_controller because I was already doing the first two lines of that helper function to get the country_code (so avoided calling those two lines twice). 

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2464

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
