### PR TITLE
P20-1273: Change `user_levels.properties` type from `text` to `json`

### DIFF
--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -16,7 +16,7 @@
 #  unlocked_at      :datetime
 #  time_spent       :integer
 #  deleted_at       :datetime
-#  properties       :text(65535)
+#  properties       :json
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20241107142204_change_properties_type_to_json_in_user_levels.rb
+++ b/dashboard/db/migrate/20241107142204_change_properties_type_to_json_in_user_levels.rb
@@ -1,0 +1,9 @@
+class ChangePropertiesTypeToJSONInUserLevels < ActiveRecord::Migration[6.1]
+  def up
+    change_column :user_levels, :properties, :json, using: 'CAST(properties AS JSON)'
+  end
+
+  def down
+    change_column :user_levels, :properties, :text
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_24_180714) do
+ActiveRecord::Schema.define(version: 2024_11_07_142204) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2287,7 +2287,7 @@ ActiveRecord::Schema.define(version: 2024_10_24_180714) do
     t.datetime "unlocked_at"
     t.integer "time_spent"
     t.datetime "deleted_at"
-    t.text "properties"
+    t.json "properties"
     t.index ["user_id", "script_id", "level_id", "deleted_at"], name: "index_user_levels_unique", unique: true
   end
 


### PR DESCRIPTION
All `user_levels.properties` columns are empty in the production database and have never been used.
## Links
- JIRA task: [P20-1273](https://codedotorg.atlassian.net/browse/P20-1273)
- Following PR: https://github.com/code-dot-org/code-dot-org/pull/62310