### PR TITLE
Reclassify some accounts as school-managed for CAP

### DIFF
--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -124,10 +124,10 @@ class Policies::ChildAccount
 
   # Login types that are considered school owned only if the user is in a section or was created via
   # roster sync from an LMS.
-  CONDITIONALLY_SCHOOL_OWNED_TYPES = Set[AuthenticationOption::GOOGLE, AuthenticationOption::MICROSOFT]
+  CONDITIONALLY_SCHOOL_OWNED_TYPES = Set[AuthenticationOption::GOOGLE, AuthenticationOption::MICROSOFT].freeze
 
   # Login types that are always considered personal logins.
-  PERSONAL_LOGIN_TYPES = Set[AuthenticationOption::EMAIL, AuthenticationOption::FACEBOOK]
+  PERSONAL_LOGIN_TYPES = Set[AuthenticationOption::EMAIL, AuthenticationOption::FACEBOOK].freeze
 
   # Does the user login using credentials they personally control?
   # For example, some accounts are created and owned by schools (Clever).
@@ -141,15 +141,15 @@ class Policies::ChildAccount
       ao_providers = Set.new(user.authentication_options.pluck(:credential_type))
 
       # Email and Facebook are always personal logins.
-      return true if ao_providers & PERSONAL_LOGIN_TYPES
+      return true if ao_providers.intersect?(PERSONAL_LOGIN_TYPES)
 
       # Clever and LTI are never personal logins if no other login types are present.
       return false if ao_providers.subset?(SCHOOL_OWNED_TYPES)
 
       # Google and Microsoft are considered school owned for users who are in sections and/or
       # if the user was created via a roster sync.
-      if ao_providers & CONDITIONALLY_SCHOOL_OWNED_TYPES
-        conditionally_school_managed?(user)
+      if ao_providers.intersect?(CONDITIONALLY_SCHOOL_OWNED_TYPES)
+        return !conditionally_school_managed?(user)
       end
 
       return true
@@ -246,7 +246,7 @@ class Policies::ChildAccount
     personal_account?(user)
   end
 
-  private def conditionally_school_managed?(user)
+  def self.conditionally_school_managed?(user)
     user.sections_as_student.present? || user.roster_synced
   end
 end

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -138,7 +138,9 @@ class Policies::ChildAccount
     if user.migrated?
       # Email + password logins are always personal logins.
       return true if user.encrypted_password.present?
+
       ao_providers = Set.new(user.authentication_options.pluck(:credential_type))
+      return true if ao_providers.empty?
 
       # Email and Facebook are always personal logins.
       return true if ao_providers.intersect?(PERSONAL_LOGIN_TYPES)

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -118,22 +118,41 @@ class Policies::ChildAccount
     user_predates_policy?(user) && !ComplianceState.permission_granted?(user)
   end
 
-  # Authentication option types which we consider to be "owned" by the school
+  # Authentication option types which we always consider to be "owned" by the school
   # the student attends because the school has admin control of the account.
-  SCHOOL_OWNED_TYPES = [AuthenticationOption::CLEVER, AuthenticationOption::LTI_V1].freeze
+  SCHOOL_OWNED_TYPES = Set[AuthenticationOption::CLEVER, AuthenticationOption::LTI_V1].freeze
+
+  # Login types that are considered school owned only if the user is in a section or was created via
+  # roster sync from an LMS.
+  CONDITIONALLY_SCHOOL_OWNED_TYPES = Set[AuthenticationOption::GOOGLE, AuthenticationOption::MICROSOFT]
+
+  # Login types that are always considered personal logins.
+  PERSONAL_LOGIN_TYPES = Set[AuthenticationOption::EMAIL, AuthenticationOption::FACEBOOK]
 
   # Does the user login using credentials they personally control?
   # For example, some accounts are created and owned by schools (Clever).
   def self.personal_account?(user)
+    # Sponsored accounts are always managed by the teacher.
     return false if user.sponsored?
-    # List of credential types which we believe schools have ownership of.
-    # Does the user have an authentication method which is not controlled by
-    # their school? The presence of at least one authentication method which
-    # is owned by the student/parent means this is a "personal account".
+
     if user.migrated?
