### PR TITLE
Music: instructions styling

### DIFF
--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -168,11 +168,14 @@
   }
 
   ol, ul {
+    font-size: 14px;
     line-height: 0;
+    margin: 0 0 10px 20px;
   }
 
   li {
     margin-bottom: 10px;
+    line-height: 1.4em;
   }
 
   code {
@@ -180,7 +183,9 @@
   }
 
   p {
+    margin-bottom: 10px;
     font-size: 14px;
+    line-height: 1.4em;
   }
 
   details {


### PR DESCRIPTION
Small update to Music Lab instructions styling.

### before

<img width="350" alt="Screenshot 2024-10-19 at 10 27 56 AM" src="https://github.com/user-attachments/assets/33971bee-f9cc-45f2-8d74-934a477d6911">

### after

<img width="350" alt="Screenshot 2024-10-19 at 10 26 28 AM" src="https://github.com/user-attachments/assets/7fb3e3a1-6df6-4754-9718-6938ad9b66cf">
