### PR TITLE
[JIMT][CT-822] FolderRow component

### DIFF
--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRow.tsx
@@ -1,0 +1,59 @@
+import {useCodebridgeContext} from '@codebridge/codebridgeContext';
+import {
+  useFileUploader,
+  useFileUploadErrorCallback,
+  useHandleFileUpload,
+} from '@codebridge/FileBrowser/hooks';
+import {ProjectFolder} from '@codebridge/types';
+import React from 'react';
+
+import {FolderRowIcon} from './FolderRowIcon';
+import {FolderRowName} from './FolderRowName';
+import {useFolderRowOptions} from './hooks';
+import {ItemRow} from './ItemRow';
+
+export type FolderRowProps = {
+  item: ProjectFolder;
+  // If the pop-up menu is enabled, we will show the 3-dot menu button on hover.
+  enableMenu: boolean;
+};
+
+/**
+ * A single folder row in the file browser. This component does not handle
+ * drag and drop, that is handled by the parent component.
+ * @param item - The ProjectFolder to be displayed.
+ * @param enableMenu - Whether to show the context menu for the folder.
+ */
+export const FolderRow: React.FunctionComponent<FolderRowProps> = ({
+  item,
+  enableMenu,
+}) => {
+  const {
+    project: {files},
+    config: {validMimeTypes},
+  } = useCodebridgeContext();
+
+  const handleFileUpload = useHandleFileUpload(files);
+  const fileUploadErrorCallback = useFileUploadErrorCallback();
+  const {startFileUpload, FileUploaderComponent} = useFileUploader({
+    callback: handleFileUpload,
+    errorCallback: fileUploadErrorCallback,
+    validMimeTypes,
+  });
+  const {toggleOpenFolder} = useCodebridgeContext();
+  const dropdownOptions = useFolderRowOptions(item, startFileUpload);
+
+  return (
+    <>
+      <FileUploaderComponent />
+      <ItemRow
+        item={item}
+        enableMenu={enableMenu}
+        dropdownOptions={dropdownOptions}
+        IconComponent={FolderRowIcon}
+        NameComponent={FolderRowName}
+        openFunction={toggleOpenFolder}
+      />
+    </>
+  );
+};

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRowIcon.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRowIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';
+
+import {FileBrowserIconComponentType} from './types';
+
+import moduleStyles from '../styles/filebrowser.module.scss';
+
+/**
+ * Renders the icon for a folder row in the file browser.
+ * @param item - The ProjectFolder for this row
+ * @returns A FontAwesomeV6Icon component representing the file icon.
+ */
+export const FolderRowIcon: FileBrowserIconComponentType = ({item}) => {
+  return (
+    <FontAwesomeV6Icon
+      iconName={item.open ? 'caret-down' : 'caret-right'}
+      iconStyle={'solid'}
+      className={moduleStyles.rowIcon}
+    />
+  );
+};

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRowName.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/FolderRowName.tsx
@@ -1,0 +1,41 @@
+import OverflowTooltip from '@codebridge/components/OverflowTooltip';
+import classNames from 'classnames';
+import React from 'react';
+
+import {useDndDataContext} from '../DnDDataContextProvider';
+
+import {FileBrowserNameComponentType} from './types';
+
+import moduleStyles from '../styles/filebrowser.module.scss';
+import darkModeStyles from '@cdo/apps/lab2/styles/dark-mode.module.scss';
+
+/**
+ * Renders the folder name for a folder row in the file browser, with an optional tooltip for long names.
+ * @param item - The ProjectFolder for this row
+ * @returns An OverflowTooltip component displaying the folder name with potential truncation.
+ */
+export const FolderRowName: FileBrowserNameComponentType = ({item}) => {
+  const {dragData, dropData} = useDndDataContext();
+  return (
+    <OverflowTooltip
+      tooltipProps={{
+        text: item.name,
+        tooltipId: `folder-tooltip-${item.id}`,
+        size: 's',
+        direction: 'onBottom',
+        className: darkModeStyles.tooltipBottom,
+      }}
+      tooltipOverlayClassName={moduleStyles.nameContainer}
+      className={moduleStyles.nameContainer}
+    >
+      <span
+        className={classNames({
+          [moduleStyles.acceptingDrop]:
+            item.id === dropData?.id && dragData?.parentId !== item.id,
+        })}
+      >
+        {item.name}
+      </span>
+    </OverflowTooltip>
+  );
+};

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/hooks/index.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/hooks/index.tsx
@@ -1,2 +1,3 @@
 export * from './useFileRowOptions';