-      user.authentication_options.any? do |option|
-        SCHOOL_OWNED_TYPES.exclude?(option.credential_type)
+      # Email + password logins are always personal logins.
+      return true if user.encrypted_password.present?
+      ao_providers = Set.new(user.authentication_options.pluck(:credential_type))
+
+      # Email and Facebook are always personal logins.
+      return true if ao_providers & PERSONAL_LOGIN_TYPES
+
+      # Clever and LTI are never personal logins if no other login types are present.
+      return false if ao_providers.subset?(SCHOOL_OWNED_TYPES)
+
+      # Google and Microsoft are considered school owned for users who are in sections and/or
+      # if the user was created via a roster sync.
+      if ao_providers & CONDITIONALLY_SCHOOL_OWNED_TYPES
+        conditionally_school_managed?(user)
       end
+
+      return true
     else
       SCHOOL_OWNED_TYPES.exclude?(user.provider)
     end
@@ -225,5 +244,9 @@ class Policies::ChildAccount
     return false unless underage?(user)
 
     personal_account?(user)
+  end
+
+  private def self.conditionally_school_managed?(user)
+    user.sections_as_student.present? || user.roster_synced
   end
 end

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -135,30 +135,25 @@ class Policies::ChildAccount
     # Sponsored accounts are always managed by the teacher.
     return false if user.sponsored?
 
-    if user.migrated?
-      # Email + password logins are always personal logins.
-      return true if user.encrypted_password.present?
+    # Email + password logins are always personal logins.
+    return true if user.encrypted_password.present?
 
-      ao_providers = Set.new(user.authentication_options.pluck(:credential_type))
-      return true if ao_providers.empty?
+    providers = user.migrated? ? Set.new(user.authentication_options.pluck(:credential_type)) : Set.new([user.provider])
+    return true if providers.empty?
 
-      # Email and Facebook are always personal logins.
-      return true if ao_providers.intersect?(PERSONAL_LOGIN_TYPES)
+    # Email and Facebook are always personal logins.
+    return true if providers.intersect?(PERSONAL_LOGIN_TYPES)
 
-      # Clever and LTI are never personal logins if no other login types are present.
-      return false if ao_providers.subset?(SCHOOL_OWNED_TYPES)
+    # Clever and LTI are never personal logins if no other login types are present.
+    return false if providers.subset?(SCHOOL_OWNED_TYPES)
 
-      # Google and Microsoft are considered school owned for users who are in sections and/or
-      # if the user was created via a roster sync.
-      if ao_providers.intersect?(CONDITIONALLY_SCHOOL_OWNED_TYPES)
-        return !conditionally_school_managed?(user)
-      end
-
-      return true
-    else
-      return !conditionally_school_managed?(user) if CONDITIONALLY_SCHOOL_OWNED_TYPES.include?(user.provider)
-      SCHOOL_OWNED_TYPES.exclude?(user.provider)
+    # Google and Microsoft are considered school owned for users who are in sections and/or
+    # if the user was created via a roster sync.
+    if providers.intersect?(CONDITIONALLY_SCHOOL_OWNED_TYPES)
+      return !conditionally_school_managed?(user)
     end
+
+    return true
   end
 
   def self.state_policies

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -246,7 +246,7 @@ class Policies::ChildAccount
     personal_account?(user)
   end
 
-  private def self.conditionally_school_managed?(user)
+  private def conditionally_school_managed?(user)
     user.sections_as_student.present? || user.roster_synced
   end
 end

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -247,6 +247,6 @@ class Policies::ChildAccount
   end
 
   def self.conditionally_school_managed?(user)
-    user.sections_as_student.present? || user.roster_synced
+    user.sections_as_student.exists? || user.roster_synced
   end
 end

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -156,6 +156,7 @@ class Policies::ChildAccount
 
       return true
     else
+      return !conditionally_school_managed?(user) if CONDITIONALLY_SCHOOL_OWNED_TYPES.include?(user.provider)
       SCHOOL_OWNED_TYPES.exclude?(user.provider)
     end
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -613,6 +613,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_lti_authentication_option do
+      after(:create) do |user|
+        create(:lti_authentication_option, user: user)
+      end
+    end
+
     trait :with_puzzles do
       transient do
         num_puzzles {1}

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -348,6 +348,13 @@ FactoryBot.define do
         end
       end
 
+      trait :in_google_section do
+        after(:create) do |user|
+          section = create :section, login_type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM
+          section.add_student user
+        end
+      end
+
       factory :student_with_ai_tutor_access do
         after(:create) do |user|
           teacher = create :teacher
