### PR TITLE
HoC 2024 - Update How-to guides

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -72,16 +72,6 @@ section.banner.homepage {
       display: none;
     }
   }
-
-  .overlay {
-    background: linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(255,255,255,0.5) 45%, rgba(255,255,255,0) 100%);
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 0;
-  }
 }
 
 section.banner {
@@ -126,5 +116,15 @@ section.banner {
 
   .button-wrapper {
     justify-content: center;
+  }
+
+  .overlay {
+    background: linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(255,255,255,0.5) 45%, rgba(255,255,255,0) 100%);
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 0;
   }
 }

--- a/pegasus/sites.v3/hourofcode.com/public/how-to/events.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/how-to/events.haml
@@ -13,7 +13,9 @@ layout: wide_index
 = view :"how-to/how_to_banner"
 
 -# Intro section
-= view :"how-to/how_to_intro", intro_header: hoc_s("hoc_how_to.events.top.heading"), intro_desc: hoc_s("hoc_how_to.events.top.desc_01"), intro_desc_02: hoc_s("hoc_how_to.events.top.desc_02")
+= view :"how-to/how_to_intro", intro_header: hoc_s("hoc_how_to.events.top.heading"), intro_desc: hoc_s("hoc_how_to.events.top_v2.desc_01"), intro_desc_02: hoc_s("hoc_how_to.events.top_v2.desc_02")
+
+= view :section_divider_line
 
 -# Steps
 = view :"how-to/steps/steps_events"

--- a/pegasus/sites.v3/hourofcode.com/public/how-to/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/how-to/index.haml
@@ -13,7 +13,9 @@ layout: wide_index
 = view :"how-to/how_to_banner"
 
 -# Intro section
-= view :"how-to/how_to_intro", intro_header: hoc_s("hoc_how_to.teachers.top.heading"), intro_desc: hoc_s("hoc_how_to.teachers.top.desc"), intro_desc_02: ""
+= view :"how-to/how_to_intro", intro_header: hoc_s("hoc_how_to.teachers.top_v2.heading"), intro_desc: hoc_s("hoc_how_to.teachers.top_v2.desc"), intro_desc_02: ""
+
+= view :section_divider_line
 
 -# Steps
 = view :"how-to/steps/steps_educators"

--- a/pegasus/sites.v3/hourofcode.com/views/how-to/how_to_banner.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/how-to/how_to_banner.haml
@@ -8,3 +8,4 @@
       %p.body-one
         =hoc_s("hoc_how_to.desc")
       = view :"how-to/how_to_guide_nav"
+    .overlay

--- a/pegasus/sites.v3/hourofcode.com/views/how-to/how_to_intro.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/how-to/how_to_intro.haml
@@ -1,4 +1,4 @@
-%section.bg-neutral-light
+%section
   .wrapper.centered
     %h2.no-margin-top
       #{intro_header}

--- a/pegasus/sites.v3/hourofcode.com/views/how-to/steps/side-nav/side_nav_educators.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/how-to/steps/side-nav/side_nav_educators.haml
@@ -9,7 +9,7 @@
     hoc_s("hoc_how_to.label.register"),
     hoc_s("hoc_how_to.label.choose"),
     hoc_s("hoc_how_to.label.plan_event"),
-    hoc_s("hoc_how_to.label.plan_hour"),
+    hoc_s("hoc_how_to.label.schedule_event"),
     hoc_s("hoc_how_to.label.spread_word"),
     hoc_s("hoc_how_to.label.get_coding"),
     hoc_s("hoc_how_to.label.celebrate"),

