### PR TITLE
Add school info query for school data component

### DIFF
--- a/apps/src/accounts/AccountInformation/style.module.scss
+++ b/apps/src/accounts/AccountInformation/style.module.scss
@@ -7,7 +7,7 @@
       margin-bottom: 0.5rem;
     }
 
-    &.authorizedTeacher {
+    &.verifiedTeacher {
       font-weight: bold;
       color: $light_affirmative_500;
       margin: 0;

--- a/apps/src/accounts/SchoolInformation/index.tsx
+++ b/apps/src/accounts/SchoolInformation/index.tsx
@@ -14,7 +14,7 @@ import commonStyles from '../common/common.styles.module.scss';
 interface SchoolInfo {
   country: string;
   school_name: string;
-  zip: string;
+  school_zip: string;
   school_id: string;
   school_type: string;
 }
@@ -35,7 +35,7 @@ export const SchoolInformation: React.FC<SchoolInformationProps> = ({
     schoolId: schoolInfo?.school_id,
     schoolName: schoolInfo?.school_name,
     country: schoolInfo?.country,
-    schoolZip: schoolInfo?.zip,
+    schoolZip: schoolInfo?.school_zip,
     schoolType: schoolInfo?.school_type,
   });
 

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -95,7 +95,8 @@ class Pd::WorkshopEnrollmentController < ApplicationController
           facilitators: facilitators,
           workshop_enrollment_status: "unsubmitted",
           previous_courses: Pd::TeacherApplicationConstants::SUBJECTS_TAUGHT_IN_PAST,
-          collect_demographics: collect_demographics
+          collect_demographics: collect_demographics,
+          school_info: Queries::SchoolInfo.current_school(current_user)
         }.to_json
       }
     end

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -124,19 +124,12 @@ class SchoolInfo < ApplicationRecord
     end
   end
 
-  # Validate records in the newer data format (see school_info_test.rb for details).
-  # The following states are valid (from the spec at https://goo.gl/Gw57rL):
-  #
-  # Country “USA” + charter + State + District + School name [selected]
-  # Country “USA” + charter + State + District + zip + School name “other” [typed]
-  # Country “USA” + charter + State + District “other” [typed] + zip + School name [typed]
-  # Country “USA” + private + State + zip + School name [typed]
-  # Country “USA” + public + State + District + School name [selected]
-  # Country “USA” + public + State + District + zip + School name “other” [typed]
-  # Country “USA” + public + State + District “other” [typed] + zip + School name [typed]
-  # Country “USA” + other + State + zip + School name [typed]
-  # Non-USA Country + any school type + address + school name
-  #
+  # Validate records
+  # Non-US schools require country and school name
+  # US nces schools sync required data from the `schools` table
+  # US non-nces schools (not found in `schools` table) require zip and school_name
+  # US non-school settings have school_type = noSchoolSetting and require zip and school_name
+
   # This method reports errors if the record has a country and is invalid.
   def validate_with_country
     return unless country && should_check_for_full_validation?

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -156,10 +156,23 @@ class SchoolInfo < ApplicationRecord
   end
 
   def validate_us
+    if school || (school_type && school_type != SCHOOL_TYPE_NO_SCHOOL_SETTING)
+      validate_nces_school
+    else
+      validate_non_nces_school
+    end
+  end
+
+  def validate_nces_school
     errors.add(:school_type, "is required") unless school_type
     errors.add(:school_type, "is invalid") unless SCHOOL_TYPES.include? school_type
     validate_private_other if [SCHOOL_TYPE_PRIVATE, SCHOOL_TYPE_OTHER].include? school_type
     validate_public_charter if [SCHOOL_TYPE_PUBLIC, SCHOOL_TYPE_CHARTER].include? school_type
+  end
+
+  def validate_non_nces_school
+    errors.add(:zip, "is required") unless zip
+    errors.add(:school_name, "is required") unless school_name || school_type == SCHOOL_TYPE_NO_SCHOOL_SETTING
   end
 
   def validate_private_other

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -144,10 +144,7 @@ class SchoolInfo < ApplicationRecord
   end
 
   def validate_non_us
-    errors.add(:school_type, "is required") unless school_type
-    errors.add(:school_type, "is invalid") unless SCHOOL_TYPES.include? school_type
     errors.add(:school_name, "is required") unless school_name
