### PR TITLE
Add more detailed ActiveJob metrics

### DIFF
--- a/dashboard/app/jobs/concerns/active_job_metrics.rb
+++ b/dashboard/app/jobs/concerns/active_job_metrics.rb
@@ -46,9 +46,10 @@ module ActiveJobMetrics
   end
 
   protected def report_job_count
+    
     Cdo::Metrics.push(METRICS_NAMESPACE,
-      # Same metrics as "bin/cron/report_activejob_metrics"
-      [
+    [
+        # Same metrics as "bin/cron/report_activejob_metrics"
         {
           metric_name: 'PendingJobCount',
           value: get_pending_job_count,
@@ -75,7 +76,35 @@ module ActiveJobMetrics
           dimensions: [
             {name: 'Environment', value: CDO.rack_env},
           ],
-        }
+        },
+        # Per Job Class metrics
+        {
+          metric_name: 'PendingJobCount',
+          value: get_my_pending_job_count,
+          unit: 'Count',
+          timestamp: Time.now,
+          dimensions: [
+            common_dimensions,
+          ],
+        },
+        {
+          metric_name: 'FailedJobCount',
+          value: get_my_failed_job_count,
+          unit: 'Count',
+          timestamp: Time.now,
+          dimensions: [
+            common_dimensions,
+          ],
+        },
+        {
+          metric_name: 'WorkableJobCount',
+          value: get_my_workable_job_count,
+          unit: 'Count',
+          timestamp: Time.now,
+          dimensions: [
+            common_dimensions,
+          ],
+        },
       ]
     )
   rescue => exception

--- a/dashboard/app/jobs/concerns/active_job_metrics.rb
+++ b/dashboard/app/jobs/concerns/active_job_metrics.rb
@@ -58,7 +58,8 @@ module ActiveJobMetrics
   end
 
   protected def report_job_count
