### PR TITLE
fix: wait for onetrust reset before proceeding with test

### DIFF
--- a/dashboard/test/ui/features/platform/one_trust.feature
+++ b/dashboard/test/ui/features/platform/one_trust.feature
@@ -4,6 +4,7 @@ Feature: OneTrust integration
   Scenario: User sees OneTrust cookie pop-up when self-hosting OneTrust libraries on hourofcode
     Given I am in Europe
     Given I am on "http://hourofcode.com/es?otreset=true&otgeo=es"
+    And I wait until current URL contains "otreset=false"
     And I open my eyes to test "Hour of code Onetrust pop up"
     And I wait until element "#onetrust-banner-sdk" is visible
     And I see no difference for "Onetrust pop up: Hour of Code" using stitch mode "none"
@@ -14,6 +15,7 @@ Feature: OneTrust integration
     Given I create a student named "Alice"
     Given I am in Europe
     Given I am on "http://studio.code.org/home?otreset=true&otgeo=es"
+    And I wait until current URL contains "otreset=false"
     And I open my eyes to test "Code.org Onetrust pop up"
     And I wait until element "#onetrust-banner-sdk" is visible
     And I see no difference for "Onetrust pop up: code.org" using stitch mode "none"
@@ -22,12 +24,14 @@ Feature: OneTrust integration
   Scenario: OneTrust cookie pop-up shows when self-hosting OneTrust libraries on hourofocode
     Given I am in Europe
     Given I am on "http://hourofcode.com/es?otreset=true&otgeo=es"
+    And I wait until current URL contains "otreset=false"
     And I wait until element "#onetrust-banner-sdk" is visible
 
   Scenario: OneTrust cookie pop-up shows when self-hosting OneTrust libraries on code.org
     Given I create a student named "Alice"
     Given I am in Europe
     Given I am on "http://studio.code.org/home?otreset=true&otgeo=es"
+    And I wait until current URL contains "otreset=false"
     And I wait until element "#onetrust-banner-sdk" is visible
 
   Scenario: The pages load the self hosted OneTrust libraries.


### PR DESCRIPTION
The onetrust UI tests navigate to the `otReset=true` path but this `otReset=true` causes the page to refresh with a new url `otReset=false`. If the jquery script is executed prior to the new page being loaded, the test will fail. If executed after the new page loads, the test will pass.

This updates the test to wait for the new page to be loaded before proceeding with the test.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [jira ticket](https://codedotorg.atlassian.net/browse/P20-1235)

## Testing story

```
./runner.rb  -f features/platform/one_trust.feature -c Safari
```

Tests passed 5/5 times

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