-    errors.add(:full_address, "is required") unless full_address
 
     errors.add(:state, "is forbidden") if state
     errors.add(:zip, "is forbidden") if zip

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -127,8 +127,8 @@ class SchoolInfo < ApplicationRecord
   # Validate records
   # Non-US schools require country and school name
   # US nces schools sync required data from the `schools` table
-  # US non-nces schools (not found in `schools` table) require zip and school_name
-  # US non-school settings have school_type = noSchoolSetting and require zip and school_name
+  # US non-nces schools (not found in `schools` table) require country (US), zip and school_name
+  # US non-school settings have school_type = noSchoolSetting and require country (US) and zip
 
   # This method reports errors if the record has a country and is invalid.
   def validate_with_country
@@ -149,6 +149,11 @@ class SchoolInfo < ApplicationRecord
   end
 
   def validate_us
+    # The right side of this expression should not be necessary, but there are a ton
+    # of legacy tests in school_info_test.rb that will fail without it. Rather than deleting
+    # the old tests, we decided to keep them until all of the front end components that update
+    # school_info are refactored to send the appropriate data. See "Validate records" comment
+    # above to understand the required data for nces and non-nces schools
     if school || (school_type && school_type != SCHOOL_TYPE_NO_SCHOOL_SETTING)
       validate_nces_school
     else

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -243,7 +243,7 @@
       studentInLockoutFlow: @student_in_lockout_flow,
       countryCode: @country_code,
       isUSA: @is_usa,
-      schoolInfo: current_user.school_info
+      schoolInfo: Queries::SchoolInfo.current_school(current_user)
     }.to_json
   }
 %script{src: webpack_asset_path('js/devise/registrations/edit.js'), data: script_data}

--- a/dashboard/app/views/layouts/_school_info_confirmation_dialog.html.haml
+++ b/dashboard/app/views/layouts/_school_info_confirmation_dialog.html.haml
@@ -8,15 +8,11 @@
 -# geocoder sometimes shows localhost's country as RD/Reserved
 - us_ip = location.nil? || ['US', 'RD'].include?(location.country_code.to_s.upcase)
 - school_info = Queries::SchoolInfo.current_school(current_user)
-- current_user_user_school_info = Queries::UserSchoolInfo.last_complete(current_user)
--# - current_user_school_info = current_user_user_school_info ? current_user_user_school_info.school_info : nil
 
 - script_data = {}
 - script_data[:existingSchoolInfo] = {}
 - if school_info
   - script_data[:existingSchoolInfo] = school_info
-- if current_user_user_school_info
-  - script_data[:existingSchoolInfo][:user_school_info_id] = current_user_user_school_info.id
 - script_data[:usIp] = us_ip
 
 - content_for(:head) do

--- a/dashboard/app/views/layouts/_school_info_confirmation_dialog.html.haml
+++ b/dashboard/app/views/layouts/_school_info_confirmation_dialog.html.haml
@@ -7,19 +7,16 @@
 - location = Geocoder.search(request.ip).try(:first)
 -# geocoder sometimes shows localhost's country as RD/Reserved
 - us_ip = location.nil? || ['US', 'RD'].include?(location.country_code.to_s.upcase)
+- school_info = Queries::SchoolInfo.current_school(current_user)
 - current_user_user_school_info = Queries::UserSchoolInfo.last_complete(current_user)
-- current_user_school_info = current_user_user_school_info ? current_user_user_school_info.school_info : nil
+-# - current_user_school_info = current_user_user_school_info ? current_user_user_school_info.school_info : nil
 
 - script_data = {}
 - script_data[:existingSchoolInfo] = {}
-- if current_user_school_info
-  - script_data[:existingSchoolInfo] = current_user_school_info.slice(:country, :school_id, :school_name, :school_type)
+- if school_info
+  - script_data[:existingSchoolInfo] = school_info
 - if current_user_user_school_info
   - script_data[:existingSchoolInfo][:user_school_info_id] = current_user_user_school_info.id
-- script_data[:existingSchoolInfo][:country] ||= 'US' if us_ip
-- script_data[:existingSchoolInfo][:school_name] ||= current_user_school_info&.school&.name
-- script_data[:existingSchoolInfo][:school_zip] ||= current_user_school_info&.school&.zip || current_user_school_info&.zip&.to_s&.rjust(5, '0')
-- script_data[:existingSchoolInfo][:school_type] ||= current_user_school_info&.school&.school_type
 - script_data[:usIp] = us_ip
 
 - content_for(:head) do

