### PR TITLE
[JIMT][CT-822] - MaybeDraggable

### DIFF
--- a/apps/src/codebridge/FileBrowser/Draggable.tsx
+++ b/apps/src/codebridge/FileBrowser/Draggable.tsx
@@ -17,7 +17,18 @@ type DraggableProps = {
   Component?: keyof JSX.IntrinsicElements;
 };
 
-export const Draggable = ({
+/**
+ * A React component that makes its children draggable using the `useDraggable` hook. Should wrap around a FileBrowserRow.
+ * If you -don't- want a row to be draggable, but still want a wrapper, you can wrap it in NotDraggable, below.
+ *
+ * @param props - The props for the `Draggable` component.
+ * @param props.children - The content to be made draggable.
+ * @param props.data - An object containing data associated with the draggable element. data must be of type DragDataType.
+ * @param props.Component - (Optional) The underlying HTML element to use as the draggable container.
+ *                         - Defaults to `'div'`.
+ * @returns A React element with the provided children, styled for dragging and handling drag events.
+ */
+export const Draggable: React.FunctionComponent<DraggableProps> = ({
   children,
   data,
   Component = 'div',
@@ -43,3 +54,7 @@ export const Draggable = ({
     children
   );
 };
+
+export const NotDraggable: React.FunctionComponent<DraggableProps> = ({
+  children,
+}) => <>{children}</>;

--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -37,7 +37,7 @@ import {
   DndDataContextProvider,
   useDndDataContext,
 } from './DnDDataContextProvider';
-import {Draggable} from './Draggable';
+import {Draggable, NotDraggable} from './Draggable';
 import {Droppable} from './Droppable';
 import {FileBrowserHeaderPopUpButton} from './FileBrowserHeaderPopUpButton';
 import FileRow from './FileRow';
@@ -230,16 +230,15 @@ const InnerFileBrowser = React.memo(
               setFileType,
               enableMenu: !dragData?.id || isDraggingLocked,
             };
-            return isDraggingLocked ? (
-              <FileRow {...fileRowProps} />
-            ) : (
-              <Draggable
+            const MaybeDraggable = isDraggingLocked ? NotDraggable : Draggable;
+            return (
+              <MaybeDraggable
                 data={{id: f.id, type: DragType.FILE, parentId: f.folderId}}
                 key={f.id}
                 Component="li"
               >
                 <FileRow {...fileRowProps} />
-              </Draggable>
+              </MaybeDraggable>
             );
           })}
       </>


### PR DESCRIPTION
Tiny tweak - just pulls apart the explicit ternary with different returns into a single return with a `MaybeDraggable` wrapper component that'll make things either `Draggable` or `NotDraggable` depending upon needs.

## Links

- jira ticket: [CT-822](https://codedotorg.atlassian.net/browse/CT-822)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
