### PR TITLE
Panels: fade over previous

### DIFF
--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -5,6 +5,7 @@ import Typist from 'react-typist';
 
 import {Button} from '@cdo/apps/componentLibrary/button';
 import TextToSpeech from '@cdo/apps/lab2/views/components/TextToSpeech';
+import usePrevious from '@cdo/apps/util/usePrevious';
 
 import FontAwesome from '../legacySharedComponents/FontAwesome';
 import EnhancedSafeMarkdown from '../templates/EnhancedSafeMarkdown';
@@ -51,6 +52,8 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
 }) => {
   const [currentPanelIndex, setCurrentPanelIndex] = useState(0);
   const [typingDone, setTypingDone] = useState(false);
+
+  const previousPanelIndex = usePrevious(currentPanelIndex);
 
   targetWidth -= horizontalMargin * 2;
   targetHeight -= verticalMargin * 2 + childrenAreaHeight;
@@ -116,10 +119,8 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
 
   const previousPanel =
     panel.fadeInOverPrevious &&
-    currentPanelIndex > 0 &&
-    panels[currentPanelIndex - 1]
-      ? panels[currentPanelIndex - 1]
-      : null;
+    previousPanelIndex !== undefined &&
+    panels[previousPanelIndex];
 
   const layoutClassMap = {
     'text-top-left': styles.textTopLeft,


### PR DESCRIPTION
Now, if a panel has `"fadeInOverPrevious": true`, it will fade over the last-shown panel, whichever one it might be.

Previously, as implemented in https://github.com/code-dot-org/code-dot-org/pull/61820, the panel faded in over the previous panel in the sequence, which was fine if navigating forward through the panels, but not ideal when jumping around.
