### PR TITLE
Panels: fix heading style

### DIFF
--- a/apps/src/panels/panelsView.module.scss
+++ b/apps/src/panels/panelsView.module.scss
@@ -75,7 +75,7 @@ $text-offset-y: 2cqw;
         margin: 0 0 1cqw 0;
         font-family: $barlowSemiCondensed-semibold;
         font-size: 3cqw;
-        line-height: 2cqw;
+        line-height: 1.2em;
       }
 
       p {


### PR DESCRIPTION
This fixes the line height of headings in panels levels.  Follow-up to https://github.com/code-dot-org/code-dot-org/pull/61820.
