### PR TITLE
Only assert that the facebook icon is visible on the certificates page once

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -168,7 +168,6 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
   And I wait for 5 seconds
   And I see no difference for "uncustomized flappy certificate"
@@ -184,7 +183,6 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
   And I wait for 5 seconds
   And I see no difference for "uncustomized oceans certificate"
@@ -200,7 +198,6 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
   And I wait for 5 seconds
   And I see no difference for "uncustomized 20-hour certificate"
@@ -219,7 +216,6 @@ Scenario: congrats certificate pages
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
   And I wait for 5 seconds
   And I see no difference for "uncustomized Course A 2017 certificate"
@@ -236,7 +232,6 @@ Scenario: congrats certificate pages show social media icons
   Given I am on "http://studio.code.org/congrats"
   And I wait until element "#uitest-certificate" is visible
   And element "#uitest-certificate" is visible
-  And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
   Then the href of selector ".social-print-link" contains "/print_certificates/"
 
@@ -245,7 +240,6 @@ Scenario: congrats certificate pages show social media icons
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
   Then the href of selector ".social-print-link" contains "/print_certificates/"
 
@@ -254,7 +248,6 @@ Scenario: congrats certificate pages show social media icons
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
   Then the href of selector ".social-print-link" contains "/print_certificates/"
 
@@ -263,7 +256,6 @@ Scenario: congrats certificate pages show social media icons
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
   Then the href of selector ".social-print-link" contains "/print_certificates/"
 
@@ -272,6 +264,5 @@ Scenario: congrats certificate pages show social media icons
   And I wait to see element with ID "uitest-certificate"
   And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
-  And I wait until element ".fa-facebook" is visible
   And I wait until element ".fa-twitter" is visible
   Then the href of selector ".social-print-link" contains "/print_certificates/"


### PR DESCRIPTION
This pr removes the assertion that the facebook share icon is visible for all but the first check. The thought was that this test has been flaky because of some throttling of the request, so hopefully asking for it only once will make the test more reliable
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-2534)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
