### PR TITLE
Upgrade eyes_selenium to 6.3.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,7 @@ group :development, :test do
 
   # For UI testing.
   gem 'cucumber'
-  gem 'eyes_selenium', '3.18.4'
+  gem 'eyes_selenium', '6.3.7'
   gem 'fakefs', '~> 2.5.0', require: false
   gem 'minitest', '~> 5.15'
   gem 'minitest-around'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,20 +345,22 @@ GEM
     eventmachine (1.2.7)
     execjs (2.7.0)
     exifr (1.2.5)
-    eyes_core (3.18.4)
-      chunky_png (= 1.3.6)
+    eyes_core (6.3.7)
+      colorize
+      eyes_universal (= 4.18.0)
       faraday
       faraday-cookie_jar
       faraday_middleware
-      oily_png (~> 1.2)
       oj
-    eyes_selenium (3.18.4)
+      sorted_set
+      websocket
+    eyes_selenium (6.3.7)
       crass
       css_parser
-      eyes_core (= 3.18.4)
-      nokogiri
-      selenium-webdriver
-      state_machine
+      eyes_core (= 6.3.7)
+      selenium-webdriver (>= 3)
+      state_machines
+    eyes_universal (4.18.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -857,7 +859,7 @@ GEM
     sshkit (1.20.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    state_machine (1.2.0)
+    state_machines (0.6.0)
     statsig (1.33.2)
       concurrent-ruby (~> 1.1)
       connection_pool (~> 2.4, >= 2.4.1)
@@ -992,7 +994,7 @@ DEPENDENCIES
   dotiw
   drb
   execjs
-  eyes_selenium (= 3.18.4)
+  eyes_selenium (= 6.3.7)
   factory_bot_rails (~> 6.2)
   fakefs (~> 2.5.0)
   faker (~> 3.4)

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -58,7 +58,7 @@ And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?$/) do |
       Applitools::STITCH_MODE[:css]
   end
 
-  @eyes.check_window(identifier, MATCH_TIMEOUT, false)
+  @eyes.check_window(identifier, MATCH_TIMEOUT)
 
   # Return to full page screenshot for remaining checkpoints in this Scenario.
   @eyes.force_full_page_screenshot = true

--- a/dashboard/test/ui/full_page_test.rb
+++ b/dashboard/test/ui/full_page_test.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+require_relative '../../../deployment'
+require 'selenium-webdriver'
+require 'eyes_selenium'
+
+eyes = Applitools::Selenium::Eyes.new
+eyes.api_key = CDO.applitools_eyes_api_key
+eyes.force_full_page_screenshot = true
+
+sauce_url = "http://#{CDO.saucelabs_username}:#{CDO.saucelabs_authkey}@ondemand.us-west-1.saucelabs.com:80/wd/hub"
+driver = Selenium::WebDriver.for(:remote,
+  url: sauce_url,
+  capabilities: Selenium::WebDriver::Remote::Capabilities.new({
+                                                                'browserName': "chrome",
+    'browserVersion': "105",
+    'platformName': "Windows 10",
+    'sauce:options': {
+      'screenResolution': "1280x1024",
+      'extendedDebugging': true,
+      'seleniumVersion': Selenium::WebDriver::VERSION,
+      idleTimeout: 60,
+    }
+                                                              }
+),
+)
+
+def then_i_see_no_difference_for(eyes, identifier, stitch_mode)
+  if stitch_mode == "none"
+    eyes.force_full_page_screenshot = false
+  else
+    eyes.stitch_mode = stitch_mode == "scroll" ?
+      Applitools::STITCH_MODE[:scroll] :
+      Applitools::STITCH_MODE[:css]
+  end
+
+  # Before: eyes.check_window(identifier, 5, false)
+  eyes.check_window(identifier, 5)
+
+  eyes.force_full_page_screenshot = true
+  eyes.stitch_mode = Applitools::STITCH_MODE[:css]
+end
+
+begin
+  eyes.open(driver: driver, app_name: 'Google News', test_name: 'full_page_test.rb')
+  driver.get 'https://slashdot.org'
+
+  identifier_frag = "initial load"
+
+  eyes.check(identifier_frag + " this works", Applitools::Selenium::Target.window.fully)
+
+  then_i_see_no_difference_for(eyes, identifier_frag, "")
+  then_i_see_no_difference_for(eyes, identifier_frag + " none", "none")
+  then_i_see_no_difference_for(eyes, identifier_frag + " scroll", "scroll")
+  then_i_see_no_difference_for(eyes, identifier_frag + " css", "css")
+
+  eyes.close
+ensure
+  driver.quit
+  eyes.abort_if_not_closed
+end


### PR DESCRIPTION
While upgrading Ruby to 3.3 ([PR](https://github.com/code-dot-org/code-dot-org/pull/60329)), we discovered two compatibility issues between our old version of eyes_selenium 3.18.4 and Ruby 3.3.

1. eyes_selenium 3.18.4 has a dependency on the state_machine gem, which is not compatible with Ruby >= 3.2, and appears not to be receiving updates either. state_machine gem appears to have been forked into the state_machines gem, which is used by newer eyes_selenium versions and is fixed.
2. eyes_selenium passes the faraday gem a hardcoded SSL cert for the applitools server in a way that breaks openssl on Ruby >= 3.1.