### PR TITLE
Don't re-use rails project in Projects middleware

### DIFF
--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -26,8 +26,7 @@ class Projects
   #### rather than this middleware class (Projects, plural)
   #### such that we can make use of model associations managed by Rails.
   def get_rails_project(project_id)
-    return @rails_project if @rails_project
-    @rails_project = Project.find(project_id)
+    Project.find(project_id)
   end
 
   def create(value, ip:, type: nil, published_at: nil, remix_parent_id: nil, standalone: true, level: nil)


### PR DESCRIPTION
Had a moment of panic when looking at the work Alice has been doing with featured projects...I added this "optimization" (read: bug) to re-use the same `Project` instance rather than having to look it up repeatedly. I'm realizing that this middleware is called Projects (plural) for a reason -- the same instance could be used to manipulate multiple projects (it's initialized with a `storage_id`, which is unique per user, not per project).

The `get_rails_project` method is only used in Project's `publish` method, which doesn't re-use the same `Projects` instance to manipulate multiple projects, so I don't think this has any negative impact currently. But wanted to fix before anyone else uses the `get_rails_project` method.

## Testing story

I didn't test this change. No expected change in behavior, so relying on tests.