### PR TITLE
[Music] Alphabetize restricted packs for levelbuilder

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -80,6 +80,7 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
       levelData.library &&
       loadedLibraries[levelData.library]
         ?.getRestrictedPacks()
+        ?.sort((a, b) => a.name.localeCompare(b.name))
         ?.map(({name, id}) => ({value: id, text: name})),
     [levelData.library, loadedLibraries]
   );


### PR DESCRIPTION
A simple request from @onlinecsteacher:
> Can we alphabetize the song list in the dropdown on the edit page?
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/8b50b9cf-d4b7-475a-9302-c1428539348e">

**With changes:**
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/f84b6e3b-931a-4ead-a329-c1982ee8c32b">
