### PR TITLE
Only strip off trailing version year when cloning levels to avoid level name collision.

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -896,10 +896,6 @@ class Level < ApplicationRecord
   # represent a version year.
   private def base_name
     base_name = name
-    if name_suffix
-      strip_suffix_regex = /^(.*)#{Regexp.escape(name_suffix)}$/
-      base_name = name[strip_suffix_regex, 1] || name
-    end
     base_name = strip_version_year_suffixes(base_name)
     base_name
   end

--- a/dashboard/test/models/levels/level_test.rb
+++ b/dashboard/test/models/levels/level_test.rb
@@ -863,18 +863,32 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal old_level, new_level
   end
 
-  test 'clone with suffix replaces old suffix' do
+  test 'clone with suffix does not replaces old suffix that are not in version year format' do
     level_1 = create :level, name: 'my_level_1'
 
     # level_1 has no name suffix, so the new suffix is appended.
-    level_2 = level_1.clone_with_suffix('_2')
-    assert_equal 'my_level_1_2', level_2.name
-    assert_equal '_2', level_2.name_suffix
+    level_2 = level_1.clone_with_suffix('pilot')
+    assert_equal 'my_level_1_pilot', level_2.name
+    assert_equal '_pilot', level_2.name_suffix
 
     # level_2 has a name suffix, which the new suffix replaces.
     level_3 = level_2.clone_with_suffix('_3')
-    assert_equal 'my_level_1_3', level_3.name
+    assert_equal 'my_level_1_pilot_3', level_3.name
     assert_equal '_3', level_3.name_suffix
+  end
+
+  test 'clone with suffix only replaces trailing version year in suffix' do
+    level_1 = create :level, name: 'my_level_1'
+
+    # level_1 has no name suffix, so the new suffix is appended.
+    level_2 = level_1.clone_with_suffix('new_2024')
+    assert_equal 'my_level_1_new_2024', level_2.name
+    assert_equal '_new_2024', level_2.name_suffix
+
+    # level_2 has a name suffix, which the new suffix replaces.
+    level_3 = level_2.clone_with_suffix('2025')
+    assert_equal 'my_level_1_new_2025', level_3.name
+    assert_equal '_2025', level_3.name_suffix
   end
 
   test 'clone with suffix properly escapes suffixes' do
@@ -886,7 +900,7 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal "your_level_1_#{tricky_suffix}", level_2.name
 
     level_3 = level_2.clone_with_suffix('_3')
-    assert_equal 'your_level_1_3', level_3.name
+    assert_equal "your_level_1_#{tricky_suffix}_3", level_3.name
   end
 
   test 'clone with suffix truncates long names' do
@@ -1355,7 +1369,7 @@ class LevelTest < ActiveSupport::TestCase
   test 'get_validations returns nil if there are no validations' do
     level = create :level, name: 'test_level'
 
-    assert_equal nil, level.get_validations
+    assert_nil level.get_validations
   end
 
   describe '#available_callouts' do


### PR DESCRIPTION
**Context**: In the curriculum scripts that were cloned for SY 24-25, we hit two instances where levels were accidentally overwritten resulting in some expected levels from previous year missing.

In both these cases, we had a collection of levels which had two versions in SY 23-24, and both of these shared the same base name, with the name_suffix being the only difference. As a result, when cloning, the new name for SY 24-25 for both versions were the same, resulting in a collision and lessons incorrectly referencing levels.

For ex, SY 23-24 had source levels
```
- CSDU6 Circuit Playground Test_mb2022 (base name: CSDU6 Circuit Playground Test; name_suffix: mb2022)
- CSDU6 Circuit Playground Test_2023 (base name: CSDU6 Circuit Playground Test; name_suffix: 2023)
```

When cloning for SY 24-25, the destination name for both levels was, resulting in a collision and units containing incorrect level content
`CSDU6 Circuit Playground Test_2024 (base name: CSDU6 Circuit Playground Test; name_suffix: 2024)`

**Root cause**: When levels are cloned, the new trailing suffix part of the name is added to the destination level under property called name_suffix. When this level is a source level of cloning, the logic today strips off the trailing name_suffix part of the level name and then any trailing version year. So, in case of above, it would result in both levels getting cloned with the same destination name. 

**Fix**: Only remove trailing version year when computing destination level's name to ensure other unique identifiers are retained. This could result in cases where a level name has too many tokens if the version year is not at the trailing part of the level name but is a manageable problem when compared to the complexity we have today when levels are overwritten. 

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1212

## Testing story

- Validated the change manually by cloning lessons in levelbuilder locally
- Validated the change by cloning CSD unit 3 to confirm the destination name only removes trailing version year
- Drone

## Deployment strategy

Regular DTP

## Follow-up work

The name_suffix property can be completely removed if this fix doesn't result in any major issues. Once we go through another year of cloning and can confidently vet there are no other issues, it would be safe to fully clean up this property.

https://codedotorg.atlassian.net/browse/TEACH-1438 is tracking this issue.

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
