### PR TITLE
HoC 2024 - Add tutorial images

### DIFF
--- a/pegasus/sites.v3/code.org/public/images/tutorials/hoc2024/scratch_inventing.png
+++ b/pegasus/sites.v3/code.org/public/images/tutorials/hoc2024/scratch_inventing.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86e7467134a4fe2b4dc309fe266c114404814e578f6f1aa036434467218156c7
+size 106805

--- a/pegasus/sites.v3/code.org/public/images/tutorials/hoc2024/scratch_kindness.png
+++ b/pegasus/sites.v3/code.org/public/images/tutorials/hoc2024/scratch_kindness.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e80cd7f28678680cb6fb2bd22640a44f06084de40e77c9708e39478644974cae
+size 100620

--- a/pegasus/sites.v3/code.org/public/images/tutorials/hoc2024/show_must_go_on.png
+++ b/pegasus/sites.v3/code.org/public/images/tutorials/hoc2024/show_must_go_on.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:381daa3881266cd5d757314e81087e4d5d65d0dabe4287d8ae1535db0cc8d550
+size 1298234


### PR DESCRIPTION
Adds tutorial images for the following activities:
- The Show Must Go On
- Inventing with Scratch and Gitanjali Rao
- Spreading Kindness with Scratch and Gitanjali Rao

These map to the `image_s` column on the `cdo-tutorials-preview` and `cdo-tutorials` gsheets.

## Links
Jira ticket: [ACQ-2520](https://codedotorg.atlassian.net/browse/ACQ-2520)

## Followup
I'll add our new Code.org Music Lab activity image when we get it

