### PR TITLE
Codebridge: update continue button visibility logic

### DIFF
--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -115,7 +115,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
     LevelStatus.free_play_complete,
     LevelStatus.completed_assessment,
   ];
-  const showPassedIcon =
+  const hasPassed =
     currentLevel && passedStatuses.includes(currentLevel.status);
 
   const dispatch = useAppDispatch();
@@ -202,11 +202,11 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
 
     // We show the finish variant if there is not a next level.
     const showFinishButton =
-      !isSubmittable && hasMetValidation && !hasNextLevel;
+      !isSubmittable && (hasMetValidation || hasPassed) && !hasNextLevel;
 
     // We show the continue variant if there is a next level.
     const showContinueButton =
-      !isSubmittable && hasMetValidation && hasNextLevel;
+      !isSubmittable && (hasMetValidation || hasPassed) && hasNextLevel;
 
     const showNavigation =
       showContinueButton || showFinishButton || showSubmitButton || false;
@@ -321,7 +321,7 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
             >
               <div className={moduleStyles.mainInstructions}>
                 <ValidationStatusIcon
-                  status={showPassedIcon ? 'passed' : 'pending'}
+                  status={hasPassed ? 'passed' : 'pending'}
                   className={moduleStyles.validationIcon}
                 />
                 <EnhancedSafeMarkdown

--- a/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
+++ b/apps/src/codebridge/InfoPanel/ValidatedInstructions.tsx
@@ -200,13 +200,14 @@ const ValidatedInstructions: React.FunctionComponent<InstructionsProps> = ({
     const showSubmitButton =
       isSubmittable && (hasMetValidation || hasSubmitted);
 
+    // If this is not a submittable level, we show the continue/finish button
+    // if the user has met validation or has already passed the level (green bubble).
+    const showButton = !isSubmittable && (hasMetValidation || hasPassed);
     // We show the finish variant if there is not a next level.
-    const showFinishButton =
-      !isSubmittable && (hasMetValidation || hasPassed) && !hasNextLevel;
+    const showFinishButton = showButton && !hasNextLevel;
 
     // We show the continue variant if there is a next level.
-    const showContinueButton =
-      !isSubmittable && (hasMetValidation || hasPassed) && hasNextLevel;
+    const showContinueButton = showButton && hasNextLevel;
 
     const showNavigation =
       showContinueButton || showFinishButton || showSubmitButton || false;


### PR DESCRIPTION
We decided that if a level has already in the passed (green bubble) state when loading, the continue button should show up without any additional user action (passing validation for a validated level or running and editing code for a non-validated level). This PR implements this behavior. This only impacts Codebridge labs.

## Links

- jira ticket: [CT-890](https://codedotorg.atlassian.net/browse/CT-890)


## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
