### PR TITLE
Add code to url in login info join instructions

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1670,7 +1670,7 @@
   "loginInfo_joinStep1": "Create a Code.org account if they haven’t already done so. They can do this at {url}. Note that they can either sign up with an email address and password, or sign up through Google, Facebook, or Microsoft by clicking on one of these buttons:",
   "loginInfo_joinStep1Buttons": "Screenshot of three buttons, reading 'Continue with Google', 'Continue with Facebook', and 'Continue with Microsoft'",
   "loginInfo_joinStep2": "Sign in to their Code.org account.",
-  "loginInfo_joinStep3": "Navigate to {url}.",
+  "loginInfo_join_navigateToLink": "Navigate to {url}.",
   "loginInfo_joinStep4": "Once they press the \"Go\" button, they should be added to your section.",
   "loginInfo_noStudents": "*It looks like you don't have any students in this section! Add some students in the [Manage Students]({url}) tab for this section.*",
   "loginInfo_oauthSectionCodes": "{provider} sections do not have 6-digit section codes, so your student will not need to use a section code to login.",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1670,7 +1670,7 @@
   "loginInfo_joinStep1": "Create a Code.org account if they haven’t already done so. They can do this at {url}. Note that they can either sign up with an email address and password, or sign up through Google, Facebook, or Microsoft by clicking on one of these buttons:",
   "loginInfo_joinStep1Buttons": "Screenshot of three buttons, reading 'Continue with Google', 'Continue with Facebook', and 'Continue with Microsoft'",
   "loginInfo_joinStep2": "Sign in to their Code.org account.",
-  "loginInfo_joinStep3": "Navigate to {url}/{code}.",
+  "loginInfo_joinStep3": "Navigate to {url}.",
   "loginInfo_joinStep4": "Once they press the \"Go\" button, they should be added to your section.",
   "loginInfo_noStudents": "*It looks like you don't have any students in this section! Add some students in the [Manage Students]({url}) tab for this section.*",
   "loginInfo_oauthSectionCodes": "{provider} sections do not have 6-digit section codes, so your student will not need to use a section code to login.",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1670,7 +1670,7 @@
   "loginInfo_joinStep1": "Create a Code.org account if they haven’t already done so. They can do this at {url}. Note that they can either sign up with an email address and password, or sign up through Google, Facebook, or Microsoft by clicking on one of these buttons:",
   "loginInfo_joinStep1Buttons": "Screenshot of three buttons, reading 'Continue with Google', 'Continue with Facebook', and 'Continue with Microsoft'",
   "loginInfo_joinStep2": "Sign in to their Code.org account.",
-  "loginInfo_joinStep3": "Navigate to {url} and type in their section code: {code}.",
+  "loginInfo_joinStep3": "Navigate to {url}/{code}.",
   "loginInfo_joinStep4": "Once they press the \"Go\" button, they should be added to your section.",
   "loginInfo_noStudents": "*It looks like you don't have any students in this section! Add some students in the [Manage Students]({url}) tab for this section.*",
   "loginInfo_oauthSectionCodes": "{provider} sections do not have 6-digit section codes, so your student will not need to use a section code to login.",

--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -1,3 +1,4 @@
+import path from 'path';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
@@ -193,8 +194,8 @@ class EmailLogins extends React.Component {
           <li>
             <SafeMarkdown
               markdown={i18n.loginInfo_joinStep3({
-                url: `${studioUrlPrefix}/join`,
-                code: sectionCode,
+                url: new URL(path.join('/join', sectionCode), studioUrlPrefix)
+                  .href,
               })}
             />
           </li>

--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -193,7 +193,7 @@ class EmailLogins extends React.Component {
           <li>{i18n.loginInfo_joinStep2()}</li>
           <li>
             <SafeMarkdown
-              markdown={i18n.loginInfo_joinStep3({
+              markdown={i18n.loginInfo_join_navigateToLink({
                 url: new URL(path.join('/join', sectionCode), studioUrlPrefix)
                   .href,
               })}

--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -191,10 +191,12 @@ class EmailLogins extends React.Component {
           </li>
           <li>{i18n.loginInfo_joinStep2()}</li>
           <li>
-            {i18n.loginInfo_joinStep3({
-              url: `${studioUrlPrefix}/join`,
-              code: sectionCode,
-            })}
+            <SafeMarkdown
+              markdown={i18n.loginInfo_joinStep3({
+                url: `${studioUrlPrefix}/join`,
+                code: sectionCode,
+              })}
+            />
           </li>
           <li>{i18n.loginInfo_joinStep4()}</li>
         </ol>


### PR DESCRIPTION
Changes the join instructions link on the login info page to have the section code in the URL.

Before:
<img width="600" alt="Screenshot 2024-10-31 at 3 24 19 PM" src="https://github.com/user-attachments/assets/77dd007e-91fe-4556-b503-2b17ad9b516f">

After:
<img width="415" alt="Screenshot 2024-10-31 at 3 21 59 PM" src="https://github.com/user-attachments/assets/4b35874f-0559-4c47-9dda-336b588bd3ae">


## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1229)

## Testing story

Create an email section and click the section code or the join instructions from the gear icon.

## Deployment strategy

## Follow-up work

The instructions on this page and the manage students tab should be refactored to use one react component instead of being two separate implementations: https://codedotorg.atlassian.net/browse/P20-1267

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
