### PR TITLE
Add feedback button to Python Lab

### DIFF
--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {Button} from '@cdo/apps/componentLibrary/button';
 import {TooltipProps, WithTooltip} from '@cdo/apps/componentLibrary/tooltip';
 import VersionHistoryButton from '@cdo/apps/lab2/views/components/versionHistory/VersionHistoryButton';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import commonI18n from '@cdo/locale';
 
 import {useCodebridgeContext} from '../codebridgeContext';
@@ -12,6 +13,8 @@ import darkModeStyles from '@cdo/apps/lab2/styles/dark-mode.module.scss';
 
 const WorkspaceHeaderButtons: React.FunctionComponent = () => {
   const {startSource} = useCodebridgeContext();
+
+  const appName = useAppSelector(state => state.lab.levelProperties?.appName);
 
   const feedbackTooltipProps: TooltipProps = {
     text: commonI18n.feedback(),
@@ -27,18 +30,20 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
 
   return (
     <div className={moduleStyles.rightHeaderButtons}>
-      <WithTooltip tooltipProps={feedbackTooltipProps}>
-        <Button
-          isIconOnly
-          icon={{iconStyle: 'solid', iconName: 'commenting'}}
-          color={'white'}
-          onClick={openFeedbackForm}
-          ariaLabel={commonI18n.feedback()}
-          size={'xs'}
-          type={'tertiary'}
-          className={darkModeStyles.iconOnlyTertiaryButton}
-        />
-      </WithTooltip>
+      {appName === 'pythonlab' && (
+        <WithTooltip tooltipProps={feedbackTooltipProps}>
+          <Button
+            isIconOnly
+            icon={{iconStyle: 'solid', iconName: 'commenting'}}
+            color={'white'}
+            onClick={openFeedbackForm}
+            ariaLabel={commonI18n.feedback()}
+            size={'xs'}
+            type={'tertiary'}
+            className={darkModeStyles.iconOnlyTertiaryButton}
+          />
+        </WithTooltip>
+      )}
       <VersionHistoryButton startSource={startSource} />
     </div>
   );

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import VersionHistoryButton from '@cdo/apps/lab2/views/components/versionHistory/VersionHistoryButton';
+import commonI18n from '@cdo/locale';
 
 import {useCodebridgeContext} from '../codebridgeContext';
 

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -1,15 +1,44 @@
 import React from 'react';
 
+import {Button} from '@cdo/apps/componentLibrary/button';
+import {TooltipProps, WithTooltip} from '@cdo/apps/componentLibrary/tooltip';
 import VersionHistoryButton from '@cdo/apps/lab2/views/components/versionHistory/VersionHistoryButton';
 import commonI18n from '@cdo/locale';
 
 import {useCodebridgeContext} from '../codebridgeContext';
 
+import moduleStyles from './workspace.module.scss';
+import darkModeStyles from '@cdo/apps/lab2/styles/dark-mode.module.scss';
+
 const WorkspaceHeaderButtons: React.FunctionComponent = () => {
   const {startSource} = useCodebridgeContext();
 
+  const feedbackTooltipProps: TooltipProps = {
+    text: commonI18n.feedback(),
+    direction: 'onLeft',
+    tooltipId: 'feedback-tooltip',
+    size: 'xs',
+    className: darkModeStyles.tooltipLeft,
+  };
+
+  const openFeedbackForm = () => {
+    window.open('https://forms.gle/Z4FsGMFzE4NrFp369', '_blank');
+  };
+
   return (
-    <div>
+    <div className={moduleStyles.rightHeaderButtons}>
+      <WithTooltip tooltipProps={feedbackTooltipProps}>
+        <Button
+          isIconOnly
+          icon={{iconStyle: 'solid', iconName: 'commenting'}}
+          color={'white'}
+          onClick={openFeedbackForm}
+          ariaLabel={commonI18n.feedback()}
+          size={'xs'}
+          type={'tertiary'}
+          className={darkModeStyles.iconOnlyTertiaryButton}
+        />
+      </WithTooltip>
       <VersionHistoryButton startSource={startSource} />
     </div>
   );

--- a/apps/src/codebridge/Workspace/HeaderButtons.tsx
+++ b/apps/src/codebridge/Workspace/HeaderButtons.tsx
@@ -30,6 +30,7 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
 
   return (
     <div className={moduleStyles.rightHeaderButtons}>
+      <VersionHistoryButton startSource={startSource} />
       {appName === 'pythonlab' && (
         <WithTooltip tooltipProps={feedbackTooltipProps}>
           <Button
@@ -44,7 +45,6 @@ const WorkspaceHeaderButtons: React.FunctionComponent = () => {
           />
         </WithTooltip>
       )}
-      <VersionHistoryButton startSource={startSource} />
     </div>
   );
 };

--- a/apps/src/codebridge/Workspace/workspace.module.scss
+++ b/apps/src/codebridge/Workspace/workspace.module.scss
@@ -73,3 +73,10 @@
 .lockedFilesBanner {
   margin-bottom: 4px;
 }
+
+.rightHeaderButtons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  margin: 4px;
+}

--- a/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
+++ b/apps/src/lab2/views/components/versionHistory/VersionHistoryButton.tsx
@@ -108,10 +108,7 @@ const VersionHistoryButton: React.FunctionComponent<VersionHistoryProps> = ({
           size={'xs'}
           disabled={buttonDisabled}
           type={'tertiary'}
-          className={classNames(
-            moduleStyles.versionHistoryButton,
-            darkModeStyles.iconOnlyTertiaryButton
-          )}
+          className={darkModeStyles.iconOnlyTertiaryButton}
         />
       </WithTooltip>
       {(loading || loadError) && (

--- a/apps/src/lab2/views/components/versionHistory/version-history.module.scss
+++ b/apps/src/lab2/views/components/versionHistory/version-history.module.scss
@@ -70,7 +70,3 @@
 .actionButton {
   margin-right: 8px;
 }
-
-.versionHistoryButton {
-  margin: 4px;
-}


### PR DESCRIPTION
This adds a feedback button that links to a google form to Python Lab. The form opens in a new tab. This is similar to the Music Lab feedback button. The button is not present for Web Lab 2.

## Header with new button
![Screenshot 2024-11-06 at 9 13 41 AM](https://github.com/user-attachments/assets/a61679f0-61d4-4cc3-869f-2173c9f8b387)

## Hover state
![Screenshot 2024-11-06 at 9 13 48 AM](https://github.com/user-attachments/assets/98b091b8-6b76-45a9-bed4-55c7978678d1)

## Links

- jira ticket: [CT-901](https://codedotorg.atlassian.net/browse/CT-901)

## Testing story
Tested locally.

## Deployment strategy
There is a [slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1730851025266299) with Sam and Curriculum deciding whether we need any additional communication with pilot teachers about this.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
