### PR TITLE
P20 1196/update statsig ruby wrapper

### DIFF
--- a/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
+++ b/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
@@ -92,7 +92,7 @@ module Lti
           metadata = {
             lms_name: platform[:name],
           }
-          Metrics::Events.log_event_with_session(
+          Metrics::Events.log_event(
             session: session,
             event_name: 'lti_dynamic_registration_completed',
             metadata: metadata,

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -430,7 +430,7 @@ class LtiV1Controller < ApplicationController
       metadata = {
         lms_name: platform_name,
       }
-      Metrics::Events.log_event_with_session(
+      Metrics::Events.log_event(
         session: session,
         event_name: 'lti_portal_registration_completed',
         metadata: metadata,

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -349,7 +349,7 @@ Devise.setup do |config|
   end
 
   OmniAuth.config.before_request_phase do |env|
-    Metrics::Events.log_event_with_session(
+    Metrics::Events.log_event(
       session: env['rack.session'],
       event_name: "#{env['omniauth.strategy'].options[:name]}-begin-auth",
       )

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -30,7 +30,7 @@ module Metrics
         event_value = event_name if event_value.nil?
         enabled_experiments = get_enabled_experiments && user.present? ? user.get_active_experiment_names : nil
         managed_test_environment = CDO.running_web_application? && CDO.test_system?
-        statsig_stable_id = session[:statsig_stable_id]
+        statsig_stable_id = session&.dig(:statsig_stable_id)
 
         if CDO.rack_env?(:development)
           log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments, statsig_stable_id: statsig_stable_id)
@@ -86,17 +86,6 @@ module Metrics
             enabled_experiments: enabled_experiments,
             stableID: statsig_stable_id,
           }.compact,
-          event_name: event_name,
-          event_value: event_value,
-          metadata: metadata,
-        }
-        puts "Logging Event: #{event_details.to_json}"
-      end
-
-      # Logs an event to stdout, useful for development and debugging
-      private def log_event_to_stdout_with_session(session:, event_name:, event_value:, metadata:)
-        event_details = {
-          user_id: session[:statsig_stable_id],
           event_name: event_name,
           event_value: event_value,
           metadata: metadata,

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -26,15 +26,16 @@ module Metrics
       # @event_value - the value of the event (optional)
       # @metadata - a metadata hash with relevant data (optional)
       # @get_enabled_experiments - include list of experiements the user is enrolled in (optional)
-      def log_event(user: nil, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false)
+      def log_event(user: nil, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false, session: nil)
         event_value = event_name if event_value.nil?
         enabled_experiments = get_enabled_experiments && user.present? ? user.get_active_experiment_names : nil
         managed_test_environment = CDO.running_web_application? && CDO.test_system?
+        statsig_stable_id = session[:statsig_stable_id]
 
         if CDO.rack_env?(:development)
-          log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments)
+          log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments, statsig_stable_id: statsig_stable_id)
         elsif CDO.rack_env?(:production) || managed_test_environment
-          log_statsig_event_with_cdo_user(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments)
+          log_statsig_event_with_cdo_user(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments, statsig_stable_id: statsig_stable_id)
         else
           # We don't want to log in other environments, just return silently
           return
@@ -46,29 +47,9 @@ module Metrics
       )
       end
 
-      def log_event_with_session(session:, event_name:, event_value: nil, metadata: {})
-        event_value = event_name if event_value.nil?
-        managed_test_environment = CDO.running_web_application? && CDO.test_system?
-        statsig_user = StatsigUser.new({'userID' => session[:statsig_stable_id]})
-
-        if CDO.rack_env?(:development)
-          log_event_to_stdout_with_session(session: session, event_name: event_name, event_value: event_value, metadata: metadata)
-        elsif CDO.rack_env?(:production) || managed_test_environment
-          log_statsig_event(statsig_user: statsig_user, event_name: event_name, event_value: event_value, metadata: metadata)
-        else
-          # We don't want to log in other environments, just return silently
-          return
-        end
-      rescue => exception
-        Honeybadger.notify(
-          exception,
-          error_message: 'Error logging session event',
-          )
-      end
-
       # Logs an event to Statsig
