### PR TITLE
Fix statsig_stable_id being re-used between session

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -399,6 +399,7 @@ const EVENTS = {
   LTI_UNLINK_MODAL_SHOWN: 'lti_unlink_modal_shown',
   LTI_UNLINK_CLICK: 'lti_unlink_click',
   LTI_UNLINK_CANCEL: 'lti_unlink_cancel',
+  LTI_DYNAMIC_REGISTRATION_COMPLETED: 'lti_dynamic_registration_completed',
 
   // Teacher Homepage
   TEACHER_HOMEPAGE_VISITED: 'Teacher Homepage Visited',

--- a/apps/src/metrics/StatsigReporter.js
+++ b/apps/src/metrics/StatsigReporter.js
@@ -58,6 +58,7 @@ class StatsigReporter {
       disableErrorLogging: true,
       overrideStableID: this.stable_id,
     };
+    this.log(`Statsig Stable ID: ${this.stable_id}`);
 
     this.initialize(this.api_key, this.user, this.options);
   }

--- a/apps/src/metrics/StatsigReporter.js
+++ b/apps/src/metrics/StatsigReporter.js
@@ -11,7 +11,6 @@ import {
   getEnvironment,
   isProductionEnvironment,
   isDevelopmentEnvironment,
-  createUuid,
 } from '../utils';
 
 // A flag that can be toggled to send events regardless of environment
