### PR TITLE
lint rules to prevent non-accessible RTL queries 

### DIFF
--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -261,6 +261,10 @@ module.exports = {
             property: 'querySelectorAll',
             message: noRestrictedQueriesMessage,
           },
+          {
+            property: 'toHaveClass',
+            message: noRestrictedQueriesMessage,
+          },
         ],
       },
     },

--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -15,6 +15,12 @@ const rulesToEventuallyReenable = {
   'jsx-a11y/tabindex-no-positive': 'off',
 };
 
+const noDataTestIdMessage =
+  'Attribute data-testid is not accessible. Tests should resemble how the user interacts with the application and should not rely on technical details, see https://testing-library.com/docs/queries/about/#priority';
+
+const noByTestIdMessage =
+  'Tests should resemble how the user interacts with the application and should not rely on technical details, see https://testing-library.com/docs/queries/about/#priority';
+
 // This config defines globals available especially in apps,
 // enables es6, and enables apps-specific plugins and rules.
 // See the root .eslintrc.js for generic eslint linting rules.
@@ -171,6 +177,41 @@ module.exports = {
             message: 'Use jest matchers instead of chai',
           },
         ],
+      },
+    ],
+    'no-restricted-properties': [
+      'error',
+      {object: 'screen', property: 'getByTestId', message: noByTestIdMessage},
+      {
+        object: 'screen',
+        property: 'queryByTestId',
+        message: noByTestIdMessage,
+      },
+      {
+        object: 'screen',
+        property: 'getAllByTestId',
+        message: noByTestIdMessage,
+      },
+      {
+        object: 'screen',
+        property: 'queryAllByTestId',
+        message: noByTestIdMessage,
+      },
+      {
+        object: 'screen',
+        property: 'findByTestId',
+        message: noByTestIdMessage,
+      },
+      {
+        object: 'screen',
+        property: 'findAllByTestId',
+        message: noByTestIdMessage,
+      },
+    ],
+    'react/forbid-dom-props': [
+      'error',
+      {
+        forbid: [{propName: 'data-testid', message: noDataTestIdMessage}],
       },
     ],
   },

--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -18,7 +18,7 @@ const rulesToEventuallyReenable = {
 const noDataTestIdMessage =
   'Attribute data-testid is not accessible. Tests should resemble how the user interacts with the application and should not rely on technical details, see https://testing-library.com/docs/queries/about/#priority';
 
-const noByTestIdMessage =
+const noRestrictedQueriesMessage =
   'Tests should resemble how the user interacts with the application and should not rely on technical details, see https://testing-library.com/docs/queries/about/#priority';
 
 // This config defines globals available especially in apps,
@@ -181,31 +181,45 @@ module.exports = {
     ],
     'no-restricted-properties': [
       'error',
-      {object: 'screen', property: 'getByTestId', message: noByTestIdMessage},
+      {
+        object: 'screen',
+        property: 'getByTestId',
+        message: noRestrictedQueriesMessage,
+      },
       {
         object: 'screen',
         property: 'queryByTestId',
-        message: noByTestIdMessage,
+        message: noRestrictedQueriesMessage,
       },
       {
         object: 'screen',
         property: 'getAllByTestId',
-        message: noByTestIdMessage,
+        message: noRestrictedQueriesMessage,
       },
       {
         object: 'screen',
         property: 'queryAllByTestId',
-        message: noByTestIdMessage,
+        message: noRestrictedQueriesMessage,
       },
       {
         object: 'screen',
         property: 'findByTestId',
-        message: noByTestIdMessage,
+        message: noRestrictedQueriesMessage,
       },
       {
         object: 'screen',
         property: 'findAllByTestId',
-        message: noByTestIdMessage,
+        message: noRestrictedQueriesMessage,
+      },
+      {
+        object: 'container',
+        property: 'querySelector',
+        message: noRestrictedQueriesMessage,
+      },
+      {
+        object: 'container',
+        property: 'querySelectorAll',
+        message: noRestrictedQueriesMessage,
       },
     ],
     'react/forbid-dom-props': [

--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -15,11 +15,12 @@ const rulesToEventuallyReenable = {
   'jsx-a11y/tabindex-no-positive': 'off',
 };
 
-const noDataTestIdMessage =
-  'Attribute data-testid is not accessible. Tests should resemble how the user interacts with the application and should not rely on technical details, see https://testing-library.com/docs/queries/about/#priority';
-
-const noRestrictedQueriesMessage =
+const accessibilityTestingMessage =
   'Tests should resemble how the user interacts with the application and should not rely on technical details, see https://testing-library.com/docs/queries/about/#priority';
+
+const noDataTestIdMessage =
+  'Attribute data-testid does not meet accessibility guidelines. ' +
+  accessibilityTestingMessage;
 
 // This config defines globals available especially in apps,
 // enables es6, and enables apps-specific plugins and rules.
@@ -229,46 +230,46 @@ module.exports = {
           {
             object: 'screen',
             property: 'getByTestId',
-            message: noRestrictedQueriesMessage,
+            message: accessibilityTestingMessage,
           },
           {
             object: 'screen',
             property: 'queryByTestId',
-            message: noRestrictedQueriesMessage,
+            message: accessibilityTestingMessage,
           },
           {
             object: 'screen',
             property: 'getAllByTestId',
-            message: noRestrictedQueriesMessage,
+            message: accessibilityTestingMessage,
           },
           {
             object: 'screen',
             property: 'queryAllByTestId',
-            message: noRestrictedQueriesMessage,
+            message: accessibilityTestingMessage,
           },
           {
             object: 'screen',
             property: 'findByTestId',
-            message: noRestrictedQueriesMessage,
+            message: accessibilityTestingMessage,
           },
           {
             object: 'screen',
             property: 'findAllByTestId',
-            message: noRestrictedQueriesMessage,
+            message: accessibilityTestingMessage,
           },
           {
             object: 'container',
             property: 'querySelector',
-            message: noRestrictedQueriesMessage,
+            message: accessibilityTestingMessage,
           },
           {
             object: 'container',
             property: 'querySelectorAll',
-            message: noRestrictedQueriesMessage,
+            message: accessibilityTestingMessage,
           },
           {
             property: 'toHaveClass',
-            message: noRestrictedQueriesMessage,
+            message: accessibilityTestingMessage,
           },
         ],
       },

--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -179,49 +179,6 @@ module.exports = {
         ],
       },
     ],
