### PR TITLE
Music: TTS tweaks

### DIFF
--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -228,8 +228,8 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
               id="instructions-feedback-message"
               className={moduleStyles['message-' + theme]}
             >
-              {offerBrowserTts && useMessage && (
-                <TextToSpeech text={useMessage} higher={canShowNextButton} />
+              {offerBrowserTts && useMessage && !canShowNextButton && (
+                <TextToSpeech text={useMessage} />
               )}
               {useMessage && (
                 <EnhancedSafeMarkdown

--- a/apps/src/lab2/views/components/Instructions.tsx
+++ b/apps/src/lab2/views/components/Instructions.tsx
@@ -229,7 +229,7 @@ const InstructionsPanel: React.FunctionComponent<InstructionsPanelProps> = ({
               className={moduleStyles['message-' + theme]}
             >
               {offerBrowserTts && useMessage && (
-                <TextToSpeech text={useMessage} />
+                <TextToSpeech text={useMessage} higher={canShowNextButton} />
               )}
               {useMessage && (
                 <EnhancedSafeMarkdown

--- a/apps/src/lab2/views/components/TextToSpeech.module.scss
+++ b/apps/src/lab2/views/components/TextToSpeech.module.scss
@@ -6,22 +6,13 @@
   display: flex;
   position: absolute;
   bottom: 7px;
-  right: 7px;
+  inset-inline-end: 7px;
   opacity: 35%;
   cursor: pointer;
   transition: opacity 0.2s ease;
 
-  html[dir="rtl"] & {
-    right: initial;
-    left: 6px;
-  }
-
   &Playing {
     opacity: 100%;
-  }
-
-  &Higher {
-    bottom: 59px;
   }
 
   &:hover {

--- a/apps/src/lab2/views/components/TextToSpeech.module.scss
+++ b/apps/src/lab2/views/components/TextToSpeech.module.scss
@@ -3,12 +3,26 @@
 
 .playButton {
   @include remove-button-styles;
+  display: flex;
   position: absolute;
-  top: 6px;
-  right: 6px;
-  opacity: 50%;
+  bottom: 7px;
+  right: 7px;
+  opacity: 35%;
   cursor: pointer;
   transition: opacity 0.2s ease;
+
+  html[dir="rtl"] & {
+    right: initial;
+    left: 6px;
+  }
+
+  &Playing {
+    opacity: 100%;
+  }
+
+  &Higher {
+    bottom: 59px;
+  }
 
   &:hover {
     opacity: 100%;
@@ -17,8 +31,4 @@
 
 .icon {
   font-size: 15px;
-}
-
-.playing {
-  opacity: 100%;
 }

--- a/apps/src/lab2/views/components/TextToSpeech.tsx
+++ b/apps/src/lab2/views/components/TextToSpeech.tsx
@@ -10,6 +10,7 @@ import moduleStyles from './TextToSpeech.module.scss';
 
 interface TextToSpeechProps {
   text: string;
+  higher?: boolean;
 }
 
 const usePause = queryParams('tts-play-pause') === 'true';
@@ -23,7 +24,10 @@ const ttsButtonEnabled = DCDO.get(
 /**
  * TextToSpeech play button.
  */
-const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
+const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({
+  text,
+  higher,
+}) => {
   const {isTtsAvailable, speak, cancel, pause, resume} =
     useBrowserTextToSpeech();
   const [isPlaying, setIsPlaying] = useState(false);
@@ -73,7 +77,8 @@ const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
     <button
       className={classNames(
         moduleStyles.playButton,
-        isPlaying && moduleStyles.playing
+        isPlaying && moduleStyles.playButtonPlaying,
+        higher && moduleStyles.playButtonHigher
       )}
       onClick={playText}
       type="button"

--- a/apps/src/lab2/views/components/TextToSpeech.tsx
+++ b/apps/src/lab2/views/components/TextToSpeech.tsx
@@ -10,7 +10,6 @@ import moduleStyles from './TextToSpeech.module.scss';
 
 interface TextToSpeechProps {
   text: string;
-  higher?: boolean;
 }
 
 const usePause = queryParams('tts-play-pause') === 'true';
@@ -24,10 +23,7 @@ const ttsButtonEnabled = DCDO.get(
 /**
  * TextToSpeech play button.
  */
-const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({
-  text,
-  higher,
-}) => {
+const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({text}) => {
   const {isTtsAvailable, speak, cancel, pause, resume} =
     useBrowserTextToSpeech();
   const [isPlaying, setIsPlaying] = useState(false);
@@ -77,8 +73,7 @@ const TextToSpeech: React.FunctionComponent<TextToSpeechProps> = ({
     <button
       className={classNames(
         moduleStyles.playButton,
-        isPlaying && moduleStyles.playButtonPlaying,
-        higher && moduleStyles.playButtonHigher
+        isPlaying && moduleStyles.playButtonPlaying
       )}
       onClick={playText}
       type="button"


### PR DESCRIPTION
Some small finesse for the text-to-speech UI.

Previously, the top-right corner was sometimes seeing the text come too close to the TTS icon:

<img width="396" alt="Screenshot 2024-11-04 at 12 32 42 AM" src="https://github.com/user-attachments/assets/1e1eef3b-4675-488a-b2f9-9c1255969f24">

While it could be possible to wrap the text around the icon, a simple way to help improve things is to move the icon to the lower right:

<img width="396" alt="Screenshot 2024-11-04 at 12 31 10 AM" src="https://github.com/user-attachments/assets/69191656-1632-4dbd-82bc-817eb33d7e07">

There wasn't a great layout solution for the case when a button is involved:

<img width="396" alt="Screenshot 2024-11-04 at 12 30 26 AM" src="https://github.com/user-attachments/assets/7f8a720d-276a-49a8-9103-a5872b94c9c1">

So we decided for now to omit the TTS icon when there is a button, since the attached text is generally not instructional:

<img width="396" alt="Screenshot 2024-11-04 at 3 39 15 PM" src="https://github.com/user-attachments/assets/39c96171-43cd-4dfe-befb-631eac763114">

This change also handles RTL:

<img width="296" alt="Screenshot 2024-11-04 at 12 28 39 AM" src="https://github.com/user-attachments/assets/46b7de35-bb4d-4b9e-9d8a-ff60dec57576">

This change maintains the strong hover style:

<img width="396" alt="Screenshot 2024-11-04 at 12 28 04 AM" src="https://github.com/user-attachments/assets/23e74a90-3ab4-4766-ab85-c7db32d843b0">

And strong playing icon:

<img width="396" alt="Screenshot 2024-11-04 at 12 27 54 AM" src="https://github.com/user-attachments/assets/8c86b63a-c394-4710-adf0-727753bb86f9">

It makes subtle adjustments so that the circular playing icon is equidistant from the right and bottom edges, and the speaker icon is positioned appropriately in that same place.  