@@ -51,7 +50,8 @@ class StatsigReporter {
       ? managed_test_environment_element.dataset.managedTestServer === 'true'
       : false;
     this.local_mode = !(isProductionEnvironment() || managed_test_environment);
-    this.stable_id = this.findOrCreateStableId();
+    // stable_id is set as a cookie in application_controller.rb
+    this.stable_id = cookies.get(STABLE_ID_KEY);
     this.options = {
       environment: {tier: getEnvironment()},
       localMode: this.local_mode,
@@ -141,18 +141,6 @@ class StatsigReporter {
       const environment = getEnvironment();
       return `${environment}-${userIdString}`;
     }
-  }
-
-  findOrCreateStableId() {
-    let stableId = cookies.get(STABLE_ID_KEY);
-    if (!stableId) {
-      stableId = createUuid();
-      cookies.set(STABLE_ID_KEY, stableId, {
-        expires: 400,
-        domain: 'code.org',
-      });
-    }
-    return stableId;
   }
 
   /**

--- a/apps/src/metrics/StatsigReporter.js
+++ b/apps/src/metrics/StatsigReporter.js
@@ -11,6 +11,7 @@ import {
   getEnvironment,
   isProductionEnvironment,
   isDevelopmentEnvironment,
+  createUuid,
 } from '../utils';
 
 // A flag that can be toggled to send events regardless of environment
@@ -50,8 +51,10 @@ class StatsigReporter {
       ? managed_test_environment_element.dataset.managedTestServer === 'true'
       : false;
     this.local_mode = !(isProductionEnvironment() || managed_test_environment);
-    // stable_id is set as a cookie in application_controller.rb
-    this.stable_id = cookies.get(STABLE_ID_KEY);
+    // stable_id is set as a cookie in application_controller.rb. However in a
+    // the rare case we are running outside of the application layout,
+    // set stable_id as a cookie here if it doesn't exist.
+    this.stable_id = this.findOrCreateStableId();
     this.options = {
       environment: {tier: getEnvironment()},
       localMode: this.local_mode,
@@ -129,6 +132,17 @@ class StatsigReporter {
       return false;
     }
     return Statsig.getExperiment(name).get(parameter, defaultValue);
+  }
+
+  findOrCreateStableId() {
+    let stableId = cookies.get(STABLE_ID_KEY);
+    if (!stableId) {
+      stableId = createUuid();
+      cookies.set(STABLE_ID_KEY, stableId, {
+        path: '/',
+      });
+    }
+    return stableId;
   }
 
   formatUserId(userId) {

--- a/apps/src/metrics/StatsigReporter.js
+++ b/apps/src/metrics/StatsigReporter.js
@@ -134,17 +134,6 @@ class StatsigReporter {
     return Statsig.getExperiment(name).get(parameter, defaultValue);
   }
 
-  findOrCreateStableId() {
-    let stableId = cookies.get(STABLE_ID_KEY);
-    if (!stableId) {
-      stableId = createUuid();
-      cookies.set(STABLE_ID_KEY, stableId, {
-        path: '/',
-      });
-    }
-    return stableId;
-  }
-
   formatUserId(userId) {
     const userIdString = userId.toString() || 'none';
     if (!userId) {
@@ -156,6 +145,17 @@ class StatsigReporter {
       const environment = getEnvironment();
       return `${environment}-${userIdString}`;
     }
+  }
+
+  findOrCreateStableId() {
+    let stableId = cookies.get(STABLE_ID_KEY);
+    if (!stableId) {
+      stableId = createUuid();
+      cookies.set(STABLE_ID_KEY, stableId, {
+        path: '/',
+      });
+    }
+    return stableId;
   }
 
   /**

--- a/apps/src/simpleSignUp/lti/registration/LtiDynamicRegistrationPage.tsx
+++ b/apps/src/simpleSignUp/lti/registration/LtiDynamicRegistrationPage.tsx
@@ -3,6 +3,8 @@ import React, {useState} from 'react';
 
 import {Button} from '@cdo/apps/componentLibrary/button';
 import Typography from '@cdo/apps/componentLibrary/typography';
+import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import i18n from '@cdo/locale';
 
 import styles from './styles.module.scss';
@@ -10,11 +12,13 @@ import styles from './styles.module.scss';
 interface LtiDynamicRegistrationProps {
   logoUrl: string;
   registrationID: string;
+  lmsName: string;
 }
 
 export const LtiDynamicRegistrationPage = ({
   logoUrl,
   registrationID,
+  lmsName,
 }: LtiDynamicRegistrationProps) => {
   const [submitDisable, setSubmitDisable] = useState<boolean>(false);
   const [email, setEmail] = useState('');
@@ -37,6 +41,11 @@ export const LtiDynamicRegistrationPage = ({
         // Send post message to Canvas parent window
         // https://canvas.instructure.com/doc/api/file.registration.html#registration-response
         window.parent.postMessage({subject: 'org.imsglobal.lti.close'}, '*');
+        analyticsReporter.sendEvent(
+          EVENTS.LTI_DYNAMIC_REGISTRATION_COMPLETED,
+          {lms_name: lmsName},
+          PLATFORMS.BOTH
+        );
       },
       error: xhr => {
         setHasError(true);

--- a/apps/src/sites/studio/pages/lti/v1/dynamic_registration.js
+++ b/apps/src/sites/studio/pages/lti/v1/dynamic_registration.js
@@ -14,12 +14,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const mountPoint = document.createElement('div');
   document.body.appendChild(mountPoint);
   const scriptData = getScriptData('json');
-  const {logoUrl, registrationID} = scriptData;
+  const {logoUrl, registrationID, lmsName} = scriptData;
 
   ReactDOM.render(
     <LtiDynamicRegistrationPage
       logoUrl={logoUrl}
       registrationID={registrationID}
+      lmsName={lmsName}
     />,
     mountPoint
   );

--- a/apps/test/unit/simpleSignUp/lti/registration/LtiDynamicRegistrationPageTest.tsx
+++ b/apps/test/unit/simpleSignUp/lti/registration/LtiDynamicRegistrationPageTest.tsx
@@ -11,11 +11,13 @@ import {expect} from '../../../../util/reconfiguredChai'; // eslint-disable-line
 const MOCK_DATA = {
   email: 'test@code.org',
   registrationID: '12345',
+  lmsName: 'testLMS',
 };
 
 const DEFAULT_PROPS = {
   logoUrl: 'https://code.org/assets/logo.svg',
   registrationID: MOCK_DATA.registrationID,
+  lmsName: MOCK_DATA.lmsName,
 };
 
 describe('LTI Dynamic Registration Page', () => {

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
 
   before_action :clear_sign_up_session_vars
 
-  before_action :initialize_statsig_session
+  before_action :initialize_statsig_stable_id
 
   around_action :with_global_current_user
 
@@ -402,10 +402,10 @@ class ApplicationController < ActionController::Base
     redirect_to lti_v1_account_linking_landing_path
   end
 
-  # Creates a stable statsig id for use of session tracking (whether the user is logged in or not)
-  # Use this session variable when you want to track the user journey when the user is not logged in.
-  protected def initialize_statsig_session
-    session[:statsig_stable_id] ||= SecureRandom.uuid
+  # Creates a stable statsig stable id for use of session tracking (whether the user is logged in or not)
+  # Use this cookie variable when you want to track the user journey when the user is not logged in.
+  protected def initialize_statsig_stable_id
+    cookies[:statsig_stable_id] ||= {value: SecureRandom.uuid, domain: :all, path: '/'}
   end
 
   private def pairing_still_enabled

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -402,8 +402,8 @@ class ApplicationController < ActionController::Base
     redirect_to lti_v1_account_linking_landing_path
   end
 
-  # Creates a stable statsig stable id for use of session tracking (whether the user is logged in or not)
-  # Use this cookie variable when you want to track the user journey when the user is not logged in.
+  # Creates a statsig stable id for use of signed-out user tracking.
+  # This cookie is used by the Statsig SDK for both JS and Ruby.
   protected def initialize_statsig_stable_id
     cookies[:statsig_stable_id] ||= {value: SecureRandom.uuid, domain: :all, path: '/'}
   end

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -17,7 +17,7 @@ class HomeController < ApplicationController
   # The terms_and_privacy page gets loaded in an iframe on the signup page, so skip
   # clearing the sign up tracking variables
   skip_before_action :clear_sign_up_session_vars, only: [:terms_and_privacy]
-  skip_before_action :initialize_statsig_session, only: [:health_check]
+  skip_before_action :initialize_statsig_stable_id, only: [:health_check]
 
   def set_locale
     params[:locale], ge_region = params[:locale]&.split('|')

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -41,7 +41,7 @@ class HomeController < ApplicationController
       redirect_path = redirect_uri.to_s
 
       Metrics::Events.log_event(
-        session: session,
+        request: request,
         user: current_user,
         event_name: 'Global Edition Region Selected',
         metadata: {

--- a/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
+++ b/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
@@ -33,6 +33,7 @@ module Lti
           issuer: openid_config['issuer'],
           lms_account_name: openid_config.dig(Policies::Lti::LTI_PLATFORM_CONFIGURATION, Policies::Lti::CANVAS_ACCOUNT_NAME),
         }
+        @lms_name = Policies::Lti.issuer_name(openid_config['issuer'])
         # Expire cache in 1 hour to match expiration of registration token
         @cache.write(@registration_id, registration_data, 1.hour)
         render 'lti/v1/dynamic_registration', layout: false
@@ -88,14 +89,6 @@ module Lti
             jwks_url: platform[:jwks_url],
             access_token_url: platform[:access_token_url],
             admin_email: admin_email,
-          )
-          metadata = {
-            lms_name: platform[:name],
-          }
-          Metrics::Events.log_event(
-            request: request,
-            event_name: 'lti_dynamic_registration_completed',
-            metadata: metadata,
           )
 
           return render status: :created, json: {}

--- a/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
+++ b/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
@@ -93,7 +93,7 @@ module Lti
             lms_name: platform[:name],
           }
           Metrics::Events.log_event(
-            cookies: cookies,
+            request: request,
             event_name: 'lti_dynamic_registration_completed',
             metadata: metadata,
           )

--- a/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
+++ b/dashboard/app/controllers/lti/v1/dynamic_registration_controller.rb
@@ -93,7 +93,7 @@ module Lti
             lms_name: platform[:name],
           }
           Metrics::Events.log_event(
-            session: session,
+            cookies: cookies,
             event_name: 'lti_dynamic_registration_completed',
             metadata: metadata,
           )

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -431,7 +431,7 @@ class LtiV1Controller < ApplicationController
         lms_name: platform_name,
       }
       Metrics::Events.log_event(
-        cookies: cookies,
+        request: request,
         event_name: 'lti_portal_registration_completed',
         metadata: metadata,
       )

--- a/dashboard/app/controllers/lti_v1_controller.rb
+++ b/dashboard/app/controllers/lti_v1_controller.rb
@@ -431,7 +431,7 @@ class LtiV1Controller < ApplicationController
         lms_name: platform_name,
       }
       Metrics::Events.log_event(
-        session: session,
+        cookies: cookies,
         event_name: 'lti_portal_registration_completed',
         metadata: metadata,
       )

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -167,7 +167,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # For some providers, signups can happen without ever having hit the sign_up page, where
     # our tracking data is usually populated, so do it here
     SignUpTracking.begin_sign_up_tracking(session)
-    SignUpTracking.log_oauth_callback provider, session, cookies
+    SignUpTracking.log_oauth_callback provider, request
 
     # Microsoft formats email and name differently, so update it to match expected structure
     if provider == AuthenticationOption::MICROSOFT
@@ -204,7 +204,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private def sign_in_google_oauth2(user)
-    SignUpTracking.log_oauth_callback AuthenticationOption::GOOGLE, session, cookies
+    SignUpTracking.log_oauth_callback AuthenticationOption::GOOGLE, request
     prepare_locale_cookie user
 
     if allows_section_takeover user
@@ -219,7 +219,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # For some providers, signups can happen without ever having hit the sign_up page, where
     # our tracking data is usually populated, so do it here
     SignUpTracking.begin_sign_up_tracking(session, split_test: true)
-    SignUpTracking.log_oauth_callback AuthenticationOption::GOOGLE, session, cookies
+    SignUpTracking.log_oauth_callback AuthenticationOption::GOOGLE, request
 
     user = User.new.tap do |u|
       User.initialize_new_oauth_user(u, auth_hash, auth_params)
@@ -241,7 +241,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private def sign_in_clever(user)
-    SignUpTracking.log_oauth_callback AuthenticationOption::CLEVER, session, cookies
+    SignUpTracking.log_oauth_callback AuthenticationOption::CLEVER, request
     prepare_locale_cookie user
     user.update_oauth_credential_tokens auth_hash
     sign_in_user user
@@ -254,7 +254,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # our tracking data is usually populated, so do it here
     # Clever performed poorly in our split test, so never send it to the experiment
     SignUpTracking.begin_sign_up_tracking(session, split_test: false)
-    SignUpTracking.log_oauth_callback AuthenticationOption::CLEVER, session, cookies
+    SignUpTracking.log_oauth_callback AuthenticationOption::CLEVER, request
 
     auth_hash = inject_clever_data(auth_hash())
     user = User.from_omniauth(auth_hash, auth_params, session, cookies)

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -167,7 +167,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # For some providers, signups can happen without ever having hit the sign_up page, where
     # our tracking data is usually populated, so do it here
     SignUpTracking.begin_sign_up_tracking(session)
-    SignUpTracking.log_oauth_callback provider, session
+    SignUpTracking.log_oauth_callback provider, session, cookies
 
     # Microsoft formats email and name differently, so update it to match expected structure
     if provider == AuthenticationOption::MICROSOFT
@@ -178,7 +178,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       auth_hash = inject_clever_data(auth_hash)
     end
 
-    user = User.from_omniauth(auth_hash, auth_params, session)
+    user = User.from_omniauth(auth_hash, auth_params, session, cookies)
 
     prepare_locale_cookie user
 
@@ -204,7 +204,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private def sign_in_google_oauth2(user)
-    SignUpTracking.log_oauth_callback AuthenticationOption::GOOGLE, session
+    SignUpTracking.log_oauth_callback AuthenticationOption::GOOGLE, session, cookies
     prepare_locale_cookie user
 
     if allows_section_takeover user
@@ -219,7 +219,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # For some providers, signups can happen without ever having hit the sign_up page, where
     # our tracking data is usually populated, so do it here
     SignUpTracking.begin_sign_up_tracking(session, split_test: true)
-    SignUpTracking.log_oauth_callback AuthenticationOption::GOOGLE, session
+    SignUpTracking.log_oauth_callback AuthenticationOption::GOOGLE, session, cookies
 
     user = User.new.tap do |u|
       User.initialize_new_oauth_user(u, auth_hash, auth_params)
@@ -241,7 +241,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private def sign_in_clever(user)
-    SignUpTracking.log_oauth_callback AuthenticationOption::CLEVER, session
+    SignUpTracking.log_oauth_callback AuthenticationOption::CLEVER, session, cookies
     prepare_locale_cookie user
     user.update_oauth_credential_tokens auth_hash
     sign_in_user user
@@ -254,10 +254,10 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # our tracking data is usually populated, so do it here
     # Clever performed poorly in our split test, so never send it to the experiment
     SignUpTracking.begin_sign_up_tracking(session, split_test: false)
-    SignUpTracking.log_oauth_callback AuthenticationOption::CLEVER, session
+    SignUpTracking.log_oauth_callback AuthenticationOption::CLEVER, session, cookies
 
     auth_hash = inject_clever_data(auth_hash())
-    user = User.from_omniauth(auth_hash, auth_params, session)
+    user = User.from_omniauth(auth_hash, auth_params, session, cookies)
     prepare_locale_cookie user
 
     # if the registration credentials identify us as an existing user, simply
@@ -458,7 +458,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     flash.notice = I18n.t('auth.signed_in')
 
     # Will only log if the sign_up page session cookie is set, so this is safe to call in all cases
-    SignUpTracking.log_sign_in(user, session, request)
+    SignUpTracking.log_sign_in(user, session, request, cookies)
 
     sign_in_and_redirect user
   end

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -178,7 +178,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       auth_hash = inject_clever_data(auth_hash)
     end
 
-    user = User.from_omniauth(auth_hash, auth_params, session, cookies)
+    user = User.from_omniauth(auth_hash, auth_params, request)
 
     prepare_locale_cookie user
 
@@ -257,7 +257,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     SignUpTracking.log_oauth_callback AuthenticationOption::CLEVER, request
 
     auth_hash = inject_clever_data(auth_hash())
-    user = User.from_omniauth(auth_hash, auth_params, session, cookies)
+    user = User.from_omniauth(auth_hash, auth_params, request)
     prepare_locale_cookie user
 
     # if the registration credentials identify us as an existing user, simply
@@ -458,7 +458,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     flash.notice = I18n.t('auth.signed_in')
 
     # Will only log if the sign_up page session cookie is set, so this is safe to call in all cases
-    SignUpTracking.log_sign_in(user, session, request, cookies)
+    SignUpTracking.log_sign_in(user, request)
 
     sign_in_and_redirect user
   end

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -55,7 +55,7 @@ class RegistrationsController < Devise::RegistrationsController
   def begin_sign_up
     @user = User.new(begin_sign_up_params)
     @user.validate_for_finish_sign_up
-    SignUpTracking.log_begin_sign_up(@user, session, cookies)
+    SignUpTracking.log_begin_sign_up(@user, request)
 
     if @user.errors.blank?
       PartialRegistration.persist_attributes(session, @user)
@@ -128,7 +128,7 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def cancel
     provider = PartialRegistration.get_provider(session) || 'email'
-    SignUpTracking.log_cancel_finish_sign_up(session, provider, cookies)
+    SignUpTracking.log_cancel_finish_sign_up(request, provider)
     SignUpTracking.end_sign_up_tracking(session)
 
     PartialRegistration.delete(session)

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -229,7 +229,7 @@ class RegistrationsController < Devise::RegistrationsController
       )
     end
 
-    SignUpTracking.log_sign_up_result resource, session, cookies
+    SignUpTracking.log_sign_up_result resource, request
   end
 
   #

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -55,7 +55,7 @@ class RegistrationsController < Devise::RegistrationsController
   def begin_sign_up
     @user = User.new(begin_sign_up_params)
     @user.validate_for_finish_sign_up
-    SignUpTracking.log_begin_sign_up(@user, session)
+    SignUpTracking.log_begin_sign_up(@user, session, cookies)
 
     if @user.errors.blank?
       PartialRegistration.persist_attributes(session, @user)
@@ -128,7 +128,7 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def cancel
     provider = PartialRegistration.get_provider(session) || 'email'
-    SignUpTracking.log_cancel_finish_sign_up(session, provider)
+    SignUpTracking.log_cancel_finish_sign_up(session, provider, cookies)
     SignUpTracking.end_sign_up_tracking(session)
 
     PartialRegistration.delete(session)
@@ -229,7 +229,7 @@ class RegistrationsController < Devise::RegistrationsController
       )
     end
 
-    SignUpTracking.log_sign_up_result resource, session
+    SignUpTracking.log_sign_up_result resource, session, cookies
   end
 
   #

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -863,14 +863,14 @@ class User < ApplicationRecord
   end
 
   CLEVER_ADMIN_USER_TYPES = ['district_admin', 'school_admin'].freeze
-  def self.from_omniauth(auth, params, session = nil, cookies = nil)
+  def self.from_omniauth(auth, params, request = nil)
     omniauth_user = find_by_credential(type: auth.provider, id: auth.uid)
 
     unless omniauth_user
       omniauth_user = create
       initialize_new_oauth_user(omniauth_user, auth, params)
       omniauth_user.save
-      SignUpTracking.log_sign_up_result(omniauth_user, session, cookies)
+      SignUpTracking.log_sign_up_result(omniauth_user, request)
     end
 
     omniauth_user.update_oauth_credential_tokens(auth)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -863,14 +863,14 @@ class User < ApplicationRecord
   end
 
   CLEVER_ADMIN_USER_TYPES = ['district_admin', 'school_admin'].freeze
-  def self.from_omniauth(auth, params, session = nil)
+  def self.from_omniauth(auth, params, session = nil, cookies = nil)
     omniauth_user = find_by_credential(type: auth.provider, id: auth.uid)
 
     unless omniauth_user
       omniauth_user = create
       initialize_new_oauth_user(omniauth_user, auth, params)
       omniauth_user.save
-      SignUpTracking.log_sign_up_result(omniauth_user, session)
+      SignUpTracking.log_sign_up_result(omniauth_user, session, cookies)
     end
 
     omniauth_user.update_oauth_credential_tokens(auth)

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -1,6 +1,6 @@
 - require '../shared/middleware/helpers/experiments'
 - require 'policies/lti'
-- SignUpTracking.log_load_finish_sign_up session, (@user.provider || 'email'), cookies
+- SignUpTracking.log_load_finish_sign_up request, (@user.provider || 'email')
 - require 'cpa'
 - require 'geocoder'
 - location = Geocoder.search(request.ip).try(:first)

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -1,6 +1,6 @@
 - require '../shared/middleware/helpers/experiments'
 - require 'policies/lti'
-- SignUpTracking.log_load_finish_sign_up session, (@user.provider || 'email')
+- SignUpTracking.log_load_finish_sign_up session, (@user.provider || 'email'), cookies
 - require 'cpa'
 - require 'geocoder'
 - location = Geocoder.search(request.ip).try(:first)

--- a/dashboard/app/views/devise/registrations/_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_sign_up.html.haml
@@ -1,4 +1,4 @@
-- SignUpTracking.log_load_sign_up session
+- SignUpTracking.log_load_sign_up request
 %link{href: "/shared/css/phase1-design-system.css", rel: "stylesheet"}
 %script{src: webpack_asset_path('js/devise/registrations/_sign_up.js')}
 

--- a/dashboard/app/views/lti/v1/dynamic_registration.html.haml
+++ b/dashboard/app/views/lti/v1/dynamic_registration.html.haml
@@ -23,6 +23,7 @@
     script_data = {}
     script_data[:logoUrl] = asset_path('logo.svg')
     script_data[:registrationID] = @registration_id
+    script_data[:lmsName] = @lms_name
 
   %script{src: webpack_asset_path('js/lti/v1/dynamic_registration.js'), data: {json: script_data.to_json}, 'data-ot-ignore' => ''}
   %body

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -353,8 +353,9 @@ Devise.setup do |config|
   end
 
   OmniAuth.config.before_request_phase do |env|
+    request = Rack::Request.new(env)
     Metrics::Events.log_event(
-      request: env['rack.request'],
+      request: request,
       event_name: "#{env['omniauth.strategy'].options[:name]}-begin-auth",
     )
   end

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -339,6 +339,7 @@ Devise.setup do |config|
     auth.cookies[environment_specific_cookie_name("_shortName")] = {value: "", expires: Time.at(0), domain: :all}
     auth.cookies[environment_specific_cookie_name("_experiments")] = {value: "", expires: Time.at(0), domain: :all}
     auth.cookies[environment_specific_cookie_name("_assumed_identity")] = {value: "", expires: Time.at(0), domain: :all, httponly: true}
+    auth.cookies[:statsig_stable_id] = {value: "", expires: Time.at(0), domain: :all}
 
     # These marketing cookies are set in the home_controller in init_homepage. When the user logs out, we
     # remove these cookies because they are user-specific. The cookies are set in init_homepage instead of after_set_user

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -354,7 +354,7 @@ Devise.setup do |config|
 
   OmniAuth.config.before_request_phase do |env|
     Metrics::Events.log_event(
-      cookies: env['rack.request.cookie_hash'],
+      request: env['rack.request'],
       event_name: "#{env['omniauth.strategy'].options[:name]}-begin-auth",
     )
   end

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -339,6 +339,9 @@ Devise.setup do |config|
     auth.cookies[environment_specific_cookie_name("_shortName")] = {value: "", expires: Time.at(0), domain: :all}
     auth.cookies[environment_specific_cookie_name("_experiments")] = {value: "", expires: Time.at(0), domain: :all}
     auth.cookies[environment_specific_cookie_name("_assumed_identity")] = {value: "", expires: Time.at(0), domain: :all, httponly: true}
+    # statsig_stable_id is set in the application controller so it's available for
+    # all users, both signed-in and signed-out. When the user logs out, we remove
+    # this cookie because it is user-specific.
     auth.cookies[:statsig_stable_id] = {value: "", expires: Time.at(0), domain: :all}
 
     # These marketing cookies are set in the home_controller in init_homepage. When the user logs out, we
@@ -351,9 +354,9 @@ Devise.setup do |config|
 
   OmniAuth.config.before_request_phase do |env|
     Metrics::Events.log_event(
-      session: env['rack.session'],
+      cookies: env['rack.request.cookie_hash'],
       event_name: "#{env['omniauth.strategy'].options[:name]}-begin-auth",
-      )
+    )
   end
 
   # ==> Mountable engine configurations

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -32,7 +32,7 @@ module Metrics
         event_value = event_name if event_value.nil?
         enabled_experiments = get_enabled_experiments && user.present? ? user.get_active_experiment_names : nil
         managed_test_environment = CDO.running_web_application? && CDO.test_system?
-        statsig_stable_id = cookies[:statsig_stable_id] if cookies[:statsig_stable_id].present?
+        statsig_stable_id = cookies&.[](:statsig_stable_id)
 
         if CDO.rack_env?(:development)
           log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments, statsig_stable_id: statsig_stable_id)

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -12,9 +12,9 @@ require 'cdo/statsig'
 # }
 #
 # Metrics::Events.log_event(event_name: 'some_event_name')
-# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', metadata: metadata)
-# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', event_value: 'some_event_value', metadata: metadata)
-# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', get_enabled_experiments: true)
+# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', metadata: metadata, cookies: cookies)
+# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', event_value: 'some_event_value', metadata: metadata, cookies: cookies)
+# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', get_enabled_experiments: true, cookies: cookies)
 
 module Metrics
   module Events

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -12,9 +12,9 @@ require 'cdo/statsig'
 # }
 #
 # Metrics::Events.log_event(event_name: 'some_event_name')
-# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', metadata: metadata, cookies: cookies)
-# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', event_value: 'some_event_value', metadata: metadata, cookies: cookies)
-# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', get_enabled_experiments: true, cookies: cookies)
+# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', metadata: metadata, request: request)
+# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', event_value: 'some_event_value', metadata: metadata, request: request)
+# Metrics::Events.log_event(user: current_user, event_name: 'some_event_name', get_enabled_experiments: true, request: request)
 
 module Metrics
   module Events
@@ -27,7 +27,7 @@ module Metrics
       # @event_value - the value of the event (optional)
       # @metadata - a metadata hash with relevant data (optional)
       # @get_enabled_experiments - include list of experiements the user is enrolled in (optional)
-      # @cookies - the cookies hash (optional)
+      # @request - the request hash (optional)
       def log_event(user: nil, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false, request: nil)
         event_value = event_name if event_value.nil?
         enabled_experiments = get_enabled_experiments && user.present? ? user.get_active_experiment_names : nil

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -28,11 +28,11 @@ module Metrics
       # @metadata - a metadata hash with relevant data (optional)
       # @get_enabled_experiments - include list of experiements the user is enrolled in (optional)
       # @cookies - the cookies hash (optional)
-      def log_event(user: nil, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false, cookies: nil)
+      def log_event(user: nil, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false, request: nil)
         event_value = event_name if event_value.nil?
         enabled_experiments = get_enabled_experiments && user.present? ? user.get_active_experiment_names : nil
         managed_test_environment = CDO.running_web_application? && CDO.test_system?
-        statsig_stable_id = cookies&.[](:statsig_stable_id)
+        statsig_stable_id = request&.cookies&.[]('statsig_stable_id')
 
         if CDO.rack_env?(:development)
           log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments, statsig_stable_id: statsig_stable_id)

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -27,11 +27,12 @@ module Metrics
       # @event_value - the value of the event (optional)
       # @metadata - a metadata hash with relevant data (optional)
       # @get_enabled_experiments - include list of experiements the user is enrolled in (optional)
-      def log_event(user: nil, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false, session: nil)
+      # @cookies - the cookies hash (optional)
+      def log_event(user: nil, event_name:, event_value: nil, metadata: {}, get_enabled_experiments: false, cookies: nil)
         event_value = event_name if event_value.nil?
         enabled_experiments = get_enabled_experiments && user.present? ? user.get_active_experiment_names : nil
         managed_test_environment = CDO.running_web_application? && CDO.test_system?
-        statsig_stable_id = session&.dig(:statsig_stable_id)
+        statsig_stable_id = cookies[:statsig_stable_id] if cookies[:statsig_stable_id].present?
 
         if CDO.rack_env?(:development)
           log_event_to_stdout(user: user, event_name: event_name, event_value: event_value, metadata: metadata, enabled_experiments: enabled_experiments, statsig_stable_id: statsig_stable_id)

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -216,6 +216,6 @@ module SignUpTracking
       },
       )
 
-    end_sign_up_tracking session if user.persisted?
+    end_sign_up_tracking this_session if user.persisted?
   end
 end

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -45,7 +45,7 @@ module SignUpTracking
     DCDO.get('sign_up_split_test', 0)
   end
 
-  def self.log_load_sign_up(session)
+  def self.log_load_sign_up(session, cookies)
     event_name = new_sign_up_experience?(session) ? 'load-new-sign-up-page' : 'load-sign-up-page'
     FirehoseClient.instance.put_record(
       :analysis,
@@ -67,7 +67,7 @@ module SignUpTracking
       )
   end
 
-  def self.log_begin_sign_up(user, session)
+  def self.log_begin_sign_up(user, session, cookies)
     return unless user && session
     result = user.errors.empty? ? 'success' : 'error'
     tracking_data = {
@@ -91,7 +91,7 @@ module SignUpTracking
       )
   end
 
-  def self.log_load_finish_sign_up(session, provider)
+  def self.log_load_finish_sign_up(session, provider, cookies)
     FirehoseClient.instance.put_record(
       :analysis,
       {
@@ -112,7 +112,7 @@ module SignUpTracking
       )
   end
 
-  def self.log_cancel_finish_sign_up(session, provider)
+  def self.log_cancel_finish_sign_up(session, provider, cookies)
     FirehoseClient.instance.put_record(
       :analysis,
       {
@@ -133,7 +133,7 @@ module SignUpTracking
       )
   end
 
-  def self.log_oauth_callback(provider, session)
+  def self.log_oauth_callback(provider, session, cookies)
     return unless provider && session
     event_name = session[:sign_up_tracking_expiration]&.future? ? "#{provider}-signup-callback" : "#{provider}-callback"
 
@@ -159,8 +159,8 @@ module SignUpTracking
       )
   end
 
-  def self.log_sign_in(user, session, request)
-    return unless user && session && request
+  def self.log_sign_in(user, session, request, cookies)
+    return unless user && session && request && cookies
     provider = request.env['omniauth.auth'].provider.to_s
     if session[:sign_up_tracking_expiration]&.future?
       tracking_data = {
@@ -183,7 +183,7 @@ module SignUpTracking
     end_sign_up_tracking session
   end
 
-  def self.log_sign_up_result(user, session)
+  def self.log_sign_up_result(user, session, cookies)
     return unless user && session
     sign_up_type = session[:sign_up_type]
     sign_up_type ||= user.email ? 'email' : 'other'

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -58,7 +58,7 @@ module SignUpTracking
     )
 
     Metrics::Events.log_event(
-      session: session,
+      cookies: cookies,
       event_name: event_name,
       metadata: {
         study: STUDY_NAME,
@@ -82,7 +82,7 @@ module SignUpTracking
     FirehoseClient.instance.put_record(:analysis, tracking_data)
 
     Metrics::Events.log_event(
-      session: session,
+      cookies: cookies,
       event_name: "begin-sign-up-#{result}",
       metadata: {
         study: STUDY_NAME,
@@ -103,7 +103,7 @@ module SignUpTracking
     )
 
     Metrics::Events.log_event(
-      session: session,
+      cookies: cookies,
       event_name: "#{provider}-load-finish-sign-up",
       metadata: {
         study: STUDY_NAME,
@@ -124,7 +124,7 @@ module SignUpTracking
     )
 
     Metrics::Events.log_event(
-      session: session,
+      cookies: cookies,
       event_name: "#{provider}-cancel-finish-sign-up",
       metadata: {
         study: STUDY_NAME,
@@ -150,7 +150,7 @@ module SignUpTracking
     end
 
     Metrics::Events.log_event(
-      session: session,
+      cookies: cookies,
       event_name: event_name,
       metadata: {
         study: STUDY_NAME,
@@ -172,7 +172,7 @@ module SignUpTracking
       FirehoseClient.instance.put_record(:analysis, tracking_data)
 
       Metrics::Events.log_event(
-        session: session,
+        cookies: cookies,
         event_name: "#{provider}-sign-in",
         metadata: {
           study: STUDY_NAME,
@@ -201,7 +201,7 @@ module SignUpTracking
     FirehoseClient.instance.put_record(:analysis, tracking_data)
 
     Metrics::Events.log_event(
-      session: session,
+      cookies: cookies,
       event_name: "#{sign_up_type}-sign-up-#{result}",
       metadata: {
         study: STUDY_NAME,

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -168,7 +168,7 @@ module SignUpTracking
     return unless user && request
     this_session = request.session
     provider = request.env['omniauth.auth'].provider.to_s
-    if session[:sign_up_tracking_expiration]&.future?
+    if this_session[:sign_up_tracking_expiration]&.future?
       tracking_data = {
         study: STUDY_NAME,
         study_group: study_group(this_session),
@@ -186,7 +186,7 @@ module SignUpTracking
         },
         )
     end
-    end_sign_up_tracking session
+    end_sign_up_tracking this_session
   end
 
   def self.log_sign_up_result(user, request)

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -45,36 +45,38 @@ module SignUpTracking
     DCDO.get('sign_up_split_test', 0)
   end
 
-  def self.log_load_sign_up(session, cookies)
-    event_name = new_sign_up_experience?(session) ? 'load-new-sign-up-page' : 'load-sign-up-page'
+  def self.log_load_sign_up(request)
+    this_session = request.session
+    event_name = new_sign_up_experience?(this_session) ? 'load-new-sign-up-page' : 'load-sign-up-page'
     FirehoseClient.instance.put_record(
       :analysis,
       {
         study: STUDY_NAME,
-        study_group: study_group(session),
+        study_group: study_group(this_session),
         event: event_name,
-        data_string: session[:sign_up_uid]
+        data_string: this_session[:sign_up_uid]
       }
     )
 
     Metrics::Events.log_event(
-      cookies: cookies,
+      request: request,
       event_name: event_name,
       metadata: {
         study: STUDY_NAME,
-        study_group: study_group(session),
+        study_group: study_group(this_session),
       },
       )
   end
 
-  def self.log_begin_sign_up(user, session, cookies)
-    return unless user && session
+  def self.log_begin_sign_up(user, request)
+    return unless user && request
+    this_session = request.session
     result = user.errors.empty? ? 'success' : 'error'
     tracking_data = {
       study: STUDY_NAME,
-      study_group: study_group(session),
+      study_group: study_group(this_session),
       event: "begin-sign-up-#{result}",
-      data_string: session[:sign_up_uid],
+      data_string: this_session[:sign_up_uid],
       data_json: {
         errors: user.errors&.full_messages
       }.to_json
@@ -82,117 +84,122 @@ module SignUpTracking
     FirehoseClient.instance.put_record(:analysis, tracking_data)
 
     Metrics::Events.log_event(
-      cookies: cookies,
+      request: request,
       event_name: "begin-sign-up-#{result}",
       metadata: {
         study: STUDY_NAME,
-        study_group: study_group(session),
+        study_group: study_group(this_session),
       },
       )
   end
 
-  def self.log_load_finish_sign_up(session, provider, cookies)
+  def self.log_load_finish_sign_up(request, provider)
+    this_session = request.session
     FirehoseClient.instance.put_record(
       :analysis,
       {
         study: STUDY_NAME,
-        study_group: study_group(session),
+        study_group: study_group(this_session),
         event: "#{provider}-load-finish-sign-up-page",
-        data_string: session[:sign_up_uid]
+        data_string: this_session[:sign_up_uid]
       }
     )
 
     Metrics::Events.log_event(
-      cookies: cookies,
+      request: request,
       event_name: "#{provider}-load-finish-sign-up",
       metadata: {
         study: STUDY_NAME,
-        study_group: study_group(session),
+        study_group: study_group(this_session),
       },
       )
   end
 
-  def self.log_cancel_finish_sign_up(session, provider, cookies)
+  def self.log_cancel_finish_sign_up(request, provider)
+    this_session = request.session
     FirehoseClient.instance.put_record(
       :analysis,
       {
         study: STUDY_NAME,
-        study_group: study_group(session),
+        study_group: study_group(this_session),
         event: "#{provider}-cancel-finish-sign-up",
-        data_string: session[:sign_up_uid]
+        data_string: this_session[:sign_up_uid]
       }
     )
 
     Metrics::Events.log_event(
-      cookies: cookies,
+      request: request,
       event_name: "#{provider}-cancel-finish-sign-up",
       metadata: {
         study: STUDY_NAME,
-        study_group: study_group(session),
+        study_group: study_group(this_session),
       },
       )
   end
 
-  def self.log_oauth_callback(provider, session, cookies)
-    return unless provider && session
-    event_name = session[:sign_up_tracking_expiration]&.future? ? "#{provider}-signup-callback" : "#{provider}-callback"
+  def self.log_oauth_callback(provider, request)
+    return unless provider && request
+    this_session = request.session
+    event_name = this_session[:sign_up_tracking_expiration]&.future? ? "#{provider}-signup-callback" : "#{provider}-callback"
 
-    if session[:sign_up_tracking_expiration]&.future?
+    if this_session[:sign_up_tracking_expiration]&.future?
       FirehoseClient.instance.put_record(
         :analysis,
         {
           study: STUDY_NAME,
-          study_group: study_group(session),
+          study_group: study_group(this_session),
           event: "#{provider}-callback",
-          data_string: session[:sign_up_uid]
+          data_string: this_session[:sign_up_uid]
         }
       )
     end
 
     Metrics::Events.log_event(
-      cookies: cookies,
+      request: request,
       event_name: event_name,
       metadata: {
         study: STUDY_NAME,
-        study_group: study_group(session),
+        study_group: study_group(this_session),
       },
       )
   end
 
-  def self.log_sign_in(user, session, request, cookies)
-    return unless user && session && request && cookies
+  def self.log_sign_in(user, request)
+    return unless user && request
+    this_session = request.session
     provider = request.env['omniauth.auth'].provider.to_s
     if session[:sign_up_tracking_expiration]&.future?
       tracking_data = {
         study: STUDY_NAME,
-        study_group: study_group(session),
+        study_group: study_group(this_session),
         event: "#{provider}-sign-in",
-        data_string: session[:sign_up_uid]
+        data_string: this_session[:sign_up_uid]
       }
       FirehoseClient.instance.put_record(:analysis, tracking_data)
 
       Metrics::Events.log_event(
-        cookies: cookies,
+        request: request,
         event_name: "#{provider}-sign-in",
         metadata: {
           study: STUDY_NAME,
-          study_group: study_group(session),
+          study_group: study_group(this_session),
         },
         )
     end
     end_sign_up_tracking session
   end
 
-  def self.log_sign_up_result(user, session, cookies)
-    return unless user && session
-    sign_up_type = session[:sign_up_type]
+  def self.log_sign_up_result(user, request)
+    return unless user && request
+    this_session = request.session
+    sign_up_type = this_session[:sign_up_type]
     sign_up_type ||= user.email ? 'email' : 'other'
     result = user.persisted? ? 'success' : 'error'
     tracking_data = {
       study: STUDY_NAME,
-      study_group: study_group(session),
+      study_group: study_group(this_session),
       event: "#{sign_up_type}-sign-up-#{result}",
-      data_string: session[:sign_up_uid],
+      data_string: this_session[:sign_up_uid],
       data_json: {
         detail: user.slice(*USER_ATTRIBUTES_OF_INTEREST),
         errors: user.errors&.full_messages
@@ -201,11 +208,11 @@ module SignUpTracking
     FirehoseClient.instance.put_record(:analysis, tracking_data)
 
     Metrics::Events.log_event(
-      cookies: cookies,
+      request: request,
       event_name: "#{sign_up_type}-sign-up-#{result}",
       metadata: {
         study: STUDY_NAME,
-        study_group: study_group(session),
+        study_group: study_group(this_session),
       },
       )
 

--- a/dashboard/test/controllers/lti/v1/dynamic_registration_controller_test.rb
+++ b/dashboard/test/controllers/lti/v1/dynamic_registration_controller_test.rb
@@ -39,16 +39,6 @@ class Lti::V1::DynamicRegistrationControllerTest < ActionController::TestCase
     response = {client_id: client_id}
     LtiDynamicRegistrationClient.any_instance.stubs(:make_registration_request).returns(response)
 
-    Metrics::Events.expects(:log_event).with(
-      has_entries(
-        session: session,
-        event_name: 'lti_dynamic_registration_completed',
-        metadata: {
-          lms_name: Policies::Lti::LMS_PLATFORMS[:canvas_cloud][:name],
-        },
-      )
-    )
-
     post :create_registration, params: {email: email, registration_id: registration_id}
     assert_response :created
     integration = Queries::Lti.get_lti_integration(registration_data[:issuer], client_id)

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -164,6 +164,7 @@ class HttpCache
       'rack.session',
       'remember_user_token',
       '__profilin', # Used by rack-mini-profiler
+      'statsig_stable_id',
       session_key,
       storage_id,
     ].concat(default_cookies)


### PR DESCRIPTION
This PR makes changes to how we set `statsig_stable_id`, which is used by the Statsig SDK's in both our client-side and server-side code. Rather than a long lived cookie or session value, it sets this id as a session cookie, which will be cleared when a user closes their browser.

It makes the following changes:

- Set a single session cookie from the application controller (no longer using the Rails session)
- Update the client-side Statsig SDK to use this cookie
- Update the Rails Statsig SDK to use this cookie
- Add logic to delete cookie when a user logs out
- Update `Metrics::Events.log_event` methods that were passing in the session hash to now pass in the cookies hash

<details>
<summary>Click For More Context</summary>

Right now, we are [setting statsig_stable_id](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/application_controller.rb#L408) in the application_controller in the Rails session. The issue with this is the Rails session is configured to have a [40 day expiration](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/config/initializers/session_store.rb#L9), which allows users to remain logged in as long as they visit our site at least once a month. However, this means that the `statsig_stable_id` is a long lived id that persists when a browser is closed. When users access our site on a shared computer, this `statsig_stable_id` ends up being associated with multiple users, where it should be unique to a single user.

Additionally, we are [setting statsig_stable_id](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/metrics/StatsigReporter.js#L151) on the client side as a cookie, with an expiration of 400 days. This also becomes a long lived cookie, rather than a “session” cookie, with the same behavior as outlined above.

The result of this is the RED team found that 15,872 stable_ids that have multiple user_ids (one with 227) in our Redshift cluster.

</details>

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[Jira](https://codedotorg.atlassian.net/browse/P20-1261)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
### Stable ID persists between page loads and sign in events

**Signed-out user lands on login page, `statsig_stable_id` is set as cookie**
<img width="1723" alt="Screenshot 2024-11-01 at 1 52 06 PM" src="https://github.com/user-attachments/assets/c19f38f8-ac10-4df1-810f-aea304711b8b">

**Client-side logging includes expected `statsig_stable_id`**
<img width="1681" alt="Screenshot 2024-11-01 at 1 53 18 PM" src="https://github.com/user-attachments/assets/bac83a0b-5613-4555-ae33-5d8e6e98633a">

**After sign-in user lands on home page, `statsig_stable_id` persists as expected**
<img width="1721" alt="Screenshot 2024-11-01 at 1 53 27 PM" src="https://github.com/user-attachments/assets/981d8bed-5742-465c-9e54-b033f0d9dd2c">

### Stable ID is reset/deleted as expected
**User closes browser, then re-opens. `statsig_stable_id` sets to new value as expected**
<img width="1725" alt="Screenshot 2024-11-01 at 1 54 55 PM" src="https://github.com/user-attachments/assets/738a8b2f-8d55-4c75-bf7a-6bca45dbcc69">

**`statsig_stable_id` is deleted when user signs-out**
<img width="1725" alt="Screenshot 2024-11-01 at 1 55 09 PM" src="https://github.com/user-attachments/assets/78b06a2b-414b-4e44-a774-f14e8d1c12da">

### Stable ID is logged appropriately in the backend, matching stable ID in cookie

**Stable ID set in cookie**
<img width="1722" alt="Screenshot 2024-11-01 at 2 22 00 PM" src="https://github.com/user-attachments/assets/dcf6ba21-8850-4a04-a96b-e6ab1183db54">

**Logged during Google Omni-Auth Sign-up, matches stable id in cookie**
<img width="1692" alt="Screenshot 2024-11-01 at 2 22 12 PM" src="https://github.com/user-attachments/assets/a02debd7-c7b6-415e-94d7-587bd082c798">

**`Metrics::Events.log_event` still works when the cookies object is not provided**
<img width="1168" alt="Screenshot 2024-11-01 at 2 24 10 PM" src="https://github.com/user-attachments/assets/d5e7ebd5-82ae-4d5a-b48e-06bbb214e2ea">


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
