### PR TITLE
Music: fix same level load

### DIFF
--- a/apps/src/lab2/utils/LifecycleNotifier.tsx
+++ b/apps/src/lab2/utils/LifecycleNotifier.tsx
@@ -38,6 +38,7 @@ class LifecycleNotifier {
       this.listeners[event] = [];
     }
     this.listeners[event]?.push(callback);
+    return this;
   }
 
   removeListener<T extends LifecycleEvent>(event: T, callback: Callback<T>) {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -183,14 +183,14 @@ class UnconnectedMusicView extends React.Component {
           this.musicBlocklyWorkspace.dispose();
         }
       })
-      .addListener(LifecycleEvent.LevelLoadCompleted, () => {
-        if (this.props.levelProperties?.appName === 'music') {
-          this.onLevelLoad(
-            this.props.levelProperties?.levelData,
-            this.props.initialSources
-          );
+      .addListener(
+        LifecycleEvent.LevelLoadCompleted,
+        ({appName, levelData}, _channel, initialSources) => {
+          if (appName === 'music') {
+            this.onLevelLoad(levelData, initialSources);
+          }
         }
-      });
+      );
   }
 
   async componentDidUpdate(prevProps) {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -182,6 +182,14 @@ class UnconnectedMusicView extends React.Component {
           this.props.clearCallout();
           this.musicBlocklyWorkspace.dispose();
         }
+      })
+      .addListener(LifecycleEvent.LevelLoadCompleted, () => {
+        if (this.props.levelProperties?.appName === 'music') {
+          this.onLevelLoad(
+            this.props.levelProperties?.levelData,
+            this.props.initialSources
+          );
+        }
       });
   }
 
@@ -210,22 +218,6 @@ class UnconnectedMusicView extends React.Component {
 
     if (prevProps.updateLoadProgress !== this.props.updateLoadProgress) {
       this.player.setUpdateLoadProgress(this.props.updateLoadProgress);
-    }
-
-    // Update components with new level data and new initial sources when
-    // the level changes.
-    if (
-      (!isEqual(prevProps.levelProperties, this.props.levelProperties) ||
-        !isEqual(prevProps.initialSources, this.props.initialSources) ||
-        prevProps.isReadOnlyWorkspace !== this.props.isReadOnlyWorkspace) &&
-      this.props.levelProperties?.appName === 'music'
-    ) {
-      if (this.props.levelProperties?.appName === 'music') {
-        this.onLevelLoad(
-          this.props.levelProperties?.levelData,
-          this.props.initialSources
-        );
-      }
     }
   }
 


### PR DESCRIPTION
This fixes an issue in which switching away from and back to the same level, rapidly, caused it to not properly load.

Issue repro: start on Music Lab level "A"; click a bubble in the header to switch to Music Lab level "B:; before that level loads, quickly press the bubble to return to Music Lab level "A".  Expected: Level "A" is loaded again.  Actual: Level "A" does not fully load, notably the Blockly workspace is never initialized.

The reason this was happening was that when we returned to the level we were already on, the following condition didn't see any change, even though Blockly had already been torn down:
https://github.com/code-dot-org/code-dot-org/blob/c248533c6afe31aefbdb713792f0759420d5a334/apps/src/music/views/MusicView.jsx#L218-L222

Now, we use a lifecycle event to perform the level load.