### PR TITLE
Enable Connection Pooling for Redis Session Store

### DIFF
--- a/dashboard/config/initializers/session_store.rb
+++ b/dashboard/config/initializers/session_store.rb
@@ -7,5 +7,5 @@ Dashboard::Application.config.session_store :redis_store,
   servers: [CDO.session_store_server || 'redis://localhost:6379/0/session'],
   secure: !CDO.no_https_store && (!Rails.env.development? || CDO.https_development),
   domain: :all,
-  expire_after: 40.days, # users who interact with the site at least once a month will remain logged in
-  pool_size: 5 # 5 is what the new Rails connection pooling in 7.2 uses as a default; see https://github.com/rails/rails/pull/45111
+  expire_after: 40.days, # Users who interact with the site at least once a month will remain logged in.
+  pool_size: 5 # We arbitrarily use the value this would default to anyway; we just have to specify *something* here to enable pooling in the first place.

--- a/dashboard/config/initializers/session_store.rb
+++ b/dashboard/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
+require 'connection_pool'
 require 'cdo/cookie_helpers'
 
 session_cookie_key = environment_specific_cookie_name('_learn_session')
@@ -6,4 +7,5 @@ Dashboard::Application.config.session_store :redis_store,
   servers: [CDO.session_store_server || 'redis://localhost:6379/0/session'],
   secure: !CDO.no_https_store && (!Rails.env.development? || CDO.https_development),
   domain: :all,
-  expire_after: 40.days # users who interact with the site at least once a month will remain logged in
+  expire_after: 40.days, # users who interact with the site at least once a month will remain logged in
+  pool_size: 5 # 5 is what the new Rails connection pooling in 7.2 uses as a default; see https://github.com/rails/rails/pull/45111


### PR DESCRIPTION
It turns out this is really simple; you just need to specify either `pool_size` or `pool_timeout`, and `redis-rack` will create a `ConnectionPool` instance for you. I set the `pool_size` to the default value of 5, and left `pool_timeout` unspecified so it will also use the default value of 5 seconds.

I have no idea whether these are the values we want, but they seem like reasonable starting places. I believe we run one process for each of the 48 cores on each of our frontend servers, so five connections per process results in `5 * 48 * (20 to 40) = 4800 to 9600` connections total at our max scale; quite a bit fewer than we currently open.

## Links

Connection pool implementation in `redis-rack`: https://github.com/redis-store/redis-rack/blob/master/lib/redis/rack/connection.rb

`connection_pool` gem: https://github.com/mperham/connection_pool

## Testing story

I am relatively unsure how to test this. I've verified with some print statements that `redis-rack` is successfully using the connection pool, but have been so far unable to figure out a good way to track current connections in local redis.

I've confirmed that everything still works, though, so I'm comfortable deploying this without necessarily being certain about the pooling functionality. Open to pushback if anyone disagrees!

## Follow-up work

We should plan to closely monitor the effect this has on our cluster; specifically, the `CurrConnections` metric. The goal for this pooling is to reduce connections so that we are no longer in danger of breaching the 65k threshold during Hour of Code. If it reduces it enough, hopefully we can also pick up the race condition fixes in https://github.com/code-dot-org/code-dot-org/pull/61815

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
