### PR TITLE
Remove unused Dropbox sync scripts

### DIFF
--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -21,7 +21,6 @@ require "open3"
 FOLDERS = {
   "code.org" => "sites.v3/code.org",
   "curriculum-6-8" => "sites/virtual/curriculum-6-8",
-  "curriculum-algebra" => "sites/virtual/curriculum-algebra",
   "curriculum-course1" => "sites/virtual/curriculum-course1",
   "curriculum-course2" => "sites/virtual/curriculum-course2",
   "curriculum-course3" => "sites/virtual/curriculum-course3",
@@ -29,9 +28,7 @@ FOLDERS = {
   "curriculum-csp" => "sites/virtual/curriculum-csp",
   "curriculum-docs" => "sites/virtual/curriculum-docs",
   "curriculum-misc" => "sites/virtual/curriculum-misc",
-  "curriculum-science" => "sites/virtual/curriculum-science",
   "emails" => "emails",
-  "hourofcode.com" => "sites.v3/hourofcode.com"
 }.freeze
 
 INTERVAL_SECONDS = 5


### PR DESCRIPTION
Removes the following Dropbox sync scripts:
- `curriculum-algebra`
- `curriculum-science`
- `hourofcode.com`

## Links
Jira ticket: [ACQ-2605](https://codedotorg.atlassian.net/browse/ACQ-2605)
Slack convo: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1729962445127179)