### PR TITLE
Stop copying data from contact_rollups_processed to contact_rollups_final

### DIFF
--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -128,17 +128,11 @@ class ContactRollupsV2
   end
 
   # Process contacts in ContactRollupsRaw table and save the results to ContactRollupsProcessed.
-  # The results are then copied over to ContactRollupsFinal for further analysis.
   def process_contacts
     start_time = Time.now
     @log_collector.time!("Processes all extracted data with batch size #{ContactRollupsProcessed::BATCH_SIZE}") do
       results = ContactRollupsProcessed.import_from_raw_table
       @log_collector.record_metrics({ContactsWithInvalidData: results[:invalid_contacts]})
-    end
-
-    @log_collector.time!("Overwrites contact_rollups_final table") do
-      truncate_or_delete_table ContactRollupsFinal
-      ContactRollupsFinal.insert_from_processed_table
     end
   ensure
     @log_collector.record_metrics(

--- a/dashboard/test/lib/contact_rollups_v2_test.rb
+++ b/dashboard/test/lib/contact_rollups_v2_test.rb
@@ -36,7 +36,7 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     refute_nil pardot_memory_record
     assert_equal({'db_Opt_In' => 'Yes'}, pardot_memory_record[:data_synced])
 
-    contact_record = ContactRollupsFinal.find_by_email(email_preference.email)
+    contact_record = ContactRollupsProcessed.find_by_email(email_preference.email)
     refute_nil contact_record
     assert_equal 1, contact_record.data['opt_in']
 
@@ -45,7 +45,7 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     refute_nil pardot_memory_record
     assert_equal({'db_Roles_0' => 'Parent'}, pardot_memory_record[:data_synced])
 
-    contact_record = ContactRollupsFinal.find_by_email(student_with_parent_email.parent_email)
+    contact_record = ContactRollupsProcessed.find_by_email(student_with_parent_email.parent_email)
     refute_nil contact_record
   end
 
@@ -83,7 +83,7 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     refute_nil pardot_memory_record
     assert_equal({'db_Opt_In' => 'No'}, pardot_memory_record[:data_synced])
 
-    contact_record = ContactRollupsFinal.find_by_email(email)
+    contact_record = ContactRollupsProcessed.find_by_email(email)
     refute_nil contact_record
     assert_equal 0, contact_record.data['opt_in']
   end


### PR DESCRIPTION
This pr simply does not write to `contact_rollups_final`, which appears to be a legacy table that is no longer read from. I am not dropping the table or deleting the model file until I'm totally sure it's not being used
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

[clean up ticket](https://codedotorg.atlassian.net/browse/ACQ-2610)

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