@@ -457,12 +464,22 @@ FactoryBot.define do
     end
 
     # We have some tests which want to create student accounts which don't have any authentication setup.
-    # Using this will put the user into an invalid state.
+    # Using this will put the user into an invalid state unless they have another authentication option.
     trait :without_encrypted_password do
       after(:create) do |user|
         user.encrypted_password = nil
         user.password = nil
         user.save validate: false
+      end
+    end
+
+    # The user factory creates an email authentication option by default. This trait will remove that option.
+    # For testing SSO users who have an email address but not an email authentication option.
+    trait :without_email_auth_option do
+      after(:create) do |user|
+        ao = user.authentication_options.find_by(credential_type: AuthenticationOption::EMAIL)
+        ao&.destroy
+        user.save
       end
     end
 

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -500,17 +500,38 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
   test '.personal_account?' do
     # [User traits, Expected result from personal_account?]
     test_matrix = [
-      # Migrated
+      # Personal Accounts
       [[:student], true], # Has email auth option and password by default
-      [[:student, :with_clever_authentication_option, :without_email_auth_option, :without_encrypted_password], false],
-      [[:student, :with_lti_auth, :without_email_auth_option, :without_encrypted_password], false],
       [[:student, :with_facebook_authentication_option, :without_email_auth_option, :without_encrypted_password], true],
       [[:student, :with_google_authentication_option, :without_email_auth_option, :without_encrypted_password], true],
       [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :without_encrypted_password], true],
+
+      # School-managed accounts
+      [[:student, :with_clever_authentication_option, :without_email_auth_option, :without_encrypted_password], false],
+      [[:student, :with_lti_authentication_option, :without_email_auth_option, :without_encrypted_password], false],
+
+      # Conditionally school-managed (when in a section or roster synced)
       [[:student, :with_google_authentication_option, :without_email_auth_option, :without_encrypted_password, {roster_synced: true}], false],
-      [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :without_encrypted_password, {roster_synced: true}], false],
       [[:student, :with_google_authentication_option, :without_email_auth_option, :without_encrypted_password, :in_google_section], false],
+      [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :without_encrypted_password, {roster_synced: true}], false],
       [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :without_encrypted_password, :in_email_section], false],
+
+      # School-managed accounts that have email logins or passwords, tainting them as personal accounts
+      [[:student, :with_clever_authentication_option, :without_encrypted_password], true],
+      [[:student, :with_clever_authentication_option, :without_email_auth_option], true],
+      [[:student, :with_lti_authentication_option, :without_encrypted_password], true],
+      [[:student, :with_lti_authentication_option, :without_email_auth_option], true],
+
+      # Conditionally school-managed accounts that have email logins or passwords, tainting them as personal accounts
+      [[:student, :with_google_authentication_option, :without_email_auth_option, {roster_synced: true}], true],
+      [[:student, :with_google_authentication_option, :without_encrypted_password, {roster_synced: true}], true],
+      [[:student, :with_google_authentication_option, :without_email_auth_option, :in_google_section], true],
+      [[:student, :with_google_authentication_option, :without_encrypted_password, :in_google_section], true],
+      [[:student, :with_microsoft_authentication_option, :without_email_auth_option, {roster_synced: true}], true],
+      [[:student, :with_microsoft_authentication_option, :without_encrypted_password, {roster_synced: true}], true],
+      [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :in_email_section], true],
+      [[:student, :with_microsoft_authentication_option, :without_encrypted_password, :in_email_section], true],
+
       # Unmigrated
       [[:student, :without_email_auth_option, :demigrated], true],
       [[:student, :clever_sso_provider, :without_email_auth_option, :without_encrypted_password, :demigrated], false],

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -497,138 +497,28 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
     end
   end
 
