### PR TITLE
Don't let user skip steps in the new signup flow

### DIFF
--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -21,7 +21,9 @@ import {navigateToHref} from '../utils';
 
 import locale from './locale';
 import {
+  ACCOUNT_TYPE_SESSION_KEY,
   EMAIL_SESSION_KEY,
+  OAUTH_LOGIN_TYPE_SESSION_KEY,
   USER_RETURN_TO_SESSION_KEY,
   clearSignUpSessionStorage,
 } from './signUpFlowConstants';
@@ -57,6 +59,16 @@ const FinishStudentAccount: React.FunctionComponent<{
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
+    // If the user hasn't selected a user type or login type, redirect them back to the incomplete step of signup.
+    if (sessionStorage.getItem(ACCOUNT_TYPE_SESSION_KEY) === null) {
+      navigateToHref('/users/new_sign_up/account_type');
+    } else if (
+      sessionStorage.getItem(EMAIL_SESSION_KEY) === null &&
+      sessionStorage.getItem(OAUTH_LOGIN_TYPE_SESSION_KEY) === null
+    ) {
+      navigateToHref('/users/new_sign_up/login_type');
+    }
+
     const fetchGdprData = async () => {
       const urlParams = new URLSearchParams(window.location.search);
       const forceInEu = urlParams.get('force_in_eu');

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -22,7 +22,9 @@ import {navigateToHref} from '../utils';
 
 import locale from './locale';
 import {
+  ACCOUNT_TYPE_SESSION_KEY,
   EMAIL_SESSION_KEY,
+  OAUTH_LOGIN_TYPE_SESSION_KEY,
   USER_RETURN_TO_SESSION_KEY,
   clearSignUpSessionStorage,
 } from './signUpFlowConstants';
@@ -44,6 +46,16 @@ const FinishTeacherAccount: React.FunctionComponent<{
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
+    // If the user hasn't selected a user type or login type, redirect them back to the incomplete step of signup.
+    if (sessionStorage.getItem(ACCOUNT_TYPE_SESSION_KEY) === null) {
+      navigateToHref('/users/new_sign_up/account_type');
+    } else if (
+      sessionStorage.getItem(EMAIL_SESSION_KEY) === null &&
+      sessionStorage.getItem(OAUTH_LOGIN_TYPE_SESSION_KEY) === null
+    ) {
+      navigateToHref('/users/new_sign_up/login_type');
+    }
+
     const fetchGdprData = async () => {
       const urlParams = new URLSearchParams(window.location.search);
       const forceInEu = urlParams.get('force_in_eu');

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -23,6 +23,7 @@ import {navigateToHref} from '../utils';
 import {
   ACCOUNT_TYPE_SESSION_KEY,
   EMAIL_SESSION_KEY,
+  OAUTH_LOGIN_TYPE_SESSION_KEY,
 } from './signUpFlowConstants';
 
 import style from './signUpFlowStyles.module.scss';
@@ -52,6 +53,11 @@ const LoginTypeSelection: React.FunctionComponent = () => {
     : studio('/users/new_sign_up/finish_student_account');
 
   useEffect(() => {
+    // If the user hasn't selected a user type, redirect them back to the first step of signup.
+    if (sessionStorage.getItem(ACCOUNT_TYPE_SESSION_KEY) === null) {
+      navigateToHref('/users/new_sign_up/account_type');
+    }
+
     async function getToken() {
       setAuthToken(await getAuthenticityToken());
     }
@@ -173,6 +179,11 @@ const LoginTypeSelection: React.FunctionComponent = () => {
     );
   }
 
+  function selectOauthLoginType(loginType: string) {
+    logUserLoginType(loginType);
+    sessionStorage.setItem(OAUTH_LOGIN_TYPE_SESSION_KEY, loginType);
+  }
+
   return (
     <div className={style.newSignupFlow}>
       <AccountBanner
@@ -195,7 +206,7 @@ const LoginTypeSelection: React.FunctionComponent = () => {
             <input type="hidden" name="finish_url" value={finishAccountUrl} />
             <button
               className={style.googleButton}
-              onClick={() => logUserLoginType('google')}
+              onClick={() => selectOauthLoginType('google')}
               type="submit"
             >
               <FontAwesomeV6Icon
@@ -210,7 +221,7 @@ const LoginTypeSelection: React.FunctionComponent = () => {
             <input type="hidden" name="finish_url" value={finishAccountUrl} />
             <button
               className={style.microsoftButton}
-              onClick={() => logUserLoginType('microsoft')}
+              onClick={() => selectOauthLoginType('microsoft')}
               type="submit"
             >
               <FontAwesomeV6Icon
@@ -225,7 +236,7 @@ const LoginTypeSelection: React.FunctionComponent = () => {
             <input type="hidden" name="finish_url" value={finishAccountUrl} />
             <button
               className={style.facebookButton}
-              onClick={() => logUserLoginType('facebook')}
+              onClick={() => selectOauthLoginType('facebook')}
               type="submit"
             >
               <FontAwesomeV6Icon
@@ -240,7 +251,7 @@ const LoginTypeSelection: React.FunctionComponent = () => {
             <input type="hidden" name="finish_url" value={finishAccountUrl} />
             <button
               className={style.cleverButton}
-              onClick={() => logUserLoginType('clever')}
+              onClick={() => selectOauthLoginType('clever')}
               type="submit"
             >
               <img src={cleverLogo} alt="" />

--- a/apps/src/signUpFlow/signUpFlowConstants.tsx
+++ b/apps/src/signUpFlow/signUpFlowConstants.tsx
@@ -5,12 +5,14 @@ export const SCHOOL_ZIP_SESSION_KEY = 'schoolZip';
 export const SCHOOL_NAME_SESSION_KEY = 'schoolName';
 export const SCHOOL_COUNTRY_SESSION_KEY = 'schoolCountry';
 export const EMAIL_SESSION_KEY = 'email';
+export const OAUTH_LOGIN_TYPE_SESSION_KEY = 'oauthType';
 export const USER_RETURN_TO_SESSION_KEY = 'userReturnTo';
 
 export const clearSignUpSessionStorage = (isTeacher: boolean) => {
   const fieldsToClear = [
     ACCOUNT_TYPE_SESSION_KEY,
     EMAIL_SESSION_KEY,
+    OAUTH_LOGIN_TYPE_SESSION_KEY,
     USER_RETURN_TO_SESSION_KEY,
   ];
   if (isTeacher) {

--- a/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
@@ -4,7 +4,11 @@ import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
 import FinishStudentAccount from '@cdo/apps/signUpFlow/FinishStudentAccount';
 import locale from '@cdo/apps/signUpFlow/locale';
-import {USER_RETURN_TO_SESSION_KEY} from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {
+  ACCOUNT_TYPE_SESSION_KEY,
+  EMAIL_SESSION_KEY,
+  USER_RETURN_TO_SESSION_KEY,
+} from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import {navigateToHref} from '@cdo/apps/utils';
 import {UserTypes} from '@cdo/generated-scripts/sharedConstants';
@@ -50,7 +54,17 @@ describe('FinishStudentAccount', () => {
     fetchStub.restore();
   });
 
-  function renderDefault(usIp: boolean = true) {
+  function renderDefault(
+    usIp: boolean = true,
+    setAccountType: boolean = true,
+    setLoginType: boolean = true
+  ) {
+    if (setAccountType) {
+      sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, 'student');
+    }
+    if (setLoginType) {
+      sessionStorage.setItem(EMAIL_SESSION_KEY, 'fake@email.com');
+    }
     render(
       <FinishStudentAccount
         ageOptions={ageOptions}
@@ -60,6 +74,26 @@ describe('FinishStudentAccount', () => {
       />
     );
   }
+
+  it('redirects user back to account type page if they have not selected account type', async () => {
+    await waitFor(() => {
+      renderDefault(true, false, false);
+    });
+
+    expect(navigateToHrefMock).toHaveBeenCalledWith(
+      '/users/new_sign_up/account_type'
+    );
+  });
+
+  it('redirects user back to login type page if they have not selected login type', async () => {
+    await waitFor(() => {
+      renderDefault(true, true, false);
+    });
+
+    expect(navigateToHrefMock).toHaveBeenCalledWith(
+      '/users/new_sign_up/login_type'
+    );
+  });
 
   it('renders finish student account page fields', () => {
     renderDefault();

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -5,6 +5,8 @@ import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 import FinishTeacherAccount from '@cdo/apps/signUpFlow/FinishTeacherAccount';
 import locale from '@cdo/apps/signUpFlow/locale';
 import {
+  ACCOUNT_TYPE_SESSION_KEY,
+  EMAIL_SESSION_KEY,
   SCHOOL_ID_SESSION_KEY,
   SCHOOL_NAME_SESSION_KEY,
   SCHOOL_ZIP_SESSION_KEY,
@@ -36,9 +38,39 @@ describe('FinishTeacherAccount', () => {
     sessionStorage.clear();
   });
 
-  function renderDefault(usIp: boolean = true) {
+  function renderDefault(
+    usIp: boolean = true,
+    setAccountType: boolean = true,
+    setLoginType: boolean = true
+  ) {
+    if (setAccountType) {
+      sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, 'teacher');
+    }
+    if (setLoginType) {
+      sessionStorage.setItem(EMAIL_SESSION_KEY, 'fake@email.com');
+    }
     render(<FinishTeacherAccount usIp={usIp} countryCode={'US'} />);
   }
+
+  it('redirects user back to account type page if they have not selected account type', async () => {
+    await waitFor(() => {
+      renderDefault(true, false, false);
+    });
+
+    expect(navigateToHrefMock).toHaveBeenCalledWith(
+      '/users/new_sign_up/account_type'
+    );
+  });
+
+  it('redirects user back to login type page if they have not selected login type', async () => {
+    await waitFor(() => {
+      renderDefault(true, true, false);
+    });
+
+    expect(navigateToHrefMock).toHaveBeenCalledWith(
+      '/users/new_sign_up/login_type'
+    );
+  });
 
   it('renders finish teacher account page with school zip when usIp is true', () => {
     renderDefault(true);

--- a/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
+++ b/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
@@ -28,9 +28,22 @@ describe('LoginTypeSelection', () => {
     sessionStorage.clear();
   });
 
-  function renderDefault() {
+  function renderDefault(userType: string | null = 'student') {
+    if (userType) {
+      sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, userType);
+    }
     render(<LoginTypeSelection />);
   }
+
+  it('redirects user back to account type page if they have not selected account type', async () => {
+    await waitFor(() => {
+      renderDefault(null);
+    });
+
+    expect(navigateToHrefMock).toHaveBeenCalledWith(
+      '/users/new_sign_up/account_type'
+    );
+  });
 
   it('renders headers, buttons and inputs', async () => {
     await waitFor(() => {
@@ -363,9 +376,8 @@ describe('LoginTypeSelection', () => {
   });
 
   it('if user selected student then finish sign up button sends user to finish student page', async () => {
-    sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, 'student');
     await waitFor(() => {
-      renderDefault();
+      renderDefault('student');
     });
 
     const finishSignUpButton = screen.getByRole('button', {
@@ -385,9 +397,8 @@ describe('LoginTypeSelection', () => {
   });
 
   it('if user selected teacher then finish sign up button sends user to finish teacher page', async () => {
-    sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, 'teacher');
     await waitFor(() => {
-      renderDefault();
+      renderDefault('teacher');
     });
 
     const finishSignUpButton = screen.getByRole('button', {


### PR DESCRIPTION
Redirects the user back to previous signup pages if they haven't completed them.

## Login Type page
This page checks if the user has selected an account type (stored in `sessionStorage`). If they haven't, they're redirected back to the Account Type page:

https://github.com/user-attachments/assets/20372551-2527-43e9-9d84-93c0e4bc7fe3

## Finish Student Account page
If the user hasn't selected an account type yet, redirect them back to the account type page:

https://github.com/user-attachments/assets/0854f3b3-269c-4e5c-90f3-3c8fa9c83570

If they have an account type set, but have not selected a login type, then they are redirected back to the login type page until they select a login type (this demo shows if they pick to use email):

https://github.com/user-attachments/assets/7e7012ca-e998-4246-9e98-8cfa65c3f744

If they have an account type set, but have not selected a login type, then they are redirected back to the login type page until they select a login type (this demo shows if they pick to use an OAuth option (since I do not have OAuth working locally, this just shows that the `sessionStorage` is set upon clicking an OAuth button)):

https://github.com/user-attachments/assets/01ed8426-3e36-405c-a00b-e6c7c8b8f0e5

## Finish Teacher Account page
If the user hasn't selected an account type yet, redirect them back to the account type page:

https://github.com/user-attachments/assets/12c0fb7a-a2d4-42a4-817b-1113f2f6b648

If they have an account type set, but have not selected a login type, then they are redirected back to the login type page until they select a login type (this demo shows if they pick to use email):

https://github.com/user-attachments/assets/d94d7123-29b6-4b84-a23f-6217c6b81a49

If they have an account type set, but have not selected a login type, then they are redirected back to the login type page until they select a login type (this demo shows if they pick to use an OAuth option (since I do not have OAuth working locally, this just shows that the `sessionStorage` is set upon clicking an OAuth button)):

https://github.com/user-attachments/assets/62e9c5b7-8db3-4dfd-a40f-f91db31b4e95

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2599)

## Testing story
Added unit tests and tested locally.
