### PR TITLE
Panels: style

### DIFF
--- a/apps/src/panels/panelsView.module.scss
+++ b/apps/src/panels/panelsView.module.scss
@@ -2,8 +2,8 @@
 @import 'font.scss';
 @import '../mixins.scss';
 
-$text-offset-x: -5cqw;
-$text-offset-y: 5cqw;
+$text-offset-x: 2cqw;
+$text-offset-y: 2cqw;
 
 @keyframes fade-in {
   0%, 50% {
@@ -89,6 +89,11 @@ $text-offset-y: 5cqw;
 
       .invisiblePlaceholder {
         opacity: 0;
+      }
+
+      code {
+        color: $light_primary_700;
+        font-size: 1.37cqw;
       }
 
       .typist {


### PR DESCRIPTION
Two small updates to panels styling: 

- A `code` block now renders at the right scale and colour, matching that seen in instructions.
- A text box can no longer overflow the browser window, because it's now always constrained inside the image area.

![Screenshot 2024-10-22 at 3 15 07 PM](https://github.com/user-attachments/assets/541799ac-4fe2-4dee-bffe-7b06601a723d)

