### PR TITLE
P20-1247/Update name during LTI sync

### DIFF
--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -333,7 +333,7 @@ module Services
       }
     end
 
-    def self.update_user_name(user, nrps_member)
+    def self.assign_user_name(user, nrps_member)
       if user.teacher?
         user.name = get_claim_from_list(nrps_member, Policies::Lti::TEACHER_NAME_KEYS)
       else

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -195,7 +195,7 @@ module Services
         # Update name if different from the NRPS response
         unless user_was_new
           nrps_member_message = Policies::Lti.issuer_accepts_resource_link?(issuer) ? nrps_member[:message].first : nrps_member
-          if user.user_type == ::User::TYPE_TEACHER
+          if user.teacher?
             user.name = Services::Lti.get_claim_from_list(nrps_member_message, Policies::Lti::TEACHER_NAME_KEYS)
           else
             user.name = Services::Lti.get_claim_from_list(nrps_member_message, Policies::Lti::STUDENT_NAME_KEYS)

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -17,7 +17,7 @@ module Services
         user.age = '21+'
         user.lti_roster_sync_enabled = true
       end
-      update_user_name(user, id_token)
+      assign_user_name(user, id_token)
 
       ao = AuthenticationOption.new(
         authentication_id: Services::Lti::AuthIdGenerator.new(id_token).call,
@@ -194,7 +194,7 @@ module Services
         # Update name if different from the NRPS response
         unless user_was_new
           nrps_member_message = Policies::Lti.issuer_accepts_resource_link?(issuer) ? nrps_member[:message].first : nrps_member
-          update_user_name(user, nrps_member_message)
+          assign_user_name(user, nrps_member_message)
         end
 
         had_changes ||= (user_was_new || user.changed?)

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -13,14 +13,12 @@ module Services
       user = ::User.new
       user.provider = ::User::PROVIDER_MIGRATED
       user.user_type = user_type
-      if user_type == ::User::TYPE_TEACHER
+      if user.teacher?
         user.age = '21+'
-        user.name = get_claim_from_list(id_token, Policies::Lti::TEACHER_NAME_KEYS)
         user.lti_roster_sync_enabled = true
-      else
-        user.name = get_claim_from_list(id_token, Policies::Lti::STUDENT_NAME_KEYS)
-        user.family_name = get_claim(id_token, :family_name)
       end
+      update_user_name(user, id_token)
+
       ao = AuthenticationOption.new(
         authentication_id: Services::Lti::AuthIdGenerator.new(id_token).call,
         credential_type: AuthenticationOption::LTI_V1,
@@ -192,16 +190,13 @@ module Services
           nrps_member: nrps_member
         )
         user_was_new = user.new_record?
+
         # Update name if different from the NRPS response
         unless user_was_new
           nrps_member_message = Policies::Lti.issuer_accepts_resource_link?(issuer) ? nrps_member[:message].first : nrps_member
-          if user.teacher?
-            user.name = Services::Lti.get_claim_from_list(nrps_member_message, Policies::Lti::TEACHER_NAME_KEYS)
-          else
-            user.name = Services::Lti.get_claim_from_list(nrps_member_message, Policies::Lti::STUDENT_NAME_KEYS)
-            user.family_name = Services::Lti.get_claim(nrps_member_message, :family_name)
-          end
+          update_user_name(user, nrps_member_message)
         end
+
         had_changes ||= (user_was_new || user.changed?)
         user.save!
         if user_was_new
@@ -336,6 +331,15 @@ module Services
         new_cta_type: new_cta_type,
         user_type: user_type,
       }
+    end
+
+    def self.update_user_name(user, nrps_member)
+      if user.teacher?
+        user.name = get_claim_from_list(nrps_member, Policies::Lti::TEACHER_NAME_KEYS)
+      else
+        user.name = get_claim_from_list(nrps_member, Policies::Lti::STUDENT_NAME_KEYS)
+        user.family_name = get_claim(nrps_member, :family_name)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR will update a user's name during an LTI sync. 

The need for this enhancement was found while investigating a Zendesk ticket detailed in the Jira ticket below. It appears the names were not labeled correctly in the LMS when the course was initially synced. After the user fixed the LMS roster, the changes were not reflected on our side.

## Links
Jira ticket: [P20-1247](https://codedotorg.atlassian.net/browse/P20-1247)

## Testing story
Added a test in `services/lti_test.rb`