### PR TITLE
Fix showing Gen AI banners behind DCDO

### DIFF
--- a/pegasus/sites.v3/code.org/views/gen_ai_launch_skinny_banner.haml
+++ b/pegasus/sites.v3/code.org/views/gen_ai_launch_skinny_banner.haml
@@ -1,4 +1,4 @@
-- if !!DCDO.get('gen-ai-launch', CDO.default_hoc_mode)
+- if !!DCDO.get('gen-ai-launch', false)
   %link{href: "/css/generated/gen-ai-launch-skinny-banner.css", rel: "stylesheet"}
   %aside.gen-ai-launch-skinny-banner
     .wrapper.flex-container.justify-space-between.align-items-center.wrap


### PR DESCRIPTION
In [this thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1729182668267659?thread_ts=1729166528.376309&cid=C0T0PNTM3), Mike and Bethany noticed that the Gen AI banners were showing on test when they shouldn't have been.

This was because of [this line here](https://github.com/code-dot-org/code-dot-org/pull/61728/files#diff-5f0a2a74d0e31f7424106201d022ddab0753c837365bc6e0fcbd4323041afaedR1). `CDO.default_hoc_mode` is a string so `!![string]` evaluates to `true`, meaning the banner would always show. The banner was originally replacing the HOC banner in some spots so there was previous logic to have it only show under certain HOC mode values as well as the `gen-ai-launch` DCDO being `true`, but that is no longer the case and I forgot to switch this line back to default to `false`. This PR defaults it back to `false` to ensure it won't show until we flip the flag.

### Defaults to not showing
![NOT SHOW](https://github.com/user-attachments/assets/0d20f3e4-eb6f-4b7c-8769-09aeaccd6936)

### Shows once flag is flipped
![SHOWS](https://github.com/user-attachments/assets/bd5c3cca-0570-4b90-8ef0-b34aa8f1de4e)

## Links
Slack thread discussion: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1729182668267659?thread_ts=1729166528.376309&cid=C0T0PNTM3)

## Testing story
Local testing.
