### PR TITLE
Music: disable keyhandler on non-music levels and share view

### DIFF
--- a/apps/src/music/views/KeyHandler.tsx
+++ b/apps/src/music/views/KeyHandler.tsx
@@ -16,6 +16,7 @@ interface KeyHandlerProps {
   togglePlaying: () => void;
   playTrigger: (triggerId: string) => void;
   uiShortcutsEnabled: boolean;
+  disabled?: boolean;
 }
 
 /**
@@ -26,6 +27,7 @@ const KeyHandler: React.FunctionComponent<KeyHandlerProps> = ({
   togglePlaying,
   playTrigger,
   uiShortcutsEnabled,
+  disabled,
 }) => {
   const analyticsReporter = useContext(AnalyticsContext);
   const dispatch = useDispatch();
@@ -46,10 +48,11 @@ const KeyHandler: React.FunctionComponent<KeyHandlerProps> = ({
       // Don't handle a keyboard shortcut if the active element is an
       // input field or textarea, since the user is probably trying to type something.
       if (
-        document.activeElement &&
-        ['input', 'textarea'].includes(
-          document.activeElement.tagName.toLowerCase()
-        )
+        disabled ||
+        (document.activeElement &&
+          ['input', 'textarea'].includes(
+            document.activeElement.tagName.toLowerCase()
+          ))
       ) {
         return;
       }
@@ -91,7 +94,14 @@ const KeyHandler: React.FunctionComponent<KeyHandlerProps> = ({
         togglePlaying();
       }
     },
-    [togglePlaying, playTrigger, reportKeyPress, dispatch, uiShortcutsEnabled]
+    [
+      togglePlaying,
+      playTrigger,
+      reportKeyPress,
+      dispatch,
+      uiShortcutsEnabled,
+      disabled,
+    ]
   );
 
   useEffect(() => {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -735,6 +735,10 @@ class UnconnectedMusicView extends React.Component {
           uiShortcutsEnabled={
             AppConfig.getValue('ui-keyboard-shortcuts-enabled') === 'true'
           }
+          disabled={
+            this.props.levelProperties?.appName !== 'music' ||
+            this.props.isPlayView
+          }
         />
         <MusicLabView
           blocklyDivId={BLOCKLY_DIV_ID}


### PR DESCRIPTION
Because Music Lab remains mounted in the background, its KeyHandler component can still respond to click events, which meant that commands like Space (which runs the song) still worked on non-Music levels (i.e. a panels level in the HOC progression). Fix here is to disable the keyhandler on non-music levels. 

This also disables it in share view since key commands like trigger work kind of unexpectedly (they do technically trigger correctly, but throw off the playhead and there is no clear UI for them). Once we have a clear UI for triggers in share view, we can look at re-enabling this.

## Links

https://codedotorg.atlassian.net/browse/LABS-1086
https://codedotorg.atlassian.net/browse/LABS-1111

## Testing story

Tested on Music Lab HOC progression, standalone levels, and lab2 showcase progression.