### PR TITLE
Music: limit playhead position changes

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -208,6 +208,18 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
             }}
             size="s"
           />
+          <Checkbox
+            checked={!!levelData.allowChangeStartingPlayheadPosition}
+            name="allowChangeStartingPlayheadPosition"
+            label="Allow change starting playhead position"
+            onChange={event => {
+              setLevelData({
+                ...levelData,
+                allowChangeStartingPlayheadPosition: event.target.checked,
+              });
+            }}
+            size="s"
+          />
         </div>
       </CollapsibleSection>
       <hr />

--- a/apps/src/music/types.ts
+++ b/apps/src/music/types.ts
@@ -15,6 +15,7 @@ export interface MusicLevelData extends ProjectLevelData {
   blockMode?: ValueOf<typeof BlockMode>;
   hideAiTemperature?: boolean;
   showAiTemperatureExplanation?: boolean;
+  allowChangeStartingPlayheadPosition?: boolean;
 }
 
 export type LoadFinishedCallback = (

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -136,6 +136,17 @@ const optionsList = [
     ],
   },
   {
+    name: 'allow-change-starting-playhead-position',
+    type: 'radio',
+    values: [
+      {
+        value: 'false',
+        description: "Don't allow change starting playhead position (default).",
+      },
+      {value: 'true', description: 'Allow change starting playhead position.'},
+    ],
+  },
+  {
     name: 'advanced-controls-enabled',
     type: 'radio',
     values: [


### PR DESCRIPTION
We have seen some user confusion when they have changed the starting playhead position, especially in levels with validation, so are limiting the ability to change it to specific levels where it's allowed by a levelbuilder.

This adds a checkbox to levelbuilder to allow it, and an optional `?allow-change-starting-playhead-position=true` URL parameter to try it out.
