### PR TITLE
Remove duplicate types from teacherSections redux calls

### DIFF
--- a/apps/src/aiTutor/views/teacherDashboard/AccessControls.tsx
+++ b/apps/src/aiTutor/views/teacherDashboard/AccessControls.tsx
@@ -1,11 +1,11 @@
 import React, {useEffect, useState} from 'react';
-import {useSelector} from 'react-redux';
 import * as Table from 'reactabular-table';
 
 import {fetchStudents} from '@cdo/apps/aiTutor/accessControlsApi';
 import {StudentAccessData} from '@cdo/apps/aiTutor/types';
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import {tableLayoutStyles as tableStyles} from '@cdo/apps/templates/tables/tableConstants';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {styleOverrides} from './InteractionsTable';
 import SectionAccessToggle from './SectionAccessToggle';
@@ -21,11 +21,6 @@ interface AccessControlsProps {
   sectionId: number;
 }
 
-interface SectionsData {
-  [index: number]: {
-    aiTutorEnabled: boolean;
-  };
-}
 interface StudentRowData {
   id: number;
   name: string;
@@ -39,9 +34,8 @@ const AccessControls: React.FC<AccessControlsProps> = ({sectionId}) => {
     null
   );
 
-  const aiTutorEnabledForSection = useSelector(
-    (state: {teacherSections: {sections: SectionsData}}) =>
-      state.teacherSections.sections[sectionId].aiTutorEnabled
+  const aiTutorEnabledForSection = useAppSelector(
+    state => state.teacherSections.sections[sectionId].aiTutorEnabled
   );
 
   const displayGlobalError = (error: string) => {

--- a/apps/src/aiTutor/views/teacherDashboard/SectionAccessToggle.tsx
+++ b/apps/src/aiTutor/views/teacherDashboard/SectionAccessToggle.tsx
@@ -1,5 +1,4 @@
 import React, {useState, useEffect} from 'react';
-import {useSelector} from 'react-redux';
 
 import {handleUpdateSectionAITutorEnabled} from '@cdo/apps/aiTutor/accessControlsApi';
 import Toggle from '@cdo/apps/componentLibrary/toggle/Toggle';
@@ -7,7 +6,7 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import InfoHelpTip from '@cdo/apps/sharedComponents/InfoHelpTip';
 import {updateSectionAiTutorEnabled} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import style from '@cdo/apps/aiTutor/views/teacherDashboard/access-controls.module.scss';
@@ -16,19 +15,10 @@ interface SectionAccessToggleProps {
   sectionId: number;
 }
 
-interface SectionsData {
-  [index: number]: {
-    aiTutorEnabled: boolean;
-  };
-}
-
 const SectionAccessToggle: React.FC<SectionAccessToggleProps> = ({
   sectionId,
 }) => {
-  const sectionList = useSelector(
-    (state: {teacherSections: {sections: SectionsData}}) =>
-      state.teacherSections.sections
-  );
+  const sectionList = useAppSelector(state => state.teacherSections.sections);
 
   const [aiTutorEnabled, setAiTutorEnabled] = useState(
     sectionList[sectionId].aiTutorEnabled

--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -26,12 +26,6 @@ import moduleStyles from './chatWorkspace.module.scss';
 interface ChatWorkspaceProps {
   onClear: () => void;
 }
-interface Students {
-  [index: number]: {
-    id: number;
-    name: string;
-  };
-}
 
 enum WorkspaceTeacherViewTab {
   STUDENT_CHAT_HISTORY = 'viewStudentChatHistory',
@@ -59,9 +53,8 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
   const visibleItems = useSelector(selectAllVisibleMessages);
 
-  const students = useSelector(
-    (state: {teacherSections: {selectedStudents: Students}}) =>
-      state.teacherSections.selectedStudents
+  const students = useAppSelector(
+    state => state.teacherSections.selectedStudents
   );
 
   const dispatch = useAppDispatch();

--- a/apps/src/code-studio/components/progress/TeacherUnitOverview.tsx
+++ b/apps/src/code-studio/components/progress/TeacherUnitOverview.tsx
@@ -1,5 +1,4 @@
 import React, {useState} from 'react';
-import {useSelector} from 'react-redux';
 import {generatePath, useNavigate, useParams} from 'react-router-dom';
 
 import {initializeHiddenScripts} from '@cdo/apps/code-studio/hiddenLessonRedux';
@@ -18,6 +17,7 @@ import {
   setPageType,
   pageTypes,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {TEACHER_NAVIGATION_PATHS} from '@cdo/apps/templates/teacherNavigation/TeacherNavigationPaths';
 import {PeerReviewLessonInfo} from '@cdo/apps/types/progressTypes';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
@@ -37,17 +37,6 @@ import {setCalendarData} from '../../calendarRedux';
 import {setVerified, setVerifiedResources} from '../../verifiedInstructorRedux';
 
 import UnitOverview from './UnitOverview';
-
-interface Section {
-  id: number;
-  courseId: number | null;
-  courseVersionId: number;
-  courseVersionName: string | null;
-  courseOfferingId: number | null;
-  unitId: number | null;
-  unitName: string | null;
-  courseDisplayName: string | null;
-}
 
 interface Resource {
   id: number;
@@ -274,12 +263,7 @@ const TeacherUnitOverview: React.FC<TeacherUnitOverviewProps> = props => {
   const [unitSummaryResponse, setUnitSummaryResponse] =
     useState<UnitSummaryResponse | null>(null);
 
-  const selectedSection = useSelector(
-    (state: {
-      teacherSections: {sections: Section[]; selectedSectionId: number};
-    }) =>
-      state.teacherSections.sections[state.teacherSections.selectedSectionId]
-  );
+  const selectedSection = useAppSelector(selectedSectionSelector);
 
   const {userId, userType} = useAppSelector(state => ({
     userId: state.currentUser.userId,
@@ -292,7 +276,7 @@ const TeacherUnitOverview: React.FC<TeacherUnitOverviewProps> = props => {
   const {unitName} = useParams();
 
   React.useEffect(() => {
-    if (!unitName && selectedSection.unitName) {
+    if (!unitName && selectedSection?.unitName) {
       navigate(selectedSection.unitName, {replace: true});
     }
   });
@@ -320,7 +304,7 @@ const TeacherUnitOverview: React.FC<TeacherUnitOverviewProps> = props => {
       });
   }, [unitName, userType, userId, dispatch]);
 
-  if (!unitSummaryResponse) {
+  if (!unitSummaryResponse || !selectedSection) {
     return <Spinner size={'large'} />;
   }
 

--- a/apps/src/lab2/views/components/PredictSummary.tsx
+++ b/apps/src/lab2/views/components/PredictSummary.tsx
@@ -1,5 +1,4 @@
 import React, {useEffect, useState} from 'react';
-import {useSelector} from 'react-redux';
 
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {LinkButton} from '@cdo/apps/componentLibrary/button';
@@ -19,9 +18,8 @@ const PredictSummary: React.FunctionComponent = () => {
     `viewAs=${ViewType.Instructor}`
   );
   const summaryUrl = document.location.pathname + SUMMARY_PATH + params;
-  const currentSectionId = useSelector(
-    (state: {teacherSections: {selectedSectionId: number}}) =>
-      state.teacherSections.selectedSectionId
+  const currentSectionId = useAppSelector(
+    state => state.teacherSections.selectedSectionId
   );
   const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
   const [responseCount, setResponseCount] = useState<number | null>(null);

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import Toggle from '@cdo/apps/componentLibrary/toggle/Toggle';
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import {setSectionCodeReviewExpiresAt} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import {selectedSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
@@ -90,8 +90,8 @@ export const UnconnectedCodeReviewGroupsStatusToggle =
 
 export default connect(
   state => ({
-    codeReviewExpiresAt: selectedSection(state).codeReviewExpiresAt,
-    sectionId: selectedSection(state).id,
+    codeReviewExpiresAt: selectedSectionSelector(state).codeReviewExpiresAt,
+    sectionId: selectedSectionSelector(state).id,
   }),
   dispatch => ({
     setCodeReviewExpiration: (sectionId, expiration) =>

--- a/apps/src/templates/courseOverview/TeacherCourseOverview.tsx
+++ b/apps/src/templates/courseOverview/TeacherCourseOverview.tsx
@@ -17,7 +17,7 @@ import {setViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {NotificationType} from '@cdo/apps/sharedComponents/Notification';
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import HttpClient from '@cdo/apps/util/HttpClient';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {UserTypes} from '@cdo/generated-scripts/sharedConstants';
 
 import {
@@ -26,6 +26,7 @@ import {
   setUserSignedIn,
 } from '../currentUserRedux';
 import {pageTypes, setPageType} from '../teacherDashboard/teacherSectionsRedux';
+import {selectedSectionSelector} from '../teacherDashboard/teacherSectionsReduxSelectors';
 import {TEACHER_NAVIGATION_PATHS} from '../teacherNavigation/TeacherNavigationPaths';
 
 import CourseOverview from './CourseOverview';
@@ -89,14 +90,6 @@ interface Announcement {
   buttonText: string | null;
 }
 
-interface Section {
-  id: number;
-  name: string;
-  courseId: number | null;
-  unitName: string | null;
-  courseVersionName: string | null;
-}
-
 const courseSummaryCachedLoader = _.memoize(async courseVersionName =>
   HttpClient.fetchJson<Response>(
     `/dashboardapi/course_summary/${courseVersionName}`
@@ -116,23 +109,9 @@ const TeacherCourseOverview: React.FC = () => {
 
   const params = useParams();
 
-  const sections = useSelector(
-    (state: {
-      teacherSections: {
-        sections: {[id: number]: Section};
-      };
-    }) => state.teacherSections.sections
-  );
+  const sections = useAppSelector(state => state.teacherSections.sections);
 
-  const selectedSection = useSelector(
-    (state: {
-      teacherSections: {
-        sections: {[id: number]: Section};
-        selectedSectionId: number;
-      };
-    }) =>
-      state.teacherSections.sections[state.teacherSections.selectedSectionId]
-  );
+  const selectedSection = useAppSelector(selectedSectionSelector);
 
   React.useEffect(() => {
     if (!selectedSection || !selectedSection?.courseVersionName) {

--- a/apps/src/templates/manageStudents/Table/UsStateColumn/BulkSetModal/index.tsx
+++ b/apps/src/templates/manageStudents/Table/UsStateColumn/BulkSetModal/index.tsx
@@ -11,7 +11,7 @@ import AccessibleDialog from '@cdo/apps/sharedComponents/AccessibleDialog';
 import {bulkSet} from '@cdo/apps/templates/manageStudents/manageStudentsRedux';
 import {BulkSetModalProps} from '@cdo/apps/templates/manageStudents/Table/UsStateColumn/interface';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
-import {selectedSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {RootState} from '@cdo/apps/types/redux';
 import {CapLinks} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
@@ -110,7 +110,7 @@ const BulkSetModal: React.FC<BulkSetModalProps> = ({
 export default connect(
   (state: RootState) => ({
     currentUser: state.currentUser,
-    section: selectedSection(state),
+    section: selectedSectionSelector(state),
   }),
   dispatch => ({
     bulkSet(studentsData: {usState: string | null}) {

--- a/apps/src/templates/manageStudents/Table/UsStateColumn/Cell.tsx
+++ b/apps/src/templates/manageStudents/Table/UsStateColumn/Cell.tsx
@@ -5,7 +5,7 @@ import {STATE_CODES} from '@cdo/apps/geographyConstants';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {editStudent} from '@cdo/apps/templates/manageStudents/manageStudentsRedux';
-import {selectedSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {RootState} from '@cdo/apps/types/redux';
 
 import {CellProps} from './interface';
@@ -65,7 +65,7 @@ const Cell: React.FC<CellProps> = ({
 export default connect(
   (state: RootState) => ({
     currentUser: state.currentUser,
-    section: selectedSection(state),
+    section: selectedSectionSelector(state),
   }),
   dispatch => ({
     editStudent(id: number, studentData: {usState: string | null}) {

--- a/apps/src/templates/manageStudents/Table/index.jsx
+++ b/apps/src/templates/manageStudents/Table/index.jsx
@@ -54,7 +54,7 @@ import {
 } from '@cdo/apps/templates/tables/tableConstants';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
 import {
-  selectedSection,
+  selectedSectionSelector,
   syncEnabled,
   sectionCode,
   sectionName,
@@ -1131,7 +1131,7 @@ export default connect(
         .participantType,
     loginType: state.manageStudents.loginType,
     studentData: convertStudentDataToArray(state.manageStudents.studentData),
-    isSectionAssignedCSA: selectedSection(state).isAssignedCSA,
+    isSectionAssignedCSA: selectedSectionSelector(state).isAssignedCSA,
     editingData: state.manageStudents.editingData,
     showSharingColumn: state.manageStudents.showSharingColumn,
     addStatus: state.manageStudents.addStatus,

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -7,7 +7,7 @@ import ErrorBoundary from '@cdo/apps/lab2/ErrorBoundary';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {selectedSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 import aiFabIcon from '@cdo/static/ai-bot-centered-teal.png';
@@ -216,5 +216,5 @@ RubricFloatingActionButton.propTypes = {
 export const UnconnectedRubricFloatingActionButton = RubricFloatingActionButton;
 
 export default connect(state => ({
-  sectionId: selectedSection(state)?.id,
+  sectionId: selectedSectionSelector(state)?.id,
 }))(RubricFloatingActionButton);

--- a/apps/src/templates/teacherDashboard/teacherSectionsReduxSelectors.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsReduxSelectors.js
@@ -66,7 +66,7 @@ export function sectionUnitName(state, sectionId) {
   return (getRoot(state).sections[sectionId] || {}).courseVersionName;
 }
 
-export function selectedSection(state) {
+export function selectedSectionSelector(state) {
   const selectedSectionId = getRoot(state).selectedSectionId;
   if (selectedSectionId) {
     return getRoot(state).sections[selectedSectionId];

--- a/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
+++ b/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {useSelector} from 'react-redux';
 import {useNavigate, NavLink} from 'react-router-dom';
 
 import {LinkButton} from '@cdo/apps/componentLibrary/button';
@@ -8,6 +7,7 @@ import {Heading3, BodyTwoText} from '@cdo/apps/componentLibrary/typography';
 import emptyDesk from '@cdo/apps/templates/teacherDashboard/images/empty_desk.svg';
 import blankScreen from '@cdo/apps/templates/teacherDashboard/images/no_curriculum_assigned.svg';
 import TeacherDashboardEmptyState from '@cdo/apps/templates/teacherNavigation/images/TeacherDashboardEmptyState.svg';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import {TEACHER_NAVIGATION_PATHS} from './TeacherNavigationPaths';
@@ -19,7 +19,7 @@ interface ElementOrEmptyPageProps {
   showNoStudents: boolean;
   showNoCurriculumAssigned: boolean;
   showNoUnitAssigned?: boolean;
-  courseName?: string;
+  courseName?: string | null;
   element: React.ReactElement;
 }
 
@@ -30,9 +30,8 @@ const ElementOrEmptyPage: React.FC<ElementOrEmptyPageProps> = ({
   courseName,
   element,
 }) => {
-  const isLoadingSectionData = useSelector(
-    (state: {teacherSections: {isLoadingSectionData: boolean}}) =>
-      state.teacherSections.isLoadingSectionData
+  const isLoadingSectionData = useAppSelector(
+    state => state.teacherSections.isLoadingSectionData
   );
 
   const textDescription = () => {

--- a/apps/src/templates/teacherNavigation/PageHeader.tsx
+++ b/apps/src/templates/teacherNavigation/PageHeader.tsx
@@ -1,13 +1,14 @@
 import classNames from 'classnames';
 import _ from 'lodash';
 import React from 'react';
-import {useSelector} from 'react-redux';
 import {matchPath, useLocation} from 'react-router-dom';
 
 import {Heading1} from '@cdo/apps/componentLibrary/typography';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+
+import {selectedSectionSelector} from '../teacherDashboard/teacherSectionsReduxSelectors';
 
 import {LABELED_TEACHER_NAVIGATION_PATHS} from './TeacherNavigationPaths';
-import {Section} from './TeacherNavigationRouter';
 
 import styles from './teacher-navigation.module.scss';
 import skeletonizeContent from '@cdo/apps/sharedComponents/skeletonize-content.module.scss';
@@ -24,23 +25,10 @@ const skeletonSectionName = (
 );
 
 const PageHeader: React.FC = () => {
-  const isLoadingSectionData = useSelector(
-    (state: {teacherSections: {isLoadingSectionData: boolean}}) =>
-      state.teacherSections.isLoadingSectionData
+  const isLoadingSectionData = useAppSelector(
+    state => state.teacherSections.isLoadingSectionData
   );
-  const selectedSection = useSelector(
-    (state: {
-      teacherSections: {
-        selectedSectionId: number | null;
-        sections: {[id: number]: Section};
-      };
-    }) =>
-      state.teacherSections.selectedSectionId
-        ? state.teacherSections.sections[
-            state.teacherSections.selectedSectionId
-          ]
-        : null
-  );
+  const selectedSection = useAppSelector(selectedSectionSelector);
 
   const location = useLocation();
   const pathName = React.useMemo(

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import React, {useState, useEffect} from 'react';
-import {useSelector} from 'react-redux';
 import {
   generatePath,
   matchPath,
@@ -10,40 +9,26 @@ import {
 
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
 import Typography from '@cdo/apps/componentLibrary/typography';
+import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
 import SidebarOption from '@cdo/apps/templates/teacherNavigation/SidebarOption';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import {LABELED_TEACHER_NAVIGATION_PATHS} from './TeacherNavigationPaths';
 
 import styles from './teacher-navigation.module.scss';
 
-interface SectionsData {
-  [sectionId: number]: {
-    name: string;
-    hidden: boolean;
-    courseVersionName: string;
-    unitName: string;
-  };
-}
-
 const TeacherNavigationBar: React.FunctionComponent = () => {
-  const sections = useSelector(
-    (state: {teacherSections: {sections: SectionsData}}) =>
-      state.teacherSections.sections
-  );
+  const sections = useAppSelector(state => state.teacherSections.sections);
 
   const [sectionArray, setSectionArray] = useState<
     {value: string; text: string}[]
   >([]);
 
-  const selectedSectionId = useSelector(
-    (state: {teacherSections: {selectedSectionId: number}}) =>
-      state.teacherSections.selectedSectionId
-  );
+  const selectedSection = useAppSelector(selectedSectionSelector);
 
-  const isLoadingSectionData = useSelector(
-    (state: {teacherSections: {isLoadingSectionData: boolean}}) =>
-      state.teacherSections.isLoadingSectionData
+  const isLoadingSectionData = useAppSelector(
+    state => state.teacherSections.isLoadingSectionData
   );
 
   useEffect(() => {
@@ -55,7 +40,7 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
       }));
 
     setSectionArray(updatedSectionArray);
-  }, [sections, selectedSectionId]);
+  }, [sections, selectedSection]);
 
   const getSectionHeader = (label: string) => {
     return (
@@ -72,7 +57,7 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
   const coursecontentSectionTitle = getSectionHeader(i18n.courseContent());
 
   let courseContentKeys: (keyof typeof LABELED_TEACHER_NAVIGATION_PATHS)[];
-  if (sections[selectedSectionId].unitName) {
+  if (selectedSection.unitName) {
     courseContentKeys = ['unitOverview', 'lessonMaterials', 'calendar'];
   } else {
     courseContentKeys = ['courseOverview', 'lessonMaterials', 'calendar'];
@@ -118,8 +103,8 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
     if (LABELED_TEACHER_NAVIGATION_PATHS[page]) {
       navigate(
         generatePath(LABELED_TEACHER_NAVIGATION_PATHS[page].absoluteUrl, {
-          sectionId: selectedSectionId,
-          courseVersionName: sections[selectedSectionId].courseVersionName,
+          sectionId: selectedSection.id,
+          courseVersionName: selectedSection.courseVersionName,
         })
       );
     }
@@ -132,8 +117,8 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
       <SidebarOption
         key={'ui-test-sidebar-' + key}
         isSelected={currentPathName === key}
-        sectionId={+selectedSectionId}
-        courseVersionName={sections[selectedSectionId].courseVersionName}
+        sectionId={+selectedSection.id}
+        courseVersionName={selectedSection.courseVersionName}
         pathKey={key as keyof typeof LABELED_TEACHER_NAVIGATION_PATHS}
         onClick={() => navigateToDifferentPage(key)}
       />
@@ -168,7 +153,7 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
           onChange={event => navigateToDifferentSection(event.target.value)}
           labelText=""
           size="m"
-          selectedValue={String(selectedSectionId)}
+          selectedValue={String(selectedSection.id)}
           className={styles.sectionDropdown}
           name="section-dropdown"
           color="gray"

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {useSelector} from 'react-redux';
 import {
   Route,
   Outlet,
@@ -11,6 +10,7 @@ import {
 
 import TutorTab from '@cdo/apps/aiTutor/views/teacherDashboard/TutorTab';
 import TeacherUnitOverview from '@cdo/apps/code-studio/components/progress/TeacherUnitOverview';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import TeacherCourseOverview from '../courseOverview/TeacherCourseOverview';
 import ManageStudents from '../manageStudents/ManageStudents';
@@ -21,7 +21,10 @@ import SectionProgressSelector from '../sectionProgressV2/SectionProgressSelecto
 import SectionsSetUpContainer from '../sectionsRefresh/SectionsSetUpContainer';
 import SectionLoginInfo from '../teacherDashboard/SectionLoginInfo';
 import StatsTableWithData from '../teacherDashboard/StatsTableWithData';
-import {sectionProviderName} from '../teacherDashboard/teacherSectionsReduxSelectors';
+import {
+  sectionProviderName,
+  selectedSectionSelector,
+} from '../teacherDashboard/teacherSectionsReduxSelectors';
 import TextResponses from '../textResponses/TextResponses';
 
 import ElementOrEmptyPage from './ElementOrEmptyPage';
@@ -46,19 +49,6 @@ interface TeacherNavigationRouterProps {
   showAITutorTab: boolean;
 }
 
-export interface Section {
-  id: number;
-  rosterProviderName: string;
-  anyStudentHasProgress: boolean;
-  name: string;
-  courseVersionName: string;
-  courseOfferingId: number;
-  unitId: number;
-  unitName: string;
-  courseDisplayName: string;
-  courseId: number;
-}
-
 const applyV1TeacherDashboardWidth = (children: React.ReactNode) => {
   return <div className={styles.widthLockedPage}>{children}</div>;
 };
@@ -67,40 +57,21 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
   studioUrlPrefix,
   showAITutorTab,
 }) => {
-  const sectionId = useSelector(
-    (state: {teacherSections: {selectedSectionId: number}}) =>
-      state.teacherSections.selectedSectionId
+  const sectionId = useAppSelector(
+    state => state.teacherSections.selectedSectionId
   );
-  const selectedSection = useSelector(
-    (state: {
-      teacherSections: {
-        selectedSectionId: number | null;
-        sections: {[id: number]: Section};
-      };
-    }) =>
-      state.teacherSections.selectedSectionId
-        ? state.teacherSections.sections[
-            state.teacherSections.selectedSectionId
-          ]
-        : null
-  );
+  const selectedSection = useAppSelector(selectedSectionSelector);
 
   const anyStudentHasProgress = React.useMemo(
     () => (selectedSection ? selectedSection.anyStudentHasProgress : true),
     [selectedSection]
   );
 
-  const studentCount = useSelector(
-    (state: {teacherSections: {selectedStudents: object[]}}) =>
-      state.teacherSections.selectedStudents.length
+  const studentCount = useAppSelector(
+    state => state.teacherSections.selectedStudents.length
   );
-  const providerName = useSelector(
-    (state: {
-      teacherSections: {
-        section: {[id: number]: Section};
-        selectedSectionId: number;
-      };
-    }) => sectionProviderName(state, state.teacherSections.selectedSectionId)
+  const providerName = useAppSelector(state =>
+    sectionProviderName(state, state.teacherSections.selectedSectionId)
   );
 
   const routes = React.useMemo(


### PR DESCRIPTION
After [this PR](https://github.com/code-dot-org/code-dot-org/pull/61597) was merged today, we can now replace all types  from `useSelector` calls in typescript files that use `teacherSection` with `useAppSelector`. 

We want to do this because:
* Reduces code complexity and duplicate code
* We don't want the duplicate types in each file to override the types in `useAppSelector`. `useAppSelector` is more carefully checked and contains the full types, instead of only the used keys of each object in each file.

Removing this already found a few places where we were assuming that `teacherSections.selectedSectionId` existed. I switched these to use the `selectedSectionSelector` which has better null type checking.

Additionally I renamed `selectedSection` to `selectedSectionSelector` because most of the added places would have conflicting names of the selector function and the object that it returned. I found `selectedSectionSelector` to be a better name.

