### PR TITLE
Music: fix trigger last measure update

### DIFF
--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -196,7 +196,10 @@ const musicSlice = createSlice({
       action: PayloadAction<{events: PlaybackEvent[]; lastMeasure: number}>
     ) => {
       state.playbackEvents.push(...action.payload.events);
-      state.lastMeasure = action.payload.lastMeasure;
+      state.lastMeasure = Math.max(
+        state.lastMeasure,
+        action.payload.lastMeasure
+      );
     },
     addOrderedFunctions: (
       state,


### PR DESCRIPTION
Quick fix for a minor bug where if your song was longer than the default number of measures and you triggered a sound that was shorter than the remaining length of the song, the last measure would incorrectly update to the end of the triggered sound, not the end of the remaining song. In practice, this bug would only appear on projects that exceeded the starting default length (currently 40 measures), and when the playhead went beyond that point.

Note that there is a related bug that is even more minor, but will need a more holistic fix to address: if you have a song that exceeds the default number of measures, and you trigger a shorter sound, and **then** change code mid-playback so that all events are re-queued, then the last measure will incorrectly show the end of the last trigger, not the end of the full song. However in order to fix this, we would need to do a more holistic refactor of how the sequencer executes and calculates the last measure. Since this only manifests in this specific case after the song reaches quite a long length, it feels like something we can address later/post-launch.

Before fix:

https://github.com/user-attachments/assets/7fed7ae9-4052-4d34-a9da-c19df3162803

After fix:

https://github.com/user-attachments/assets/896fd08b-ae46-4acd-ade8-a93dff0bb874

## Links

https://codedotorg.atlassian.net/browse/LABS-847

## Testing story

Tested locally.

## Follow-up work

Logging related bug in https://codedotorg.atlassian.net/browse/LABS-847
