### PR TITLE
[Music] Sort pack options by artist

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -75,19 +75,26 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
     [levelData.library, loadedLibraries]
   );
 
-  const restrictedPacks = useMemo(
+  const restrictedPackOptions = useMemo(
     () =>
       levelData.library &&
       loadedLibraries[levelData.library]
         ?.getRestrictedPacks()
-        ?.sort((a, b) => a.name.localeCompare(b.name))
-        ?.map(({name, id}) => ({value: id, text: name})),
+        // Sort by artist name, then by pack name if artists are the same
+        ?.sort((a, b) =>
+          a.artist && b.artist
+            ? a.artist.localeCompare(b.artist) || a.name.localeCompare(b.name)
+            : 0
+        )
+        ?.map(({name, id, artist}) => ({
+          value: id,
+          text: `${artist} - ${name}`,
+        })),
     [levelData.library, loadedLibraries]
   );
 
   const restrictedPackKeys =
-    (restrictedPacks || []).map(pack => pack.value) || [];
-
+    (restrictedPackOptions || []).map(pack => pack.value) || [];
   return (
     <div>
       <input
@@ -123,7 +130,7 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
               }}
             />
           </div>
-          {hasRestrictedSounds && restrictedPacks && (
+          {hasRestrictedSounds && restrictedPackOptions && (
             <div>
               <SimpleDropdown
                 labelText="Selected Artist Pack"
@@ -132,7 +139,7 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
                 items={[
                   {value: 'none', text: '(none)'},
                   {value: DEFAULT_PACK, text: 'Code.org (Default)'},
-                  ...restrictedPacks,
+                  ...restrictedPackOptions,
                 ]}
                 selectedValue={levelData.packId}
                 onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
Follow-up to:
- https://github.com/code-dot-org/code-dot-org/pull/61837

After merging a requested change to sort packs by song title, @breville pointed out that we can also sort by (and show) the artist names: https://github.com/code-dot-org/code-dot-org/pull/61837#issuecomment-2420502896

> It might help for this UI to show artist name & song name with a separator in between? If so, then you can borrow this [snippet](https://github.com/code-dot-org/code-dot-org/blob/27a0e50555dbf9f6192796f0635c46cbb9a866a0/apps/src/music/views/PackDialog2.tsx#L264) to sort by artist and then by song inside artist.

I ran this by the curriculum team, and they agreed: https://codedotorg.slack.com/archives/C04TH8400AU/p1729198528735779?thread_ts=1729112877.680779&cid=C04TH8400AU

They indicated they'd prefer "Artist - Song" format as it aligns to how we list songs for Dance Party.

Here's how the list will look now:


![image (240)](https://github.com/user-attachments/assets/67195b27-6229-410e-80f9-7296276b8166)

While here, I renamed the variable `restrictedPackOptions` to better represent what this is. (We use these exclusively to populate the dropdown on the level edit page.)
