### PR TITLE
Fix links to teacher-dashboard

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -10,7 +10,6 @@ import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import progressRedux from '@cdo/apps/code-studio/progressRedux';
 import verifiedInstructor from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import viewAs from '@cdo/apps/code-studio/viewAsRedux';
-import DCDO from '@cdo/apps/dcdo';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import locales, {setLocaleCode} from '@cdo/apps/redux/localesRedux';
 import unitSelection, {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
@@ -35,8 +34,8 @@ import teacherSections, {
   setStudentsForCurrentSection,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {sectionProviderName} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+import {showV2TeacherDashboard} from '@cdo/apps/templates/teacherNavigation/TeacherNavFlagUtils';
 import TeacherNavigationRouter from '@cdo/apps/templates/teacherNavigation/TeacherNavigationRouter';
-import experiments from '@cdo/apps/util/experiments';
 
 const script = document.querySelector('script[data-dashboard]');
 const scriptData = JSON.parse(script.dataset.dashboard);
@@ -76,10 +75,6 @@ $(document).ready(function () {
   store.dispatch(setLocaleCode(localeCode));
 
   const showAITutorTab = canViewStudentAIChatMessages;
-
-  const showV2TeacherDashboard =
-    DCDO.get('teacher-local-nav-v2', false) ||
-    experiments.isEnabled('teacher-local-nav-v2');
 
   // When removing v1TeacherDashboard after v2 launch, remove `selectedSection` from api response.
   const getV1TeacherDashboard = () => {
@@ -135,7 +130,7 @@ $(document).ready(function () {
 
   ReactDOM.render(
     <Provider store={store}>
-      {!showV2TeacherDashboard ? (
+      {!showV2TeacherDashboard() ? (
         getV1TeacherDashboard()
       ) : (
         <TeacherNavigationRouter

--- a/apps/src/templates/manageStudents/ManageStudentsNameCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsNameCell.jsx
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 
 import {getSelectedScriptName} from '@cdo/apps/redux/unitSelectionRedux';
-import {scriptUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
+import {unitUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import i18n from '@cdo/locale';
 
 import {
@@ -35,7 +35,7 @@ class ManageStudentNameCell extends Component {
   render() {
     const {id, sectionId, name, username, email, editedValue, scriptName} =
       this.props;
-    const studentUrl = scriptUrlForStudent(sectionId, scriptName, id);
+    const studentUrl = unitUrlForStudent(sectionId, scriptName, id);
 
     return (
       <div style={tableLayoutStyles.tableText}>

--- a/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
+++ b/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
@@ -10,6 +10,7 @@ import i18n from '@cdo/locale';
 import {h3Style} from '../../legacySharedComponents/Headings';
 import firehoseClient from '../../metrics/firehose';
 import color from '../../util/color';
+import {getUnitUrl} from '../teacherDashboard/urlHelpers';
 
 import {ViewType, unitDataPropType} from './sectionProgressConstants';
 import {getCurrentUnitData} from './sectionProgressRedux';
@@ -27,7 +28,13 @@ class ProgressViewHeader extends Component {
 
   getLinkToOverview() {
     const {scriptData, sectionId} = this.props;
-    return scriptData ? `${scriptData.path}?section_id=${sectionId}` : null;
+    return scriptData
+      ? getUnitUrl(
+          sectionId,
+          scriptData.name,
+          `${scriptData.path}?section_id=${sectionId}`
+        )
+      : null;
   }
 
   navigateToScript = () => {

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
@@ -5,7 +5,7 @@ import * as Table from 'reactabular-table';
 import * as Virtualized from 'reactabular-virtualized';
 
 import {getFullName} from '@cdo/apps/templates/manageStudents/utils.ts';
-import {scriptUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
+import {unitUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import i18n from '@cdo/locale';
 
 import {
@@ -58,7 +58,7 @@ export default class ProgressTableStudentList extends React.Component {
 
   studentNameFormatter(rowData) {
     const {sectionId, scriptData, studentTimestamps} = this.props;
-    const studentUrl = scriptUrlForStudent(
+    const studentUrl = unitUrlForStudent(
       sectionId,
       scriptData.name,
       rowData.student.id

--- a/apps/src/templates/teacherDashboard/StatsTable.jsx
+++ b/apps/src/templates/teacherDashboard/StatsTable.jsx
@@ -6,7 +6,7 @@ import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 
 import {getSelectedScriptName} from '@cdo/apps/redux/unitSelectionRedux';
-import {scriptUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
+import {unitUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import i18n from '@cdo/locale';
 
 import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
@@ -35,7 +35,7 @@ class StatsTable extends Component {
 
   nameFormatter = (name, {rowData}) => {
     const {sectionId, scriptName} = this.props;
-    const studentUrl = scriptUrlForStudent(sectionId, scriptName, rowData.id);
+    const studentUrl = unitUrlForStudent(sectionId, scriptName, rowData.id);
 
     if (studentUrl) {
       return (

--- a/apps/src/templates/teacherDashboard/urlHelpers.js
+++ b/apps/src/templates/teacherDashboard/urlHelpers.js
@@ -14,14 +14,22 @@ export const teacherDashboardUrl = (sectionId, path = '') => {
   return dashboardPrefix + sectionId + path;
 };
 
+export const getUnitUrl = (sectionId, unitName, unassignedUnitUrl) => {
+  if (showV2TeacherDashboard() && sectionId && unitName) {
+    return `/teacher_dashboard/sections/${sectionId}/unit/${unitName}`;
+  }
+
+  return unassignedUnitUrl;
+};
+
 export const unitUrlForStudent = (sectionId, unitName, studentId) => {
   if (!unitName) {
     return null;
   }
 
-  if (showV2TeacherDashboard()) {
-    return `/teacher_dashboard/sections/${sectionId}/unit/${unitName}`;
-  }
-
-  return `/s/${unitName}?section_id=${sectionId}&user_id=${studentId}&viewAs=Instructor`;
+  return getUnitUrl(
+    sectionId,
+    unitName,
+    `/s/${unitName}?section_id=${sectionId}&user_id=${studentId}&viewAs=Instructor`
+  );
 };

--- a/apps/src/templates/teacherDashboard/urlHelpers.js
+++ b/apps/src/templates/teacherDashboard/urlHelpers.js
@@ -1,3 +1,5 @@
+import {showV2TeacherDashboard} from '@cdo/apps/templates/teacherNavigation/TeacherNavFlagUtils';
+
 const dashboardPrefix = '/teacher_dashboard/sections/';
 
 /**
@@ -12,10 +14,14 @@ export const teacherDashboardUrl = (sectionId, path = '') => {
   return dashboardPrefix + sectionId + path;
 };
 
-export const scriptUrlForStudent = (sectionId, scriptName, studentId) => {
-  if (!scriptName) {
+export const unitUrlForStudent = (sectionId, unitName, studentId) => {
+  if (!unitName) {
     return null;
   }
 
-  return `/s/${scriptName}?section_id=${sectionId}&user_id=${studentId}&viewAs=Instructor`;
+  if (showV2TeacherDashboard()) {
+    return `/teacher_dashboard/sections/${sectionId}/unit/${unitName}`;
+  }
+
+  return `/s/${unitName}?section_id=${sectionId}&user_id=${studentId}&viewAs=Instructor`;
 };

--- a/apps/src/templates/teacherNavigation/TeacherNavFlagUtils.ts
+++ b/apps/src/templates/teacherNavigation/TeacherNavFlagUtils.ts
@@ -3,8 +3,9 @@ import _ from 'lodash';
 import DCDO from '@cdo/apps/dcdo';
 import experiments from '@cdo/apps/util/experiments';
 
-export const showV2TeacherDashboard = () =>
-  _.once(() => {
+export const showV2TeacherDashboard: () => boolean = _.once(() => {
+  return (
     DCDO.get('teacher-local-nav-v2', false) ||
-      experiments.isEnabled('teacher-local-nav-v2');
-  });
+    experiments.isEnabled('teacher-local-nav-v2')
+  );
+});

--- a/apps/src/templates/teacherNavigation/TeacherNavFlagUtils.ts
+++ b/apps/src/templates/teacherNavigation/TeacherNavFlagUtils.ts
@@ -1,0 +1,10 @@
+import _ from 'lodash';
+
+import DCDO from '@cdo/apps/dcdo';
+import experiments from '@cdo/apps/util/experiments';
+
+export const showV2TeacherDashboard = () =>
+  _.once(() => {
+    DCDO.get('teacher-local-nav-v2', false) ||
+      experiments.isEnabled('teacher-local-nav-v2');
+  });

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -112,7 +112,7 @@ const UnitCalendar: React.FC = () => {
           </div>
           <UnitCalendarGrid
             lessons={calendarLessons}
-            weeklyInstructionalMinutes={weeklyInstructionalMinutes}
+            weeklyInstructionalMinutes={parseInt(weeklyInstructionalMinutes)}
             weekWidth={WEEK_WIDTH}
           />
         </div>

--- a/apps/src/templates/textResponses/TextResponsesTable.jsx
+++ b/apps/src/templates/textResponses/TextResponsesTable.jsx
@@ -5,7 +5,7 @@ import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
-import {scriptUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
+import {unitUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import i18n from '@cdo/locale';
 
 import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
@@ -35,7 +35,7 @@ class TextResponsesTable extends Component {
 
   studentNameFormatter = (name, {rowData}) => {
     const {sectionId, scriptName} = this.props;
-    const studentUrl = scriptUrlForStudent(
+    const studentUrl = unitUrlForStudent(
       sectionId,
       scriptName,
       rowData.studentId


### PR DESCRIPTION
I did a full audit of all links on teacher dashboard pages and made sure than any links to a unit or course overview page would link to the teacher dashboard version.

I only found two places:
* Student names in the v1 progress page
* The header in the v1 progress page

I also fixed a console error in UnitCalendar from sending a string instead of a number as a prop.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1352
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

