### PR TITLE
Add music-jam-2024 HOC script to list of cached units

### DIFF
--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -101,6 +101,7 @@ class HttpCache
     hello-world-emoji-2021
     hello-world-space-2022
     hello-world-soccer-2022
+    music-jam-2024
     outbreak
   ).map do |script_name|
     # Most scripts use the default route pattern.

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -86,7 +86,6 @@ class HttpCache
     starwarsblocks
     mc
     frozen
-    gumball
     minecraft
     hero
     sports


### PR DESCRIPTION
Add the upcoming Music Lab HOC script ('music-jam-2024') to the list of cached units. The music-jam-2024 is entirely Lab2 which means that even project backed levels will have their user and level specific data fetched asynchronously after page load.

## Links

https://codedotorg.slack.com/archives/C03CK49G9/p1730322306558319?thread_ts=1730152740.086889&cid=C03CK49G9
