### PR TITLE
[JIMT][CT-822 (partial)] openConfirmDelete(file|folder)

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileRow.tsx
@@ -32,7 +32,6 @@ interface FileRowProps {
   appName?: string;
   hasValidationFile: boolean; // If the project has a validation file already.
   isStartMode: boolean;
-  handleDeleteFile: (fileId: string) => void;
   setFileType: setFileType;
 }
 
@@ -52,7 +51,6 @@ const FileRow: React.FunctionComponent<FileRowProps> = ({
   appName,
   hasValidationFile,
   isStartMode,
-  handleDeleteFile,
   setFileType,
 }) => {
   const {
@@ -60,7 +58,8 @@ const FileRow: React.FunctionComponent<FileRowProps> = ({
     openFile,
     config: {editableFileTypes},
   } = useCodebridgeContext();
-  const {openMoveFilePrompt, openRenameFilePrompt} = usePrompts();
+  const {openConfirmDeleteFile, openMoveFilePrompt, openRenameFilePrompt} =
+    usePrompts();
   const {iconName, iconStyle, isBrand} = getFileIconNameAndStyle(file);
   const iconClassName = isBrand
     ? classNames('fa-brands', moduleStyles.rowIcon)
@@ -100,7 +99,7 @@ const FileRow: React.FunctionComponent<FileRowProps> = ({
       condition: !isLocked,
       iconName: 'trash',
       labelText: codebridgeI18n.deleteFile(),
-      clickHandler: () => handleDeleteFile(file.id),
+      clickHandler: () => openConfirmDeleteFile({file}),
     },
   ];
 

--- a/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
@@ -1,6 +1,7 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {
   openConfirmDeleteFile as globalOpenConfirmDeleteFile,
+  openConfirmDeleteFolder as globalOpenConfirmDeleteFolder,
   openNewFolderPrompt as globalOpenNewFolderPrompt,
   openNewFilePrompt as globalOpenNewFilePrompt,
   openMoveFilePrompt as globalOpenMoveFilePrompt,
@@ -41,6 +42,7 @@ export const usePrompts = () => {
   const {
     project,
     deleteFile,
+    deleteFolder,
     moveFile,
     moveFolder,
     newFolder,
@@ -63,9 +65,19 @@ export const usePrompts = () => {
     dialogControl,
     deleteFile,
     sendCodebridgeAnalyticsEvent,
-    dispatch,
     cleanupValidationFile,
   } satisfies PAFunctionArgs<typeof globalOpenConfirmDeleteFile>);
+
+  const openConfirmDeleteFolder = usePartialApply(
+    globalOpenConfirmDeleteFolder,
+    {
+      dialogControl,
+      deleteFolder,
+      sendCodebridgeAnalyticsEvent,
+      projectFiles: project.files,
+      projectFolders: project.folders,
+    } satisfies PAFunctionArgs<typeof globalOpenConfirmDeleteFolder>
+  );
 
   const openNewFolderPrompt = usePartialApply(globalOpenNewFolderPrompt, {
     dialogControl,
@@ -119,6 +131,7 @@ export const usePrompts = () => {
   return useMemo(
     () => ({
       openConfirmDeleteFile,
+      openConfirmDeleteFolder,
       openNewFilePrompt,
       openNewFolderPrompt,
       openMoveFilePrompt,
@@ -128,6 +141,7 @@ export const usePrompts = () => {
     }),
     [
       openConfirmDeleteFile,
+      openConfirmDeleteFolder,
       openNewFilePrompt,
       openNewFolderPrompt,
       openMoveFilePrompt,

--- a/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
+++ b/apps/src/codebridge/FileBrowser/hooks/usePrompts.ts
@@ -1,5 +1,6 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import {
+  openConfirmDeleteFile as globalOpenConfirmDeleteFile,
   openNewFolderPrompt as globalOpenNewFolderPrompt,
   openNewFilePrompt as globalOpenNewFilePrompt,
   openMoveFilePrompt as globalOpenMoveFilePrompt,
@@ -12,9 +13,10 @@ import {useCallback, useMemo} from 'react';
 
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {usePartialApply, PAFunctionArgs} from '@cdo/apps/lab2/hooks';
+import {setOverrideValidations} from '@cdo/apps/lab2/lab2Redux';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {useDialogControl} from '@cdo/apps/lab2/views/dialogs';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 /**
  * Provides functions to open new file or folder prompts within the application.
@@ -34,9 +36,11 @@ export const usePrompts = () => {
   );
   const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
   const dialogControl = useDialogControl();
+  const dispatch = useAppDispatch();
 
   const {
     project,
+    deleteFile,
     moveFile,
     moveFolder,
     newFolder,
@@ -49,6 +53,19 @@ export const usePrompts = () => {
     (event: string) => globalSendCodebridgeAnalyticsEvent(event, appName),
     [appName]
   );
+
+  const cleanupValidationFile = useCallback(
+    () => dispatch(setOverrideValidations([])),
+    [dispatch]
+  );
+
+  const openConfirmDeleteFile = usePartialApply(globalOpenConfirmDeleteFile, {
+    dialogControl,
+    deleteFile,
+    sendCodebridgeAnalyticsEvent,
+    dispatch,
+    cleanupValidationFile,
+  } satisfies PAFunctionArgs<typeof globalOpenConfirmDeleteFile>);
 
   const openNewFolderPrompt = usePartialApply(globalOpenNewFolderPrompt, {
     dialogControl,
@@ -101,6 +118,7 @@ export const usePrompts = () => {
 
   return useMemo(
     () => ({
+      openConfirmDeleteFile,
       openNewFilePrompt,
       openNewFolderPrompt,
       openMoveFilePrompt,
@@ -109,6 +127,7 @@ export const usePrompts = () => {
       openRenameFolderPrompt,
     }),
     [
+      openConfirmDeleteFile,
       openNewFilePrompt,
       openNewFolderPrompt,
       openMoveFilePrompt,

--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -1,8 +1,4 @@
-import {
-  useCodebridgeContext,
-  findFiles,
-  findSubFolders,
-} from '@codebridge/codebridgeContext';
+import {useCodebridgeContext} from '@codebridge/codebridgeContext';
 import OverflowTooltip from '@codebridge/components/OverflowTooltip';
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
 import {PopUpButton} from '@codebridge/PopUpButton/PopUpButton';
@@ -12,7 +8,6 @@ import {
   getPossibleDestinationFoldersForFolder,
   validateFileName as globalValidateFileName,
   validateFolderName,
-  sendCodebridgeAnalyticsEvent,
   shouldShowFile,
 } from '@codebridge/utils';
 import {
@@ -36,7 +31,6 @@ import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {ProjectFileType} from '@cdo/apps/lab2/types';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
-import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {
@@ -69,6 +63,7 @@ type FilesComponentProps = {
 const InnerFileBrowser = React.memo(
   ({parentId, folders, files, setFileType, appName}: FilesComponentProps) => {
     const {
+      openConfirmDeleteFolder,
       openMoveFolderPrompt,
       openNewFilePrompt,
       openNewFolderPrompt,
@@ -76,11 +71,9 @@ const InnerFileBrowser = React.memo(
     } = usePrompts();
     const {
       toggleOpenFolder,
-      deleteFolder,
       config: {validMimeTypes},
     } = useCodebridgeContext();
     const {dragData, dropData} = useDndDataContext();
-    const dialogControl = useDialogControl();
     const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
     const handleFileUpload = useHandleFileUpload(files);
     const fileUploadErrorCallback = useFileUploadErrorCallback();
@@ -90,53 +83,6 @@ const InnerFileBrowser = React.memo(
       errorCallback: fileUploadErrorCallback,
       validMimeTypes,
     });
-
-    const handleConfirmDeleteFolder = (folderId: string) => {
-      deleteFolder(folderId);
-      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_DELETE_FOLDER, appName);
-    };
-
-    const handleDeleteFolder = (folderId: string) => {
-      const folderName = folders[folderId].name;
-      const projectFolders = Object.values(folders);
-      const projectFiles = Object.values(files);
-      const folderCount = findSubFolders(folderId, projectFolders).length;
-      const fileCount = findFiles(
-        folderId,
-        projectFiles,
-        projectFolders
-      ).length;
-
-      const title = codebridgeI18n.areYouSure();
-      const confirmation = codebridgeI18n.deleteFolderConfirm({folderName});
-      let additionalWarning = '';
-      if (fileCount && folderCount) {
-        additionalWarning = codebridgeI18n.deleteFolderConfirmBoth({
-          fileCount: `${fileCount}`,
-          folderCount: `${folderCount}`,
-          folderName,
-        });
-      } else if (fileCount) {
-        additionalWarning = codebridgeI18n.deleteFolderConfirmFiles({
-          fileCount: `${fileCount}`,
-          folderName,
-        });
-      } else if (folderCount) {
-        additionalWarning = codebridgeI18n.deleteFolderConfirmSubfolders({
-          folderCount: `${folderCount}`,
-          folderName,
-        });
-      }
-      const message = confirmation + ' ' + additionalWarning;
-      dialogControl?.showDialog({
-        type: DialogType.GenericConfirmation,
-        handleConfirm: () => handleConfirmDeleteFolder(folderId),
-        title,
-        message,
-        confirmText: codebridgeI18n.delete(),
-        destructive: true,
-      });
-    };
 
     const hasValidationFile = !!Object.values(files).find(
       f => f.type === ProjectFileType.VALIDATION
@@ -246,7 +192,9 @@ const InnerFileBrowser = React.memo(
                         <PopUpButtonOption
                           iconName="trash"
                           labelText={codebridgeI18n.deleteFolder()}
-                          clickHandler={() => handleDeleteFolder(f.id)}
+                          clickHandler={() =>
+                            openConfirmDeleteFolder({folder: f})
+                          }
                         />
                       </span>
                     </PopUpButton>

--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -31,16 +31,13 @@ import codebridgeI18n from '@cdo/apps/codebridge/locale';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {usePartialApply, PAFunctionArgs} from '@cdo/apps/lab2/hooks';
-import {
-  isReadOnlyWorkspace,
-  setOverrideValidations,
-} from '@cdo/apps/lab2/lab2Redux';
+import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
 import {ProjectFileType} from '@cdo/apps/lab2/types';
 import PanelContainer from '@cdo/apps/lab2/views/components/PanelContainer';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
-import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {
   DndDataContextProvider,
@@ -78,7 +75,6 @@ const InnerFileBrowser = React.memo(
       openRenameFolderPrompt,
     } = usePrompts();
     const {
-      deleteFile,
       toggleOpenFolder,
       deleteFolder,
       config: {validMimeTypes},
@@ -94,31 +90,6 @@ const InnerFileBrowser = React.memo(
       errorCallback: fileUploadErrorCallback,
       validMimeTypes,
     });
-    const dispatch = useAppDispatch();
-
-    const handleConfirmDeleteFile = (fileId: string) => {
-      // If we are deleting a validation file, we are in start mode, and we should
-      // ensure that the override validation is set to an empty list.
-      if (files[fileId]?.type === ProjectFileType.VALIDATION) {
-        dispatch(setOverrideValidations([]));
-      }
-      deleteFile(fileId);
-      sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_DELETE_FILE, appName);
-    };
-
-    const handleDeleteFile = (fileId: string) => {
-      const filename = files[fileId].name;
-      const title = codebridgeI18n.areYouSure();
-      const message = codebridgeI18n.deleteFileConfirm({filename});
-      dialogControl?.showDialog({
-        type: DialogType.GenericConfirmation,
-        handleConfirm: () => handleConfirmDeleteFile(fileId),
-        title,
-        message,
-        confirmText: codebridgeI18n.delete(),
-        destructive: true,
-      });
-    };
 
     const handleConfirmDeleteFolder = (folderId: string) => {
       deleteFolder(folderId);
@@ -309,7 +280,6 @@ const InnerFileBrowser = React.memo(
               hasValidationFile,
               isStartMode,
               setFileType,
-              handleDeleteFile,
               enableMenu: !dragData?.id || isDraggingLocked,
             };
             return isDraggingLocked ? (

--- a/apps/src/codebridge/FileBrowser/prompts/index.ts
+++ b/apps/src/codebridge/FileBrowser/prompts/index.ts
@@ -1,4 +1,5 @@
 export * from './openConfirmDeleteFile';
+export * from './openConfirmDeleteFolder';
 export * from './openMoveFilePrompt';
 export * from './openMoveFolderPrompt';
 export * from './openNewFilePrompt';

--- a/apps/src/codebridge/FileBrowser/prompts/index.ts
+++ b/apps/src/codebridge/FileBrowser/prompts/index.ts
@@ -1,3 +1,4 @@
+export * from './openConfirmDeleteFile';
 export * from './openMoveFilePrompt';
 export * from './openMoveFolderPrompt';
 export * from './openNewFilePrompt';

--- a/apps/src/codebridge/FileBrowser/prompts/openConfirmDeleteFile.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openConfirmDeleteFile.tsx
@@ -1,0 +1,43 @@
+import {DeleteFileFunction} from '@codebridge/codebridgeContext/types';
+import {ProjectFile} from '@codebridge/types';
+
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import {ProjectFileType} from '@cdo/apps/lab2/types';
+import {DialogType, DialogControlInterface} from '@cdo/apps/lab2/views/dialogs';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+
+type OpenConfirmDeleteFileArgsType = {
+  file: ProjectFile;
+  dialogControl: Pick<DialogControlInterface, 'showDialog'>;
+  deleteFile: DeleteFileFunction;
+  sendCodebridgeAnalyticsEvent: (eventName: string) => unknown;
+  cleanupValidationFile: () => void;
+};
+
+// this is ~technically~ not a prompt in that it's merely a confirmation dialog,
+// but this was still the most logical place to put it.
+export const openConfirmDeleteFile = async ({
+  file,
+  dialogControl,
+  deleteFile,
+  sendCodebridgeAnalyticsEvent,
+  cleanupValidationFile,
+}: OpenConfirmDeleteFileArgsType) => {
+  const results = await dialogControl?.showDialog({
+    type: DialogType.GenericConfirmation,
+    title: codebridgeI18n.areYouSure(),
+    message: codebridgeI18n.deleteFileConfirm({filename: file.name}),
+    confirmText: codebridgeI18n.delete(),
+    destructive: true,
+  });
+
+  if (results.type === 'confirm') {
+    // If we are deleting a validation file, we are in start mode, and we should
+    // ensure that the override validation is set to an empty list.
+    if (file.type === ProjectFileType.VALIDATION) {
+      cleanupValidationFile();
+    }
+    deleteFile(file.id);
+    sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_DELETE_FILE);
+  }
+};

--- a/apps/src/codebridge/FileBrowser/prompts/openConfirmDeleteFolder.tsx
+++ b/apps/src/codebridge/FileBrowser/prompts/openConfirmDeleteFolder.tsx
@@ -1,0 +1,73 @@
+import {findFiles, findSubFolders} from '@codebridge/codebridgeContext';
+import {DeleteFolderFunction} from '@codebridge/codebridgeContext/types';
+import {ProjectFolder, ProjectType} from '@codebridge/types';
+
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
+import {DialogType, DialogControlInterface} from '@cdo/apps/lab2/views/dialogs';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+
+type OpenConfirmDeleteFileArgsType = {
+  folder: ProjectFolder;
+  dialogControl: Pick<DialogControlInterface, 'showDialog'>;
+  deleteFolder: DeleteFolderFunction;
+  sendCodebridgeAnalyticsEvent: (eventName: string) => unknown;
+  projectFiles: ProjectType['files'];
+  projectFolders: ProjectType['folders'];
+};
+
+// this is ~technically~ not a prompt in that it's merely a confirmation dialog,
+// but this was still the most logical place to put it.
+export const openConfirmDeleteFolder = async ({
+  folder,
+  dialogControl,
+  deleteFolder,
+  sendCodebridgeAnalyticsEvent,
+  projectFiles,
+  projectFolders,
+}: OpenConfirmDeleteFileArgsType) => {
+  const folderName = folder.name;
+  const folderCount = findSubFolders(
+    folder.id,
+    Object.values(projectFolders)
+  ).length;
+  const fileCount = findFiles(
+    folder.id,
+    Object.values(projectFiles),
+    Object.values(projectFolders)
+  ).length;
+
+  const title = codebridgeI18n.areYouSure();
+  const confirmation = codebridgeI18n.deleteFolderConfirm({folderName});
+  let additionalWarning = '';
+  if (fileCount && folderCount) {
+    additionalWarning = codebridgeI18n.deleteFolderConfirmBoth({
+      fileCount: `${fileCount}`,
+      folderCount: `${folderCount}`,
+      folderName,
+    });
+  } else if (fileCount) {
+    additionalWarning = codebridgeI18n.deleteFolderConfirmFiles({
+      fileCount: `${fileCount}`,
+      folderName,
+    });
+  } else if (folderCount) {
+    additionalWarning = codebridgeI18n.deleteFolderConfirmSubfolders({
+      folderCount: `${folderCount}`,
+      folderName,
+    });
+  }
+  const message = confirmation + ' ' + additionalWarning;
+
+  const results = await dialogControl?.showDialog({
+    type: DialogType.GenericConfirmation,
+    title,
+    message,
+    confirmText: codebridgeI18n.delete(),
+    destructive: true,
+  });
+
+  if (results.type === 'confirm') {
+    deleteFolder(folder.id);
+    sendCodebridgeAnalyticsEvent(EVENTS.CODEBRIDGE_DELETE_FOLDER);
+  }
+};

--- a/apps/test/unit/codebridge/FileBrowser/prompts/openConfirmDeleteFileTest.ts
+++ b/apps/test/unit/codebridge/FileBrowser/prompts/openConfirmDeleteFileTest.ts
@@ -1,0 +1,94 @@
+import {DeleteFileFunction} from '@codebridge/codebridgeContext/types';
+import {openConfirmDeleteFile} from '@codebridge/FileBrowser/prompts/openConfirmDeleteFile';
+import {ProjectFile} from '@codebridge/types';
+
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+
+import {testProject} from '../../test-files/';
+import {getDialogAlertMock, getAnalyticsMock} from '../../test_utils';
+
+const getDeleteFileMock = (): [ProjectFile, DeleteFileFunction] => {
+  const deleteFileData = {} as ProjectFile;
+  const mock: DeleteFileFunction = fileId => {
+    deleteFileData.id = fileId;
+  };
+
+  return [deleteFileData, mock];
+};
+
+const getCleaupValidationMock = (): [{called: boolean}, () => void] => {
+  const cleanupValidationFileData = {called: false};
+  const mock = () => {
+    cleanupValidationFileData.called = true;
+  };
+
+  return [cleanupValidationFileData, mock];
+};
+
+describe('openConfirmDeleteFile', function () {
+  it('can successfully delete a file', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '4';
+
+    const [deleteFileData, deleteFileDataMock] = getDeleteFileMock();
+    const [cleanupValidationFileData, cleanupValidationFile] =
+      getCleaupValidationMock();
+
+    await openConfirmDeleteFile({
+      file: testProject.files[fileId],
+      dialogControl: getDialogAlertMock('confirm'),
+      deleteFile: deleteFileDataMock,
+      sendCodebridgeAnalyticsEvent,
+      cleanupValidationFile,
+    });
+
+    expect(deleteFileData.id).toEqual(fileId);
+
+    expect(analyticsData.event).toEqual(EVENTS.CODEBRIDGE_DELETE_FILE);
+    expect(cleanupValidationFileData.called).toEqual(false);
+  });
+
+  it('can successfully delete a validation file', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '7';
+
+    const [deleteFileData, deleteFileDataMock] = getDeleteFileMock();
+    const [cleanupValidationFileData, cleanupValidationFile] =
+      getCleaupValidationMock();
+
+    await openConfirmDeleteFile({
+      file: testProject.files[fileId],
+      dialogControl: getDialogAlertMock('confirm'),
+      deleteFile: deleteFileDataMock,
+      sendCodebridgeAnalyticsEvent,
+      cleanupValidationFile,
+    });
+
+    expect(deleteFileData.id).toEqual(fileId);
+
+    expect(analyticsData.event).toEqual(EVENTS.CODEBRIDGE_DELETE_FILE);
+    expect(cleanupValidationFileData.called).toEqual(true);
+  });
+
+  it('can cancel deleting a file', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const fileId = '1';
+
+    const [deleteFileData, deleteFileDataMock] = getDeleteFileMock();
+    const [cleanupValidationFileData, cleanupValidationFile] =
+      getCleaupValidationMock();
+
+    await openConfirmDeleteFile({
+      file: testProject.files[fileId],
+      dialogControl: getDialogAlertMock('cancel'),
+      deleteFile: deleteFileDataMock,
+      sendCodebridgeAnalyticsEvent,
+      cleanupValidationFile,
+    });
+
+    expect(deleteFileData.id).toBeUndefined();
+
+    expect(analyticsData.event).toBeUndefined();
+    expect(cleanupValidationFileData.called).toEqual(false);
+  });
+});

--- a/apps/test/unit/codebridge/FileBrowser/prompts/openConfirmDeleteFolderTest.ts
+++ b/apps/test/unit/codebridge/FileBrowser/prompts/openConfirmDeleteFolderTest.ts
@@ -1,0 +1,59 @@
+import {DeleteFolderFunction} from '@codebridge/codebridgeContext/types';
+import {openConfirmDeleteFolder} from '@codebridge/FileBrowser/prompts/openConfirmDeleteFolder';
+import {ProjectFolder} from '@codebridge/types';
+
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+
+import {testProject} from '../../test-files/';
+import {getDialogAlertMock, getAnalyticsMock} from '../../test_utils';
+
+const getDeleteFolderMock = (): [ProjectFolder, DeleteFolderFunction] => {
+  const deleteFolderData = {} as ProjectFolder;
+  const mock: DeleteFolderFunction = FolderId => {
+    deleteFolderData.id = FolderId;
+  };
+
+  return [deleteFolderData, mock];
+};
+
+describe('openConfirmDeleteFolder', function () {
+  it('can successfully delete a Folder', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const folderId = '4';
+
+    const [deleteFolderData, deleteFolderDataMock] = getDeleteFolderMock();
+
+    await openConfirmDeleteFolder({
+      folder: testProject.folders[folderId],
+      dialogControl: getDialogAlertMock('confirm'),
+      deleteFolder: deleteFolderDataMock,
+      sendCodebridgeAnalyticsEvent,
+      projectFiles: testProject.files,
+      projectFolders: testProject.folders,
+    });
+
+    expect(deleteFolderData.id).toEqual(folderId);
+
+    expect(analyticsData.event).toEqual(EVENTS.CODEBRIDGE_DELETE_FOLDER);
+  });
+
+  it('can cancel deleting a folder', async function () {
+    const [analyticsData, sendCodebridgeAnalyticsEvent] = getAnalyticsMock();
+    const folderId = '1';
+
+    const [deleteFolderData, deleteFolderDataMock] = getDeleteFolderMock();
+
+    await openConfirmDeleteFolder({
+      folder: testProject.folders[folderId],
+      dialogControl: getDialogAlertMock('cancel'),
+      deleteFolder: deleteFolderDataMock,
+      sendCodebridgeAnalyticsEvent,
+      projectFiles: testProject.files,
+      projectFolders: testProject.folders,
+    });
+
+    expect(deleteFolderData.id).toBeUndefined();
+
+    expect(analyticsData.event).toBeUndefined();
+  });
+});

--- a/apps/test/unit/codebridge/test_utils.ts
+++ b/apps/test/unit/codebridge/test_utils.ts
@@ -14,6 +14,18 @@ export const getDialogControlMock = (
   },
 });
 
+export const getDialogAlertMock = (
+  type: 'cancel' | 'confirm'
+): Pick<DialogControlInterface, 'showDialog'> => ({
+  showDialog: () => {
+    if (type === 'confirm') {
+      return Promise.resolve({type: 'confirm'});
+    } else {
+      return Promise.resolve({type: 'cancel'});
+    }
+  },
+});
+
 type AnalyticsDataType = {event: string};
 type AnalyticsMockType = (event: string) => void;
 


### PR DESCRIPTION
I stuffed both of these mods into a single PR for time constraint's sake and because they're right next to each other anyway.

Just breaks out the `handleDeleteFile`/`handleConfirmDeleteFile` and `handleDeleteFolder`/`handleConfirmDeleteFolder` pairs into new utility functions wrapped into hooks @ `openConfirmDeleteFile` and `openConfirmDeleteFolder`

Plus adds unit tests for both.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CT-822](https://codedotorg.atlassian.net/browse/CT-822)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
