### PR TITLE
Remove unnecessary type definition for Link subtypes

### DIFF
--- a/apps/src/componentLibrary/link/Link.tsx
+++ b/apps/src/componentLibrary/link/Link.tsx
@@ -31,14 +31,12 @@ export interface LinkBaseProps extends HTMLAttributes<HTMLAnchorElement> {
 export type LinkWithChildren = LinkBaseProps & {
   /** Link content */
   children: React.ReactNode;
-  className?: string;
   text?: never;
 };
 
 export type LinkWithText = LinkBaseProps & {
   /** Link text content */
   text: string;
-  className?: string;
   children?: never;
 };
 


### PR DESCRIPTION
Remove unnecessary typing since `className` is an existing field in `LinkBaseProps`. Follow-up to https://github.com/code-dot-org/code-dot-org/pull/61857