--- a/dashboard/app/views/layouts/_school_info_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_school_info_interstitial.html.haml
@@ -8,15 +8,12 @@
 - location = Geocoder.search(request.ip).try(:first)
 -# geocoder sometimes shows localhost's country as RD/Reserved
 - us_ip = location.nil? || ['US', 'RD'].include?(location.country_code.to_s.upcase)
-- current_user_school_info = current_user.school_info
+- school_info = Queries::SchoolInfo.current_school(current_user)
 
 - script_data = {}
 - script_data[:existingSchoolInfo] = {}
-- if current_user_school_info
-  - script_data[:existingSchoolInfo] = current_user_school_info.slice(:country, :school_id, :school_name, :school_type)
-- script_data[:existingSchoolInfo][:school_zip] ||= current_user_school_info&.school&.zip || current_user_school_info&.zip&.to_s&.rjust(5, '0')
-- script_data[:existingSchoolInfo][:school_type] ||= current_user_school_info&.school&.school_type
-- script_data[:existingSchoolInfo][:country] ||= 'US' if us_ip
+- if school_info
+  - script_data[:existingSchoolInfo] = school_info
 - script_data[:usIp] = us_ip
 
 - content_for(:head) do

--- a/dashboard/lib/queries/school_info.rb
+++ b/dashboard/lib/queries/school_info.rb
@@ -4,7 +4,8 @@ class Queries::SchoolInfo
   end
 
   def self.current_school(user)
-    existing_school_info = Queries::UserSchoolInfo.last_complete(user)&.school_info
+    user_school_info = Queries::UserSchoolInfo.last_complete(user)
+    existing_school_info = user_school_info&.school_info
 
     return nil unless existing_school_info
 
@@ -16,7 +17,8 @@ class Queries::SchoolInfo
         school_type: existing_school_info.school.school_type,
         school_id: existing_school_info.school.id,
         school_zip: existing_school_info.school.zip,
-        country: 'US'
+        country: 'US',
+        user_school_info_id: user_school_info.id,
       }
     else
       # Return data from existing_school_info if no associated school is present
@@ -25,7 +27,8 @@ class Queries::SchoolInfo
         school_type: existing_school_info.school_type,
         school_id: existing_school_info.school_id,
         school_zip: existing_school_info.zip&.to_s&.rjust(5, '0'),
-        country: existing_school_info.country
+        country: existing_school_info.country,
+        user_school_info_id: user_school_info.id,
       }
     end
   end

--- a/dashboard/lib/queries/school_info.rb
+++ b/dashboard/lib/queries/school_info.rb
@@ -2,4 +2,31 @@ class Queries::SchoolInfo
   def self.last_complete(user)
     Queries::UserSchoolInfo.last_complete(user)&.school_info
   end
+
+  def self.current_school(user)
+    existing_school_info = Queries::UserSchoolInfo.last_complete(user)&.school_info
+
+    return nil unless existing_school_info
+
+    # Use values from the associated nces school if it exists, otherwise fallback to school_info
+    if existing_school_info.school
+      # Return data directly from the associated school if it exists
+      {
+        school_name: existing_school_info.school.name,
+        school_type: existing_school_info.school.school_type,
+        school_id: existing_school_info.school.id,
+        school_zip: existing_school_info.school.zip,
+        country: 'US'
+      }
+    else
+      # Return data from existing_school_info if no associated school is present
+      {
+        school_name: existing_school_info.school_name,
+        school_type: existing_school_info.school_type,
+        school_id: existing_school_info.school_id,
+        school_zip: existing_school_info.zip&.to_s&.rjust(5, '0'),
+        country: existing_school_info.country
+      }
+    end
+  end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1496,9 +1496,19 @@ FactoryBot.define do
 
   factory :school_info_non_us, class: SchoolInfo do
     country {'GB'}
-    school_type {SchoolInfo::SCHOOL_TYPE_PUBLIC}
-    full_address {'31 West Bank, London, England'}
     school_name {'Grazebrook'}
+  end
+
+  factory :school_info_us_non_nces, class: SchoolInfo do
+    country {'US'}
+    school_name {'Non NCES School'}
+    zip {'12345'}
+  end
+
+  factory :school_info_us_non_school_setting, class: SchoolInfo do
+    country {'US'}
+    school_type {SchoolInfo::SCHOOL_TYPE_NO_SCHOOL_SETTING}
+    zip {'12345'}
   end
 
   factory :school_info_us, class: SchoolInfo do

