### PR TITLE
Music: fix older drums

### DIFF
--- a/apps/src/music/blockly/extensions.js
+++ b/apps/src/music/blockly/extensions.js
@@ -1,4 +1,4 @@
-import {TICKS_PER_MEASURE} from '../constants';
+import {TICKS_PER_MEASURE, DEFAULT_PATTERN_LENGTH} from '../constants';
 import MusicLibrary from '../player/MusicLibrary';
 
 import {BlockTypes} from './blockTypes';
@@ -211,7 +211,9 @@ export const fieldPatternsValidator = function () {
         // Remove events with notes that not part of the current kit's sounds. (Ex. 1...8)
         kitNotes.includes(event.note) &&
         // Remove event with ticks that are outside the expected tick range.
-        event.tick <= newValue.length * TICKS_PER_MEASURE
+        // (Older blocks might be missing the length field.)
+        event.tick <=
+          (newValue.length || DEFAULT_PATTERN_LENGTH) * TICKS_PER_MEASURE
     );
     return newValue;
   });


### PR DESCRIPTION
This fixes an issue in which older `play drums` blocks would have their events removed.

#### Repro
Save a project with `play drums` and some events inside it, a few weeks ago.  Reopen it now.  Expected: events would still be inside it.  Actual: events would be gone, and attempting to add more would do nothing.

#### Details
https://github.com/code-dot-org/code-dot-org/pull/61602 updated the default `play drums` value to [get](https://github.com/code-dot-org/code-dot-org/pull/61602/files#diff-64f5a6e727252fd7c75488cade3df5e2f3d32a066754c237a37343f3ece7ccc1R61) a `length` property.  New instances of the block would get this property, but existing ones wouldn't.  https://github.com/code-dot-org/code-dot-org/pull/61970 added a filter to remove invalid drum events, and [depended](https://github.com/code-dot-org/code-dot-org/commit/d22fff95397ff22c1f39db62684e3c707334ea40#diff-f2bb81600c5b33c778df333b1e8651276f06f7bcda2e5516e639a7579ba0fd11R214) upon the `length` property; events without the property would be filtered out. 

#### Fix

The fix is simply to default to a length of 1 for older `play drums` blocks as they are encountered in the filter.
