### PR TITLE
Fix a bug where teacher dashboard would not load if teacher only had one section

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -72,7 +72,7 @@ $(document).ready(function () {
   store.dispatch(
     setCurrentUserHasSeenStandardsReportInfo(hasSeenStandardsReportInfo)
   );
-  store.dispatch(setSections(sections));
+  store.dispatch(setSections(sections, false));
   store.dispatch(setLocaleCode(localeCode));
 
   const showAITutorTab = canViewStudentAIChatMessages;

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -200,7 +200,11 @@ export const pageTypes = {
  * Set the list of sections to display.
  * @param sections
  */
-export const setSections = sections => ({type: SET_SECTIONS, sections});
+export const setSections = (sections, autoSelectOnlySection = true) => ({
+  type: SET_SECTIONS,
+  sections,
+  autoSelectOnlySection,
+});
 export const selectSection = sectionId => ({type: SELECT_SECTION, sectionId});
 export const removeSection = sectionId => ({type: REMOVE_SECTION, sectionId});
 export const updateSelectedSection = section => ({
@@ -784,7 +788,10 @@ export default function teacherSections(state = initialState, action) {
 
     let selectedSectionId = state.selectedSectionId;
     // If we have only one section, autoselect it
-    if (Object.keys(action.sections).length === 1) {
+    if (
+      action.autoSelectOnlySection &&
+      Object.keys(action.sections).length === 1
+    ) {
       selectedSectionId = action.sections[0].id;
     }
 

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -267,6 +267,12 @@ describe('teacherSectionsRedux', () => {
       assert.strictEqual(nextState.selectedSectionId, sections[0].id);
     });
 
+    it('does not set selectedSectionId if passed a single section and autoSelect false', () => {
+      const action = setSections(sections.slice(0, 1), false);
+      const nextState = reducer(startState, action);
+      assert.strictEqual(nextState.selectedSectionId, NO_SECTION);
+    });
+
     it('throws rather than let us destroy data', () => {
       const action = setSections(sections);
       const nextState = reducer(startState, action);


### PR DESCRIPTION
When a teacher has one section, by default, that section is selected. We then have logic that we only load section data if we don't have a section selected or the new section to select is different from the selected section. The auto-selected section was then never loaded from the BE and caused errors like thinking the section did not have any students.

In the v2 teacher dashboard, we do not want to auto-select a section. We always want to select the section that is the URL parameters after the section data is loaded. Therefore, this PR prevents the auto-selection of a section when on the teacher dashboard.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1420