-    # Splitting into two pushes because 'includes_metrics' can't match multiple metrics with the same name.
+    # Splitting into two pushes because our 'includes_metrics' testing
+    # utility can't match multiple metrics with the same name.
     # Generic Metrics (similar to "bin/cron/report_activejob_metrics")
     generic_metrics = [
       {

--- a/dashboard/app/jobs/concerns/active_job_metrics.rb
+++ b/dashboard/app/jobs/concerns/active_job_metrics.rb
@@ -35,9 +35,17 @@ module ActiveJobMetrics
     Delayed::Job.where.not(failed_at: nil).count
   end
 
+  def get_my_failed_job_count
+    Delayed::Job.where.not(failed_at: nil).where('handler LIKE ?', "%job_class: #{self.class.name}%").count
+  end
+
   # Pending jobs are those that have not yet been run.
   def get_pending_job_count
     Delayed::Job.where(failed_at: nil).count
+  end
+
+  def get_my_pending_job_count
+    Delayed::Job.where(failed_at: nil).where('handler LIKE ?', "%job_class: #{self.class.name}%").count
   end
 
   # Workable jobs are those that are not locked and are ready to run.
@@ -45,68 +53,64 @@ module ActiveJobMetrics
     Delayed::Job.where(failed_at: nil, locked_at: nil).where('run_at <= ?', Time.now).count
   end
 
+  def get_my_workable_job_count
+    Delayed::Job.where(failed_at: nil, locked_at: nil).where('run_at <= ?', Time.now).where('handler LIKE ?', "%job_class: #{self.class.name}%").count
+  end
+
   protected def report_job_count
-    
-    Cdo::Metrics.push(METRICS_NAMESPACE,
-    [
-        # Same metrics as "bin/cron/report_activejob_metrics"
-        {
-          metric_name: 'PendingJobCount',
-          value: get_pending_job_count,
-          unit: 'Count',
-          timestamp: Time.now,
-          dimensions: [
-            {name: 'Environment', value: CDO.rack_env},
-          ],
-        },
-        {
-          metric_name: 'FailedJobCount',
-          value: get_failed_job_count,
-          unit: 'Count',
-          timestamp: Time.now,
-          dimensions: [
-            {name: 'Environment', value: CDO.rack_env},
-          ],
-        },
-        {
-          metric_name: 'WorkableJobCount',
-          value: get_workable_job_count,
-          unit: 'Count',
-          timestamp: Time.now,
-          dimensions: [
-            {name: 'Environment', value: CDO.rack_env},
-          ],
-        },
-        # Per Job Class metrics
-        {
-          metric_name: 'PendingJobCount',
-          value: get_my_pending_job_count,
-          unit: 'Count',
-          timestamp: Time.now,
-          dimensions: [
-            common_dimensions,
-          ],
-        },
-        {
-          metric_name: 'FailedJobCount',
-          value: get_my_failed_job_count,
-          unit: 'Count',
-          timestamp: Time.now,
-          dimensions: [
-            common_dimensions,
-          ],
-        },
-        {
-          metric_name: 'WorkableJobCount',
-          value: get_my_workable_job_count,
-          unit: 'Count',
-          timestamp: Time.now,
-          dimensions: [
-            common_dimensions,
-          ],
-        },
-      ]
-    )
+    # Splitting into two pushes because 'includes_metrics' can't match multiple metrics with the same name.
+    # Generic Metrics (similar to "bin/cron/report_activejob_metrics")
+    generic_metrics = [
+      {
+        metric_name: 'PendingJobCount',
+        value: get_pending_job_count,
+        unit: 'Count',
+        timestamp: Time.now,
+        dimensions: [{name: 'Environment', value: CDO.rack_env}]
+      },
+      {
+        metric_name: 'FailedJobCount',
+        value: get_failed_job_count,
+        unit: 'Count',
+        timestamp: Time.now,
+        dimensions: [{name: 'Environment', value: CDO.rack_env}]
+      },
+      {
+        metric_name: 'WorkableJobCount',
+        value: get_workable_job_count,
+        unit: 'Count',
+        timestamp: Time.now,
+        dimensions: [{name: 'Environment', value: CDO.rack_env}]
+      }
+    ]
+
+    per_job_class_metrics = [
+      {
+        metric_name: 'PendingJobCount',
+        value: get_my_pending_job_count,
+        unit: 'Count',
+        timestamp: Time.now,
+        dimensions: common_dimensions
+      },
+      {
+        metric_name: 'FailedJobCount',
+        value: get_my_failed_job_count,
+        unit: 'Count',
+        timestamp: Time.now,
+        dimensions: common_dimensions
+      },
+      {
+        metric_name: 'WorkableJobCount',
+        value: get_my_workable_job_count,
+        unit: 'Count',
+        timestamp: Time.now,
+        dimensions: common_dimensions
+      }
+    ]
+
+    # Push metrics
+    Cdo::Metrics.push(METRICS_NAMESPACE, generic_metrics)
+    Cdo::Metrics.push(METRICS_NAMESPACE, per_job_class_metrics)
   rescue => exception
     Honeybadger.notify(exception, error_message: 'Error reporting ActiveJob metrics')
   end


### PR DESCRIPTION
This adds a JobName dimension to make tracking different jobs easier.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

the actual database queries aren't tested, here I've run them manually to confirm they work:

```
[production] dashboard > Delayed::Job.where.not(failed_at: nil).where('handler LIKE ?', "%job_class: EvaluateRubricJob%").count
=> 4060
[production] dashboard > Delayed::Job.where(failed_at: nil).where('handler LIKE ?', "%job_class: EvaluateRubricJob%").count
=> 1
[production] dashboard > Delayed::Job.where(failed_at: nil, locked_at: nil).where('run_at <= ?', Time.now).where('handler LIKE ?', "%job_class: EvaluateRubricJob%").count
=> 0
```

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
