### PR TITLE
[Google Blockly] Disable/Enable blocks in start mode

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -810,7 +810,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       }
     };
 
-    if (!blocklyWrapper.isStartMode && !optOptionsExtended.isBlockEditMode) {
+    if (!blocklyWrapper.isToolboxMode && !optOptionsExtended.isBlockEditMode) {
       workspace.addChangeListener(disableOrphans);
     }
     if (blocklyWrapper.blockLimitMap && blocklyWrapper.blockLimitMap.size > 0) {


### PR DESCRIPTION
Bug report from @onlinecsteacher:
> If I copy code from the workspace into the Start code and it had been disabled when I copied it, connecting it to When Run doesn’t enable it automatically

https://github.com/user-attachments/assets/0acf9055-a3d8-4c9e-9c31-83ccad5b1094

This is also a problem even without copy/paste as she explains here:
> I switched over to trying to trying to edit in Start Mode so I wouldn’t have to keep copying and pasting my code from the workspace to Start Mode. But the issue is that blocks that are not connected to When Run are still enabled. 

Our Google Blockly labs use a `disableOrphans` change handler which handles toggling of blocks' enabled/disabled state based on whether they are connected to a valid top block.
Currently, we skip adding this listener if we are editing individual blocks (ie. in a block pool) or if we are "in start mode". I use quotes here, because `isStartMode` currently doesn't differentiate between are modes for editing start block or toolbox blocks.

`editBlocks` is an injection option that would typically be either `'start_blocks'` or `'toolbox_blocks'` if it's provided. We set `Blockly.isStartMode` to true if either (any truthy) value is present:
https://github.com/code-dot-org/code-dot-org/blob/mike/disableOrphans/apps/src/blockly/googleBlocklyWrapper.ts#L778

We want to skip this listener for `isBlockEditMode` because blocks in pools don't need to be disabled while they are being edited (https://github.com/code-dot-org/code-dot-org/pull/49798):
![image](https://github.com/user-attachments/assets/5286c51d-5a5f-4c34-9daf-2693bc22584c)

Similarly, we don't want to disable blocks when a toolbox is being edited:
![image](https://github.com/user-attachments/assets/950a1bb6-024b-4a86-92e1-b42389164e5a)

However, there's no reason we shouldn't follow our normal workspace behavior when editing start blocks. I believe this was simply an oversight. This commit from 2021 introduces `isStartMode` with the intention that it provides "fixes for edit toolbox mode": https://github.com/code-dot-org/code-dot-org/commit/379b9892c4291f2693bc255e5a697d37bb1b1ce5#diff-4bb5cd14d37a6317347cd31fb35a19d7277907cd228ad731ffae7dc4894e0318R17

I think that we've just been lucky that the hasn't caused issues so far as curriculum writers have edited start blocks on already-migrated labs.

To fix this, we can just prevent toggling enabled/disabled blocks in toolbox edit mode instead of any edit mode. As a follow-up, I'd like to make sure that `Blockly.isStartMode` is true if and only if we're actually in start mode. This isn't a trivial change because there are places where we read this value to determine if we're in either edit mode. (For example, we add a context menu option for levelbuilders to make blocks uneditable, which should work in start mode or toolbox mode.)

## Testing story

In start mode, blocks now have their state toggled as expected. I tested this with Music Lab (Lab2) and Sprite Lab. I also manually tested that there are no regressions when editing toolbox blocks (not supported for Lab2) or when editing a block in a pool (not supported for Lab2). 


https://github.com/user-attachments/assets/d680b968-0bb3-4064-a9fb-0f969d8bc49a


## Follow-up work

Clean up definition and uses of `Blockly.isStartMode`

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