--- a/dashboard/test/lib/queries/school_info_test.rb
+++ b/dashboard/test/lib/queries/school_info_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+class Queries::SchoolInfoTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:teacher)
+  end
+
+  test 'when school_info exists with an associated school' do
+    school = create(:school, name: 'Test School', school_type: 'public', id: '1', zip: '12345')
+    school_info = create(:school_info, school: school)
+    user_school_info = create(:user_school_info, user: @user, school_info: school_info)
+
+    Queries::UserSchoolInfo.expects(:last_complete).with(@user).returns(user_school_info)
+
+    result = Queries::SchoolInfo.current_school(@user)
+
+    expected_result = {
+      school_name: 'Test School',
+      school_type: 'public',
+      school_id: '1',
+      school_zip: '12345',
+      country: 'US'
+    }
+
+    assert_equal expected_result, result
+  end
+
+  test 'when US school_info exists without an associated school' do
+    school_info = create(:school_info_us, school_name: 'Unknown School', zip: 1234) # zip column in school_infos is an int, but probably shouldn't be
+    user_school_info = create(:user_school_info, user: @user, school_info: school_info)
+
+    Queries::UserSchoolInfo.stubs(:last_complete).with(@user).returns(user_school_info)
+
+    result = Queries::SchoolInfo.current_school(@user)
+
+    expected_result = {
+      school_name: 'Unknown School',
+      school_type: nil,
+      school_id: nil,
+      school_zip: '01234', # zip is padded with a leading zero
+      country: 'US'
+    }
+
+    assert_equal expected_result, result
+  end
+
+  test 'when US school_info exists for a non-school setting' do
+    school_info = create(:school_info_us, school_name: 'Not a school', zip: 12, school_type: SchoolInfo::SCHOOL_TYPE_NO_SCHOOL_SETTING)
+    user_school_info = create(:user_school_info, user: @user, school_info: school_info)
+
+    Queries::UserSchoolInfo.stubs(:last_complete).with(@user).returns(user_school_info)
+
+    result = Queries::SchoolInfo.current_school(@user)
+
+    expected_result = {
+      school_name: 'Not a school',
+      school_type: SchoolInfo::SCHOOL_TYPE_NO_SCHOOL_SETTING,
+      school_id: nil,
+      school_zip: '00012', # zip is padded with leading zeros
+      country: 'US'
+    }
+
+    assert_equal expected_result, result
+  end
+
+  test 'when non-US school_info exists without an associated school' do
+    school_info = create(:school_info_non_us, school_name: 'Non-US School', school_type: nil, full_address: nil)
+    user_school_info = create(:user_school_info, user: @user, school_info: school_info)
+
+    Queries::UserSchoolInfo.stubs(:last_complete).with(@user).returns(user_school_info)
+
+    result = Queries::SchoolInfo.current_school(@user)
+
+    expected_result = {
+      school_name: 'Non-US School',
+      school_type: nil,
+      school_id: nil,
+      school_zip: nil,
+      country: 'GB'
+    }
+
+    assert_equal expected_result, result
+  end
+
+  test 'when no school_info exists' do
+    Queries::UserSchoolInfo.stubs(:last_complete).with(@user).returns(nil)
+
+    result = Queries::SchoolInfo.current_school(@user)
+    assert_nil result
+  end
+end

--- a/dashboard/test/lib/queries/school_info_test.rb
+++ b/dashboard/test/lib/queries/school_info_test.rb
@@ -19,7 +19,8 @@ class Queries::SchoolInfoTest < ActiveSupport::TestCase
       school_type: 'public',
       school_id: '1',
       school_zip: '12345',
-      country: 'US'
+      country: 'US',
+      user_school_info_id: user_school_info.id
     }
 
     assert_equal expected_result, result
@@ -38,7 +39,8 @@ class Queries::SchoolInfoTest < ActiveSupport::TestCase
       school_type: nil,
       school_id: nil,
       school_zip: '01234', # zip is padded with a leading zero
-      country: 'US'
+      country: 'US',
+      user_school_info_id: user_school_info.id
     }
 
     assert_equal expected_result, result
@@ -57,7 +59,8 @@ class Queries::SchoolInfoTest < ActiveSupport::TestCase
       school_type: SchoolInfo::SCHOOL_TYPE_NO_SCHOOL_SETTING,
       school_id: nil,
       school_zip: '00012', # zip is padded with leading zeros
