### PR TITLE
show TA notification bubble when there are AI evaluations to review

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -155,6 +155,7 @@
   "aiEvaluationStatusAll_ready": "AI analysis can be generated for {unevaluatedCount} student projects.",
   "aiEvaluationStatusAll_summary": "The AI assessment has successfully run for {evaluatedCount}/{totalCount} student projects.",
   "aiEvaluationDetails": "The AI Assessment runs automatically when a student presses \"submit\" for their project. If students forget to submit, you can run the AI Assessment for the entire class using the button above, or run it for an individual student while viewing their rubric.",
+  "aiEvaluationsToReview": "AI evaluations to review",
   "aiSettings": "AI Settings",
   "aiStudentAssessment": "{studentName} has achieved {understandingLevel} for this learning goal.",
   "aiSubmitShouldKeepWorking": "Student should keep working",

--- a/apps/src/code-studio/teacherPanelRedux.js
+++ b/apps/src/code-studio/teacherPanelRedux.js
@@ -6,9 +6,12 @@ import {getCurrentLevel} from './progressReduxSelectors';
 const SET_LEVELS_WITH_PROGRESS = 'progress/SET_LEVELS_WITH_PROGRESS';
 const SET_LOADING_LEVELS_WITH_PROGRESS =
   'progress/SET_LOADING_LEVELS_WITH_PROGRESS';
+const SET_LOADED_LEVELS_WITH_PROGRESS =
+  'progress/SET_LOADED_LEVELS_WITH_PROGRESS';
 
 const initialState = {
   isLoadingLevelsWithProgress: false,
+  hasLoadedLevelsWithProgress: false,
   levelsWithProgress: [],
 };
 
@@ -27,6 +30,13 @@ export default function reducer(state = initialState, action) {
     };
   }
 
+  if (action.type === SET_LOADED_LEVELS_WITH_PROGRESS) {
+    return {
+      ...state,
+      hasLoadedLevelsWithProgress: true,
+    };
+  }
+
   return state;
 }
 
