### PR TITLE
Music: dark buttons

### DIFF
--- a/apps/src/music/views/PackDialog2.module.scss
+++ b/apps/src/music/views/PackDialog2.module.scss
@@ -62,7 +62,7 @@
 
     .segmentedButtons {
       span {
-        font-size: 12px !important;
+        user-select: none;
       }
     }
 

--- a/apps/src/music/views/PackDialog2.tsx
+++ b/apps/src/music/views/PackDialog2.tsx
@@ -278,7 +278,7 @@ const PackDialog2: React.FunctionComponent<PackDialogProps> = ({player}) => {
             {musicI18n.packDialogTitle()}
           </Typography>
 
-          <div className={styles.body}>
+          <div className={styles.body} data-theme="Dark">
             <div>{musicI18n.packDialogBody()}</div>
 
             <SegmentedButtons

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -327,7 +327,11 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
       >
         <div id="hidden-item" tabIndex={0} role="button" />
         {showSoundFilters && (
-          <div id="sounds-panel-top" className={styles.soundsPanelTop}>
+          <div
+            id="sounds-panel-top"
+            className={styles.soundsPanelTop}
+            data-theme="Dark"
+          >
             <SegmentedButtons
               selectedButtonValue={mode}
               buttons={[

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -12,6 +12,12 @@
     justify-content: space-between;
     margin-bottom: 5px;
     gap: 8px;
+
+    .segmentedButtons {
+      span {
+        user-select: none;
+      }
+    }
   }
 
   &Body {


### PR DESCRIPTION
This updates the sounds panel and the proposed pack dialog update to both use the new dark mode styling of the `SegmentedButtons` component. 

### sounds panel

<img width="650" alt="Screenshot 2024-10-16 at 3 51 53 PM" src="https://github.com/user-attachments/assets/add03437-2114-4bd8-aa86-7478570fbd15">

### proposed pack dialog update

<img width="876" alt="Screenshot 2024-10-16 at 3 49 22 PM" src="https://github.com/user-attachments/assets/d0abdab3-d74c-4813-aaf5-f6e632cdf636">

