### PR TITLE
Music: fix same level load (WIP)

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -98,6 +98,7 @@ class UnconnectedMusicView extends React.Component {
     addPlaybackEvents: PropTypes.func,
     addOrderedFunctions: PropTypes.func,
     currentlyPlayingBlockIds: PropTypes.array,
+    isLoadingProjectOrLevel: PropTypes.bool,
     setIsLoading: PropTypes.func,
     setPageError: PropTypes.func,
     initialSources: PropTypes.object,
@@ -215,9 +216,8 @@ class UnconnectedMusicView extends React.Component {
     // Update components with new level data and new initial sources when
     // the level changes.
     if (
-      (!isEqual(prevProps.levelProperties, this.props.levelProperties) ||
-        !isEqual(prevProps.initialSources, this.props.initialSources) ||
-        prevProps.isReadOnlyWorkspace !== this.props.isReadOnlyWorkspace) &&
+      prevProps.isLoadingProjectOrLevel &&
+      !this.props.isLoadingProjectOrLevel &&
       this.props.levelProperties?.appName === 'music'
     ) {
       if (this.props.levelProperties?.appName === 'music') {
@@ -767,6 +767,7 @@ const MusicView = connect(
     selectedBlockId: state.music.selectedBlockId,
     showInstructions: state.music.showInstructions,
     currentlyPlayingBlockIds: getCurrentlyPlayingBlockIds(state),
+    isLoadingProjectOrLevel: state.lab.isLoadingProjectOrLevel,
     initialSources: state.lab.initialSources,
     levelProperties: state.lab.levelProperties,
     longInstructions: state.lab.levelProperties?.longInstructions,


### PR DESCRIPTION
Issue repro: start on Music Lab level "A"; click a bubble in the header to switch to Music Lab level "B:; before that level loads, quickly press the bubble to return to Music Lab level "A".  Expected: Level "A" is loaded again.  Actual: Level "A" does not fully load, notably the Blockly workspace is never initialized.

The reason this happens is that when we return to the level we were already on, the following condition doesn't see any change, even though Blockly has already been torn down:
https://github.com/code-dot-org/code-dot-org/blob/c248533c6afe31aefbdb713792f0759420d5a334/apps/src/music/views/MusicView.jsx#L218-L222

The code in this PR does seem to make things work again, by ensuring that we do a fresh `onLevelLoad` after loading a level or project, but it doesn't feel like the ideal solution. 