### PR TITLE
P20-1160: Log Global Edition region in Statsig

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -220,6 +220,7 @@
     "@react-bootstrap/pagination": "^1.0.0",
     "@reduxjs/toolkit": "^1.9.3",
     "@selectize/selectize": "^0.15.2",
+    "@statsig/web-analytics": "^3.2.0",
     "@types/htmlhint": "^1.1.5",
     "@types/papaparse": "^5.3.14",
     "@types/qrcode.react": "^1.0.5",

--- a/apps/script/checkEntryPoints.js
+++ b/apps/script/checkEntryPoints.js
@@ -83,6 +83,7 @@ const SILENCED = [
   'cookieBanner',
   'userHeaderEventLogger',
   'regionalPartnerMiniContact',
+  'statsigWebAnalytics',
 
   // other entry points
   'blockly',

--- a/apps/src/metrics/StatsigReporter.js
+++ b/apps/src/metrics/StatsigReporter.js
@@ -1,8 +1,11 @@
+import {StatsigClient} from '@statsig/js-client';
+import {runStatsigAutoCapture} from '@statsig/web-analytics';
 import cookies from 'js-cookie';
 import Statsig from 'statsig-js';
 
 import logToCloud from '@cdo/apps/logToCloud';
 import experiments from '@cdo/apps/util/experiments';
+import {getGlobalEditionRegion} from '@cdo/apps/util/globalEdition';
 
 import {
   getEnvironment,
@@ -21,6 +24,7 @@ class StatsigReporter {
     let user = {
       custom: {
         enabledExperiments: experiments.getEnabledExperiments(),
+        geRegion: getGlobalEditionRegion(),
       },
     };
     const user_id_element = document.querySelector('script[data-user-id]');
@@ -33,10 +37,13 @@ class StatsigReporter {
       user.userID = this.formatUserId(user_id);
       user.custom.userType = user_type;
     }
+    this.user = user;
+
     const api_element = document.querySelector(
       'script[data-statsig-api-client-key]'
     );
-    const api_key = api_element ? api_element.dataset.statsigApiClientKey : '';
+    this.api_key = api_element ? api_element.dataset.statsigApiClientKey : '';
+
     const managed_test_environment_element = document.querySelector(
       'script[data-managed-test-server]'
     );
@@ -45,13 +52,14 @@ class StatsigReporter {
       : false;
     this.local_mode = !(isProductionEnvironment() || managed_test_environment);
     this.stable_id = this.findOrCreateStableId();
-    const options = {
+    this.options = {
       environment: {tier: getEnvironment()},
       localMode: this.local_mode,
       disableErrorLogging: true,
       overrideStableID: this.stable_id,
     };
-    this.initialize(api_key, user, options);
+
+    this.initialize(this.api_key, this.user, this.options);
   }
 
   // This user object will potentially update via a setUserProperties call
@@ -161,6 +169,18 @@ class StatsigReporter {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Runs Web Analytics auto-capturing.
+   * @see https://docs.statsig.com/webanalytics/overview
+   */
+  async runAutoCapture() {
+    if (this.shouldPutRecord(ALWAYS_SEND)) {
+      const client = new StatsigClient(this.api_key, this.user, this.options);
+      runStatsigAutoCapture(client);
+      await client.initializeAsync();
+    }
   }
 }
 

--- a/apps/src/metrics/statsigWebAnalytics.js
+++ b/apps/src/metrics/statsigWebAnalytics.js
@@ -1,0 +1,4 @@
+import statsigReporter from '@cdo/apps/metrics/StatsigReporter';
+
+// Runs Statsig Web Analytics auto-capturing.
+statsigReporter.runAutoCapture();

--- a/apps/src/util/globalEdition.ts
+++ b/apps/src/util/globalEdition.ts
@@ -1,0 +1,13 @@
+import {get} from 'js-cookie';
+
+export const getGlobalEditionRegion = () => {
+  const geRegionScript = document.querySelector(
+    'script[data-ge-region]'
+  ) as HTMLScriptElement;
+
+  const geRegion = geRegionScript
+    ? geRegionScript.dataset.geRegion
+    : get('ge_region');
+
+  return geRegion || null;
+};

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -275,6 +275,7 @@ const PROFESSIONAL_DEVELOPMENT_ENTRIES = {
 const SHARED_ENTRIES = {
   cookieBanner: './src/cookieBanner/cookieBanner.js',
   userHeaderEventLogger: './src/userHeaderEventLogger/userHeaderEventLogger.js',
+  statsigWebAnalytics: './src/metrics/statsigWebAnalytics.js',
 };
 
 // prettier-ignore

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -4842,6 +4842,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@statsig/client-core@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@statsig/client-core@npm:3.2.0"
+  checksum: 8c4b9b8f680b2cc413bad369871785d98b13c5caf781a594219154424794aa2143cfa4d95904231609d137f80f74a6fdd5b2d08edcdd53f7f8ab3b47b09f96bd
+  languageName: node
+  linkType: hard
+
+"@statsig/js-client@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@statsig/js-client@npm:3.2.0"
+  dependencies:
+    "@statsig/client-core": 3.2.0
+  checksum: 2c361fb0676ef459627be40b20e546f491f233e674302e36489f3d8e5725459d0b47d0caa60ab3a8c61426acf163bb23669f9889ae7f161209e3609439e7722a
+  languageName: node
+  linkType: hard
+
+"@statsig/web-analytics@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@statsig/web-analytics@npm:3.2.0"
+  dependencies:
+    "@statsig/client-core": 3.2.0
+    "@statsig/js-client": 3.2.0
+  checksum: e34edb9e30a8018565e0977fd31be409639a057c4955a8f35951949bdb1212953bb2cfd53453371d34b4a2f26642e4e976b73080dda0fdde01a251d025cdcc59
+  languageName: node
+  linkType: hard
+
 "@storybook/addon-a11y@npm:~8.1.11":
   version: 8.1.11
   resolution: "@storybook/addon-a11y@npm:8.1.11"
@@ -8729,6 +8755,7 @@ __metadata:
     "@react-bootstrap/pagination": ^1.0.0
     "@reduxjs/toolkit": ^1.9.3
     "@selectize/selectize": ^0.15.2
+    "@statsig/web-analytics": ^3.2.0
     "@storybook/addon-a11y": ~8.1.11
     "@storybook/addon-essentials": ~8.1.11
     "@storybook/addon-webpack5-compiler-babel": ^3.0.0

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -33,7 +33,7 @@ class HomeController < ApplicationController
     # Query parameter for browser cache to be avoided and load new locale
     redirect_path = "#{redirect_path}?lang=#{params[:locale]}" if params[:locale]
 
-    unless ge_region == helpers.ge_region
+    unless ge_region == request.ge_region
       redirect_uri = URI(redirect_path)
       redirect_params = URI.decode_www_form(redirect_uri.query.to_s).to_h
       redirect_params[Rack::GlobalEdition::REGION_KEY] = ge_region
@@ -41,13 +41,13 @@ class HomeController < ApplicationController
       redirect_path = redirect_uri.to_s
 
       Metrics::Events.log_event(
+        session: session,
         user: current_user,
-        event_name: 'Global Edition Region And Locale Changed',
+        event_name: 'Global Edition Region Selected',
         metadata: {
           country: request.country_code,
-          locale: params[:locale],
           region: ge_region,
-          prevRegion: helpers.ge_region,
+          locale: params[:locale],
         }
       )
     end

--- a/dashboard/app/helpers/global_edition_helper.rb
+++ b/dashboard/app/helpers/global_edition_helper.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module GlobalEditionHelper
-  def ge_region
-    cookies[Rack::GlobalEdition::REGION_KEY]
-  end
-end

--- a/dashboard/app/helpers/locale_helper.rb
+++ b/dashboard/app/helpers/locale_helper.rb
@@ -50,7 +50,7 @@ module LocaleHelper
   def current_locale_option(global_edition: false)
     return locale unless global_edition
     # Combines the current locale with the Global Edition region, e.g. "fa-IR|fa".
-    [locale, ge_region].select(&:presence).join('|')
+    [locale, request.ge_region].select(&:presence).join('|')
   end
 
   def options_for_locale_code_select

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -36,14 +36,14 @@
   hamburger_options[:loc_prefix] = "nav.header."
   hamburger_options[:page_mode] = request.cookies['pm']
   hamburger_options[:dashboard] = true
-  hamburger_options[:ge_region] = ge_region
+  hamburger_options[:ge_region] = request.ge_region
 
   header_contents_options = {}
   header_contents_options[:user_type] = user_type
   header_contents_options[:language] = request.language
   header_contents_options[:loc_prefix] = "nav.header."
   header_contents_options[:page_mode] = request.cookies['pm']
-  header_contents_options[:ge_region] = ge_region
+  header_contents_options[:ge_region] = request.ge_region
 
   should_show_progress = (script_level || @lesson_extras) && !@is_code_reviewing
 
@@ -60,7 +60,7 @@
   user_header_options[:session_pairings] = session[:pairings]
   user_header_options[:loc_prefix] = 'nav.user.'
   user_header_options[:level] = level
-  user_header_options[:ge_region] = ge_region
+  user_header_options[:ge_region] = request.ge_region
 
   require 'cdo/hamburger'
 

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -26,6 +26,8 @@
     -# data needed for dcdo.js. This tag is needed on every page because our translation code is
     -# making use of the dcdo feature.
     %script{data: {'dcdo': DCDO.frontend_config.to_json}}
+    -# current Global Edition region
+    %script{'data-ge-region' => request.ge_region.to_s}}
     -# auth key needed for amplitude analytics.
     %script{data: {'amplitude-api-key': CDO.safe_amplitude_api_key}}
     -# auth key needed for statsig analytics
@@ -50,6 +52,8 @@
     -# which we only use when optimizing our webpack build (ie, non-development environments).
     - if CDO.optimize_webpack_assets
       %script{src: webpack_asset_path('js/code-studio-common.js'), 'data-ot-ignore' => ''}
+    - if request.ge_region
+      %script{src: webpack_asset_path('js/statsigWebAnalytics.js'), 'data-ot-ignore' => ''}
     = csrf_meta_tags
     = yield :head
     - if content_for? :og

--- a/dashboard/lib/metrics/events.rb
+++ b/dashboard/lib/metrics/events.rb
@@ -1,3 +1,4 @@
+require 'cdo/global_edition'
 require 'cdo/statsig'
 
 # This is a wrapper for the Statsig SDK.
@@ -64,32 +65,33 @@ module Metrics
 
       # Builds a StatsigUser object from a user entity
       private def build_statsig_user(user:, enabled_experiments:, statsig_stable_id:)
-        custom_ids = {stableID: statsig_stable_id}
+        user_params = {
+          user_id: '',
+          custom: {
+            geRegion: Cdo::GlobalEdition.current_region,
+          },
+          custom_ids: {
+            stableID: statsig_stable_id,
+          },
+        }
 
         if user.present?
-          custom_ids.merge!(
-            {
-              user_type: user.user_type,
-              enabled_experiments: enabled_experiments,
-            }.compact
-          )
-          StatsigUser.new({'userID' => user.id.to_s, 'custom_ids' => custom_ids})
-        else
-          StatsigUser.new({'userID' => '', 'custom_ids' => custom_ids})
+          user_params[:user_id] = user.id.to_s
+          user_params[:custom_ids][:user_type] = user.user_type if user.user_type
+          user_params[:custom_ids][:enabled_experiments] = enabled_experiments if enabled_experiments
         end
+
+        StatsigUser.new(user_params)
       end
 
       # Logs an event to stdout, useful for development and debugging
       private def log_event_to_stdout(user:, event_name:, event_value:, metadata:, enabled_experiments:, statsig_stable_id:)
-        user_id = user.present? ? user.id : ''
-        user_type = user.present? ? user.user_type : ''
         event_details = {
-          user_id: user_id,
-          custom_ids: {
-            user_type: user_type,
+          **build_statsig_user(
+            user: user,
             enabled_experiments: enabled_experiments,
-            stableID: statsig_stable_id,
-          }.compact,
+            statsig_stable_id: statsig_stable_id,
+          ).serialize(true),
           event_name: event_name,
           event_value: event_value,
           metadata: metadata,

--- a/dashboard/test/integration/global_edition_test.rb
+++ b/dashboard/test/integration/global_edition_test.rb
@@ -3,11 +3,14 @@
 require 'test_helper'
 
 class GlobalEditionTest < ActionDispatch::IntegrationTest
+  let(:document) {Nokogiri::HTML(response.body)}
+
   describe 'routing' do
     let(:international_page_path) {'/incubator'}
     let(:ge_region) {'fa'}
     let(:ge_region_locale) {'fa-IR'}
     let(:regional_page_path) {File.join('/global', ge_region, international_page_path)}
+    let(:ge_region_script_data) {document.at('script[data-ge-region]').try(:[], 'data-ge-region')}
 
     describe 'international page' do
       subject(:get_international_page) {get international_page_path, params: params}
@@ -91,6 +94,11 @@ class GlobalEditionTest < ActionDispatch::IntegrationTest
 
         must_respond_with 200
         _(path).must_equal regional_page_path
+      end
+
+      it 'script data is set' do
+        get_regional_page
+        _(ge_region_script_data).must_equal ge_region
       end
 
       it 'request cookies contains ge_region' do

--- a/lib/cdo/global_edition.rb
+++ b/lib/cdo/global_edition.rb
@@ -3,12 +3,19 @@
 module Cdo
   # Lazily loads global configurations for regional pages
   module GlobalEdition
+    REGION_KEY = 'ge_region'
+
     # Retrieves a list a global region names.
     REGIONS = Dir.glob('*.yml', base: CDO.dir('config', 'global_editions')).map {|f| File.basename(f, '.yml')}.freeze
 
     TARGET_HOSTNAMES = Set[
       CDO.dashboard_hostname,
     ].freeze
+
+    # @see +Rack::GlobalEdition::RouteHandler#response+
+    def self.current_region
+      RequestStore.store[REGION_KEY]
+    end
 
     # Freezes an entire complex data structure
     def self.deep_freeze(data)

--- a/lib/cdo/global_edition.rb
+++ b/lib/cdo/global_edition.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'request_store'
+
 module Cdo
   # Lazily loads global configurations for regional pages
   module GlobalEdition

--- a/lib/cdo/rack/global_edition.rb
+++ b/lib/cdo/rack/global_edition.rb
@@ -61,6 +61,8 @@ module Rack
         end
 
         response.finish
+      ensure
+        RequestStore.store.delete(Cdo::GlobalEdition::REGION_KEY)
       end
 
       private def region

--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -3,6 +3,7 @@ require 'rack/session/abstract/id'
 require 'ipaddr'
 require 'json'
 require 'country_codes'
+require 'cdo/global_edition'
 
 module Cdo
   module RequestExtension
@@ -126,6 +127,10 @@ module Cdo
 
     def gdpr?
       gdpr_country_code?(country)
+    end
+
+    def ge_region
+      Cdo::GlobalEdition.current_region
     end
 
     # Initialize a private instance of the SessionStore used in Dashboard, so

--- a/pegasus/sites.v3/code.org/views/header.haml
+++ b/pegasus/sites.v3/code.org/views/header.haml
@@ -1,6 +1,4 @@
 :ruby
-  require 'cdo/rack/global_edition'
-
   cookie_key = environment_specific_cookie_name '_user_type'
   user_type = request.cookies[cookie_key]
   user_type = "student" if user_type == "student_y"
@@ -14,7 +12,7 @@
   hamburger_options[:show_gallery] = true
   hamburger_options[:loc_prefix] = "header_"
   hamburger_options[:page_mode] = request.cookies['pm']
-  hamburger_options[:ge_region] = request.cookies[Rack::GlobalEdition::REGION_KEY]
+  hamburger_options[:ge_region] = request.ge_region
 
   header_contents_options = {}
   header_contents_options[:user_type] = user_type

--- a/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
+++ b/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
@@ -15,6 +15,13 @@
 
 %script{src:'https://www.googleoptimize.com/optimize.js?id=OPT-KBX3C3L'}
 
+%script{'data-statsig-api-client-key' => CDO.safe_statsig_api_client_key}}
+%script{'data-managed-test-server' => "#{CDO.running_web_application? && CDO.test_system?}"}}
+%script{'data-ge-region' => request.ge_region.to_s}}
+
+- if request.ge_region
+  %script{src: webpack_asset_path('js/statsigWebAnalytics.js'), 'data-ot-ignore' => ''}
+
 =view :fonts
 -if @header['style_min'] && request.site == 'code.org'
   =inline_css 'style-min.css'


### PR DESCRIPTION
## Summary
- Added the Global Edition region as a `custom` user attribute across all Statsig metrics.
- Enable Statsig Web Analytics auto-capturing on the Pegasus and Studio regional pages.

**Note:** Statsig Web Analytics auto-capturing will only function in Pegasus after enabling the Global Edition middleware. See: https://github.com/code-dot-org/code-dot-org/pull/62061

## Links
- JIRA task: [P20-1160](https://codedotorg.atlassian.net/browse/P20-1160)
- Original PR: https://github.com/code-dot-org/code-dot-org/pull/61989
- Revert PR: https://github.com/code-dot-org/code-dot-org/pull/62182