### PR TITLE
Do not email global with unmatched regional partners

### DIFF
--- a/dashboard/app/models/pd/regional_partner_mini_contact.rb
+++ b/dashboard/app/models/pd/regional_partner_mini_contact.rb
@@ -48,8 +48,6 @@ class Pd::RegionalPartnerMiniContact < ApplicationRecord
           Pd::RegionalPartnerMiniContactMailer.matched(form, rp_pm).deliver_now
         end
       end
-    else
-      Pd::RegionalPartnerMiniContactMailer.unmatched(form, UNMATCHED_FORM_EMAIL).deliver_now
     end
 
     Pd::RegionalPartnerMiniContactMailer.receipt(form, regional_partner).deliver_now

--- a/dashboard/test/mailers/pd/regional_partner_mini_contact_mailer_test.rb
+++ b/dashboard/test/mailers/pd/regional_partner_mini_contact_mailer_test.rb
@@ -15,16 +15,6 @@ class RegionalPartnerMiniContactMailerTest < ActionMailer::TestCase
     assert_sendable mail
   end
 
-  # TODO: When cc is suported, remove email from unmatched
-  test 'unmatched links are valid urls' do
-    regional_partner_mini_contact = build :pd_regional_partner_mini_contact
-    form = regional_partner_mini_contact.sanitized_and_trimmed_form_data_hash
-    mail = Pd::RegionalPartnerMiniContactMailer.unmatched(form, 'nimisha@code.org')
-
-    assert links_are_complete_urls?(mail)
-    assert_sendable mail
-  end
-
   test 'matched receipt links are valid urls' do
     regional_partner = build :regional_partner
     regional_partner_mini_contact = build :pd_regional_partner_mini_contact, regional_partner: regional_partner

--- a/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
+++ b/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
@@ -126,18 +126,6 @@ class Pd::RegionalPartnerMiniContactTest < ActiveSupport::TestCase
     assert_sendable mail
   end
 
-  test 'Unmatched' do
-    RegionalPartner.stubs(:find_by_zip).returns([nil, nil])
-    create :pd_regional_partner_mini_contact, form_data: build(:pd_regional_partner_mini_contact_hash).to_json
-    mail = ActionMailer::Base.deliveries.first
-
-    assert_equal ['team-global@code.org'], mail.to
-    assert_equal 'A teacher wants to connect with Code.org', mail.subject
-    assert_equal ['partner@code.org'], mail.from
-    assert_equal 2, ActionMailer::Base.deliveries.count
-    assert_sendable mail
-  end
-
   test 'Receipt email' do
     RegionalPartner.stubs(:find_by_zip).returns([nil, nil])
     create :pd_regional_partner_mini_contact, form_data: build(:pd_regional_partner_mini_contact_hash).to_json


### PR DESCRIPTION
The global team was being spammed with emails from users who completed a form without a regional partner. This does not send an email if a regional partner cannot be found

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-2583)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
