### PR TITLE
Fix dropdown styling width on Finish Student Account page

### DIFF
--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -244,6 +244,7 @@ const FinishStudentAccount: React.FunctionComponent<{
           <div>
             <SimpleDropdown
               name="userAge"
+              className={style.dropdownContainer}
               labelText={locale.what_is_your_age()}
               size="m"
               items={ageOptions}
@@ -260,6 +261,7 @@ const FinishStudentAccount: React.FunctionComponent<{
             <div>
               <SimpleDropdown
                 name="userState"
+                className={style.dropdownContainer}
                 labelText={locale.what_state_are_you_in()}
                 size="m"
                 items={usStateOptions}

--- a/apps/src/signUpFlow/signUpFlowStyles.module.scss
+++ b/apps/src/signUpFlow/signUpFlowStyles.module.scss
@@ -475,6 +475,10 @@ span {
       margin: 0.375rem 0 !important;
     }
   }
+
+  .dropdownContainer div {
+    width: 100%;
+  }
 }
 
 .finishSignUpButtonContainer {


### PR DESCRIPTION
Persumably from an update to the dropdown component, the styling of dropdowns on the [Finish Student Account page](https://studio.code.org/users/new_sign_up/finish_student_account) had inconsistent widths:
![current look](https://github.com/user-attachments/assets/a3341427-59fb-4c90-a04d-488a4dde8142)

This PR fixes that styling:
![FIXED STUDENT](https://github.com/user-attachments/assets/b6bd7fba-dca6-4cb6-a33e-125f05cbce1c)

And does not affect the Finish Teacher Account page (which still looks good on production):
![teacher unchanged](https://github.com/user-attachments/assets/304d786e-41f6-479d-a190-0a93ebad76aa)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2529)

## Testing story
Local testing.
