### PR TITLE
Fixes styling and links for tos and privacy line in new sign up flow

### DIFF
--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -347,9 +347,10 @@ const FinishStudentAccount: React.FunctionComponent<{
       <SafeMarkdown
         className={style.tosAndPrivacy}
         markdown={locale.by_signing_up({
-          tosLink: 'code.org/tos',
-          privacyPolicyLink: 'code.org/privacy',
+          tosLink: 'https://code.org/tos',
+          privacyPolicyLink: 'https://code.org/privacy',
         })}
+        openExternalLinksInNewTab={true}
       />
     </div>
   );

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -225,9 +225,10 @@ const FinishTeacherAccount: React.FunctionComponent<{
       <SafeMarkdown
         className={style.tosAndPrivacy}
         markdown={locale.by_signing_up({
-          tosLink: 'code.org/tos',
-          privacyPolicyLink: 'code.org/privacy',
+          tosLink: 'https://code.org/tos',
+          privacyPolicyLink: 'https://code.org/privacy',
         })}
+        openExternalLinksInNewTab={true}
       />
     </div>
   );

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -367,10 +367,12 @@ const LoginTypeSelection: React.FunctionComponent = () => {
         </div>
       </div>
       <SafeMarkdown
+        className={style.tosAndPrivacy}
         markdown={locale.by_signing_up({
-          tosLink: 'code.org/tos',
-          privacyPolicyLink: 'code.org/privacy',
+          tosLink: 'https://code.org/tos',
+          privacyPolicyLink: 'https://code.org/privacy',
         })}
+        openExternalLinksInNewTab={true}
       />
     </div>
   );

--- a/apps/src/signUpFlow/signUpFlowStyles.module.scss
+++ b/apps/src/signUpFlow/signUpFlowStyles.module.scss
@@ -69,8 +69,7 @@ span {
   max-width: 100%;
 
   a {
-    text-decoration: underline;
-    color: unset;
+    @include link-style;
   }
 
   .containerWrapper {
@@ -553,5 +552,6 @@ span {
   a {
     text-decoration: underline !important;
     color: unset !important;
+    font-weight: 700;
   }
 }


### PR DESCRIPTION
There were three issues with the footer of the loginSelectionType and Student and Teacher finish pages:
1. The links on the login selection page were not bold
2. The links did not open in a new tab
3. The links were broken (there is some 'smart' logic that treats a string as a relative url if it doesn't see a full address)

Before:
<img width="849" alt="Screenshot 2024-10-22 at 4 21 55 PM" src="https://github.com/user-attachments/assets/7c5a948c-222f-4f02-b766-750c238a86ad">
<img width="359" alt="Screenshot 2024-10-22 at 4 22 03 PM" src="https://github.com/user-attachments/assets/6e895dc8-bce1-433d-99a1-e67eea96184e">


After:

<img width="868" alt="Screenshot 2024-10-22 at 4 54 24 PM" src="https://github.com/user-attachments/assets/2169e5c7-6f2d-4df6-82e4-556c72114679">
<img width="356" alt="Screenshot 2024-10-22 at 4 31 38 PM" src="https://github.com/user-attachments/assets/ba96db69-1582-49e2-8b3b-45e83e4c58f6">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2587
- https://codedotorg.atlassian.net/browse/ACQ-2588

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
