### PR TITLE
Adding Student and Teacher tests to Oauth platforms

### DIFF
--- a/dashboard/test/integration/omniauth/clever_test.rb
+++ b/dashboard/test/integration/omniauth/clever_test.rb
@@ -16,6 +16,32 @@ module OmniauthCallbacksControllerTests
       SignUpTracking.stubs(:split_test_percentage).returns(100)
     end
 
+    test "student sign up for newest sign up flow" do
+      auth_hash = mock_oauth user_type: User::TYPE_STUDENT
+
+      post "/users/auth/clever"
+      get '/users/auth/clever/callback', params: {finish_url: '/users/new_sign_up/finish_student_account'}
+      assert_template 'omniauth/redirect'
+      assert PartialRegistration.in_progress? session
+
+      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_STUDENT, true}
+      refute PartialRegistration.in_progress? session
+
+      created_user = User.find signed_in_user_id
+      assert_valid_student created_user, expected_email: auth_hash.info.email
+      assert_credentials auth_hash, created_user
+
+      assert_sign_up_tracking(
+        SignUpTracking::CONTROL_GROUP,
+        %w(
+          clever-callback
+          clever-sign-up-success
+        )
+      )
+    ensure
+      created_user&.destroy!
+    end
+
     test "student sign-up" do
       auth_hash = mock_oauth user_type: User::TYPE_STUDENT
 
@@ -31,6 +57,32 @@ module OmniauthCallbacksControllerTests
 
       assert_sign_up_tracking(
         SignUpTracking::NOT_IN_STUDY_GROUP,
+        %w(
+          clever-callback
+          clever-sign-up-success
+        )
+      )
+    ensure
+      created_user&.destroy!
+    end
+
+    test "teacher sign up for newest sign up flow" do
+      auth_hash = mock_oauth
+
+      post "/users/auth/clever"
+      get '/users/auth/clever/callback', params: {finish_url: '/users/new_sign_up/finish_teacher_account'}
+      assert_template 'omniauth/redirect'
+      assert PartialRegistration.in_progress? session
+
+      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_TEACHER, true}
+      refute PartialRegistration.in_progress? session
+
+      created_user = User.find signed_in_user_id
+      assert_valid_teacher created_user, expected_email: auth_hash.info.email
+      assert_credentials auth_hash, created_user
+
+      assert_sign_up_tracking(
+        SignUpTracking::CONTROL_GROUP,
         %w(
           clever-callback
           clever-sign-up-success

--- a/dashboard/test/integration/omniauth/clever_test.rb
+++ b/dashboard/test/integration/omniauth/clever_test.rb
@@ -16,32 +16,6 @@ module OmniauthCallbacksControllerTests
       SignUpTracking.stubs(:split_test_percentage).returns(100)
     end
 
-    test "student sign up for newest sign up flow" do
-      auth_hash = mock_oauth user_type: User::TYPE_STUDENT
-
-      post "/users/auth/clever"
-      get '/users/auth/clever/callback', params: {finish_url: '/users/new_sign_up/finish_student_account'}
-      assert_template 'omniauth/redirect'
-      assert PartialRegistration.in_progress? session
-
-      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_STUDENT, true}
-      refute PartialRegistration.in_progress? session
-
-      created_user = User.find signed_in_user_id
-      assert_valid_student created_user, expected_email: auth_hash.info.email
-      assert_credentials auth_hash, created_user
-
-      assert_sign_up_tracking(
-        SignUpTracking::CONTROL_GROUP,
-        %w(
-          clever-callback
-          clever-sign-up-success
-        )
-      )
-    ensure
-      created_user&.destroy!
-    end
-
     test "student sign-up" do
       auth_hash = mock_oauth user_type: User::TYPE_STUDENT
 
@@ -57,32 +31,6 @@ module OmniauthCallbacksControllerTests
 
       assert_sign_up_tracking(
         SignUpTracking::NOT_IN_STUDY_GROUP,
-        %w(
-          clever-callback
-          clever-sign-up-success
-        )
-      )
-    ensure
-      created_user&.destroy!
-    end
-
-    test "teacher sign up for newest sign up flow" do
-      auth_hash = mock_oauth
-
-      post "/users/auth/clever"
-      get '/users/auth/clever/callback', params: {finish_url: '/users/new_sign_up/finish_teacher_account'}
-      assert_template 'omniauth/redirect'
-      assert PartialRegistration.in_progress? session
-
-      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_TEACHER, true}
-      refute PartialRegistration.in_progress? session
-
-      created_user = User.find signed_in_user_id
-      assert_valid_teacher created_user, expected_email: auth_hash.info.email
-      assert_credentials auth_hash, created_user
-
-      assert_sign_up_tracking(
-        SignUpTracking::CONTROL_GROUP,
         %w(
           clever-callback
           clever-sign-up-success

--- a/dashboard/test/integration/omniauth/facebook_test.rb
+++ b/dashboard/test/integration/omniauth/facebook_test.rb
@@ -31,9 +31,10 @@ module OmniauthCallbacksControllerTests
       assert_credentials auth_hash, created_user
 
       assert_sign_up_tracking(
-        SignUpTracking::CONTROL_GROUP,
+        SignUpTracking::NOT_IN_STUDY_GROUP,
         %w(
           facebook-callback
+          facebook-sign-up-error
           facebook-sign-up-success
         )
       )
@@ -90,9 +91,10 @@ module OmniauthCallbacksControllerTests
       assert_credentials auth_hash, created_user
 
       assert_sign_up_tracking(
-        SignUpTracking::CONTROL_GROUP,
+        SignUpTracking::NOT_IN_STUDY_GROUP,
         %w(
           facebook-callback
+          facebook-sign-up-error
           facebook-sign-up-success
         )
       )

--- a/dashboard/test/integration/omniauth/facebook_test.rb
+++ b/dashboard/test/integration/omniauth/facebook_test.rb
@@ -15,6 +15,32 @@ module OmniauthCallbacksControllerTests
       SignUpTracking.stubs(:split_test_percentage).returns(0)
     end
 
+    test "student sign up for newest sign up flow" do
+      auth_hash = mock_oauth
+
+      post "/users/auth/facebook"
+      get '/users/auth/facebook/callback', params: {finish_url: '/users/new_sign_up/finish_student_account'}
+      assert_template 'omniauth/redirect'
+      assert PartialRegistration.in_progress? session
+
+      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_STUDENT, true}
+      refute PartialRegistration.in_progress? session
+
+      created_user = User.find signed_in_user_id
+      assert_valid_student created_user, expected_email: auth_hash.info.email
+      assert_credentials auth_hash, created_user
+
+      assert_sign_up_tracking(
+        SignUpTracking::CONTROL_GROUP,
+        %w(
+          facebook-callback
+          facebook-sign-up-success
+        )
+      )
+    ensure
+      created_user&.destroy!
+    end
+
     test "student sign-up" do
       auth_hash = mock_oauth
 
@@ -41,6 +67,32 @@ module OmniauthCallbacksControllerTests
           facebook-callback
           facebook-sign-up-error
           facebook-load-finish-sign-up-page
+          facebook-sign-up-success
+        )
+      )
+    ensure
+      created_user&.destroy!
+    end
+
+    test "teacher sign up for newest sign up flow" do
+      auth_hash = mock_oauth
+
+      post "/users/auth/facebook"
+      get '/users/auth/facebook/callback', params: {finish_url: '/users/new_sign_up/finish_teacher_account'}
+      assert_template 'omniauth/redirect'
+      assert PartialRegistration.in_progress? session
+
+      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_TEACHER, true}
+      refute PartialRegistration.in_progress? session
+
+      created_user = User.find signed_in_user_id
+      assert_valid_teacher created_user, expected_email: auth_hash.info.email
+      assert_credentials auth_hash, created_user
+
+      assert_sign_up_tracking(
+        SignUpTracking::CONTROL_GROUP,
+        %w(
+          facebook-callback
           facebook-sign-up-success
         )
       )

