### PR TITLE
Adds tos saving to new user builder for new sign up flow

### DIFF
--- a/dashboard/lib/services/partial_registration/user_builder.rb
+++ b/dashboard/lib/services/partial_registration/user_builder.rb
@@ -43,7 +43,7 @@ module Services
             user_params[:parent_email_preference_source] = EmailPreference::ACCOUNT_SIGN_UP
           end
         end
-        user_params[:terms_of_service_version] = User::TERMS_OF_SERVICE_VERSIONS.last
+        user_params[:terms_of_service_version] = ::User::TERMS_OF_SERVICE_VERSIONS.last
         user_params[:data_transfer_agreement_accepted] = user_params[:data_transfer_agreement_accepted] == '1'
         if user_params[:data_transfer_agreement_required] && user_params[:data_transfer_agreement_accepted]
           user_params[:data_transfer_agreement_request_ip] = request.ip

--- a/dashboard/lib/services/partial_registration/user_builder.rb
+++ b/dashboard/lib/services/partial_registration/user_builder.rb
@@ -43,7 +43,7 @@ module Services
             user_params[:parent_email_preference_source] = EmailPreference::ACCOUNT_SIGN_UP
           end
         end
-
+        user_params[:terms_of_service_version] = User::TERMS_OF_SERVICE_VERSIONS.last
         user_params[:data_transfer_agreement_accepted] = user_params[:data_transfer_agreement_accepted] == '1'
         if user_params[:data_transfer_agreement_required] && user_params[:data_transfer_agreement_accepted]
           user_params[:data_transfer_agreement_request_ip] = request.ip
@@ -81,7 +81,8 @@ module Services
           :data_transfer_agreement_request_ip,
           :data_transfer_agreement_source,
           :data_transfer_agreement_kind,
-          :data_transfer_agreement_at
+          :data_transfer_agreement_at,
+          :terms_of_service_version
         ]
       end
     end


### PR DESCRIPTION
When looking through our current finish_sign_up.html.haml, I noticed we had a hidden field that wasn't being accounted for in our new flow- :terms_of_service_version. Because we are changing how this looks on the front end (hitting create account means they implicitly agree to our tos instead of having to check a box), I opted to implement this on the back end in our user builder. This also most closely matches [how the field is currently being saved](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml#L224) for users on our existing sign up flow
<img width="1012" alt="Screenshot 2024-10-18 at 8 13 14 AM" src="https://github.com/user-attachments/assets/8e83c8d6-401d-41c0-b798-950eaa32465d">
. 

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2555

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
