### PR TITLE
[JIMT][CT-822 (partial)][CT-617 (partial)] open rename file prompt

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileRow.tsx
@@ -18,7 +18,7 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 
 import {usePrompts} from './hooks';
 import StartModeFileDropdownOptions from './StartModeFileDropdownOptions';
-import {renameFilePromptType, setFileType} from './types';
+import {setFileType} from './types';
 
 import moduleStyles from './styles/filebrowser.module.scss';
 import darkModeStyles from '@cdo/apps/lab2/styles/dark-mode.module.scss';
@@ -31,7 +31,6 @@ interface FileRowProps {
   appName?: string;
   hasValidationFile: boolean; // If the project has a validation file already.
   isStartMode: boolean;
-  renameFilePrompt: renameFilePromptType;
   handleDeleteFile: (fileId: string) => void;
   setFileType: setFileType;
 }
@@ -52,7 +51,6 @@ const FileRow: React.FunctionComponent<FileRowProps> = ({
   appName,
   hasValidationFile,
   isStartMode,
-  renameFilePrompt,
   handleDeleteFile,
   setFileType,
 }) => {
@@ -60,7 +58,7 @@ const FileRow: React.FunctionComponent<FileRowProps> = ({
     openFile,
     config: {editableFileTypes},
   } = useCodebridgeContext();
-  const {openMoveFilePrompt} = usePrompts();
+  const {openMoveFilePrompt, openRenameFilePrompt} = usePrompts();
   const {iconName, iconStyle, isBrand} = getFileIconNameAndStyle(file);
   const iconClassName = isBrand
     ? classNames('fa-brands', moduleStyles.rowIcon)
@@ -78,7 +76,7 @@ const FileRow: React.FunctionComponent<FileRowProps> = ({
       condition: !isLocked,
       iconName: 'pencil',
       labelText: codebridgeI18n.renameFile(),
-      clickHandler: () => renameFilePrompt(file.id),
+      clickHandler: () => openRenameFilePrompt({fileId: file.id}),
     },
     {
       condition: editableFileTypes.includes(file.language),

--- a/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
@@ -4,6 +4,7 @@ import {
   openNewFilePrompt as globalOpenNewFilePrompt,
   openMoveFilePrompt as globalOpenMoveFilePrompt,
   openMoveFolderPrompt as globalOpenMoveFolderPrompt,
+  openRenameFilePrompt as globalOpenRenameFilePrompt,
   openRenameFolderPrompt as globalOpenRenameFolderPrompt,
 } from '@codebridge/FileBrowser/prompts';
 import {sendCodebridgeAnalyticsEvent as globalSendCodebridgeAnalyticsEvent} from '@codebridge/utils';
@@ -23,6 +24,7 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
  *   - **openMoveFolderPrompt:** Opens a prompt for moving a folder within the project.
  *   - **openNewFilePrompt:** Opens a prompt for creating a new file within the project.
  *   - **openNewFolderPrompt:** Opens a prompt for creating a new folder within the project.
+ *   - **openRenameFilePrompt:** Opens a prompt for renaming a file within the project.
  *   - **openRenameFolderPrompt:** Opens a prompt for renaming a folder within the project.
  */
 export const usePrompts = () => {
@@ -33,8 +35,15 @@ export const usePrompts = () => {
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const dialogControl = useDialogControl();
 
-  const {project, moveFile, moveFolder, newFolder, newFile, renameFolder} =
-    useCodebridgeContext();
+  const {
+    project,
+    moveFile,
+    moveFolder,
+    newFolder,
+    newFile,
+    renameFile,
+    renameFolder,
+  } = useCodebridgeContext();
 
   const sendCodebridgeAnalyticsEvent = useCallback(
     (event: string) => globalSendCodebridgeAnalyticsEvent(event, appName),
@@ -74,6 +83,15 @@ export const usePrompts = () => {
     sendCodebridgeAnalyticsEvent,
   } satisfies PAFunctionArgs<typeof globalOpenMoveFolderPrompt>);
 
+  const openRenameFilePrompt = usePartialApply(globalOpenRenameFilePrompt, {
+    dialogControl,
+    renameFile,
+    projectFiles: project.files,
+    sendCodebridgeAnalyticsEvent,
+    isStartMode,
+    validationFile,
+  } satisfies PAFunctionArgs<typeof globalOpenRenameFilePrompt>);
+
   const openRenameFolderPrompt = usePartialApply(globalOpenRenameFolderPrompt, {
     dialogControl,
     renameFolder,
@@ -87,6 +105,7 @@ export const usePrompts = () => {
       openNewFolderPrompt,
       openMoveFilePrompt,
       openMoveFolderPrompt,
+      openRenameFilePrompt,
       openRenameFolderPrompt,
     }),
     [
@@ -94,6 +113,7 @@ export const usePrompts = () => {
       openNewFolderPrompt,
       openMoveFilePrompt,
       openMoveFolderPrompt,
+      openRenameFilePrompt,
       openRenameFolderPrompt,
     ]
   );

--- a/apps/src/codebridge/FileBrowser/prompts/index.ts
+++ b/apps/src/codebridge/FileBrowser/prompts/index.ts
@@ -2,4 +2,5 @@ export * from './openMoveFilePrompt';
 export * from './openMoveFolderPrompt';
 export * from './openNewFilePrompt';
 export * from './openNewFolderPrompt';
+export * from './openRenameFilePrompt';
 export * from './openRenameFolderPrompt';

--- a/apps/src/codebridge/FileBrowser/prompts/openRenameFilePrompt.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openRenameFilePrompt.tsx
@@ -1,0 +1,62 @@
+import {RenameFileFunction} from '@codebridge/codebridgeContext/types';
+import {ProjectFile, ProjectType, FileId} from '@codebridge/types';
+import {validateFileName} from '@codebridge/utils';
+
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import {
+  DialogType,
+  DialogControlInterface,
+  extractUserInput,
+} from '@cdo/apps/lab2/views/dialogs';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+
+type RenameNewFilePromptArgsType = {
+  fileId: FileId;
+  dialogControl: Pick<DialogControlInterface, 'showDialog'>;
+  renameFile: RenameFileFunction;
+  projectFiles: ProjectType['files'];
+  isStartMode: boolean;
+  validationFile: ProjectFile | undefined;
+  sendCodebridgeAnalyticsEvent: (eventName: string) => unknown;
+};
+
+export const openRenameFilePrompt = async ({
+  fileId,
+  dialogControl,
+  renameFile,
+  projectFiles,
+  sendCodebridgeAnalyticsEvent,
+  isStartMode,
+  validationFile,
+}: RenameNewFilePromptArgsType) => {
+  const file = projectFiles[fileId];
+  const results = await dialogControl?.showDialog({
+    type: DialogType.GenericPrompt,
+    title: codebridgeI18n.renameFile(),
+    value: file.name,
+    validateInput: (newName: string) => {
+      if (!newName.length) {
+        return;
+      }
+      if (newName === file.name) {
+        return;
+      }
+
+      return validateFileName({
+        fileName: newName,
+        folderId: file.folderId,
+        projectFiles,
+        isStartMode,
+        validationFile,
+      });
+    },
+  });
+
+  if (results.type !== 'confirm') {
+    return;
+  }
+
+  const newName = extractUserInput(results);
+  renameFile(fileId, newName);
+  sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_RENAME_FILE);
+};

--- a/apps/test/unit/codebridge/FileBrowser/prompts/openRenameFilePromptTest.ts
+++ b/apps/test/unit/codebridge/FileBrowser/prompts/openRenameFilePromptTest.ts
@@ -1,0 +1,149 @@
+import {RenameFileFunction} from '@codebridge/codebridgeContext/types';
+import {openRenameFilePrompt} from '@codebridge/FileBrowser/prompts/openRenameFilePrompt';
+import {ProjectFolder} from '@codebridge/types';
+
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+
+import {testProject} from '../../test-files/';
+import {getDialogControlMock, getAnalyticsMock} from '../../test_utils';
+
+const getRenameFileMock = (): [ProjectFolder, RenameFileFunction] => {
+  const renameFileData = {} as ProjectFolder;
+  const mock: RenameFileFunction = (fileId, newName) => {
+    renameFileData.name = newName;
+    renameFileData.id = fileId;
+  };
+
+  return [renameFileData, mock];
+};
+
+describe('openRenameFilePrompt', function () {
+  it('can successfully rename a file', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '1';
+    const newFileName = 'valid_file_name.txt';
+
+    const [renameFileData, renameFileDataMock] = getRenameFileMock();
+
+    await openRenameFilePrompt({
+      fileId,
+      dialogControl: getDialogControlMock(newFileName),
+      renameFile: renameFileDataMock,
+      projectFiles: testProject.files,
+      sendCodebridgeAnalyticsEvent,
+      isStartMode: false,
+      validationFile: undefined,
+    });
+
+    expect(renameFileData.id).toEqual(fileId);
+    expect(renameFileData.name).toEqual(newFileName);
+    expect(analyticsData.event).toEqual(EVENTS.CODEBRIDGE_RENAME_FILE);
+  });
+
+  it('can rename a file to itself', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '1';
+    const newFileName = testProject.files[fileId].name;
+
+    const [renameFileData, renameFileDataMock] = getRenameFileMock();
+
+    await openRenameFilePrompt({
+      fileId,
+      dialogControl: getDialogControlMock(newFileName),
+      renameFile: renameFileDataMock,
+      projectFiles: testProject.files,
+      sendCodebridgeAnalyticsEvent,
+      isStartMode: false,
+      validationFile: undefined,
+    });
+
+    expect(renameFileData.id).toEqual(fileId);
+    expect(renameFileData.name).toEqual(newFileName);
+    expect(analyticsData.event).toEqual(EVENTS.CODEBRIDGE_RENAME_FILE);
+  });
+
+  it('can rename a file to nothing', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '1';
+    const newFileName = '';
+
+    const [renameFileData, renameFileDataMock] = getRenameFileMock();
+
+    await openRenameFilePrompt({
+      fileId,
+      dialogControl: getDialogControlMock(newFileName),
+      renameFile: renameFileDataMock,
+      projectFiles: testProject.files,
+      sendCodebridgeAnalyticsEvent,
+      isStartMode: false,
+      validationFile: undefined,
+    });
+
+    expect(renameFileData.id).toEqual(fileId);
+    expect(renameFileData.name).toEqual(newFileName);
+    expect(analyticsData.event).toEqual(EVENTS.CODEBRIDGE_RENAME_FILE);
+  });
+
+  it('can refuse to rename a file to a duplicate name', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '1';
+    const newFileName = 'testFile3.txt';
+
+    const [renameFileData, renameFileDataMock] = getRenameFileMock();
+
+    await openRenameFilePrompt({
+      fileId,
+      dialogControl: getDialogControlMock(newFileName),
+      renameFile: renameFileDataMock,
+      projectFiles: testProject.files,
+      sendCodebridgeAnalyticsEvent,
+      isStartMode: false,
+      validationFile: undefined,
+    });
+
+    expect(Object.keys(renameFileData).length).toEqual(0);
+    expect(Object.keys(analyticsData).length).toEqual(0);
+  });
+
+  it('can refuse to rename a file to an invalid name', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '1';
+    const newFileName = 'testfolder!';
+
+    const [renameFileData, renameFileDataMock] = getRenameFileMock();
+
+    await openRenameFilePrompt({
+      fileId,
+      dialogControl: getDialogControlMock(newFileName),
+      renameFile: renameFileDataMock,
+      projectFiles: testProject.files,
+      sendCodebridgeAnalyticsEvent,
+      isStartMode: false,
+      validationFile: undefined,
+    });
+
+    expect(Object.keys(renameFileData).length).toEqual(0);
+    expect(Object.keys(analyticsData).length).toEqual(0);
+  });
+
+  it('can refuse to rename a file to not have an extension', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '1';
+    const newFileName = 'invalidFile';
+
+    const [renameFileData, renameFileDataMock] = getRenameFileMock();
+
+    await openRenameFilePrompt({
+      fileId,
+      dialogControl: getDialogControlMock(newFileName),
+      renameFile: renameFileDataMock,
+      projectFiles: testProject.files,
+      sendCodebridgeAnalyticsEvent,
+      isStartMode: false,
+      validationFile: undefined,
+    });
+
+    expect(Object.keys(renameFileData).length).toEqual(0);
+    expect(Object.keys(analyticsData).length).toEqual(0);
+  });
+});


### PR DESCRIPTION
I think this is the last of the CT-822 work. There's always more we could do, but my original goal was to get all of the memoized prompts out of the `FileBrowser` component and compartmentalized and tested.

This just moves the inlined `renameFilePrompt` function to an external `openRenameFilePrompt` function, as well as adds tests for it.

After this PR, `FileBrowser/index.tsx` is down to 453 lines vs 943 lines before I started the work. 🎉 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CT-617](https://codedotorg.atlassian.net/browse/CT-617)
- jira ticket: [CT-822](https://codedotorg.atlassian.net/browse/CT-822)


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
