### PR TITLE
P20/help fix flaky header hamburger tests

### DIFF
--- a/dashboard/test/ui/features/platform/hamburger.feature
+++ b/dashboard/test/ui/features/platform/hamburger.feature
@@ -7,7 +7,7 @@ Feature: Hamburger dropdown
     And I change the browser window size to 1300 by 768
     Then I wait to see ".header_button"
     Then element "#hamburger-icon" is not visible
-    Then I change the browser window size to 1280 by 1024
+    Then I maximize the browser window
 
   @no_mobile
   @eyes
@@ -31,7 +31,7 @@ Feature: Hamburger dropdown
     And I see "#report-bug"
     And I see no difference for "Signed out small desktop hamburger"
     And I close my eyes
-    Then I change the browser window size to 1280 by 1024
+    Then I maximize the browser window
 
   @no_mobile
   Scenario: Signed out user in English should see hamburger on tablet
@@ -51,7 +51,7 @@ Feature: Hamburger dropdown
     And I see "#legal_entries"
     And I see "#support"
     And I see "#report-bug"
-    Then I change the browser window size to 1280 by 1024
+    Then I maximize the browser window
 
   @only_phone
   Scenario: Signed out user should see Sign in and Create account buttons on code.org mobile
@@ -318,7 +318,7 @@ Feature: Hamburger dropdown
       | Help and support       | https://support.code.org/                       |
       | Report a problem       | https://support.code.org/hc/en-us/requests/new  |
 
-    Then I change the browser window size to 1280 by 1024
+    Then I maximize the browser window
     And I delete the cookie named "_loc_notice"
 
   @chrome
@@ -463,7 +463,7 @@ Feature: Hamburger dropdown
       | Report a problem       | https://support.code.org/hc/en-us/requests/new  |
       | Teacher forum          | https://forum.code.org/                          |
 
-    Then I change the browser window size to 1280 by 1024
+    Then I maximize the browser window
     Then I delete the cookie named "_loc_notice"
 
   @chrome
@@ -488,5 +488,5 @@ Feature: Hamburger dropdown
       | Help and support       | https://support.code.org/                      |
       | Report a problem       | https://support.code.org/hc/en-us/requests/new |
 
-    Then I change the browser window size to 1280 by 1024
+    Then I maximize the browser window
     Then I delete the cookie named "_loc_notice"

--- a/dashboard/test/ui/features/platform/header.feature
+++ b/dashboard/test/ui/features/platform/header.feature
@@ -35,7 +35,7 @@ Feature: Header navigation bar
     And element "#header-help" is not visible
     And element "#header-about" is not visible
     And element "#header-incubator" is not visible
-    Then I change the browser window size to 1280 by 1024
+    Then I maximize the browser window
 
   Scenario: Student in English should see 4 header links
     Given I create a student named "Sally Student" and go home

--- a/dashboard/test/ui/features/step_definitions/browser_control.rb
+++ b/dashboard/test/ui/features/step_definitions/browser_control.rb
@@ -2,6 +2,11 @@ And(/^I change the browser window size to (\d+) by (\d+)$/) do |length, height|
   @browser.manage.window.resize_to(length, height)
 end
 
+And(/^I maximize the browser window$/) do
+  max_width, max_height = @browser.execute_script('return [window.screen.availWidth, window.screen.availHeight];')
+  @browser.manage.window.resize_to(max_width, max_height)
+end
+
 # for explanation of js function, see
 # https://stackoverflow.com/questions/45243992/verification-of-element-in-viewport-in-selenium
 # upd. e2 is for the case when element is partially hidden by other elemnts


### PR DESCRIPTION
Just a simple patch to handle differing window sizes within the single session header tests. It so happens that the 1280 width isn't the actual default... the non-single-session tests always revert the window size to the "maximum" size, which was a tricky thing to notice.

This adds the ability to re-establish the maximum size such that these single session tests can revert themselves at the end to support the next tests in the file.

## Links

- jira ticket: [P20-1257](https://codedotorg.atlassian.net/browse/P20-1257)
- jira ticket: [P20-1258](https://codedotorg.atlassian.net/browse/P20-1258)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
