### PR TITLE
Python Lab: update and add logs/metrics

### DIFF
--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -45,15 +45,21 @@ let pyodideReadyPromise: Promise<void> | null = null;
 // Pyodide defines the globals object as any.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let pyodideGlobals: any | null = null;
+let loadStartTime: number | undefined;
 async function initializePyodide() {
   const promiseWasNull = pyodideReadyPromise === null;
   if (promiseWasNull) {
+    loadStartTime = Date.now();
     pyodideReadyPromise = loadPyodideAndPackages();
     postMessage({type: 'loading_pyodide'});
   }
   await pyodideReadyPromise;
   if (promiseWasNull) {
-    postMessage({type: 'loaded_pyodide'});
+    const loadTime = loadStartTime ? Date.now() - loadStartTime : undefined;
+    postMessage({
+      type: 'loaded_pyodide',
+      message: loadTime,
+    });
   }
   pyodideGlobals = pyodide.globals.toJs();
 }

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -21,7 +21,6 @@ let callbacks: {[key: number]: (event: PyodideMessage) => void} = {};
 const setUpPyodideWorker = () => {
   // @ts-expect-error because TypeScript does not like this syntax.
   const worker = new Worker(new URL('./pyodideWebWorker.ts', import.meta.url));
-  let loadStartTime: number | undefined;
 
   callbacks = {};
 
@@ -65,18 +64,13 @@ const setUpPyodideWorker = () => {
         break;
       case 'loading_pyodide':
         getStore().dispatch(setLoadedCodeEnvironment(false));
-        loadStartTime = Date.now();
         break;
       case 'loaded_pyodide':
         getStore().dispatch(setLoadedCodeEnvironment(true));
-        if (loadStartTime) {
+        if (message && parseInt(message)) {
           Lab2Registry.getInstance()
             .getMetricsReporter()
-            .reportLoadTime(
-              'PythonLab.PyodideLoadTime',
-              Date.now() - loadStartTime
-            );
-          loadStartTime = undefined;
+            .reportLoadTime('PythonLab.PyodideLoadTime', parseInt(message));
         }
         break;
       default:

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -6,10 +6,10 @@ import {
   appendSystemError,
 } from '@codebridge/redux/consoleRedux';
 
+import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {setAndSaveProjectSource} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import {setLoadedCodeEnvironment} from '@cdo/apps/lab2/redux/systemRedux';
 import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
-import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
 import {getStore} from '@cdo/apps/redux';
 
 import {parseErrorMessage} from './pythonHelpers/messageHelpers';
@@ -21,6 +21,7 @@ let callbacks: {[key: number]: (event: PyodideMessage) => void} = {};
 const setUpPyodideWorker = () => {
   // @ts-expect-error because TypeScript does not like this syntax.
   const worker = new Worker(new URL('./pyodideWebWorker.ts', import.meta.url));
+  let loadStartTime: number | undefined;
 
   callbacks = {};
 
@@ -53,22 +54,27 @@ const setUpPyodideWorker = () => {
         break;
       case 'system_error':
         getStore().dispatch(appendSystemError(message));
-        MetricsReporter.logError({
-          type: 'PythonLabSystemCodeError',
-          message,
-        });
+        Lab2Registry.getInstance()
+          .getMetricsReporter()
+          .logError('Python Lab System Code Error', undefined, {message});
         break;
       case 'internal_error':
-        MetricsReporter.logError({
-          type: 'PythonLabInternalError',
-          message,
-        });
+        Lab2Registry.getInstance()
+          .getMetricsReporter()
+          .logError('Python Lab Internal Error', undefined, {message});
         break;
       case 'loading_pyodide':
         getStore().dispatch(setLoadedCodeEnvironment(false));
+        loadStartTime = Date.now();
         break;
       case 'loaded_pyodide':
         getStore().dispatch(setLoadedCodeEnvironment(true));
+        if (loadStartTime) {
+          Lab2Registry.getInstance()
+            .getMetricsReporter()
+            .reportLoadTime('PyodideLoadTime', Date.now() - loadStartTime);
+          loadStartTime = undefined;
+        }
         break;
       default:
         console.warn(
@@ -112,6 +118,9 @@ const restartPyodideIfProgramIsRunning = () => {
     pyodideWorker.terminate();
     pyodideWorker = setUpPyodideWorker();
     getStore().dispatch(appendSystemMessage('Program stopped.'));
+    Lab2Registry.getInstance()
+      .getMetricsReporter()
+      .incrementCounter('PythonLab.PyodideRestarted');
   }
 };
 

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -72,7 +72,10 @@ const setUpPyodideWorker = () => {
         if (loadStartTime) {
           Lab2Registry.getInstance()
             .getMetricsReporter()
-            .reportLoadTime('PyodideLoadTime', Date.now() - loadStartTime);
+            .reportLoadTime(
+              'PythonLab.PyodideLoadTime',
+              Date.now() - loadStartTime
+            );
           loadStartTime = undefined;
         }
         break;


### PR DESCRIPTION
Couple updates to logs and metrics in Python Lab:
- I wasn't using the Lab2 Metrics Reporter for the current error logs I had set up, which meant they weren't tagged with `pythonlab` and other helpful metadata. I updated them to use the correct reporter.
- Added a load time metric
- Added a restart metric

I am also updating the `LevelLoad` metric that is currently only reported by Music Lab to be reported by all lab2 labs. That was distinct enough from this work and requires some refactoring of lab2 things, so I am splitting that into its own PR.

## Links
- jira ticket: [CT-897](https://codedotorg.atlassian.net/browse/CT-897)


## Testing story
Tested locally. On localhost, logs/metrics are printed to the console.

## Follow-up work
Once these are in, I will add new widgets to the PythonLab cloudwatch dashboard.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
