### PR TITLE
Panels: typing option

### DIFF
--- a/apps/src/lab2/levelEditors/panels/EditPanels.tsx
+++ b/apps/src/lab2/levelEditors/panels/EditPanels.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
+import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import {
@@ -237,6 +238,20 @@ const EditPanel: React.FunctionComponent<EditPanelProps> = ({
           updateImageUrl={imageUrl => {
             updatePanel({...panel, imageUrl: imageUrl});
           }}
+        />
+      </div>
+      <div className={moduleStyles.fieldRow}>
+        <Checkbox
+          checked={!!panel.typing}
+          name="typing"
+          label="Typing? (No markdown support)"
+          size="s"
+          onChange={event =>
+            updatePanel({
+              ...panel,
+              typing: event.target.checked,
+            })
+          }
         />
       </div>
       {last && (


### PR DESCRIPTION
The typing effect for panels text added in https://github.com/code-dot-org/code-dot-org/pull/61820 can now be set with a new checkbox in levelbuilder.

<img width="849" alt="Screenshot 2024-11-04 at 4 37 47 PM" src="https://github.com/user-attachments/assets/e2f7b3cb-5c6d-450d-a87f-8ef2324441a8">