--- a/pegasus/sites.v3/hourofcode.com/views/how-to/steps/side-nav/side_nav_events.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/how-to/steps/side-nav/side_nav_events.haml
@@ -8,8 +8,8 @@
   steps_nav_label = [
     hoc_s("hoc_how_to.label.register"),
     hoc_s("hoc_how_to.label.choose"),
-    hoc_s("hoc_how_to.label.prepare"),
-    hoc_s("hoc_how_to.label.plan_hour"),
+    hoc_s("hoc_how_to.label.plan_event"),
+    hoc_s("hoc_how_to.label.schedule_event"),
     hoc_s("hoc_how_to.label.get_coding"),
     hoc_s("hoc_how_to.label.after"),
     hoc_s("hoc_how_to.label.beyond")

--- a/pegasus/sites.v3/hourofcode.com/views/how-to/steps/steps_educators.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/how-to/steps/steps_educators.haml
@@ -1,3 +1,4 @@
+-# TODO ACQ-2556 - Remove DCDO logic after launch
 - nov_launch = !!DCDO.get('hoc-2024-nov-launch', false)
 - music_url = "https://code.org/music"
 - mc_url = "https://aka.ms/hourofcode"

--- a/pegasus/sites.v3/hourofcode.com/views/how-to/steps/steps_educators.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/how-to/steps/steps_educators.haml
@@ -1,3 +1,7 @@
+- nov_launch = !!DCDO.get('hoc-2024-nov-launch', false)
+- music_url = "https://code.org/music"
+- mc_url = "https://aka.ms/hourofcode"
+
 :ruby
   steps_educators_index = 8
 
@@ -5,7 +9,7 @@
     hoc_s("hoc_how_to.label.register"),
     hoc_s("hoc_how_to.label.choose"),
     hoc_s("hoc_how_to.label.plan_event"),
-    hoc_s("hoc_how_to.label.plan_hour"),
+    hoc_s("hoc_how_to.label.schedule_event"),
     hoc_s("hoc_how_to.label.spread_word"),
     hoc_s("hoc_how_to.label.get_coding"),
     hoc_s("hoc_how_to.label.celebrate"),
@@ -13,10 +17,10 @@
   ]
 
   steps_educators_desc = [
-    hoc_s("hoc_how_to.teachers.steps.register"),
-    hoc_s("hoc_how_to.teachers.steps.choose_activity"),
-    "",
-    hoc_s("hoc_how_to.teachers.steps.plan_hour.body_01"),
+    hoc_s("hoc_how_to.teachers.steps_v2.register"),
+    nov_launch ? hoc_s("hoc_how_to.teachers.steps_v2.choose_activity", markdown: :inline, locals: {music_url: music_url, mc_url: mc_url, transformers_url: "https://studio.code.org/s/hello-world-transformers-one-2024/lessons/1/levels/1"}) : hoc_s("hoc_how_to.teachers.steps.choose_activity"),
+    hoc_s("hoc_how_to.teachers.steps_v2.plan_event.body_01", markdown: :inline),
+    hoc_s("hoc_how_to.teachers.steps_v2.schedule.body_01", markdown: :inline, locals: {music_url: music_url, mc_url: mc_url}),
     hoc_s("hoc_how_to.teachers.steps.spread_word.body_01", markdown: :inline, locals:{emails_url: resolve_url("/resources#sample-emails")}),
     hoc_s("hoc_how_to.teachers.steps.get_coding"),
     hoc_s("hoc_how_to.teachers.steps.celebrate"),
@@ -51,23 +55,19 @@
             - if index === 1
               %img{src: "/images/activities_2024.jpg", alt: ""}
               %a.link-button{href: resolve_url("/learn")}
-                =hoc_s("hoc_how_to.button.select_activity")
+                =hoc_s(:call_to_action_explore_activities)
 
             -# Step 3 additional content
             - if index === 2
-              %p
-                %strong=hoc_s(:what)
-                =hoc_s(:hoc_how_to_step_educators_plan_desc_01)
-              %p
-                %strong=hoc_s(:when)
-                =hoc_s(:hoc_how_to_step_educators_plan_desc_02, markdown: :inline, locals: {campaign_date: campaign_date("full")})
-              %p
-                %strong=hoc_s(:where)
-                =hoc_s(:hoc_how_to_step_educators_plan_desc_03)
+              %p=hoc_s("hoc_how_to.teachers.steps_v2.plan_event.body_02", markdown: :inline)
+              %p=hoc_s("hoc_how_to.teachers.steps_v2.plan_event.body_03", markdown: :inline, locals:{posters_url: resolve_url("/resources#posters")})
+              %p=hoc_s("hoc_how_to.teachers.steps_v2.plan_event.body_04")
               %img{src: "/images/how-to-neon.png", alt: ""}
 
             -# Step 4 additional content
             - if index === 3
+              %p=hoc_s("hoc_how_to.teachers.steps_v2.schedule.body_02", markdown: :inline)
+              %p=hoc_s("hoc_how_to.teachers.steps_v2.schedule.body_03", markdown: :inline)
               %ul
                 %li
                   =hoc_s("hoc_how_to.teachers.steps.plan_hour.list_01", markdown: :inline, locals:{video_url: resolve_url("/resources#videos")})

--- a/pegasus/sites.v3/hourofcode.com/views/how-to/steps/steps_events.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/how-to/steps/steps_events.haml
@@ -4,16 +4,16 @@
   steps_educators_heading = [
     hoc_s("hoc_how_to.label.register"),
     hoc_s("hoc_how_to.label.choose"),
-    hoc_s("hoc_how_to.label.prepare"),
-    hoc_s("hoc_how_to.label.plan_hour"),
+    hoc_s("hoc_how_to.label.plan_event"),
+    hoc_s("hoc_how_to.label.schedule_event"),
     hoc_s("hoc_how_to.label.get_coding"),
     hoc_s("hoc_how_to.label.after"),
     hoc_s("hoc_how_to.label.beyond")
   ]
 
   steps_educators_desc = [
-    hoc_s("hoc_how_to.events.steps.register"),
-    hoc_s("hoc_how_to.events.steps.choose_activity"),
+    hoc_s("hoc_how_to.events.steps_v2.register"),
+    hoc_s("hoc_how_to.events.steps_v2.choose_activity"),
     "",
     hoc_s("hoc_how_to.events.steps.plan.body_01"),
     hoc_s("hoc_how_to.events.steps.get_coding.body_01"),
@@ -68,17 +68,17 @@
             - if index === 3
               %ul
                 %li
-                  =hoc_s(:hoc_how_to_step_events_plan_hour_desc_02, markdown: :inline, locals:{videos_url: resolve_url("/resources#videos")})
+                  =hoc_s("hoc_how_to.events.steps_v2.plan.list_01", markdown: :inline, locals:{video_url: resolve_url("/resources#videos")})
                 %li
-                  =hoc_s("hoc_how_to.events.steps.plan.list_02")
+                  =hoc_s("hoc_how_to.events.steps_v2.plan.list_02")
                 %li
-                  =hoc_s("hoc_how_to.events.steps.plan.list_03")
+                  =hoc_s("hoc_how_to.events.steps_v2.plan.list_03")
                 %li
-                  =hoc_s("hoc_how_to.events.steps.plan.list_04")
+                  =hoc_s("hoc_how_to.events.steps_v2.plan.list_04")
                 %li
-                  =hoc_s("hoc_how_to.events.steps.plan.list_05")
+                  =hoc_s("hoc_how_to.events.steps_v2.plan.list_05")
                 %li
-                  =hoc_s("hoc_how_to.events.steps.plan.list_06")
+                  =hoc_s("hoc_how_to.events.steps_v2.plan.list_06")
 
             -# Step 5 additional content
             - if index === 4
@@ -91,15 +91,13 @@
             - if index === 5
               %ul
                 %li
-                  =hoc_s("hoc_how_to.events.steps.after.list_01")
+                  =hoc_s("hoc_how_to.events.steps_v2.after.list_01")
                 %li
-                  =hoc_s("hoc_how_to.events.steps.after.list_02")
+                  =hoc_s("hoc_how_to.events.steps_v2.after.list_02")
                 %li
                   =hoc_s("hoc_how_to.events.steps.after.list_03")
                 %li
                   =hoc_s("hoc_how_to.events.steps.after.list_04")
-                %li
-                  =hoc_s("hoc_how_to.events.steps.after.list_05")
               %a.link-button.has-external-link{href: "https://code.org/certificates", target: "_blank", rel: "noopener noreferrer"}
                 =hoc_s("hoc_how_to.button.print_certificates")
 


### PR DESCRIPTION
Updates https://hourofcode.com/how-to and https://hourofcode.com/how-to/events for the Nov launch. Some copy updates are hidden behind the `hoc-2024-nov-launch` DCDO flag since they include a link to Music Lab: Jam Session.

This also updates the hero banners to have a fade to match the homepage.

## Links
Jira ticket: [ACQ-2545](https://codedotorg.atlassian.net/browse/ACQ-2545)
Figma mocks: [teachers](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=4065-1423&m=dev), [events](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=4065-1603&m=dev)

## Testing story
Tested locally

## Followup
I'll clean up the DCDO logic in this ticket: [ACQ-2556](https://codedotorg.atlassian.net/browse/ACQ-2556)

----

## hourofcode.com/how-to
### All of the sections in the video changed

https://github.com/user-attachments/assets/cd087a58-9121-46ed-8f9f-92bc69d4c0a3


| DCDO is `false` | DCDO is `true` |
| ---- | ---- |
| <img width="1180" alt="false" src="https://github.com/user-attachments/assets/cf2a9751-6e5a-4f76-ab21-e4fcb8209ed3"> | <img width="1180" alt="true" src="https://github.com/user-attachments/assets/65b144df-9c45-4370-ac57-66890a4dfc77"> |

## hourofcode.com/how-to/events
### I hovered around the sections the changed in the video


https://github.com/user-attachments/assets/a42381b4-1b0d-4d07-9313-e24b2b4fe837

