### PR TITLE
[Google Blockly] Fix dropdown field text for RTL blocks

### DIFF
--- a/apps/src/blockly/addons/cdoFieldDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldDropdown.ts
@@ -199,6 +199,7 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
    * Get the text from this field to display on the block. May differ from
    * `getText` due to ellipsis, and other formatting.
    * @override Handling of text for RTL blocks is customized.
+   * See: https://github.com/google/blockly/issues/8645
    * @returns Text to display.
    */
   protected getDisplayText_(): string {

--- a/apps/src/blockly/addons/cdoFieldDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldDropdown.ts
@@ -194,6 +194,31 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (this as any).arrow = arrow;
   }
+
+  /**
+   * Get the text from this field to display on the block. May differ from
+   * `getText` due to ellipsis, and other formatting.
+   * @override
+   * @returns Text to display.
+   */
+  protected getDisplayText_(): string {
+    let text = this.getText();
+    if (!text) {
+      // Prevent the field from disappearing if empty.
+      return GoogleBlockly.Field.NBSP;
+    }
+    if (text.length > this.maxDisplayLength) {
+      // Truncate displayed string and add an ellipsis ('...').
+      text = text.substring(0, this.maxDisplayLength - 2) + '…';
+    }
+    // Replace whitespace with non-breaking spaces so the text doesn't collapse.
+    text = text.replace(/\s/g, GoogleBlockly.Field.NBSP);
+    if (this.sourceBlock_ && this.sourceBlock_.RTL) {
+      // The SVG is LTR, force text to be RTL by adding an RLM.
+      text += '\u200F';
+    }
+    return text;
+  }
 }
 
 /**

--- a/apps/src/blockly/addons/cdoFieldDropdown.ts
+++ b/apps/src/blockly/addons/cdoFieldDropdown.ts
@@ -198,7 +198,7 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
   /**
    * Get the text from this field to display on the block. May differ from
    * `getText` due to ellipsis, and other formatting.
-   * @override
+   * @override Handling of text for RTL blocks is customized.
    * @returns Text to display.
    */
   protected getDisplayText_(): string {
@@ -214,8 +214,13 @@ export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
     // Replace whitespace with non-breaking spaces so the text doesn't collapse.
     text = text.replace(/\s/g, GoogleBlockly.Field.NBSP);
     if (this.sourceBlock_ && this.sourceBlock_.RTL) {
-      // The SVG is LTR, force text to be RTL by adding an RLM.
-      text += '\u200F';
+      // Begin CDO Customization:
+      // Add RTL override '\u202E' and then a pop directional formatting '\u202C'.
+      // This approach enforces the RTL direction for the entire text consistently.
+      // The PDF mark ensures the override is localized to this field's text.
+      // Core Blockly instead adds a RTL Mark (text += '\u200F').
+      text = '\u202E' + text + '\u202C';
+      // End CDO Customization
     }
     return text;
   }


### PR DESCRIPTION
Bug report for Music Lab:
> The “rest for x” block has a bug in RTL languages. The correct translations are displayed in the dropdown options, but when one chooses one of the options the chosen option appears to flip when selected. The number should be to the right of the word, but the number appears on the left after selecting an option from the dropdown. 

https://github.com/user-attachments/assets/f0849f33-51c2-4deb-b225-e16aeeae3d87

This inconsistency seems to be due to Blockly's menu items with `direction: RTL`, but not the field text. The dropdown div includes this CSS rule based on the block's `RTL` property.

There appears to be a bug in how dropdown field's currently process the field's text for RTL blocks. Currently, this is handled by Core Blockly's `getDisplayText_` method, which is called when the field is rendered. This method adds an RTL mark to the end of the text string. The RLM character only hints at a directional bias near the boundary where it’s placed, which can be inadequate for consistently enforcing RTL directionality across a full line of text, especially in cases with mixed content (e.g., truncated strings or embedded Latin characters).

To improve the RTL, we can instead wrap the text in Right-to-left Override and Pop Directional Formatting characters. The RLO forces the entire span of text that follows it to be displayed right-to-left, regardless of surrounding text or the container's CSS styling. This ensures that all characters within the override are arranged in a predictable RTL flow. By using PDF immediately after the text, we "pop" the directional override back to its original state, limiting the scope of the RTL effect to just this field’s text.

With this change, the translations match between the dropdown options and the selected text on the block field:

![image](https://github.com/user-attachments/assets/88ad51ec-3432-468d-b37f-e0ec78b6c5d6)![image](https://github.com/user-attachments/assets/3f7ddba8-c8c4-4374-a88b-6ad0643eba2a)



## Links

https://codedotorg.atlassian.net/browse/LABS-1097
https://github.com/google/blockly/issues/8645

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Deployment strategy/Follow-up work

I've opened an issue with Blockly here: https://github.com/google/blockly/issues/8645

If this fix or a similar one makes it into a mainline release, we can remove this customization.

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
