### PR TITLE
Import 2021-2022 Private School data

### DIFF
--- a/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_pss
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_pss
@@ -1,0 +1,94 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../dashboard/config/environment'
+
+CDO.log = Logger.new($stdout)
+
+SURVEY_YEAR = '2021-2022'.freeze
+
+# Override for the dry run variable using an commandline argument
+DRY_RUN = !(ARGV.find {|arg| arg.casecmp('-dryrun')}).nil?
+
+COMMUNITY_TYPE_MAP = {
+  '11' => 'city_large',
+  '12' => 'city_midsize',
+  '13' => 'city_small',
+  '21' => 'suburban_large',
+  '22' => 'suburban_midsize',
+  '23' => 'suburban_small',
+  '31' => 'town_fringe',
+  '32' => 'town_distant',
+  '33' => 'town_remote',
+  '41' => 'rural_fringe',
+  '42' => 'rural_distant',
+  '43' => 'rural_remote'
+}.freeze
+
+def get_offered_grades(row)
+  {
+    # Transitional Kindergarten also counts as Pre-Kindergarten
+    'PK' => row['P145'] == '1' || row['P165'] == '1' ? '1' : '0',
+    # Transitional 1st Grade also counts as Kindergarten
+    'KG' => row['P155'] == '1' || row['P175'] == '1' ? '1' : '0',
+    '01' => row['P185'] == '1' ? '1' : '0',
+    '02' => row['P195'] == '1' ? '1' : '0',
+    '03' => row['P205'] == '1' ? '1' : '0',
+    '04' => row['P215'] == '1' ? '1' : '0',
+    '05' => row['P225'] == '1' ? '1' : '0',
+    '06' => row['P235'] == '1' ? '1' : '0',
+    '07' => row['P245'] == '1' ? '1' : '0',
+    '08' => row['P255'] == '1' ? '1' : '0',
+    '09' => row['P265'] == '1' ? '1' : '0',
+    '10' => row['P275'] == '1' ? '1' : '0',
+    '11' => row['P285'] == '1' ? '1' : '0',
+    '12' => row['P295'] == '1' ? '1' : '0',
+  }
+end
+
+# The LOGR2022 and HIGR2022 values are incorrect so we need to manually calculate the lowest and highest grades taught.
+def get_low_high_offered_grades(offered_grades)
+  {
+    'low' => offered_grades.keys.find {|k| offered_grades[k] == '1'},
+    'high' => offered_grades.keys.reverse.find {|k| offered_grades[k] == '1'}
+  }
+end
+
+AWS::S3.process_file('cdo-nces', "2021-2022/pss/schools_private.csv") do |filename|
+  SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, dry_run: DRY_RUN) do |row|
+    offered_grades = get_offered_grades(row)
+    low_high_offered_grades = get_low_high_offered_grades(offered_grades)
+    {
+      school_id:          row['PPIN'],
+      school_year:        SURVEY_YEAR,
+      grades_offered_lo:  low_high_offered_grades['low'],
+      grades_offered_hi:  low_high_offered_grades['high'],
+      grade_pk_offered:   offered_grades['PK'],
+      grade_kg_offered:   offered_grades['KG'],
+      grade_01_offered:   offered_grades['01'],
+      grade_02_offered:   offered_grades['02'],
+      grade_03_offered:   offered_grades['03'],
+      grade_04_offered:   offered_grades['04'],
+      grade_05_offered:   offered_grades['05'],
+      grade_06_offered:   offered_grades['06'],
+      grade_07_offered:   offered_grades['07'],
+      grade_08_offered:   offered_grades['08'],
+      grade_09_offered:   offered_grades['09'],
+      grade_10_offered:   offered_grades['10'],
+      grade_11_offered:   offered_grades['11'],
+      grade_12_offered:   offered_grades['12'],
+      grade_13_offered:   false,
+      virtual_status:     'MISSING',
+      students_total:     row['P305'].presence.try {|v| v.to_i <= 0 ? nil : v.to_i},
+      student_am_count:   row['P310'].presence.try {|v| v.to_i < 0 ? nil : v.to_i},
+      student_as_count:   row['P316'].presence.try {|v| v.to_i < 0 ? nil : v.to_i},
+      student_hi_count:   row['P320'].presence.try {|v| v.to_i < 0 ? nil : v.to_i},
+      student_bl_count:   row['P325'].presence.try {|v| v.to_i < 0 ? nil : v.to_i},
+      student_wh_count:   row['P330'].presence.try {|v| v.to_i < 0 ? nil : v.to_i},
+      student_hp_count:   row['P318'].presence.try {|v| v.to_i < 0 ? nil : v.to_i},
+      student_tr_count:   row['P332'].presence.try {|v| v.to_i < 0 ? nil : v.to_i},
+      title_i_status:     nil,
+      frl_eligible_total: nil,
+      community_type:     row['ULOCALE22'].presence.try {|v| COMMUNITY_TYPE_MAP[v]}
+    }
+  end
+end

