### PR TITLE
test server: increase delayed_jobs workers from 1 to 10

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -119,7 +119,7 @@ namespace :build do
         # Start new workers
         if rack_env?(:production)
           RakeUtils.system 'bin/delayed_job', '-n', '50', 'start'
-        elsif rack_env?(:test)
+        elsif CDO.test_system?
           RakeUtils.system 'bin/delayed_job', '-n', '10', 'start'
         elsif !rack_env?(:development)
           RakeUtils.system 'bin/delayed_job', 'start'

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -119,6 +119,8 @@ namespace :build do
         # Start new workers
         if rack_env?(:production)
           RakeUtils.system 'bin/delayed_job', '-n', '50', 'start'
+        elsif rack_env?(:test)
+          RakeUtils.system 'bin/delayed_job', '-n', '10', 'start'
         elsif !rack_env?(:development)
           RakeUtils.system 'bin/delayed_job', 'start'
         end


### PR DESCRIPTION
This PR increases the number of delayed_jobs workers launched on the test server from 1 to 10.

Currently we start 50 delayed_job workers on production-daemon, but only 1 delayed_job worker on the test server. 

Impact: primary impact will be on RAM usage, but the test server consistently has >200GB of RAM free, and the expected RAM usage of 10x delayed_job workers is <20GB (probably much lower).

I have no evidence that the single worker is currently a bottleneck, but the point of our jobs is that many of them take NN seconds, and we like to run lots of tests in parallel, we like to test our ActiveJobs, and our usage of testing ActiveJobs is only going to go up. Having a single worker will bottleneck any tests of ActiveJob trying to run at once to a single thread, and like I said, many of these jobs block for 10+ seconds. If its not a problem now, it will be in the future.