### PR TITLE
Fix typo on Gen AI page

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -1274,7 +1274,7 @@
       explore_gen_ai_card:
         title: "Exploring Generative AI"
         desc: "Prepare your students for the future with an engaging curriculum that demystifies generative AI. Through hands-on projects and ethical discussions, students gain the skills to become creators and critical thinkers in an AI-powered world."
-        see_pl: "See professional learrning"
+        see_pl: "See professional learning"
     flexible_units:
       title: "Flexible units in this course"
       desc: "Choose standalone units to fit your classroom needs or combine them for a deeper dive into AI concepts."


### PR DESCRIPTION
In production:
![Screenshot 2024-10-28 at 3 27 19 PM](https://github.com/user-attachments/assets/2f57ce1a-aefb-4ab7-9e23-4f8a8f02cc7a)

After this change:
![Screenshot 2024-10-28 at 3 31 50 PM](https://github.com/user-attachments/assets/958e1a89-f8bf-4c53-8619-93fee75fc967)