--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -423,6 +423,26 @@ class School < ApplicationRecord
         end
       end
 
+      CDO.log.info "Seeding 2021-2022 private school data."
+      AWS::S3.seed_from_file('cdo-nces', "2021-2022/pss/schools_private.csv") do |filename|
+        merge_from_csv(filename, {headers: true, encoding: 'bom|utf-8'}, true, is_dry_run: false) do |row|
+          {
+            id:                           row['PPIN'],
+            name:                         row['PINST'].upcase,
+            address_line1:                row['PADDRS'].to_s.upcase.truncate(50).presence,
+            address_line2:                nil,
+            address_line3:                nil,
+            city:                         row['PCITY'].to_s.upcase.presence,
+            state:                        row['PSTABB'].to_s.strip.upcase.presence,
+            zip:                          row['PZIP'],
+            latitude:                     row['LATITUDE22'].to_f,
+            longitude:                    row['LONGITUDE22'].to_f,
+            school_type:                  'private',
+            school_district_id:           nil
+          }
+        end
+      end
+
       # Some of this data has #- appended to the front, so we strip that off with .to_s.slice(2) (it's always a single digit)
       CDO.log.info "Seeding 2022-2023 public school data."
       AWS::S3.seed_from_file('cdo-nces', "2022-2023/ccd/schools_public.csv") do |filename|


### PR DESCRIPTION
Imports the [2021-2022 Private School data](https://drive.google.com/drive/u/3/folders/18t4p2xf9igu9augR5nT1pZKYOxnX0gMh). I followed the [NCES data ingestion doc](https://docs.google.com/document/d/1CZbauSgOf81C9JbTdorXrNcO1SqccwCCMkNp0ElWRnw/edit?tab=t.0#heading=h.fe6apk36vf4v)'s instructions and Vijaya's previous [seeding script update PR](https://github.com/code-dot-org/code-dot-org/pull/51416) and [SchoolStatsByYear update script PR](https://github.com/code-dot-org/code-dot-org/pull/51491) as guides to test.

I tested locally that I could successfully `seed:schools` with the new private school data:
![successfully seeded private schools](https://github.com/user-attachments/assets/2c407cb8-b32a-4fc6-82b7-84e8153925ff)

Then I ran a dry run of the new script that updates the `SchoolStatsByYear` table:
![dryrun SUCCESS](https://github.com/user-attachments/assets/0ad0e65b-5fcb-43b2-988e-3787d698ab13)

Since this stated it would successfully add each school and had 0 schools it failed to add, I then successfully ran it without the `-dryrun` parameter:
![actual run SUCCESS](https://github.com/user-attachments/assets/455d27f7-bad9-4ca5-a13c-3f6eaf63c6e0)

To double check that it actually updated the `SchoolStatsByYear` table and that it assigned values to the right fields, I checked some of the entries to make sure the values made sense:
![value checks](https://github.com/user-attachments/assets/2bfa85f2-0156-45d4-a1f9-4fa525af31ca)


## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-1627)
2021-2022 private school data: [here](https://drive.google.com/drive/u/3/folders/18t4p2xf9igu9augR5nT1pZKYOxnX0gMh)
NCES data ingestion doc: [here](https://docs.google.com/document/d/1CZbauSgOf81C9JbTdorXrNcO1SqccwCCMkNp0ElWRnw/edit?tab=t.0#heading=h.fe6apk36vf4v)
Vijaya's PR for ingesting the 2021-2022 public school data: [here](https://github.com/code-dot-org/code-dot-org/pull/51416)
Vijaya's PR for populating the `SchoolStatsByYear` table with the 2021-2022 public school data: [here](https://github.com/code-dot-org/code-dot-org/pull/51491)

## Testing story
Local testing.

## Follow-up work
Once this is on production, I'll run a dryrun of `bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_pss` to check that none of the schools would fail to be added. If everything looks good, I'll run it normally and double check the production database afterwards.