--- a/dashboard/test/integration/omniauth/google_oauth2_test.rb
+++ b/dashboard/test/integration/omniauth/google_oauth2_test.rb
@@ -15,6 +15,32 @@ module OmniauthCallbacksControllerTests
       SignUpTracking.stubs(:split_test_percentage).returns(0)
     end
 
+    test "student sign up for newest sign up flow" do
+      auth_hash = mock_oauth
+
+      post "/users/auth/google_oauth2"
+      get '/users/auth/google_oauth2/callback', params: {finish_url: '/users/new_sign_up/finish_student_account'}
+      assert_template 'omniauth/redirect'
+      assert PartialRegistration.in_progress? session
+
+      assert_creates(User) {finish_sign_up auth_hash, User::TYPE_STUDENT, true}
+      refute PartialRegistration.in_progress? session
+
+      created_user = User.find signed_in_user_id
+      assert_valid_student created_user, expected_email: auth_hash.info.email
+      assert_credentials auth_hash, created_user
+
+      assert_sign_up_tracking(
+        SignUpTracking::CONTROL_GROUP,
+        %w(
+          google_oauth2-callback
+          google_oauth2-sign-up-success
+        )
+      )
+    ensure
+      created_user&.destroy!
+    end
+
     test "student sign-up" do
       auth_hash = mock_oauth
 


### PR DESCRIPTION
Adds student and teacher tests to match the existing new teacher test in the google oauth test file. 

This is an attempt to further test the logic added in the following three PRs:
1. [Oauth back end pr](https://github.com/code-dot-org/code-dot-org/pull/61496)
2. [Save student pr](https://github.com/code-dot-org/code-dot-org/pull/61616)
3. [Save teacher pr](https://github.com/code-dot-org/code-dot-org/pull/60761)

PR 1 above added one test for the teacher google flow. This PR adds tests for google and facebook for students (both) and teacher (facebook). To see the logic we are testing, I'd first check out PR #1. 

The existing clever testing doesn't touch the omniauth/redirect file I edited, but I am open to feedback about how to test that flow specifically. There also doesn't exist a microsoft test file. The flow for all four is nearly the same so I'm not sure if adding one would be redundant (and am unclear on the initial reasoning to not have one). Perhaps Platform can provide more context.

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2430

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
