### PR TITLE
Panels: fix reset

### DIFF
--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -83,19 +83,19 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
     setCurrentPanelIndex(index);
   };
 
-  // Reset to first panel whenever panels content changes if specified.
-  useEffect(() => {
-    if (resetOnChange) {
-      setCurrentPanelIndex(0);
-    }
-  }, [panels, resetOnChange]);
-
   // Reset to last panel if number of panels has reduced.
   useEffect(() => {
     if (currentPanelIndex >= panels.length) {
       setCurrentPanelIndex(Math.max(panels.length - 1, 0));
     }
   }, [currentPanelIndex, panels]);
+
+  // Reset to first panel whenever panels content changes if specified.
+  useEffect(() => {
+    if (resetOnChange) {
+      setCurrentPanelIndex(0);
+    }
+  }, [panels, resetOnChange]);
 
   // Cancel any in-progress text-to-speech when the panel changes.
   useEffect(() => {

--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -83,19 +83,19 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
     setCurrentPanelIndex(index);
   };
 
-  // Reset to last panel if number of panels has reduced.
-  useEffect(() => {
-    if (currentPanelIndex >= panels.length) {
-      setCurrentPanelIndex(Math.max(panels.length - 1, 0));
-    }
-  }, [currentPanelIndex, panels]);
-
   // Reset to first panel whenever panels content changes if specified.
   useEffect(() => {
     if (resetOnChange) {
       setCurrentPanelIndex(0);
     }
   }, [panels, resetOnChange]);
+
+  // Reset to last panel if number of panels has reduced.
+  useEffect(() => {
+    if (!resetOnChange && currentPanelIndex >= panels.length) {
+      setCurrentPanelIndex(Math.max(panels.length - 1, 0));
+    }
+  }, [currentPanelIndex, panels, resetOnChange]);
 
   // Cancel any in-progress text-to-speech when the panel changes.
   useEffect(() => {


### PR DESCRIPTION
This fixes an issue in which switching from one panels level to another one doesn't always reset to the first panel.

Repro case: start on a panels level with three panels, switch to the third panel; switch to a panels level with two panels.  Expected: you're on the first panel.  Actual: you're on the second panel. 

The issue is that one `useEffect` is asynchronously switching the current panel index back to 0, but a second `useEffect` is seeing that the same initial current panel index is beyond the last panel, and switching to the current level's last panel.

The first `useEffect` only does anything when in a level (due to `resetOnChange` being `true`).  The second `useEffect` appears intended for the editor only, so limiting it to that case (when `resetOnChange` is `false`) appears to resolve the issue.
