### PR TITLE
Change '/manage_students' url to '/roster' in v2 teacher dashboard

### DIFF
--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef} from 'react';
-import {Route, Routes, useLocation} from 'react-router-dom';
+import {Navigate, Route, Routes, useLocation} from 'react-router-dom';
 
 import TutorTab from '@cdo/apps/aiTutor/views/teacherDashboard/TutorTab';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
@@ -210,6 +210,13 @@ function TeacherDashboard({
             }
           />
         )}
+        {/* '/roster' is the new URL for '/manage_students' in TeacherNavigationRouter. We should redirect to manage students if a user somehow gets sent `/roster' */}
+        <Route
+          path="/roster"
+          element={
+            <Navigate to={TEACHER_DASHBOARD_PATHS.manageStudents} replace />
+          }
+        />
       </Routes>
     </div>
   );

--- a/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
+++ b/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
@@ -59,8 +59,8 @@ const ElementOrEmptyPage: React.FC<ElementOrEmptyPageProps> = ({
     if (showNoStudents) {
       return (
         <NavLink
-          key={TEACHER_NAVIGATION_PATHS.manageStudents}
-          to={TEACHER_NAVIGATION_PATHS.manageStudents}
+          key={TEACHER_NAVIGATION_PATHS.roster}
+          to={TEACHER_NAVIGATION_PATHS.roster}
           className={styles.navLink}
         >
           {i18n.addStudents()}

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -84,7 +84,7 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
 
   const classroomContentSectionTitle = getSectionHeader(i18n.classroom());
   const classroomContentKeys: (keyof typeof LABELED_TEACHER_NAVIGATION_PATHS)[] =
-    ['manageStudents', 'settings'];
+    ['roster', 'settings'];
 
   const teacherNavigationBarContent = [
     {title: coursecontentSectionTitle, keys: courseContentKeys},

--- a/apps/src/templates/teacherNavigation/TeacherNavigationPaths.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationPaths.tsx
@@ -11,7 +11,7 @@ export const TEACHER_NAVIGATION_PATHS = {
   assessments: 'assessments',
   projects: 'projects',
   stats: 'stats',
-  manageStudents: 'manage_students',
+  roster: 'roster',
   loginInfo: 'login_info',
   standardsReport: 'standards_report',
   aiTutorChatMessages: 'ai_tutor',
@@ -56,9 +56,9 @@ export const LABELED_TEACHER_NAVIGATION_PATHS = {
     label: i18n.teacherTabStats(),
     icon: 'chart-simple',
   },
-  manageStudents: {
-    url: TEACHER_NAVIGATION_PATHS.manageStudents,
-    absoluteUrl: getAbsolutePath(TEACHER_NAVIGATION_PATHS.manageStudents),
+  roster: {
+    url: TEACHER_NAVIGATION_PATHS.roster,
+    absoluteUrl: getAbsolutePath(TEACHER_NAVIGATION_PATHS.roster),
     label: i18n.roster(),
     icon: 'users',
   },

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -142,7 +142,7 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
             }
           />
           <Route
-            path={TEACHER_NAVIGATION_PATHS.manageStudents}
+            path={TEACHER_NAVIGATION_PATHS.roster}
             element={applyV1TeacherDashboardWidth(
               <ManageStudents studioUrlPrefix={studioUrlPrefix} />
             )}
@@ -292,6 +292,16 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
             />
           )}
         </Route>
+        {/* /manage_students is the legacy url for /roster. Redirect to /roster so that old bookmarks continue to work */}
+        <Route
+          path={'manage_students'}
+          element={
+            <Navigate
+              to={'../' + TEACHER_NAVIGATION_PATHS.roster}
+              replace={true}
+            />
+          }
+        />
       </Route>
     ),
     [

--- a/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
+++ b/apps/test/unit/templates/teacherNavigation/TeacherNavigationBarTest.jsx
@@ -97,7 +97,7 @@ describe('TeacherNavigationBar', () => {
                     }
                   />
                   <Route
-                    path={'manage_students'}
+                    path={'roster'}
                     element={
                       <div>
                         <LocationElement location={location} />
@@ -173,7 +173,7 @@ describe('TeacherNavigationBar', () => {
 
     screen.getByText('Roster').click();
 
-    await screen.findByText('/sections/11/manage_students path');
+    await screen.findByText('/sections/11/roster path');
   });
 
   test('section dropdown switches url', async () => {


### PR DESCRIPTION
Changes `/manage_students` to `/roster`
Redirect `/manage_students` to `/roster`
Change all links to new URL

V1 dashboard redirects `/roster` to `/manage_students`

## Links
https://codedotorg.atlassian.net/browse/TEACH-1360
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
