### PR TITLE
Create embeddable version of the state map

### DIFF
--- a/lib/state_abbr.rb
+++ b/lib/state_abbr.rb
@@ -101,4 +101,4 @@ STATE_ABBR_HASH = {
   WY: 'Wyoming',
 }.freeze
 
-STATE_ABBR_WITH_DC_HASH = STATE_ABBR_HASH.merge({DC: 'Washington DC'})
+STATE_ABBR_WITH_DC_HASH = STATE_ABBR_HASH.merge({DC: 'Washington, D.C.'})

--- a/lib/state_abbr.rb
+++ b/lib/state_abbr.rb
@@ -101,4 +101,4 @@ STATE_ABBR_HASH = {
   WY: 'Wyoming',
 }.freeze
 
-STATE_ABBR_WITH_DC_HASH = STATE_ABBR_HASH.merge({DC: 'Washington, D.C.'})
+STATE_ABBR_WITH_DC_HASH = STATE_ABBR_HASH.merge({DC: 'Washington DC'})

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -284,6 +284,11 @@ class Documents < Sinatra::Base
       response.headers['X-Frame-Options'] = 'ALLOWALL'
     end
 
+    if @header['embeddable']
+      response.headers['X-Frame-Options'] = 'ALLOWALL'
+      response.headers['Content-Security-Policy'] = 'frame-ancestors *'
+    end
+
     if @header['content-type']
       response.headers['Content-Type'] = @header['content-type']
     end

--- a/pegasus/sites.v3/code.org/layouts/default.haml
+++ b/pegasus/sites.v3/code.org/layouts/default.haml
@@ -3,17 +3,16 @@
 .wrapper
   = view :unsupported_browser
 
-  -if request.path.include?('/global/fa')
-    = view :"global/fa/farsiheader"
-  -elsif request.site == 'code.org'
-    = view :header
-  -elsif @header['theme'] == 'responsive'
-    #desktop-header.desktop-feature
+  -unless @header['no_header']
+    -if request.path.include?('/global/fa')
+      = view :"global/fa/farsiheader"
+    -elsif request.site == 'code.org'
       = view :header
-    #mobile-header.mobile-headers.mobile-feature
-      = view :mobile_header_responsive
-  -else
-    = view :header
+    -elsif @header['theme'] == 'responsive'
+      #desktop-header.desktop-feature
+        = view :header
+      #mobile-header.mobile-headers.mobile-feature
+        = view :mobile_header_responsive
 
   -if @header['theme'] == 'responsive'
     -if @header['responsivePadMobile']
@@ -84,16 +83,17 @@
       %br/
   .push
 
-- if request.path.include?('/global/fa')
-  = view :"global/fa/farsifooter"
--elsif @header['theme'] == 'responsive' || 'responsive_full_width'
-  .desktop-feature
-    -if @header['footer'] == 'donor_footer'
-      = view :donor_slider
+- unless @header['no_footer']
+  - if request.path.include?('/global/fa')
+    = view :"global/fa/farsifooter"
+  -elsif @header['theme'] == 'responsive' || 'responsive_full_width'
+    .desktop-feature
+      -if @header['footer'] == 'donor_footer'
+        = view :donor_slider
+      = view :footer
+    .mobile-headers.mobile-feature
+      -if @header['footer'] == 'donor_footer'
+        = view :donor_slider
+      = view :mobile_footer_responsive
+  -else
     = view :footer
-  .mobile-headers.mobile-feature
-    -if @header['footer'] == 'donor_footer'
-      = view :donor_slider
-    = view :mobile_footer_responsive
--else
-  = view :footer

--- a/pegasus/sites.v3/code.org/layouts/default.haml
+++ b/pegasus/sites.v3/code.org/layouts/default.haml
@@ -13,6 +13,8 @@
         = view :header
       #mobile-header.mobile-headers.mobile-feature
         = view :mobile_header_responsive
+    -else
+      = view :header
 
   -if @header['theme'] == 'responsive'
     -if @header['responsivePadMobile']

--- a/pegasus/sites.v3/code.org/public/embeddable_state_map.haml
+++ b/pegasus/sites.v3/code.org/public/embeddable_state_map.haml
@@ -1,0 +1,13 @@
+---
+theme: responsive
+no_header: true
+no_footer: true 
+---
+
+%script{:src=>"/js/jquery.placeholder.js"}
+%link{:href=>"/css/promote.css", :rel=>"stylesheet"}
+%link{:href=>"/css/interactive-map.css", :rel=>"stylesheet"}
+
+#interactive-map.section.clear
+  = view :interactive_map, use_url: false
+

