### PR TITLE
Block CAP-affected users from adding personal email logins

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1808,7 +1808,7 @@
   "manageLinkedAccounts": "Manage Linked Accounts",
   "manageLinkedAccounts_actions": "Actions",
   "manageLinkedAccounts_noLoginTooltip": "To make sure you can still sign in to your account, please add a password or another linked account first.",
-  "manageLinkedAccounts_stateRequired": "Uh oh! Please provide your state before adding a linked account.",
+  "manageLinkedAccounts_ageAndStateRequired": "Uh oh! Please provide your age and state before adding a linked account.",
   "manageLinkedAccounts_parentalPermissionRequired": "Uh oh! You must obtain parental permission before creating a linked account.",
   "manageLinkedAccounts_clever": "Clever Account",
   "manageLinkedAccounts_connect": "Connect",

--- a/apps/src/accounts/AddPasswordController.js
+++ b/apps/src/accounts/AddPasswordController.js
@@ -4,15 +4,23 @@ import ReactDOM from 'react-dom';
 import AddPasswordForm from './AddPasswordForm';
 
 export default class AddPasswordController {
-  constructor(form, mountPoint) {
+  constructor(form, mountPoint, disabled = false, userAge, userUsState) {
     this.form = form;
     this.mountPoint = mountPoint;
+    this.disabled = disabled;
+    this.userAge = userAge;
+    this.userUsState = userUsState;
     this.renderAddPasswordForm();
   }
 
   renderAddPasswordForm = () => {
     ReactDOM.render(
-      <AddPasswordForm handleSubmit={this.submitAddPassword} />,
+      <AddPasswordForm
+        handleSubmit={this.submitAddPassword}
+        disabled={this.disabled}
+        userAge={this.userAge}
+        userUsState={this.userUsState}
+      />,
       this.mountPoint
     );
   };

--- a/apps/src/accounts/AddPasswordForm.jsx
+++ b/apps/src/accounts/AddPasswordForm.jsx
@@ -27,6 +27,9 @@ const DEFAULT_STATE = {
 export default class AddPasswordForm extends React.Component {
   static propTypes = {
     handleSubmit: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
+    userAge: PropTypes.number,
+    userUsState: PropTypes.string,
   };
 
   state = DEFAULT_STATE;
@@ -110,21 +113,29 @@ export default class AddPasswordForm extends React.Component {
 
   render() {
     const {password, passwordConfirmation, submissionState} = this.state;
+    const {disabled, userAge, userUsState} = this.props;
     let statusTextStyles = styles.statusText;
     statusTextStyles = submissionState.isError
       ? {...statusTextStyles, ...styles.errorText}
       : statusTextStyles;
+    const disabledHint =
+      userAge && userUsState
+        ? i18n.manageLinkedAccounts_parentalPermissionRequired()
+        : i18n.manageLinkedAccounts_ageAndStateRequired();
 
     return (
       <div style={styles.container}>
         <hr />
         <h2 style={styles.header}>{i18n.addPassword()}</h2>
-        <div style={styles.hint}>{i18n.addPasswordHint()}</div>
+        <div style={styles.hint}>
+          {disabled ? disabledHint : i18n.addPasswordHint()}
+        </div>
         <PasswordField
           label={i18n.password()}
           error={this.minimumLengthError(password)}
           value={password}
           onChange={this.onPasswordChange}
+          disabled={disabled}
         />
         <PasswordField
           label={i18n.passwordConfirmation()}
@@ -134,6 +145,7 @@ export default class AddPasswordForm extends React.Component {
           }
           value={passwordConfirmation}
           onChange={this.onPasswordConfirmationChange}
+          disabled={disabled}
         />
         <div style={styles.buttonContainer}>
           <div id="uitest-add-password-status" style={statusTextStyles}>
@@ -157,10 +169,11 @@ class PasswordField extends React.Component {
     error: PropTypes.string,
     value: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
   };
 
   render() {
-    const {label, value, onChange, error} = this.props;
+    const {label, value, onChange, error, disabled} = this.props;
     return (
       <Field label={label} error={error}>
         <input
@@ -171,6 +184,7 @@ class PasswordField extends React.Component {
           maxLength="255"
           size="255"
           style={styles.input}
+          disabled={disabled}
         />
       </Field>
     );

--- a/apps/src/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/accounts/ManageLinkedAccounts.jsx
@@ -57,6 +57,7 @@ class ManageLinkedAccounts extends React.Component {
     isCleverStudent: PropTypes.bool.isRequired,
     personalAccountLinkingEnabled: PropTypes.bool.isRequired,
     usStateCode: PropTypes.string,
+    age: PropTypes.number,
     lmsName: PropTypes.string,
   };
 
@@ -230,9 +231,9 @@ class ManageLinkedAccounts extends React.Component {
         {lockedOptions.length > 0 && (
           <>
             <p style={styles.message}>
-              {this.props.usStateCode
+              {this.props.usStateCode && this.props.age
                 ? i18n.manageLinkedAccounts_parentalPermissionRequired()
-                : i18n.manageLinkedAccounts_stateRequired()}
+                : i18n.manageLinkedAccounts_ageAndStateRequired()}
             </p>
             <div style={styles.lockContainer}>
               <table style={{...styles.table, ...styles.lockedTable}}>
@@ -281,6 +282,7 @@ export default connect(state => ({
   personalAccountLinkingEnabled:
     state.manageLinkedAccounts.personalAccountLinkingEnabled,
   usStateCode: state.currentUser.usStateCode,
+  age: state.currentUser.age,
   lmsName: state.manageLinkedAccounts.lmsName,
 }))(ManageLinkedAccounts);
 

--- a/apps/src/sites/studio/pages/devise/registrations/edit.js
+++ b/apps/src/sites/studio/pages/devise/registrations/edit.js
@@ -25,6 +25,8 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 const scriptData = getScriptData('edit');
 const {
   userType,
+  userAge,
+  userUsState,
   isAdmin,
   isPasswordRequired,
   authenticationOptions,
@@ -94,7 +96,13 @@ $(document).ready(() => {
 
   const addPasswordMountPoint = document.getElementById('add-password-fields');
   if (addPasswordMountPoint) {
-    new AddPasswordController($('#add-password-form'), addPasswordMountPoint);
+    new AddPasswordController(
+      $('#add-password-form'),
+      addPasswordMountPoint,
+      !personalAccountLinkingEnabled,
+      userAge,
+      userUsState
+    );
   }
 
   const ltiSyncSettingsMountPoint =

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -247,6 +247,7 @@ export default function currentUser(state = initialState, action) {
       child_account_compliance_state,
       country_code,
       us_state_code,
+      age,
       in_section,
       created_at,
       is_verified_instructor,
@@ -286,6 +287,7 @@ export default function currentUser(state = initialState, action) {
       childAccountComplianceState: child_account_compliance_state,
       countryCode: country_code,
       usStateCode: us_state_code,
+      age,
       inSection: in_section,
       userCreatedAt: created_at,
     };

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -40,6 +40,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
         child_account_compliance_state: current_user.cap_status,
         country_code: helpers.country_code(current_user, request),
         us_state_code: current_user.us_state_code,
+        age: current_user.age,
         in_section: current_user.student? ? current_user.sections_as_student.present? : nil,
         created_at: current_user.created_at,
         has_seen_ai_assessments_announcement: current_user.has_seen_ai_assessments_announcement?,

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -458,40 +458,26 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def edit
     @permission_status = current_user.cap_status
+    cpa_partial_locked_enabled = !!experiment_value('cpa-partial-lockout', request)
 
     # Get the request location
     location = Geocoder.search(request.ip).try(:first)
     @country_code = location&.country_code.to_s.upcase
     @is_usa = ['US', 'RD'].include?(@country_code)
 
-    # We determine if the student is potentially locked by looking at their age
-    # If they are older (or there is no policy for them) they are unlocked
-    # This ignores them being explicitly unlocked by parental permission so we
-    # can show the 'Granted' status of that permission later.
-    @potentially_locked = Policies::ChildAccount.underage?(current_user)
+    # A student is underage if they reside in a state with a CAP policy and are in the affected age range.
+    underage = Policies::ChildAccount.underage?(current_user)
 
     # The student is in a 'lockout' flow if they are potentially locked out and not unlocked
-    @student_in_lockout_flow = @potentially_locked && !Policies::ChildAccount::ComplianceState.permission_granted?(current_user)
-    # We need to also account for the case when the US State is not specified
-    # All students are locked out of account settings features until they specify these
-    @locked = @student_in_lockout_flow || current_user.country_code.nil? || current_user.us_state.nil?
-    # Only for students
-    @locked &&= current_user.student?
-    # Only for US-based requests
-    @locked &&= @is_usa
-    # Put this behind an experiment flag for now
-    @locked &&= !!experiment_value('cpa-partial-lockout', request)
+    @student_in_lockout_flow = underage && !Policies::ChildAccount::ComplianceState.permission_granted?(current_user)
 
-    @personal_account_linking_enabled = !@locked
+    @personal_account_linking_enabled = Policies::ChildAccount.can_link_new_personal_account?(current_user) && !Policies::ChildAccount.partially_locked_out?(current_user) && cpa_partial_locked_enabled
 
     # Handle users who aren't locked out, but still need parent permission to link personal accounts.
-    if @potentially_locked
+    if underage || !Policies::ChildAccount.has_required_information?(current_user)
       permission_request = current_user.latest_parental_permission_request
       @pending_email = permission_request&.parent_email
       @request_date = permission_request&.updated_at || Date.new
-
-      partially_locked = Policies::ChildAccount.partially_locked_out?(current_user) && experiment_value('cpa-partial-lockout', request)
-      @personal_account_linking_enabled = false if partially_locked
     end
   end
 

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -458,7 +458,7 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def edit
     @permission_status = current_user.cap_status
-    cpa_partial_locked_enabled = !!experiment_value('cpa-partial-lockout', request)
+    cpa_partial_lockout_enabled = !!experiment_value('cpa-partial-lockout', request)
 
     # Get the request location
     location = Geocoder.search(request.ip).try(:first)
@@ -471,7 +471,7 @@ class RegistrationsController < Devise::RegistrationsController
     # The student is in a 'lockout' flow if they are potentially locked out and not unlocked
     @student_in_lockout_flow = underage && !Policies::ChildAccount::ComplianceState.permission_granted?(current_user)
 
-    @personal_account_linking_enabled = Policies::ChildAccount.can_link_new_personal_account?(current_user) && !Policies::ChildAccount.partially_locked_out?(current_user) && cpa_partial_locked_enabled
+    @personal_account_linking_enabled = Policies::ChildAccount.can_link_new_personal_account?(current_user) && !Policies::ChildAccount.partially_locked_out?(current_user) && cpa_partial_lockout_enabled
 
     # Handle users who aren't locked out, but still need parent permission to link personal accounts.
     if underage || !Policies::ChildAccount.has_required_information?(current_user)

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -72,7 +72,7 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put, id: 'lti-sync-settings-form'}) do |f|
     = f.hidden_field :lti_roster_sync_enabled
 
-- if @potentially_locked && experiment_value('cpa-partial-lockout', request)
+- if !@personal_account_linking_enabled && experiment_value('cpa-partial-lockout', request)
   %div#lockout-linked-accounts{
     data: {
       request_date: @request_date&.iso8601,
@@ -93,7 +93,7 @@
   %h2= t('user.create_personal_login')
 
   %p#edit_user_create_personal_account_description
-    - if @locked
+    - unless @personal_account_linking_enabled
       - if current_user.us_state.nil?
         = t('user.create_personal_login_state_required')
       - else
@@ -102,14 +102,14 @@
       = no_email ? t('user.create_personal_login_under_13_info') : t('user.create_personal_login_info')
       = t('user.create_personal_login_link_account') if current_user.migrated?
   .div{style: 'position: relative'}
-    = form_for(current_user, url: '/users/upgrade', html: {id: 'edit_user_create_personal_account', style: (@locked ? 'opacity: 0.25;' : '')}, namespace: 'create_personal') do |form|
+    = form_for(current_user, url: '/users/upgrade', html: {id: 'edit_user_create_personal_account', style: (!@personal_account_linking_enabled ? 'opacity: 0.25;' : '')}, namespace: 'create_personal') do |form|
       = form.hidden_field :hashed_email
       %h3= t('user.enter_new_login_info')
       - if no_email
         = hidden_field_tag :noEmail, true
         .field
           = form.label t('user.create_personal_login_under_13_username'), class: "label-bold"
-          = form.text_field :username, maxlength: 255, disabled: @locked
+          = form.text_field :username, maxlength: 255, disabled: !@personal_account_linking_enabled
       - else
         .field
           = form.label :personal_email, class: "label-bold" do
@@ -118,26 +118,26 @@
           = form.email_field :email, placeholder: '', autocomplete: 'off', maxlength: 255
       .field
         = form.label :password, maxlength: 255, class: "label-bold"
-        = form.password_field :password, autocomplete: 'off', maxlength: 255, disabled: @locked
+        = form.password_field :password, autocomplete: 'off', maxlength: 255, disabled: !@personal_account_linking_enabled
       .field
         = form.label :password_confirmation, class: "label-bold"
         = form.password_field :password_confirmation, autocomplete: 'off', maxlength: 255
-      - if !@locked
+      - if @personal_account_linking_enabled
         - if current_user.secret_word_account?
           %h3= t('user.confirm_secret_words')
           .field
             = form.label :secret_words, class: "label-bold"
-            = form.text_field :secret_words, autocomplete: 'off', value: '', maxlength: 255, disabled: @locked
+            = form.text_field :secret_words, autocomplete: 'off', value: '', maxlength: 255, disabled: !@personal_account_linking_enabled
         - if no_email
           %h3= t('user.enter_parent_email')
           .field
             = form.label t('user.create_personal_login_under_13_parent_email'), class: "label-bold"
-            = form.text_field :parent_email, maxlength: 255, disabled: @locked
+            = form.text_field :parent_email, maxlength: 255, disabled: !@personal_account_linking_enabled
         = t('user.create_personal_login_terms_markdown', terms_of_service_url: CDO.code_org_url('/tos'), markdown: true).html_safe
         - unless no_email
           = t('user.create_personal_login_email_note_markdown', privacy_policy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
         %div= form.submit t('crud.submit'), id: 'create-personal-login', class: 'btn btn-warning'
-    - if @locked
+    - if !@personal_account_linking_enabled
       %div{style: 'position: absolute; left: 0; right: 0; top: 0; bottom: 0; display: flex; flex-direction: row; align-items: center; justify-content: center; pointer-events: none'}
         %img{src: asset_path('auth/lock.svg'), style: 'width: 3rem; height: 3rem'}
 
@@ -214,6 +214,7 @@
       userDisplayName: current_user.name,
       userEmail: current_user.email,
       userProperties: current_user.properties,
+      userUsState: current_user.us_state,
       isAdmin: current_user.admin,
       isOauth: current_user.oauth?,
       isPasswordRequired: current_user.encrypted_password.present?,

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -72,7 +72,7 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put, id: 'lti-sync-settings-form'}) do |f|
     = f.hidden_field :lti_roster_sync_enabled
 
-- if !@personal_account_linking_enabled && experiment_value('cpa-partial-lockout', request)
+- if (!@personal_account_linking_enabled || Policies::ChildAccount::ComplianceState.permission_granted?(current_user)) && experiment_value('cpa-partial-lockout', request)
   %div#lockout-linked-accounts{
     data: {
       request_date: @request_date&.iso8601,

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -196,11 +196,16 @@ class Policies::ChildAccount
   # Whether or not the user can create/link new personal logins
   def self.can_link_new_personal_account?(user)
     return true unless user.student?
-    return false unless user.us_state && user.country_code
-    return true unless user.birthday
+    return false unless has_required_information?(user)
+    return true unless ['US', 'RD'].include?(user.country_code)
     return true unless underage?(user)
 
     ComplianceState.permission_granted?(user)
+  end
+
+  # Returns true if the user has provided the minimum information we need to decide if their account is affected by our Child Account Policy.
+  def self.has_required_information?(user)
+    [user.us_state, user.country_code, user.birthday].all?(&:present?)
   end
 
   # Check if parent permission is required for this account according to our

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -468,8 +468,8 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
     context 'when the user is a student without a birthday' do
       let(:user_birthday) {nil}
 
-      it 'returns true' do
-        _(can_link_new_personal_account?).must_equal true
+      it 'returns false' do
+        _(can_link_new_personal_account?).must_equal false
       end
     end
 


### PR DESCRIPTION
This solves a few issues relating to LTI accounts and accounts missing `us_state` and/or `age`:
- Disables the "add a password" (aka personal login) form on the account settings page, regardless of account type, if the user would otherwise be locked out of adding oauth-based logins. The criteria being that they're either U13 and in a CAP state without permission, or missing age, state, or country code.
- Adjusts the criteria for being locked out of adding a new login via the Managed Linked Accounts table to include age as a required field.
- Refactors the `edit` route in the `registrations_controller` to reduce confusion caused by all the similarly-named lockout-related variables.

<img width="899" alt="Screenshot 2024-10-17 at 4 05 31 PM" src="https://github.com/user-attachments/assets/5ef21269-9ebb-4ba2-8795-bd06ca23bdae">


## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1236)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
