### PR TITLE
Ensure custom ASGCount Resource is invoked on every Stack Update.

### DIFF
--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -108,7 +108,8 @@ frontend_device_name ||= '/dev/sda1'
     AutoScalingGroupTags: [
       {Key: 'aws:cloudformation:stack-id', Value: {Ref: 'AWS::StackId'}},
       {Key: 'aws:cloudformation:logical-id', Value: 'Frontends'}
-    ]
+    ],
+    LatestStackUpdateDateTime: Time.now # Trigger update of this custom Resource (invocation of the Lambda) for each Stack update.
   %>
   Frontends:
     Type: AWS::AutoScaling::AutoScalingGroup


### PR DESCRIPTION
Fix for production outage caused by #62122 

The custom `ASGCount` CloudFormation Resource needs to be updated with each production release so that the current number of Minimum and Desired web application server EC2 Instances can be set correctly on the Auto Scaling Group as it carries out a Rolling Batch deployment.

## Testing story

Successfully verified we can render a valid full stack CloudFormation template from this feature branch:

`bundle exec rake adhoc:full_stack:start RAILS_ENV=adhoc STACK_NAME=adhoc-fix-asgcount ALARMS=yes VERBOSE=true`


## Deployment strategy

Deploy during a time period when usage is dropping. Manualy increase Minimum / Desired Instances on the Auto Scaling Group before the release starts to ensure those values are collected by the custom `ASGCount` resource.

## Follow-up work

Switch to whatever is the recommended mechanism with Auto Scaling Group to carry out a rolling deploy that maintains the current dynamically scaled Minimum/Desired Instances.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
