### PR TITLE
Lab2: instructions list margin

### DIFF
--- a/apps/src/lab2/views/components/instructions.module.scss
+++ b/apps/src/lab2/views/components/instructions.module.scss
@@ -176,7 +176,7 @@
   ol, ul {
     font-size: 14px;
     line-height: 0;
-    margin: 0 0 10px 20px;
+    margin: 0 0 0 20px;
   }
 
   li {


### PR DESCRIPTION
A small adjustment to the Lab2 instructions' list `margin-bottom`, so that we don't add an extra `10px` at the bottom when the last list has already added `10px` of its own.

### before

<img width="396" alt="Screenshot 2024-11-04 at 12 45 31 AM" src="https://github.com/user-attachments/assets/8688a26c-8f02-43b9-ad5c-68729de4ef33">

<img width="396" alt="Screenshot 2024-11-04 at 12 48 48 AM" src="https://github.com/user-attachments/assets/3ec57897-2490-4f69-9cff-ef5d7125fc5f">

### after

<img width="396" alt="Screenshot 2024-11-04 at 12 46 21 AM" src="https://github.com/user-attachments/assets/88dd03da-fae3-4775-a660-26ad67608b02">

<img width="396" alt="Screenshot 2024-11-04 at 12 47 32 AM" src="https://github.com/user-attachments/assets/dad2b6b5-55ee-4d0b-b50c-b831e3ed5ccd">

