### PR TITLE
HoC 2024 - Add disclaimer on hourofcode.com/events form

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -11002,6 +11002,7 @@
       heading: "Register your event"
       disclaimer: "Registrations close on %{close_date}"
       desc: "Join millions worldwide in the Hour of Code! Whether you're hosting an event at school, in the community, or online, we invite you to register your event today."
+      disclaimer: "Having issues seeing the form? Try disabling any extensions, including Ad Blockers, and refresh the page."
       how_to: "Looking for more guidance on how to host an Hour of Code? [Check out our How-To Guide](%{how_to_url})"
     resources:
       heading: "Additional resources for your Hour of Code"

--- a/pegasus/sites.v3/hourofcode.com/views/events/event_registration_form.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/events/event_registration_form.haml
@@ -45,6 +45,7 @@
       =hoc_s("hoc_events.register.disclaimer", markdown: :inline, locals:{close_date: "December 31, 2024"})
     %p.body-three
       =hoc_s("hoc_events.register.desc")
+    = view :"events/form_disclaimer"
     %hr
     %p.body-three.no-margin-bottom
       =hoc_s("hoc_events.register.how_to", markdown: :inline, locals:{how_to_url: resolve_url('/how-to')})

--- a/pegasus/sites.v3/hourofcode.com/views/events/form_disclaimer.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/events/form_disclaimer.haml
@@ -1,0 +1,3 @@
+%p.body-three
+  %i{class: "fa fa-circle-exclamation"}
+  =hoc_s("hoc_events.register.disclaimer")

--- a/pegasus/sites.v3/hourofcode.com/views/events/form_disclaimer.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/events/form_disclaimer.haml
@@ -1,3 +1,3 @@
 %p.body-three
   %i{class: "fa fa-circle-exclamation"}
-  =hoc_s("hoc_events.register.disclaimer")
+  %em=hoc_s("hoc_events.register.disclaimer")

--- a/pegasus/sites.v3/hourofcode.com/views/events/off_season_interest_form.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/events/off_season_interest_form.haml
@@ -8,5 +8,6 @@
       =hoc_s(:hoc_interest_form_desc)
     %p.body-three
       %em=hoc_s(:subscribe_form_section_unsubscribe)
+    = view :"events/form_disclaimer"
   %figure
     %iframe{allowtransparency: "true", frameborder: "0", height: "325px", src: "https://go.pardot.com/l/153401/2024-01-03/pqtwb6", style: "border: 0", type: "text/html", width: "100%"}


### PR DESCRIPTION
Adds a disclaimer message to the form section on https://hourofcode.com/events. We've been getting a few Zendesk tickets that people aren't seeing the form so this should hopefully help folks out in the moment.

## Links
Jira ticket: [ACQ-2614](https://codedotorg.atlassian.net/browse/ACQ-2614)
Slack convo: [here](https://codedotorg.slack.com/archives/C5V9YCXTR/p1730217623665849)

----

## HOC season form
<img width="1316" alt="in_season" src="https://github.com/user-attachments/assets/6aafce00-623c-4633-bef6-c88baa0344ac">

## Off season form
<img width="1316" alt="Screenshot 2024-10-29 at 10 15 13 AM" src="https://github.com/user-attachments/assets/1edac4df-2049-41cc-bcec-1d2ebdcd00d9">