-      private def log_statsig_event_with_cdo_user(user:, event_name:, event_value:, metadata:, enabled_experiments:)
-        statsig_user = build_statsig_user(user: user, enabled_experiments: enabled_experiments)
+      private def log_statsig_event_with_cdo_user(user:, event_name:, event_value:, metadata:, enabled_experiments:, statsig_stable_id:)
+        statsig_user = build_statsig_user(user: user, enabled_experiments: enabled_experiments, statsig_stable_id: statsig_stable_id)
         log_statsig_event(statsig_user: statsig_user, event_name: event_name, event_value: event_value, metadata: metadata)
       end
 
@@ -79,20 +60,23 @@ module Metrics
       end
 
       # Builds a StatsigUser object from a user entity
-      private def build_statsig_user(user:, enabled_experiments:)
+      private def build_statsig_user(user:, enabled_experiments:, statsig_stable_id:)
+        custom_ids = {stableID: statsig_stable_id}
+
         if user.present?
-          custom_ids = {
+          custom_ids.merge!({
             user_type: user.user_type,
             enabled_experiments: enabled_experiments,
           }.compact
+)
           StatsigUser.new({'userID' => user.id.to_s, 'custom_ids' => custom_ids})
         else
-          StatsigUser.new({'userID' => ''})
+          StatsigUser.new({'userID' => '', 'custom_ids' => custom_ids})
         end
       end
 
       # Logs an event to stdout, useful for development and debugging
-      private def log_event_to_stdout(user:, event_name:, event_value:, metadata:, enabled_experiments:)
+      private def log_event_to_stdout(user:, event_name:, event_value:, metadata:, enabled_experiments:, statsig_stable_id:)
         user_id = user.present? ? user.id : ''
         user_type = user.present? ? user.user_type : ''
         event_details = {
@@ -100,6 +84,7 @@ module Metrics
           custom_ids: {
             user_type: user_type,
             enabled_experiments: enabled_experiments,
+            stableID: statsig_stable_id,
           }.compact,
           event_name: event_name,
           event_value: event_value,

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -47,7 +47,7 @@ module Metrics
         Honeybadger.notify(
           exception,
           error_message: 'Error logging event',
-      )
+        )
       end
 
       # Logs an event to Statsig
@@ -67,11 +67,12 @@ module Metrics
         custom_ids = {stableID: statsig_stable_id}
 
         if user.present?
-          custom_ids.merge!({
-            user_type: user.user_type,
-            enabled_experiments: enabled_experiments,
-          }.compact
-)
+          custom_ids.merge!(
+            {
+              user_type: user.user_type,
+              enabled_experiments: enabled_experiments,
+            }.compact
+          )
           StatsigUser.new({'userID' => user.id.to_s, 'custom_ids' => custom_ids})
         else
           StatsigUser.new({'userID' => '', 'custom_ids' => custom_ids})

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -41,6 +41,9 @@ module Metrics
           return
         end
       rescue => exception
+        if CDO.rack_env?(:development)
+          puts "Error logging event: #{exception}"
+        end
         Honeybadger.notify(
           exception,
           error_message: 'Error logging event',

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -57,7 +57,7 @@ module SignUpTracking
       }
     )
 
