### PR TITLE
P20-1215/Add uniqueness constraint to LtiUserIdentity

### DIFF
--- a/dashboard/app/models/lti_user_identity.rb
+++ b/dashboard/app/models/lti_user_identity.rb
@@ -24,4 +24,5 @@ class LtiUserIdentity < ApplicationRecord
   has_and_belongs_to_many :lti_deployments
 
   validates :subject, presence: true
+  validates :subject, uniqueness: {scope: :lti_integration_id}
 end

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -30,7 +30,7 @@ module Services
     end
 
     def self.create_lti_user_identity(user)
-      auth_option = user.authentication_options.find(&:lti?)
+      auth_option = user.authentication_options.order(created_at: :desc).find(&:lti?)
       issuer, client_id, subject = auth_option.authentication_id.split('|')
       lti_integration = Queries::Lti.get_lti_integration(issuer, client_id)
       LtiUserIdentity.create!(user: user, subject: subject, lti_integration: lti_integration)

--- a/dashboard/test/lib/services/lti_test.rb
+++ b/dashboard/test/lib/services/lti_test.rb
@@ -312,10 +312,29 @@ class Services::LtiTest < ActiveSupport::TestCase
     auth_id = "#{lti_integration[:issuer]}|#{lti_integration[:client_id]}|#{SecureRandom.alphanumeric}"
     user = build :student
     user.authentication_options << build(:lti_authentication_option, user: user, authentication_id: auth_id)
+
+    #LtiUserIdentity created after creation of LTI user
     user.save
 
-    lti_user_identity = Services::Lti.create_lti_user_identity(user)
-    assert lti_user_identity
+    refute user.lti_user_identities.empty?
+  end
+
+  test 'create_lti_user_identity should create a unique LtiUserIdentity with multiple LTI auth options' do
+    lti_integration = create :lti_integration
+    auth_id = "#{lti_integration[:issuer]}|#{lti_integration[:client_id]}|#{SecureRandom.alphanumeric}"
+    user = build :student
+    user.authentication_options << build(:lti_authentication_option, user: user, authentication_id: auth_id, created_at: 2.hours.ago)
+    user.save
+
+    # Add a second LTI auth option
+    new_auth_id = "#{lti_integration[:issuer]}|#{lti_integration[:client_id]}|#{SecureRandom.alphanumeric}"
+    user.authentication_options << build(:lti_authentication_option, user: user, authentication_id: new_auth_id)
+    user.save
+    second_lti_user_identity = Services::Lti.create_lti_user_identity(user)
+
+    first_lti_user_identity = user.lti_user_identities.first
+    refute_equal first_lti_user_identity.subject, second_lti_user_identity.subject
+    assert_equal user.lti_user_identities.count, 2
   end
 
   test 'create_lti_integration should create an LtiIntegration when given valid inputs' do
@@ -439,15 +458,16 @@ class Services::LtiTest < ActiveSupport::TestCase
 
   test 'should update a section name if it has changed' do
     teacher = create :teacher
-    lti_integration = create :lti_integration
-    create :lti_user_identity, lti_integration: lti_integration, user: teacher, subject: 'user-id-1'
-    lti_course = create :lti_course, lti_integration: lti_integration
+    auth_id = "#{@lti_integration[:issuer]}|#{@lti_integration[:client_id]}|user-id-1"
+    create :lti_authentication_option, user: teacher, authentication_id: auth_id
+    Services::Lti.create_lti_user_identity(teacher)
+    lti_course = create :lti_course, lti_integration: @lti_integration
     section = create :section, user: teacher
 
     create :lti_section, lti_course: lti_course, section: section
     Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
     parsed_response = Services::Lti.parse_nrps_response(@nrps_full_response, @id_token[:iss])
-    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
+    Services::Lti.sync_course_roster(lti_integration: @lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
 
     # initial names
     expected_section_names = @lms_section_names.map {|name| "#{@course_name}: #{name}"}
@@ -462,7 +482,7 @@ class Services::LtiTest < ActiveSupport::TestCase
     end
     Policies::Lti.stubs(:issuer_accepts_resource_link?).returns(true)
     parsed_response = Services::Lti.parse_nrps_response(new_response, @id_token[:iss])
-    Services::Lti.sync_course_roster(lti_integration: lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
+    Services::Lti.sync_course_roster(lti_integration: @lti_integration, lti_course: lti_course, nrps_sections: parsed_response, current_user: teacher)
     new_expected_names = JSON.parse(new_names).map {|name| "#{@course_name}: #{name}"}
     actual_section_names = lti_course.reload.sections.map(&:name)
     assert_empty new_expected_names - actual_section_names

--- a/dashboard/test/models/lti_user_identity_test.rb
+++ b/dashboard/test/models/lti_user_identity_test.rb
@@ -6,4 +6,8 @@ class LtiUserIdentityTest < ActiveSupport::TestCase
     refute build(:lti_user_identity, user: nil).valid? "user is required"
     refute build(:lti_user_identity, lti_integration: nil).valid? "lti_integration is required"
   end
+  test "should not allow duplicate subject/lti_integration_id" do
+    lti_user_identity = create(:lti_user_identity)
+    refute build(:lti_user_identity, lti_integration_id: lti_user_identity.lti_integration.id, subject: lti_user_identity.subject).valid?
+  end
 end


### PR DESCRIPTION
This PR adds a uniqueness constraint to `LtiUserIdentity`, which disallows `LtiUserIdentities` to have the same `subject` and `lti_integration_id`. It also fixes a bug that caused most of the users that break this new constraint to have duplicate `lti_user_identites` associated with their account. Details on the investigation into the duplicate `LtiUserIdentites` can be found in the Jira ticket below. 

## Links
Jira: [P20-1215](https://codedotorg.atlassian.net/browse/P20-1215)

## Testing story
New tests were added to `services/lti_test.rb` and `lti_user_identity_test.rb`. Test modifications were also made in `services/lti_test.rb`

## Follow-up work
~~More work will need to be done to address the 35 users that currently break this constraint in production.~~
All accounts have been taken care of before merging this PR.
