### PR TITLE
Music: use separate samplers for preview instruments

### DIFF
--- a/apps/src/music/player/ToneJSPlayer.ts
+++ b/apps/src/music/player/ToneJSPlayer.ts
@@ -39,6 +39,7 @@ const EMPTY_EFFECTS_KEY = '';
  */
 class ToneJSPlayer implements AudioPlayer {
   private samplers: {[instrument: string]: {[effectsKey: string]: Sampler}};
+  private previewSamplers: {[instrument: string]: Sampler};
   private activePlayers: Source<SourceOptions>[];
   private currentPreview: {
     url: string;
@@ -59,6 +60,7 @@ class ToneJSPlayer implements AudioPlayer {
     Transport.bpm.value = bpm;
     this.activePlayers = [];
     this.samplers = {};
+    this.previewSamplers = {};
     this.currentPreview = null;
     this.effectBusses = {};
     this.registeredCallbacks = {};
@@ -142,6 +144,8 @@ class ToneJSPlayer implements AudioPlayer {
     }
 
     this.samplers[instrumentName] = effectsSamplers;
+    // Create a separate sampler without effects for previews
+    this.previewSamplers[instrumentName] = new Sampler(urls).toDestination();
     for (const callback of this.registeredCallbacks['InstrumentLoaded'] || []) {
       callback(instrumentName);
     }
@@ -215,7 +219,7 @@ class ToneJSPlayer implements AudioPlayer {
     onStop?: () => void
   ) {
     this.cancelPreviews();
-    if (this.samplers[instrument] === undefined) {
+    if (this.previewSamplers[instrument] === undefined) {
       this.metricsReporter.logError(`Instrument not loaded: ${instrument}`);
       return;
     }
@@ -227,11 +231,9 @@ class ToneJSPlayer implements AudioPlayer {
         this.playbackTimeToTransportTime(playbackPosition)
       );
       lastSampleStart = Math.max(lastSampleStart, offsetSeconds);
-      this.samplers[instrument][EMPTY_EFFECTS_KEY].unsync().triggerAttack(
-        notes,
-        `+${offsetSeconds}`,
-        1
-      );
+      this.previewSamplers[instrument]
+        .unsync()
+        .triggerAttack(notes, `+${offsetSeconds}`, 1);
     });
 
     // Play every tick (quarter note) of the sequence.
@@ -258,7 +260,10 @@ class ToneJSPlayer implements AudioPlayer {
 
     this.currentPreview = null;
 
-    this.stopAllSamplers();
+    // Release all preview samplers
+    Object.values(this.previewSamplers).forEach(sampler =>
+      sampler.releaseAll()
+    );
   }
 
   setBpm(bpm: number) {


### PR DESCRIPTION
Fixes a bug where the AI-generated pattern preview that plays after Generate is clicked would not play properly if the playback was also in progress. The root cause was that when a new pattern is generated via the Generate button, the value of the block is updated which triggers our system to cancel and re-queue all events. Currently, both regular playback and preview share the same set of instrument samplers, so cancel all events also meant shutting down all samplers. The AI block would try to start a preview, but the sampler would quickly get shut down after a single note was queued.

The solution here is to create a separate set of samplers that are dedicated to playing previews only, similar to the `currentPreview` player node that's managed separately from regular playback player nodes.

## Links

https://codedotorg.atlassian.net/browse/LABS-1056

## Testing story

Tested locally with AI block in various permutations.
