### PR TITLE
Codebridge: update height of console

### DIFF
--- a/apps/src/codebridge/Console/console.module.scss
+++ b/apps/src/codebridge/Console/console.module.scss
@@ -13,6 +13,7 @@
   font-family:'Courier New', Courier, monospace;
   overflow-y: scroll;
   user-select: text;
+  height: 100%
 }
 
 .errorLine {


### PR DESCRIPTION
Tiny css fix to make it so the horizontal scrollbar on the console appears at the bottom of the console area rather than the bottom of the text.

## Before
![Screenshot 2024-10-17 at 3 37 09 PM](https://github.com/user-attachments/assets/3ace5c1b-1666-449a-b9db-3d13919806f2)

## After
![Screenshot 2024-10-17 at 3 14 17 PM](https://github.com/user-attachments/assets/9b940532-e9ba-4a6a-bb44-4eee9bf54edf)


## Links

- jira ticket: [CT-867](https://codedotorg.atlassian.net/browse/CT-867)

## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
