### PR TITLE
remove ui test step which creates single section experiments

### DIFF
--- a/dashboard/test/ui/features/step_definitions/experiment_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/experiment_steps.rb
@@ -32,11 +32,3 @@ And /^I add the current user to the "([^"]*)" single user experiment$/ do |exper
     body: {experiment_name: experiment_name}
   )
 end
-
-And /^I add the current user to the "([^"]*)" single section experiment for the "([^"]*)" course$/ do |experiment_name, script_name|
-  browser_request(
-    url: '/api/test/set_single_section_experiment',
-    method: 'POST',
-    body: {experiment_name: experiment_name, script_name: script_name}
-  )
-end


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-666. The uses of the problem step were already removed when the TA feature launched, so all this PR does is remove the step definition.

