### PR TITLE
Music: AI analytics updates

### DIFF
--- a/apps/src/music/ai/patternAi.ts
+++ b/apps/src/music/ai/patternAi.ts
@@ -25,7 +25,7 @@ export function generatePattern(
   const analyticsReporter = MusicRegistry.analyticsReporter;
   // Report attempt
   reporter.incrementCounter('MusicAI.GeneratePatternAttempt');
-  analyticsReporter.onGenerateAiPatternStart();
+  analyticsReporter.onGenerateAiPatternStart(temperature);
 
   worker.postMessage([
     Message.GeneratePattern,
@@ -45,7 +45,8 @@ export function generatePattern(
       case Message.Result:
         analyticsReporter.onGenerateAiPatternEnd(
           e.data[2] / 1000,
-          isInitialGenerate
+          isInitialGenerate,
+          temperature
         );
         onComplete(e.data[1]);
         // Flip the flag after the first successful generate.

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -31,6 +31,7 @@ const blockFeatureList = [
   BlockTypes.PLAY_SOUNDS_SEQUENTIAL,
   'functions',
   BlockTypes.PLAY_REST_AT_CURRENT_LOCATION_SIMPLE2,
+  BlockTypes.PLAY_PATTERN_AI_AT_CURRENT_LOCATION_SIMPLE2,
 ];
 
 const triggerBlocks: string[] = [
@@ -220,14 +221,19 @@ export default class AnalyticsReporter {
     this.trackUIEvent('Pattern AI panel opened');
   }
 
-  onGenerateAiPatternStart() {
-    this.trackUIEvent('Generate AI pattern start');
+  onGenerateAiPatternStart(temperature: number) {
+    this.trackUIEvent('Generate AI pattern start', {temperature});
   }
 
-  onGenerateAiPatternEnd(timeSeconds: number, isInitialGenerate: boolean) {
+  onGenerateAiPatternEnd(
+    timeSeconds: number,
+    isInitialGenerate: boolean,
+    temperature: number
+  ) {
     this.trackUIEvent('Generate AI pattern end', {
       timeSeconds,
       isInitialGenerate,
+      temperature,
     });
   }
 


### PR DESCRIPTION
Two analytics updates: tracks the chosen temperature with the start and end events, and adds the AI block to the list of tracked blocks that corresponds to features used in the session end event.

Screenshots:
- <img width="822" alt="Screenshot 2024-10-16 at 11 46 59 AM" src="https://github.com/user-attachments/assets/f81c7180-848c-4085-a44f-128d467aa43c">

- <img width="807" alt="Screenshot 2024-10-16 at 11 47 05 AM" src="https://github.com/user-attachments/assets/d189fcb1-58a4-450c-b235-d0a6c82578fb">

Field added to "Session end":

- <img width="444" alt="Screenshot 2024-10-16 at 11 50 01 AM" src="https://github.com/user-attachments/assets/b9b36c77-f1e9-4731-b6ce-c0f1a75d626b">


## Links

https://codedotorg.atlassian.net/browse/LABS-1054

## Testing story

Tested locally with amplitude