### PR TITLE
Music: playhead position update

### DIFF
--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -207,7 +207,7 @@ const musicSlice = createSlice({
     setSoundLoadingProgress: (state, action: PayloadAction<number>) => {
       state.soundLoadingProgress = action.payload;
     },
-    setStartPlayheadPosition: (state, action: PayloadAction<number>) => {
+    setStartingPlayheadPosition: (state, action: PayloadAction<number>) => {
       state.startingPlayheadPosition = action.payload;
     },
     moveStartPlayheadPositionForward: state => {
@@ -329,7 +329,7 @@ export const {
   addPlaybackEvents,
   addOrderedFunctions,
   setSoundLoadingProgress,
-  setStartPlayheadPosition,
+  setStartingPlayheadPosition,
   moveStartPlayheadPositionForward,
   moveStartPlayheadPositionBackward,
   setUndoStatus,

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -40,6 +40,7 @@ import {
   setPackId,
   setIsPlaying,
   setCurrentPlayheadPosition,
+  setStartingPlayheadPosition,
   clearSelectedBlockId,
   selectBlockId,
   setShowInstructions,
@@ -85,6 +86,8 @@ class UnconnectedMusicView extends React.Component {
     isPlaying: PropTypes.bool,
     setIsPlaying: PropTypes.func,
     setCurrentPlayheadPosition: PropTypes.func,
+    startingPlayheadPosition: PropTypes.number,
+    setStartingPlayheadPosition: PropTypes.func,
     selectedBlockId: PropTypes.string,
     selectBlockId: PropTypes.func,
     setSelectedTriggerId: PropTypes.func,
@@ -103,7 +106,7 @@ class UnconnectedMusicView extends React.Component {
     initialSources: PropTypes.object,
     levelProperties: PropTypes.object,
     longInstructions: PropTypes.string,
-    startingPlayheadPosition: PropTypes.number,
+
     isProjectLevel: PropTypes.bool,
     isReadOnlyWorkspace: PropTypes.bool,
     updateLoadProgress: PropTypes.func,
@@ -334,6 +337,8 @@ class UnconnectedMusicView extends React.Component {
     MusicRegistry.showAiTemperatureExplanation =
       levelData?.showAiTemperatureExplanation ||
       AppConfig.getValue('show-ai-temperature-explanation') === 'true';
+
+    this.props.setStartingPlayheadPosition(1);
 
     Lab2Registry.getInstance()
       .getMetricsReporter()
@@ -782,6 +787,8 @@ const MusicView = connect(
     setIsPlaying: isPlaying => dispatch(setIsPlaying(isPlaying)),
     setCurrentPlayheadPosition: currentPlayheadPosition =>
       dispatch(setCurrentPlayheadPosition(currentPlayheadPosition)),
+    setStartingPlayheadPosition: startingPlayheadPosition =>
+      dispatch(setStartingPlayheadPosition(startingPlayheadPosition)),
     selectBlockId: blockId => dispatch(selectBlockId(blockId)),
     setSelectedTriggerId: id => dispatch(setSelectedTriggerId(id)),
     clearSelectedTriggerId: () => dispatch(clearSelectedTriggerId()),

--- a/apps/src/music/views/Timeline.tsx
+++ b/apps/src/music/views/Timeline.tsx
@@ -9,7 +9,7 @@ import {BlockMode, MIN_NUM_MEASURES} from '../constants';
 import {
   clearSelectedBlockId,
   getBlockMode,
-  setStartPlayheadPosition,
+  setStartingPlayheadPosition,
 } from '../redux/musicRedux';
 import {MusicLevelData} from '../types';
 
@@ -105,11 +105,15 @@ const Timeline: React.FunctionComponent = () => {
     (_, i) => i + 1
   );
 
+  const currentlyAllowChangeStartingPlayheadPosition =
+    !isPlaying && allowChangeStartingPlayheadPosition;
+
   const onMeasuresBackgroundClick = useCallback(
     (event: MouseEvent) => {
-      if (isPlaying || !allowChangeStartingPlayheadPosition) {
+      if (!currentlyAllowChangeStartingPlayheadPosition) {
         return;
       }
+
       const offset =
         event.clientX -
         (event.target as Element).getBoundingClientRect().x -
@@ -117,20 +121,20 @@ const Timeline: React.FunctionComponent = () => {
       const exactMeasure = offset / barWidth + 1;
       // Round measure to the nearest beat (1/4 note).
       const roundedMeasure = Math.round(exactMeasure * 4) / 4;
-      dispatch(setStartPlayheadPosition(roundedMeasure));
+      dispatch(setStartingPlayheadPosition(roundedMeasure));
     },
-    [dispatch, isPlaying, allowChangeStartingPlayheadPosition]
+    [dispatch, currentlyAllowChangeStartingPlayheadPosition]
   );
 
   const onMeasureNumberClick = useCallback(
     (measureNumber: number) => {
-      if (isPlaying) {
+      if (!currentlyAllowChangeStartingPlayheadPosition) {
         return;
       }
 
-      dispatch(setStartPlayheadPosition(measureNumber));
+      dispatch(setStartingPlayheadPosition(measureNumber));
     },
-    [dispatch, isPlaying]
+    [dispatch, currentlyAllowChangeStartingPlayheadPosition]
   );
 
   const onTimelineClick = useCallback(() => {
@@ -173,7 +177,7 @@ const Timeline: React.FunctionComponent = () => {
         className={classNames(
           moduleStyles.measuresBackground,
           moduleStyles.fullWidthOverlay,
-          allowChangeStartingPlayheadPosition &&
+          currentlyAllowChangeStartingPlayheadPosition &&
             moduleStyles.measuresBackgroundClickable
         )}
         style={{width: paddingOffset + measuresToDisplay * barWidth}}
@@ -194,7 +198,8 @@ const Timeline: React.FunctionComponent = () => {
                   moduleStyles.barNumber,
                   measure === Math.floor(currentPlayheadPosition) &&
                     moduleStyles.barNumberCurrent,
-                  !isPlaying && moduleStyles.barNumberClickable
+                  currentlyAllowChangeStartingPlayheadPosition &&
+                    moduleStyles.barNumberClickable
                 )}
                 onClick={() => onMeasureNumberClick(measure)}
               >


### PR DESCRIPTION
A few updates to playhead position management:
- Fixes an issue in which bar numbers could still be clicked to change starting playhead position when it should not have been allowed.
- Resets the starting playhead position when switching to a new level.
- Small tidy-up.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/62002.  
