### PR TITLE
limit ai score text width when student name is too long

### DIFF
--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -615,6 +615,9 @@ p.aiAssessmentScoreText {
   strong::after {
     content: ' ';
   }
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 p.aiAssessmentEvidenceBlock {


### PR DESCRIPTION
Quick fit-and-finish fix for a text overflow issue I noticed while testing long student names.

### before

![376787083-bbabe883-c34b-4f49-8fb2-a00b43d83715](https://github.com/user-attachments/assets/3b2e8988-d5bb-4d52-af2c-833d49c17a31)

### after

![Screenshot 2024-10-15 at 1 16 55 PM](https://github.com/user-attachments/assets/d4a7e18e-7cc3-4c69-875e-4f000933a989)
