### PR TITLE
Report browser metrics with and without version dimension

### DIFF
--- a/apps/src/metrics/MetricsReporter.ts
+++ b/apps/src/metrics/MetricsReporter.ts
@@ -79,6 +79,9 @@ class MetricsReporter {
 
   /**
    * Publish a metric.
+   *
+   * Note that this will send two metrics, with and without the browser version dimension.
+   * This allows us to more easily aggregate metrics by browser.
    */
   publishMetric(
     name: string,
@@ -96,7 +99,14 @@ class MetricsReporter {
       console.info('[MetricsReporter] ' + JSON.stringify(metric));
       return;
     }
-    this.sendMetric(metric);
+    // Send a version of the metric with and without the browser version dimension
+    this.sendMetrics([
+      metric,
+      {
+        ...metric,
+        dimensions: [...metric.dimensions, this.getBrowserVersionDimension()],
+      },
+    ]);
   }
 
   private async log(level: LogLevel, message: string | object) {
@@ -119,16 +129,16 @@ class MetricsReporter {
     }
   }
 
-  private async sendMetric(metric: MetricDatum) {
+  private async sendMetrics(metrics: MetricDatum[]) {
     if (!this.isReportingEnabled()) {
-      this.fallbackLog(metric);
+      this.fallbackLog(metrics);
       return;
     }
 
     try {
-      await this.metricsApi.sendMetricData([metric]);
+      await this.metricsApi.sendMetricData(metrics);
     } catch (error) {
-      this.fallbackLog(metric);
+      this.fallbackLog(metrics);
       this.handleError(error as Error);
     }
   }
@@ -163,11 +173,14 @@ class MetricsReporter {
         name: 'Browser',
         value: getBrowserName(),
       },
-      {
-        name: 'BrowserVersion',
-        value: getBrowserName(true),
-      },
     ];
+  }
+
+  private getBrowserVersionDimension(): MetricDimension {
+    return {
+      name: 'BrowserVersion',
+      value: getBrowserName(true),
+    };
   }
 
   private fallbackLog(payload: object) {


### PR DESCRIPTION
This updates `MetricsReporter`, which forwards browser logs and metrics to Cloudwatch via a dashboard, to send two versions of each metric event, with and without the browser version dimension. 

The goal here is to make metrics easier to aggregate in Cloudwatch, since Cloudwatch treats each different dimension value as a distinct metric. Aggregating across dimensions is possible, but requires a 'SEARCH' query, which thus far has been manageable; however, Cloudwatch [doesn't allow you create alarms from a SEARCH query](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create-alarm-on-metric-math-expression.html), which means that we can't create alarm based on browser metrics unless we pick a specific browser version of set of versions. By adding a second metric that doesn't include browser version though, we can still aggregate by browser by simply using the version of the metric that doesn't include the version dimension, while maintaining version-specific granularity as well. This is currently relevant for adding Gen AI curriculum alarms to track client-facing failure rates but will be useful across the board.

## Links

https://codedotorg.atlassian.net/browse/LABS-1170

## Testing story

Tested locally by enabling reporting and confirmed that both versions of the metrics appear:

Without version:
<img width="950" alt="Screenshot 2024-10-28 at 4 27 06 PM" src="https://github.com/user-attachments/assets/38f0796c-8601-4867-9336-0865c7c8b4b4">

With version:
<img width="1126" alt="Screenshot 2024-10-28 at 4 27 14 PM" src="https://github.com/user-attachments/assets/b6df7416-ab02-45f0-91d3-0d6134e9d8de">