### PR TITLE
Gen AI: Add "learn more" link to error message when unauthorized

### DIFF
--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -515,7 +515,7 @@ async function handleChatCompletionError(
       addChatEvent({
         id: getNewMessageId(),
         text: messageText,
-        notificationType: 'error',
+        notificationType: 'permissionsError',
         timestamp: Date.now(),
       })
     );

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -39,7 +39,7 @@ export interface ModelUpdate extends ChatEvent {
 export interface Notification extends ChatEvent {
   id: number;
   text: string;
-  notificationType: 'error' | 'success';
+  notificationType: 'permissionsError' | 'error' | 'success';
   includeInChatHistory?: boolean;
 }
 

--- a/apps/src/aichat/views/ChatEventView.tsx
+++ b/apps/src/aichat/views/ChatEventView.tsx
@@ -19,6 +19,8 @@ import {
 
 import {AI_CUSTOMIZATIONS_LABELS} from './modelCustomization/constants';
 
+import styles from './chatWorkspace.module.scss';
+
 interface ChatEventViewProps {
   event: ChatEvent;
   isTeacherView?: boolean;
@@ -78,6 +80,7 @@ const ChatEventView: React.FunctionComponent<ChatEventViewProps> = ({
             ? {
                 href: 'https://support.code.org/hc/en-us/articles/30162711193741-AI-Chat-Lab-FAQ',
                 text: commonI18n.learnMore(),
+                className: styles.alertLink,
               }
             : undefined
         }

--- a/apps/src/aichat/views/ChatEventView.tsx
+++ b/apps/src/aichat/views/ChatEventView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import ChatMessage from '@cdo/apps/aiComponentLibrary/chatMessage/ChatMessage';
 import Alert from '@cdo/apps/componentLibrary/alert/Alert';
+import {commonI18n} from '@cdo/apps/types/locale';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 
 import {modelDescriptions} from '../constants';
@@ -64,9 +65,21 @@ const ChatEventView: React.FunctionComponent<ChatEventViewProps> = ({
     return (
       <Alert
         text={`${text} ${timestampToLocalTime(timestamp)}`}
-        type={notificationType === 'error' ? 'danger' : 'success'}
+        type={
+          ['error', 'permissionsError'].includes(notificationType)
+            ? 'danger'
+            : 'success'
+        }
         onClose={
           isTeacherView ? undefined : () => dispatch(removeUpdateMessage(id))
+        }
+        link={
+          notificationType === 'permissionsError'
+            ? {
+                href: 'https://support.code.org/hc/en-us/articles/30162711193741-AI-Chat-Lab-FAQ',
+                text: commonI18n.learnMore(),
+              }
+            : undefined
         }
         size="s"
       />

--- a/apps/src/aichat/views/chatWorkspace.module.scss
+++ b/apps/src/aichat/views/chatWorkspace.module.scss
@@ -29,7 +29,7 @@ $tabs-default-spacing: 4px;
   padding: $tabs-default-spacing $tabs-default-spacing 0 $tabs-default-spacing;
   ul {
     li > button[role="tab"] {
-      max-width: 300px;  
+      max-width: 300px;
     }
   }
 }
@@ -61,4 +61,8 @@ $tabs-default-spacing: 4px;
   gap: 2px;
   padding: 16px 6px;
   border-top: 1px solid $light_gray_200;
+}
+
+.alertLink {
+  white-space: nowrap;
 }

--- a/apps/src/componentLibrary/link/Link.tsx
+++ b/apps/src/componentLibrary/link/Link.tsx
@@ -31,12 +31,14 @@ export interface LinkBaseProps extends HTMLAttributes<HTMLAnchorElement> {
 export type LinkWithChildren = LinkBaseProps & {
   /** Link content */
   children: React.ReactNode;
+  className?: string;
   text?: never;
 };
 
 export type LinkWithText = LinkBaseProps & {
   /** Link text content */
   text: string;
+  className?: string;
   children?: never;
 };
 


### PR DESCRIPTION
Adds a link to a Zendesk article with Gen AI FAQ when you try to submit a chat when unauthorized. Also makes a slight modification to our design system Alert component to allow styling to force the link to be on a single line (see context in [this thread](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1729190737181309?thread_ts=1729021564.344969&cid=C06FELVTV0Q)).

**After this change (no "Learn more" link previously)**

![image](https://github.com/user-attachments/assets/02b45f8c-d180-41ef-839b-e409df358cfa)

## Links

- jira ticket: [LABS-1118](https://codedotorg.atlassian.net/browse/LABS-1118)

## Testing story

Tested as a signed out user. Also tested that a error alert like the one we display if your model customizations failed to save does not display this link (I had to comment out the toxicity detection to test this out).

## Follow-up work

Planning on copying over these same error messages and display them if you try to submit a model customization without being authorized.