-    'no-restricted-properties': [
-      'error',
-      {
-        object: 'screen',
-        property: 'getByTestId',
-        message: noRestrictedQueriesMessage,
-      },
-      {
-        object: 'screen',
-        property: 'queryByTestId',
-        message: noRestrictedQueriesMessage,
-      },
-      {
-        object: 'screen',
-        property: 'getAllByTestId',
-        message: noRestrictedQueriesMessage,
-      },
-      {
-        object: 'screen',
-        property: 'queryAllByTestId',
-        message: noRestrictedQueriesMessage,
-      },
-      {
-        object: 'screen',
-        property: 'findByTestId',
-        message: noRestrictedQueriesMessage,
-      },
-      {
-        object: 'screen',
-        property: 'findAllByTestId',
-        message: noRestrictedQueriesMessage,
-      },
-      {
-        object: 'container',
-        property: 'querySelector',
-        message: noRestrictedQueriesMessage,
-      },
-      {
-        object: 'container',
-        property: 'querySelectorAll',
-        message: noRestrictedQueriesMessage,
-      },
-    ],
     'react/forbid-dom-props': [
       'error',
       {
@@ -256,6 +213,54 @@ module.exports = {
       files: ['*.story.@(ts|tsx|js|jsx)'],
       rules: {
         'storybook/no-title-property-in-meta': 'error',
+      },
+    },
+    {
+      files: ['test/unit/**'],
+      rules: {
+        'no-restricted-properties': [
+          'error',
+          {
+            object: 'screen',
+            property: 'getByTestId',
+            message: noRestrictedQueriesMessage,
+          },
+          {
+            object: 'screen',
+            property: 'queryByTestId',
+            message: noRestrictedQueriesMessage,
+          },
+          {
+            object: 'screen',
+            property: 'getAllByTestId',
+            message: noRestrictedQueriesMessage,
+          },
+          {
+            object: 'screen',
+            property: 'queryAllByTestId',
+            message: noRestrictedQueriesMessage,
+          },
+          {
+            object: 'screen',
+            property: 'findByTestId',
+            message: noRestrictedQueriesMessage,
+          },
+          {
+            object: 'screen',
+            property: 'findAllByTestId',
+            message: noRestrictedQueriesMessage,
+          },
+          {
+            object: 'container',
+            property: 'querySelector',
+            message: noRestrictedQueriesMessage,
+          },
+          {
+            object: 'container',
+            property: 'querySelectorAll',
+            message: noRestrictedQueriesMessage,
+          },
+        ],
       },
     },
   ],

--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -100,7 +100,6 @@ module.exports = {
     Turtle: 'readonly',
     YT: 'readonly',
   },
-  reportUnusedDisableDirectives: true,
   rules: {
     ...rulesToEventuallyReenable,
     'babel/semi': 'error', // autofixable

--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -185,6 +185,12 @@ module.exports = {
         forbid: [{propName: 'data-testid', message: noDataTestIdMessage}],
       },
     ],
+    'react/forbid-component-props': [
+      'error',
+      {
+        forbid: [{propName: 'data-testid', message: noDataTestIdMessage}],
+      },
+    ],
   },
   settings: {
     react: {

--- a/apps/.eslintrc.js
+++ b/apps/.eslintrc.js
@@ -100,6 +100,7 @@ module.exports = {
     Turtle: 'readonly',
     YT: 'readonly',
   },
+  reportUnusedDisableDirectives: true,
   rules: {
     ...rulesToEventuallyReenable,
     'babel/semi': 'error', // autofixable

--- a/apps/src/code-studio/pd/professional_learning_landing/SelfPacedProgressTable.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/SelfPacedProgressTable.jsx
@@ -41,6 +41,7 @@ const CourseRow = ({
             {percent_completed}% {i18n.selfPacedPlCompleted()}
           </BodyThreeText>
           {/* Progress bar */}
+          {/* eslint-disable-next-line react/forbid-dom-props */}
           <div className={styles.progressBar} data-testid="progress-bar">
             <span
               className={styles.progressBarFill}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
@@ -99,7 +99,7 @@ export default class WorkshopTableLoader extends React.Component {
         // While reloading, preserve the height of the previous child component so the refresh is smoother.
         <div
           style={{height: this.childHeight}}
-          data-testid={'enrolled-workshops-loader'}
+          data-testid={'enrolled-workshops-loader'} // eslint-disable-line react/forbid-dom-props
         >
           <Spinner />
         </div>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table_loader.jsx
@@ -99,7 +99,8 @@ export default class WorkshopTableLoader extends React.Component {
         // While reloading, preserve the height of the previous child component so the refresh is smoother.
         <div
           style={{height: this.childHeight}}
-          data-testid={'enrolled-workshops-loader'} // eslint-disable-line react/forbid-dom-props
+          // eslint-disable-next-line react/forbid-dom-props
+          data-testid={'enrolled-workshops-loader'}
         >
           <Spinner />
         </div>

--- a/apps/src/componentLibrary/breadcrumbs/Breadcrumbs.tsx
+++ b/apps/src/componentLibrary/breadcrumbs/Breadcrumbs.tsx
@@ -44,7 +44,7 @@ const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({
         moduleStyles[`breadcrumbs-${size}`],
         className
       )}
-      data-testid={`breadcrumbs-${name}`}
+      data-testid={`breadcrumbs-${name}`} // eslint-disable-line react/forbid-dom-props
     >
       {breadcrumbs.map(({text, href, ...rest}, i) => (
         <React.Fragment key={`${text}-${href}`}>

--- a/apps/src/componentLibrary/breadcrumbs/Breadcrumbs.tsx
+++ b/apps/src/componentLibrary/breadcrumbs/Breadcrumbs.tsx
@@ -44,7 +44,8 @@ const Breadcrumbs: React.FunctionComponent<BreadcrumbsProps> = ({
         moduleStyles[`breadcrumbs-${size}`],
         className
       )}
-      data-testid={`breadcrumbs-${name}`} // eslint-disable-line react/forbid-dom-props
+      // eslint-disable-next-line react/forbid-dom-props
+      data-testid={`breadcrumbs-${name}`}
     >
       {breadcrumbs.map(({text, href, ...rest}, i) => (
         <React.Fragment key={`${text}-${href}`}>

--- a/apps/src/componentLibrary/chips/Chips.tsx
+++ b/apps/src/componentLibrary/chips/Chips.tsx
@@ -73,7 +73,8 @@ const Chips: React.FunctionComponent<ChipsProps> = ({
         moduleStyles[`chips-${size}`],
         className
       )}
-      data-testid={`chips-${name}`} // eslint-disable-line react/forbid-dom-props
+      // eslint-disable-next-line react/forbid-dom-props
+      data-testid={`chips-${name}`}
     >
       <fieldset>
         {label && <label className={moduleStyles.groupLabel}>{label}</label>}

--- a/apps/src/componentLibrary/chips/Chips.tsx
+++ b/apps/src/componentLibrary/chips/Chips.tsx
@@ -73,7 +73,7 @@ const Chips: React.FunctionComponent<ChipsProps> = ({
         moduleStyles[`chips-${size}`],
         className
       )}
-      data-testid={`chips-${name}`}
+      data-testid={`chips-${name}`} // eslint-disable-line react/forbid-dom-props
     >
       <fieldset>
         {label && <label className={moduleStyles.groupLabel}>{label}</label>}

--- a/apps/src/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon.tsx
+++ b/apps/src/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon.tsx
@@ -63,7 +63,8 @@ const FontAwesomeV6Icon: React.FunctionComponent<FontAwesomeV6IconProps> = ({
   ...HTMLAttributes
 }) => (
   <i
-    data-testid="font-awesome-v6-icon" // eslint-disable-line react/forbid-dom-props
+    // eslint-disable-next-line react/forbid-dom-props
+    data-testid="font-awesome-v6-icon"
     className={classNames(
       iconFamily && `fa-${iconFamily}`,
       iconStyle && `fa-${iconStyle}`,

--- a/apps/src/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon.tsx
+++ b/apps/src/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon.tsx
@@ -63,7 +63,7 @@ const FontAwesomeV6Icon: React.FunctionComponent<FontAwesomeV6IconProps> = ({
   ...HTMLAttributes
 }) => (
   <i
-    data-testid="font-awesome-v6-icon"
+    data-testid="font-awesome-v6-icon" // eslint-disable-line react/forbid-dom-props
     className={classNames(
       iconFamily && `fa-${iconFamily}`,
       iconStyle && `fa-${iconStyle}`,

--- a/apps/src/componentLibrary/tags/Tags.tsx
+++ b/apps/src/componentLibrary/tags/Tags.tsx
@@ -40,7 +40,7 @@ const Tags: React.FunctionComponent<TagsProps> = ({
       moduleStyles[`tags-${size}`],
       className
     )}
-    data-testid="tags"
+    data-testid="tags" // eslint-disable-line react/forbid-dom-props
   >
     {tagsList.map(({tooltipId, label, tooltipContent, ariaLabel, icon}) => (
       <Tag

--- a/apps/src/componentLibrary/tags/Tags.tsx
+++ b/apps/src/componentLibrary/tags/Tags.tsx
@@ -40,7 +40,8 @@ const Tags: React.FunctionComponent<TagsProps> = ({
       moduleStyles[`tags-${size}`],
       className
     )}
-    data-testid="tags" // eslint-disable-line react/forbid-dom-props
+    // eslint-disable-next-line react/forbid-dom-props
+    data-testid="tags"
   >
     {tagsList.map(({tooltipId, label, tooltipContent, ariaLabel, icon}) => (
       <Tag

--- a/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
@@ -795,6 +795,7 @@ class UnitEditor extends React.Component {
                   </div>
                 )}
               {!this.props.hasCourse && (
+                // eslint-disable-next-line react/forbid-dom-props
                 <div data-testid="course-version-publishing-editor">
                   <CourseVersionPublishingEditor
                     pilotExperiment={this.state.pilotExperiment}

--- a/apps/src/sharedComponents/card/Card.story.tsx
+++ b/apps/src/sharedComponents/card/Card.story.tsx
@@ -21,7 +21,9 @@ type Story = StoryObj<typeof Card>;
 
 export const UserSignupCard: Story = {
   render: () => (
+    // eslint-disable-next-line react/forbid-dom-props
     <Card data-testid={'existing-account-card'}>
+      {' '}
       <CardHeader title={i18n.ltiLinkAccountExistingAccountCardHeaderLabel()} />
       <CardContent className={cardStyles.cardContent}>
         {i18n.ltiLinkAccountExistingAccountCardContent({

--- a/apps/src/sharedComponents/card/Card.story.tsx
+++ b/apps/src/sharedComponents/card/Card.story.tsx
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof Card>;
 
 export const UserSignupCard: Story = {
   render: () => (
-    // eslint-disable-next-line react/forbid-dom-props
+    // eslint-disable-next-line react/forbid-component-props
     <Card data-testid={'existing-account-card'}>
       <CardHeader title={i18n.ltiLinkAccountExistingAccountCardHeaderLabel()} />
       <CardContent className={cardStyles.cardContent}>

--- a/apps/src/sharedComponents/card/Card.story.tsx
+++ b/apps/src/sharedComponents/card/Card.story.tsx
@@ -23,7 +23,6 @@ export const UserSignupCard: Story = {
   render: () => (
     // eslint-disable-next-line react/forbid-dom-props
     <Card data-testid={'existing-account-card'}>
-      {' '}
       <CardHeader title={i18n.ltiLinkAccountExistingAccountCardHeaderLabel()} />
       <CardContent className={cardStyles.cardContent}>
         {i18n.ltiLinkAccountExistingAccountCardContent({

--- a/apps/src/sharedComponents/card/Card/index.tsx
+++ b/apps/src/sharedComponents/card/Card/index.tsx
@@ -11,7 +11,6 @@ export const Card = ({children, ...props}: CardProps) => {
   return (
     // eslint-disable-next-line react/forbid-dom-props
     <div className={styles.cardContainer} data-testid={props['data-testid']}>
-      {' '}
       {children}
     </div>
   );

--- a/apps/src/sharedComponents/card/Card/index.tsx
+++ b/apps/src/sharedComponents/card/Card/index.tsx
@@ -9,7 +9,9 @@ interface CardProps {
 
 export const Card = ({children, ...props}: CardProps) => {
   return (
+    // eslint-disable-next-line react/forbid-dom-props
     <div className={styles.cardContainer} data-testid={props['data-testid']}>
+      {' '}
       {children}
     </div>
   );

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiContinueAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiContinueAccountCard/index.tsx
@@ -57,7 +57,6 @@ const LtiContinueAccountCard = () => {
   return (
     // eslint-disable-next-line react/forbid-dom-props
     <Card data-testid={'continue-account-card'}>
-      {' '}
       <CardHeader
         title={i18n.ltiLinkAccountNewAccountCardHeaderLabel()}
         icon={

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiContinueAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiContinueAccountCard/index.tsx
@@ -55,7 +55,7 @@ const LtiContinueAccountCard = () => {
   };
 
   return (
-    // eslint-disable-next-line react/forbid-dom-props
+    // eslint-disable-next-line react/forbid-component-props
     <Card data-testid={'continue-account-card'}>
       <CardHeader
         title={i18n.ltiLinkAccountNewAccountCardHeaderLabel()}

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiContinueAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiContinueAccountCard/index.tsx
@@ -55,7 +55,9 @@ const LtiContinueAccountCard = () => {
   };
 
   return (
+    // eslint-disable-next-line react/forbid-dom-props
     <Card data-testid={'continue-account-card'}>
+      {' '}
       <CardHeader
         title={i18n.ltiLinkAccountNewAccountCardHeaderLabel()}
         icon={

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiExistingAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiExistingAccountCard/index.tsx
@@ -48,7 +48,9 @@ const LtiExistingAccountCard = () => {
   };
 
   return (
+    // eslint-disable-next-line react/forbid-dom-props
     <Card data-testid={'existing-account-card'}>
+      {' '}
       <CardHeader
         title={i18n.ltiLinkAccountExistingAccountCardHeaderLabel()}
         icon={

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiExistingAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiExistingAccountCard/index.tsx
@@ -48,7 +48,7 @@ const LtiExistingAccountCard = () => {
   };
 
   return (
-    // eslint-disable-next-line react/forbid-dom-props
+    // eslint-disable-next-line react/forbid-component-props
     <Card data-testid={'existing-account-card'}>
       <CardHeader
         title={i18n.ltiLinkAccountExistingAccountCardHeaderLabel()}

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiExistingAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiExistingAccountCard/index.tsx
@@ -50,7 +50,6 @@ const LtiExistingAccountCard = () => {
   return (
     // eslint-disable-next-line react/forbid-dom-props
     <Card data-testid={'existing-account-card'}>
-      {' '}
       <CardHeader
         title={i18n.ltiLinkAccountExistingAccountCardHeaderLabel()}
         icon={

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -62,7 +62,7 @@ const LtiNewAccountCard = () => {
   };
 
   return (
-    // eslint-disable-next-line react/forbid-dom-props
+    // eslint-disable-next-line react/forbid-component-props
     <Card data-testid={'new-account-card'}>
       <CardHeader
         title={i18n.ltiLinkAccountNewAccountCardHeaderLabel()}

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -64,7 +64,6 @@ const LtiNewAccountCard = () => {
   return (
     // eslint-disable-next-line react/forbid-dom-props
     <Card data-testid={'new-account-card'}>
-      {' '}
       <CardHeader
         title={i18n.ltiLinkAccountNewAccountCardHeaderLabel()}
         icon={

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -80,7 +80,8 @@ const LtiNewAccountCard = () => {
         })}
 
         <form
-          data-testid={'new-account-form'} // eslint-disable-line react/forbid-dom-props
+          // eslint-disable-next-line react/forbid-dom-props
+          data-testid={'new-account-form'}
           action={newAccountUrl}
           ref={finishSignupFormRef}
           method="post"

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -62,7 +62,9 @@ const LtiNewAccountCard = () => {
   };
 
   return (
+    // eslint-disable-next-line react/forbid-dom-props
     <Card data-testid={'new-account-card'}>
+      {' '}
       <CardHeader
         title={i18n.ltiLinkAccountNewAccountCardHeaderLabel()}
         icon={
@@ -78,7 +80,7 @@ const LtiNewAccountCard = () => {
         })}
 
         <form
-          data-testid={'new-account-form'}
+          data-testid={'new-account-form'} // eslint-disable-line react/forbid-dom-props
           action={newAccountUrl}
           ref={finishSignupFormRef}
           method="post"

--- a/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.tsx
+++ b/apps/src/simpleSignUp/lti/sync/LtiSectionSyncDialog.tsx
@@ -104,6 +104,7 @@ export default function LtiSectionSyncDialog({
       PLATFORMS.STATSIG
     );
     return (
+      // eslint-disable-next-line react/forbid-dom-props
       <div data-testid={'disable-roster-sync'}>
         <div>
           <h2 style={styles.dialogHeader}>

--- a/apps/src/simpleSignUp/lti/upgrade/LtiUpgradeAccountDialog.tsx
+++ b/apps/src/simpleSignUp/lti/upgrade/LtiUpgradeAccountDialog.tsx
@@ -70,6 +70,7 @@ export const LtiUpgradeAccountDialog = ({
     }
 
     return (
+      // eslint-disable-next-line react/forbid-dom-props
       <div data-testid="lti-upgrade-account">
         <h2 style={styles.dialogHeader}>
           {i18n.ltiUpgradeAccountDialogTitle()}

--- a/apps/src/templates/account/AccountCard.tsx
+++ b/apps/src/templates/account/AccountCard.tsx
@@ -38,7 +38,9 @@ const AccountCard: React.FunctionComponent<{
   onClick,
   iconList,
 }) => (
+  // eslint-disable-next-line react/forbid-dom-props
   <Card data-testid={id}>
+    {' '}
     <div className={styles.contentWrapper}>
       <CardHeader
         title={title}

--- a/apps/src/templates/account/AccountCard.tsx
+++ b/apps/src/templates/account/AccountCard.tsx
@@ -38,7 +38,7 @@ const AccountCard: React.FunctionComponent<{
   onClick,
   iconList,
 }) => (
-  // eslint-disable-next-line react/forbid-dom-props
+  // eslint-disable-next-line react/forbid-component-props
   <Card data-testid={id}>
     <div className={styles.contentWrapper}>
       <CardHeader

--- a/apps/src/templates/account/AccountCard.tsx
+++ b/apps/src/templates/account/AccountCard.tsx
@@ -40,7 +40,6 @@ const AccountCard: React.FunctionComponent<{
 }) => (
   // eslint-disable-next-line react/forbid-dom-props
   <Card data-testid={id}>
-    {' '}
     <div className={styles.contentWrapper}>
       <CardHeader
         title={title}

--- a/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
+++ b/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
@@ -44,7 +44,7 @@ const SummaryEntryPoint = ({scriptData, students, selectedSection}) => {
           </div>
           <div
             className={styles.responseCounter}
-            data-testid={'response-counter'}
+            data-testid={'response-counter'} // eslint-disable-line react/forbid-dom-props
           >
             <p>
               <span className={styles.counter}>

--- a/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
+++ b/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
@@ -44,7 +44,8 @@ const SummaryEntryPoint = ({scriptData, students, selectedSection}) => {
           </div>
           <div
             className={styles.responseCounter}
-            data-testid={'response-counter'} // eslint-disable-line react/forbid-dom-props
+            // eslint-disable-next-line react/forbid-dom-props
+            data-testid={'response-counter'}
           >
             <p>
               <span className={styles.counter}>

--- a/apps/src/templates/manageStudents/ManageStudents.jsx
+++ b/apps/src/templates/manageStudents/ManageStudents.jsx
@@ -22,6 +22,7 @@ function ManageStudents({
   }, [sectionId, isLoadingSectionData, loadSectionStudentData]);
 
   return (
+    // eslint-disable-next-line react/forbid-dom-props
     <div data-testid={'manage-students-tab'}>
       {isLoadingStudents && <Spinner />}
       {!isLoadingStudents && (

--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
@@ -71,7 +71,8 @@ const AgeGatedStudentsModal: React.FC<Props> = ({
     >
       <div
         className={styles.modalContainer}
-        data-testid="age-gated-students-modal" // eslint-disable-line react/forbid-dom-props
+        // eslint-disable-next-line react/forbid-dom-props
+        data-testid="age-gated-students-modal"
         id="uitest-age-gated-students-modal"
       >
         <div>

--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
@@ -71,7 +71,7 @@ const AgeGatedStudentsModal: React.FC<Props> = ({
     >
       <div
         className={styles.modalContainer}
-        data-testid="age-gated-students-modal"
+        data-testid="age-gated-students-modal" // eslint-disable-line react/forbid-dom-props
         id="uitest-age-gated-students-modal"
       >
         <div>

--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsTable.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsTable.tsx
@@ -142,7 +142,8 @@ const AgeGatedStudentsTable: React.FC<Props> = ({studentData}) => {
         <Table.Provider
           columns={columns}
           style={tableLayoutStyles.table}
-          data-testid="uitest-age-gated-students-table" // eslint-disable-line react/forbid-dom-props
+          // eslint-disable-next-line react/forbid-dom-props
+          data-testid="uitest-age-gated-students-table"
         >
           <Table.Header />
           <Table.Body rows={studentData} rowKey="id" />

--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsTable.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsTable.tsx
@@ -142,7 +142,7 @@ const AgeGatedStudentsTable: React.FC<Props> = ({studentData}) => {
         <Table.Provider
           columns={columns}
           style={tableLayoutStyles.table}
-          data-testid="uitest-age-gated-students-table"
+          data-testid="uitest-age-gated-students-table" // eslint-disable-line react/forbid-dom-props
         >
           <Table.Header />
           <Table.Body rows={studentData} rowKey="id" />

--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsTable.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsTable.tsx
@@ -142,7 +142,7 @@ const AgeGatedStudentsTable: React.FC<Props> = ({studentData}) => {
         <Table.Provider
           columns={columns}
           style={tableLayoutStyles.table}
-          // eslint-disable-next-line react/forbid-dom-props
+          // eslint-disable-next-line react/forbid-component-props
           data-testid="uitest-age-gated-students-table"
         >
           <Table.Header />

--- a/apps/src/templates/rubrics/AiAssessmentFeedback.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentFeedback.jsx
@@ -130,7 +130,7 @@ export default function AiAssessmentFeedback({aiEvalInfo, aiFeedbackId}) {
                   setAIOtherContent(e.target.value);
                 }}
                 type="text"
-                data-testid="ai-assessment-feedback-textarea"
+                data-testid="ai-assessment-feedback-textarea" // eslint-disable-line react/forbid-dom-props
               />
             </div>
           )}

--- a/apps/src/templates/rubrics/AiAssessmentFeedback.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentFeedback.jsx
@@ -130,7 +130,8 @@ export default function AiAssessmentFeedback({aiEvalInfo, aiFeedbackId}) {
                   setAIOtherContent(e.target.value);
                 }}
                 type="text"
-                data-testid="ai-assessment-feedback-textarea" // eslint-disable-line react/forbid-dom-props
+                // eslint-disable-next-line react/forbid-dom-props
+                data-testid="ai-assessment-feedback-textarea"
               />
             </div>
           )}

--- a/apps/src/templates/rubrics/AiAssessmentFeedbackRadio.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentFeedbackRadio.jsx
@@ -51,10 +51,10 @@ export default function AiAssessmentFeedbackRadio({aiEvalId, setAiFeedbackId}) {
             aria-hidden="true"
           >
             {aiFeedback === THUMBS_UP ? (
-              // eslint-disable-next-line react/forbid-dom-props
+              // eslint-disable-next-line react/forbid-component-props
               <FontAwesome icon="thumbs-up" data-testid="thumbs-up" />
             ) : (
-              // eslint-disable-next-line react/forbid-dom-props
+              // eslint-disable-next-line react/forbid-component-props
               <FontAwesome icon="thumbs-o-up" data-testid="thumbs-o-up" />
             )}
           </span>
@@ -76,10 +76,10 @@ export default function AiAssessmentFeedbackRadio({aiEvalId, setAiFeedbackId}) {
             aria-hidden="true"
           >
             {aiFeedback === THUMBS_DOWN ? (
-              // eslint-disable-next-line react/forbid-dom-props
+              // eslint-disable-next-line react/forbid-component-props
               <FontAwesome icon="thumbs-down" data-testid="thumbs-down" />
             ) : (
-              //  eslint-disable-next-line react/forbid-dom-props
+              // eslint-disable-next-line react/forbid-component-props
               <FontAwesome icon="thumbs-o-down" data-testid="thumbs-o-down" />
             )}
           </span>

--- a/apps/src/templates/rubrics/AiAssessmentFeedbackRadio.jsx
+++ b/apps/src/templates/rubrics/AiAssessmentFeedbackRadio.jsx
@@ -51,8 +51,10 @@ export default function AiAssessmentFeedbackRadio({aiEvalId, setAiFeedbackId}) {
             aria-hidden="true"
           >
             {aiFeedback === THUMBS_UP ? (
+              // eslint-disable-next-line react/forbid-dom-props
               <FontAwesome icon="thumbs-up" data-testid="thumbs-up" />
             ) : (
+              // eslint-disable-next-line react/forbid-dom-props
               <FontAwesome icon="thumbs-o-up" data-testid="thumbs-o-up" />
             )}
           </span>
@@ -74,8 +76,10 @@ export default function AiAssessmentFeedbackRadio({aiEvalId, setAiFeedbackId}) {
             aria-hidden="true"
           >
             {aiFeedback === THUMBS_DOWN ? (
+              // eslint-disable-next-line react/forbid-dom-props
               <FontAwesome icon="thumbs-down" data-testid="thumbs-down" />
             ) : (
+              //  eslint-disable-next-line react/forbid-dom-props
               <FontAwesome icon="thumbs-o-down" data-testid="thumbs-o-down" />
             )}
           </span>

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -267,7 +267,7 @@ function RubricContainer({
       handle=".ai-rubric-handle"
     >
       <div
-        data-testid="draggable-test-id"
+        data-testid="draggable-test-id" // eslint-disable-line react/forbid-dom-props
         id="draggable-id"
         className={style.rubricContainer}
         style={open ? null : {display: 'none'}}
@@ -294,7 +294,7 @@ function RubricContainer({
         />
         <div
           className={classnames(style.rubricHeaderRedesign, 'ai-rubric-handle')}
-          data-testid="ai-rubric-handle-test-id"
+          data-testid="ai-rubric-handle-test-id" // eslint-disable-line react/forbid-dom-props
         >
           <div className={style.rubricHeaderLeftSide}>
             <img

--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -267,7 +267,8 @@ function RubricContainer({
       handle=".ai-rubric-handle"
     >
       <div
-        data-testid="draggable-test-id" // eslint-disable-line react/forbid-dom-props
+        // eslint-disable-next-line react/forbid-dom-props
+        data-testid="draggable-test-id"
         id="draggable-id"
         className={style.rubricContainer}
         style={open ? null : {display: 'none'}}
@@ -294,7 +295,8 @@ function RubricContainer({
         />
         <div
           className={classnames(style.rubricHeaderRedesign, 'ai-rubric-handle')}
-          data-testid="ai-rubric-handle-test-id" // eslint-disable-line react/forbid-dom-props
+          // eslint-disable-next-line react/forbid-dom-props
+          data-testid="ai-rubric-handle-test-id"
         >
           <div className={style.rubricHeaderLeftSide}>
             <img

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -178,7 +178,7 @@ export const InfoAlert = ({text, dismissable}) => {
         [style.infoAlert]: !closed,
         [style.infoAlertClosed]: !!closed,
       })}
-      data-testid="info-alert"
+      data-testid="info-alert" // eslint-disable-line react/forbid-dom-props
     >
       <div className={style.infoAlertLeft}>
         <FontAwesome

--- a/apps/src/templates/rubrics/RubricContent.jsx
+++ b/apps/src/templates/rubrics/RubricContent.jsx
@@ -178,7 +178,8 @@ export const InfoAlert = ({text, dismissable}) => {
         [style.infoAlert]: !closed,
         [style.infoAlertClosed]: !!closed,
       })}
-      data-testid="info-alert" // eslint-disable-line react/forbid-dom-props
+      // eslint-disable-next-line react/forbid-dom-props
+      data-testid="info-alert"
     >
       <div className={style.infoAlertLeft}>
         <FontAwesome

--- a/apps/src/templates/sectionAssessments/SectionAssessments.jsx
+++ b/apps/src/templates/sectionAssessments/SectionAssessments.jsx
@@ -196,6 +196,7 @@ class SectionAssessments extends Component {
       this.props.assessmentId === ASSESSMENT_FEEDBACK_OPTION_ID;
 
     return (
+      // eslint-disable-next-line react/forbid-dom-props
       <div data-testid={'assessments-tab'}>
         <div style={styles.selectors}>
           <div style={styles.unitSelection}>

--- a/apps/src/templates/sectionProgress/ProgressBox.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.jsx
@@ -77,6 +77,7 @@ export default class ProgressBox extends Component {
     };
 
     return (
+      // eslint-disable-next-line react/forbid-dom-props
       <div style={boxWithBorderStyle} data-testid="progress-box">
         {this.props.lessonNumber && (
           <div style={lessonNumberStyle}>{this.props.lessonNumber}</div>

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -189,7 +189,7 @@ class SectionProgress extends Component {
             ? navigationStyles.widthLockedPage
             : dashboardStyles.dashboardPage
         }
-        data-testid="section-progress-v1"
+        data-testid="section-progress-v1" // eslint-disable-line react/forbid-dom-props
       >
         <div style={styles.topRowContainer}>
           <div>

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -189,7 +189,8 @@ class SectionProgress extends Component {
             ? navigationStyles.widthLockedPage
             : dashboardStyles.dashboardPage
         }
-        data-testid="section-progress-v1" // eslint-disable-line react/forbid-dom-props
+        // eslint-disable-next-line react/forbid-dom-props
+        data-testid="section-progress-v1"
       >
         <div style={styles.topRowContainer}>
           <div>

--- a/apps/src/templates/sectionProgressV2/IconKey.jsx
+++ b/apps/src/templates/sectionProgressV2/IconKey.jsx
@@ -67,7 +67,8 @@ export default function IconKey({sectionId}) {
         <div
           onClick={clickListener}
           className={styles.iconKeyTitle}
-          data-testid="expandable-container" // eslint-disable-line react/forbid-dom-props
+          // eslint-disable-next-line react/forbid-dom-props
+          data-testid="expandable-container"
           role="button"
           aria-expanded={isOpen}
           tabIndex="0"

--- a/apps/src/templates/sectionProgressV2/IconKey.jsx
+++ b/apps/src/templates/sectionProgressV2/IconKey.jsx
@@ -67,7 +67,7 @@ export default function IconKey({sectionId}) {
         <div
           onClick={clickListener}
           className={styles.iconKeyTitle}
-          data-testid="expandable-container"
+          data-testid="expandable-container" // eslint-disable-line react/forbid-dom-props
           role="button"
           aria-expanded={isOpen}
           tabIndex="0"

--- a/apps/src/templates/sectionProgressV2/LessonDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonDataCell.jsx
@@ -43,7 +43,7 @@ function LessonDataCell({
           href={teacherDashboardUrl(sectionId, '/assessments')}
           openInNewTab
           external
-          // eslint-disable-next-line react/forbid-dom-props
+          // eslint-disable-next-line react/forbid-component-props
           data-testid={'lesson-data-cell-' + lesson.id + '-' + studentId}
         >
           {children}

--- a/apps/src/templates/sectionProgressV2/LessonDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonDataCell.jsx
@@ -43,7 +43,8 @@ function LessonDataCell({
           href={teacherDashboardUrl(sectionId, '/assessments')}
           openInNewTab
           external
-          data-testid={'lesson-data-cell-' + lesson.id + '-' + studentId} // eslint-disable-line react/forbid-dom-props
+          // eslint-disable-next-line react/forbid-dom-props
+          data-testid={'lesson-data-cell-' + lesson.id + '-' + studentId}
         >
           {children}
         </Link>
@@ -59,7 +60,8 @@ function LessonDataCell({
           interactive && styles.lessonInteractive
         )}
         onClick={expandLesson}
-        data-testid={'lesson-data-cell-' + lesson.id + '-' + studentId} // eslint-disable-line react/forbid-dom-props
+        // eslint-disable-next-line react/forbid-dom-props
+        data-testid={'lesson-data-cell-' + lesson.id + '-' + studentId}
       >
         {children}
       </div>

--- a/apps/src/templates/sectionProgressV2/LessonDataCell.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonDataCell.jsx
@@ -43,7 +43,7 @@ function LessonDataCell({
           href={teacherDashboardUrl(sectionId, '/assessments')}
           openInNewTab
           external
-          data-testid={'lesson-data-cell-' + lesson.id + '-' + studentId}
+          data-testid={'lesson-data-cell-' + lesson.id + '-' + studentId} // eslint-disable-line react/forbid-dom-props
         >
           {children}
         </Link>
@@ -59,7 +59,7 @@ function LessonDataCell({
           interactive && styles.lessonInteractive
         )}
         onClick={expandLesson}
-        data-testid={'lesson-data-cell-' + lesson.id + '-' + studentId}
+        data-testid={'lesson-data-cell-' + lesson.id + '-' + studentId} // eslint-disable-line react/forbid-dom-props
       >
         {children}
       </div>

--- a/apps/src/templates/sectionProgressV2/LessonProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonProgressColumnHeader.jsx
@@ -44,7 +44,7 @@ const getSkeletonLessonHeader = lessonId => (
     key={lessonId}
   >
     <div
-      data-testid={'skeletonize-content'}
+      data-testid={'skeletonize-content'} // eslint-disable-line react/forbid-dom-props
       className={classNames(
         styles.lessonSkeletonHeaderCell,
         skeletonizeContent.skeletonizeContent

--- a/apps/src/templates/sectionProgressV2/LessonProgressColumnHeader.jsx
+++ b/apps/src/templates/sectionProgressV2/LessonProgressColumnHeader.jsx
@@ -44,7 +44,8 @@ const getSkeletonLessonHeader = lessonId => (
     key={lessonId}
   >
     <div
-      data-testid={'skeletonize-content'} // eslint-disable-line react/forbid-dom-props
+      // eslint-disable-next-line react/forbid-dom-props
+      data-testid={'skeletonize-content'}
       className={classNames(
         styles.lessonSkeletonHeaderCell,
         skeletonizeContent.skeletonizeContent

--- a/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
@@ -14,7 +14,7 @@ export default function ProgressIcon({itemType}) {
     <div
       className={classNames(styles.needsFeedback, styles.cornerBox)}
       aria-label={itemType['title']}
-      data-testid="needs-feedback-triangle"
+      data-testid="needs-feedback-triangle" // eslint-disable-line react/forbid-dom-props
     />
   );
 
@@ -22,11 +22,12 @@ export default function ProgressIcon({itemType}) {
     <div
       className={classNames(styles.feedbackGiven, styles.cornerBox)}
       aria-label={itemType['title']}
-      data-testid="feedback-given-triangle"
+      data-testid="feedback-given-triangle" // eslint-disable-line react/forbid-dom-props
     />
   );
 
   return (
+    // eslint-disable-next-line react/forbid-dom-props
     <div data-testid="progress-icon">
       {itemType['icon'] !== undefined && (
         <FontAwesome

--- a/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
@@ -14,7 +14,8 @@ export default function ProgressIcon({itemType}) {
     <div
       className={classNames(styles.needsFeedback, styles.cornerBox)}
       aria-label={itemType['title']}
-      data-testid="needs-feedback-triangle" // eslint-disable-line react/forbid-dom-props
+      // eslint-disable-next-line react/forbid-dom-props
+      data-testid="needs-feedback-triangle"
     />
   );
 
@@ -22,7 +23,8 @@ export default function ProgressIcon({itemType}) {
     <div
       className={classNames(styles.feedbackGiven, styles.cornerBox)}
       aria-label={itemType['title']}
-      data-testid="feedback-given-triangle" // eslint-disable-line react/forbid-dom-props
+      // eslint-disable-next-line react/forbid-dom-props
+      data-testid="feedback-given-triangle"
     />
   );
 

--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -86,6 +86,7 @@ function SectionProgressV2({
   }, [expandedLessonIds, unitData]);
 
   return (
+    // eslint-disable-next-line react/forbid-dom-props
     <div className={styles.progressV2Page} data-testid="section-progress-v2">
       {!hideTopHeading && <Heading1>{i18n.progressBeta()}</Heading1>}
       <IconKey

--- a/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
@@ -23,7 +23,8 @@ const getSkeletonCell = (id, key = undefined) => (
   <div
     className={classNames(styles.gridBox, styles.gridBoxLesson)}
     key={key}
-    data-testid={'lesson-skeleton-cell-' + id} // eslint-disable-line react/forbid-dom-props
+    // eslint-disable-next-line react/forbid-dom-props
+    data-testid={'lesson-skeleton-cell-' + id}
   >
     {skeletonContent}
   </div>
@@ -34,13 +35,15 @@ const getMetadataExpandedSkeletonCell = id => (
     {getSkeletonCell(id)}
     <div
       className={classNames(styles.gridBox, styles.gridBoxMetadata)}
-      data-testid={'lesson-skeleton-cell-' + id + '-time-spent'} // eslint-disable-line react/forbid-dom-props
+      // eslint-disable-next-line react/forbid-dom-props
+      data-testid={'lesson-skeleton-cell-' + id + '-time-spent'}
     >
       {skeletonContent}
     </div>
     <div
       className={classNames(styles.gridBox, styles.gridBoxMetadata)}
-      data-testid={'lesson-skeleton-cell-' + id + '-last-updated'} // eslint-disable-line react/forbid-dom-props
+      // eslint-disable-next-line react/forbid-dom-props
+      data-testid={'lesson-skeleton-cell-' + id + '-last-updated'}
     >
       {skeletonContent}
     </div>

--- a/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
@@ -23,7 +23,7 @@ const getSkeletonCell = (id, key = undefined) => (
   <div
     className={classNames(styles.gridBox, styles.gridBoxLesson)}
     key={key}
-    data-testid={'lesson-skeleton-cell-' + id}
+    data-testid={'lesson-skeleton-cell-' + id} // eslint-disable-line react/forbid-dom-props
   >
     {skeletonContent}
   </div>
@@ -34,13 +34,13 @@ const getMetadataExpandedSkeletonCell = id => (
     {getSkeletonCell(id)}
     <div
       className={classNames(styles.gridBox, styles.gridBoxMetadata)}
-      data-testid={'lesson-skeleton-cell-' + id + '-time-spent'}
+      data-testid={'lesson-skeleton-cell-' + id + '-time-spent'} // eslint-disable-line react/forbid-dom-props
     >
       {skeletonContent}
     </div>
     <div
       className={classNames(styles.gridBox, styles.gridBoxMetadata)}
-      data-testid={'lesson-skeleton-cell-' + id + '-last-updated'}
+      data-testid={'lesson-skeleton-cell-' + id + '-last-updated'} // eslint-disable-line react/forbid-dom-props
     >
       {skeletonContent}
     </div>

--- a/apps/src/templates/sectionProgressV2/StudentColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/StudentColumn.jsx
@@ -29,7 +29,8 @@ const skeletonCell = key => (
         styles.gridBoxSkeleton
       )}
       style={{width: _.random(30, 90) + '%'}}
-      data-testid="skeleton-cell" // eslint-disable-line react/forbid-dom-props
+      // eslint-disable-next-line react/forbid-dom-props
+      data-testid="skeleton-cell"
     />
   </div>
 );

--- a/apps/src/templates/sectionProgressV2/StudentColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/StudentColumn.jsx
@@ -29,7 +29,7 @@ const skeletonCell = key => (
         styles.gridBoxSkeleton
       )}
       style={{width: _.random(30, 90) + '%'}}
-      data-testid="skeleton-cell"
+      data-testid="skeleton-cell" // eslint-disable-line react/forbid-dom-props
     />
   </div>
 );

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -25,7 +25,8 @@ export default function TwoColumnActionBlock({
     <div
       id={id}
       className={styles.container}
-      data-testid="two-column-action-block" // eslint-disable-line react/forbid-dom-props
+      // eslint-disable-next-line react/forbid-dom-props
+      data-testid="two-column-action-block"
     >
       {heading && <Heading2>{heading}</Heading2>}
       <div
@@ -36,7 +37,8 @@ export default function TwoColumnActionBlock({
           src={imageUrl}
           alt=""
           className={styles.image}
-          data-testid="two-column-action-block-img" // eslint-disable-line react/forbid-dom-props
+          // eslint-disable-next-line react/forbid-dom-props
+          data-testid="two-column-action-block-img"
         />
         <div className={styles.contentWrapper}>
           {subHeading && (

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -25,7 +25,7 @@ export default function TwoColumnActionBlock({
     <div
       id={id}
       className={styles.container}
-      data-testid="two-column-action-block"
+      data-testid="two-column-action-block" // eslint-disable-line react/forbid-dom-props
     >
       {heading && <Heading2>{heading}</Heading2>}
       <div
@@ -36,7 +36,7 @@ export default function TwoColumnActionBlock({
           src={imageUrl}
           alt=""
           className={styles.image}
-          data-testid="two-column-action-block-img"
+          data-testid="two-column-action-block-img" // eslint-disable-line react/forbid-dom-props
         />
         <div className={styles.contentWrapper}>
           {subHeading && (

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -242,7 +242,8 @@ class LoginTypePicker extends Component {
             </Typography>
             <div
               style={style.lmsInfoCardsContainer}
-              data-testid={'lms-info-cards-container'} // eslint-disable-line react/forbid-dom-props
+              // eslint-disable-next-line react/forbid-dom-props
+              data-testid={'lms-info-cards-container'}
             >
               {!withClever && (
                 <LmsInformationalCard

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -242,7 +242,7 @@ class LoginTypePicker extends Component {
             </Typography>
             <div
               style={style.lmsInfoCardsContainer}
-              data-testid={'lms-info-cards-container'}
+              data-testid={'lms-info-cards-container'} // eslint-disable-line react/forbid-dom-props
             >
               {!withClever && (
                 <LmsInformationalCard

--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
@@ -84,7 +84,7 @@ export const courseLinkFormatter = function (course, {rowData}) {
       ) : (
         <span
           className={skeletonizeContent.skeletonizeContent}
-          data-testid={'skeletonize-content'}
+          data-testid={'skeletonize-content'} // eslint-disable-line react/forbid-dom-props
           style={{width: random(30, 90) + '%'}}
         />
       )}

--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
@@ -84,7 +84,8 @@ export const courseLinkFormatter = function (course, {rowData}) {
       ) : (
         <span
           className={skeletonizeContent.skeletonizeContent}
-          data-testid={'skeletonize-content'} // eslint-disable-line react/forbid-dom-props
+          // eslint-disable-next-line react/forbid-dom-props
+          data-testid={'skeletonize-content'}
           style={{width: random(30, 90) + '%'}}
         />
       )}

--- a/apps/src/templates/teacherNavigation/lessonMaterials/ResourceIcon.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/ResourceIcon.tsx
@@ -26,7 +26,8 @@ const ResourceIcon: React.FC<ResourceIconProps> = ({
 
   return (
     <div
-      data-testid={'resource-icon-' + iconType.icon} // eslint-disable-line react/forbid-dom-props
+      // eslint-disable-next-line react/forbid-dom-props
+      data-testid={'resource-icon-' + iconType.icon}
       className={classNames(styles.resourceIconContainer, iconType.class)}
     >
       <FontAwesomeV6Icon iconName={iconType.icon} className={styles.icon} />

--- a/apps/src/templates/teacherNavigation/lessonMaterials/ResourceIcon.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/ResourceIcon.tsx
@@ -26,7 +26,7 @@ const ResourceIcon: React.FC<ResourceIconProps> = ({
 
   return (
     <div
-      data-testid={'resource-icon-' + iconType.icon}
+      data-testid={'resource-icon-' + iconType.icon} // eslint-disable-line react/forbid-dom-props
       className={classNames(styles.resourceIconContainer, iconType.class)}
     >
       <FontAwesomeV6Icon iconName={iconType.icon} className={styles.icon} />

--- a/apps/src/templates/teacherNavigation/lessonMaterials/ResourceRow.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/ResourceRow.tsx
@@ -39,6 +39,7 @@ const ResourceRow: React.FC<ResourceRowProps> = ({
   ) : null;
 
   return (
+    // eslint-disable-next-line react/forbid-dom-props
     <div className={styles.rowContainer} data-testid="resource-row">
       <div className={styles.iconAndName}>
         <ResourceIcon resourceType={resource.type} resourceUrl={resource.url} />

--- a/apps/src/templates/teacherNavigation/lessonMaterials/ResourceViewOptionsDropdown.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/ResourceViewOptionsDropdown.tsx
@@ -133,6 +133,7 @@ const ResourceViewOptionsDropdown: React.FC<
   }, [materialType, resource]);
 
   return (
+    // eslint-disable-next-line react/forbid-dom-props
     <div data-testid={'view-options-dropdown'}>
       <ActionDropdown
         name="view-options"

--- a/apps/src/templates/teacherNavigation/lessonMaterials/UnitResourcesDropdown.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/UnitResourcesDropdown.tsx
@@ -36,6 +36,7 @@ const UnitResourcesDropdown: React.FC<UnitResourcesDropdownProps> = ({
   ];
 
   return (
+    // eslint-disable-next-line react/forbid-dom-props
     <div data-testid={'unit-resources-download-dropdown'}>
       <ActionDropdown
         name="view-options"

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
@@ -88,6 +88,7 @@ describe('LandingPage', () => {
     });
     screen.getByText(i18n.plLandingGettingStartedHeading());
     expect(screen.queryByText(i18n.plLandingStartSurvey())).toBeFalsy();
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('enrolled-workshops-loader');
     expect(
       screen.queryByText(i18n.plLandingSelfPacedProgressHeading())
@@ -101,6 +102,7 @@ describe('LandingPage', () => {
       screen.queryByText(i18n.plLandingGettingStartedHeading())
     ).toBeFalsy();
     screen.getByText(i18n.plLandingStartSurvey());
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('enrolled-workshops-loader');
     screen.getByText(i18n.plLandingSelfPacedProgressHeading());
     screen.getByText(i18n.plLandingStaticPLMidHighHeading());
@@ -112,6 +114,7 @@ describe('LandingPage', () => {
       screen.queryByText(i18n.plLandingGettingStartedHeading())
     ).toBeFalsy();
     screen.getByText(i18n.plLandingStartSurvey());
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('enrolled-workshops-loader');
     screen.getByText(i18n.plLandingSelfPacedProgressHeading());
     screen.getByText(i18n.plLandingStaticPLMidHighHeading());
@@ -126,6 +129,7 @@ describe('LandingPage', () => {
       screen.queryByText(i18n.plLandingGettingStartedHeading())
     ).toBeFalsy();
     expect(screen.queryByText(i18n.plLandingStartSurvey())).toBeFalsy();
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('enrolled-workshops-loader');
     screen.getByText(i18n.plLandingSelfPacedProgressHeading());
     screen.getByText(i18n.plLandingStaticPLMidHighHeading());
@@ -134,6 +138,7 @@ describe('LandingPage', () => {
   it('page shows self-paced progress table if enrolled in self-paced courses', () => {
     renderDefault();
     screen.getByText(i18n.plLandingSelfPacedProgressHeading());
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.getAllByTestId('progress-bar').length).toBe(2);
     expect(screen.getByText(i18n.selfPacedPlCompleted()));
     expect(screen.getAllByText(i18n.selfPacedPlContinueCourse()).length).toBe(
@@ -153,6 +158,7 @@ describe('LandingPage', () => {
   it('page shows enrolled workshops table', () => {
     renderDefault();
 
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('enrolled-workshops-loader');
   });
 

--- a/apps/test/unit/componentLibrary/AlertTest.jsx
+++ b/apps/test/unit/componentLibrary/AlertTest.jsx
@@ -84,6 +84,7 @@ describe('Design System - Alert', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const iconElement = container.querySelector('.fa-check-circle');
 
     expect(screen.getByText('Full Alert')).toBeDefined();

--- a/apps/test/unit/componentLibrary/AlertTest.jsx
+++ b/apps/test/unit/componentLibrary/AlertTest.jsx
@@ -15,6 +15,7 @@ describe('Design System - Alert', () => {
     const icon = {iconName: 'check-circle'};
     render(<Alert text="Alert text" icon={icon} />);
 
+    // eslint-disable-next-line no-restricted-properties
     const iconElement = screen.getByTestId('font-awesome-v6-icon');
     expect(iconElement).toBeDefined();
     expect(iconElement.className).toContain('fa-check-circle');
@@ -22,21 +23,25 @@ describe('Design System - Alert', () => {
 
   it('Alert - renders default icon for specific types', () => {
     const {rerender} = render(<Alert text="Success Alert" type="success" />);
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.getByTestId('font-awesome-v6-icon').className).toContain(
       'fa-check-circle'
     );
 
     rerender(<Alert text="Danger Alert" type="danger" />);
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.getByTestId('font-awesome-v6-icon').className).toContain(
       'fa-circle-xmark'
     );
 
     rerender(<Alert text="Warning Alert" type="warning" />);
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.getByTestId('font-awesome-v6-icon').className).toContain(
       'fa-exclamation-circle'
     );
 
     rerender(<Alert text="Info Alert" type="info" />);
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.getByTestId('font-awesome-v6-icon').className).toContain(
       'fa-circle-info'
     );

--- a/apps/test/unit/componentLibrary/BreadcrumbsTest.tsx
+++ b/apps/test/unit/componentLibrary/BreadcrumbsTest.tsx
@@ -48,6 +48,7 @@ describe('Breadcrumbs Component', () => {
 
     // eslint-disable-next-line no-restricted-properties
     const container = screen.getByTestId('breadcrumbs-test-breadcrumbs');
+    // eslint-disable-next-line no-restricted-properties
     expect(container).toHaveClass(customClass);
   });
 

--- a/apps/test/unit/componentLibrary/BreadcrumbsTest.tsx
+++ b/apps/test/unit/componentLibrary/BreadcrumbsTest.tsx
@@ -37,6 +37,7 @@ describe('Breadcrumbs Component', () => {
   it('renders correct test id for the breadcrumbs container', () => {
     setup();
 
+    // eslint-disable-next-line no-restricted-properties
     const container = screen.getByTestId('breadcrumbs-test-breadcrumbs');
     expect(container).toBeInTheDocument();
   });
@@ -45,6 +46,7 @@ describe('Breadcrumbs Component', () => {
     const customClass = 'custom-class';
     setup({className: customClass});
 
+    // eslint-disable-next-line no-restricted-properties
     const container = screen.getByTestId('breadcrumbs-test-breadcrumbs');
     expect(container).toHaveClass(customClass);
   });
@@ -53,6 +55,7 @@ describe('Breadcrumbs Component', () => {
     setup();
 
     // Since the FontAwesome icon might not have a clear role, check it by query
+    // eslint-disable-next-line no-restricted-properties
     const chevrons = screen.getAllByTestId('font-awesome-v6-icon');
     expect(chevrons.length).toBe(breadcrumbsData.length - 1); // Should be one less than breadcrumbs
   });

--- a/apps/test/unit/componentLibrary/ChipsTest.jsx
+++ b/apps/test/unit/componentLibrary/ChipsTest.jsx
@@ -23,6 +23,7 @@ describe('Design System - Chips', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const chips = screen.getByTestId('chips-test-chips');
     expect(chips).toBeDefined();
     expect(screen.getByText('Chips label')).toBeDefined();
@@ -38,6 +39,7 @@ describe('Design System - Chips', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const chips = screen.getByTestId('chips-test-chips');
     expect(chips).toBeDefined();
     expect(screen.queryByText('Chips label')).toBeNull();
@@ -63,6 +65,7 @@ describe('Design System - Chips', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const chips = screen.getByTestId('chips-test-chips');
     expect(chips).toBeDefined();
 
@@ -159,6 +162,7 @@ describe('Design System - Chips', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const chips = screen.getByTestId('chips-test-chips');
     expect(chips).toBeDefined();
 
@@ -246,6 +250,7 @@ describe('Design System - Chips', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const chips = screen.getByTestId('chips-test-chips');
     expect(chips).toBeDefined();
 

--- a/apps/test/unit/componentLibrary/FontAwesomeV6IconTest.jsx
+++ b/apps/test/unit/componentLibrary/FontAwesomeV6IconTest.jsx
@@ -14,6 +14,7 @@ describe('Design System - FontAwesomeV6Icon', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const icon = screen.getByTestId('font-awesome-v6-icon');
     expect(icon).toBeDefined();
     expect(icon.classList.contains('fa-solid')).toBe(true);

--- a/apps/test/unit/componentLibrary/PopoverTest.jsx
+++ b/apps/test/unit/componentLibrary/PopoverTest.jsx
@@ -58,6 +58,7 @@ describe('Design System - Popover Component', () => {
     const icon = screen.getByTitle('check-icon');
 
     expect(icon).toBeInTheDocument();
+    // eslint-disable-next-line no-restricted-properties
     expect(icon).toHaveClass('fa-solid', 'fa-check');
   });
 

--- a/apps/test/unit/componentLibrary/SliderTest.tsx
+++ b/apps/test/unit/componentLibrary/SliderTest.tsx
@@ -65,8 +65,8 @@ describe('Slider Component', () => {
   //   expect(slider).toHaveAttribute('value', '50');
   //
   //   // Check that the center mark is rendered correctly
-  //   const centerMark = screen.getByTestId('slider-center-mark');
-  //   expect(centerMark).toBeInTheDocument();
+  // eslint-disable-next-line no-restricted-properties
+  //   const centerMark = screen.getByTestId('slider-center-mark');  //   expect(centerMark).toBeInTheDocument();
   //   expect(centerMark).toHaveStyle('left: calc(50% - 1px)');
   // });
 
@@ -141,7 +141,7 @@ describe('Slider Component', () => {
   // it('renders correctly with step marks when steps are provided', () => {
   //   renderComponent({steps: [0, 25, 50, 75, 100], value: 50});
   //
-  //   const stepMarks = screen.getAllByTestId('step-mark');
-  //   expect(stepMarks.length).toBe(5); // Should render 5 step marks
+  // eslint-disable-next-line no-restricted-properties
+  //   const stepMarks = screen.getAllByTestId('step-mark');  //   expect(stepMarks.length).toBe(5); // Should render 5 step marks
   // });
 });

--- a/apps/test/unit/componentLibrary/SliderTest.tsx
+++ b/apps/test/unit/componentLibrary/SliderTest.tsx
@@ -65,8 +65,8 @@ describe('Slider Component', () => {
   //   expect(slider).toHaveAttribute('value', '50');
   //
   //   // Check that the center mark is rendered correctly
-  // eslint-disable-next-line no-restricted-properties
-  //   const centerMark = screen.getByTestId('slider-center-mark');  //   expect(centerMark).toBeInTheDocument();
+  //   const centerMark = screen.getByTestId('slider-center-mark');
+  //   expect(centerMark).toBeInTheDocument();
   //   expect(centerMark).toHaveStyle('left: calc(50% - 1px)');
   // });
 
@@ -141,7 +141,7 @@ describe('Slider Component', () => {
   // it('renders correctly with step marks when steps are provided', () => {
   //   renderComponent({steps: [0, 25, 50, 75, 100], value: 50});
   //
-  // eslint-disable-next-line no-restricted-properties
-  //   const stepMarks = screen.getAllByTestId('step-mark');  //   expect(stepMarks.length).toBe(5); // Should render 5 step marks
+  //   const stepMarks = screen.getAllByTestId('step-mark');
+  //   expect(stepMarks.length).toBe(5); // Should render 5 step marks
   // });
 });

--- a/apps/test/unit/componentLibrary/TagsTest.jsx
+++ b/apps/test/unit/componentLibrary/TagsTest.jsx
@@ -23,6 +23,7 @@ describe('Design System - Tags', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const tags = screen.getByTestId('tags');
     expect(tags).toBeDefined();
     expect(screen.getByText('tag1')).toBeDefined();
@@ -50,6 +51,7 @@ describe('Design System - Tags', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const tags = screen.getByTestId('tags');
     const tag1 = screen.getByText('tag1');
     const plusOneTag = screen.getByText('+1');

--- a/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -121,17 +121,20 @@ describe('UnitEditor', () => {
   describe('Script Editor', () => {
     it('does not show publishing editor if hasCourse is true', () => {
       renderDefault({hasCourse: true});
+      // eslint-disable-next-line no-restricted-properties
       expect(screen.queryByTestId('course-version-publishing-editor')).to.not
         .exist;
     });
 
     it('shows publishing editor if hasCourse is false', () => {
       renderDefault({hasCourse: false});
+      // eslint-disable-next-line no-restricted-properties
       screen.queryByTestId('course-version-publishing-editor');
     });
 
     it('topic tags is a multiple chips component with initial options selected', () => {
       renderDefault({initialTopicTags: ['music_lab', 'ai']});
+      // eslint-disable-next-line no-restricted-properties
       const topicTags = screen.getByTestId('chips-unit-editor-topic-tags');
       expect(within(topicTags).getAllByRole('checkbox').length).to.equal(3);
 
@@ -148,6 +151,7 @@ describe('UnitEditor', () => {
 
     it('selecting topic tag chips updates input element selection state', () => {
       renderDefault({initialTopicTags: ['music_lab', 'ai']});
+      // eslint-disable-next-line no-restricted-properties
       const topicTags = screen.getByTestId('chips-unit-editor-topic-tags');
       expect(within(topicTags).getAllByRole('checkbox').length).to.equal(3);
 

--- a/apps/test/unit/puzzleRatingUtilsTest.js
+++ b/apps/test/unit/puzzleRatingUtilsTest.js
@@ -56,6 +56,7 @@ describe('Puzzle Rating Utils', function () {
     });
 
     it('saves the rating if a button is enabled', function () {
+      // eslint-disable-next-line no-restricted-properties
       container
         .querySelectorAll('.puzzle-rating-btn')[0]
         .classList.add('enabled');
@@ -68,6 +69,7 @@ describe('Puzzle Rating Utils', function () {
 
     it("doesn' squash existing ratings", function () {
       puzzleRatingUtils.setPuzzleRatings_(sampleRatings);
+      // eslint-disable-next-line no-restricted-properties
       container
         .querySelectorAll('.puzzle-rating-btn')[0]
         .classList.add('enabled');

--- a/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -35,6 +35,7 @@ describe('LTI Link Account Page Tests', () => {
         </LtiProviderContext.Provider>
       );
 
+      // eslint-disable-next-line no-restricted-properties
       const existingAccountCard = screen.getByTestId('existing-account-card');
       const withinExistingAccountCard = within(existingAccountCard);
       const urlParams = new URLSearchParams({
@@ -72,6 +73,7 @@ describe('LTI Link Account Page Tests', () => {
         </LtiProviderContext.Provider>
       );
 
+      // eslint-disable-next-line no-restricted-properties
       const newAccountCard = screen.getByTestId('new-account-card');
       const withinNewAccountCard = within(newAccountCard);
 
@@ -84,8 +86,8 @@ describe('LTI Link Account Page Tests', () => {
         i18n.ltiLinkAccountNewAccountCardContent({providerName: 'Canvas'})
       );
       const newAccountForm: HTMLFormElement =
+        // eslint-disable-next-line no-restricted-properties
         screen.getByTestId('new-account-form');
-
       const formValues = new FormData(newAccountForm);
 
       expect(formValues.get('user[email]')).toEqual(

--- a/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -88,6 +88,7 @@ describe('LTI Link Account Page Tests', () => {
       const newAccountForm: HTMLFormElement =
         // eslint-disable-next-line no-restricted-properties
         screen.getByTestId('new-account-form');
+
       const formValues = new FormData(newAccountForm);
 
       expect(formValues.get('user[email]')).toEqual(

--- a/apps/test/unit/simpleSignUp/lti/sync/LtiSectionSyncDialogTest.tsx
+++ b/apps/test/unit/simpleSignUp/lti/sync/LtiSectionSyncDialogTest.tsx
@@ -169,6 +169,7 @@ describe('LTI Section Sync Dialog', () => {
       );
 
       const cancelButton = within(
+        // eslint-disable-next-line no-restricted-properties
         screen.getByTestId('disable-roster-sync')
       ).getByText(i18n.dialogCancel());
 

--- a/apps/test/unit/simpleSignUp/workshop/WorkshopLinkAccountPageTest.tsx
+++ b/apps/test/unit/simpleSignUp/workshop/WorkshopLinkAccountPageTest.tsx
@@ -19,6 +19,7 @@ describe('Workshop Link Account Page Tests', () => {
     it('should render an existing account card', () => {
       renderDefault();
 
+      // eslint-disable-next-line no-restricted-properties
       const existingAccountCard = screen.getByTestId('existing-account-card');
       const withinExistingAccountCard = within(existingAccountCard);
 
@@ -44,6 +45,7 @@ describe('Workshop Link Account Page Tests', () => {
     it('should render a new account card', async () => {
       renderDefault();
 
+      // eslint-disable-next-line no-restricted-properties
       const newAccountCard = screen.getByTestId('new-account-card');
       const withinNewAccountCard = within(newAccountCard);
 

--- a/apps/test/unit/simpleSignUp/workshop/WorkshopStudentEnrollPageTest.tsx
+++ b/apps/test/unit/simpleSignUp/workshop/WorkshopStudentEnrollPageTest.tsx
@@ -13,6 +13,7 @@ describe('Workshop Link Account Page Tests', () => {
     it('should render a keep student account card', () => {
       renderDefault();
 
+      // eslint-disable-next-line no-restricted-properties
       const keepStudentAccountCard = screen.getByTestId(
         'keep-student-account-card'
       );
@@ -40,6 +41,7 @@ describe('Workshop Link Account Page Tests', () => {
     it('should render a switch to teacher account card', async () => {
       renderDefault();
 
+      // eslint-disable-next-line no-restricted-properties
       const switchToTeacherAccountCard = screen.getByTestId(
         'switch-to-teacher-account-card'
       );

--- a/apps/test/unit/templates/ImageWithStatusTest.js
+++ b/apps/test/unit/templates/ImageWithStatusTest.js
@@ -16,6 +16,7 @@ describe('ImageWithStatus', () => {
         height={THUMBNAIL_SIZE}
       />
     );
+    // eslint-disable-next-line no-restricted-properties
     const loading = container.querySelector('div[data-image-status="loading"]');
     expect(loading).not.toBeNull();
   });
@@ -29,10 +30,12 @@ describe('ImageWithStatus', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const image = container.querySelector(`img[src='${CAT_IMAGE_URL}']`);
     image.dispatchEvent(new Event('load'));
 
     const loaded = await waitFor(() =>
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('div[data-image-status="loaded"]')
     );
     expect(loaded).not.toBeNull();
@@ -47,10 +50,12 @@ describe('ImageWithStatus', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const image = container.querySelector(`img[src='${CAT_IMAGE_URL}']`);
     image.dispatchEvent(new Event('load'));
 
     let loaded = await waitFor(() =>
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('div[data-image-status="loaded"]')
     );
     expect(loaded).not.toBeNull();
@@ -64,12 +69,14 @@ describe('ImageWithStatus', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const loading = container.querySelector('div[data-image-status="loading"]');
     expect(loading).not.toBeNull();
 
     image.dispatchEvent(new Event('load'));
 
     loaded = await waitFor(() =>
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('div[data-image-status="loaded"]')
     );
     expect(loaded).not.toBeNull();
@@ -84,10 +91,12 @@ describe('ImageWithStatus', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const image = container.querySelector(`img[src='${BOGUS_IMAGE_URL}']`);
     image.dispatchEvent(new Event('error'));
 
     const error = await waitFor(() =>
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('div[data-image-status="error"]')
     );
     expect(error).not.toBeNull();

--- a/apps/test/unit/templates/certificates/CertificateShareTest.js
+++ b/apps/test/unit/templates/certificates/CertificateShareTest.js
@@ -40,6 +40,7 @@ describe('CertificateShare', () => {
     const image = screen.getByRole('img', {name: defaultImageAlt});
     expect(image.src).toContain('/certificate-image');
 
+    // eslint-disable-next-line no-restricted-properties
     const twoColumnActionBlock = screen.getByTestId('two-column-action-block');
     const announcementImg = within(twoColumnActionBlock).getByTestId(
       'two-column-action-block-img'
@@ -56,6 +57,7 @@ describe('CertificateShare', () => {
 
     screen.findByRole('link', {name: defaultImageAlt});
 
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId('two-column-action-block')).toBeFalsy();
   });
 });

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -196,6 +196,7 @@ describe('CurriculumCatalogCard', () => {
     const {container} = renderCurriculumCard();
 
     expect(screen.queryByTitle(translationIconTitle)).toBeNull();
+    // eslint-disable-next-line no-restricted-properties
     expect(container.querySelectorAll('i[class*=language]')).toHaveLength(0);
   });
 
@@ -207,6 +208,7 @@ describe('CurriculumCatalogCard', () => {
     });
 
     expect(screen.queryByTitle(translationIconTitle)).toBeNull();
+    // eslint-disable-next-line no-restricted-properties
     expect(container.querySelectorAll('i[class*=language]')).toHaveLength(0);
   });
 
@@ -218,6 +220,7 @@ describe('CurriculumCatalogCard', () => {
     });
 
     screen.getByTitle(translationIconTitle);
+    // eslint-disable-next-line no-restricted-properties
     expect(container.querySelectorAll('i[class*=language]')).toHaveLength(1);
   });
 
@@ -231,6 +234,7 @@ describe('CurriculumCatalogCard', () => {
         }`
       )
     );
+    // eslint-disable-next-line no-restricted-properties
     expect(container.querySelectorAll('i[class*=user]')).toHaveLength(1);
   });
 
@@ -242,6 +246,7 @@ describe('CurriculumCatalogCard', () => {
     });
 
     screen.getByText(new RegExp(`Grade: ${grade}`));
+    // eslint-disable-next-line no-restricted-properties
     expect(container.querySelectorAll('i[class*=user]')).toHaveLength(1);
   });
 
@@ -249,6 +254,7 @@ describe('CurriculumCatalogCard', () => {
     const {container} = renderCurriculumCard();
 
     screen.getByText(defaultProps.duration, {exact: false});
+    // eslint-disable-next-line no-restricted-properties
     expect(container.querySelectorAll('i[class*=clock]')).toHaveLength(1);
   });
 

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogExpandedCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogExpandedCardTest.jsx
@@ -74,6 +74,7 @@ describe('CurriculumCatalogExpandedCard', () => {
     const {container} = renderCurriculumExpandedCard();
 
     screen.getByText(defaultProps.gradeRange);
+    // eslint-disable-next-line no-restricted-properties
     expect(container.querySelectorAll('i[class*=user]')).toHaveLength(1);
   });
 
@@ -85,6 +86,7 @@ describe('CurriculumCatalogExpandedCard', () => {
     });
 
     screen.getByText(grade);
+    // eslint-disable-next-line no-restricted-properties
     expect(container.querySelectorAll('i[class*=user]')).toHaveLength(1);
   });
 
@@ -96,6 +98,7 @@ describe('CurriculumCatalogExpandedCard', () => {
     });
 
     screen.getByText(duration);
+    // eslint-disable-next-line no-restricted-properties
     expect(container.querySelectorAll('i[class*=clock]')).toHaveLength(1);
   });
 
@@ -105,6 +108,7 @@ describe('CurriculumCatalogExpandedCard', () => {
     screen.getByText(
       new RegExp(`Topic: ${defaultProps.subjectsAndTopics.join(', ')}`)
     );
+    // eslint-disable-next-line no-restricted-properties
     expect(container.querySelectorAll('i[class*=book]')).toHaveLength(1);
   });
 
@@ -157,6 +161,7 @@ describe('CurriculumCatalogExpandedCard', () => {
     });
 
     //Checks for correct amount of Horizontal dividers
+    // eslint-disable-next-line no-restricted-properties
     expect(availableResourcesContainer.querySelectorAll('hr')).toHaveLength(
       Object.keys(availableResources).length
     );

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogExpandedCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogExpandedCardTest.jsx
@@ -161,7 +161,6 @@ describe('CurriculumCatalogExpandedCard', () => {
     });
 
     //Checks for correct amount of Horizontal dividers
-    // eslint-disable-next-line no-restricted-properties
     expect(availableResourcesContainer.querySelectorAll('hr')).toHaveLength(
       Object.keys(availableResources).length
     );

--- a/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
@@ -430,9 +430,13 @@ describe('LearningGoals - React Testing Library', () => {
       render(<LearningGoals {...feedbackProps} />);
 
       // neither thumb is selected
+      // eslint-disable-next-line no-restricted-properties
       screen.getByTestId('thumbs-o-up');
+      // eslint-disable-next-line no-restricted-properties
       expect(screen.queryByTestId('thumbs-up')).not.toBeInTheDocument();
+      // eslint-disable-next-line no-restricted-properties
       screen.getByTestId('thumbs-o-down');
+      // eslint-disable-next-line no-restricted-properties
       expect(screen.queryByTestId('thumbs-down')).not.toBeInTheDocument();
 
       // checkboxes not visible
@@ -459,10 +463,12 @@ describe('LearningGoals - React Testing Library', () => {
         }
       });
 
+      // eslint-disable-next-line no-restricted-properties
       const thumbsUpButton = screen.getByTestId('thumbs-o-up');
       fireEvent.click(thumbsUpButton);
       await wait();
 
+      // eslint-disable-next-line no-restricted-properties
       screen.getByTestId('thumbs-up');
       expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
 
@@ -505,12 +511,13 @@ describe('LearningGoals - React Testing Library', () => {
         }
       });
 
+      // eslint-disable-next-line no-restricted-properties
       const thumbsUpButton = screen.getByTestId('thumbs-o-down');
       fireEvent.click(thumbsUpButton);
       await wait();
 
+      // eslint-disable-next-line no-restricted-properties
       screen.getByTestId('thumbs-down');
-
       const expectedBody = JSON.stringify({
         learningGoalAiEvaluationId: 2,
         aiFeedbackApproval: THUMBS_DOWN,
@@ -553,6 +560,7 @@ describe('LearningGoals - React Testing Library', () => {
       // survey not visible
       expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
 
+      // eslint-disable-next-line no-restricted-properties
       const thumbsUpButton = screen.getByTestId('thumbs-o-down');
       fireEvent.click(thumbsUpButton);
       await wait();
@@ -560,14 +568,15 @@ describe('LearningGoals - React Testing Library', () => {
       // survey is visible
       expect(screen.getAllByRole('checkbox')).toHaveLength(4);
 
+      // eslint-disable-next-line no-restricted-properties
       expect(screen.queryByTestId('ai-assessment-feedback-textarea')).not
         .toBeInTheDocument;
 
       const checkbox = screen.getByRole('checkbox', {name: 'Other'});
       fireEvent.click(checkbox);
 
+      // eslint-disable-next-line no-restricted-properties
       screen.getByTestId('ai-assessment-feedback-textarea');
-
       fetchStub.mockRestore();
     });
 
@@ -599,6 +608,7 @@ describe('LearningGoals - React Testing Library', () => {
       // survey not visible
       expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
 
+      // eslint-disable-next-line no-restricted-properties
       const thumbsUpButton = screen.getByTestId('thumbs-o-down');
       fireEvent.click(thumbsUpButton);
       await wait();
@@ -619,6 +629,7 @@ describe('LearningGoals - React Testing Library', () => {
       fireEvent.click(submitButton);
       await wait();
 
+      // eslint-disable-next-line no-restricted-properties
       expect(screen.queryByTestId('ai-assessment-feedback-textarea')).not
         .toBeInTheDocument;
 

--- a/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
+++ b/apps/test/unit/templates/rubrics/LearningGoalsTest.jsx
@@ -518,6 +518,7 @@ describe('LearningGoals - React Testing Library', () => {
 
       // eslint-disable-next-line no-restricted-properties
       screen.getByTestId('thumbs-down');
+
       const expectedBody = JSON.stringify({
         learningGoalAiEvaluationId: 2,
         aiFeedbackApproval: THUMBS_DOWN,

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -891,6 +891,7 @@ describe('RubricContainer', () => {
     // Perform fetches
     await wait();
 
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId('info-alert')).not.toBeInTheDocument();
     const button = screen.getByRole('button', {
       name: 'Run AI Assessment for Project',

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -311,19 +311,25 @@ describe('RubricContainer', () => {
     // eslint-disable-next-line no-restricted-properties
     let content = container.querySelector('#uitest-rubric-content');
 
+    // eslint-disable-next-line no-restricted-properties
     expect(content).toHaveClass('visibleRubricContent');
+    // eslint-disable-next-line no-restricted-properties
     expect(settings).toHaveClass('settingsHidden');
 
     fireEvent.click(screen.getByText(i18n.rubricTabClassManagement()));
 
+    // eslint-disable-next-line no-restricted-properties
     expect(content).toHaveClass('hiddenRubricContent');
+    // eslint-disable-next-line no-restricted-properties
     expect(settings).toHaveClass('settingsVisible');
 
     fireEvent.click(
       screen.getAllByRole('button', {name: i18n.rubricTabStudent()})[0]
     );
 
+    // eslint-disable-next-line no-restricted-properties
     expect(content).toHaveClass('visibleRubricContent');
+    // eslint-disable-next-line no-restricted-properties
     expect(settings).toHaveClass('settingsHidden');
   });
 

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -306,7 +306,9 @@ describe('RubricContainer', () => {
     // approach is difficult because jest-dom can't see the styles in our
     // CSS modules which control element visibility.
 
+    // eslint-disable-next-line no-restricted-properties
     let settings = container.querySelector('.uitest-rubric-settings');
+    // eslint-disable-next-line no-restricted-properties
     let content = container.querySelector('#uitest-rubric-content');
 
     expect(content).toHaveClass('visibleRubricContent');

--- a/apps/test/unit/templates/rubrics/RubricSubmitFooterTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricSubmitFooterTest.jsx
@@ -245,6 +245,7 @@ describe('RubricSubmitFooter', () => {
     const priorDate = new Date(priorTimestamp);
     const priorCheck = priorDate.toLocaleString();
     expect(
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('#ui-feedback-submitted-timestamp').textContent
     ).to.contain(priorCheck);
 
@@ -263,6 +264,7 @@ describe('RubricSubmitFooter', () => {
     const lastSubmittedDateObj = new Date(timestamp);
     const check = lastSubmittedDateObj.toLocaleString();
     expect(
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('#ui-feedback-submitted-timestamp').textContent
     ).to.contain(check);
   });
@@ -298,6 +300,7 @@ describe('RubricSubmitFooter', () => {
 
     // There's no prior timestamp
     expect(
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('#ui-feedback-submitted-timestamp').textContent
     ).to.equal('');
 
@@ -374,6 +377,7 @@ describe('RubricSubmitFooter', () => {
 
     // There's no prior timestamp
     expect(
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('#ui-feedback-submitted-timestamp').textContent
     ).to.equal('');
 
@@ -391,6 +395,7 @@ describe('RubricSubmitFooter', () => {
     sinon.assert.called(postStub);
 
     // Assert that the feedback error is NOT there
+    // eslint-disable-next-line no-restricted-properties
     expect(container.querySelector('#ui-feedback-submitted-error')).to.be.null;
   });
 
@@ -418,6 +423,7 @@ describe('RubricSubmitFooter', () => {
 
     // There's no prior timestamp
     expect(
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('#ui-feedback-submitted-timestamp').textContent
     ).to.equal('');
 
@@ -430,6 +436,7 @@ describe('RubricSubmitFooter', () => {
 
     // Assert that the feedback error appears
     expect(
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('#ui-feedback-submitted-error').textContent
     ).to.contain(i18n.errorSubmittingFeedback());
   });
@@ -459,6 +466,7 @@ describe('RubricSubmitFooter', () => {
 
     // There's no prior timestamp
     expect(
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('#ui-feedback-submitted-timestamp').textContent
     ).to.equal('');
 
@@ -471,6 +479,7 @@ describe('RubricSubmitFooter', () => {
 
     // Assert that the feedback error appears
     expect(
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('#ui-feedback-submitted-error').textContent
     ).to.contain(i18n.errorSubmittingFeedback());
   });
@@ -500,6 +509,7 @@ describe('RubricSubmitFooter', () => {
 
     // There's no prior timestamp
     expect(
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('#ui-feedback-submitted-timestamp').textContent
     ).to.equal('');
 
@@ -512,6 +522,7 @@ describe('RubricSubmitFooter', () => {
 
     // Assert that the feedback error appears
     expect(
+      // eslint-disable-next-line no-restricted-properties
       container.querySelector('#ui-feedback-submitted-error').textContent
     ).to.contain(i18n.errorSubmittingFeedback());
   });

--- a/apps/test/unit/templates/sectionProgressV2/IconKeyTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/IconKeyTest.jsx
@@ -33,6 +33,7 @@ describe('IconKey Component', () => {
   it('expands collapses on click', () => {
     jest.spyOn(utils, 'tryGetLocalStorage').mockClear().mockReturnValue('true');
     render(<IconKey />);
+    // eslint-disable-next-line no-restricted-properties
     const containerDiv = screen.getByTestId('expandable-container');
     fireEvent.click(containerDiv);
     expect(screen.queryByText('Assignment Completion States')).to.be.null;

--- a/apps/test/unit/templates/sectionProgressV2/LessonDataCellTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/LessonDataCellTest.jsx
@@ -30,6 +30,7 @@ describe('LevelDataCell', () => {
   it('Shows empty if no progress', () => {
     renderDefault({studentLessonProgress: null});
 
+    // eslint-disable-next-line no-restricted-properties
     const cell = screen.getByTestId('lesson-data-cell-1-1');
     expect(cell.children).toHaveLength(0);
   });

--- a/apps/test/unit/templates/sectionProgressV2/LessonProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/LessonProgressDataColumnTest.jsx
@@ -122,6 +122,7 @@ describe('LessonProgressDataColumn', () => {
   it('shows progress for all students', () => {
     renderDefault();
 
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.queryAllByTestId(/lesson-data-cell/)).toHaveLength(
       STUDENTS.length
     );

--- a/apps/test/unit/templates/sectionProgressV2/ProgressIconTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressIconTest.jsx
@@ -28,12 +28,14 @@ describe('ProgressIconComponent', () => {
 
   it('renders the feedback given triangle when itemType is FEEDBACK_GIVEN', () => {
     render(<ProgressIcon itemType={ITEM_TYPE.FEEDBACK_GIVEN} />);
+    // eslint-disable-next-line no-restricted-properties
     const feedbackGivenTriangle = screen.getByTestId('feedback-given-triangle');
     expect(feedbackGivenTriangle).to.be.visible;
   });
 
   it('renders the feedback needed triangle when itemType is NEEDS_FEEDBACK', () => {
     render(<ProgressIcon itemType={ITEM_TYPE.NEEDS_FEEDBACK} />);
+    // eslint-disable-next-line no-restricted-properties
     const feedbackGivenTriangle = screen.getByTestId('needs-feedback-triangle');
     expect(feedbackGivenTriangle).to.be.visible;
   });

--- a/apps/test/unit/templates/sectionProgressV2/ProgressTableV2Test.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/ProgressTableV2Test.jsx
@@ -79,9 +79,11 @@ describe('ProgressTableV2', () => {
       Node.DOCUMENT_POSITION_FOLLOWING
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const cell1 = screen.getByTestId(
       'lesson-data-cell-' + LESSON_ID_1 + '-' + STUDENT_1.id
     );
+    // eslint-disable-next-line no-restricted-properties
     const cell2 = screen.getByTestId(
       'lesson-data-cell-' + LESSON_ID_1 + '-' + STUDENT_2.id
     );
@@ -99,12 +101,14 @@ describe('ProgressTableV2', () => {
       Node.DOCUMENT_POSITION_PRECEDING
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const cell1 = screen.getByTestId(
       'lesson-data-cell-' + LESSON_ID_1 + '-' + STUDENT_1.id,
       {
         exact: false,
       }
     );
+    // eslint-disable-next-line no-restricted-properties
     const cell2 = screen.getByTestId(
       'lesson-data-cell-' + LESSON_ID_1 + '-' + STUDENT_2.id,
       {

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
@@ -94,8 +94,9 @@ describe('SectionProgressSelector', () => {
     renderDefault();
     store.dispatch(setShowProgressTableV2(true));
 
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
-
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V2_TEST_ID)).toBeFalsy();
   });
 
@@ -103,9 +104,10 @@ describe('SectionProgressSelector', () => {
     renderDefault();
 
     screen.getByText(V1_PAGE_LINK_TEXT);
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
-
     expect(screen.queryByText(V2_PAGE_LINK_TEXT)).toBeFalsy();
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V2_TEST_ID)).toBeFalsy();
   });
 
@@ -114,9 +116,10 @@ describe('SectionProgressSelector', () => {
     store.dispatch(setShowProgressTableV2(true));
 
     screen.getByText(V2_PAGE_LINK_TEXT);
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V2_TEST_ID);
-
     expect(screen.queryByText(V1_PAGE_LINK_TEXT)).toBeFalsy();
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V1_TEST_ID)).toBeFalsy();
   });
 
@@ -125,9 +128,10 @@ describe('SectionProgressSelector', () => {
     store.dispatch(setShowProgressTableV2(undefined));
 
     screen.getByText(V1_PAGE_LINK_TEXT);
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
-
     expect(screen.queryByText(V2_PAGE_LINK_TEXT)).toBeFalsy();
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V2_TEST_ID)).toBeFalsy();
   });
 
@@ -137,9 +141,10 @@ describe('SectionProgressSelector', () => {
     renderDefault();
 
     screen.getByText(V2_PAGE_LINK_TEXT);
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V2_TEST_ID);
-
     expect(screen.queryByText(V1_PAGE_LINK_TEXT)).toBeFalsy();
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V1_TEST_ID)).toBeFalsy();
   });
 
@@ -165,7 +170,9 @@ describe('SectionProgressSelector', () => {
     expect(screen.queryByText(V1_PAGE_LINK_TEXT)).toBeFalsy();
     expect(screen.queryByText(V2_PAGE_LINK_TEXT)).toBeFalsy();
 
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V2_TEST_ID)).toBeFalsy();
   });
 
@@ -177,7 +184,9 @@ describe('SectionProgressSelector', () => {
 
     screen.getByText(V1_PAGE_LINK_TEXT);
 
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V2_TEST_ID)).toBeFalsy();
   });
 
@@ -187,9 +196,10 @@ describe('SectionProgressSelector', () => {
     renderDefault();
 
     screen.getByText(V1_PAGE_LINK_TEXT);
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
-
     expect(screen.queryByText(V2_PAGE_LINK_TEXT)).toBeFalsy();
+    // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V2_TEST_ID)).toBeFalsy();
   });
 
@@ -217,8 +227,8 @@ describe('SectionProgressSelector', () => {
     renderDefault();
 
     screen.getByText(V1_PAGE_LINK_TEXT);
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
-
     expect(screen.queryByText(i18n.progressTrackingAnnouncement())).toBeFalsy();
   });
 
@@ -239,8 +249,8 @@ describe('SectionProgressSelector', () => {
 
     // Check that the modal is not shown.
     screen.getByText(V1_PAGE_LINK_TEXT);
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
-
     expect(screen.queryByText(i18n.progressTrackingAnnouncement())).toBeFalsy();
   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressSelectorTest.jsx
@@ -106,6 +106,7 @@ describe('SectionProgressSelector', () => {
     screen.getByText(V1_PAGE_LINK_TEXT);
     // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
+
     expect(screen.queryByText(V2_PAGE_LINK_TEXT)).toBeFalsy();
     // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V2_TEST_ID)).toBeFalsy();
@@ -118,6 +119,7 @@ describe('SectionProgressSelector', () => {
     screen.getByText(V2_PAGE_LINK_TEXT);
     // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V2_TEST_ID);
+
     expect(screen.queryByText(V1_PAGE_LINK_TEXT)).toBeFalsy();
     // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V1_TEST_ID)).toBeFalsy();
@@ -130,6 +132,7 @@ describe('SectionProgressSelector', () => {
     screen.getByText(V1_PAGE_LINK_TEXT);
     // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
+
     expect(screen.queryByText(V2_PAGE_LINK_TEXT)).toBeFalsy();
     // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V2_TEST_ID)).toBeFalsy();
@@ -143,6 +146,7 @@ describe('SectionProgressSelector', () => {
     screen.getByText(V2_PAGE_LINK_TEXT);
     // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V2_TEST_ID);
+
     expect(screen.queryByText(V1_PAGE_LINK_TEXT)).toBeFalsy();
     // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V1_TEST_ID)).toBeFalsy();
@@ -198,6 +202,7 @@ describe('SectionProgressSelector', () => {
     screen.getByText(V1_PAGE_LINK_TEXT);
     // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
+
     expect(screen.queryByText(V2_PAGE_LINK_TEXT)).toBeFalsy();
     // eslint-disable-next-line no-restricted-properties
     expect(screen.queryByTestId(V2_TEST_ID)).toBeFalsy();
@@ -229,6 +234,7 @@ describe('SectionProgressSelector', () => {
     screen.getByText(V1_PAGE_LINK_TEXT);
     // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
+
     expect(screen.queryByText(i18n.progressTrackingAnnouncement())).toBeFalsy();
   });
 
@@ -251,6 +257,7 @@ describe('SectionProgressSelector', () => {
     screen.getByText(V1_PAGE_LINK_TEXT);
     // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(V1_TEST_ID);
+
     expect(screen.queryByText(i18n.progressTrackingAnnouncement())).toBeFalsy();
   });
 });

--- a/apps/test/unit/templates/sectionProgressV2/SectionProgressV2Test.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SectionProgressV2Test.jsx
@@ -76,6 +76,7 @@ describe('SectionProgressV2', () => {
 
     screen.getByText('Progress (beta)');
     screen.getByText('Students');
+    // eslint-disable-next-line no-restricted-properties
     screen.getAllByTestId('skeleton-cell');
     expect(screen.queryAllByText(/Student [1-9]/)).toHaveLength(0);
   });

--- a/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
@@ -79,10 +79,13 @@ describe('SkeletonProgressDataColumn', () => {
   it('Shows skeleton if fake lesson', () => {
     renderDefault({lesson: {id: 1, isFake: true}});
 
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(getTestId(1, STUDENT_1.id));
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(getTestId(1, STUDENT_2.id));
     screen.getByLabelText('Loading lesson');
     expect(
+      // eslint-disable-next-line no-restricted-properties
       screen.getAllByTestId('lesson-skeleton-cell', {exact: false})
     ).toHaveLength(2);
   });
@@ -90,10 +93,13 @@ describe('SkeletonProgressDataColumn', () => {
   it('Shows real header', () => {
     renderDefault();
 
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id));
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(getTestId(LESSON.id, STUDENT_2.id));
     expect(screen.queryByLabelText('Loading lesson')).toBeFalsy();
     expect(
+      // eslint-disable-next-line no-restricted-properties
       screen.getAllByTestId('lesson-skeleton-cell', {exact: false})
     ).toHaveLength(2);
   });
@@ -102,11 +108,16 @@ describe('SkeletonProgressDataColumn', () => {
     renderDefault({expandedMetadataStudentIds: [1]});
     store.dispatch(expandMetadataForStudents([STUDENT_1.id]));
 
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id));
-    screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id, '-last-updated'));
+    // eslint-disable-next-line no-restricted-properties
+    screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id, '-last-updated')); // eslint-disable-next-line no-restricted-properties
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id, '-time-spent'));
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(getTestId(LESSON.id, STUDENT_2.id));
     expect(
+      // eslint-disable-next-line no-restricted-properties
       screen.getAllByTestId('lesson-skeleton-cell', {exact: false})
     ).toHaveLength(4);
   });

--- a/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
+++ b/apps/test/unit/templates/sectionProgressV2/SkeletonProgressDataColumnTest.jsx
@@ -111,7 +111,7 @@ describe('SkeletonProgressDataColumn', () => {
     // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id));
     // eslint-disable-next-line no-restricted-properties
-    screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id, '-last-updated')); // eslint-disable-next-line no-restricted-properties
+    screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id, '-last-updated'));
     // eslint-disable-next-line no-restricted-properties
     screen.getByTestId(getTestId(LESSON.id, STUDENT_1.id, '-time-spent'));
     // eslint-disable-next-line no-restricted-properties

--- a/apps/test/unit/templates/teacherDashboard/LoginTypePickerTest.jsx
+++ b/apps/test/unit/templates/teacherDashboard/LoginTypePickerTest.jsx
@@ -42,6 +42,7 @@ describe('LoginTypePicker', () => {
     const realSendEvent = analyticsReporter.sendEvent;
     analyticsReporter.sendEvent = jest.fn();
 
+    // eslint-disable-next-line no-restricted-properties
     const pictureLoginCard = container.querySelector('.uitest-pictureLogin');
     fireEvent.click(pictureLoginCard);
 

--- a/apps/test/unit/templates/teacherDashboard/LoginTypePickerTest.jsx
+++ b/apps/test/unit/templates/teacherDashboard/LoginTypePickerTest.jsx
@@ -68,6 +68,7 @@ describe('LoginTypePicker', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const lmsCards = screen.getByTestId('lms-info-cards-container');
     expect(lmsCards.children).toHaveLength(4);
   });
@@ -87,6 +88,7 @@ describe('LoginTypePicker', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const lmsCards = screen.getByTestId('lms-info-cards-container');
     expect(lmsCards.children).toHaveLength(4);
   });
@@ -106,6 +108,7 @@ describe('LoginTypePicker', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const lmsCards = screen.getByTestId('lms-info-cards-container');
     expect(lmsCards.children).toHaveLength(3);
     expect(
@@ -128,6 +131,7 @@ describe('LoginTypePicker', () => {
       />
     );
 
+    // eslint-disable-next-line no-restricted-properties
     const lmsCards = screen.getByTestId('lms-info-cards-container');
     expect(lmsCards.children).toHaveLength(3);
     expect(within(lmsCards).queryByText(LmsLoginTypeNames.clever)).toBeNull();

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
@@ -100,26 +100,31 @@ describe('TeacherDashboard', () => {
 
   it('defaults to progress tab if no tab provided in route', () => {
     renderDefault(['/']);
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('section-progress', {exact: false});
   });
 
   it('defaults to progress tab if incorrect tab provided in route', () => {
     renderDefault(['/some_fake_path']);
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('section-progress', {exact: false});
   });
 
   it('defaults to manage students tab if no tab provided in route and section has 0 students', () => {
     renderDefault(['/'], {studentCount: 0});
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('manage-students-tab');
   });
 
   it('defaults to manage students tab if incorrect tab provided in route and section has 0 students', () => {
     renderDefault(['/some-fake-path'], {studentCount: 0});
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('manage-students-tab');
   });
 
   it('does not override given path if there are students and path is legitimate', () => {
     renderDefault(['/assessments']);
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('assessments-tab');
   });
 });

--- a/apps/test/unit/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainerTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainerTest.tsx
@@ -103,8 +103,10 @@ describe('LessonMaterialsContainer', () => {
 
     // Teacher resources, including lesson plan, unit vocab and unit standards
     screen.getByText('Teacher Resources');
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('resource-icon-' + RESOURCE_ICONS.SLIDES.icon);
     screen.getByText('Slides: my slides');
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('resource-icon-' + RESOURCE_ICONS.LESSON_PLAN.icon);
     screen.getByText('Lesson Plan: First lesson');
     // checks that standards and vocab are rendered only once and not rendred in the "student resoruces section"
@@ -113,6 +115,7 @@ describe('LessonMaterialsContainer', () => {
 
     // Student resources
     screen.getByText('Student Resources');
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('resource-icon-' + RESOURCE_ICONS.VIDEO.icon);
     screen.getByText('Video: my linked video');
   });
@@ -124,12 +127,15 @@ describe('LessonMaterialsContainer', () => {
 
     fireEvent.change(selectedLessonInput, {target: {value: '2'}});
 
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('resource-icon-' + RESOURCE_ICONS.LESSON_PLAN.icon);
     screen.getByText('Lesson Plan: Second lesson');
 
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('resource-icon-' + RESOURCE_ICONS.VIDEO.icon);
     screen.getByText('Video: my video resource');
     expect(
+      // eslint-disable-next-line no-restricted-properties
       screen.queryAllByTestId('resource-icon-' + RESOURCE_ICONS.SLIDES.icon)
         .length === 0
     );

--- a/apps/test/unit/templates/teacherNavigation/lessonMaterials/ResourceIconTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/lessonMaterials/ResourceIconTest.tsx
@@ -14,7 +14,9 @@ describe('ResourceIcon', () => {
     render(
       <ResourceIcon resourceType={'Slides'} resourceUrl={googleSlidesUrl} />
     );
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('font-awesome-v6-icon');
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('resource-icon-' + RESOURCE_ICONS.SLIDES.icon);
   });
 
@@ -22,7 +24,9 @@ describe('ResourceIcon', () => {
     render(
       <ResourceIcon resourceType={'Handout'} resourceUrl={googleDocsUrl} />
     );
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('font-awesome-v6-icon');
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('resource-icon-' + RESOURCE_ICONS.GOOGLE_DOC.icon);
   });
 
@@ -30,7 +34,9 @@ describe('ResourceIcon', () => {
     render(
       <ResourceIcon resourceType={'Video'} resourceUrl={nonGoogleResourceUrl} />
     );
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('font-awesome-v6-icon');
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('resource-icon-' + RESOURCE_ICONS.VIDEO.icon);
   });
 
@@ -41,7 +47,9 @@ describe('ResourceIcon', () => {
         resourceUrl={nonGoogleResourceUrl}
       />
     );
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('font-awesome-v6-icon');
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('resource-icon-' + RESOURCE_ICONS.LESSON_PLAN.icon);
   });
 
@@ -52,7 +60,9 @@ describe('ResourceIcon', () => {
         resourceUrl={nonGoogleResourceUrl}
       />
     );
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('font-awesome-v6-icon');
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('resource-icon-' + RESOURCE_ICONS.LINK.icon);
   });
 });

--- a/apps/test/unit/templates/teacherNavigation/lessonMaterials/ResourceRowTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/lessonMaterials/ResourceRowTest.tsx
@@ -30,8 +30,9 @@ describe('ResourceRow', () => {
     screen.getByText('Handout: Handout for teacher');
     screen.getByText('3.2');
 
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('resource-icon-' + RESOURCE_ICONS.LINK.icon);
-
+    // eslint-disable-next-line no-restricted-properties
     screen.getByTestId('view-options-dropdown');
   });
 });


### PR DESCRIPTION
a quick search of our code shows the following approximate counts of indicators that the accessibility benefits of RTL are being circumvented:

| string | count |
|--------|--------|
| `data-testid` |  53 |
| `ByTestId(` |  133 |
| `container.querySelector` |  35 |
| `toHaveClass` |  8 |

This PR adds linting rules to disallow each of these anti-patterns. 

example lint errors:

```
Dave-MBP:~/src/cdo2/apps (dave/no-data-testid *)$ yarn eslint src/templates/rubrics/AiAssessmentFeedback.jsx test/unit/templates/rubrics/RubricContainerTest.jsx test/unit/templates/ImageWithStatusTest.js

/Users/dsb/src/cdo2/apps/src/templates/rubrics/AiAssessmentFeedback.jsx
  135:17  error  data-testid is not accessible. Tests should resemble how the user interacts with the application and should not rely on technical details, see https://testing-library.com/docs/queries/about/#priority  react/forbid-dom-props

/Users/dsb/src/cdo2/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
  314:5  error  'toHaveClass' is restricted from being used. Tests should resemble how the user interacts with the application and should not rely on technical details, see https://testing-library.com/docs/queries/about/#priority  no-restricted-properties
  894:12  error  'screen.queryByTestId' is restricted from being used. Tests should resemble how the user interacts with the application and should not rely on technical details, see https://testing-library.com/docs/queries/about/#priority  no-restricted-properties

/Users/dsb/src/cdo2/apps/test/unit/templates/ImageWithStatusTest.js
  19:21  error  'container.querySelector' is restricted from being used. Tests should resemble how the user interacts with the application and should not rely on technical details, see https://testing-library.com/docs/queries/about/#priority  no-restricted-properties
```

## Testing story

* `yarn lint` passing locally
* temporarily set `reportUnusedDisableDirectives` and fixed any eslint-disable directives which were reported to have no effect

## Follow-up work

enable `reportUnusedDisableDirectives` to detect potentially broken lint rules and/or eslint-disable commands