### PR TITLE
[test eyes] Flaky test - waiting for table to load using td:contains first name

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/manage_students_tab_views_eyes.feature
@@ -14,7 +14,7 @@ Feature: Using the manage students tab of the teacher dashboard
     And I wait until element "#uitest-manage-students-table" is visible
 
     # Add a family name for Sally
-    And I wait until element "span:contains('SallyHasAVeryVeryLongFirstName')" is visible
+    And I wait until element "td:contains('SallyHasAVeryVeryLongFirstName')" is visible
     And I click selector "#uitest-manage-students-table th:contains(Actions) i" once I see it
     And I click selector ".pop-up-menu-item:contains(Edit all)" once I see it
     And I wait until element with css selector "input[name='uitest-family-name']" is enabled


### PR DESCRIPTION
This is a fix to the original change in [this](https://github.com/code-dot-org/code-dot-org/pull/61692) PR to address flakiness in eyes test manage_student_view_eyes. 

Issue: The teacher_dashboard_manage_students_tab_views_eyes test intermittently fails at the step where student's last name is edited, due to the input field not being visible.

Root cause: In some cases the "Edit all" button is pressed before the student table is loaded with data, resulting in the edit button click leading to no-op.

The first attempt to fix this issue waited for the table to load by waiting for span containing student first name. But since the teacher's name contained the same student first name and it was available in the span at the nav bar top  right, this check did not help.

Fix: Using a more specific check to look for the first name in a table instead of just a span tag.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

JIRA https://codedotorg.atlassian.net/browse/TEACH-1262

## Testing story

Drone: https://app.saucelabs.com/tests/858042db682f4aa393888e9c24f85a4f#55

## Deployment strategy

DTP

## Follow-up work

Monitor the test issues are fixed 

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