-  describe '.personal_account?' do
-    let(:personal_account?) {Policies::ChildAccount.personal_account?(user)}
-
-    let(:user_sponsored?) {false}
-    let(:user_migrated?) {false}
-    let(:user_provider) {nil}
-    let(:user_encrypted_password) {nil}
-    let(:user_roster_synced) {false}
-    let(:user_auth_option_credential_type) {::AuthenticationOption::EMAIL}
-    let(:user_auth_option) {build_stubbed(:authentication_option, credential_type: user_auth_option_credential_type)}
-    let(:user_has_extra_auth_option?) {false}
-    let(:extra_auth_option_type) {::AuthenticationOption::EMAIL}
-    let(:user_in_section?) {false}
-    let(:section) {build_stubbed(:section)}
-    let(:extra_auth_option) {build_stubbed(:authentication_option, credential_type: extra_auth_option_type)}
-    let(:user) {build_stubbed(:user, provider: user_provider, encrypted_password: user_encrypted_password, roster_synced: user_roster_synced)}
-
-    before do
-      user.stubs(:sponsored?).returns(user_sponsored?)
-      user.stubs(:migrated?).returns(user_migrated?)
-      auth_options = []
-      auth_options << user_auth_option if user_migrated?
-      auth_options << extra_auth_option if user_has_extra_auth_option?
-      user.stubs(:authentication_options).returns(auth_options)
-      user.stubs(:sections_as_student).returns(section) if user_in_section?
+  test '.personal_account?' do
+    # [User traits, Expected result from personal_account?]
+    test_matrix = [
+      [[:student], true], # Has email auth option and password by default
+      [[:student, :with_clever_authentication_option, :without_email_auth_option, :without_encrypted_password], false],
+      [[:student, :with_lti_auth, :without_email_auth_option, :without_encrypted_password], false],
+      [[:student, :with_facebook_authentication_option, :without_email_auth_option, :without_encrypted_password], true],
+      [[:student, :with_google_authentication_option, :without_email_auth_option, :without_encrypted_password], true],
+      [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :without_encrypted_password], true],
+      [[:student, :with_google_authentication_option, :without_email_auth_option, :without_encrypted_password, {roster_synced: true}], false],
+      [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :without_encrypted_password, {roster_synced: true}], false],
+      [[:student, :with_google_authentication_option, :without_email_auth_option, :without_encrypted_password, :in_google_section], false],
+      [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :without_encrypted_password, :in_email_section], false],
+    ]
+    failures = []
+    test_matrix.each do |traits, expected_result|
+      user = create(*traits)
+      actual_result = Policies::ChildAccount.personal_account?(user)
+      failure_msg = "Expected personal_account?(#{traits}) to be #{expected_result} but it was #{actual_result}"
+      failures << failure_msg if actual_result != expected_result
     end
-
-    context 'when legacy/unmigrated user' do
-      context 'when user has a password' do
-        let(:user_encrypted_password) {'password'}
-        it 'returns true' do
-          _(personal_account?).must_equal true
-        end
-      end
-
-      context 'when user provider is Clever' do
-        let(:user_provider) {::AuthenticationOption::CLEVER}
-
-        it 'returns false' do
-          _(personal_account?).must_equal false
-        end
-      end
-    end
-
-    context 'when user is migrated' do
-      let(:user_migrated?) {true}
-      let(:user_provider) {::User::PROVIDER_MIGRATED}
-
-      it 'returns true' do
-        _(personal_account?).must_equal true
-      end
-
-      context 'when Clever auth option' do
-        let(:user_auth_option_credential_type) {::AuthenticationOption::CLEVER}
-
-        it 'returns false' do
-          _(personal_account?).must_equal false
-        end
-
-        context 'when user has a password' do
-          let(:user_encrypted_password) {'password'}
-
-          it 'returns true' do
-            _(personal_account?).must_equal true
-          end
-        end
-
-        context 'when user also has an email auth option' do
-          let(:user_has_extra_auth_option?) {true}
-
-          it 'returns true' do
-            _(personal_account?).must_equal true
-          end
-        end
-      end
-
-      context 'when LTI auth option' do
-        let(:user_auth_option_credential_type) {::AuthenticationOption::LTI_V1}
-
-        it 'returns false' do
-          _(personal_account?).must_equal false
-        end
-
-        context 'when user has a password' do
-          let(:user_encrypted_password) {'password'}
-
-          it 'returns true' do
-            _(personal_account?).must_equal true
-          end
-        end
-
-        context 'when user also has an email auth option' do
-          let(:user_has_extra_auth_option?) {true}
-
-          it 'returns true' do
-            _(personal_account?).must_equal true
-          end
-        end
-      end
-
-      context 'when Google auth option' do
-        let(:user_auth_option_credential_type) {::AuthenticationOption::GOOGLE}
-
-        it 'returns true' do
-          _(personal_account?).must_equal true
-        end
-
-        context 'when roster synced' do
-          let(:user_roster_synced) {true}
-
-          it 'returns false' do
-            _(personal_account?).must_equal false
-          end
-        end
-
-        context 'when user is in a section' do
-          let(:user_in_section?) {true}
-
-          it 'returns false' do
-            _(personal_account?).must_equal false
-          end
-        end
-      end
-    end
-
-    context 'when user is sponsored' do
-      let(:user_sponsored?) {true}
-
-      it 'returns false' do
-        _(personal_account?).must_equal false
-      end
-    end
+    assert failures.empty?, failures.join("\n")
   end
 
   describe '.parent_permission_required?' do

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -36,7 +36,8 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       [[:non_compliant_child, :unknown_us_region], true],
       [[:non_compliant_child, :not_U13], true],
       [[:non_compliant_child, :migrated_imported_from_clever], true],
