### PR TITLE
Music: finish button

### DIFF
--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -217,6 +217,8 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   text={
                     hasNextLevel ? commonI18n.continue() : commonI18n.finish()
                   }
+                  type={hasNextLevel ? 'primary' : 'secondary'}
+                  color={hasNextLevel ? 'purple' : 'black'}
                   onClick={onContinueOrFinish}
                   className={moduleStyles.buttonInstruction}
                 />


### PR DESCRIPTION
This change proposes reducing the prominence of the `Finish` button that shows in the final freeplay level of the Music lab HOC progression, so that it's a bit less tempting to click right away.

### before

<img width="514" alt="Screenshot 2024-10-20 at 12 28 17 AM" src="https://github.com/user-attachments/assets/dacfb9c9-3595-4239-85de-d0643b6b643c">

### after

<img width="514" alt="Screenshot 2024-10-20 at 12 25 43 AM" src="https://github.com/user-attachments/assets/d97a0a76-3037-45a7-a7a6-8083b55bc81f">
