### PR TITLE
HoC 2024 - Add Music Lab: Jam Session side-by-side banner (code only)

### DIFF
--- a/dashboard/config/marketing/announcements.json
+++ b/dashboard/config/marketing/announcements.json
@@ -53,6 +53,15 @@
       "buttonText": "Learn more",
       "buttonUrl": "https://code.org/curriculum/generative-ai",
       "buttonId": "gen-ai-launch-2024"
+    },
+    "music-lab-jam-launch-2024": {
+      "dcdo": "hoc-2024-nov-launch",
+      "image": "/shared/images/banners/banner-music-lab-jam-launch-2024.png",
+      "title": "Introducing Music Lab: Jam Session",
+      "body": "Make music and learn to code in our new Music Lab activity for Hour of Code! In this self-guided, one-hour activity, students remix tracks from artists like Sabrina Carpenter, Lady Gaga, and Shakira while mastering coding basics such as sequencing, functions, and exploring AI-driven beat creation.",
+      "buttonText": "Explore Music Lab: Jam Session",
+      "buttonUrl": "https://code.org/music",
+      "buttonId": "music-lab-jam-launch-2024"
     }
   }
 }

--- a/shared/images/banners/banner-music-lab-jam-launch-2024.png
+++ b/shared/images/banners/banner-music-lab-jam-launch-2024.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bb52865f299e217024eee04be31068f34f4474581f2f0e8885d7796f20fce65
+size 125702


### PR DESCRIPTION
Adds the Music Lab: Jam Session side-by-side banner to `announcements.json`.

We are holding off on applying this banner due to an overlap with the Gen AI launch. I have a followup ticket to apply this banner on 11/8 [here](https://codedotorg.atlassian.net/browse/ACQ-2609), but since it's behind the `hoc-2024-nov-launch` DCDO flag it won't go live until 11/13. 

## Links
Jira ticket: [ACQ-2613](https://codedotorg.atlassian.net/browse/ACQ-2613)
Figma mock: [here](https://www.figma.com/design/emvQNdidNnPvoU1NucF7Re/Hour-of-Code-2024?node-id=4065-819&t=FKQZOir6QPCqwKVa-1)

----

## This is how it will look when it goes live:

<img width="1333" alt="Screenshot 2024-10-29 at 9 41 05 AM" src="https://github.com/user-attachments/assets/a17ced04-cbf5-466e-b197-61cd64e031eb">