-      [[:non_compliant_child, :with_lti_auth], true],
+      [[:non_compliant_child, :with_lti_auth], false],
+      [[:non_compliant_child, :with_lti_auth, :without_encrypted_password], true],
       [[:non_compliant_child, {created_at: '2023-06-30T23:59:59MST'}], false],
       [[:non_compliant_child, :skip_validation, {birthday: nil}], true],
       [[:non_compliant_child, :with_interpolated_co], true],
@@ -81,13 +82,13 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       [[:non_compliant_child, {created_at: '2023-06-29T23:59:59MDT'}], true],
       [[:non_compliant_child, {created_at: '2024-06-29T23:59:59MDT'}], false],
       [[:non_compliant_child, {created_at: '2024-07-01T00:00:00MDT'}], false],
-      [[:non_compliant_child, :migrated_imported_from_clever, {created_at: '2023-06-29T23:59:59MDT'}], false],
-      [[:non_compliant_child, :migrated_imported_from_clever, {created_at: '2024-06-29T23:59:59MDT'}], false],
-      [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2023-06-29T23:59:59MDT'}], true],
-      [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2024-06-29T23:59:59MDT'}], true],
-      [[:non_compliant_child, :migrated_imported_from_google_classroom, {created_at: '2024-07-01T00:00:00MDT'}], false],
-      [[:non_compliant_child, :with_google_authentication_option, {created_at: '2024-06-29T23:59:59MDT'}], true],
-      [[:non_compliant_child, :with_google_authentication_option, {created_at: '2024-07-01T00:00:00MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_clever, :without_encrypted_password, {created_at: '2023-06-29T23:59:59MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_clever, :without_encrypted_password, {created_at: '2024-06-29T23:59:59MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_google_classroom, :without_encrypted_password, {created_at: '2023-06-29T23:59:59MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_google_classroom, :without_encrypted_password, {created_at: '2024-06-29T23:59:59MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_google_classroom, :without_encrypted_password, {created_at: '2024-07-01T00:00:00MDT'}], false],
+      [[:non_compliant_child, :with_google_authentication_option, :without_encrypted_password, {created_at: '2024-06-29T23:59:59MDT'}], true],
+      [[:non_compliant_child, :with_google_authentication_option, :without_encrypted_password, {created_at: '2024-07-01T00:00:00MDT'}], false],
     ]
     failures = []
     test_matrix.each do |traits, compliance|
@@ -501,57 +502,122 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
 
     let(:user_sponsored?) {false}
     let(:user_migrated?) {false}
-    let(:user_provider) {'email'}
-    let(:user_auth_option_credential_type) {'email'}
+    let(:user_provider) {nil}
+    let(:user_encrypted_password) {nil}
+    let(:user_roster_synced) {false}
+    let(:user_auth_option_credential_type) {::AuthenticationOption::EMAIL}
     let(:user_auth_option) {build_stubbed(:authentication_option, credential_type: user_auth_option_credential_type)}
-    let(:user) {build_stubbed(:user, provider: user_provider, authentication_options: [user_auth_option])}
+    let(:user_has_extra_auth_option?) {false}
+    let(:extra_auth_option_type) {::AuthenticationOption::EMAIL}
+    let(:user_in_section?) {false}
+    let(:section) {build_stubbed(:section)}
+    let(:extra_auth_option) {build_stubbed(:authentication_option, credential_type: extra_auth_option_type)}
+    let(:user) {build_stubbed(:user, provider: user_provider, encrypted_password: user_encrypted_password, roster_synced: user_roster_synced)}
 
     before do
       user.stubs(:sponsored?).returns(user_sponsored?)
       user.stubs(:migrated?).returns(user_migrated?)
+      auth_options = []
+      auth_options << user_auth_option if user_migrated?
+      auth_options << extra_auth_option if user_has_extra_auth_option?
+      user.stubs(:authentication_options).returns(auth_options)
+      user.stubs(:sections_as_student).returns(section) if user_in_section?
     end
 
-    it 'returns true' do
-      _(personal_account?).must_equal true
-    end
-
-    context 'when user provider is Clever' do
-      let(:user_provider) {'clever'}
-
-      it 'returns false' do
-        _(personal_account?).must_equal false
-      end
-    end
-
-    context 'when user provider is LTI v1' do
-      let(:user_provider) {'lti_v1'}
-
-      it 'returns false' do
-        _(personal_account?).must_equal false
-      end
-    end
-
-    context 'when user is migrated' do
-      let(:user_migrated?) {true}
-      let(:user_provider) {'clever'}
-
-      it 'returns true' do
-        _(personal_account?).must_equal true
+    context 'when legacy/unmigrated user' do
+      context 'when user has a password' do
+        let(:user_encrypted_password) {'password'}
+        it 'returns true' do
+          _(personal_account?).must_equal true
+        end
       end
 
-      context 'when credential type of user auth option is Clever' do
-        let(:user_auth_option_credential_type) {'clever'}
+      context 'when user provider is Clever' do
+        let(:user_provider) {::AuthenticationOption::CLEVER}
 
         it 'returns false' do
           _(personal_account?).must_equal false
         end
       end
+    end
 
-      context 'when credential type of user auth option is LTI v1' do
-        let(:user_auth_option_credential_type) {'lti_v1'}
+    context 'when user is migrated' do
+      let(:user_migrated?) {true}
+      let(:user_provider) {::User::PROVIDER_MIGRATED}
+
+      it 'returns true' do
+        _(personal_account?).must_equal true
+      end
+
+      context 'when Clever auth option' do
+        let(:user_auth_option_credential_type) {::AuthenticationOption::CLEVER}
 
         it 'returns false' do
           _(personal_account?).must_equal false
+        end
+
+        context 'when user has a password' do
+          let(:user_encrypted_password) {'password'}
+
+          it 'returns true' do
+            _(personal_account?).must_equal true
+          end
+        end
+
+        context 'when user also has an email auth option' do
+          let(:user_has_extra_auth_option?) {true}
+
+          it 'returns true' do
+            _(personal_account?).must_equal true
+          end
+        end
+      end
+
+      context 'when LTI auth option' do
+        let(:user_auth_option_credential_type) {::AuthenticationOption::LTI_V1}
+
+        it 'returns false' do
+          _(personal_account?).must_equal false
+        end
+
+        context 'when user has a password' do
+          let(:user_encrypted_password) {'password'}
+
+          it 'returns true' do
+            _(personal_account?).must_equal true
+          end
+        end
+
+        context 'when user also has an email auth option' do
+          let(:user_has_extra_auth_option?) {true}
+
+          it 'returns true' do
+            _(personal_account?).must_equal true
+          end
+        end
+      end
+
+      context 'when Google auth option' do
+        let(:user_auth_option_credential_type) {::AuthenticationOption::GOOGLE}
+
+        it 'returns true' do
+          _(personal_account?).must_equal true
+        end
+
+        context 'when roster synced' do
+          let(:user_roster_synced) {true}
+
+          it 'returns false' do
+            _(personal_account?).must_equal false
+          end
+        end
+
+        context 'when user is in a section' do
+          let(:user_in_section?) {true}
+
+          it 'returns false' do
+            _(personal_account?).must_equal false
+          end
         end
       end
     end

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -82,13 +82,13 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       [[:non_compliant_child, {created_at: '2023-06-29T23:59:59MDT'}], true],
       [[:non_compliant_child, {created_at: '2024-06-29T23:59:59MDT'}], false],
       [[:non_compliant_child, {created_at: '2024-07-01T00:00:00MDT'}], false],
-      [[:non_compliant_child, :migrated_imported_from_clever, :without_encrypted_password, {created_at: '2023-06-29T23:59:59MDT'}], false],
-      [[:non_compliant_child, :migrated_imported_from_clever, :without_encrypted_password, {created_at: '2024-06-29T23:59:59MDT'}], false],
-      [[:non_compliant_child, :migrated_imported_from_google_classroom, :without_encrypted_password, {created_at: '2023-06-29T23:59:59MDT'}], false],
-      [[:non_compliant_child, :migrated_imported_from_google_classroom, :without_encrypted_password, {created_at: '2024-06-29T23:59:59MDT'}], false],
-      [[:non_compliant_child, :migrated_imported_from_google_classroom, :without_encrypted_password, {created_at: '2024-07-01T00:00:00MDT'}], false],
-      [[:non_compliant_child, :with_google_authentication_option, :without_encrypted_password, {created_at: '2024-06-29T23:59:59MDT'}], true],
-      [[:non_compliant_child, :with_google_authentication_option, :without_encrypted_password, {created_at: '2024-07-01T00:00:00MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_clever, :without_email_auth_option, :without_encrypted_password, {created_at: '2023-06-29T23:59:59MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_clever, :without_email_auth_option, :without_encrypted_password, {created_at: '2024-06-29T23:59:59MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_google_classroom, :without_email_auth_option, :without_encrypted_password, {created_at: '2023-06-29T23:59:59MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_google_classroom, :without_email_auth_option, :without_encrypted_password, {created_at: '2024-06-29T23:59:59MDT'}], false],
+      [[:non_compliant_child, :migrated_imported_from_google_classroom, :without_email_auth_option, :without_encrypted_password, {created_at: '2024-07-01T00:00:00MDT'}], false],
+      [[:non_compliant_child, :with_google_authentication_option, :without_email_auth_option, :without_encrypted_password, {created_at: '2024-06-29T23:59:59MDT'}], true],
+      [[:non_compliant_child, :with_google_authentication_option, :without_email_auth_option, :without_encrypted_password, {created_at: '2024-07-01T00:00:00MDT'}], false],
     ]
     failures = []
     test_matrix.each do |traits, compliance|

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -500,6 +500,7 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
   test '.personal_account?' do
     # [User traits, Expected result from personal_account?]
     test_matrix = [
+      # Migrated
       [[:student], true], # Has email auth option and password by default
       [[:student, :with_clever_authentication_option, :without_email_auth_option, :without_encrypted_password], false],
       [[:student, :with_lti_auth, :without_email_auth_option, :without_encrypted_password], false],
@@ -510,6 +511,14 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
       [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :without_encrypted_password, {roster_synced: true}], false],
       [[:student, :with_google_authentication_option, :without_email_auth_option, :without_encrypted_password, :in_google_section], false],
       [[:student, :with_microsoft_authentication_option, :without_email_auth_option, :without_encrypted_password, :in_email_section], false],
+      # Unmigrated
+      [[:student, :without_email_auth_option, :demigrated], true],
+      [[:student, :clever_sso_provider, :without_email_auth_option, :without_encrypted_password, :demigrated], false],
+      [[:student, :facebook_sso_provider, :without_email_auth_option, :without_encrypted_password, :demigrated], true],
+      [[:student, :google_sso_provider, :without_email_auth_option, :without_encrypted_password, :demigrated], true],
+      [[:student, :google_sso_provider, :without_email_auth_option, :without_encrypted_password, :demigrated, :in_google_section], false],
+      [[:student, :microsoft_v2_sso_provider, :without_email_auth_option, :without_encrypted_password, :demigrated], true],
+      [[:student, :microsoft_v2_sso_provider, :without_email_auth_option, :without_encrypted_password, :in_email_section, :demigrated], false],
     ]
     failures = []
     test_matrix.each do |traits, expected_result|


### PR DESCRIPTION
Google and Microsoft-based accounts are now considered school-managed if they meet one of the following criteria:

- The account was created via a roster sync operation
- The account is in a section

This PR accommodates these exceptions by changing the `Policies::ChildAccount.personal_account?` method. Previously, the method recognized any auth option other than Clever and LTI as personal. Now, the method considers Google and Microsoft accounts to be conditionally school owned, if the user is either in a section or roster synced.

## Links

[JIRA for roster-synced students](https://codedotorg.atlassian.net/browse/P20-1244)
[JIRA for sectioned students](https://codedotorg.atlassian.net/browse/P20-1230)

## Testing story

Refactored the existing spec-style test to a matrix-style test using the same pattern as the other tests in the file that have a long list of test cases. I realize this is a bit backwards, but the test matrix is significantly more concise. Open to suggestions and can look into refactoring it if anyone feels strongly.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
