### PR TITLE
Python Lab: More UI tests

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserHeaderPopUpButton.tsx
@@ -35,7 +35,7 @@ export const FileBrowserHeaderPopUpButton = () => {
   return (
     <>
       <FileUploaderComponent />
-      <PopUpButton iconName="plus" alignment="left">
+      <PopUpButton iconName="plus" alignment="left" id="uitest-files-plus">
         <PopUpButtonOption
           iconName="plus"
           labelText={codebridgeI18n.newFolder()}
@@ -47,6 +47,7 @@ export const FileBrowserHeaderPopUpButton = () => {
           iconName="plus"
           labelText={codebridgeI18n.newFile()}
           clickHandler={() => openNewFilePrompt({folderId: DEFAULT_FOLDER_ID})}
+          id="uitest-new-file"
         />
 
         <PopUpButtonOption

--- a/apps/src/codebridge/FileBrowser/FileRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileRow.tsx
@@ -105,7 +105,7 @@ const FileRow: React.FunctionComponent<FileRowProps> = ({
   ];
 
   return (
-    <div className={moduleStyles.row}>
+    <div className={moduleStyles.row} id={`uitest-file-${file.id}-row`}>
       <div className={moduleStyles.label} onClick={() => openFile(file.id)}>
         <FontAwesomeV6Icon
           iconName={iconName}
@@ -131,8 +131,12 @@ const FileRow: React.FunctionComponent<FileRowProps> = ({
         <PopUpButton
           iconName="ellipsis-v"
           className={moduleStyles['button-kebab']}
+          id={`uitest-file-${file.id}-kebab`}
         >
-          <span className={moduleStyles['button-bar']}>
+          <span
+            className={moduleStyles['button-bar']}
+            id={`uitest-file-${file.id}-popup`}
+          >
             {dropdownOptions.map(
               ({condition, iconName, labelText, clickHandler}, index) =>
                 condition && (

--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -446,7 +446,7 @@ export const FileBrowser = React.memo(() => {
               }
             )}
           >
-            <ul>
+            <ul id="uitest-files-list">
               <InnerFileBrowser
                 parentId={DEFAULT_FOLDER_ID}
                 folders={project.folders}

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -269,6 +269,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
         )}
         color={'white'}
         size={'s'}
+        id={'uitest-validate-button'}
       />
     );
   };

--- a/apps/src/codebridge/PopUpButton/PopUpButton.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButton.tsx
@@ -11,6 +11,7 @@ type PopUpButtonProps = {
   children?: React.ReactNode;
   className?: string;
   alignment?: 'left' | 'right';
+  id?: string;
 };
 
 export const PopUpButton = ({
@@ -18,6 +19,7 @@ export const PopUpButton = ({
   iconName,
   className,
   alignment = 'left',
+  id,
 }: PopUpButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [buttonRect, setButtonRect] = useState<DOMRect>();
@@ -67,6 +69,7 @@ export const PopUpButton = ({
         isIconOnly
         onClick={clickHandler}
         type={'tertiary'}
+        id={id}
       />
       {isOpen && buttonRect && offsetParent && (
         <div

--- a/apps/src/codebridge/PopUpButton/PopUpButtonOption.tsx
+++ b/apps/src/codebridge/PopUpButton/PopUpButtonOption.tsx
@@ -18,12 +18,14 @@ type PopUpButtonOptionProps = {
   iconName: string;
   labelText: string;
   clickHandler?: () => void;
+  id?: string;
 };
 
 export const PopUpButtonOption = ({
   iconName,
   labelText,
   clickHandler,
+  id,
 }: PopUpButtonOptionProps) => {
   return (
     <div
@@ -32,6 +34,7 @@ export const PopUpButtonOption = ({
         darkModeStyles.dropdownItem,
         moduleStyles.dropdownItem
       )}
+      id={id}
     >
       <FontAwesomeV6Icon iconName={iconName} iconStyle="solid" />
       <div>{labelText}</div>

--- a/apps/src/lab2/views/dialogs/GenericDialog.tsx
+++ b/apps/src/lab2/views/dialogs/GenericDialog.tsx
@@ -190,6 +190,7 @@ const GenericDialog: React.FunctionComponent<GenericDialogProps> = ({
                     : buttonColors.purple
                 }
                 text={buttons?.confirm?.text || commonI18n.dialogOK()}
+                id="uitest-generic-dialog-ok"
               />
             </div>
           </div>

--- a/apps/src/lab2/views/dialogs/GenericPrompt.tsx
+++ b/apps/src/lab2/views/dialogs/GenericPrompt.tsx
@@ -63,6 +63,7 @@ const GenericPromptBody: React.FunctionComponent<GenericPromptBodyProps> = ({
         onChange={e => handleInputChange(e.target.value)}
         errorMessage={errorMessage}
         color={theme === Theme.DARK ? 'white' : undefined}
+        id="uitest-prompt-field"
       />
     </>
   );

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_files.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_files.feature
@@ -4,11 +4,10 @@
 Feature: Python Lab manage files and folders
 
 Background:
-  Given I create a student named "Penelope"
   And I am on "http://studio.code.org/s/allthethings/lessons/50/levels/1"
   And I wait to see "#uitest-codebridge-run"
 
-Scenario: Can add a file
+Scenario: Can add a new, unlocked file
   And I press "uitest-files-plus"
   And I wait to see "#uitest-new-file"
   And I press "uitest-new-file"
@@ -17,4 +16,13 @@ Scenario: Can add a file
   And I press "uitest-generic-dialog-ok"
   And element ".cm-content" contains text "Add your changes to new_file.py"
   And element "#uitest-files-list" contains text "new_file.py"
+  And I hover over selector "#uitest-file-3-row"
+  And I press "uitest-file-3-kebab"
+  And element "#uitest-file-3-popup" contains text "Download"
+  And element "#uitest-file-3-popup" contains text "Delete"
 
+Scenario: main.py is locked
+  And I hover over selector "#uitest-file-0-row"
+  And I press "uitest-file-0-kebab"
+  And element "#uitest-file-0-popup" contains text "Download"
+  And element "#uitest-file-0-popup" does not contain text "Rename"

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_files.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_files.feature
@@ -1,0 +1,20 @@
+@no_mobile
+# Our minimum version of Safari does not support web workers
+@no_safari
+Feature: Python Lab manage files and folders
+
+Background:
+  Given I create a student named "Penelope"
+  And I am on "http://studio.code.org/s/allthethings/lessons/50/levels/1"
+  And I wait to see "#uitest-codebridge-run"
+
+Scenario: Can add a file
+  And I press "uitest-files-plus"
+  And I wait to see "#uitest-new-file"
+  And I press "uitest-new-file"
+  And I wait to see "#uitest-prompt-field"
+  And I press keys "new_file.py" for element "#uitest-prompt-field"
+  And I press "uitest-generic-dialog-ok"
+  And element ".cm-content" contains text "Add your changes to new_file.py"
+  And element "#uitest-files-list" contains text "new_file.py"
+

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -13,3 +13,25 @@ Scenario: Can run and see output of Python program
   And I press "uitest-codebridge-run"
   And I wait until "#uitest-codebridge-console" contains text "Hello from the start!"
   Then I sign out
+
+Scenario: Continue button and progress status shows up correctly
+  And I focus selector ".cm-content"
+
+  # Level 1 is not validated; continue button will show up after editing and running code.
+  And I press keys "print('more code')"
+  And I press "uitest-codebridge-run"
+  And I wait until "#uitest-codebridge-console" contains text "more code"
+  And element "#instructions-navigation" is visible
+  And element "#instructions-navigation" contains text "Continue"
+  And I press "instructions-navigation"
+  Then I verify progress in the header of the current page is "perfect" for level 1
+
+  # Validated level that passes by default, running validation will pass the level and
+  # cause the continue button to show up
+  And check that I am on "http://studio.code.org/s/allthethings/lessons/50/levels/2"
+  And I wait until "#uitest-validate-button" is not disabled
+  And I press "uitest-validate-button"
+  And I wait until element "#instructions-navigation" is visible
+  And element "#instructions-navigation" contains text "Continue"
+  Then I verify progress in the header of the current page is "perfect" for level 2
+  Then I sign out

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -16,8 +16,10 @@ Scenario: Can run and see output of Python program
 
 Scenario: Continue button and progress status shows up correctly
   # Level 1 is not validated; continue button will show up after editing and running code.
+  And I verify progress in the header of the current page is "not_tried" for level 1
   And I focus selector ".cm-content"
-  And I press keys "print('more code')"
+  And I press keys "print('more code')\n"
+  Then I verify progress in the header of the current page is "attempted" for level 1
   And I press "uitest-codebridge-run"
   And I wait until "#uitest-codebridge-console" contains text "more code"
   And element "#instructions-navigation" is visible

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -15,9 +15,8 @@ Scenario: Can run and see output of Python program
   Then I sign out
 
 Scenario: Continue button and progress status shows up correctly
-  And I focus selector ".cm-content"
-
   # Level 1 is not validated; continue button will show up after editing and running code.
+  And I focus selector ".cm-content"
   And I press keys "print('more code')"
   And I press "uitest-codebridge-run"
   And I wait until "#uitest-codebridge-console" contains text "more code"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1584,3 +1584,8 @@ And(/^I wait until ai assessments announcement is marked as seen$/) do
     response['has_seen_ai_assessments_announcement']
   end
 end
+
+And(/^I hover over selector "([^"]*)"$/) do |selector|
+  element = @browser.find_element(:css, selector)
+  @browser.action.move_to(element).perform
+end


### PR DESCRIPTION
A few more UI tests for python lab:
- Basic file management
- Locked starter file
- Continue button and progress shows up correctly for both validated and non-validated levels

## Links
- jira ticket: [CT-725](https://codedotorg.atlassian.net/browse/CT-725)

##  Follow up work
I want to also add a UI test (and/or an eyes test) for start mode, since we've broken it a fair number of times, which I'll do as a follow-up and keep CT-725 open (if I decide it makes the most sense as an eyes test, I'll resolve CT-725). We also have an eyes test ticket, which I will use to add a basic run eyes test and a version history eyes test.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