-      country: 'US'
+      country: 'US',
+      user_school_info_id: user_school_info.id
     }
 
     assert_equal expected_result, result
@@ -76,7 +79,8 @@ class Queries::SchoolInfoTest < ActiveSupport::TestCase
       school_type: nil,
       school_id: nil,
       school_zip: nil,
-      country: 'GB'
+      country: 'GB',
+      user_school_info_id: user_school_info.id
     }
 
     assert_equal expected_result, result

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -49,6 +49,32 @@ class SchoolInfoTest < ActiveSupport::TestCase
     assert_equal 'School type is invalid', school_info.errors.full_messages.first
   end
 
+  # US non-nces school
+
+  test 'US non-nces school succeeds' do
+    school_info = build :school_info_us_non_nces
+    assert school_info.valid?, school_info.errors.full_messages
+  end
+
+  test "US non-nces school without zip fails" do
+    school_info = build :school_info_us_non_nces, zip: nil
+    refute school_info.valid?  # Run the validations and set errors
+    assert_equal 'Zip is required', school_info.errors.full_messages.first
+  end
+
+  # US non-school setting
+
+  test 'US non-school setting succeeds' do
+    school_info = build :school_info_us_non_school_setting
+    assert school_info.valid?, school_info.errors.full_messages
+  end
+
+  test "US non-school setting without zip fails" do
+    school_info = build :school_info_us_non_school_setting, zip: nil
+    refute school_info.valid?  # Run the validations and set errors
+    assert_equal 'Zip is required', school_info.errors.full_messages.first
+  end
+
   # US, private
 
   test 'US private with school succeeds' do

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -20,7 +20,7 @@ class SchoolInfoTest < ActiveSupport::TestCase
   # US
 
   test "US without school type fails" do
-    school_info = build :school_info_us
+    school_info = build(:school_info_us, :with_district, :with_school, school: build(:public_school, school_type: nil))
     refute school_info.valid?  # Run the validations and set errors
     assert_equal 'School type is required', school_info.errors.full_messages.first
   end

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -6,33 +6,15 @@ class SchoolInfoTest < ActiveSupport::TestCase
 
   # non-US
 
-  test 'non-US with type, name and address succeeds' do
+  test 'non-US with name succeeds' do
     school_info = build :school_info_non_us
     assert school_info.valid?, school_info.errors.full_messages
-  end
-
-  test 'non-US without address fails' do
-    school_info = build :school_info_non_us, full_address: nil
-    refute school_info.valid?  # Run the validations and set errors
-    assert_equal 'Full address is required', school_info.errors.full_messages.first
   end
 
   test 'non-US without name fails' do
     school_info = build :school_info_non_us, school_name: nil
     refute school_info.valid?  # Run the validations and set errors
     assert_equal 'School name is required', school_info.errors.full_messages.first
-  end
-
-  test 'non-US without type fails' do
-    school_info = build :school_info_non_us, school_type: nil
-    refute school_info.valid?  # Run the validations and set errors
-    assert_equal 'School type is required', school_info.errors.full_messages.first
-  end
-
-  test 'non-US with nonexistent type fails' do
-    school_info = build :school_info_non_us, school_type: 'fake type'
-    refute school_info.valid?
-    assert_equal 'School type is invalid', school_info.errors.full_messages.first
   end
 
   # US


### PR DESCRIPTION
This adds a `current_school` query to `SchoolInfo` that returns just the data needed for the school info forms in the front end. It first checks for an associated nces school if it exists, otherwise it returns data stored in the `school_infos` table (ie. non-us schools, us schools entered manually, and non-school settings)

Having a single source of truth for school info also helps to simplify some of the haml files and fixes a bug where leading zeros in zip codes were being stripped out (`school_infos` table stores zip codes as integers, whereas `schools` stores it correctly as text)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[leading zeros bug ticket](https://codedotorg.atlassian.net/browse/ACQ-2585)
[school info query ticket](https://codedotorg.atlassian.net/browse/ACQ-2563)
[fix school info model validation](https://codedotorg.atlassian.net/browse/ACQ-2564)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I added unit tests for the new `current_school` query

After cleaning up the model validation so that my `current_school` unit tests would actually work, I broke existing tests covering the validation. Some of those tests were no longer relevant and could be removed. Others just needed more setup.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
