### PR TITLE
Remove is_current column in Schools database

### DIFF
--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -18,12 +18,10 @@
 #  longitude                   :decimal(9, 6)
 #  school_category             :string(255)
 #  last_known_school_year_open :string(9)
-#  is_current                  :boolean
 #
 # Indexes
 #
 #  index_schools_on_id                           (id) UNIQUE
-#  index_schools_on_is_current                   (is_current)
 #  index_schools_on_last_known_school_year_open  (last_known_school_year_open)
 #  index_schools_on_name_and_city                (name,city)
 #  index_schools_on_school_district_id           (school_district_id)

--- a/dashboard/db/migrate/20241022150616_remove_is_current_column.rb
+++ b/dashboard/db/migrate/20241022150616_remove_is_current_column.rb
@@ -1,0 +1,8 @@
+class RemoveIsCurrentColumn < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :schools,
+      name: 'index_schools_on_is_current',
+      column: :is_current
+    remove_column :schools, :is_current, :boolean, if_exists: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_09_182721) do
+ActiveRecord::Schema.define(version: 2024_10_22_150616) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1911,9 +1911,7 @@ ActiveRecord::Schema.define(version: 2024_10_09_182721) do
     t.decimal "longitude", precision: 9, scale: 6, comment: "Location longitude"
     t.string "school_category"
     t.string "last_known_school_year_open", limit: 9
-    t.boolean "is_current"
     t.index ["id"], name: "index_schools_on_id", unique: true
-    t.index ["is_current"], name: "index_schools_on_is_current"
     t.index ["last_known_school_year_open"], name: "index_schools_on_last_known_school_year_open"
     t.index ["name", "city"], name: "index_schools_on_name_and_city", type: :fulltext
     t.index ["school_district_id"], name: "index_schools_on_school_district_id"


### PR DESCRIPTION
Removes the `is_current` column in the `Schools` database.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1796)

## Testing story
I first checked that we aren't using `is_current` anywhere, then I created the migration.

Before running the migration, the `is_current` column is present:
![show is_current](https://github.com/user-attachments/assets/653dc4b6-37b3-425b-b8a9-bd6e2db6f933)

I was then able to successfully run the new migration:
![successfully ran new migration](https://github.com/user-attachments/assets/3e87c6e8-4ee2-4cab-b4f5-c48f980e3fb7)

I double checked that when viewing the MySQL database, the `is_current` column didn't show up:
![no more is current](https://github.com/user-attachments/assets/0670f2b4-64d3-44f5-978c-4d583152b64e)
