### PR TITLE
Bump sauce labs idleTimeout config to 90 seconds from 60

### DIFF
--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -29,7 +29,7 @@ def saucelabs_browser(test_run_name)
     name: test_run_name,
     tags: [ENV.fetch('GIT_BRANCH', nil)],
     build: CDO.circle_run_identifier || ENV.fetch('BUILD', nil),
-    idleTimeout: 60,
+    idleTimeout: 90,
     seleniumVersion: Selenium::WebDriver::VERSION
   }
 


### PR DESCRIPTION
`require_rails_env` is taking a long time, occasionally getting too close to the timeout. According to a comment from 9 years ago, it should be used sparingly because it takes 20-30 seconds, but now, as the application has gotten more complex, it seems it's taking upwards of a minute

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[slack](https://codedotorg.slack.com/archives/C046G4TRLEN/p1730150279728729?thread_ts=1729910404.855329&cid=C046G4TRLEN)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
