### PR TITLE
HoC 2024 - Add new code.org strings for November launch

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -2581,8 +2581,8 @@
         start: "Start Music Lab: Jam Session"
       banner:
         desc_01: "Learn to code as you remix your favorite artists' tracks and explore creating beats with AI!"
-        desc_02: "Make music and learn to code in our new Music Lab activity for Hour of Code! In this self-guided, one-hour activity, students remix tracks from artists like %{artist_list} while mastering coding basics such as sequencing, functions, and exploring AI-driven beat creation."
-        desc_03: "Remix tracks from artists like %{artist_list} while exploring coding basics like sequencing, functions, and generating beats with AI."
+        desc_02: "Make music and learn to code in our new Music Lab activity for Hour of Code! In this self-guided, one-hour activity, students remix tracks from artists like %{artist_list}, and %{artist_name} while mastering coding basics such as sequencing, functions, and exploring AI-driven beat creation."
+        desc_03: "Remix tracks from artists like %{artist_list}, and %{artist_name} while exploring coding basics like sequencing, functions, and generating beats with AI."
       block:
         title: "Teach Music Lab Beyond An Hour of Code"
         desc: "Use our full Music Lab tutorial to unleash your students' musical creativity, combining the joy of music with the principles of coding."

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1032,6 +1032,9 @@
   minecraft_education_activity_desc_2020: "Program the Minecraft Agent to collect data about forest fires. Learn coding basics and explore a real-world example of artificial intelligence."
   minecraft_resources_desc_01: "Utilize this on demand [free course](%{course_url}) or register your entire class to attend a live Hour of Code workshop with a guest teacher. Offered at multiple times during CSEdWeek, %{campaign_date}."
   minecraft_resources_desc_02: "Inspire STEM passion in K-12 learners with 200 hours of computer science curriculum, from block to python, supported by professional development."
+  minecraft_show:
+    title: "Minecraft: The Show Must Go On!"
+    desc: "Step into the theater to save the day in The Show Must Go On! Find the missing star, unlock hidden gags, and interact with a cast of mobs. Help the Agent overcome stage fright as you solve fun coding puzzles. Watch your coding skills shine in an epic final performance!"
 
   afe_page_heading: "Free resources from Amazon Future Engineer"
   afe_page_top_desc: "Enhance your teaching experience with Code.org in partnership with [Amazon Future Engineer](%{afe_url}). Eligible educators from underserved schools can access these benefits at no cost:"
@@ -2571,6 +2574,18 @@
         teachers_guide_desc: "Check out the teacher's guide to learn how to get started, explore activity ideas, and get answers to common questions."
       videos:
         heading: "Videos to help you get started with Music Lab"
+    jam_session:
+      name: "Music Lab: Jam Session"
+      button:
+        explore: "Explore Music Lab: Jam Session"
+        start: "Start Music Lab: Jam Session"
+      banner:
+        desc_01: "Learn to code as you remix your favorite artists' tracks and explore creating beats with AI!"
+        desc_02: "Make music and learn to code in our new Music Lab activity for Hour of Code! In this self-guided, one-hour activity, students remix tracks from artists like Sabrina Carpenter, Lady Gaga, and Shakira while mastering coding basics such as sequencing, functions, and exploring AI-driven beat creation."
+        desc_03: "Remix tracks from artists like Sabrina Carpenter, Lady Gaga, and Shakira while exploring coding basics like sequencing, functions, and generating beats with AI."
+      block:
+        title: "Teach Music Lab Beyond An Hour of Code"
+        desc: "Use our full Music Lab tutorial to unleash your students' musical creativity, combining the joy of music with the principles of coding."
 
   game_design_page:
     heading: "Game design"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -2581,8 +2581,8 @@
         start: "Start Music Lab: Jam Session"
       banner:
         desc_01: "Learn to code as you remix your favorite artists' tracks and explore creating beats with AI!"
-        desc_02: "Make music and learn to code in our new Music Lab activity for Hour of Code! In this self-guided, one-hour activity, students remix tracks from artists like Sabrina Carpenter, Lady Gaga, and Shakira while mastering coding basics such as sequencing, functions, and exploring AI-driven beat creation."
-        desc_03: "Remix tracks from artists like Sabrina Carpenter, Lady Gaga, and Shakira while exploring coding basics like sequencing, functions, and generating beats with AI."
+        desc_02: "Make music and learn to code in our new Music Lab activity for Hour of Code! In this self-guided, one-hour activity, students remix tracks from artists like %{artist_list} while mastering coding basics such as sequencing, functions, and exploring AI-driven beat creation."
+        desc_03: "Remix tracks from artists like %{artist_list} while exploring coding basics like sequencing, functions, and generating beats with AI."
       block:
         title: "Teach Music Lab Beyond An Hour of Code"
         desc: "Use our full Music Lab tutorial to unleash your students' musical creativity, combining the joy of music with the principles of coding."


### PR DESCRIPTION
Adds strings in preparation for changes to code.org for the 2024 Hour of Code November launch. Includes updates for Music Lab: Jam Session and the new Minecraft The Show Must Go On activity.

## Links
Jira ticket: [ACQ-2565](https://codedotorg.atlassian.net/browse/ACQ-2565)
Figma mocks: [strings](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=4986-2527&t=XSFAvBYgHw4NQAbm-1), [banners](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=4065-818&t=XSFAvBYgHw4NQAbm-1), [Minecraft](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=4072-3840&t=XSFAvBYgHw4NQAbm-1)