### PR TITLE
Reduce Redis session traffic

### DIFF
--- a/dashboard/config/initializers/session_store.rb
+++ b/dashboard/config/initializers/session_store.rb
@@ -1,7 +1,7 @@
 require 'cdo/cookie_helpers'
 
 session_cookie_key = environment_specific_cookie_name('_learn_session')
-Dashboard::Application.config.session_store :redis_store,
+Dashboard::Application.config.session_store Middlewares::RedisSessionStore,
   key: session_cookie_key,
   servers: [CDO.session_store_server || 'redis://localhost:6379/0/session'],
   secure: !CDO.no_https_store && (!Rails.env.development? || CDO.https_development),

--- a/dashboard/lib/middlewares/redis_session_store.rb
+++ b/dashboard/lib/middlewares/redis_session_store.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Middlewares
   class RedisSessionStore < ActionDispatch::Session::RedisStore
     # Extends +ActionDispatch::Request::Session+ to allow identifying whether a session has been changed.
@@ -8,6 +6,7 @@ module Middlewares
         @changed.present?
       end
 
+      # @see https://github.com/rails/rails/blob/v6.1.7.7/actionpack/lib/action_dispatch/request/session.rb#L229-L231
       private def load_for_write!
         @changed = true
         super
@@ -30,6 +29,7 @@ module Middlewares
       # it's likely due to the presence of options like +:max_age+ and +:expire_after+,
       # which are intended to prolong the session.
       # In this case, we can skip committing for AJAX requests to reduce Redis traffic.
+      # See: https://github.com/rack/rack/blob/v2.2.9/lib/rack/session/abstract/id.rb#L355-L357
       result = !req.xhr? if result && !session.changed? && forced_session_update?(session, options)
 
       result

--- a/dashboard/lib/middlewares/redis_session_store.rb
+++ b/dashboard/lib/middlewares/redis_session_store.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Middlewares
+  class RedisSessionStore < ActionDispatch::Session::RedisStore
+    # Extends +ActionDispatch::Request::Session+ to allow identifying whether a session has been changed.
+    module SessionExtension
+      def changed?
+        @changed.present?
+      end
+
+      private def load_for_write!
+        @changed = true
+        super
+      end
+    end
+
+    def initialize(...)
+      ActionDispatch::Request::Session.prepend(SessionExtension)
+      super
+    end
+
+    # Overrides +Rack::Session::Abstract::Persisted#commit_session?+ to skip committing
+    # unchanged sessions for AJAX requests to reduce Redis traffic.
+    #
+    # @see https://github.com/rack/rack/blob/v2.2.9/lib/rack/session/abstract/id.rb#L342
+    private def commit_session?(req, session, options)
+      result = super
+
+      # If the session has not changed but still requires committing,
+      # it's likely due to the presence of options like +:max_age+ and +:expire_after+,
+      # which are intended to prolong the session.
+      # In this case, we can skip committing for AJAX requests to reduce Redis traffic.
+      result = !req.xhr? if result && !session.changed? && forced_session_update?(session, options)
+
+      result
+    end
+  end
+end

--- a/dashboard/test/lib/middlewares/redis_session_store_test.rb
+++ b/dashboard/test/lib/middlewares/redis_session_store_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'fakeredis'
+
+class Middlewares::RedisSessionStoreTest < ActiveSupport::TestCase
+  let(:redis_session_store) {described_class.new(app)}
+
+  let(:app) {->(_env) {[200, {}, 'success']}}
+  let(:request) {ActionDispatch::TestRequest.create}
+
+  let(:session_id) {Rack::Session::SessionId.new(SecureRandom.hex)}
+  let(:session_data) {{fake_session_data: 'default'}}
+  let(:session_options) {{}}
+  let!(:session) {ActionDispatch::Request::Session.create(redis_session_store, request, session_options)}
+
+  before do
+    request.cookies['_session_id'] = session_id.to_s
+    redis_session_store.write_session(request, session_id, session_data)
+  end
+
+  describe '#commit_session?' do
+    subject(:commit_session?) {redis_session_store.send(:commit_session?, request, session, options)}
+
+    let(:options) {{}}
+
+    it 'returns false' do
+      _commit_session?.must_equal false
+    end
+
+    context 'when session is forced to be updated' do
+      let(:options) {{max_age: 10.years}}
+
+      before do
+        _(redis_session_store.send(:forced_session_update?, session, options)).must_equal true
+      end
+
+      it 'returns true' do
+        _commit_session?.must_equal true
+      end
+
+      context 'if request is an AJAX request' do
+        before do
+          request.set_header('HTTP_X_REQUESTED_WITH', 'XMLHttpRequest')
+          _(request.xhr?).must_equal true
+        end
+
+        it 'returns false' do
+          _commit_session?.must_equal false
+        end
+
+        context 'and session has been changed' do
+          before do
+            session[:fake_session_data] = 'updated'
+            _(session.changed?).must_equal true
+          end
+
+          it 'returns true' do
+            _commit_session?.must_equal true
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Prevented asynchronous AJAX requests from committing session changes unless they have made actual modifications,  resulting in only regular HTTP requests resetting the session’s expiration time.