### PR TITLE
Cleanup 2024 Access Report test script

### DIFF
--- a/bin/test_staging_update_census_mapbox
+++ b/bin/test_staging_update_census_mapbox
@@ -1,17 +1,26 @@
 #!/usr/bin/env ruby
 
 # The map on code.org/yourschool is run off of Mapbox.
-# This script updates the data on Mapbox by querying all rows from
-# census_summaries table for the appropriate school year,
-# creating maptiles with Mapbox's command line tool, Tippecanoe,
-# and uploading them to Mapbox's server.
+# This script updates the data on Mapbox by reading the rows from
+# the given AWS file and creating maptiles with Mapbox's command
+# line tool, Tippecanoe, and uploading them to Mapbox's server
+# under the `censustiles-dev` tileset.
+#
+# This can be used on staging to test that the data and script will
+# work with the new year's data before merging + running on
+# production using ./bin/update_census_mapbox.
+#
+# Note: This script does not read from the CensusSummaries table while
+# the real update_census_mapbox script does. Both read from the
+# Schools database.
 
 require_relative '../dashboard/config/environment'
 require_relative '../pegasus/helpers/properties'
-
 require_relative './cron/upload_to_mapbox'
 
-raise "CDO.mapbox_upload_token is not defined" unless CDO.mapbox_upload_token
+# Constants to update for the given year
+AWS_ACCESS_REPORT_DATA_FILE = "access-report-data-files-2024/final-csv/final_csv_2024_09_30.csv"
+ACCESS_REPORT_YEAR = "2024"
 
 CSV_IMPORT_OPTIONS = {col_sep: ",", headers: true, encoding: 'bom|utf-8'}.freeze
 
@@ -23,8 +32,7 @@ end
 
 def main
   CDO.log.info "Loading census summary data."
-  AWS::S3.seed_from_file('cdo-census', "access-report-data-files-2024/final-csv/final_csv_2024_09_30.csv") do |filename|
-    year = '2024'
+  AWS::S3.seed_from_file('cdo-census', AWS_ACCESS_REPORT_DATA_FILE) do |filename|
     geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
     entries_skipped = 0
 
