### PR TITLE
Hoc 2024 - Update images on hourofcode.com

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/images/action-blocks/action-block-register.png
+++ b/pegasus/sites.v3/hourofcode.com/public/images/action-blocks/action-block-register.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1f71cddc146e2df41eb1c118b1b9f30c85860abe8030c3cbd14011d19042104
-size 163861
+oid sha256:8b7326787a3db5b8483ea6b9ca99999d4bf267092c4dabcfa0c441850c193bfb
+size 126617

--- a/pegasus/sites.v3/hourofcode.com/public/images/events-page-header.png
+++ b/pegasus/sites.v3/hourofcode.com/public/images/events-page-header.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e08ffae4b2f2b0ea3cac4fef35df9bbc7a2f29234d8bb1352b475f427b271a10
-size 167870
+oid sha256:116750271693dc733e903bd0a5866974ff426ebda230a219cf5bc9ce2d287a5b
+size 184521

--- a/pegasus/sites.v3/hourofcode.com/public/images/homepage-students-computer.png
+++ b/pegasus/sites.v3/hourofcode.com/public/images/homepage-students-computer.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e725f0f8941afcb3d8dedadcaf2a344a5433918de682a1f1d686c4cc6543861
-size 184770
+oid sha256:007e5c00ec241bf6c742f619ae7dc1e884b533d1f07f5a3de5a6950eab91ad74
+size 219978

--- a/pegasus/sites.v3/hourofcode.com/public/images/how-to-neon.png
+++ b/pegasus/sites.v3/hourofcode.com/public/images/how-to-neon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ebaf3afff9c36ae823ffc6df08fdd902997139a9b7961a87af0044a0f788808
+size 264985

--- a/pegasus/sites.v3/hourofcode.com/views/how-to/steps/steps_educators.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/how-to/steps/steps_educators.haml
@@ -64,7 +64,7 @@
               %p
                 %strong=hoc_s(:where)
                 =hoc_s(:hoc_how_to_step_educators_plan_desc_03)
-              %img{src: "/images/group_ipad.jpg", alt: ""}
+              %img{src: "/images/how-to-neon.png", alt: ""}
 
             -# Step 4 additional content
             - if index === 3


### PR DESCRIPTION
Updates images on the following pages:
- https://hourofcode.com homepage
- https://hourofcode.com/events
- https://hourofcode/com/how-to

## Links
Jira ticket: [ACQ-2544](https://codedotorg.atlassian.net/browse/ACQ-2544)
Figma mocks: [homepage](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=4065-1154&t=ULkcx0MeUsNlwgfO-1), [events](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=4065-1380&t=ULkcx0MeUsNlwgfO-1), [how-to](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=4065-1423&t=ULkcx0MeUsNlwgfO-1)

----

## Homepage
<img width="1243" alt="homepage" src="https://github.com/user-attachments/assets/8c42a933-c436-4f93-8adc-9462ea5fc48b">

## Events
<img width="1243" alt="events" src="https://github.com/user-attachments/assets/bb084c42-d6a6-4604-8fc3-903e3f248bef">

## How-to
<img width="1243" alt="how-to" src="https://github.com/user-attachments/assets/43c96571-ede5-441e-9f31-fdd085a326d5">
<img width="1243" alt="how-to-resources" src="https://github.com/user-attachments/assets/10b62b13-2656-4f54-8ed4-0a1bc0e9caf0">
