### PR TITLE
increase delayed job worker count to 50

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -118,7 +118,7 @@ namespace :build do
         RakeUtils.system 'bin/delayed_job', 'stop'
         # Start new workers
         if rack_env?(:production)
-          RakeUtils.system 'bin/delayed_job', '-n', '10', 'start'
+          RakeUtils.system 'bin/delayed_job', '-n', '50', 'start'
         elsif !rack_env?(:development)
           RakeUtils.system 'bin/delayed_job', 'start'
         end


### PR DESCRIPTION
see slack threads:
* https://codedotorg.slack.com/archives/C0T0PNTM3/p1729814399829559
* https://codedotorg.slack.com/archives/C0T0PNTM3/p1729873691993309?thread_ts=1729868497.125879&cid=C0T0PNTM3

## Testing story

in the course of resolving two different production issues with delayed job workers, we have manually increased the number of workers to 50. the production-daemon machine has proven to continue working well in both cases.