### PR TITLE
[Google Blockly] Fix variable fields in embedded workspaces

### DIFF
--- a/apps/src/blockly/addons/cdoFieldVariable.ts
+++ b/apps/src/blockly/addons/cdoFieldVariable.ts
@@ -113,6 +113,7 @@ export default class CdoFieldVariable extends GoogleBlockly.FieldVariable {
 
     const filteredOptions = options.filter(option => {
       const workspace = this.getSourceBlock()?.workspace;
+      // Embedded workspaces are read-only, so we don't need to modify the dropdown options.
       if (!workspace || Blockly.embeddedWorkspaces.includes(workspace.id)) {
         return true;
       }

--- a/apps/src/blockly/addons/cdoFieldVariable.ts
+++ b/apps/src/blockly/addons/cdoFieldVariable.ts
@@ -113,7 +113,7 @@ export default class CdoFieldVariable extends GoogleBlockly.FieldVariable {
 
     const filteredOptions = options.filter(option => {
       const workspace = this.getSourceBlock()?.workspace;
-      if (!workspace) {
+      if (!workspace || Blockly.embeddedWorkspaces.includes(workspace.id)) {
         return true;
       }
 


### PR DESCRIPTION
Multiple users have reported a page crash when students click for a hint in the Star Quilts level. This is a regression caused by some work to improve function parameters in Music Lab. In that work, we began filtering the options in a variable field dropdown to remove any variables that are exclusively used by functions (ie. they're parameters). This is done by looking at the variable models associated with each block, which includes looking at the parameters of associated procedure models. In our embedded workspaces, procedure blocks don't have models, so this was causing the crash. 
The fix is straight-forward because we don't need to filter dropdown options in an embedded (read-only) workspace.

With this change, the hint can be opened as expected, without errors.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/e49de3d8-7f88-49f9-b4bc-28cbf8780a91">


## Links

https://codedotorg.slack.com/archives/C03DBDN67B7/p1730177712548659
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
