### PR TITLE
Panels: typing preview

### DIFF
--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -7,6 +7,7 @@ import {Button} from '@cdo/apps/componentLibrary/button';
 import TextToSpeech from '@cdo/apps/lab2/views/components/TextToSpeech';
 import usePrevious from '@cdo/apps/util/usePrevious';
 
+import {queryParams} from '../code-studio/utils';
 import FontAwesome from '../legacySharedComponents/FontAwesome';
 import {useBrowserTextToSpeech} from '../sharedComponents/BrowserTextToSpeechWrapper';
 import EnhancedSafeMarkdown from '../templates/EnhancedSafeMarkdown';
@@ -143,8 +144,11 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
 
   const plainText = markdownToTxt(panel.text);
 
+  const showTyping =
+    panel.typing || queryParams('panels-show-typing') === 'true';
+
   // When typing, only show the button when the typing is done.
-  const showButton = !panel.typing || typingDone;
+  const showButton = !showTyping || typingDone;
 
   return (
     <div
@@ -176,7 +180,7 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
             )}
           >
             {offerBrowserTts && <TextToSpeech text={panel.text} />}
-            {panel.typing ? (
+            {showTyping ? (
               <div>
                 <div className={styles.invisiblePlaceholder}>{plainText}</div>
                 <Typist
@@ -208,7 +212,7 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
             onClick={handleButtonClick}
             className={classNames(
               styles.button,
-              panel.typing ? styles.buttonReady : styles.buttonDelay
+              showTyping ? styles.buttonReady : styles.buttonDelay
             )}
             text={buttonText}
           />

--- a/apps/src/panels/panelsView.module.scss
+++ b/apps/src/panels/panelsView.module.scss
@@ -4,6 +4,8 @@
 
 $text-offset-x: 2cqw;
 $text-offset-y: 2cqw;
+$text-vertical-padding: 1.8cqw;
+$text-horizontal-padding: 2.6cqw;
 
 @keyframes fade-in {
   0%, 50% {
@@ -61,7 +63,7 @@ $text-offset-y: 2cqw;
       border-radius: 5px;
       width: 40%;
       position: absolute;
-      padding: 1.8cqw 2.6cqw;
+      padding: $text-vertical-padding $text-horizontal-padding;
       animation: fade-in 1.5s;
       font-size: 1.6cqw;
       line-height: 1.4em;
@@ -99,6 +101,7 @@ $text-offset-y: 2cqw;
       .typist {
         position: absolute;
         top: 1.8cqw;
+        width: calc(100% - 2 * $text-horizontal-padding);
       }
 
       &TopLeft {


### PR DESCRIPTION
As we consider turning on typing text for some panels levels, this adds an optional URL parameter `?panels-show-typing=true` that will preview how that looks.

This also fixes the sizing of the text area when typing is shown. 