### PR TITLE
Set flag for roster synced users

### DIFF
--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -61,7 +61,7 @@ class OmniAuthSection < Section
     oauth_section.update(hidden: false) if oauth_section.hidden
 
     oauth_students = students.map do |student|
-      User.from_omniauth(student, {'user_type' => User::TYPE_STUDENT})
+      User.from_omniauth(student, {'user_type' => User::TYPE_STUDENT}, true)
     end
 
     oauth_section.set_exact_student_list(oauth_students)

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -61,7 +61,7 @@ class OmniAuthSection < Section
     oauth_section.update(hidden: false) if oauth_section.hidden
 
     oauth_students = students.map do |student|
-      User.from_omniauth(student, {'user_type' => User::TYPE_STUDENT}, true)
+      User.from_omniauth(student, {'user_type' => User::TYPE_STUDENT}, nil, true)
     end
 
     oauth_section.set_exact_student_list(oauth_students)

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -61,7 +61,7 @@ class OmniAuthSection < Section
     oauth_section.update(hidden: false) if oauth_section.hidden
 
     oauth_students = students.map do |student|
-      User.from_omniauth(student, {'user_type' => User::TYPE_STUDENT}, nil, true)
+      User.from_omniauth(student, {'user_type' => User::TYPE_STUDENT}, roster_sync: true)
     end
 
     oauth_section.set_exact_student_list(oauth_students)

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -61,7 +61,7 @@ class OmniAuthSection < Section
     oauth_section.update(hidden: false) if oauth_section.hidden
 
     oauth_students = students.map do |student|
-      User.from_omniauth(student, {'user_type' => User::TYPE_STUDENT}, roster_sync: true)
+      User.from_omniauth(student, {'user_type' => User::TYPE_STUDENT, 'roster_synced' => true})
     end
 
     oauth_section.set_exact_student_list(oauth_students)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -863,7 +863,7 @@ class User < ApplicationRecord
   end
 
   CLEVER_ADMIN_USER_TYPES = ['district_admin', 'school_admin'].freeze
-  def self.from_omniauth(auth, params, session = nil, roster_sync = false)
+  def self.from_omniauth(auth, params, session = nil, roster_sync: false)
     omniauth_user = find_by_credential(type: auth.provider, id: auth.uid)
 
     unless omniauth_user

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -863,13 +863,12 @@ class User < ApplicationRecord
   end
 
   CLEVER_ADMIN_USER_TYPES = ['district_admin', 'school_admin'].freeze
-  def self.from_omniauth(auth, params, session = nil, roster_sync: false)
+  def self.from_omniauth(auth, params, session = nil)
     omniauth_user = find_by_credential(type: auth.provider, id: auth.uid)
 
     unless omniauth_user
       omniauth_user = create
       initialize_new_oauth_user(omniauth_user, auth, params)
-      omniauth_user.roster_synced = true if roster_sync
       omniauth_user.save
       SignUpTracking.log_sign_up_result(omniauth_user, session)
     end
@@ -911,6 +910,7 @@ class User < ApplicationRecord
 
     user.gender_third_party_input = auth.info.gender
     user.gender = Policies::Gender.normalize auth.info.gender
+    user.roster_synced = params['roster_synced'] || false
   end
 
   def oauth?

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -102,6 +102,7 @@ module Services
 
       user = ::User.new
       user.provider = ::User::PROVIDER_MIGRATED
+      user.roster_synced = true
       user.name = get_claim_from_list(nrps_member_message, Policies::Lti::STUDENT_NAME_KEYS)
 
       if account_type == ::User::TYPE_TEACHER && email_address.present?

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -359,6 +359,11 @@ class Services::LtiTest < ActiveSupport::TestCase
     assert_equal user.user_type, User::TYPE_STUDENT
   end
 
+  test 'should mark the user as roster synced' do
+    user = Services::Lti.initialize_lti_user_from_nrps(client_id: @id_token[:aud], issuer: @id_token[:iss], nrps_member: @nrps_student)
+    assert_equal user.roster_synced, true
+  end
+
   test 'should create a student user if LTI does not provide email despite instructor role' do
     Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
     @nrps_teacher[:message].first.delete(@custom_claims_key)

--- a/dashboard/test/models/sections/omni_auth_section_test.rb
+++ b/dashboard/test/models/sections/omni_auth_section_test.rb
@@ -22,6 +22,7 @@ class OmniAuthSectionTest < ActiveSupport::TestCase
     section.reload
     assert_equal 'G-222222', section.code
     assert_equal User.from_omniauth(students.first, {}), section.students.first
+    assert_equal section.students.first.roster_synced, true
 
     assert_no_difference 'User.count' do
       # Should find the existing Google Classroom section.

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3841,7 +3841,7 @@ class UserTest < ActiveSupport::TestCase
     params = {}
 
     assert_creates(User) do
-      user = User.from_omniauth(auth, params, nil, true)
+      user = User.from_omniauth(auth, params, roster_sync: true)
       assert_equal 'migrated', user.provider
       assert_equal 'Some User', user.name
       assert_equal 'google_oauth2', user.primary_contact_info.credential_type

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3841,13 +3841,14 @@ class UserTest < ActiveSupport::TestCase
     params = {}
 
     assert_creates(User) do
-      user = User.from_omniauth(auth, params)
+      user = User.from_omniauth(auth, params, nil, true)
       assert_equal 'migrated', user.provider
       assert_equal 'Some User', user.name
       assert_equal 'google_oauth2', user.primary_contact_info.credential_type
       assert_equal 'fake oauth token', user.primary_contact_info.data_hash[:oauth_token]
       assert_equal 'fake refresh token', user.primary_contact_info.data_hash[:oauth_refresh_token]
       assert_equal User::TYPE_STUDENT, user.user_type
+      assert_equal true, user.roster_synced
     end
   end
 
@@ -3872,6 +3873,7 @@ class UserTest < ActiveSupport::TestCase
       assert_equal 'fake oauth token', user.primary_contact_info.data_hash[:oauth_token]
       assert_equal 'fake refresh token', user.primary_contact_info.data_hash[:oauth_refresh_token]
       assert_equal 'google_oauth2', user.primary_contact_info.credential_type
+      assert_nil user.roster_synced
     end
   end
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3838,10 +3838,12 @@ class UserTest < ActiveSupport::TestCase
         user_type: 'student'
       },
     )
-    params = {}
+    params = {
+      'roster_synced' => true
+    }
 
     assert_creates(User) do
-      user = User.from_omniauth(auth, params, roster_sync: true)
+      user = User.from_omniauth(auth, params)
       assert_equal 'migrated', user.provider
       assert_equal 'Some User', user.name
       assert_equal 'google_oauth2', user.primary_contact_info.credential_type


### PR DESCRIPTION
Marks users as "roster synced" using a serialized attribute. It is set to true if the user was created via LTI or oauth-based sync operations. This is a prereq for making roster synced users exempt from CAP policies.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1243)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
