### PR TITLE
Update en.yml to add in missing header link localizations.

### DIFF
--- a/config/global_editions/fa.yml
+++ b/config/global_editions/fa.yml
@@ -22,21 +22,18 @@ header:
         id: header-about
         domain: code.org
         url: /global/fa/about
-      - title: csf
+      - title: header_csf
         id: header-csf
         domain: code.org
         url: /global/fa/csf
-        loc_prefix: header_
-      - title: hour_of_code
+      - title: header_hour_of_code
         id: header-hoc
         domain: code.org
         url: /global/fa/hourofcode
-        loc_prefix: header_
-      - title: videos
+      - title: header_videos
         id: header-videos
         domain: code.org
         url: /global/fa/videos
-        loc_prefix: header_
 
     student:
       - title: my_dashboard

--- a/config/global_editions/fa.yml
+++ b/config/global_editions/fa.yml
@@ -22,15 +22,15 @@ header:
         id: header-about
         domain: code.org
         url: /global/fa/about
-      - title: header_csf
+      - title: csf
         id: header-csf
         domain: code.org
         url: /global/fa/csf
-      - title: header_hour_of_code
+      - title: hour_of_code
         id: header-hoc
         domain: code.org
         url: /global/fa/hourofcode
-      - title: header_videos
+      - title: videos
         id: header-videos
         domain: code.org
         url: /global/fa/videos

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -428,9 +428,9 @@ en:
       legal_privacy: "Privacy Policy"
       legal_cookie_notice: "Cookie Notice"
       legal_tos: "Terms of Service"
-      header_videos: "Videos"
-      header_hour_of_code: "Hour of Code"
-      header_csf: "CS Fundamentals"
+      videos: "Videos"
+      hour_of_code: "Hour of Code"
+      csf: "CS Fundamentals"
 
     user:
       classroom: 'Teacher Home Page'

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -428,6 +428,9 @@ en:
       legal_privacy: "Privacy Policy"
       legal_cookie_notice: "Cookie Notice"
       legal_tos: "Terms of Service"
+      header_videos: "Videos"
+      header_hour_of_code: "Hour of Code"
+      header_csf: "CS Fundamentals"
 
     user:
       classroom: 'Teacher Home Page'


### PR DESCRIPTION
Fixes these issues as seen on an Adhoc (also seen on Production if manually visited)

![image](https://github.com/user-attachments/assets/3bb0c0cf-c8d9-44cb-ae40-017fc09c841d)

Dashboard does not have the i18n keys that Pegasus has... so we duplicate them here for now.

The Dashboard header mimics the same strings as the Pegasus one when you are looking at the sign in screen (or manage to find yourself on any dashboard page not logged in)

These particular strings are only referenced for the `/global/fa` header that was introduced to Pegasus not too long ago. This fixes its use in Dashboard by adding those keys over to the Dashboard localization files.

The strings in Pegasus are [here](https://github.com/code-dot-org/code-dot-org/blob/c6759ecd99a16dc8c3b9626352bc118e9b985e7a/pegasus/cache/i18n/en-US.json#L1484).

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
