### PR TITLE
Fix: storing zip for non-nces US schools is necessary for school info update flow

### DIFF
--- a/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
+++ b/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
@@ -29,15 +29,28 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     [initialState.country, initialState.usIp]
   );
 
-  const detectedSchoolId = useMemo(
-    () =>
-      initialState.schoolType === NonSchoolOptions.NO_SCHOOL_SETTING
-        ? NonSchoolOptions.NO_SCHOOL_SETTING
-        : initialState.schoolId ||
-          sessionStorage.getItem(SCHOOL_ID_SESSION_KEY) ||
-          NonSchoolOptions.SELECT_A_SCHOOL,
-    [initialState.schoolId, initialState.schoolType]
-  );
+  const detectedSchoolId = useMemo(() => {
+    if (initialState.schoolType === NonSchoolOptions.NO_SCHOOL_SETTING) {
+      return NonSchoolOptions.NO_SCHOOL_SETTING;
+    }
+    if (
+      !initialState.schoolId &&
+      initialState.schoolName &&
+      initialState.schoolZip
+    ) {
+      return NonSchoolOptions.CLICK_TO_ADD;
+    }
+    return (
+      initialState.schoolId ||
+      sessionStorage.getItem(SCHOOL_ID_SESSION_KEY) ||
+      NonSchoolOptions.SELECT_A_SCHOOL
+    );
+  }, [
+    initialState.schoolId,
+    initialState.schoolType,
+    initialState.schoolName,
+    initialState.schoolZip,
+  ]);
 
   const detectedZip = useMemo(
     () =>

--- a/apps/src/schoolInfo/utils/buildSchoolData.ts
+++ b/apps/src/schoolInfo/utils/buildSchoolData.ts
@@ -42,6 +42,7 @@ export function buildSchoolData({
         school_info_attributes: {
           country,
           school_type: NonSchoolOptions.NO_SCHOOL_SETTING,
+          zip: schoolZip,
         },
       },
     };
@@ -53,6 +54,7 @@ export function buildSchoolData({
         school_info_attributes: {
           country,
           school_name: schoolName,
+          zip: country === US_COUNTRY_CODE ? schoolZip : undefined,
         },
       },
     };

--- a/apps/test/unit/schoolInfo/utils/buildSchoolDataTest.js
+++ b/apps/test/unit/schoolInfo/utils/buildSchoolDataTest.js
@@ -21,7 +21,7 @@ describe('buildSchoolData', () => {
       });
     });
 
-    it('should return school info with country and school_name when schoolId is empty', () => {
+    it('should return school info with country, zip, and school_name when schoolId is empty', () => {
       const result = buildSchoolData({
         schoolId: '',
         country: US_COUNTRY_CODE,
@@ -34,12 +34,13 @@ describe('buildSchoolData', () => {
           school_info_attributes: {
             country: US_COUNTRY_CODE,
             school_name: 'Test School',
+            zip: '54321',
           },
         },
       });
     });
 
-    it('should return school info with country and school_name when schoolId is CLICK_TO_ADD', () => {
+    it('should return school info with country, zip, and school_name when schoolId is CLICK_TO_ADD', () => {
       const result = buildSchoolData({
         schoolId: NonSchoolOptions.CLICK_TO_ADD,
         country: US_COUNTRY_CODE,
@@ -52,12 +53,13 @@ describe('buildSchoolData', () => {
           school_info_attributes: {
             country: US_COUNTRY_CODE,
             school_name: 'Test School',
+            zip: '54321',
           },
         },
       });
     });
 
-    it('should return school info with country and school_name when schoolId is SELECT_A_SCHOOL', () => {
+    it('should return school info with country, zip, and school_name when schoolId is SELECT_A_SCHOOL', () => {
       const result = buildSchoolData({
         schoolId: NonSchoolOptions.SELECT_A_SCHOOL,
         country: US_COUNTRY_CODE,
@@ -70,12 +72,13 @@ describe('buildSchoolData', () => {
           school_info_attributes: {
             country: US_COUNTRY_CODE,
             school_name: 'Test School',
+            zip: '54321',
           },
         },
       });
     });
 
-    it('should return school info with country and school_type when schoolId is NO_SCHOOL_SETTING', () => {
+    it('should return school info with country, zip, and school_type when schoolId is NO_SCHOOL_SETTING', () => {
       const result = buildSchoolData({
         schoolId: NonSchoolOptions.NO_SCHOOL_SETTING,
         country: 'US',
@@ -88,6 +91,7 @@ describe('buildSchoolData', () => {
           school_info_attributes: {
             country: 'US',
             school_type: NonSchoolOptions.NO_SCHOOL_SETTING,
+            zip: '54321',
           },
         },
       });

--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -45,3 +45,7 @@ Scenario: School Info Confirmation Dialog
   And one year passes for user "Teacher_Chuba"
   Then I reload the page
   And element ".modal-body" is visible
+  Then I press "#update-button" using jQuery
+  And I wait until element "#uitest-country-dropdown" contains text "United States"
+  And I wait until element "#uitest-school-zip" contains text "31513"
+  And I wait until element "#uitest-school-dropdown" contains text "Appling County High School"

--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -46,6 +46,7 @@ Scenario: School Info Confirmation Dialog
   Then I reload the page
   And element ".modal-body" is visible
   Then I press "#update-button" using jQuery
-  And I wait until element "#uitest-country-dropdown" contains text "United States"
-  And I wait until element "#uitest-school-zip" contains text "31513"
-  And I wait until element "#uitest-school-dropdown" contains text "Appling County High School"
+  And element ".modal" is visible
+  Then I wait to see a modal containing text "United States"
+  Then element "#uitest-school-zip" has value "31513"
+  Then I wait to see a modal containing text "Appling County High School"


### PR DESCRIPTION
In the new school info update flow, we show/enable inputs based on the previous input. If a user enters `United States` we ask for the zip code, once the zip code is entered we show the dropdown of schools and options to add their own school manually. For non-nces schools (not in the zip code search results) or non-school settings we weren't storing the zip code, meaning we could never truly persist the users' full form, making it look like they had never entered more info than their country. This pr persists the zip code in the `school_infos` table when the user is in the US and does not have an nces school to select

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
