### PR TITLE
Fix RTL support on Swiper carousels

### DIFF
--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -803,11 +803,23 @@ swiper-slide {
   background: url("/images/carousel/prev.svg") no-repeat;
   left: -4rem;
   border: 0;
+
+  html[dir="rtl"] & {
+    background: url("/images/carousel/next.svg") no-repeat;
+    left: unset;
+    right: -4rem;
+  }
 }
 
 .carousel-wrapper .swiper-nav-next {
   background: url("/images/carousel/next.svg") no-repeat;
   right: -4rem;
+
+  html[dir="rtl"] & {
+    background: url("/images/carousel/prev.svg") no-repeat;
+    right: unset;
+    left: -4rem;
+  }
 }
 
 .carousel-wrapper .swiper-button-disabled {

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -836,7 +836,7 @@ swiper-slide {
 /* Video carousel styles */
 .carousel-wrapper.video-carousel swiper-slide {
   display: block;
-  text-align: left;
+  text-align: initial;
 }
 
 .carousel-wrapper.video-carousel .swiper-nav-prev,

--- a/pegasus/sites.v3/hourofcode.com/styles/040-page.css
+++ b/pegasus/sites.v3/hourofcode.com/styles/040-page.css
@@ -487,7 +487,7 @@ swiper-slide {
 /* Video carousel styles */
 .carousel-wrapper.video-carousel swiper-slide {
   display: block;
-  text-align: left;
+  text-align: initial;
 }
 
 .carousel-wrapper.video-carousel iframe {

--- a/pegasus/sites.v3/hourofcode.com/styles/040-page.css
+++ b/pegasus/sites.v3/hourofcode.com/styles/040-page.css
@@ -454,11 +454,23 @@ swiper-slide {
   background: url("/images/carousel/prev.svg") no-repeat;
   left: -4rem;
   border: 0;
+
+  html[dir="rtl"] & {
+    background: url("/images/carousel/next.svg") no-repeat;
+    left: unset;
+    right: -4rem;
+  }
 }
 
 .carousel-wrapper .swiper-nav-next {
   background: url("/images/carousel/next.svg") no-repeat;
   right: -4rem;
+
+  html[dir="rtl"] & {
+    background: url("/images/carousel/prev.svg") no-repeat;
+    right: unset;
+    left: -4rem;
+  }
 }
 
 .carousel-wrapper .swiper-button-disabled {


### PR DESCRIPTION
Fixes the direction of the previous and next buttons and text-align direction on all Swiper carousels across code.org and hourofcode.com.

## Links
Jira ticket: [ACQ-2452](https://codedotorg.atlassian.net/browse/ACQ-2452)

## Testing story
Tested locally

----

## RTL - code.org


https://github.com/user-attachments/assets/7ef3801d-b966-400f-b01c-5f3a773f8c6c



https://github.com/user-attachments/assets/e77b01eb-3e46-4d20-8d4f-6bbff650af0d



## RTL - hourofcode.com


https://github.com/user-attachments/assets/a49d9b6f-5398-4a55-abfb-8a4bcda6414f


https://github.com/user-attachments/assets/f888912b-6bd0-4247-ad74-ff5eb5e99a50



## LTR still works as expected - code.org & hourofcode.com

https://github.com/user-attachments/assets/121f8f0f-b98c-4d6f-8d30-451402c84d4a


https://github.com/user-attachments/assets/4f99a696-1822-43f1-9e3d-23abb5406384

