### PR TITLE
Music: block first use tip

### DIFF
--- a/apps/src/lab2/progress/ProgressManager.ts
+++ b/apps/src/lab2/progress/ProgressManager.ts
@@ -11,6 +11,7 @@ export abstract class Validator {
   abstract checkConditions(): void;
   abstract conditionsMet(conditions: Condition[]): boolean;
   abstract clear(): void;
+  abstract onLevelChange(): void;
   abstract getValidationResults(): ValidationResult[] | undefined;
 }
 
@@ -64,6 +65,12 @@ export default class ProgressManager {
    */
   onLevelChange(validations?: Validation[]) {
     this.currentValidations = validations;
+
+    if (this.validator) {
+      // Give the lab the chance to clear anything level-specific.
+      this.validator.onLevelChange();
+    }
+
     this.resetValidation();
   }
 
@@ -95,7 +102,10 @@ export default class ProgressManager {
     // Go through each validation to see if we have a match.
     for (const validation of this.currentValidations) {
       // If it's a non-successful validation (i.e. validation.next is false), then
-      // make sure the lab-specific validator is ready for it.
+      // make sure the lab-specific validator is ready for it.  Sometimes a lab
+      // only wants to deliver success validations early on (allowing a user to
+      // move to the next level immediately), while it waits longer to start evaluating
+      // remaining validations.
       if (this.validator.shouldCheckNextConditionsOnly() && !validation.next) {
         continue;
       }

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -162,15 +162,15 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
 
   const showSecondaryFinishButton = useSecondaryFinishButton && !hasNextLevel;
 
-  const useMessage =
-    showSecondaryFinishButton &&
-    queryParams('show-secondary-finish-button-question') === 'true'
-      ? commonI18n.finishMessage()
-      : message;
-
   // The secondary finish button avoids a reappearance animation by not using
   // the unique index.
   const useMessageIndex = useSecondaryFinishButton ? undefined : messageIndex;
+
+  // The secondary finish button can have its own optional message.
+  const secondaryFinishButtonMessage =
+    showSecondaryFinishButton &&
+    queryParams('show-secondary-finish-button-question') === 'true' &&
+    commonI18n.finishMessage();
 
   return (
     <div
@@ -215,30 +215,25 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
             </div>
           </div>
         )}
-        {(useMessage || canShowNextButton) && (
+        {(message || (!showSecondaryFinishButton && canShowNextButton)) && (
           <div
-            key={useMessageIndex + ' - ' + useMessage}
+            key={useMessageIndex + ' - ' + message}
             id="instructions-feedback"
-            className={classNames(
-              moduleStyles.feedback,
-              showSecondaryFinishButton && moduleStyles.feedbackBottom
-            )}
+            className={moduleStyles.feedback}
           >
             <div
               id="instructions-feedback-message"
               className={moduleStyles['message-' + theme]}
             >
-              {offerBrowserTts && useMessage && (
-                <TextToSpeech text={useMessage} />
-              )}
-              {useMessage && (
+              {offerBrowserTts && message && <TextToSpeech text={message} />}
+              {message && (
                 <EnhancedSafeMarkdown
-                  markdown={useMessage}
+                  markdown={message}
                   className={moduleStyles.markdownText}
                   handleInstructionsTextClick={handleInstructionsTextClick}
                 />
               )}
-              {canShowNextButton && (
+              {canShowNextButton && !showSecondaryFinishButton && (
                 <Button
                   id="instructions-continue-button"
                   text={
@@ -246,10 +241,43 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
                   }
                   onClick={onContinueOrFinish}
                   className={moduleStyles.buttonInstruction}
-                  type={showSecondaryFinishButton ? 'secondary' : 'primary'}
-                  color={showSecondaryFinishButton ? 'black' : 'purple'}
+                  type={'primary'}
+                  color={'purple'}
                 />
               )}
+            </div>
+          </div>
+        )}
+        {showSecondaryFinishButton && (
+          <div
+            id="secondary-finish"
+            className={classNames(
+              moduleStyles.feedback,
+              moduleStyles.feedbackBottom
+            )}
+          >
+            <div
+              id="instructions-feedback-message"
+              className={moduleStyles['message-' + theme]}
+            >
+              {offerBrowserTts && secondaryFinishButtonMessage && (
+                <TextToSpeech text={secondaryFinishButtonMessage} />
+              )}
+              {secondaryFinishButtonMessage && (
+                <EnhancedSafeMarkdown
+                  markdown={secondaryFinishButtonMessage}
+                  className={moduleStyles.markdownText}
+                  handleInstructionsTextClick={handleInstructionsTextClick}
+                />
+              )}
+              <Button
+                id="instructions-continue-button"
+                text={commonI18n.finish()}
+                onClick={onContinueOrFinish}
+                className={moduleStyles.buttonInstruction}
+                type={'secondary'}
+                color={'black'}
+              />
             </div>
           </div>
         )}

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -139,7 +139,8 @@ class UnconnectedMusicView extends React.Component {
       this.getPlaybackEvents,
       this.getValidationTimeout,
       this.player,
-      this.getPlayingTriggers
+      this.getPlayingTriggers,
+      this.getCurrentBlocks
     );
 
     // Set shared shared objects in the MusicRegistry so views outside of this
@@ -411,6 +412,10 @@ class UnconnectedMusicView extends React.Component {
 
   getPlayingTriggers = () => {
     return this.playingTriggers;
+  };
+
+  getCurrentBlocks = () => {
+    return this.musicBlocklyWorkspace.getAllBlocks().map(block => block.type);
   };
 
   getCurrentPlayheadPosition = () => {

--- a/apps/src/pythonlab/progress/PythonValidator.ts
+++ b/apps/src/pythonlab/progress/PythonValidator.ts
@@ -46,6 +46,8 @@ export default class PythonValidator extends Validator {
     return true;
   }
 
+  onLevelChange() {}
+
   clear(): void {
     this.pythonValidationTracker.reset();
   }


### PR DESCRIPTION
This adds support for a late-breaking feature in which a freeplay level can display a "first use" tip for a block.

Ten block types can now have an additional piece of "Did you know?" information displayed below the instructions, the first time they are used.  The content is stored as validation message on the level, with a special condition syntax.

It works particularly well with the secondary finish button introduced in https://github.com/code-dot-org/code-dot-org/pull/62035, since the additional information will be shown in a standalone box while the finish button remains separate down below.

### Level data

Here is an example extract from the level:

```
    "validations": [
      {
        "key": "music-ai-freeplay_ec7ca941-da29-4cb6-8b82-1bcb522e5a4f",
        "message": "**Did you know?** The trigger block lets you play a sound whenever you like by pressing a button.\n- Connect code to the trigger  block.\n- Press “Run”.\n- Press 1 to play your sound.\n\n",
        "next": true,
        "conditions": [
          {
            "name": "tip--triggered_at_simple2"
          }
        ]
      },
      {
        "key": "music-ai-freeplay_cd60a2cd-9522-4ec6-bdf1-0b7699733814",
        "message": "**Did you know?** The repeat block lets you play the sounds inside it over and over. \n- Add sounds into the repeat block. \n- Change the number to how many times you want them to play.\n",
        "next": true,
        "conditions": [
          {
            "name": "tip--repeat_simple2"
          }
        ]
      }
    ],
```

### Video

And here it is in action:

https://github.com/user-attachments/assets/f4b4bc63-1f95-4140-8476-5563f7ba4986

Notice that the "first use" tip only shows once, even if the block is removed and re-added to the workspace.  A level switch or page reload must be performed for it to show again.

Also note that "first use" tips are never shown on the first run; blocks must be added after the first run to be noticed.  This prevents a bunch of tips from showing when resuming work on existing level content.

If more than one of the blocks with tips is added at once, a tip is shown for each upon each subsequent run, assuming it is not removed again.

#### Notes

I'm not a great fan of the additional statefulness this adds to `MusicValidator`.  It would be nice if this could be a fully-functional component with no state at all.  This work is an attempt to integrate cautiously with the existing system, particularly so close to Music Lab launch for HOC.

The heuristics for showing these tips could also be changed, but a major goal of this PR is to enable strings to be entered as validations on levelbuilder so that they can begin to be localized.

No levelbuilder UI has been exposed for this feature yet, as it still feels somewhat exploratory.

This change might imply that the current `"validations"` section of a level might be more aptly named `"feedback"`, `"assistance"`, or similar.