### PR TITLE
Remove webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,9 @@ group :development, :test do
   gem 'net-http-persistent'
   gem 'rinku'
   gem 'rspec', require: false
-  gem 'selenium-webdriver', '~> 4.25'
+  # Starting with version 4.6, Selenium uses Selenium Manager, eliminating the need for the webdriver gem.
+  # See: https://github.com/titusfortner/webdrivers/commit/5b3dc29ff5cdb7bec110de949e78184c789ef63a
+  gem 'selenium-webdriver', '~> 4.6'
   gem 'simplecov', '~> 0.22.0', require: false
   gem 'spring', '~> 3.1.1'
   gem 'spring-commands-testunit'

--- a/Gemfile
+++ b/Gemfile
@@ -109,11 +109,10 @@ group :development, :test do
   gem 'net-http-persistent'
   gem 'rinku'
   gem 'rspec', require: false
-  gem 'selenium-webdriver', '~> 4.0'
+  gem 'selenium-webdriver', '~> 4.25'
   gem 'simplecov', '~> 0.22.0', require: false
   gem 'spring', '~> 3.1.1'
   gem 'spring-commands-testunit'
-  gem 'webdrivers', '~> 5.2'
 
   # For pegasus PDF generation / merging testing.
   gem 'parallel_tests'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1094,7 +1094,7 @@ DEPENDENCIES
   scenic-mysql_adapter
   scss_lint
   sd_notify
-  selenium-webdriver (~> 4.25)
+  selenium-webdriver (~> 4.6)
   sequel (~> 5.29)
   simplecov (~> 0.22.0)
   sinatra (= 2.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -513,7 +513,7 @@ GEM
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    logger (1.6.0)
+    logger (1.6.1)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -814,7 +814,7 @@ GEM
     scss_lint (0.60.0)
       sass (~> 3.5, >= 3.5.5)
     sd_notify (0.1.1)
-    selenium-webdriver (4.23.0)
+    selenium-webdriver (4.25.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
@@ -893,8 +893,6 @@ GEM
     uber (0.1.0)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
-    unf (0.1.4)
-      unf_ext
     unf_ext (0.0.7.4)
     unicode-display_width (2.5.0)
     unicode_utils (1.4.0)
@@ -914,10 +912,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -1100,7 +1094,7 @@ DEPENDENCIES
   scenic-mysql_adapter
   scss_lint
   sd_notify
-  selenium-webdriver (~> 4.0)
+  selenium-webdriver (~> 4.25)
   sequel (~> 5.29)
   simplecov (~> 0.22.0)
   sinatra (= 2.2.3)
@@ -1123,7 +1117,6 @@ DEPENDENCIES
   validates_email_format_of
   vcr
   web-console (~> 4.2.0)
-  webdrivers (~> 5.2)
   webmock (~> 3.8)
   xxhash
   youtube-dl.rb

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -1,5 +1,4 @@
 require 'selenium/webdriver'
-require 'webdrivers'
 
 module SeleniumBrowser
   def self.local(browser: :chrome, headless: true)


### PR DESCRIPTION
We can remove the webdrivers gem because, starting with Selenium version 4.6, it manages the drivers by itself:
https://github.com/titusfortner/webdrivers/commit/5b3dc29ff5cdb7bec110de949e78184c789ef63a