### PR TITLE
HoC 2024 - Update hourofcode.com homepage banner design

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -11,6 +11,7 @@
 
 // Homepage banner
 section.banner.homepage {
+  padding-bottom: 4rem;
 
   h2 {
     font-weight: 400;
@@ -35,15 +36,25 @@ section.banner.homepage {
     height: 552px;
     position: relative;
 
+    html[dir="rtl"] & {
+      background: url('/images/hoc-2024-graphic-bg-rtl.png') no-repeat center center;
+      background-size: contain;
+    }
+
     .text-wrapper {
       position: absolute;
       bottom: 6rem;
       left: 3rem;
-      text-align: left;
+      text-align: initial;
       max-width: 390px;
+
+      html[dir="rtl"] & {
+        right: 3rem;
+      }
 
       h1, h2, p {
         color: var(--neutral_white);
+        text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
       }
     }
 
@@ -52,7 +63,7 @@ section.banner.homepage {
     }
   }
 
-  @media (max-width: 1130px) {
+  @media (max-width: 1024px) {
     .show-tablet {
       display: block;
     }

--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -9,6 +9,60 @@
   background-color: rgba($neutral-white, .9);
 }
 
+// Homepage banner
+section.banner.homepage {
+
+  h2 {
+    font-weight: 400;
+  }
+
+  p {
+    margin-bottom: 1.5rem;
+  }
+
+  figure {
+    margin: 0 auto 2rem;
+  }
+
+  .show-tablet {
+    display: none;
+  }
+
+  .wrapper.show-desktop {
+    background: url('/images/hoc-2024-graphic-bg.png') no-repeat center center;
+    background-size: contain;
+    max-width: 1130px;
+    height: 648px;
+    position: relative;
+
+    .text-wrapper {
+      position: absolute;
+      bottom: 6rem;
+      left: 3rem;
+      text-align: left;
+      max-width: 390px;
+
+      h1, h2, p {
+        color: var(--neutral_white);
+      }
+    }
+
+    .button-wrapper {
+      justify-content: start;
+    }
+  }
+
+  @media (max-width: 1130px) {
+    .show-tablet {
+      display: block;
+    }
+
+    .show-desktop {
+      display: none;
+    }
+  }
+}
+
 section.banner {
   padding: 2rem 0 6rem;
 
@@ -52,5 +106,9 @@ section.banner {
     img {
       width: 100%;
     }
+  }
+
+  .button-wrapper {
+    justify-content: center;
   }
 }

--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -61,18 +61,31 @@ section.banner.homepage {
       display: none;
     }
   }
+
+  .overlay {
+    background: linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(255,255,255,0.5) 45%, rgba(255,255,255,0) 100%);
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 0;
+  }
 }
 
 section.banner {
   padding: 2rem 0 6rem;
+  position: relative;
 
   .wrapper {
+    position: relative;
     margin: 0 auto;
     max-width: 800px;
     text-align: center;
     flex-direction: column;
     align-items: center;
     gap: 2rem;
+    z-index: 1;
 
     @media screen and (max-width: $width-md) {
       width: 80%;

--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -31,8 +31,8 @@ section.banner.homepage {
   .wrapper.show-desktop {
     background: url('/images/hoc-2024-graphic-bg.png') no-repeat center center;
     background-size: contain;
-    max-width: 1130px;
-    height: 648px;
+    max-width: 960px;
+    height: 552px;
     position: relative;
 
     .text-wrapper {

--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -63,7 +63,7 @@ section.banner.homepage {
     }
   }
 
-  @media (max-width: 1024px) {
+  @media (max-width: $width-lg) {
     .show-tablet {
       display: block;
     }

--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -13,6 +13,11 @@
 section.banner.homepage {
   padding-bottom: 4rem;
 
+  h1 {
+    font-size: 3rem;
+    margin-block: 0 1rem;
+  }
+
   h2 {
     font-weight: 400;
   }
@@ -63,7 +68,7 @@ section.banner.homepage {
     }
   }
 
-  @media (max-width: $width-lg) {
+  @media (max-width: 1023px) {
     .show-tablet {
       display: block;
     }
@@ -105,23 +110,6 @@ section.banner {
 
   h1, p {
     color: var(--neutral_dark);
-  }
-
-  h1 {
-    font-size: 3rem;
-    margin-block: 0 1rem;
-  }
-
-  p {
-    margin-bottom: 0;
-  }
-
-  a {
-    color: var(--neutral_dark);
-
-    &.link-button {
-      text-decoration: none;
-    }
   }
 
   figure {

--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -13,11 +13,6 @@
 section.banner.homepage {
   padding-bottom: 4rem;
 
-  h1 {
-    font-size: 3rem;
-    margin-block: 0 1rem;
-  }
-
   h2 {
     font-weight: 400;
   }
@@ -110,6 +105,15 @@ section.banner {
 
   h1, p {
     color: var(--neutral_dark);
+  }
+
+  h1 {
+    font-size: 3rem;
+    margin-block: 0 1rem;
+  }
+
+  p {
+    margin-bottom: 0;
   }
 
   figure {

--- a/pegasus/sites.v3/hourofcode.com/public/images/hoc-2024-graphic-bg-rtl.png
+++ b/pegasus/sites.v3/hourofcode.com/public/images/hoc-2024-graphic-bg-rtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c961ebb052a2dbeb3dac28898700781e79a6ea581d89d65302826acf61d827b
+size 2127099

--- a/pegasus/sites.v3/hourofcode.com/public/images/hoc-2024-graphic-bg.png
+++ b/pegasus/sites.v3/hourofcode.com/public/images/hoc-2024-graphic-bg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa43cefccf28fca9a9134a619eff045fd2bc87131bae19779f2b0f4c0adeb3d1
+size 639827

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -21,15 +21,14 @@ layout: wide_index
   #fullwidth
     = view :header
     %section.banner.homepage
-      .wrapper.flex-container
+      .wrapper.show-desktop
+        .text-wrapper
+          = view :hoc_2024_homepage_hero_text, class_name: "white"
+      .wrapper.show-tablet.flex-container
         %figure
           %img{src: "/images/hoc-2024-graphic.png", alt: ""}
         .text-wrapper
-          %h1=hoc_s("hoc_2024.header")
-          %p.body-one
-            =hoc_s("hoc_2024.banner.desc.join_millions")
-        %a.link-button.black{href: resolve_url("/events")}
-          =hoc_s("hoc_2024.button_host_an_event")
+          = view :hoc_2024_homepage_hero_text, class_name: "black"
 
 %main
   -# What is HoC?

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -23,12 +23,12 @@ layout: wide_index
     %section.banner.homepage
       .wrapper.show-desktop
         .text-wrapper
-          = view :hoc_2024_homepage_hero_text, class_name: "white"
+          = view :hoc_2024_homepage_hero_text, button_color: "white"
       .wrapper.show-tablet.flex-container
         %figure
           %img{src: "/images/hoc-2024-graphic.png", alt: ""}
         .text-wrapper
-          = view :hoc_2024_homepage_hero_text, class_name: "black"
+          = view :hoc_2024_homepage_hero_text, button_color: "black"
       .overlay
 
 %main

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -29,14 +29,15 @@ layout: wide_index
           %img{src: "/images/hoc-2024-graphic.png", alt: ""}
         .text-wrapper
           = view :hoc_2024_homepage_hero_text, class_name: "black"
+      .overlay
 
 %main
   -# What is HoC?
-  %section.bg-neutral-light
+  %section
     .wrapper
       %h2.no-margin-top.centered
         =hoc_s("hoc_homepage.what_is_hoc.heading")
-      %p.centered.body-two.wrap-balance
+      %p.centered.body-two.wrap-balance.no-margin-bottom
         =hoc_s("hoc_homepage.what_is_hoc.desc")
       -# Spanish video and banner
       - if ['es', 'la', 'pt', 'po'].include?(@language)
@@ -53,6 +54,8 @@ layout: wide_index
                   = hoc_s(:hoc_live_learn_message)
                 %a.link-button{href: 'https://code.org/envivo'}
                   = hoc_s(:hoc_live_learn_more)
+
+  = view :section_divider_line
 
   -# Host an Hour of Code
   %section.no-padding-bottom
@@ -88,7 +91,7 @@ layout: wide_index
   -# Stats
   %section.stats.bg-neutral-dark
     .wrapper.centered
-      %h2.white
+      %h2.white.no-margin-top
         =hoc_s("hoc_homepage.global.heading")
       %p.body-two.no-margin-bottom.white
         =hoc_s("hoc_homepage.global.desc")

--- a/pegasus/sites.v3/hourofcode.com/styles/040-page.css
+++ b/pegasus/sites.v3/hourofcode.com/styles/040-page.css
@@ -424,6 +424,25 @@ td {
 section.bg-neutral-light { background-color: var(--neutral_light); }
 section.bg-neutral-dark { background-color: var(--neutral_dark); }
 
+/* Line divider for use between sections
+Use .no-margin-bottom to remove extra space above
+a section that starts with an h2 */
+div.section-divider-line {
+  max-width: 960px;
+  margin: 0 auto;
+
+  @media screen and (max-width: 992px) {
+    padding: 0 2rem;
+  }
+
+  & > hr {
+    border: 0;
+    border-top: 1px solid var(--neutral_dark60);
+    margin: 0;
+    width: 100%;
+  }
+}
+
 /* Start carousel styles ------------------------ */
 .carousel-wrapper {
   position: relative;

--- a/pegasus/sites.v3/hourofcode.com/views/hoc_2024_homepage_hero_text.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/hoc_2024_homepage_hero_text.haml
@@ -1,0 +1,11 @@
+%h1.no-margin-bottom
+  =hoc_s("hoc_homepage.hero.heading")
+%h2.no-margin-top
+  =hoc_s("hoc_homepage.hero.subhead")
+%p.body-one
+  =hoc_s("hoc_homepage.hero.desc")
+.button-wrapper
+  %a.link-button{href: resolve_url("/learn"), class: class_name}
+    =hoc_s(:call_to_action_explore_activities)
+  %a.link-button{href: resolve_url("/events"), class: class_name}
+    =hoc_s("hoc_2024.button_host_an_event")

--- a/pegasus/sites.v3/hourofcode.com/views/hoc_2024_homepage_hero_text.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/hoc_2024_homepage_hero_text.haml
@@ -5,7 +5,7 @@
 %p.body-two
   =hoc_s("hoc_homepage.hero.desc")
 .button-wrapper
-  %a.link-button{href: resolve_url("/learn"), class: class_name}
+  %a.link-button{href: resolve_url("/learn"), class: button_color}
     =hoc_s(:call_to_action_explore_activities)
-  %a.link-button{href: resolve_url("/events"), class: class_name}
+  %a.link-button{href: resolve_url("/events"), class: button_color}
     =hoc_s("hoc_2024.button_host_an_event")

--- a/pegasus/sites.v3/hourofcode.com/views/hoc_2024_homepage_hero_text.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/hoc_2024_homepage_hero_text.haml
@@ -2,7 +2,7 @@
   =hoc_s("hoc_homepage.hero.heading")
 %h2.no-margin-top
   =hoc_s("hoc_homepage.hero.subhead")
-%p.body-one
+%p.body-two
   =hoc_s("hoc_homepage.hero.desc")
 .button-wrapper
   %a.link-button{href: resolve_url("/learn"), class: class_name}

--- a/pegasus/sites.v3/hourofcode.com/views/section_divider_line.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/section_divider_line.haml
@@ -1,0 +1,2 @@
+%div.section-divider-line
+  %hr


### PR DESCRIPTION
Updates the hero banner design on https://hourofcode.com. This will only show on desktop, the stacked design will continue to show for screen sizes under `1024px`.

## Links
Jira ticket: [ACQ-2550](https://codedotorg.atlassian.net/browse/ACQ-2550)
Figma mock: [here](https://www.figma.com/file/emvQNdidNnPvoU1NucF7Re?type=design&node-id=4065%3A1154&mode=dev)

----

## Desktop
https://github.com/user-attachments/assets/527e3f40-c91a-4d26-b735-e46efe3b5132

## Responsive

https://github.com/user-attachments/assets/131f70a8-91a1-4aec-b0fd-8ab57cbaef93

## RTL
![RTL](https://github.com/user-attachments/assets/8cb8898f-00af-4be5-89f9-19889abe7a4c)
