### PR TITLE
Music: new callout

### DIFF
--- a/apps/src/music/views/Callouts.tsx
+++ b/apps/src/music/views/Callouts.tsx
@@ -73,6 +73,10 @@ const availableCallouts: AvailableCallouts = {
   'flyout-first-block': {
     selector: '.blocklyFlyout:not([style*="display: none;"]) .blocklyDraggable',
   },
+  'flyout-second-block': {
+    selector:
+      '.blocklyFlyout:not([style*="display: none;"]) .blocklyDraggable ~ .blocklyDraggable',
+  },
   'toolbox-second-block': {
     selector:
       '.blocklyFlyout:not([style*="display: none;"]) .blocklyDraggable ~ .blocklyDraggable',


### PR DESCRIPTION
Adds a new callout, `flyout-second-block`, which points at the second block in a flyout (i.e. non-category) toolbox.  Sequel to https://github.com/code-dot-org/code-dot-org/pull/61484.
