### PR TITLE
Updated homepage Edit Section Details button to direct to dashboard

### DIFF
--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -11,6 +11,7 @@ import PopUpMenu from '@cdo/apps/sharedComponents/PopUpMenu';
 import QuickActionsCell from '@cdo/apps/templates/tables/QuickActionsCell';
 import {setRosterProvider} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
+import experiments from '@cdo/apps/util/experiments';
 import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
@@ -79,7 +80,12 @@ class SectionActionDropdown extends Component {
    * Returns the URL to the correct section to be edited
    */
   editRedirectUrl = (sectionId, isPl) => {
-    let editSectionUrl = '/sections/' + sectionId + '/edit';
+    let editSectionUrl;
+    if (experiments.isEnabled('teacher-local-nav-v2')) {
+      editSectionUrl = teacherDashboardUrl(sectionId, '/settings');
+    } else {
+      editSectionUrl = '/sections/' + sectionId + '/edit';
+    }
     editSectionUrl += isPl ? '?redirectToPage=my-professional-learning' : '';
     return editSectionUrl;
   };

--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -11,13 +11,13 @@ import PopUpMenu from '@cdo/apps/sharedComponents/PopUpMenu';
 import QuickActionsCell from '@cdo/apps/templates/tables/QuickActionsCell';
 import {setRosterProvider} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
-import experiments from '@cdo/apps/util/experiments';
 import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
 import FontAwesome from '../../legacySharedComponents/FontAwesome';
 import color from '../../util/color';
 import BaseDialog from '../BaseDialog';
+import {showV2TeacherDashboard} from '../teacherNavigation/TeacherNavFlagUtils';
 
 import DialogFooter from './DialogFooter';
 import PrintCertificates from './PrintCertificates';
@@ -81,7 +81,7 @@ class SectionActionDropdown extends Component {
    */
   editRedirectUrl = (sectionId, isPl) => {
     let editSectionUrl;
-    if (experiments.isEnabled('teacher-local-nav-v2')) {
+    if (showV2TeacherDashboard()) {
       editSectionUrl = teacherDashboardUrl(sectionId, '/settings');
     } else {
       editSectionUrl = '/sections/' + sectionId + '/edit';

--- a/apps/test/unit/templates/teacherDashboard/SectionActionDropdownTest.js
+++ b/apps/test/unit/templates/teacherDashboard/SectionActionDropdownTest.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PrintCertificates from '@cdo/apps/templates/teacherDashboard/PrintCertificates';
 import {UnconnectedSectionActionDropdown as SectionActionDropdown} from '@cdo/apps/templates/teacherDashboard/SectionActionDropdown';
 import {setRosterProvider} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import experiments from '@cdo/apps/util/experiments';
+import * as TeacherNavFlagUtils from '@cdo/apps/templates/teacherNavigation/TeacherNavFlagUtils.ts';
 
 import {expect} from '../../../util/deprecatedChai'; // eslint-disable-line no-restricted-imports
 
@@ -177,7 +177,11 @@ describe('SectionActionDropdown', () => {
   });
 
   it('sends selected user to the new teacher dashboard settings page', () => {
-    experiments.setEnabled('teacher-local-nav-v2', true);
+    jest
+      .spyOn(TeacherNavFlagUtils, 'showV2TeacherDashboard')
+      .mockImplementation(() => {
+        return true;
+      });
     const wrapper = shallow(
       <SectionActionDropdown {...DEFAULT_PROPS} sectionData={sections[3]} />
     );
@@ -188,5 +192,6 @@ describe('SectionActionDropdown', () => {
     expect(wrapper.find('.edit-section-details-link').props().href).to.equal(
       expectedUrl
     );
+    jest.restoreAllMocks();
   });
 });

--- a/apps/test/unit/templates/teacherDashboard/SectionActionDropdownTest.js
+++ b/apps/test/unit/templates/teacherDashboard/SectionActionDropdownTest.js
@@ -4,6 +4,7 @@ import React from 'react';
 import PrintCertificates from '@cdo/apps/templates/teacherDashboard/PrintCertificates';
 import {UnconnectedSectionActionDropdown as SectionActionDropdown} from '@cdo/apps/templates/teacherDashboard/SectionActionDropdown';
 import {setRosterProvider} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import experiments from '@cdo/apps/util/experiments';
 
 import {expect} from '../../../util/deprecatedChai'; // eslint-disable-line no-restricted-imports
 
@@ -169,6 +170,20 @@ describe('SectionActionDropdown', () => {
       '/sections/' +
       sectionId +
       '/edit?redirectToPage=my-professional-learning';
+    expect(wrapper).to.contain('Edit Section Details');
+    expect(wrapper.find('.edit-section-details-link').props().href).to.equal(
+      expectedUrl
+    );
+  });
+
+  it('sends selected user to the new teacher dashboard settings page', () => {
+    experiments.setEnabled('teacher-local-nav-v2', true);
+    const wrapper = shallow(
+      <SectionActionDropdown {...DEFAULT_PROPS} sectionData={sections[3]} />
+    );
+    const sectionId = wrapper.instance().props.sectionData.id;
+    const expectedUrl =
+      '/teacher_dashboard/sections/' + sectionId + '/settings';
     expect(wrapper).to.contain('Edit Section Details');
     expect(wrapper.find('.edit-section-details-link').props().href).to.equal(
       expectedUrl


### PR DESCRIPTION
This update modifies the Edit Section Details link on the Teacher Homepage to redirect to the new teacher dashboard if the 'teacher-local-nav-v2' experiment is enabled. Checked for additional links to /section/{section#}/edit, and found that this is the only one that is not deprecated.

## Links

[TEACH-1406](https://codedotorg.atlassian.net/browse/TEACH-1406)

## Testing story

Added a unit test to SectionActionDropdownTest to confirm the redirect works when the experiment is enabled.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
