### PR TITLE
Add courseUmbrella to data

### DIFF
--- a/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
@@ -6,7 +6,7 @@ import {connect} from 'react-redux';
 import {queryUserProgress} from '@cdo/apps/code-studio/progressRedux';
 import {loadLevelsWithProgress} from '@cdo/apps/code-studio/teacherPanelRedux';
 import Button from '@cdo/apps/legacySharedComponents/Button';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants.js';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import firehoseClient from '@cdo/apps/metrics/firehose';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
@@ -43,6 +43,7 @@ export class EditableTeacherFeedback extends Component {
     selectedSectionId: PropTypes.number,
     updateUserProgress: PropTypes.func.isRequired,
     canHaveFeedbackReviewState: PropTypes.bool,
+    scriptName: PropTypes.string,
   };
 
   constructor(props) {
@@ -64,6 +65,29 @@ export class EditableTeacherFeedback extends Component {
       allowEditing: verifiedInstructor || allowUnverified,
     };
   }
+
+  determineCurriculumUmbrella = () => {
+    const {scriptName} = this.props;
+    const csfCourses = [
+      'coursea',
+      'courseb',
+      'coursec',
+      'coursed',
+      'coursee',
+      'coursef',
+    ];
+    if (scriptName.includes('csd')) {
+      return 'csd';
+    } else if (scriptName.includes('csp')) {
+      return 'csp';
+    } else if (scriptName.includes('csa')) {
+      return 'csa';
+    } else if (csfCourses.some(course => scriptName.includes(course))) {
+      return 'csf';
+    } else {
+      return scriptName;
+    }
+  };
 
   componentDidMount = () => {
     window.addEventListener('beforeunload', this.onUnload);
@@ -167,12 +191,17 @@ export class EditableTeacherFeedback extends Component {
           submitting: false,
         });
       });
-    analyticsReporter.sendEvent(EVENTS.FEEDBACK_SUBMITTED, {
-      sectionId: this.props.selectedSectionId,
-      unitId: this.props.serverScriptId,
-      levelId: this.props.serverLevelId,
-      isRubric: this.props.rubric,
-    });
+    analyticsReporter.sendEvent(
+      EVENTS.FEEDBACK_SUBMITTED,
+      {
+        sectionId: this.props.selectedSectionId,
+        unitId: this.props.serverScriptId,
+        levelId: this.props.serverLevelId,
+        isRubric: this.props.rubric,
+        curriculumUmbrella: this.determineCurriculumUmbrella(),
+      },
+      PLATFORMS.BOTH
+    );
   };
 
   didFeedbackChange = () => {
@@ -311,6 +340,7 @@ export default connect(
     selectedSectionId: state.teacherSections?.selectedSectionId,
     canHaveFeedbackReviewState:
       state.pageConstants && state.pageConstants.canHaveFeedbackReviewState,
+    scriptName: state.progress.scriptName,
   }),
   dispatch => ({
     updateUserProgress(userId) {

--- a/apps/test/unit/templates/instructions/teacherFeedback/EditableTeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/EditableTeacherFeedbackTest.jsx
@@ -25,6 +25,7 @@ const DEFAULT_PROPS = {
   selectedSectionId: 789,
   canHaveFeedbackReviewState: true,
   allowUnverified: false,
+  scriptName: 'csa1-2022',
   updateUserProgress: () => {},
 };
 


### PR DESCRIPTION
1. Adds statsig to the analytics reporter
2. Adds in proxy for curriculumUmbrella.  Note that this wasn't already passed in through state so getting it passed in would be a bit tricky.  I talked to Bryan and he agreed that the solution presented here would be sufficient for what he is wanting to do.


## Links
[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1259)