### PR TITLE
[Ai chat] Fix Initial Temperature range in level editor

### DIFF
--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -131,9 +131,9 @@ const SetupCustomization: React.FunctionComponent = () => {
   const sliderProps: SliderProps = {
     name: 'temperature-slider',
     value: aiCustomizations.temperature * 10,
-    minValue: MIN_TEMPERATURE,
-    maxValue: MAX_TEMPERATURE,
-    step: SET_TEMPERATURE_STEP,
+    minValue: MIN_TEMPERATURE * 10,
+    maxValue: MAX_TEMPERATURE * 10,
+    step: SET_TEMPERATURE_STEP * 10,
     hideValue: true,
     disabled: isDisabled(temperature) || readOnlyWorkspace,
     onChange: event => {

--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -128,12 +128,16 @@ const SetupCustomization: React.FunctionComponent = () => {
     );
   };
 
+  // The reason we're multiplying by 10 and dividing by 10 is because the slider
+  // component adds and subtracts by the step value, and with float math, those values
+  // can end up being slightly off after multiple increments/decrements by 0.1.
+  // This way, we can avoid any issues from funky float math.
   const sliderProps: SliderProps = {
     name: 'temperature-slider',
-    value: aiCustomizations.temperature * 10,
-    minValue: MIN_TEMPERATURE * 10,
-    maxValue: MAX_TEMPERATURE * 10,
-    step: SET_TEMPERATURE_STEP * 10,
+    value: Math.round(aiCustomizations.temperature * 10),
+    minValue: Math.round(MIN_TEMPERATURE * 10),
+    maxValue: Math.round(MAX_TEMPERATURE * 10),
+    step: Math.round(SET_TEMPERATURE_STEP * 10),
     hideValue: true,
     disabled: isDisabled(temperature) || readOnlyWorkspace,
     onChange: event => {

--- a/apps/src/aichat/views/modelCustomization/constants.ts
+++ b/apps/src/aichat/views/modelCustomization/constants.ts
@@ -7,9 +7,9 @@ import {
   Visibility,
 } from '../../types';
 
-export const MIN_TEMPERATURE = 1;
-export const MAX_TEMPERATURE = 10;
-export const SET_TEMPERATURE_STEP = 1;
+export const MIN_TEMPERATURE = 0.1;
+export const MAX_TEMPERATURE = 1;
+export const SET_TEMPERATURE_STEP = 0.1;
 export const MAX_RETRIEVAL_CONTEXTS = 20;
 export const MAX_ASK_ABOUT_TOPICS = 10;
 


### PR DESCRIPTION
Fix regression from #61725 where the level editor was not allowing values in the correct range for the initial temperature value.  `MIN_TEMPERATURE` and `MAX _TEMPERATURE` were updated to allow for more reliable math in the slider component, but those consts are also used to set the initial temp in levelbuilder for ai chat levels, which broke the ability to set the correct values in level editor. This change constrains the logic for avoiding funky float values to the `sliderProps`, and reverts the temperature consts back to their original values.

## Links

- [slack thread with bug report and discussion](https://codedotorg.slack.com/archives/C06FELVTV0Q/p1729802026168849)

## Testing story

Tested locally that the 
 - slider still works as expected in an aichat level
   - values shown are from 0.1-1
   - customizations are using values 0.1-1 when updating main.json
 - the level editor allows values from 0.1 to 1.


## Follow-up work

Dan will need to go back and update a handful of levels to have the correct initial temperature.
