### PR TITLE
Fix flaky Minecraft HoC Pegasus share page scenario

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -53,11 +53,9 @@ Scenario: Pegasus share page preserves certificate when redirecting
   Given I am on "http://studio.code.org/s/mc/reset"
   And I wait for the lab page to fully load
   Then I wait until the Minecraft game is loaded
-  And I wait for 3 seconds
 
   # Set up a customized certificate
   Given I am on "http://code.org/api/hour/finish/mc"
-  And I wait for 3 seconds
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
   And I type "Robo Coder" into "#name"

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -53,9 +53,11 @@ Scenario: Pegasus share page preserves certificate when redirecting
   Given I am on "http://studio.code.org/s/mc/reset"
   And I wait for the lab page to fully load
   Then I wait until the Minecraft game is loaded
+  And I wait for 3 seconds
 
   # Set up a customized certificate
   Given I am on "http://code.org/api/hour/finish/mc"
+  And I wait for 3 seconds
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
   And I type "Robo Coder" into "#name"

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -51,6 +51,7 @@ Scenario: Pegasus share page preserves certificate when redirecting
   # Reset lesson data (otherwise it will pull a cached certificate from
   # other tests)
   Given I am on "http://studio.code.org/s/mc/reset"
+  And I wait for the lab page to fully load
   Then I wait until the Minecraft game is loaded
 
   # Set up a customized certificate

--- a/dashboard/test/ui/features/step_definitions/minecraft.rb
+++ b/dashboard/test/ui/features/step_definitions/minecraft.rb
@@ -19,5 +19,5 @@ end
 
 Then /^I wait until the Minecraft game is loaded$/ do
   wait = Selenium::WebDriver::Wait.new(timeout: 60)
-  wait.until {@browser.execute_script('return Craft.phaserLoaded();')}
+  wait.until {@browser.execute_script('return Craft?.phaserLoaded();')}
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR includes a prospective fix for the flaky `hour_of_code_finish.feature` UI test. This UI test has been flaky on Ipad and in particular on iPhone (top failing UI test on iPhone).

<img width="1347" alt="Screenshot 2024-10-16 at 8 46 07 AM" src="https://github.com/user-attachments/assets/6ccbffc4-23cf-462c-b4cb-ea825cc8cd4e">

This UI test has been disabled in Safari https://github.com/code-dot-org/code-dot-org/pull/60103 because the test was flaky at `> 0.33` on Safari. I propose that we merge this PR and monitor for a few days. If the failure rate decreases on Iphone and Ipad, we can consider enabling this UI test on Safari.
@wilkie proposed a [refactoring of `Phaser`'s `isLoading`](https://github.com/code-dot-org/code-dot-org/pull/59857) which I think would also be helpful in deflaking this test. (More details below.)

When looking at the Saucelabs replays of the UI test, there is one scenario which is frequently flaky: 'Pegasus share page preserves certificate when redirecting' in `hour_of_code_finish.feature`.  I observed 2 different errors which resulted in a failed state. A third error that didn't lead to a failed state but I thought was still noteworthy is described in the Follow-up work section.

## Error 1:
- minecraft page loading error - https://app.saucelabs.com/tests/825198f289eb4594a18f038aae82bba4#27

```
HTTP Status: 500
{
	"message": "An unknown server-side error occurred while processing the command. Original error: null is not an object (evaluating 'Craft.gameController.game.load.isLoading')",
	"error": "unknown error"
}
```

To help resolve the first error, I am adding the step ['And I wait for the lab page to fully load'](https://github.com/code-dot-org/code-dot-org/blob/75f5f0398c76cd00b8e432a72fd6362b421a391f/dashboard/test/ui/features/step_definitions/steps.rb#L193-L199) so that there is time to check for `Craft.phaserLoaded`. https://github.com/code-dot-org/code-dot-org/blob/75f5f0398c76cd00b8e432a72fd6362b421a391f/dashboard/test/ui/features/step_definitions/minecraft.rb#L20-L23

FYI, In `craft.js`, `Craft.phaserLoaded` is defined as 
```
Craft.phaserLoaded = function () {
  return (
    Craft.gameController &&
    Craft.gameController.game &&
    !Craft.gameController.game.load.isLoading
  );
};
```
@wilkie is proposing a possible solution at https://github.com/code-dot-org/code-dot-org/pull/59857 to help resolve the  `null is not an object (evaluating 'Craft.gameController.game.load.isLoading` error. He investigated the logic behind `phaserLoaded`. I think it would also be helpful to update the code in `craft` to avoid the JS error.



## Error 2:
- congrats page error - https://app.saucelabs.com/tests/26e3f5ab9be14abeb54c97675652d04c#24: 

<img width="1120" alt="Screenshot 2024-10-15 at 5 03 25 PM" src="https://github.com/user-attachments/assets/8040e29e-6442-48a7-a2ad-66d35a5c4870">






In the second error, we have completed the the first 4 steps of the scenario, and we are now on step `Given I am on "http://code.org/api/hour/finish/mc"`.

When we check `And I wait until current URL contains "/congrats"`we see this message at the top of the screen:
'Puma caught this error: undefined method `by_short_code` for {"dance-ai-2023"=>...'

`by_short_code` is defined at https://github.com/code-dot-org/code-dot-org/blob/75f5f0398c76cd00b8e432a72fd6362b421a391f/pegasus/src/database.rb#L72.

When '/api/hour/finish/mc' redirects to '/congrats', the fetching of tutorial data appears to not have been successful.
~~I propose adding a wait after the Minecraft game loads and after `Given I am on "http://code.org/api/hour/finish/mc"`.~~
After consulting with @wilkie, we are going to monitor this UI test as we are unsure why this error is occurring.
From Wilkie: 'the code seems to deterministically build a cached key/value store that maps things like "mc" to the CdoTutorial record... and I can't see why that would fail unless the database itself were misbehaving somehow.'

I also added a check for `Craft` in the 'I wait until the Minecraft game is loaded' so that `phaserLoaded` is not called unless `Craft` is defined.

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1109)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I ran this updated scenario against `test` 10 times and it passed 10 times in a row.
![Screenshot 2024-10-16 at 9 42 00 AM](https://github.com/user-attachments/assets/7e34c5a5-1e32-4205-a975-59c9cf54c95d)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
UPDATE: Resolved [Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1729031909981389)
One of the three errors from the Saucelabs replay videos involved a YouTube error

- YouTube error - https://app.saucelabs.com/tests/e53b4f945abf469398d657009cf765a7#29
'Sign in to confirm you're not a bot'.
<img width="1209" alt="Screenshot 2024-10-15 at 5 11 21 PM" src="https://github.com/user-attachments/assets/eb84ace4-0393-43ce-98a7-f624e3c7f25b">


Note that this error didn't lead to a failed state (the Minecraft loading error did), but I was able to repro this on my iPhone on `production` so logging a ticket to investigate this at https://codedotorg.atlassian.net/browse/LABS-1119.

![IMG_2784](https://github.com/user-attachments/assets/c8b6a5c6-5583-4ece-a68b-1673fa05c10b)


<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