--- a/pegasus/sites.v3/code.org/public/embeddable_state_map.haml
+++ b/pegasus/sites.v3/code.org/public/embeddable_state_map.haml
@@ -3,6 +3,7 @@ theme: responsive
 no_header: true
 no_footer: true
 embeddable: true
+english_only: true
 ---
 
 - fill_color = request.params['fill_color']

--- a/pegasus/sites.v3/code.org/public/embeddable_state_map.haml
+++ b/pegasus/sites.v3/code.org/public/embeddable_state_map.haml
@@ -4,10 +4,14 @@ no_header: true
 no_footer: true 
 ---
 
+- fill_color = request.params['fill_color']
+- stroke_color = request.params['stroke_color']
+- hover_color = request.params['hover_color']
+- click_color = request.params['click_color']
+
 %script{:src=>"/js/jquery.placeholder.js"}
 %link{:href=>"/css/promote.css", :rel=>"stylesheet"}
 %link{:href=>"/css/interactive-map.css", :rel=>"stylesheet"}
 
 #interactive-map.section.clear
-  = view :interactive_map, use_url: false
-
+  = view :interactive_map, use_url: false, fill_color: fill_color, stroke_color: stroke_color, hover_color: hover_color, click_color: click_color

--- a/pegasus/sites.v3/code.org/public/embeddable_state_map.haml
+++ b/pegasus/sites.v3/code.org/public/embeddable_state_map.haml
@@ -1,7 +1,8 @@
 ---
 theme: responsive
 no_header: true
-no_footer: true 
+no_footer: true
+embeddable: true
 ---
 
 - fill_color = request.params['fill_color']

--- a/pegasus/sites.v3/code.org/views/interactive_map.haml
+++ b/pegasus/sites.v3/code.org/views/interactive_map.haml
@@ -1,10 +1,10 @@
 - require 'state_abbr'
 
 - advocacy_variation ||= false
-- fill_color = '#0094a3'
-- stroke_color = 'white'
-- hover_color = '#59cad3'
-- click_color = '#ffa400'
+- fill_color ||= '#0094a3'
+- stroke_color ||= 'white'
+- hover_color ||= '#59cad3'
+- click_color ||= '#ffa400'
 
 #state-list.phone-feature
   - if advocacy_variation

--- a/pegasus/sites.v3/code.org/views/promote_state.haml
+++ b/pegasus/sites.v3/code.org/views/promote_state.haml
@@ -1,7 +1,7 @@
 -require 'state_abbr'
 -data = DB[:cdo_state_promote].where(state_code_s:state).first
 -pass if data.nil?
--statename = get_us_state_from_abbr(state)
+-statename = get_us_state_from_abbr(state, include_dc: true)
 -statename_no_space = statename.gsub(/\s+/, "")
 -petition_url = data[:petition_url_t]
 %script{type: "text/javascript", src: "/shared/js/helpers.js"}

--- a/pegasus/sites.v3/code.org/views/theme_common_body_after.haml
+++ b/pegasus/sites.v3/code.org/views/theme_common_body_after.haml
@@ -1,3 +1,4 @@
-=view :display_language_lightbox
+- unless @header['english_only']
+  =view :display_language_lightbox
 =view :cookie_banner
 =view :font_awesome_icon_class


### PR DESCRIPTION
Creates an embeddable version of the state map at /embeddable_state_map.

Additionally, allows the colors of the map to be specified by URL param. The new movement site is likely to use different branding and would want different colors.

Default:

![Screenshot 2024-10-31 at 8 27 15 AM](https://github.com/user-attachments/assets/24ae5d75-523d-490d-9b42-bcc0f4b92398)

With `fill_color=%238c52ba` specified (`%23` is the URL encoding for `#` and my browser was not automatically encoding it)

![Screenshot 2024-10-31 at 8 32 45 AM](https://github.com/user-attachments/assets/bba3b09e-90cc-436f-96e6-84b8b05348b8)

With `fill_color=%238c52ba&stroke_color=orange` specified

![Screenshot 2024-10-31 at 8 34 12 AM](https://github.com/user-attachments/assets/f77c6936-7927-4a96-bf02-ec03d02668ef)

With `fill_color=%238c52ba&click_color=%2359cad3&hover_color=%23d6b6f0`


https://github.com/user-attachments/assets/837a7e80-b47b-471f-a37c-a0cfae800c28




How it looks (quickly) embedded in LeadPages. This isn't perfect, but there are things we can do on the LeadPages side to make it better. There also may be adjustments we need to make closer to the time on our side, but I'd like to get more clarity on other pieces first.

<img width="1421" alt="Screenshot 2024-10-31 at 1 55 01 PM" src="https://github.com/user-attachments/assets/4ae55014-1c9a-41ec-832a-b50f97597652">

