### PR TITLE
Fix flaky Python Lab test

### DIFF
--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -19,17 +19,18 @@ Scenario: Continue button and progress status shows up correctly
   And I verify progress in the header of the current page is "not_tried" for level 1
   And I focus selector ".cm-content"
   And I press keys "print('more code')\n"
-  Then I verify progress in the header of the current page is "attempted" for level 1
   And I press "uitest-codebridge-run"
   And I wait until "#uitest-codebridge-console" contains text "more code"
+  Then I verify progress in the header of the current page is "attempted" for level 1
   And element "#instructions-navigation" is visible
   And element "#instructions-navigation" contains text "Continue"
   And I press "instructions-navigation"
-  Then I verify progress in the header of the current page is "perfect" for level 1
 
   # Validated level that passes by default, running validation will pass the level and
   # cause the continue button to show up
-  And check that I am on "http://studio.code.org/s/allthethings/lessons/50/levels/2"
+  And I wait until current URL contains "http://studio.code.org/s/allthethings/lessons/50/levels/2"
+  # Check that progress has been updated for the previous level
+  Then I verify progress in the header of the current page is "perfect" for level 1
   And I wait until "#uitest-validate-button" is not disabled
   And I press "uitest-validate-button"
   And I wait until element "#instructions-navigation" is visible

--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -19,6 +19,8 @@ Scenario: Continue button and progress status shows up correctly
   And I verify progress in the header of the current page is "not_tried" for level 1
   And I focus selector ".cm-content"
   And I press keys "print('more code')\n"
+  # Wait to ensure the editor has the updated text before clicking run 
+  And I wait for 1 second
   And I press "uitest-codebridge-run"
   And I wait until "#uitest-codebridge-console" contains text "more code"
   Then I verify progress in the header of the current page is "attempted" for level 1


### PR DESCRIPTION
The test I added that verified progress updates was a bit flaky because we need to wait for a network round trip to see the progress bubble update. It also assumed a very quick load time for switching levels and could get into a race condition between updating the editor and clicking run.

To fix the progress issue, I delayed the checks for progress updates by a few steps (the first includes waiting for code to run, the second includes waiting for a level load), that should allow for the progress to be updated by the time we check it. I didn't update the final progress check; it already waits to see the continue button, which I'm hoping is enough, but I can circle back here if it's not.

For the level switching check, I switched from checking if we are on the new level to waiting for the level to load. 

For the race condition with the editor, I added a 1 second wait after adding text before clicking run.

I didn't see these issues when originally testing this because I was running against localhost rather than test, which is slower. 

## Links

- jira ticket: [CT-887](https://codedotorg.atlassian.net/browse/CT-887)


## Testing story
I ran the new version against test via sauce-connect 5 times for Chrome and Firefox. It did fail 1 time for Chrome because pyodide didn't finish loading in time; I haven't seen this error before and our other tests also rely on pyodide loading in time. I will keep an eye out to see if this was a one-off or something to look into further.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
