### PR TITLE
Music: fix older drums

### DIFF
--- a/apps/src/music/blockly/FieldPattern.js
+++ b/apps/src/music/blockly/FieldPattern.js
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom';
 import color from '@cdo/apps/util/color';
 import experiments from '@cdo/apps/util/experiments';
 
+import {DEFAULT_PATTERN_LENGTH} from '../constants';
 import {generateGraphDataFromPattern} from '../utils/Patterns';
 import PatternPanel from '../views/PatternPanel';
 
@@ -35,6 +36,7 @@ class FieldPattern extends GoogleBlockly.Field {
       state.instrument = state.kit;
       delete state.kit;
     }
+    state.length ||= DEFAULT_PATTERN_LENGTH;
     this.setValue(state);
   }
 
@@ -171,10 +173,6 @@ class FieldPattern extends GoogleBlockly.Field {
     });
 
     this.renderContent();
-  }
-
-  getText() {
-    return this.getValue().kit;
   }
 
   updateSize_() {

--- a/apps/src/music/blockly/FieldPatternAi.js
+++ b/apps/src/music/blockly/FieldPatternAi.js
@@ -178,10 +178,6 @@ class FieldPatternAi extends GoogleBlockly.Field {
     this.renderContent();
   }
 
-  getText() {
-    return this.getValue().kit;
-  }
-
   updateSize_() {
     const width = FIELD_WIDTH + 2 * FIELD_PADDING;
     const height = FIELD_HEIGHT + 2 * FIELD_PADDING;


### PR DESCRIPTION
This fixes an issue in which older `play drums` blocks would have their events removed.

#### Repro
Save a project with `play drums` and some events inside it, a few weeks ago.  Reopen it now.  Expected: events would still be inside it.  Actual: events would be gone, and attempting to add more would do nothing.

#### Details
https://github.com/code-dot-org/code-dot-org/pull/61602 updated the default `play drums` value to [get](https://github.com/code-dot-org/code-dot-org/pull/61602/files#diff-64f5a6e727252fd7c75488cade3df5e2f3d32a066754c237a37343f3ece7ccc1R61) a `length` property.  New instances of the block would get this property, but existing ones wouldn't.  https://github.com/code-dot-org/code-dot-org/pull/61970 added a filter to remove invalid drum events, and [depended](https://github.com/code-dot-org/code-dot-org/commit/d22fff95397ff22c1f39db62684e3c707334ea40#diff-f2bb81600c5b33c778df333b1e8651276f06f7bcda2e5516e639a7579ba0fd11R214) upon the `length` property; events without the property would be filtered out. 

#### Fix

The fix is simply to "fix up" older `play drums` blocks as they are loaded, so that they get the missing `length` property.  

The "fix up" is done adjacent to a similar one in which the `kit` field is renamed to `instrument`. 

This change also removes a couple of unused `getText` functions which relied on that `kit` field, which was renamed to `instrument` in https://github.com/code-dot-org/code-dot-org/pull/61564.
