### PR TITLE
Raise exception if start_sauce_connect fails so drone fails fast+clear

### DIFF
--- a/bin/sauce_connect
+++ b/bin/sauce_connect
@@ -4,4 +4,8 @@ require_relative '../deployment'
 require 'cdo/sauce_connect'
 
 # Start sc, the Sauce Connect Proxy, and keep it running in the background.
-Cdo::SauceConnect.start_sauce_connect(daemonize: true)
+begin
+  Cdo::SauceConnect.start_sauce_connect(daemonize: true)
+rescue
+  exit 1
+end

--- a/lib/cdo/sauce_connect.rb
+++ b/lib/cdo/sauce_connect.rb
@@ -62,12 +62,12 @@ module Cdo
           puts "Log:"
           puts log_lines.map {|line| "  #{line}"}.join
           puts
-          if tests_started == :timeout
-            log "ERROR: timed out waiting #{SC_START_TIMEOUT_S} seconds for '#{SC_START_MESSAGE}', stopping sc"
-            stop_sauce_connect
-          else
-            log "ERROR: couldn't start sc"
-          end
+          msg = tests_started == :timeout ?
+            "ERROR: timed out waiting #{SC_START_TIMEOUT_S} seconds for '#{SC_START_MESSAGE}', stopping sc" :
+            "ERROR: couldn't start sc, stopping sc"
+          stop_sauce_connect
+          log msg
+          raise "#{msg}, see log at #{log_file.path}"
         end
       ensure
         log_file.close

--- a/lib/cdo/sauce_connect.rb
+++ b/lib/cdo/sauce_connect.rb
@@ -35,6 +35,7 @@ module Cdo
 
         cmd = [
           "sc", "run",
+          "--fail",
           "--region", "us-west-1",
           "--tunnel-domains", tunnel_domains,
           "--tunnel-name", CDO.saucelabs_tunnel_name,

--- a/lib/cdo/sauce_connect.rb
+++ b/lib/cdo/sauce_connect.rb
@@ -35,7 +35,6 @@ module Cdo
 
         cmd = [
           "sc", "run",
-          "--fail",
           "--region", "us-west-1",
           "--tunnel-domains", tunnel_domains,
           "--tunnel-name", CDO.saucelabs_tunnel_name,


### PR DESCRIPTION
Followup to #62021

When circle.rake ran start_sauce_connect, and it failed, this didn't raise an exception or stop circle.rake from running. This meant sauce_connect failures were buried deep in the UI test startup noise.

This PR makes start_sauce_connect raise an exception and stops the build as soon as the tunnel fails.