+export * from './useFolderRowOptions';
 export * from './useStartModeFileRowOptions';

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/hooks/useFolderRowOptions.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/hooks/useFolderRowOptions.tsx
@@ -1,0 +1,98 @@
+import {useCodebridgeContext} from '@codebridge/codebridgeContext';
+import {useFileUploader, usePrompts} from '@codebridge/FileBrowser/hooks';
+import {ProjectFolder} from '@codebridge/types';
+import {getPossibleDestinationFoldersForFolder} from '@codebridge/utils';
+import {useMemo} from 'react';
+
+import codebridgeI18n from '@cdo/apps/codebridge/locale';
+
+/**
+ * Generates options for the context menu displayed for a folder row in the file browser.
+ * @param folder - The ProjectFolder object representing the folder for which options are generated.
+ * @param startFileUpload - a function to start a file upload, should be handed in from the return of `useFileUploader`
+ * @returns An array of objects representing the context menu options.
+ *   Each object has the following properties:
+ *     - `condition`:  A boolean that determines if the option should be displayed.
+ *     - `iconName`: The name of the icon to display for the option.
+ *     - `labelText`: The text label to display for the option.
+ *     - `clickHandler`: The function to be called when the option is clicked.
+ */
+export const useFolderRowOptions = (
+  folder: ProjectFolder,
+  startFileUpload: ReturnType<typeof useFileUploader>['startFileUpload']
+) => {
+  const {
+    project: {folders: projectFolders},
+  } = useCodebridgeContext();
+
+  const {
+    openConfirmDeleteFolder,
+    openMoveFolderPrompt,
+    openNewFilePrompt,
+    openNewFolderPrompt,
+    openRenameFolderPrompt,
+  } = usePrompts();
+
+  const dropdownOptions = useMemo(() => {
+    const options = [];
+    if (
+      getPossibleDestinationFoldersForFolder({
+        folder,
+        projectFolders,
+      }).length
+    ) {
+      options.push({
+        condition: true,
+        iconName: 'arrow-right',
+        labelText: codebridgeI18n.moveFolder(),
+        clickHandler: () => openMoveFolderPrompt({folderId: folder.id}),
+      });
+    }
+
+    options.push(
+      {
+        condition: true,
+        iconName: 'pencil',
+        labelText: codebridgeI18n.renameFolder(),
+        clickHandler: () => openRenameFolderPrompt({folderId: folder.id}),
+      },
+      {
+        condition: true,
+        iconName: 'folder-plus',
+        labelText: codebridgeI18n.addSubFolder(),
+        clickHandler: () => openNewFolderPrompt({parentId: folder.id}),
+      },
+      {
+        condition: true,
+        iconName: 'plus',
+        labelText: codebridgeI18n.newFile(),
+        clickHandler: () => openNewFilePrompt({folderId: folder.id}),
+      },
+      {
+        condition: true,
+        iconName: 'upload',
+        labelText: codebridgeI18n.uploadFile(),
+        clickHandler: () => startFileUpload(folder.id),
+      },
+      {
+        condition: true,
+        iconName: 'trash',
+        labelText: codebridgeI18n.deleteFolder(),
+        clickHandler: () => openConfirmDeleteFolder({folder}),
+      }
+    );
+
+    return options;
+  }, [
+    folder,
+    openConfirmDeleteFolder,
+    openMoveFolderPrompt,
+    openNewFilePrompt,
+    openNewFolderPrompt,
+    openRenameFolderPrompt,
+    projectFolders,
+    startFileUpload,
+  ]);
+
+  return dropdownOptions;
+};

