### PR TITLE
Codebridge: Don't send console analytics event on level change

### DIFF
--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -1,4 +1,5 @@
 import {resetOutput} from '@codebridge/redux/consoleRedux';
+import {sendCodebridgeAnalyticsEvent} from '@codebridge/utils/analyticsReporterHelper';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useDispatch} from 'react-redux';
 
@@ -9,8 +10,6 @@ import {LifecycleEvent} from '@cdo/apps/lab2/utils/LifecycleNotifier';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
-
-import {sendCodebridgeAnalyticsEvent} from '../utils/analyticsReporterHelper';
 
 import ControlButtons from './ControlButtons';
 import GraphModal from './GraphModal';
@@ -30,14 +29,22 @@ const Console: React.FunctionComponent = () => {
   // TODO: Update this with other apps that use the console as needed.
   const systemMessagePrefix = appName === 'pythonlab' ? '[PYTHON LAB] ' : '';
 
-  const clearOutput = useCallback(() => {
-    dispatch(resetOutput());
-    sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_CLEAR_CONSOLE, appName);
-    setGraphModalOpen(false);
-  }, [dispatch, appName]);
+  const clearOutput = useCallback(
+    (sendAnalytics: boolean) => {
+      dispatch(resetOutput());
+      if (sendAnalytics) {
+        sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_CLEAR_CONSOLE, appName);
+      }
+      setGraphModalOpen(false);
+    },
+    [dispatch, appName]
+  );
 
-  // Clear console when we change levels.
-  useLifecycleNotifier(LifecycleEvent.LevelLoadCompleted, clearOutput);
+  // Clear console when we change levels. Don't send an analytics event
+  // as the user did not initiate this action.
+  useLifecycleNotifier(LifecycleEvent.LevelLoadCompleted, () =>
+    clearOutput(false)
+  );
 
   useEffect(() => {
     scrollAnchorRef.current?.scrollIntoView({
@@ -56,7 +63,9 @@ const Console: React.FunctionComponent = () => {
       id="codebridge-console"
       className={moduleStyles.consoleContainer}
       headerContent={'Console'}
-      rightHeaderContent={<RightButtons clearOutput={clearOutput} />}
+      rightHeaderContent={
+        <RightButtons clearOutput={() => clearOutput(true)} />
+      }
       leftHeaderContent={<ControlButtons />}
       headerClassName={moduleStyles.consoleHeader}
     >


### PR DESCRIPTION
Tiny cleanup to a codebridge analytics event. We clear the console when switching levels, and were sending the "console cleared" analytics event when this happened. Since the user does not initiate this event, sending an analytics event here doesn't make sense, and will make it look like way more users are using the clear console button than actually are. This change skips sending the event when switching levels. 


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