@@ -49,7 +57,7 @@ def main
           },
           properties: {
             school_id: school.id,
-            year: year,
+            year: ACCESS_REPORT_YEAR,
             school_name: school.name.titleize,
             school_city: school.city.titleize,
             school_state: school.state,

--- a/bin/test_staging_update_census_mapbox
+++ b/bin/test_staging_update_census_mapbox
@@ -31,71 +31,73 @@ def make_location(lat, long)
 end
 
 def main
-  CDO.log.info "Loading census summary data."
-  AWS::S3.seed_from_file('cdo-census', AWS_ACCESS_REPORT_DATA_FILE) do |filename|
-    geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
-    entries_skipped = 0
+  if rack_env?(:staging)
+    CDO.log.info "Loading census summary data."
+    AWS::S3.seed_from_file('cdo-census', AWS_ACCESS_REPORT_DATA_FILE) do |filename|
+      geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
+      entries_skipped = 0
 
-    CSV.read(filename, **CSV_IMPORT_OPTIONS).each do |row|
-      # Parse or skip row data
-      parsed = row.to_hash.symbolize_keys
-      school = School.find_by_id(parsed[:school_id])
+      CSV.read(filename, **CSV_IMPORT_OPTIONS).each do |row|
+        # Parse or skip row data
+        parsed = row.to_hash.symbolize_keys
+        school = School.find_by_id(parsed[:school_id])
 
-      if school.nil?
-        entries_skipped += 1
-        next
+        if school.nil?
+          entries_skipped += 1
+          next
+        end
+
+        teaches_cs = parsed[:teaches_cs] == 'unknown' ? 'U' : parsed[:teaches_cs]
+
+        # Add parsed row to map
+        geojson["features"] <<
+          {
+            geometry: {
+              coordinates: [school.longitude.to_f, school.latitude.to_f],
+              type: "Point"
+            },
+            properties: {
+              school_id: school.id,
+              year: ACCESS_REPORT_YEAR,
+              school_name: school.name.titleize,
+              school_city: school.city.titleize,
+              school_state: school.state,
+              teaches_cs: teaches_cs
+            },
+            type: "Feature"
+          }
       end
 
-      teaches_cs = parsed[:teaches_cs] == 'unknown' ? 'U' : parsed[:teaches_cs]
+      CDO.log.info "#{entries_skipped} census summaries skipped due to no school_id match in database."
+      CDO.log.info "Census summaries loading: done processing #{filename}.\n"
 
-      # Add parsed row to map
-      geojson["features"] <<
-        {
-          geometry: {
-            coordinates: [school.longitude.to_f, school.latitude.to_f],
-            type: "Point"
-          },
-          properties: {
-            school_id: school.id,
-            year: ACCESS_REPORT_YEAR,
-            school_name: school.name.titleize,
-            school_city: school.city.titleize,
-            school_state: school.state,
-            teaches_cs: teaches_cs
-          },
-          type: "Feature"
-        }
-    end
-
-    CDO.log.info "#{entries_skipped} census summaries skipped due to no school_id match in database."
-    CDO.log.info "Census summaries loading: done processing #{filename}.\n"
-
-    file = Tempfile.new(['census', 'geojson'])
-    tiles = Tempfile.new(['censustiles-dev', 'mbtiles'])
-    file.write(JSON.pretty_generate(geojson))
-    _stdout, stderr, tippecanoe_status = Open3.capture3(
-      # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
-      # clusters points that are approximately 2 pixels apart, and drops points to make them fit if they can't.
-      # The layer is called "census". DO NOT change the layer name without changing the map
-      # in the Mapbox UI.
-      "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"census\" --force #{file.path}"
-    )
-    upload_successful = false
-    if tippecanoe_status.success?
-      upload_successful = upload_maptiles(tiles.path, 'censustiles-dev')
-    end
-    unless tippecanoe_status.success? && upload_successful
-      CDO.log.info "Error in uploading"
-      CDO.log.info `Success state: #{tippecanoe_status.success?}`
-      CDO.log.info `Upload successful: #{upload_successful}`
-      Honeybadger.notify(
-        error_message: "Updating Census map on Mapbox failed",
-        error_class: "Census Map Update Failure",
-        context: {
-          tippecanoe_status: stderr,
-          upload_status: upload_successful
-        }
+      file = Tempfile.new(['census', 'geojson'])
+      tiles = Tempfile.new(['censustiles-dev', 'mbtiles'])
+      file.write(JSON.pretty_generate(geojson))
+      _stdout, stderr, tippecanoe_status = Open3.capture3(
+        # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
+        # clusters points that are approximately 2 pixels apart, and drops points to make them fit if they can't.
+        # The layer is called "census". DO NOT change the layer name without changing the map
+        # in the Mapbox UI.
+        "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"census\" --force #{file.path}"
       )
+      upload_successful = false
+      if tippecanoe_status.success?
+        upload_successful = upload_maptiles(tiles.path, 'censustiles-dev')
+      end
+      unless tippecanoe_status.success? && upload_successful
+        CDO.log.info "Error in uploading"
+        CDO.log.info `Success state: #{tippecanoe_status.success?}`
+        CDO.log.info `Upload successful: #{upload_successful}`
+        Honeybadger.notify(
+          error_message: "Updating Census map on Mapbox failed",
+          error_class: "Census Map Update Failure",
+          context: {
+            tippecanoe_status: stderr,
+            upload_status: upload_successful
+          }
+        )
+      end
     end
   end
 end

--- a/bin/test_staging_update_census_mapbox
+++ b/bin/test_staging_update_census_mapbox
@@ -18,6 +18,8 @@ require_relative '../dashboard/config/environment'
 require_relative '../pegasus/helpers/properties'
 require_relative './cron/upload_to_mapbox'
 
+raise "CDO.mapbox_upload_token is not defined" unless CDO.mapbox_upload_token
+
 # Constants to update for the given year
 AWS_ACCESS_REPORT_DATA_FILE = "access-report-data-files-2024/final-csv/final_csv_2024_09_30.csv"
 ACCESS_REPORT_YEAR = "2024"


### PR DESCRIPTION
This PR provides the cleanup from [this PR](https://github.com/code-dot-org/code-dot-org/pull/61466), which added a clone of the [/yourschool page](https://code.org/yourschool) and a script similar to the `update_census_mapbox` script which used this year's Access Report data to populate the cloned /yourschool map (using the `censustiles-dev` tileset rather than `censustiles`) without touching the `CensusSummaries` data table. This will make it easier year-over-year to do the access report without having to use adhocs which were [having lots of issues](https://codedotorg.slack.com/archives/C03CK49G9/p1727722207177409) with being able to show the new data.

Cleanup tasks:
- Clean up the `test_staging_update_census_mapbox` test script so it can be used in future years on staging to test if the new data looks good
- (not in the PR but part of the cleanup) Update the [Acess Report instruction doc](https://docs.google.com/document/d/1ZcvnXAUfOwnmWdS8Z8JwwYDdHWTF6CrCWCmpgiKlw4U/edit?tab=t.0#heading=h.rizng6chl91e) to reflect using the new test script

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2510)
PR these files were added in: [here](https://github.com/code-dot-org/code-dot-org/pull/61466)
Access Report doc: [here](https://docs.google.com/document/d/1ZcvnXAUfOwnmWdS8Z8JwwYDdHWTF6CrCWCmpgiKlw4U/edit?tab=t.0#heading=h.rizng6chl91e)