--- a/apps/src/codebridge/FileBrowser/FileBrowserRow/index.tsx
+++ b/apps/src/codebridge/FileBrowser/FileBrowserRow/index.tsx
@@ -2,3 +2,6 @@ export * from './ItemRow';
 export * from './FileRow';
 export * from './FileRowIcon';
 export * from './FileRowName';
+export * from './FolderRow';
+export * from './FolderRowIcon';
+export * from './FolderRowName';

--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -1,13 +1,7 @@
 import {useCodebridgeContext} from '@codebridge/codebridgeContext';
-import OverflowTooltip from '@codebridge/components/OverflowTooltip';
 import {DEFAULT_FOLDER_ID} from '@codebridge/constants';
-import {PopUpButton} from '@codebridge/PopUpButton/PopUpButton';
-import {PopUpButtonOption} from '@codebridge/PopUpButton/PopUpButtonOption';
 import {ProjectType, FolderId} from '@codebridge/types';
-import {
-  getPossibleDestinationFoldersForFolder,
-  shouldShowFile,
-} from '@codebridge/utils';
+import {shouldShowFile} from '@codebridge/utils';
 import {
   DndContext,
   DragStartEvent,
@@ -20,8 +14,6 @@ import {
 import classNames from 'classnames';
 import React, {useMemo, useState} from 'react';
 
-import codebridgeI18n from '@cdo/apps/codebridge/locale';
-import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import {START_SOURCES} from '@cdo/apps/lab2/constants';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
@@ -36,18 +28,11 @@ import {
 import {Draggable, NotDraggable} from './Draggable';
 import {Droppable} from './Droppable';
 import {FileBrowserHeaderPopUpButton} from './FileBrowserHeaderPopUpButton';
-import {FileRow, FileRowProps} from './FileBrowserRow';
-import {
-  useFileUploader,
-  useFileUploadErrorCallback,
-  useHandleDragEnd,
-  useHandleFileUpload,
-  usePrompts,
-} from './hooks';
+import {FileRow, FileRowProps, FolderRow} from './FileBrowserRow';
+import {useHandleDragEnd} from './hooks';
 import {DragType, DragDataType, DropDataType, setFileType} from './types';
 
 import moduleStyles from './styles/filebrowser.module.scss';
-import darkModeStyles from '@cdo/apps/lab2/styles/dark-mode.module.scss';
 
 type FilesComponentProps = {
   files: ProjectType['files'];
@@ -59,27 +44,8 @@ type FilesComponentProps = {
 
 const InnerFileBrowser = React.memo(
   ({parentId, folders, files, setFileType, appName}: FilesComponentProps) => {
-    const {
-      openConfirmDeleteFolder,
-      openMoveFolderPrompt,
-      openNewFilePrompt,
-      openNewFolderPrompt,
-      openRenameFolderPrompt,
-    } = usePrompts();
-    const {
-      toggleOpenFolder,
-      config: {validMimeTypes},
-    } = useCodebridgeContext();
     const {dragData, dropData} = useDndDataContext();
     const isStartMode = getAppOptionsEditBlocks() === START_SOURCES;
-    const handleFileUpload = useHandleFileUpload(files);
-    const fileUploadErrorCallback = useFileUploadErrorCallback();
-
-    const {startFileUpload, FileUploaderComponent} = useFileUploader({
-      callback: handleFileUpload,
-      errorCallback: fileUploadErrorCallback,
-      validMimeTypes,
-    });
 
     const hasValidationFile = !!Object.values(files).find(
       f => f.type === ProjectFileType.VALIDATION
@@ -88,7 +54,6 @@ const InnerFileBrowser = React.memo(
 
     return (
       <>
-        <FileUploaderComponent />
         {Object.values(folders)
           .filter(f => f.parentId === parentId)
           .sort((a, b) => a.name.localeCompare(b.name))
@@ -105,98 +70,7 @@ const InnerFileBrowser = React.memo(
               <Draggable
                 data={{id: f.id, type: DragType.FOLDER, parentId: f.parentId}}
               >
-                <div className={moduleStyles.row}>
-                  <span
-                    className={moduleStyles.title}
-                    onClick={() => toggleOpenFolder(f.id)}
-                  >
-                    <FontAwesomeV6Icon
-                      iconName={f.open ? 'caret-down' : 'caret-right'}
-                      iconStyle={'solid'}
-                      className={moduleStyles.rowIcon}
-                    />
-
-                    <OverflowTooltip
-                      tooltipProps={{
-                        text: f.name,
-                        tooltipId: `folder-tooltip-${f.id}`,
-                        size: 's',
-                        direction: 'onBottom',
-                        className: darkModeStyles.tooltipBottom,
-                      }}
-                      tooltipOverlayClassName={moduleStyles.nameContainer}
-                      className={moduleStyles.nameContainer}
-                    >
-                      <span
-                        className={classNames({
-                          [moduleStyles.acceptingDrop]:
-                            f.id === dropData?.id &&
-                            dragData?.parentId !== f.id,
-                        })}
-                      >
-                        {f.name}
-                      </span>
-                    </OverflowTooltip>
-                  </span>
-                  {!isReadOnly && !dragData?.id && (
-                    <PopUpButton
-                      iconName="ellipsis-v"
-                      className={moduleStyles['button-kebab']}
-                    >
-                      <span className={moduleStyles['button-bar']}>
-                        {Boolean(
-                          getPossibleDestinationFoldersForFolder({
-                            folder: f,
-                            projectFolders: folders,
-                          }).length
-                        ) && (
-                          <PopUpButtonOption
-                            iconName="arrow-right"
-                            labelText={codebridgeI18n.moveFolder()}
-                            clickHandler={() =>
-                              openMoveFolderPrompt({folderId: f.id})
-                            }
-                          />
-                        )}
-                        <PopUpButtonOption
-                          iconName="pencil"
-                          labelText={codebridgeI18n.renameFolder()}
-                          clickHandler={() =>
-                            openRenameFolderPrompt({folderId: f.id})
-                          }
-                        />
-                        <PopUpButtonOption
-                          iconName="folder-plus"
-                          labelText={codebridgeI18n.addSubFolder()}
-                          clickHandler={() =>
-                            openNewFolderPrompt({parentId: f.id})
-                          }
-                        />
-                        <PopUpButtonOption
-                          iconName="plus"
-                          labelText={codebridgeI18n.newFile()}
-                          clickHandler={() =>
-                            openNewFilePrompt({folderId: f.id})
-                          }
-                        />
-
-                        <PopUpButtonOption
-                          iconName="upload"
-                          labelText={codebridgeI18n.uploadFile()}
-                          clickHandler={() => startFileUpload(f.id)}
-                        />
-
-                        <PopUpButtonOption
-                          iconName="trash"
-                          labelText={codebridgeI18n.deleteFolder()}
-                          clickHandler={() =>
-                            openConfirmDeleteFolder({folder: f})
-                          }
-                        />
-                      </span>
-                    </PopUpButton>
-                  )}
-                </div>
+                <FolderRow item={f} enableMenu={!isReadOnly && !dragData?.id} />
                 {f.open && (
                   <ul>
                     <InnerFileBrowser


### PR DESCRIPTION
I think this'll be the final refactoring PR. This breaks apart the embedded rendering of the folder rows in `FileBrower/index.tsx` into an explicit `FolderRow` component, which uses `useFolderRowOptions` to build its dropdown and hand everything up to `ItemRow` for rendering. Otherwise follows the same pattern as the work in #62149 for the `FileRow` component.

## Links

- jira ticket: [CT-822](https://codedotorg.atlassian.net/browse/CT-822)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