-    Metrics::Events.log_event_with_session(
+    Metrics::Events.log_event(
       session: session,
       event_name: event_name,
       metadata: {
@@ -81,7 +81,7 @@ module SignUpTracking
     }
     FirehoseClient.instance.put_record(:analysis, tracking_data)
 
-    Metrics::Events.log_event_with_session(
+    Metrics::Events.log_event(
       session: session,
       event_name: "begin-sign-up-#{result}",
       metadata: {
@@ -102,7 +102,7 @@ module SignUpTracking
       }
     )
 
-    Metrics::Events.log_event_with_session(
+    Metrics::Events.log_event(
       session: session,
       event_name: "#{provider}-load-finish-sign-up",
       metadata: {
@@ -123,7 +123,7 @@ module SignUpTracking
       }
     )
 
-    Metrics::Events.log_event_with_session(
+    Metrics::Events.log_event(
       session: session,
       event_name: "#{provider}-cancel-finish-sign-up",
       metadata: {
@@ -149,7 +149,7 @@ module SignUpTracking
       )
     end
 
-    Metrics::Events.log_event_with_session(
+    Metrics::Events.log_event(
       session: session,
       event_name: event_name,
       metadata: {
@@ -171,7 +171,7 @@ module SignUpTracking
       }
       FirehoseClient.instance.put_record(:analysis, tracking_data)
 
-      Metrics::Events.log_event_with_session(
+      Metrics::Events.log_event(
         session: session,
         event_name: "#{provider}-sign-in",
         metadata: {
@@ -200,7 +200,7 @@ module SignUpTracking
     }
     FirehoseClient.instance.put_record(:analysis, tracking_data)
 
-    Metrics::Events.log_event_with_session(
+    Metrics::Events.log_event(
       session: session,
       event_name: "#{sign_up_type}-sign-up-#{result}",
       metadata: {

--- a/dashboard/test/controllers/lti/v1/dynamic_registration_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/dynamic_registration_controller_test.rb
@@ -39,7 +39,7 @@ class Lti::V1::DynamicRegistrationControllerTest < ActionController::TestCase
     response = {client_id: client_id}
     LtiDynamicRegistrationClient.any_instance.stubs(:make_registration_request).returns(response)
 
-    Metrics::Events.expects(:log_event_with_session).with(
+    Metrics::Events.expects(:log_event).with(
       has_entries(
         session: session,
         event_name: 'lti_dynamic_registration_completed',


### PR DESCRIPTION
This PR was reverted, as it was throwing errors logged to Honeybadger when trying to access `session[:statsig_stable_id]` when `session` wasn't being passed into the `Metrics::Events.log_event` method.

This new PR re-adds the reverted functionality, with the addition of:

<details>

<summary>Use safe navigation when accessing session</summary>

```ruby
statsig_stable_id = session&.dig(:statsig_stable_id)
```
</details>

<details>
<summary>Remove unused private method definition</summary>

[log_event_with_session](https://github.com/code-dot-org/code-dot-org/pull/62004/files#diff-cea5401e339a2dc25611ae02e29f3a86355fc79c0b7ef79e7e850fedf21ac54bL110-L120) is no longer needed, as we include the `statsig_stable_id` in the `log_event_to_stdout` method, under the `custom_ids[:stableID]` hash

</details>



<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1729809514849999)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I was able to repro the error locally
<img width="503" alt="Screenshot 2024-10-25 at 11 08 06 AM" src="https://github.com/user-attachments/assets/33017e9f-eeca-4973-a679-df2b8dcbf880">

Confirmed that with the new changes (using the safe navigation operator), it no longer errors, and we can see events
populated to Statsig whether `session` is included or not (user id is empty as I am logging from a page as a signed out user).

<details>
<summary>With session (note StableID is present)</summary>

<img width="791" alt="Screenshot 2024-10-25 at 11 34 31 AM" src="https://github.com/user-attachments/assets/6dadaeaa-6e52-442b-9418-2b6c5fdf9b28">
</details>


<details>
<summary>Without session (note StableID is not present</summary>

<img width="785" alt="Screenshot 2024-10-25 at 11 34 43 AM" src="https://github.com/user-attachments/assets/ba2bc600-18db-44af-84b2-75b9973814db">
</deatils>

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
