### PR TITLE
HoC 2024 - Update code.org/minecraft and add poster to hourofcode.com/resources

### DIFF
--- a/pegasus/sites.v3/code.org/public/images/mc/minecraft-activity-show-2024.png
+++ b/pegasus/sites.v3/code.org/public/images/mc/minecraft-activity-show-2024.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fb82af40f0212001e93f435dfdc242800376dfc59714a69702016ece1ff92cb
+size 134109

--- a/pegasus/sites.v3/code.org/views/minecraft/minecraft_education_activities.haml
+++ b/pegasus/sites.v3/code.org/views/minecraft/minecraft_education_activities.haml
@@ -16,19 +16,9 @@
     }
   ]
 
--# Hiding the Minecraft AI for Earth activity until further
--# notice from Microsoft — put this object back in the activity_item
--# array if we need to add this back.
--# {
--#   title: hoc_s(:minecraft_education_activity_title_2020),
--#   image: "/images/mc/minecraft-activity-gen-ai-for-earth-2020.png",
--#   desc: hoc_s(:minecraft_education_activity_desc_2020),
--#   url: "https://education.minecraft.net/en-us/lessons/minecraft-hour-of-code",
--#   aria_label: hoc_s(:aria_label_call_to_action_minecraft_2020)
--# }
-
 .action-block.action-block--two-col
-  %img.col-50{src: "/images/mc/minecraft-activity-gen-ai-2023.png", alt: ""}
+  .media-wrapper.col-50
+    %img{src: "/images/mc/minecraft-activity-show-2024.png", alt: ""}
   .text-wrapper.col-50
     .flex-container.justify-space-between.align-items-start
       %p.overline
@@ -37,10 +27,10 @@
       %p.new
         =hoc_s(:new)
     %h3.heading-md
-      = hoc_s(:minecraft_education_activity_title_2023)
+      = hoc_s("minecraft_show.title")
     %p
-      = hoc_s(:minecraft_education_activity_desc_2023)
-    %a.link-button.has-external-link{href: "https://aka.ms/hourofcode", target: "_blank", rel: "noopener noreferrer", "aria-label": hoc_s(:aria_label_call_to_action_minecraft_2023)}
+      = hoc_s("minecraft_show.desc")
+    %a.link-button.has-external-link{href: "https://aka.ms/hourofcode", target: "_blank", rel: "noopener noreferrer", "aria-label": hoc_s("minecraft_show.aria_label")}
       = hoc_s(:call_to_action_get_started)
   .clear
 

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1035,6 +1035,7 @@
   minecraft_show:
     title: "Minecraft: The Show Must Go On!"
     desc: "Step into the theater to save the day in The Show Must Go On! Find the missing star, unlock hidden gags, and interact with a cast of mobs. Help the Agent overcome stage fright as you solve fun coding puzzles. Watch your coding skills shine in an epic final performance!"
+    aria_label: "Get started with Minecraft: The Show Must Go On"
 
   afe_page_heading: "Free resources from Amazon Future Engineer"
   afe_page_top_desc: "Enhance your teaching experience with Code.org in partnership with [Amazon Future Engineer](%{afe_url}). Eligible educators from underserved schools can access these benefits at no cost:"

--- a/pegasus/sites.v3/hourofcode.com/public/images/poster_minecraft_show_must_go_on.png
+++ b/pegasus/sites.v3/hourofcode.com/public/images/poster_minecraft_show_must_go_on.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17280709a3089755eb4ea85de2f3732886ee01ed819050b4d2a5d4da71119254
+size 119828

--- a/pegasus/sites.v3/hourofcode.com/views/resources/resources_posters.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/resources/resources_posters.haml
@@ -1,6 +1,11 @@
 :ruby
   posters = [
     {
+      url: "poster_minecraft_show_must_go_on.pdf",
+      aria_label: hoc_s(:poster_aria_label_minecraft),
+      thumbnail_img: "poster_minecraft_show_must_go_on.png"
+    },
+    {
       url: "poster_minecraft.pdf",
       aria_label: hoc_s(:poster_aria_label_minecraft),
       thumbnail_img: "poster_minecraft.png"


### PR DESCRIPTION
Adds the new The Show Must Go On activity to https://code.org/minecraft and adds the new poster to https://hourofcode.com/resources. The poster PDF was added in S3 in the `downloads.code.org/posters/` bucket.

**Note:** this needs to go live on 10/29 so I will plan to merge this EOD Monday 10/28.

## Links
Jira tickets: [ACQ-2528](https://codedotorg.atlassian.net/browse/ACQ-2528), [ACQ-2581](https://codedotorg.atlassian.net/browse/ACQ-2581)
Figma mock: [here](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=4072-3840&m=dev)

----

## code.org/minecraft
<img width="1025" alt="Screenshot 2024-10-24 at 8 53 44 AM" src="https://github.com/user-attachments/assets/2fccd41f-88d0-4778-b095-7392ca42fdba">

## hourofcode.com/resources
<img width="1177" alt="Screenshot 2024-10-24 at 9 04 25 AM" src="https://github.com/user-attachments/assets/22aaca00-7755-4062-8210-e0e19b006acf">

