### PR TITLE
Fix Gen AI PL urls

### DIFF
--- a/pegasus/sites.v3/code.org/public/curriculum/generative-ai.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/generative-ai.haml
@@ -51,7 +51,7 @@ theme: responsive_full_width
         %a.link-button{href: CDO.studio_url("/courses/exploring-gen-ai-2024?viewAs=Instructor")}
           =hoc_s(:call_to_action_explore_course)
         %br
-        %a.link-button.secondary{href: CDO.studio_url("/s/self-paced-gen-ai-2024")}
+        %a.link-button.secondary{href: CDO.studio_url("/courses/self-paced-exploring-gen-ai-2024")}
           =hoc_s("gen_ai_page.teach_complete_course.explore_gen_ai_card.see_pl")
       .clear
 
@@ -99,7 +99,7 @@ theme: responsive_full_width
         %p.overline=hoc_s("gen_ai_page.preparing_to_explore.teaching_card.overline")
         %h3=hoc_s("gen_ai_page.preparing_to_explore.teaching_card.title")
         %p=hoc_s("gen_ai_page.preparing_to_explore.teaching_card.desc")
-        %a.link-button{href: CDO.studio_url("/s/self-paced-gen-ai-2024")}
+        %a.link-button{href: CDO.studio_url("/courses/self-paced-exploring-gen-ai-2024")}
           =hoc_s("gen_ai_page.preparing_to_explore.teaching_card.button")
 
 %section


### PR DESCRIPTION
In [this PR](https://github.com/code-dot-org/code-dot-org/pull/61026), the PL urls were set to the wrong link (as noted in [this thread](https://codedotorg.slack.com/archives/C05PP07KC1L/p1730305311123449)) on the [Gen AI page](https://code.org/curriculum/generative-ai). This PR fixes them to use the production-ready urls: /courses/self-paced-exploring-gen-ai-2024.

## Previous
"Teach the complete course" section:
![broken top link](https://github.com/user-attachments/assets/57632d05-5da6-41a0-a2c9-55aa350cb857)

"Preparing to teach Exploring Generative AI" section:
![broken bottom link](https://github.com/user-attachments/assets/ac1fbe4e-f4be-4ab0-a56c-9f70d0855a6f)

## New
"Teach the complete course" section:
![fixed top](https://github.com/user-attachments/assets/b451d7f7-1491-4507-8485-05378a3c2c7c)

"Preparing to teach Exploring Generative AI" section:
![fixed bottom](https://github.com/user-attachments/assets/27bf229a-ad15-42c3-8bba-e5374cda485a)

## Links
Slack discussion: [here](https://codedotorg.slack.com/archives/C05PP07KC1L/p1730305311123449)
PR these links were originally added: [here](https://github.com/code-dot-org/code-dot-org/pull/61026)

## Testing story
Local testing.
