### PR TITLE
Music: random doesn't work for chord and drum blocks

### DIFF
--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -303,6 +303,9 @@ export default class MusicPlayer {
 
   private scheduleEvents(events: PlaybackEvent[]) {
     for (const event of events) {
+      if (event.skipContext?.skipSound) {
+        continue;
+      }
       if (isSoundEvent(event) || !this.audioPlayer.supportsSamplers()) {
         const reportCallback = (soundId: string) => {
           this.analyticsReporter?.onSoundPlayed(soundId);
@@ -340,10 +343,6 @@ export default class MusicPlayer {
     const library = MusicLibrary.getInstance();
     if (!library) {
       this.metricsReporter.logWarning('Library not set. Cannot play sounds.');
-      return [];
-    }
-
-    if (event.skipContext?.skipSound) {
       return [];
     }
 


### PR DESCRIPTION
Likely a regression from updating the instrument interface or from the ToneJS migration. We were only looking at `skipSound` for sound events, and not for instrument/kit events. The rest of the UI still displays everything correctly (only the playing block is highlighted and colored in the timeline).

## Links

https://codedotorg.atlassian.net/browse/LABS-1189

## Testing story

Tested locally.
