### PR TITLE
Avoid GDPR and Section Setup modals from overlapping when a teacher signs up

### DIFF
--- a/dashboard/app/helpers/initial_section_creation_interstitial_helper.rb
+++ b/dashboard/app/helpers/initial_section_creation_interstitial_helper.rb
@@ -3,12 +3,12 @@ require 'policies/lti'
 module InitialSectionCreationInterstitialHelper
   # Determine whether or not to show the initial section creation interstitial popup to a user
   # This interstitial should be shown only to teachers on their first sign-in
-  def self.show?(user, request)
+  def self.show?(user, showing_gdpr = false)
     return false if user.nil?
     return false unless user.teacher?
     return false if Policies::Lti.lti?(user)
     # Don't show popup if user is also being shown the GDPR modal to avoid overlap.
-    return false if request.gdpr?
+    return false if showing_gdpr
 
     return user.sign_in_count <= 1
   end

--- a/dashboard/app/helpers/initial_section_creation_interstitial_helper.rb
+++ b/dashboard/app/helpers/initial_section_creation_interstitial_helper.rb
@@ -3,10 +3,12 @@ require 'policies/lti'
 module InitialSectionCreationInterstitialHelper
   # Determine whether or not to show the initial section creation interstitial popup to a user
   # This interstitial should be shown only to teachers on their first sign-in
-  def self.show?(user)
+  def self.show?(user, request)
     return false if user.nil?
     return false unless user.teacher?
     return false if Policies::Lti.lti?(user)
+    # Don't show popup if user is also being shown the GDPR modal to avoid overlap.
+    return false if request.gdpr?
 
     return user.sign_in_count <= 1
   end

--- a/dashboard/app/views/home/index.html.haml
+++ b/dashboard/app/views/home/index.html.haml
@@ -15,7 +15,7 @@
 - if current_user && current_user.teacher? && !current_user.accepted_latest_terms?
   - current_user.update_user_tos_version_accept()
   = render partial: 'layouts/implicit_new_user_terms_interstitial'
-- elsif InitialSectionCreationInterstitialHelper.show?(current_user, request)
+- elsif InitialSectionCreationInterstitialHelper.show?(current_user, request.gdpr?)
   = render partial: 'layouts/initial_section_creation_interstitial'
 - elsif @show_section_creation_celebration_dialog
   = render partial: 'layouts/section_creation_celebration_dialog'

--- a/dashboard/app/views/home/index.html.haml
+++ b/dashboard/app/views/home/index.html.haml
@@ -15,7 +15,7 @@
 - if current_user && current_user.teacher? && !current_user.accepted_latest_terms?
   - current_user.update_user_tos_version_accept()
   = render partial: 'layouts/implicit_new_user_terms_interstitial'
-- elsif InitialSectionCreationInterstitialHelper.show?(current_user)
+- elsif InitialSectionCreationInterstitialHelper.show?(current_user, request)
   = render partial: 'layouts/initial_section_creation_interstitial'
 - elsif @show_section_creation_celebration_dialog
   = render partial: 'layouts/section_creation_celebration_dialog'

--- a/dashboard/test/helpers/initial_section_creation_interstitial_helper_test.rb
+++ b/dashboard/test/helpers/initial_section_creation_interstitial_helper_test.rb
@@ -3,31 +3,45 @@ require 'test_helper'
 # Tests following spec:
 # We should pop up this interstitial only for teachers on their first sign-in.
 class InitialSectionCreationInterstitialHelperTest < ActiveSupport::TestCase
+  setup do
+    @country_code = 'US'
+    @request = ActionDispatch::Request.new({'HTTP_CLOUDFRONT_VIEWER_COUNTRY' => @country_code.downcase})
+  end
+
   test 'does not show a dialog if user is not a teacher' do
     @user = create :user
 
     refute @user.teacher?
-    refute InitialSectionCreationInterstitialHelper.show?(@user)
+    refute InitialSectionCreationInterstitialHelper.show?(@user, @request)
   end
 
   test 'does not show a dialog if the user has signed in before' do
     @teacher = create :teacher
     @teacher.update(sign_in_count: 2)
 
