### PR TITLE
Add StudentLearning Urgent & WorkdayUrgent SNS topics

### DIFF
--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -87,8 +87,3 @@
       Type: 'AWS::SNS::Topic'
       Properties:
         DisplayName: StudentLearning-WorkdayUrgent
-  
-  StudentLearningUrgent:
-    Type: 'AWS::SNS::Topic'
-    Properties:
-      DisplayName: StudentLearning-Urgent

--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -82,3 +82,13 @@
     Type: 'AWS::SNS::Topic'
     Properties:
       DisplayName: Infra-Urgent
+
+  StudentLearningWorkdayUrgent:
+      Type: 'AWS::SNS::Topic'
+      Properties:
+        DisplayName: StudentLearning-WorkdayUrgent
+  
+  StudentLearningUrgent:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      DisplayName: StudentLearning-Urgent


### PR DESCRIPTION
Creates `StudentLearningWorkdayUrgent` and `StudentLearningUrgent` SNS topics that can be used for pager duty and slack integration with alarms. In the immediate term, we plan to use these for recently created Gen AI alarms (https://github.com/code-dot-org/code-dot-org/pull/61833). 

## Links

https://codedotorg.atlassian.net/browse/LABS-1136