### PR TITLE
fix: wait for jquery to load after new page load

### DIFF
--- a/dashboard/test/ui/features/platform/one_trust.feature
+++ b/dashboard/test/ui/features/platform/one_trust.feature
@@ -5,6 +5,7 @@ Feature: OneTrust integration
     Given I am in Europe
     Given I am on "http://hourofcode.com/es?otreset=true&otgeo=es"
     And I wait until current URL contains "otreset=false"
+    And I wait for jquery to load
     And I open my eyes to test "Hour of code Onetrust pop up"
     And I wait until element "#onetrust-banner-sdk" is visible
     And I see no difference for "Onetrust pop up: Hour of Code" using stitch mode "none"
@@ -16,6 +17,7 @@ Feature: OneTrust integration
     Given I am in Europe
     Given I am on "http://studio.code.org/home?otreset=true&otgeo=es"
     And I wait until current URL contains "otreset=false"
+    And I wait for jquery to load
     And I open my eyes to test "Code.org Onetrust pop up"
     And I wait until element "#onetrust-banner-sdk" is visible
     And I see no difference for "Onetrust pop up: code.org" using stitch mode "none"
@@ -25,6 +27,7 @@ Feature: OneTrust integration
     Given I am in Europe
     Given I am on "http://hourofcode.com/es?otreset=true&otgeo=es"
     And I wait until current URL contains "otreset=false"
+    And I wait for jquery to load
     And I wait until element "#onetrust-banner-sdk" is visible
 
   Scenario: OneTrust cookie pop-up shows when self-hosting OneTrust libraries on code.org
@@ -32,6 +35,7 @@ Feature: OneTrust integration
     Given I am in Europe
     Given I am on "http://studio.code.org/home?otreset=true&otgeo=es"
     And I wait until current URL contains "otreset=false"
+    And I wait for jquery to load
     And I wait until element "#onetrust-banner-sdk" is visible
 
   Scenario: The pages load the self hosted OneTrust libraries.


### PR DESCRIPTION
This PR adds a jquery wait. Previously, the fix only checked that the URL contained the `otreset=false` flag but did not check if the page was loaded such that jquery was available.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

```
./runner.rb  -f features/platform/one_trust.feature -c Safari
```

Tested, passed 5/5 times

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
