### PR TITLE
HoC 2024 - Add fade to hero banner on hourofcode.com/learn

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -31,6 +31,7 @@ layout: wide_index
   = view :header
   %section.banner
     = view :learn_banner_text
+    .overlay
 
 -# Not ideal but we can pull the undigested files from /blockly.
 - locale_code = hoc_get_locale_code


### PR DESCRIPTION
Adds fade to hero banner on https://hourofcode.com/learn to match the homepage fade done in this PR: https://github.com/code-dot-org/code-dot-org/pull/61964

## Links
Jira ticket: [ACQ-2596](https://codedotorg.atlassian.net/browse/ACQ-2596)
Figma mock: [here](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=4065-1228&m=dev)

----

## Before
![hourofcode com_us_learn](https://github.com/user-attachments/assets/2d3ebf04-349c-4779-9b2a-ef974d30fc58)

## After
![localhost hourofcode com_3000_us_learn](https://github.com/user-attachments/assets/0eb048d8-18d4-4288-94ce-0741801c6334)
