### PR TITLE
Lab2: DCDO flag to disable TTS

### DIFF
--- a/apps/src/lab2/views/components/TextToSpeech.tsx
+++ b/apps/src/lab2/views/components/TextToSpeech.tsx
@@ -3,6 +3,7 @@ import React, {useState} from 'react';
 
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
+import DCDO from '@cdo/apps/dcdo';
 import {useBrowserTextToSpeech} from '@cdo/apps/sharedComponents/BrowserTextToSpeechWrapper';
 
 import moduleStyles from './TextToSpeech.module.scss';
@@ -14,6 +15,10 @@ interface TextToSpeechProps {
 const usePause = queryParams('tts-play-pause') === 'true';
 const playIcon = (queryParams('tts-play-icon') as string) || 'volume';
 const stopIcon = (queryParams('tts-stop-icon') as string) || 'circle-stop';
+const ttsButtonEnabled = DCDO.get(
+  'browser-tts-button-enabled',
+  true
+) as boolean;
 
 /**
  * TextToSpeech play button.
@@ -60,7 +65,7 @@ const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
     }
   };
 
-  if (!isTtsAvailable) {
+  if (!ttsButtonEnabled || !isTtsAvailable) {
     return null;
   }
 

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -60,6 +60,7 @@ class DCDOBase < DynamicConfigBase
       'hoc-2024-sweepstakes': DCDO.get('hoc-2024-sweepstakes', false),
       # TODO ACQ-2556 - Remove this after the 2024 HOC launch
       'hoc-2024-nov-launch': DCDO.get('hoc-2024-nov-launch', false),
+      'browser-tts-button-enabled': DCDO.get('browser-tts-button-enabled', true),
     }
   end
 end


### PR DESCRIPTION
Adds a DCDO flag to disable the browser TTS button if necessary. Currently this defaults to true, as the browser TTS button is still opt-in only on certain levels (ex. the Music Lab HOC progression).

## Links

https://codedotorg.atlassian.net/browse/LABS-1139

## Testing story

Tested locally by setting DCDO flag in my local environment.