### PR TITLE
Python Lab: Add a basic UI test

### DIFF
--- a/apps/src/codebridge/Console/ControlButtons.tsx
+++ b/apps/src/codebridge/Console/ControlButtons.tsx
@@ -39,8 +39,8 @@ const ControlButtons: React.FunctionComponent = () => {
   const isPredictLevel = useAppSelector(
     state => state.lab.levelProperties?.predictSettings?.isPredictLevel
   );
-  const isLoadingEnvironment = useAppSelector(
-    state => state.lab2System.loadingCodeEnvironment
+  const hasLoadedEnvironment = useAppSelector(
+    state => state.lab2System.loadedCodeEnvironment
   );
   const isRunning = useAppSelector(state => state.lab2System.isRunning);
   const isValidating = useAppSelector(state => state.lab2System.isValidating);
@@ -91,7 +91,7 @@ const ControlButtons: React.FunctionComponent = () => {
     let tooltip = null;
     if (awaitingPredictSubmit) {
       tooltip = codebridgeI18n.predictRunDisabledTooltip();
-    } else if (isLoadingEnvironment) {
+    } else if (!hasLoadedEnvironment) {
       tooltip = codebridgeI18n.loadingEnvironmentTooltip();
     } else if (isValidating) {
       tooltip = codebridgeI18n.validatingRunDisabledTooltip();
@@ -100,7 +100,7 @@ const ControlButtons: React.FunctionComponent = () => {
   };
 
   const disabledCodeActionsTooltip = getDisabledCodeActionsTooltip();
-  const disabledCodeActionsIcon = isLoadingEnvironment
+  const disabledCodeActionsIcon = !hasLoadedEnvironment
     ? 'fa-spinner fa-spin'
     : 'fa-question-circle-o';
 
@@ -129,6 +129,7 @@ const ControlButtons: React.FunctionComponent = () => {
           }}
         >
           <Button
+            id="uitest-codebridge-run"
             text={'Run'}
             onClick={handleRun}
             disabled={!!disabledCodeActionsTooltip}

--- a/apps/src/codebridge/Console/index.tsx
+++ b/apps/src/codebridge/Console/index.tsx
@@ -69,7 +69,7 @@ const Console: React.FunctionComponent = () => {
       leftHeaderContent={<ControlButtons />}
       headerClassName={moduleStyles.consoleHeader}
     >
-      <div className={moduleStyles.console}>
+      <div className={moduleStyles.console} id="uitest-codebridge-console">
         {codeOutput.map((outputLine, index) => {
           if (outputLine.type === 'img') {
             return (

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -100,11 +100,11 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
 
   const appType = useAppSelector(state => state.lab.levelProperties?.appName);
   const isValidating = useAppSelector(state => state.lab2System.isValidating);
-  const isLoadingEnvironment = useAppSelector(
-    state => state.lab2System.loadingCodeEnvironment
+  const hasLoadedEnvironment = useAppSelector(
+    state => state.lab2System.loadedCodeEnvironment
   );
   const isRunning = useAppSelector(state => state.lab2System.isRunning);
-  const shouldValidateBeDisabled = isLoadingEnvironment || isRunning;
+  const shouldValidateBeDisabled = !hasLoadedEnvironment || isRunning;
 
   const scriptName =
     useAppSelector(state => state.progress.scriptName) || undefined;

--- a/apps/src/lab2/redux/systemRedux.ts
+++ b/apps/src/lab2/redux/systemRedux.ts
@@ -5,14 +5,14 @@ import {PayloadAction, createSlice} from '@reduxjs/toolkit';
 // responsible for setting this state as needed (some labs may not care about these
 // states, and therefore may not set these values).
 export interface Lab2SystemState {
-  loadingCodeEnvironment: boolean;
+  loadedCodeEnvironment: boolean;
   isRunning: boolean;
   hasRun: boolean;
   isValidating: boolean;
 }
 
 const initialState: Lab2SystemState = {
-  loadingCodeEnvironment: false,
+  loadedCodeEnvironment: false,
   isRunning: false,
   hasRun: false,
   isValidating: false,
@@ -23,8 +23,8 @@ const systemSlice = createSlice({
   name: 'lab2System',
   initialState,
   reducers: {
-    setLoadingCodeEnvironment(state, action: PayloadAction<boolean>) {
-      state.loadingCodeEnvironment = action.payload;
+    setLoadedCodeEnvironment(state, action: PayloadAction<boolean>) {
+      state.loadedCodeEnvironment = action.payload;
     },
     setIsRunning(state, action: PayloadAction<boolean>) {
       state.isRunning = action.payload;
@@ -39,7 +39,7 @@ const systemSlice = createSlice({
 });
 
 export const {
-  setLoadingCodeEnvironment,
+  setLoadedCodeEnvironment,
   setIsRunning,
   setHasRun,
   setIsValidating,

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -7,7 +7,7 @@ import {
 } from '@codebridge/redux/consoleRedux';
 
 import {setAndSaveProjectSource} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
-import {setLoadingCodeEnvironment} from '@cdo/apps/lab2/redux/systemRedux';
+import {setLoadedCodeEnvironment} from '@cdo/apps/lab2/redux/systemRedux';
 import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
 import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
 import {getStore} from '@cdo/apps/redux';
@@ -65,10 +65,10 @@ const setUpPyodideWorker = () => {
         });
         break;
       case 'loading_pyodide':
-        getStore().dispatch(setLoadingCodeEnvironment(true));
+        getStore().dispatch(setLoadedCodeEnvironment(false));
         break;
       case 'loaded_pyodide':
-        getStore().dispatch(setLoadingCodeEnvironment(false));
+        getStore().dispatch(setLoadedCodeEnvironment(true));
         break;
       default:
         console.warn(

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -1,0 +1,15 @@
+@no_mobile
+# Our minimum version of Safari does not support web workers
+@no_safari
+Feature: Python Lab run code
+
+Background:
+  Given I create a student named "Penelope"
+  And I am on "http://studio.code.org/s/allthethings/lessons/50/levels/1"
+  And I wait to see "#uitest-codebridge-run"
+  And I wait until "#uitest-codebridge-run" is not disabled
+
+Scenario: Can run and see output of Python program
+  And I press "uitest-codebridge-run"
+  And I wait until "#uitest-codebridge-console" contains text "Hello from the start!"
+  Then I sign out


### PR DESCRIPTION
This PR creates a basic UI test that verifies we can run Python code. As part of this I fixed a little issue where the run button is briefly enabled on load, then becomes disabled while we load pyodide. This was not a problem in normal usage because it's so brief, but the test could try to click run before we had loaded pyodide if it checked the button at the right time. To fix this I switched around the flag from `isLoadingEnvironment` to `hasLoadedEnvironment`, so it starts out false and becomes true once we've loaded. I also added a couple ids for ease of finding elements in the UI test.

## Links

- jira ticket: [CT-725](https://codedotorg.atlassian.net/browse/CT-725) I'll keep this ticket open so we can add more UI tests. I wanted to start with a simple one and get it through the pipeline as a sanity check.


## Testing story
Tested that the test passes on a saucelabs tunnel. I have it disabled for mobile and Safari because we don't support mobile and our minimum version of Safari does not support web workers. I [started a thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1729268180973819) about this, for pilot it's fine that we expect a higher version of Safari than our minimum version.

## Follow-up work
More tests!


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