-    refute InitialSectionCreationInterstitialHelper.show?(@teacher)
+    refute InitialSectionCreationInterstitialHelper.show?(@teacher, @request)
   end
 
   test 'shows the dialog if the teacher signed in for the first time' do
     @teacher = create :teacher
     @teacher.update(sign_in_count: 1)
 
-    assert InitialSectionCreationInterstitialHelper.show?(@teacher)
+    assert InitialSectionCreationInterstitialHelper.show?(@teacher, @request)
   end
 
   test 'does not show the dialog if the teacher is an LTI user' do
     @teacher = create :teacher, :with_lti_auth
     @teacher.update(sign_in_count: 1)
 
-    refute InitialSectionCreationInterstitialHelper.show?(@teacher)
+    refute InitialSectionCreationInterstitialHelper.show?(@teacher, @request)
+  end
+
+  test 'does not show the dialog if gdpr dialog is showing' do
+    eu_country_code = 'FR'
+    eu_request = ActionDispatch::Request.new({'HTTP_CLOUDFRONT_VIEWER_COUNTRY' => eu_country_code.downcase})
+    @teacher = create :teacher
+    @teacher.update(sign_in_count: 1)
+
+    refute InitialSectionCreationInterstitialHelper.show?(@teacher, eu_request)
   end
 end

--- a/dashboard/test/helpers/initial_section_creation_interstitial_helper_test.rb
+++ b/dashboard/test/helpers/initial_section_creation_interstitial_helper_test.rb
@@ -3,37 +3,32 @@ require 'test_helper'
 # Tests following spec:
 # We should pop up this interstitial only for teachers on their first sign-in.
 class InitialSectionCreationInterstitialHelperTest < ActiveSupport::TestCase
-  setup do
-    @country_code = 'US'
-    @request = ActionDispatch::Request.new({'HTTP_CLOUDFRONT_VIEWER_COUNTRY' => @country_code.downcase})
-  end
-
   test 'does not show a dialog if user is not a teacher' do
     @user = create :user
 
     refute @user.teacher?
-    refute InitialSectionCreationInterstitialHelper.show?(@user, @request)
+    refute InitialSectionCreationInterstitialHelper.show?(@user)
   end
 
   test 'does not show a dialog if the user has signed in before' do
     @teacher = create :teacher
     @teacher.update(sign_in_count: 2)
 
-    refute InitialSectionCreationInterstitialHelper.show?(@teacher, @request)
+    refute InitialSectionCreationInterstitialHelper.show?(@teacher)
   end
 
   test 'shows the dialog if the teacher signed in for the first time' do
     @teacher = create :teacher
     @teacher.update(sign_in_count: 1)
 
-    assert InitialSectionCreationInterstitialHelper.show?(@teacher, @request)
+    assert InitialSectionCreationInterstitialHelper.show?(@teacher)
   end
 
   test 'does not show the dialog if the teacher is an LTI user' do
     @teacher = create :teacher, :with_lti_auth
     @teacher.update(sign_in_count: 1)
 
-    refute InitialSectionCreationInterstitialHelper.show?(@teacher, @request)
+    refute InitialSectionCreationInterstitialHelper.show?(@teacher)
   end
 
   test 'does not show the dialog if gdpr dialog is showing' do
@@ -42,6 +37,6 @@ class InitialSectionCreationInterstitialHelperTest < ActiveSupport::TestCase
     @teacher = create :teacher
     @teacher.update(sign_in_count: 1)
 
-    refute InitialSectionCreationInterstitialHelper.show?(@teacher, eu_request)
+    refute InitialSectionCreationInterstitialHelper.show?(@teacher, eu_request.gdpr?)
   end
 end


### PR DESCRIPTION
Currently, on production, if a teacher in the EU signs up, they'll see both the GDPR modal and the Section Signup modal:

![prod](https://github.com/user-attachments/assets/bdc3ce4c-d677-4006-ac9d-b279f3683af9)

This PR fixes this by not showing the Section Signup modal if the GDPR one will show.

### Shows Section Setup modal if in non-EU country
![not gdpr](https://github.com/user-attachments/assets/5a3632ea-a243-44b4-85be-f98bb72e34aa)

### Shows GDPR modal if in EU country
![only show gdpr](https://github.com/user-attachments/assets/e5664d56-965b-4d90-93c5-5ca898583b91)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2603)

## Testing story
Local testing and adding a unit test.
