### PR TITLE
Lab2: consolidate lesson continue/finish logic

### DIFF
--- a/apps/src/aichat/views/AichatView.tsx
+++ b/apps/src/aichat/views/AichatView.tsx
@@ -2,7 +2,6 @@
 
 import React, {useCallback, useEffect} from 'react';
 
-import {sendSuccessReport} from '@cdo/apps/code-studio/progressRedux';
 import Button from '@cdo/apps/componentLibrary/button/Button';
 import ActionDropdown from '@cdo/apps/componentLibrary/dropdown/actionDropdown/ActionDropdown';
 import SegmentedButtons, {
@@ -61,10 +60,6 @@ const AichatView: React.FunctionComponent = () => {
 
   const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
   const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
-
-  const beforeNextLevel = useCallback(() => {
-    dispatch(sendSuccessReport('aichat'));
-  }, [dispatch]);
 
   const levelAichatSettings = useAppSelector(
     state =>
@@ -255,10 +250,7 @@ const AichatView: React.FunctionComponent = () => {
                   }
                 )}
               >
-                <Instructions
-                  beforeNextLevel={beforeNextLevel}
-                  className={moduleStyles.instructions}
-                />
+                <Instructions className={moduleStyles.instructions} />
               </PanelContainer>
             </div>
             {!allFieldsHidden && (

--- a/apps/src/lab2/progress/continueOrFinishLesson.ts
+++ b/apps/src/lab2/progress/continueOrFinishLesson.ts
@@ -12,8 +12,7 @@ import {shareLab2Project} from '../header/lab2HeaderShare';
 /**
  * Handles all logic for continuing lesson progression, either to the next level or finishing the lesson.
  */
-export const continueOrFinishLesson =
-  (): ThunkAction<void, RootState, undefined, AnyAction> =>
+export default (): ThunkAction<void, RootState, undefined, AnyAction> =>
   (dispatch, getState) => {
     const levelProperties = getState().lab.levelProperties;
     if (!levelProperties) {

--- a/apps/src/lab2/progress/progressThunks.tsx
+++ b/apps/src/lab2/progress/progressThunks.tsx
@@ -1,0 +1,45 @@
+import {AnyAction, ThunkAction} from '@reduxjs/toolkit';
+
+import {
+  navigateToNextLevel,
+  sendSuccessReport,
+} from '@cdo/apps/code-studio/progressRedux';
+import {nextLevelId} from '@cdo/apps/code-studio/progressReduxSelectors';
+import {RootState} from '@cdo/apps/types/redux';
+
+import {shareLab2Project} from '../header/lab2HeaderShare';
+
+/**
+ * Handles all logic for continuing lesson progression, either to the next level or finishing the lesson.
+ */
+export const continueOrFinishLesson =
+  (): ThunkAction<void, RootState, undefined, AnyAction> =>
+  (dispatch, getState) => {
+    const levelProperties = getState().lab.levelProperties;
+    if (!levelProperties) {
+      // Level has not been set up yet.
+      return;
+    }
+
+    // If there are no validation conditions, go ahead and send a success report when we continue.
+    // Otherwise, success reports are managed by the ProgressContainer and ProgressManager.
+    if (!getState().lab.validationState.hasConditions) {
+      dispatch(sendSuccessReport(levelProperties.appName));
+    }
+
+    // If we are not at the last level, continue to the next level.
+    if (nextLevelId(getState()) !== undefined) {
+      dispatch(navigateToNextLevel());
+      return;
+    }
+
+    const {finishUrl, finishDialog} = levelProperties;
+    // If we have a finish URL, show the finish dialog if present, or redirect to the finish URL.
+    if (finishUrl) {
+      if (finishDialog) {
+        shareLab2Project(finishDialog, finishUrl);
+      } else {
+        window.location.href = finishUrl;
+      }
+    }
+  };

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -1,11 +1,9 @@
 import classNames from 'classnames';
-import React, {useCallback, useContext, useEffect, useState} from 'react';
+import React, {useContext} from 'react';
 import {useSelector} from 'react-redux';
 
-import {navigateToNextLevel} from '@cdo/apps/code-studio/progressRedux';
 import {nextLevelId} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {Button} from '@cdo/apps/componentLibrary/button';
-import {shareLab2Project} from '@cdo/apps/lab2/header/lab2HeaderShare';
 import {LevelPredictSettings} from '@cdo/apps/lab2/levelEditors/types';
 import {
   isPredictAnswerLocked,
@@ -14,7 +12,7 @@ import {
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {LabState} from '../../lab2Redux';
+import {continueOrFinishLesson} from '../../progress/progressThunks';
 import {ThemeContext} from '../ThemeWrapper';
 
 import PredictQuestion from './PredictQuestion';
@@ -26,14 +24,13 @@ import moduleStyles from './instructions.module.scss';
 const commonI18n = require('@cdo/locale');
 
 interface InstructionsProps {
-  /** Additional callback to fire before navigating to the next level. */
-  beforeNextLevel?: () => void;
   /** If the instructions panel should be rendered vertically or horizontally. Defaults to vertical. */
   layout?: 'vertical' | 'horizontal';
   /**
    * A callback when the user clicks on clickable text.
    */
   handleInstructionsTextClick?: (id: string) => void;
+  /** Whether the instructions panel should show lesson navigation buttons (Continue & Finish) */
   manageNavigation?: boolean;
   /** Optional classname for the container */
   className?: string;
@@ -50,54 +47,28 @@ interface InstructionsProps {
  * For Teachers Only, etc.
  */
 const Instructions: React.FunctionComponent<InstructionsProps> = ({
-  beforeNextLevel,
   layout,
   handleInstructionsTextClick,
   className,
   manageNavigation = true,
   offerTts = false,
 }) => {
-  const instructionsText = useSelector(
-    (state: {lab: LabState}) => state.lab.levelProperties?.longInstructions
+  const instructionsText = useAppSelector(
+    state => state.lab.levelProperties?.longInstructions
   );
   const hasNextLevel = useSelector(state => nextLevelId(state) !== undefined);
-  const {hasConditions, message, satisfied, index} = useSelector(
-    (state: {lab: LabState}) => state.lab.validationState
+  const {hasConditions, message, satisfied, index} = useAppSelector(
+    state => state.lab.validationState
   );
   const predictSettings = useAppSelector(
     state => state.lab.levelProperties?.predictSettings
   );
   const predictResponse = useAppSelector(state => state.predictLevel.response);
   const predictAnswerLocked = useAppSelector(isPredictAnswerLocked);
-  const finishUrl = useAppSelector(
-    state => state.lab.levelProperties?.finishUrl
-  );
-  const finishDialog = useAppSelector(
-    state => state.lab.levelProperties?.finishDialog
-  );
-
-  // If there are no validation conditions, we can show the continue button so long as
-  // there is another level and manageNavigation is true.
-  // If validation is present, also check that conditions are satisfied.
-  const showContinueButton =
-    manageNavigation && (!hasConditions || satisfied) && hasNextLevel;
-
-  // If there are no validation conditions, we can show the finish button so long as
-  // this is the last level in the progression and the instructions panel is managing navigation.
-  // If validation is present, also check that conditions are satisfied.
-  const showFinishButton =
-    manageNavigation && (!hasConditions || satisfied) && !hasNextLevel;
 
   const dispatch = useAppDispatch();
 
   const {theme} = useContext(ThemeContext);
-
-  const onNextPanel = useCallback(() => {
-    if (beforeNextLevel) {
-      beforeNextLevel();
-    }
-    dispatch(navigateToNextLevel());
-  }, [dispatch, beforeNextLevel]);
 
   // Don't render anything if we don't have any instructions.
   if (instructionsText === undefined) {
@@ -109,10 +80,6 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
       text={instructionsText}
       message={message || undefined}
       messageIndex={index}
-      showContinueButton={showContinueButton}
-      showFinishButton={showFinishButton}
-      beforeFinish={beforeNextLevel}
-      onNextPanel={onNextPanel}
       theme={theme}
       predictSettings={predictSettings}
       predictResponse={predictResponse}
@@ -121,9 +88,10 @@ const Instructions: React.FunctionComponent<InstructionsProps> = ({
       layout={layout}
       handleInstructionsTextClick={handleInstructionsTextClick}
       offerTts={offerTts}
-      finishUrl={finishUrl}
-      finishDialog={finishDialog}
       className={className}
+      canShowNextButton={manageNavigation && (!hasConditions || satisfied)}
+      hasNextLevel={hasNextLevel}
+      onContinueOrFinish={() => dispatch(continueOrFinishLesson())}
     />
   );
 };
@@ -135,14 +103,6 @@ interface InstructionsPanelProps {
   message?: string;
   /** Key for rendering the optional message. A unique value ensures the appearance animation shows. */
   messageIndex?: number;
-  /** If the continue button should be shown. */
-  showContinueButton?: boolean;
-  /** If the finish button should be shown. */
-  showFinishButton?: boolean;
-  /** Additional callback to fire before finishing the level. */
-  beforeFinish?: () => void;
-  /** Callback to call when clicking the next button. */
-  onNextPanel?: () => void;
   /** If the instructions panel should be rendered vertically or horizontally. Defaults to vertical. */
   layout?: 'vertical' | 'horizontal';
   /** Display theme. Defaults to dark. */
@@ -158,8 +118,9 @@ interface InstructionsPanelProps {
   /** Optional classname for the container */
   className?: string;
   offerTts?: boolean;
-  finishUrl?: string;
-  finishDialog?: string;
+  canShowNextButton: boolean;
+  hasNextLevel: boolean;
+  onContinueOrFinish: () => void;
 }
 
 /**
@@ -175,10 +136,6 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
   text,
   message,
   messageIndex,
-  showContinueButton,
-  showFinishButton,
-  beforeFinish,
-  onNextPanel,
   layout = 'vertical',
   theme = 'dark',
   handleInstructionsTextClick,
@@ -188,36 +145,11 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
   predictAnswerLocked,
   className,
   offerTts,
-  finishUrl,
-  finishDialog,
+  canShowNextButton,
+  hasNextLevel,
+  onContinueOrFinish,
 }) => {
-  const [isFinished, setIsFinished] = useState(false);
-
   const vertical = layout === 'vertical';
-
-  const canShowContinueButton = showContinueButton && onNextPanel;
-
-  const canShowFinishButton = showFinishButton;
-
-  const onFinish = useCallback(() => {
-    if (!isFinished && beforeFinish) {
-      beforeFinish();
-      setIsFinished(true);
-    }
-
-    if (finishUrl) {
-      if (finishDialog) {
-        shareLab2Project(finishDialog, finishUrl);
-      } else {
-        window.location.href = finishUrl;
-      }
-    }
-  }, [isFinished, beforeFinish, finishDialog, finishUrl]);
-
-  // Reset the Finish button state when it changes from shown to hidden.
-  useEffect(() => {
-    setIsFinished(false);
-  }, [canShowFinishButton]);
 
   return (
     <div
@@ -262,7 +194,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
             </div>
           </div>
         )}
-        {(message || canShowContinueButton || canShowFinishButton) && (
+        {(message || canShowNextButton) && (
           <div
             key={messageIndex + ' - ' + message}
             id="instructions-feedback"
@@ -280,23 +212,15 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   handleInstructionsTextClick={handleInstructionsTextClick}
                 />
               )}
-              {canShowContinueButton && (
+              {canShowNextButton && (
                 <Button
                   id="instructions-continue-button"
-                  text={commonI18n.continue()}
-                  onClick={onNextPanel}
+                  text={
+                    hasNextLevel ? commonI18n.continue() : commonI18n.finish()
+                  }
+                  onClick={onContinueOrFinish}
                   className={moduleStyles.buttonInstruction}
                 />
-              )}
-              {canShowFinishButton && (
-                <>
-                  <Button
-                    id="instructions-finish-button"
-                    onClick={onFinish}
-                    className={moduleStyles.buttonInstruction}
-                    text={commonI18n.finish()}
-                  />
-                </>
               )}
             </div>
           </div>

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -5,14 +5,15 @@ import {useSelector} from 'react-redux';
 import {nextLevelId} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {Button} from '@cdo/apps/componentLibrary/button';
 import {LevelPredictSettings} from '@cdo/apps/lab2/levelEditors/types';
+import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLesson';
 import {
   isPredictAnswerLocked,
   setPredictResponse,
 } from '@cdo/apps/lab2/redux/predictLevelRedux';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
+import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
-import {continueOrFinishLesson} from '../../progress/progressThunks';
 import {ThemeContext} from '../ThemeWrapper';
 
 import PredictQuestion from './PredictQuestion';
@@ -20,8 +21,6 @@ import PredictSummary from './PredictSummary';
 import TextToSpeech from './TextToSpeech';
 
 import moduleStyles from './instructions.module.scss';
-
-const commonI18n = require('@cdo/locale');
 
 interface InstructionsProps {
   /** If the instructions panel should be rendered vertically or horizontally. Defaults to vertical. */

--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -5,12 +5,12 @@
 
 import React, {useCallback} from 'react';
 
+import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLesson';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {sendSuccessReport} from '../code-studio/progressRedux';
 import {queryParams} from '../code-studio/utils';
-import {continueOrFinishLesson} from '../lab2/progress/progressThunks';
 import useWindowSize from '../util/hooks/useWindowSize';
 
 import PanelsView from './PanelsView';

--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -5,14 +5,12 @@
 
 import React, {useCallback} from 'react';
 
-import {
-  sendSuccessReport,
-  navigateToNextLevel,
-} from '@cdo/apps/code-studio/progressRedux';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {sendSuccessReport} from '../code-studio/progressRedux';
 import {queryParams} from '../code-studio/utils';
+import {continueOrFinishLesson} from '../lab2/progress/progressThunks';
 import useWindowSize from '../util/hooks/useWindowSize';
 
 import PanelsView from './PanelsView';
@@ -40,12 +38,12 @@ const PanelsLabView: React.FunctionComponent = () => {
   const onContinue = useCallback(
     (nextUrl?: string) => {
       if (nextUrl) {
-        // This is a short-term solution for the Music Lab progression in incubation.  We will not attempt
-        // to send a success report for a level that uses this feature.
+        // This is a short-term solution for the Music Lab progression in incubation.
+        // Send a success report so we turn the bubble green.
+        dispatch(sendSuccessReport(appName));
         window.location.href = nextUrl;
       } else {
-        dispatch(sendSuccessReport(appName));
-        dispatch(navigateToNextLevel());
+        dispatch(continueOrFinishLesson());
       }
     },
     [dispatch]


### PR DESCRIPTION
Consolidates all logic related to continuing/finish a lesson so it can be accessed from multiple components. Previously, our Instructions component was managing the bulk of this logic (whether to continue or finish, what dialog to show, when to navigate to next level, etc), and we had some hooks like the `beforeNextLevel` callback for individual labs to trigger side effects when changing levels, but it was a bit hard to track across different labs and to make sure we were sending all the right success reports. Most labs do indeed use the Instructions component to manage level transition, but for example, Panels is a lab type that doesn't have instructions and needs to navigate the right next level / lesson finish experience.

Given that all the information that determines if we should transition levels and/or what finish experience to render is available in redux, I just moved the logic to a standalone thunk that can be called by Instructions or Panels. Additionally this does away with the `beforeNextLevel` callback since sending a success report is also handled by that thunk. 

**Here's a key assumption I'm making though**: if a level has no validation conditions, then we should send a success report when advancing levels or finishing. I _think_ this is always true, and is what the `beforeNextLevel` callback was being used for in AI Chat, but let me know if I'm missing something.

### Testing story
Tested on Music Lab intro, AI Chat staging script, and allthethings. Codebridge uses a separate instructions panel so it isn't affected by this, but as per [Slack discussion](https://codedotorg.slack.com/archives/C044AGTKW3D/p1729033333242169), this might be something that can be reused in the Codebridge instructions panel too.

This also automatically turns the bubble green for the last freeplay level in the Music Lab HOC script (tested with hoc-music-ai-pilot-4) and the last panel level in the intro script
