### PR TITLE
Update middle_high? to include Foundations of... currriculum umbrellas

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -934,10 +934,18 @@ class Unit < ApplicationRecord
     in_initiative?('CSC')
   end
 
+  def foundations_of_cs?
+    under_curriculum_umbrella?('Foundations of CS')
+  end
+
+  def foundations_of_programming?
+    under_curriculum_umbrella?('Foundations of Programming')
+  end
+
   # TODO: (Dani) Update to use new course types framework.
   # Currently this grouping is used to determine whether the script should have # a custom end-of-lesson experience.
   def middle_high?
-    csd? || csp? || csa?
+    csd? || csp? || csa? || foundations_of_cs? || foundations_of_programming?
   end
 
   def requires_verified_instructor?
@@ -2129,8 +2137,7 @@ class Unit < ApplicationRecord
   # To help teachers have more control over the pacing of certain scripts, we
   # send students on the last level of a lesson to the unit overview page.
   def show_unit_overview_between_lessons?
-    middle_high? || ['vpl-csd-summer-pilot'].include?(get_course_version&.course_offering&.key) ||
-      in_initiative?('Foundations of CS') || in_initiative?('Foundations of Programming')
+    middle_high? || ['vpl-csd-summer-pilot'].include?(get_course_version&.course_offering&.key)
   end
 
   def ai_assessment_enabled?

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -2129,7 +2129,8 @@ class Unit < ApplicationRecord
   # To help teachers have more control over the pacing of certain scripts, we
   # send students on the last level of a lesson to the unit overview page.
   def show_unit_overview_between_lessons?
-    middle_high? || ['vpl-csd-summer-pilot'].include?(get_course_version&.course_offering&.key)
+    middle_high? || ['vpl-csd-summer-pilot'].include?(get_course_version&.course_offering&.key) ||
+      in_initiative?('Foundations of CS') || in_initiative?('Foundations of Programming')
   end
 
   def ai_assessment_enabled?

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1069,6 +1069,20 @@ FactoryBot.define do
       participant_audience {"teacher"}
       instructor_audience {"facilitator"}
     end
+
+    factory :foundations_of_cs_script do
+      after(:create) do |foundations_of_cs_script|
+        foundations_of_cs_script.curriculum_umbrella = Curriculum::SharedCourseConstants::CURRICULUM_UMBRELLA.foundations_of_cs
+        foundations_of_cs_script.save!
+      end
+    end
+
+    factory :foundations_of_programming_script do
+      after(:create) do |foundations_of_programming_script|
+        foundations_of_programming_script.curriculum_umbrella = Curriculum::SharedCourseConstants::CURRICULUM_UMBRELLA.foundations_of_programming
+        foundations_of_programming_script.save!
+      end
+    end
   end
 
   factory :project_storage do

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -45,6 +45,9 @@ class UnitTest < ActiveSupport::TestCase
     # We also want to test level_concept_difficulties, so make sure to give it
     # one.
     @cacheable_level = create(:level, :with_script, level_concept_difficulty: create(:level_concept_difficulty))
+
+    @foundations_of_cs_unit = create :foundations_of_cs_script, name: 'foundations-of-cs-1'
+    @foundations_of_programming_unit = create :foundations_of_programming_script, name: 'foundations-of-programming-1'
   end
 
   setup do
@@ -1985,6 +1988,8 @@ class UnitTest < ActiveSupport::TestCase
     assert @csd_unit.middle_high?
     assert @csp_unit.middle_high?
     assert @csa_unit.middle_high?
+    assert @foundations_of_cs_unit.middle_high?
+    assert @foundations_of_programming_unit.middle_high?
 
     refute @csf_unit.middle_high?
     refute @csc_unit.middle_high?


### PR DESCRIPTION
Foundations of CS and Foundations of Programming are two new curriculum umbrellas that should be defined as middle_high. This makes it so they will direct students to the unit overview page between lessons rather than go straight to the next lesson (because of [this method](https://github.com/code-dot-org/code-dot-org/blob/39cbbdf32fea8f5548990f84d335592df8c21959/dashboard/app/models/unit.rb#L2131-L2133)).

## Links
- jira ticket: [CT-878](https://codedotorg.atlassian.net/browse/CT-878)


## Testing story
Tested that `data-science-with-python-2024` now has the correct redirect behavior, and updated the `middle_high` unit test.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
