### PR TITLE
Panels: typing earlier

### DIFF
--- a/apps/src/panels/PanelsView.tsx
+++ b/apps/src/panels/PanelsView.tsx
@@ -186,7 +186,7 @@ const PanelsView: React.FunctionComponent<PanelsProps> = ({
               <div>
                 <div className={styles.invisiblePlaceholder}>{plainText}</div>
                 <Typist
-                  startDelay={1500}
+                  startDelay={750}
                   avgTypingDelay={35}
                   stdTypingDelay={15}
                   cursor={{show: false}}


### PR DESCRIPTION
Start the panels typing a little earlier, so that it begins as the text box completes its slide into place.
