### PR TITLE
Add onDeactivate prop to AccessibleDialog

### DIFF
--- a/apps/src/sharedComponents/AccessibleDialog.jsx
+++ b/apps/src/sharedComponents/AccessibleDialog.jsx
@@ -19,6 +19,7 @@ function AccessibleDialog({
   fallbackFocus,
   initialFocus = true,
   closeOnClickBackdrop = false,
+  onDeactivate = onClose,
 }) {
   // If these styles are provided by the given stylesheet, use them
   const modalStyle = styles?.modal || defaultStyle.modal;
@@ -36,7 +37,7 @@ function AccessibleDialog({
         <FocusTrap
           focusTrapOptions={{
             initialFocus: initialFocus,
-            onDeactivate: onClose,
+            onDeactivate: onDeactivate,
             clickOutsideDeactivates: closeOnClickBackdrop,
             fallbackFocus: fallbackFocus,
           }}
@@ -72,6 +73,7 @@ AccessibleDialog.propTypes = {
   fallbackFocus: PropTypes.string,
   initialFocus: PropTypes.bool,
   closeOnClickBackdrop: PropTypes.bool,
+  onDeactivate: PropTypes.func,
 };
 
 export default AccessibleDialog;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds an optional `onDeactivate` prop to the `AccessibleDialog` component.

Currently, this [`FocusTrap`](https://github.com/focus-trap/focus-trap-react) option is set to `onClose` so that `onClose` is executed when the focus trap is deactivated. This PR adds the `onDeactivate` prop and if the prop is not set, then `onClose` is assigned so that components currently using `AccessibleDialog` are not impacted by this update.

A reason to add this optional prop is that in https://github.com/code-dot-org/code-dot-org/pull/62069a `SubmitProjectDialog` includes both a close (x) button and a 'Go back' button. The 'Go back' button closes `SubmitProjectDialog` and opens the lab2 `ShareDialog`. The close(x) button closes the `SubmitProjectDialog` and does NOT open the lab2 `ShareDialog`. Thus we have two different paths we would like to define when deactivating the focus from the `SubmitProjectDialog`. [PR comment](https://github.com/code-dot-org/code-dot-org/pull/62069#discussion_r1826319200)

If `onDeactivate` option is set to `null`, then the default behavior is called to handle the deactivation of focus. See: https://github.com/focus-trap/focus-trap-react/blob/5b810f006c1f86ef79c04052851e98a4136d1f4a/src/focus-trap-react.js#L186-L188

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