@@ -39,6 +49,10 @@ export const setLevelsWithProgress = levelsWithProgress => ({
 const setLoadingLevelsWithProgress = isLoading => ({
   type: SET_LOADING_LEVELS_WITH_PROGRESS,
   isLoading,
+});
+
+const setLoadedLevelsWithProgress = () => ({
+  type: SET_LOADED_LEVELS_WITH_PROGRESS,
 });
 
 export const loadLevelsWithProgress = () => (dispatch, getState) => {
@@ -61,6 +75,7 @@ export const loadLevelsWithProgress = () => (dispatch, getState) => {
     .done(data => {
       dispatch(setLevelsWithProgress(data));
       dispatch(setLoadingLevelsWithProgress(false));
+      dispatch(setLoadedLevelsWithProgress());
     })
     .fail(err => {
       console.log(

--- a/apps/src/code-studio/teacherPanelRedux.js
+++ b/apps/src/code-studio/teacherPanelRedux.js
@@ -55,6 +55,8 @@ const setLoadedLevelsWithProgress = () => ({
   type: SET_LOADED_LEVELS_WITH_PROGRESS,
 });
 
+export const setLoadedLevelsWithProgressForTest = setLoadedLevelsWithProgress;
+
 export const loadLevelsWithProgress = () => (dispatch, getState) => {
   const state = getState();
 

--- a/apps/src/code-studio/teacherPanelTypes.ts
+++ b/apps/src/code-studio/teacherPanelTypes.ts
@@ -7,5 +7,6 @@ export interface LevelWithProgress {
 }
 
 export interface TeacherPanelState {
+  hasLoadedLevelsWithProgress: boolean;
   levelsWithProgress: LevelWithProgress[];
 }

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -16,6 +16,7 @@ import instructions, {
   setTaRubric,
 } from '@cdo/apps/redux/instructions';
 import RubricFloatingActionButton from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
+import experiments from '@cdo/apps/util/experiments';
 import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 
 $(document).ready(initPage);
@@ -111,6 +112,9 @@ function initPage() {
           PLATFORMS.BOTH
         );
       }
+      const notificationsEnabled = experiments.isEnabled(
+        experiments.TA_NOTIFICATIONS
+      );
       ReactDOM.render(
         <Provider store={getStore()}>
           <RubricFloatingActionButton
@@ -119,6 +123,7 @@ function initPage() {
             reportingData={reportingData}
             currentLevelName={config.level_name}
             aiEnabled={rubric.learningGoals.some(lg => lg.aiEnabled)}
+            notificationsEnabled={notificationsEnabled}
           />
         </Provider>,
         rubricFabMountPoint

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -74,6 +74,7 @@ function RubricFloatingActionButton({
   reportingData,
   aiEnabled,
   sectionId,
+  notificationsEnabled,
 }) {
   const sessionStorageKey = 'RubricFabOpenStateKey';
   const [isOpen, setIsOpen] = useState(
@@ -91,7 +92,8 @@ function RubricFloatingActionButton({
 
   const readyStudentCount = useAppSelector(selectReadyStudentCount);
   const hasLoadedStudentStatus = useAppSelector(selectHasLoadedStudentStatus);
-  const showCountBubble = hasLoadedStudentStatus && readyStudentCount > 0;
+  const showCountBubble =
+    notificationsEnabled && hasLoadedStudentStatus && readyStudentCount > 0;
 
   const eventData = useMemo(() => {
     return {
@@ -235,6 +237,7 @@ RubricFloatingActionButton.propTypes = {
   reportingData: reportingDataShape,
   aiEnabled: PropTypes.bool,
   sectionId: PropTypes.number,
+  notificationsEnabled: PropTypes.bool,
 };
 
 export const UnconnectedRubricFloatingActionButton = RubricFloatingActionButton;

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -183,7 +183,11 @@ function RubricFloatingActionButton({
       {showCountBubble ? (
         <div className={style.countOverlay}>
           <BodyFourText className={style.countText}>
-            <StrongText>{readyStudentCount}</StrongText>
+            <StrongText>
+              <span aria-label={i18n.aiEvaluationsToReview()}>
+                {readyStudentCount}
+              </span>
+            </StrongText>
           </BodyFourText>
         </div>
       ) : (

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -7,7 +7,12 @@ import ErrorBoundary from '@cdo/apps/lab2/ErrorBoundary';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {
+  selectHasLoadedStudentStatus,
+  selectReadyStudentCount,
+} from '@cdo/apps/templates/rubrics/teacherRubricRedux';
 import {selectedSectionSelector} from '@cdo/apps/templates/teacherDashboard/teacherSectionsReduxSelectors';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 import aiFabIcon from '@cdo/static/ai-bot-centered-teal.png';
@@ -82,6 +87,11 @@ function RubricFloatingActionButton({
   const [isTaImageLoaded, setIsTaImageLoaded] = useState(false);
 
   const [internalError, setInternalError] = useState(null);
+
+  const readyStudentCount = useAppSelector(selectReadyStudentCount);
+  const hasLoadedStudentStatus = useAppSelector(selectHasLoadedStudentStatus);
+
+  console.log('FAB', hasLoadedStudentStatus, readyStudentCount);
 
   const eventData = useMemo(() => {
     return {

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, {useEffect, useMemo, useState} from 'react';
 import {connect} from 'react-redux';
 
+import {BodyFourText, StrongText} from '@cdo/apps/componentLibrary/typography';
 import ErrorBoundary from '@cdo/apps/lab2/ErrorBoundary';
 import FontAwesome from '@cdo/apps/legacySharedComponents/FontAwesome';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
@@ -90,8 +91,7 @@ function RubricFloatingActionButton({
 
   const readyStudentCount = useAppSelector(selectReadyStudentCount);
   const hasLoadedStudentStatus = useAppSelector(selectHasLoadedStudentStatus);
-
-  console.log('FAB', hasLoadedStudentStatus, readyStudentCount);
+  const showCountBubble = hasLoadedStudentStatus && readyStudentCount > 0;
 
   const eventData = useMemo(() => {
     return {
@@ -157,8 +157,10 @@ function RubricFloatingActionButton({
   }, [isOpen]);
 
   const fabIcon = aiEnabled ? aiFabIcon : rubricFabIcon;
+  const allImagesLoaded =
+    isFabImageLoaded && (showCountBubble || isTaImageLoaded);
 
-  const showPulse = isFirstSession && isFabImageLoaded && isTaImageLoaded;
+  const showPulse = isFirstSession && allImagesLoaded && hasLoadedStudentStatus;
   const classes = showPulse
     ? classnames(style.floatingActionButton, style.pulse, 'unittest-fab-pulse')
     : style.floatingActionButton;
@@ -178,16 +180,24 @@ function RubricFloatingActionButton({
           onLoad={() => !isFabImageLoaded && setIsFabImageLoaded(true)}
         />
       </button>
-      <div
-        className={style.taOverlay}
-        style={{backgroundImage: `url(${taIcon})`}}
-      >
-        <img
-          src={taIcon}
-          alt="TA overlay"
-          onLoad={() => !isTaImageLoaded && setIsTaImageLoaded(true)}
-        />
-      </div>
+      {showCountBubble ? (
+        <div className={style.countOverlay}>
+          <BodyFourText className={style.countText}>
+            <StrongText>{readyStudentCount}</StrongText>
+          </BodyFourText>
+        </div>
+      ) : (
+        <div
+          className={style.taOverlay}
+          style={{backgroundImage: `url(${taIcon})`}}
+        >
+          <img
+            src={taIcon}
+            alt="TA overlay"
+            onLoad={() => !isTaImageLoaded && setIsTaImageLoaded(true)}
+          />
+        </div>
+      )}
       {/* TODO: do not hardcode in AI setting */}
       <ErrorBoundary
         fallback={

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -56,6 +56,36 @@
   border-style: solid;
 }
 
+.countOverlay {
+  position: fixed;
+  left: 51px;
+  bottom: 97px;
+
+  border-radius: 100px;
+  border-width: 2px;
+  border-color: $background_gray;
+  border-style: solid;
+
+  display: inline-flex;
+  height: 18px;
+  min-width: 18px;
+  padding: 2px 2px;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+
+  background: var(--sentiment-error-50, #E5311A);
+}
+
+.countText {
+  margin-top: 1px;
+  margin-bottom: 0;
+  padding: 0 2px;
+
+  color: var(--light-white, #FFF);
+  font-feature-settings: 'liga' off, 'clig' off;
+}
+
 .rubricContainer {
   position: fixed;
   left: 10px;

--- a/apps/src/templates/rubrics/rubrics.module.scss
+++ b/apps/src/templates/rubrics/rubrics.module.scss
@@ -83,7 +83,7 @@
   padding: 0 2px;
 
   color: var(--light-white, #FFF);
-  font-feature-settings: 'liga' off, 'clig' off;
+  font-variant-ligatures: no-common-ligatures;
 }
 
 .rubricContainer {

--- a/apps/src/templates/rubrics/teacherRubricRedux.ts
+++ b/apps/src/templates/rubrics/teacherRubricRedux.ts
@@ -5,6 +5,7 @@ import {
   createAsyncThunk,
 } from '@reduxjs/toolkit';
 
+import {setLoadedLevelsWithProgressForTest} from '@cdo/apps/code-studio/teacherPanelRedux';
 import {LevelWithProgress} from '@cdo/apps/code-studio/teacherPanelTypes';
 import {computeBubbleStatus} from '@cdo/apps/templates/rubrics/rubricUtils';
 import {RootState} from '@cdo/apps/types/redux';
@@ -163,6 +164,15 @@ export const loadAiEvalStatusForAll = createAsyncThunk(
         });
       }
     });
+  }
+);
+
+export const setLoadedStudentStatusForTest = createAsyncThunk(
+  'teacherRubric/setLoadedStudentStatusForTest',
+  async (_, thunkAPI) => {
+    thunkAPI.dispatch(setLoadedHasTeacherFeedback());
+    thunkAPI.dispatch(setLoadedAiEvalStatus());
+    thunkAPI.dispatch(setLoadedLevelsWithProgressForTest());
   }
 );
 

--- a/apps/src/templates/rubrics/teacherRubricRedux.ts
+++ b/apps/src/templates/rubrics/teacherRubricRedux.ts
@@ -43,6 +43,8 @@ export interface TeacherRubricState {
   hasTeacherFeedbackMap: HasTeacherFeedbackMap;
   aiEvalStatusCounters: AiEvalStatusCounters;
   aiEvalStatusMap: AiEvalStatusMap;
+  hasLoadedTeacherFeedback: boolean;
+  hasLoadedAiEvalStatus: boolean;
 }
 
 // map from user id to student progress status
@@ -55,6 +57,8 @@ const initialState: TeacherRubricState = {
   hasTeacherFeedbackMap: {},
   aiEvalStatusCounters: {},
   aiEvalStatusMap: {},
+  hasLoadedTeacherFeedback: false,
+  hasLoadedAiEvalStatus: false,
 };
 
 const teacherRubricReduxSlice = createSlice({
@@ -93,6 +97,12 @@ const teacherRubricReduxSlice = createSlice({
         return {payload: {userId, status}};
       },
     },
+    setLoadedHasTeacherFeedback: state => {
+      state.hasLoadedTeacherFeedback = true;
+    },
+    setLoadedAiEvalStatus: state => {
+      state.hasLoadedAiEvalStatus = true;
+    },
   },
 });
 
@@ -122,6 +132,7 @@ export const loadAllTeacherEvaluationData = createAsyncThunk(
         response.json().then(data => {
           initializeHasTeacherFeedbackMap(data);
           thunkAPI.dispatch(setAllTeacherEvaluationData(data));
+          thunkAPI.dispatch(setLoadedHasTeacherFeedback());
         });
       }
     });
@@ -148,6 +159,7 @@ export const loadAiEvalStatusForAll = createAsyncThunk(
           thunkAPI.dispatch(setAiEvalStatusMap(data.aiEvalStatusMap));
           delete data.aiEvalStatusMap;
           thunkAPI.dispatch(setAiEvalStatusCounters(data));
+          thunkAPI.dispatch(setLoadedAiEvalStatus());
         });
       }
     });
@@ -172,8 +184,38 @@ export const selectStudentProgressStatusMap = createSelector(
   }
 );
 
+export const selectReadyStudentCount = createSelector(
+  selectStudentProgressStatusMap,
+  statusMap =>
+    Object.values(statusMap).filter(status => status === 'READY_TO_REVIEW')
+      .length
+);
+
+export const selectHasLoadedStudentStatus = createSelector(
+  [
+    (state: RootState) => state.teacherRubric.hasLoadedTeacherFeedback,
+    (state: RootState) => state.teacherRubric.hasLoadedAiEvalStatus,
+    (state: RootState) => state.teacherPanel.hasLoadedLevelsWithProgress,
+  ],
+  (
+    hasLoadedTeacherFeedback: boolean,
+    hasLoadedAiEvalStatus: boolean,
+    hasLoadedLevelsWithProgress: boolean
+  ) => {
+    return (
+      hasLoadedTeacherFeedback &&
+      hasLoadedAiEvalStatus &&
+      hasLoadedLevelsWithProgress
+    );
+  }
+);
+
 // For internal use only
-const {setHasTeacherFeedbackMap} = teacherRubricReduxSlice.actions;
+const {
+  setHasTeacherFeedbackMap,
+  setLoadedHasTeacherFeedback,
+  setLoadedAiEvalStatus,
+} = teacherRubricReduxSlice.actions;
 
 // Exported for testing only
 export const {setAllTeacherEvaluationData, setAiEvalStatusCounters} =

--- a/apps/src/templates/rubrics/teacherRubricRedux.ts
+++ b/apps/src/templates/rubrics/teacherRubricRedux.ts
@@ -122,7 +122,7 @@ export const loadAllTeacherEvaluationData = createAsyncThunk(
       allTeacherEvaluationData: AllTeacherEvaluationData
     ) => {
       const hasFeedbackMap: HasTeacherFeedbackMap = {};
-      allTeacherEvaluationData?.forEach(userEvalData => {
+      allTeacherEvaluationData.forEach(userEvalData => {
         hasFeedbackMap[userEvalData.user_id] = userEvalData.eval.length > 0;
       });
       thunkAPI.dispatch(setHasTeacherFeedbackMap(hasFeedbackMap));

--- a/apps/src/templates/rubrics/teacherRubricRedux.ts
+++ b/apps/src/templates/rubrics/teacherRubricRedux.ts
@@ -122,7 +122,7 @@ export const loadAllTeacherEvaluationData = createAsyncThunk(
       allTeacherEvaluationData: AllTeacherEvaluationData
     ) => {
       const hasFeedbackMap: HasTeacherFeedbackMap = {};
-      allTeacherEvaluationData.forEach(userEvalData => {
+      allTeacherEvaluationData?.forEach(userEvalData => {
         hasFeedbackMap[userEvalData.user_id] = userEvalData.eval.length > 0;
       });
       thunkAPI.dispatch(setHasTeacherFeedbackMap(hasFeedbackMap));

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -29,6 +29,8 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS =
   'teacher-dashboard-section-buttons';
 experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
   'teacher-dashboard-section-buttons-alternate-text';
+// Enables notifications in Teaching Assistant when new AI evaluations are ready to review
+experiments.TA_NOTIFICATIONS = 'taNotifications';
 experiments.FINISH_DIALOG_METRICS = 'finish-dialog-metrics';
 experiments.I18N_TRACKING = 'frontend-i18n-tracking';
 experiments.TIME_SPENT = 'time-spent';

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -27,6 +27,7 @@ import {RubricAiEvaluationLimits} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 import {
+  stubFetch,
   studentAlice,
   levelNotTried,
   levelSubmitted,
@@ -67,49 +68,6 @@ describe('RubricContainer', () => {
         await Promise.resolve();
       });
     }
-  }
-
-  function stubFetch({
-    evalStatusForUser = {},
-    evalStatusForAll = {},
-    aiEvals = [],
-    teacherEvals = [],
-    tourStatus = {},
-    updateTourStatus = {},
-  }) {
-    fetchStub.mockImplementation(url => {
-      // Stubs out getting the AI status for a particular user
-      if (/rubrics\/\d+\/ai_evaluation_status_for_user.*/.test(url)) {
-        return Promise.resolve(new Response(JSON.stringify(evalStatusForUser)));
-      }
-
-      // Stubs out getting the overall AI status, which is part of RubricSettings but
-      // useful to track alongside the user status, here
-      if (/rubrics\/\d+\/ai_evaluation_status_for_all.*/.test(url)) {
-        return Promise.resolve(new Response(JSON.stringify(evalStatusForAll)));
-      }
-
-      // This stubs out polling the AI evaluation list which can be provided by 'data'
-      if (/rubrics\/\d+\/get_ai_evaluations.*/.test(url)) {
-        return Promise.resolve(new Response(JSON.stringify(aiEvals)));
-      }
-
-      if (/rubrics\/\d+\/get_teacher_evaluations_for_all.*/.test(url)) {
-        return Promise.resolve(new Response(JSON.stringify(teacherEvals)));
-      }
-
-      if (/rubrics\/\w+\/get_ai_rubrics_tour_seen/.test(url)) {
-        return Promise.resolve(new Response(JSON.stringify(tourStatus)));
-      }
-
-      if (/rubrics\/\w+\/update_ai_rubrics_tour_seen/.test(url)) {
-        return Promise.resolve(new Response(JSON.stringify(updateTourStatus)));
-      }
-
-      if (/rubrics\/\d+\/run_ai_evaluations_for_user$/.test(url)) {
-        return Promise.resolve(new Response(JSON.stringify({})));
-      }
-    });
   }
 
   beforeEach(() => {
@@ -404,7 +362,10 @@ describe('RubricContainer', () => {
     // 2. User clicks button to run analysis
 
     // Stub out running the assessment and have it return pending status when asked next
-    stubFetch({evalStatusForUser: pendingJson, tourStatus: {seen: true}});
+    fetchStub = stubFetch({
+      evalStatusForUser: pendingJson,
+      tourStatus: {seen: true},
+    });
 
     fireEvent.click(button);
 

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -23,12 +23,27 @@ import teacherRubric from '@cdo/apps/templates/rubrics/teacherRubricRedux';
 import teacherSections, {
   setStudentsForCurrentSection,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import {
-  RubricAiEvaluationLimits,
-  RubricAiEvaluationStatus,
-  LevelStatus,
-} from '@cdo/generated-scripts/sharedConstants';
+import {RubricAiEvaluationLimits} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
+
+import {
+  studentAlice,
+  levelNotTried,
+  levelSubmitted,
+  notAttemptedJson,
+  notAttemptedJsonAll,
+  readyJson,
+  readyJsonAll,
+  pendingJson,
+  runningJson,
+  successJson,
+  successJsonAll,
+  defaultRubric,
+  noEvals,
+  oneEval,
+  defaultStudentInfo,
+  mockAiEvaluations,
+} from './rubricTestHelper';
 
 jest.mock('@cdo/apps/util/HttpClient', () => ({
   post: jest.fn().mockResolvedValue({
@@ -38,24 +53,7 @@ jest.mock('@cdo/apps/util/HttpClient', () => ({
 
 fetch.mockIf(/\/rubrics\/.*/, JSON.stringify(''));
 
-const studentAlice = {id: 11, name: 'Alice'};
 const sectionId = 999;
-const levelNotTried = {
-  id: '123',
-  assessment: null,
-  contained: false,
-  paired: false,
-  partnerNames: null,
-  partnerCount: null,
-  isConceptLevel: false,
-  levelNumber: 4,
-  passed: false,
-  status: LevelStatus.not_tried,
-};
-const levelSubmitted = {
-  ...levelNotTried,
-  status: LevelStatus.submitted,
-};
 
 describe('RubricContainer', () => {
   let store;
@@ -150,134 +148,6 @@ describe('RubricContainer', () => {
     restoreRedux();
     jest.restoreAllMocks();
   });
-
-  const notAttemptedJson = {
-    status: null,
-    attempted: false,
-    lastAttemptEvaluated: false,
-    csrfToken: 'abcdef',
-  };
-
-  const notAttemptedJsonAll = {
-    attemptedCount: 0,
-    attemptedUnevaluatedCount: 1,
-    csrfToken: 'abcdef',
-    aiEvalStatusMap: {
-      11: 'NOT_STARTED',
-    },
-  };
-
-  const readyJson = {
-    status: null,
-    attempted: true,
-    lastAttemptEvaluated: false,
-    csrfToken: 'abcdef',
-  };
-
-  const readyJsonAll = {
-    attemptedCount: 1,
-    attemptedUnevaluatedCount: 1,
-    csrfToken: 'abcdef',
-    aiEvalStatusMap: {
-      11: 'IN_PROGRESS',
-    },
-  };
-
-  const pendingJson = {
-    attempted: true,
-    lastAttemptEvaluated: false,
-    csrfToken: 'abcdef',
-    status: RubricAiEvaluationStatus.QUEUED,
-  };
-
-  const runningJson = {
-    attempted: true,
-    lastAttemptEvaluated: false,
-    csrfToken: 'abcdef',
-    status: RubricAiEvaluationStatus.RUNNING,
-  };
-
-  const successJson = {
-    attempted: true,
-    lastAttemptEvaluated: true,
-    csrfToken: 'abcdef',
-    status: RubricAiEvaluationStatus.SUCCESS,
-  };
-
-  const successJsonAll = {
-    attemptedCount: 1,
-    attemptedUnevaluatedCount: 0,
-    csrfToken: 'abcdef',
-    aiEvalStatusMap: {
-      11: 'READY_TO_REVIEW',
-    },
-  };
-
-  const defaultRubric = {
-    id: 1,
-    learningGoals: [
-      {
-        id: 1,
-        key: '1',
-        learningGoal: 'goal 1',
-        aiEnabled: false,
-        evidenceLevels: [{understanding: 1, id: 1, teacherDescription: 'test'}],
-      },
-      {
-        id: 2,
-        key: '2',
-        learningGoal: 'goal 2',
-        aiEnabled: true,
-        evidenceLevels: [{understanding: 1, id: 2, teacherDescription: 'test'}],
-      },
-    ],
-    script: {
-      id: 42,
-    },
-    lesson: {
-      position: 3,
-      name: 'Data Structures',
-    },
-    level: {
-      id: 107,
-      name: 'test_level',
-      position: 7,
-    },
-  };
-
-  const noEvals = [
-    {
-      user_name: 'Stilgar',
-      user_id: 1,
-      eval: [],
-    },
-    {
-      user_name: 'Chani',
-      user_id: 1,
-      eval: [],
-    },
-  ];
-
-  const oneEval = [
-    {
-      user_name: studentAlice.name,
-      user_id: studentAlice.id,
-      eval: [
-        {
-          feedback: '',
-          id: studentAlice.id,
-          learning_goal_id: 1587,
-          understanding: 0,
-        },
-      ],
-    },
-  ];
-
-  const defaultStudentInfo = {user_id: 11, name: 'Alice'};
-
-  const mockAiEvaluations = [
-    {id: 2, learning_goal_id: 2, understanding: 0, aiConfidencePassFail: 2},
-  ];
 
   it('switches components when tabs are clicked', async () => {
     stubFetch({

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -24,6 +24,7 @@ import teacherSections, {
 import i18n from '@cdo/locale';
 
 import {
+  stubFetch,
   defaultRubric,
   studentAlice,
   levelNotTried,
@@ -58,29 +59,6 @@ const defaultProps = {
 describe('RubricFloatingActionButton', () => {
   let sendEventSpy;
   let store;
-  let fetchStub;
-
-  function stubFetch({
-    evalStatusForAll = {},
-    teacherEvals = [],
-    tourStatus = {seen: true},
-  }) {
-    fetchStub.mockImplementation(url => {
-      // Stubs out getting the overall AI status, which is part of RubricSettings but
-      // useful to track alongside the user status, here
-      if (/rubrics\/\d+\/ai_evaluation_status_for_all.*/.test(url)) {
-        return Promise.resolve(new Response(JSON.stringify(evalStatusForAll)));
-      }
-
-      if (/rubrics\/\d+\/get_teacher_evaluations_for_all.*/.test(url)) {
-        return Promise.resolve(new Response(JSON.stringify(teacherEvals)));
-      }
-
-      if (/rubrics\/\w+\/get_ai_rubrics_tour_seen/.test(url)) {
-        return Promise.resolve(new Response(JSON.stringify(tourStatus)));
-      }
-    });
-  }
 
   beforeEach(() => {
     stubRedux();
@@ -91,7 +69,7 @@ describe('RubricFloatingActionButton', () => {
     });
     store = getStore();
     sendEventSpy = jest.spyOn(analyticsReporter, 'sendEvent');
-    fetchStub = jest.spyOn(window, 'fetch');
+    jest.spyOn(window, 'fetch');
     sessionStorage.clear();
   });
 

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -99,6 +99,25 @@ describe('RubricFloatingActionButton', () => {
       expect(fab.classList.contains('unittest-fab-pulse')).toBe(true);
     });
 
+    it('does not render pulse animation before student status loads', () => {
+      render(
+        <Provider store={store}>
+          <RubricFloatingActionButton {...defaultProps} />
+        </Provider>
+      );
+
+      const fabImage = screen.getByRole('img', {name: 'AI bot'});
+      fireEvent.load(fabImage);
+
+      const taImage = screen.getByRole('img', {name: 'TA overlay'});
+      fireEvent.load(taImage);
+
+      const fab = screen.getByRole('button', {
+        name: i18n.openOrCloseTeachingAssistant(),
+      });
+      expect(fab.classList.contains('unittest-fab-pulse')).toBe(false);
+    });
+
     it('does not render pulse animation when open state is present in session storage', () => {
       store.dispatch(setLoadedStudentStatusForTest());
       sessionStorage.setItem('RubricFabOpenStateKey', 'false');

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -54,6 +54,7 @@ const defaultProps = {
   rubric: defaultRubric,
   currentLevelName: 'test_level',
   studentLevelInfo: null,
+  notificationsEnabled: true,
 };
 
 describe('RubricFloatingActionButton', () => {
@@ -199,6 +200,30 @@ describe('RubricFloatingActionButton', () => {
       const countBubble = screen.getByLabelText(i18n.aiEvaluationsToReview());
       expect(countBubble).toBeVisible();
       expect(countBubble.textContent).toBe('1');
+    });
+
+    it('does not render count bubble when notifications are disabled', async () => {
+      stubFetch({
+        evalStatusForAll: successJsonAll,
+        teacherEvals: noEvals,
+      });
+
+      render(
+        <Provider store={store}>
+          <RubricFloatingActionButton
+            {...defaultProps}
+            sectionId={sectionId}
+            notificationsEnabled={false}
+          />
+        </Provider>
+      );
+
+      await wait();
+
+      expect(screen.getByRole('img', {name: 'TA overlay'})).toBeVisible();
+      expect(
+        screen.queryByLabelText(i18n.aiEvaluationsToReview())
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -12,7 +12,9 @@ import {
   restoreRedux,
 } from '@cdo/apps/redux';
 import {UnconnectedRubricFloatingActionButton as RubricFloatingActionButton} from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
-import teacherRubric from '@cdo/apps/templates/rubrics/teacherRubricRedux';
+import teacherRubric, {
+  setLoadedStudentStatusForTest,
+} from '@cdo/apps/templates/rubrics/teacherRubricRedux';
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import i18n from '@cdo/locale';
 
@@ -70,6 +72,7 @@ describe('RubricFloatingActionButton', () => {
 
   describe('pulse animation', () => {
     it('renders pulse animation when session storage is empty', () => {
+      store.dispatch(setLoadedStudentStatusForTest());
       render(
         <Provider store={store}>
           <RubricFloatingActionButton {...defaultProps} />
@@ -97,6 +100,7 @@ describe('RubricFloatingActionButton', () => {
     });
 
     it('does not render pulse animation when open state is present in session storage', () => {
+      store.dispatch(setLoadedStudentStatusForTest());
       sessionStorage.setItem('RubricFabOpenStateKey', 'false');
       render(
         <Provider store={store}>

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -70,7 +70,7 @@ describe('RubricFloatingActionButton', () => {
     });
     store = getStore();
     sendEventSpy = jest.spyOn(analyticsReporter, 'sendEvent');
-    jest.spyOn(window, 'fetch');
+    stubFetch({});
     sessionStorage.clear();
   });
 

--- a/apps/test/unit/templates/rubrics/rubricTestHelper.js
+++ b/apps/test/unit/templates/rubrics/rubricTestHelper.js
@@ -3,6 +3,55 @@ import {
   RubricAiEvaluationStatus,
 } from '@cdo/generated-scripts/sharedConstants';
 
+// stub fetch
+
+export function stubFetch({
+  evalStatusForUser = {},
+  evalStatusForAll = {},
+  aiEvals = [],
+  teacherEvals = [],
+  tourStatus = {},
+  updateTourStatus = {},
+}) {
+  const fetchStub = jest.spyOn(window, 'fetch');
+
+  fetchStub.mockImplementation(url => {
+    // Stubs out getting the AI status for a particular user
+    if (/rubrics\/\d+\/ai_evaluation_status_for_user.*/.test(url)) {
+      return Promise.resolve(new Response(JSON.stringify(evalStatusForUser)));
+    }
+
+    // Stubs out getting the overall AI status, which is part of RubricSettings but
+    // useful to track alongside the user status, here
+    if (/rubrics\/\d+\/ai_evaluation_status_for_all.*/.test(url)) {
+      return Promise.resolve(new Response(JSON.stringify(evalStatusForAll)));
+    }
+
+    // This stubs out polling the AI evaluation list which can be provided by 'data'
+    if (/rubrics\/\d+\/get_ai_evaluations.*/.test(url)) {
+      return Promise.resolve(new Response(JSON.stringify(aiEvals)));
+    }
+
+    if (/rubrics\/\d+\/get_teacher_evaluations_for_all.*/.test(url)) {
+      return Promise.resolve(new Response(JSON.stringify(teacherEvals)));
+    }
+
+    if (/rubrics\/\w+\/get_ai_rubrics_tour_seen/.test(url)) {
+      return Promise.resolve(new Response(JSON.stringify(tourStatus)));
+    }
+
+    if (/rubrics\/\w+\/update_ai_rubrics_tour_seen/.test(url)) {
+      return Promise.resolve(new Response(JSON.stringify(updateTourStatus)));
+    }
+
+    if (/rubrics\/\d+\/run_ai_evaluations_for_user$/.test(url)) {
+      return Promise.resolve(new Response(JSON.stringify({})));
+    }
+  });
+
+  return fetchStub;
+}
+
 // rubric
 
 export const defaultRubric = {

--- a/apps/test/unit/templates/rubrics/rubricTestHelper.js
+++ b/apps/test/unit/templates/rubrics/rubricTestHelper.js
@@ -1,0 +1,165 @@
+import {
+  LevelStatus,
+  RubricAiEvaluationStatus,
+} from '@cdo/generated-scripts/sharedConstants';
+
+// rubric
+
+export const defaultRubric = {
+  id: 1,
+  learningGoals: [
+    {
+      id: 1,
+      key: '1',
+      learningGoal: 'goal 1',
+      aiEnabled: false,
+      evidenceLevels: [{understanding: 1, id: 1, teacherDescription: 'test'}],
+    },
+    {
+      id: 2,
+      key: '2',
+      learningGoal: 'goal 2',
+      aiEnabled: true,
+      evidenceLevels: [{understanding: 1, id: 2, teacherDescription: 'test'}],
+    },
+  ],
+  script: {
+    id: 42,
+  },
+  lesson: {
+    position: 3,
+    name: 'Data Structures',
+  },
+  level: {
+    id: 107,
+    name: 'test_level',
+    position: 7,
+  },
+};
+
+// students
+
+export const studentAlice = {id: 11, name: 'Alice'};
+
+export const defaultStudentInfo = {user_id: 11, name: 'Alice'};
+
+// level info
+
+export const levelNotTried = {
+  id: '123',
+  assessment: null,
+  contained: false,
+  paired: false,
+  partnerNames: null,
+  partnerCount: null,
+  isConceptLevel: false,
+  levelNumber: 4,
+  passed: false,
+  status: LevelStatus.not_tried,
+};
+export const levelSubmitted = {
+  ...levelNotTried,
+  status: LevelStatus.submitted,
+};
+
+// ai evaluations
+
+export const mockAiEvaluations = [
+  {id: 2, learning_goal_id: 2, understanding: 0, aiConfidencePassFail: 2},
+];
+
+// ai eval status
+
+export const notAttemptedJson = {
+  status: null,
+  attempted: false,
+  lastAttemptEvaluated: false,
+  csrfToken: 'abcdef',
+};
+
+export const readyJson = {
+  status: null,
+  attempted: true,
+  lastAttemptEvaluated: false,
+  csrfToken: 'abcdef',
+};
+
+export const pendingJson = {
+  attempted: true,
+  lastAttemptEvaluated: false,
+  csrfToken: 'abcdef',
+  status: RubricAiEvaluationStatus.QUEUED,
+};
+
+export const runningJson = {
+  attempted: true,
+  lastAttemptEvaluated: false,
+  csrfToken: 'abcdef',
+  status: RubricAiEvaluationStatus.RUNNING,
+};
+
+export const successJson = {
+  attempted: true,
+  lastAttemptEvaluated: true,
+  csrfToken: 'abcdef',
+  status: RubricAiEvaluationStatus.SUCCESS,
+};
+
+// ai eval status all
+
+export const notAttemptedJsonAll = {
+  attemptedCount: 0,
+  attemptedUnevaluatedCount: 1,
+  csrfToken: 'abcdef',
+  aiEvalStatusMap: {
+    11: 'NOT_STARTED',
+  },
+};
+
+export const readyJsonAll = {
+  attemptedCount: 1,
+  attemptedUnevaluatedCount: 1,
+  csrfToken: 'abcdef',
+  aiEvalStatusMap: {
+    11: 'IN_PROGRESS',
+  },
+};
+
+export const successJsonAll = {
+  attemptedCount: 1,
+  attemptedUnevaluatedCount: 0,
+  csrfToken: 'abcdef',
+  aiEvalStatusMap: {
+    11: 'READY_TO_REVIEW',
+  },
+};
+
+// teacher evaluations
+
+export const noEvals = [
+  {
+    user_name: 'Stilgar',
+    user_id: 1,
+    eval: [],
+  },
+  {
+    user_name: 'Chani',
+    user_id: 1,
+    eval: [],
+  },
+];
+
+export const oneEval = [
+  {
+    user_name: studentAlice.name,
+    user_id: studentAlice.id,
+    eval: [
+      {
+        feedback: '',
+        id: studentAlice.id,
+        learning_goal_id: 1587,
+        understanding: 0,
+      },
+    ],
+  },
+];


### PR DESCRIPTION
Continues on [AITT-816: Alert teachers of waiting scores - US 3](https://codedotorg.atlassian.net/browse/AITT-816), specifically it launches the red notification bubbles behind an experiment flag.

### screenshots

with experiment enabled:
![Screenshot 2024-11-04 at 7 48 27 PM](https://github.com/user-attachments/assets/d0c54828-c5f1-4c31-8b04-f908051e8c31)

with experiment disabled, we see the original TA bubble in place of the notification.

for additional screenshots, see this [slack thread](https://codedotorg.slack.com/archives/C050HE4QDHR/p1730315126243229).

## Testing story

* new unit tests
* manually verified notifications working end-to-end as shown in screenshots
* manually verified disabling experiment disables the notifications
* manually verified notification bubble disappears when teacher evaluates the last student
