### PR TITLE
Revert "Codebridge: Add start source fallback to loadVersion"

### DIFF
--- a/apps/src/lab2/redux/lab2ProjectRedux.ts
+++ b/apps/src/lab2/redux/lab2ProjectRedux.ts
@@ -46,18 +46,12 @@ export const setAndSaveProjectSource = (
 
 export const loadVersion = createAsyncThunk(
   'lab2Project/loadVersion',
-  async (
-    payload: {versionId: string; startSource: ProjectSources},
-    thunkAPI
-  ) => {
+  async (payload: {versionId: string}, thunkAPI) => {
     const projectManager = Lab2Registry.getInstance().getProjectManager();
     if (projectManager) {
       // We need to ensure we save the existing project before loading a new one.
       await projectManager.flushSave();
-      // Fall back to start source if we can't load the version.
-      const sources =
-        (await projectManager.loadSources(payload.versionId)) ||
-        payload.startSource;
+      const sources = await projectManager.loadSources(payload.versionId);
       thunkAPI.dispatch(setPreviousVersionSource(sources));
     }
   }

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryDropdown.tsx
@@ -229,7 +229,7 @@ const VersionHistoryDropdown: React.FunctionComponent<
       } else if (isLatest) {
         dispatch(resetToCurrentVersion());
       } else {
-        dispatch(loadVersion({versionId: e.target.value, startSource}));
+        dispatch(loadVersion({versionId: e.target.value}));
       }
     },
     [appName, dispatch, isLatestVersion, startSource]


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#62029

The test [failed](https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_code_tools_pythonlab_pythonlab_run_output.html?versionId=EpBvaI4ch58DjHepAS0eMJEC5nhGVsni) on the dtt, I think the progress checking may need an additional wait. Reverting to diagnose further.