### PR TITLE
HoC 2024 - Create DCDO flag for November launch

### DIFF
--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -56,7 +56,9 @@ class DCDOBase < DynamicConfigBase
       'teacher-local-nav-v2': DCDO.get('teacher-local-nav-v2', false),
       'best-of-stem-2024': DCDO.get('best-of-stem-2024', false),
       lti_account_unlinking: DCDO.get('lti_account_unlinking', false),
+      # TODO ACQ-2556 - Remove this after the 2024 HOC launch
       'hoc-2024-sweepstakes': DCDO.get('hoc-2024-sweepstakes', false),
+      # TODO ACQ-2556 - Remove this after the 2024 HOC launch
       'hoc-2024-nov-launch': DCDO.get('hoc-2024-nov-launch', false),
     }
   end

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -56,7 +56,7 @@ class DCDOBase < DynamicConfigBase
       'teacher-local-nav-v2': DCDO.get('teacher-local-nav-v2', false),
       'best-of-stem-2024': DCDO.get('best-of-stem-2024', false),
       lti_account_unlinking: DCDO.get('lti_account_unlinking', false),
-      # TODO ACQ-2556 - Remove this after the 2024 HOC launch
+      # TODO ACQ-2556 - Remove this after the 2024 HOC sweepstakes is over
       'hoc-2024-sweepstakes': DCDO.get('hoc-2024-sweepstakes', false),
       # TODO ACQ-2556 - Remove this after the 2024 HOC launch
       'hoc-2024-nov-launch': DCDO.get('hoc-2024-nov-launch', false),

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -57,6 +57,7 @@ class DCDOBase < DynamicConfigBase
       'best-of-stem-2024': DCDO.get('best-of-stem-2024', false),
       lti_account_unlinking: DCDO.get('lti_account_unlinking', false),
       'hoc-2024-sweepstakes': DCDO.get('hoc-2024-sweepstakes', false),
+      'hoc-2024-nov-launch': DCDO.get('hoc-2024-nov-launch', false),
     }
   end
 end


### PR DESCRIPTION
Adds a `hoc-2024-nov-launch` DCDO flag ahead of updates for the November Hour of Code launch. Also added clean up comments.

## Links
Jira ticket: [ACQ-2594](https://codedotorg.atlassian.net/browse/ACQ-2594)