### PR TITLE
Adds sign up started event to existing LTI integration

### DIFF
--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -4,7 +4,7 @@ import React, {useContext, useRef, useState} from 'react';
 import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';
 import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
-import {PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
   Card,
@@ -31,6 +31,11 @@ const LtiNewAccountCard = () => {
       lms_name: ltiProviderName,
       user_type: userType,
     };
+    analyticsReporter.sendEvent(
+      EVENTS.SIGN_UP_STARTED_EVENT,
+      {},
+      PLATFORMS.BOTH
+    );
     analyticsReporter.sendEvent(
       'lti_new_account_click',
       eventPayload,

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -33,7 +33,7 @@ const LtiNewAccountCard = () => {
     };
     analyticsReporter.sendEvent(
       EVENTS.SIGN_UP_STARTED_EVENT,
-      {ltiIntegration: true},
+      {source: 'LTI'},
       PLATFORMS.BOTH
     );
     analyticsReporter.sendEvent(

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -33,7 +33,7 @@ const LtiNewAccountCard = () => {
     };
     analyticsReporter.sendEvent(
       EVENTS.SIGN_UP_STARTED_EVENT,
-      {},
+      {ltiIntegration: true},
       PLATFORMS.BOTH
     );
     analyticsReporter.sendEvent(

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -89,6 +89,7 @@ $(document).ready(() => {
         has_marketing_value = true;
       }
     }
+    let sourceString = isLTI ? 'LTI' : '';
     analyticsReporter.sendEvent(
       EVENTS.SIGN_UP_FINISHED_EVENT,
       {
@@ -96,7 +97,7 @@ $(document).ready(() => {
         'has school': has_school,
         'has marketing value selected': has_marketing_value,
         'has display name': has_display_name,
-        'LTI integration': isLTI,
+        source: sourceString,
       },
       PLATFORMS.BOTH
     );

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -89,7 +89,7 @@ $(document).ready(() => {
         has_marketing_value = true;
       }
     }
-    let sourceString = isLTI ? 'LTI' : '';
+    const sourceString = isLTI ? 'LTI' : '';
     analyticsReporter.sendEvent(
       EVENTS.SIGN_UP_FINISHED_EVENT,
       {

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -30,7 +30,7 @@ const STUDENT_ONLY_FIELDS = [
 // Values loaded from scriptData are always initial values, not the latest
 // (possibly unsaved) user-edited values on the form.
 const scriptData = getScriptData('signup');
-const {usIp, signUpUID} = scriptData;
+const {usIp, signUpUID, isLTI} = scriptData;
 
 // User type buttons
 const teacherButton = document.getElementById('select-user-type-teacher');
@@ -96,6 +96,7 @@ $(document).ready(() => {
         'has school': has_school,
         'has marketing value selected': has_marketing_value,
         'has display name': has_display_name,
+        'LTI integration': isLTI,
       },
       PLATFORMS.BOTH
     );

--- a/apps/src/sites/studio/pages/followers/student_user_new.js
+++ b/apps/src/sites/studio/pages/followers/student_user_new.js
@@ -6,7 +6,7 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 $(document).ready(() => {
   analyticsReporter.sendEvent(
     EVENTS.SIGN_UP_STARTED_EVENT,
-    {sectionCodeSignUpForm: true},
+    {source: 'section code sign up form'},
     PLATFORMS.STATSIG
   );
 
@@ -15,7 +15,7 @@ $(document).ready(() => {
     .addEventListener('click', () => {
       analyticsReporter.sendEvent(
         EVENTS.SIGN_UP_FINISHED_EVENT,
-        {sectionCodeSignUpForm: true},
+        {source: 'section code sign up form'},
         PLATFORMS.STATSIG
       );
     });

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -248,7 +248,8 @@
   script_data = {
     signup: {
       usIp: us_ip,
-      signUpUID: "#{session[:sign_up_uid]}"
+      signUpUID: "#{session[:sign_up_uid]}",
+      isLTI: is_lti
     }.to_json
   }
 %script{src: webpack_asset_path('js/devise/registrations/_finish_sign_up.js'), data: script_data}


### PR DESCRIPTION
I discovered today that while LTI users are landing on our finish sign up page (and therefore, we are sending a SIGN_UP_FINISHED event for them), we have not been sending a corresponding SIGN_UP_STARTED statsig event. This pr adds that event so that our conversion metrics are correct.

This is the button for the 'Finish Creating my Account' card on the left that sends users to the finish_sign_up.haml file.

Additionally, this updates the metadata format for the section code sign up form to match this format, where we now have a 'source' data point which can be blank (the usual flow), 'LTI', or 'section code sign up form'. 

<img width="600" alt="Screenshot 2024-10-24 at 3 51 36 PM" src="https://github.com/user-attachments/assets/3b861b7d-1b3f-412c-aa3d-3008818042e4">

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2598

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
