### PR TITLE
Update /yourschool map to use Code.org colors

### DIFF
--- a/apps/src/templates/census/CensusMap.jsx
+++ b/apps/src/templates/census/CensusMap.jsx
@@ -18,35 +18,35 @@ class CensusMapInfoWindow extends Component {
 
   render() {
     let censusMessage;
-    let color = '';
+    let responseColorStyle = '';
 
     switch (this.props.teachesCs) {
       case 'YES':
       case 'Y':
         censusMessage = 'We believe this school offers Computer Science.';
-        color = 'legend-offers-cs';
+        responseColorStyle = 'legend-offers-cs';
         break;
       case 'NO':
       case 'N':
         censusMessage =
           'We believe this school offers no Computer Science opportunities.';
-        color = 'legend-limited-cs';
+        responseColorStyle = 'legend-limited-cs';
         break;
       case 'HISTORICAL_YES':
       case 'HY':
         censusMessage =
           'We believe this school historically offered Computer Science.';
-        color = 'legend-offers-cs';
+        responseColorStyle = 'legend-offers-cs';
         break;
       case 'HISTORICAL_NO':
       case 'HN':
         censusMessage =
           'We believe this school historically offered no Computer Science opportunities.';
-        color = 'legend-limited-cs';
+        responseColorStyle = 'legend-limited-cs';
         break;
       default:
         censusMessage = 'We need data for this school.';
-        color = 'legend-no-data-cs';
+        responseColorStyle = 'legend-no-data-cs';
     }
 
     const schoolDropdownOption = {
@@ -62,7 +62,7 @@ class CensusMapInfoWindow extends Component {
       },
     };
 
-    const colorClass = `color-small ${color}`;
+    const colorClass = `color-small ${responseColorStyle}`;
 
     return (
       <div id="census-info-window" className="census-info-window">

--- a/apps/src/templates/census/CensusMap.jsx
+++ b/apps/src/templates/census/CensusMap.jsx
@@ -24,29 +24,29 @@ class CensusMapInfoWindow extends Component {
       case 'YES':
       case 'Y':
         censusMessage = 'We believe this school offers Computer Science.';
-        color = 'green';
+        color = 'legend-offers-cs';
         break;
       case 'NO':
       case 'N':
         censusMessage =
           'We believe this school offers no Computer Science opportunities.';
-        color = 'blue';
+        color = 'legend-limited-cs';
         break;
       case 'HISTORICAL_YES':
       case 'HY':
         censusMessage =
           'We believe this school historically offered Computer Science.';
-        color = 'green';
+        color = 'legend-offers-cs';
         break;
       case 'HISTORICAL_NO':
       case 'HN':
         censusMessage =
           'We believe this school historically offered no Computer Science opportunities.';
-        color = 'blue';
+        color = 'legend-limited-cs';
         break;
       default:
         censusMessage = 'We need data for this school.';
-        color = 'white';
+        color = 'legend-no-data-cs';
     }
 
     const schoolDropdownOption = {
@@ -207,10 +207,10 @@ export default class CensusMap extends Component {
             'match',
             ['get', 'teaches_cs'],
             ['NO', 'N', 'HISTORICAL_NO', 'HN'],
-            '#989CF8',
+            '#8C52BA',
             'white',
           ],
-          'circle-stroke-width': 1,
+          'circle-stroke-width': 0.5,
           'circle-stroke-color': '#000000',
         },
         filter: [
@@ -224,14 +224,23 @@ export default class CensusMap extends Component {
       });
       _this.map.addLayer({
         id: 'census-schools-teaching-cs',
-        type: 'symbol',
+        type: 'circle',
         source: _this.props.tileset,
         'source-layer': 'census',
         layout: {
-          'icon-image': 'marker-15-green',
-          'icon-allow-overlap': true,
-          // Increase the icon size as we zoom in
-          'icon-size': ['interpolate', ['linear'], ['zoom'], 1, 0.7, 14, 1.6],
+          visibility: 'visible',
+        },
+        paint: {
+          'circle-radius': 4,
+          'circle-color': [
+            'match',
+            ['get', 'teaches_cs'],
+            ['YES', 'Y', 'HISTORICAL_YES', 'HY'],
+            '#0093A4',
+            'white',
+          ],
+          'circle-stroke-width': 0.5,
+          'circle-stroke-color': '#000000',
         },
         filter: [
           'any',

--- a/pegasus/sites.v3/code.org/public/css/census-map.css
+++ b/pegasus/sites.v3/code.org/public/css/census-map.css
@@ -79,13 +79,15 @@
   font-size: 18px;
   color: #008b9a;
   font-weight: bold;
-  margin-bottom: 5px;
+  margin-bottom: 8px;
 }
 
 .color {
   border: 1px solid;
+  border-radius: 50%;
   height: 12px;
   width: 12px;
+  margin-top: 1px;
   margin-right: 3px;
   float: left;
 }
@@ -184,19 +186,18 @@
 }
 
 #census-map .legend-offers-cs {
-  background-color: #66DC57;
+  background-color: #0093A4;
+  border-color: #0093A4;
 }
 
 #census-map .legend-limited-cs {
-  background-color: #989CF8;
-}
-
-#census-map .legend-inconclusive-cs {
-  background-color: #FFFDA6;
+  background-color: #8C52BA;
+  border-color: #8C52BA;
 }
 
 #census-map .legend-no-data-cs {
   background-color: #FFFFFF;
+  border-color: #D1D4D8;
 }
 
 .mapboxgl-map button {

--- a/pegasus/sites.v3/code.org/public/css/census-map.css
+++ b/pegasus/sites.v3/code.org/public/css/census-map.css
@@ -95,6 +95,7 @@
 .color-small {
   display: inline-block;
   border: 1px solid;
+  border-radius: 50%;
   height: 10px;
   width: 10px;
   margin-right: 8px;


### PR DESCRIPTION
Updates the [/yourschool map](https://code.org/yourschool) to use the code.org colors.

## Previous look
![PREVIOUS](https://github.com/user-attachments/assets/6aeab74f-6fe4-4f55-9f26-fd0bab4e6493)

## New look
![new map look](https://github.com/user-attachments/assets/1d3f0ae6-b41c-4339-858e-e54e3e7886b1)

Selected school that teaches CS:
![zoom in YES](https://github.com/user-attachments/assets/6de26e18-3e4a-4389-97fd-e4fceb4d7de6)

Selected school that does not teach CS:
![zoom in NO](https://github.com/user-attachments/assets/59ad977c-1045-48df-baf4-258d723d695a)

Selected school with unknown data:
![zoom in IDK](https://github.com/user-attachments/assets/48164157-bcb6-4d16-9e01-4f6903dec211)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2476)
Figma: [here](https://www.figma.com/design/DQzjYf8Kuti11l5f30uu9J/State-of-CS-2024?node-id=2312-8973&node-type=frame&t=VWAKBv4s4N1rpH4P-0)

## Testing story
Local testing.
