### PR TITLE
[Google Blockly] Update fromJson types

### DIFF
--- a/apps/src/blockly/addons/cdoFieldButton.ts
+++ b/apps/src/blockly/addons/cdoFieldButton.ts
@@ -55,7 +55,8 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
     this.allowReadOnlyClick = allowReadOnlyClick;
   }
 
-  static fromJson(options: CdoFieldButtonOptions) {
+  static fromJson(_options: GoogleBlockly.FieldConfig) {
+    const options = _options as CdoFieldButtonOptions;
     return new CdoFieldButton(options);
   }
 

--- a/apps/src/blockly/addons/cdoFieldFlyout.ts
+++ b/apps/src/blockly/addons/cdoFieldFlyout.ts
@@ -29,10 +29,11 @@ export default class CdoFieldFlyout extends GoogleBlockly.Field {
   /**
    * Construct a FieldFlyout from a JSON arg object.
    *
-   * @param {Object} options A JSON object with options.
+   * @param {GoogleBlockly.FieldConfig} _options A JSON object with options.
    * @returns {CdoFieldFlyout} The new field instance.
    */
-  static fromJson(options: FieldFlyoutConfig) {
+  static fromJson(_options: GoogleBlockly.FieldConfig) {
+    const options = _options as FieldFlyoutConfig;
     return new CdoFieldFlyout(options.flyoutKey, options);
   }
 

--- a/apps/src/blockly/addons/cdoFieldToggle.ts
+++ b/apps/src/blockly/addons/cdoFieldToggle.ts
@@ -58,10 +58,11 @@ export default class CdoFieldToggle extends GoogleBlockly.Field {
   /**
    * Construct a CdoFieldToggle from a JSON arg object.
    *
-   * @param {Object} options - A JSON object with options.
+   * @param {GoogleBlockly.FieldConfig} _options - A JSON object with options.
    * @returns {CdoFieldToggle} The new field instance.
    */
-  static fromJson(options: CdoFieldButtonToggleOptions) {
+  static fromJson(_options: GoogleBlockly.FieldConfig): CdoFieldToggle {
+    const options = _options as CdoFieldButtonToggleOptions;
     return new CdoFieldToggle(options);
   }
 

--- a/apps/src/music/blockly/FieldChord.ts
+++ b/apps/src/music/blockly/FieldChord.ts
@@ -24,7 +24,8 @@ interface FieldChordOptions {
  * "play_chord" block. The UI is rendered by {@link ChordPanel}.
  */
 export default class FieldChord extends GoogleBlockly.Field {
-  static fromJson(options: FieldChordOptions) {
+  static fromJson(_options: GoogleBlockly.FieldConfig) {
+    const options = _options as FieldChordOptions;
     return new FieldChord(options);
   }
 

--- a/apps/src/music/blockly/FieldTune.ts
+++ b/apps/src/music/blockly/FieldTune.ts
@@ -24,7 +24,8 @@ interface FieldTuneOptions {
  * "play_tune" block. The UI is rendered by {@link TunePanel}.
  */
 export default class FieldTune extends GoogleBlockly.Field {
-  static fromJson(options: FieldTuneOptions) {
+  static fromJson(_options: GoogleBlockly.FieldConfig) {
+    const options = _options as FieldTuneOptions;
     return new FieldTune(options);
   }
 


### PR DESCRIPTION
This is one of several tasks that should help to unblock the Blockly v11 bump. A draft of this project is collected here:
- https://github.com/code-dot-org/code-dot-org/pull/62301/commits

After updating Blockly and its plugins, several field classes are hit by new errors due to stricter types. Example:

```
Class static side 'typeof CdoFieldButton' incorrectly extends base class static side 'typeof Field'.
  Types of property 'fromJson' are incompatible.
    Type '(options: CdoFieldButtonOptions) => CdoFieldButton' is not assignable to type '(_options: FieldConfig) => Field<any>'.
      Types of parameters 'options' and '_options' are incompatible.
        Property 'onClick' is missing in type 'FieldConfig' but required in type 'CdoFieldButtonOptions'.
```

These CDO classes use custom interfaces that align with how the fields are created, but Blockly is still expecting a compatible signature. To handle this, we can cast the options object for each field to its associated interface. When testing v11 locally, this resolves errors like the above. When testing this branch against staging, no regressions are found.

## Links

https://codedotorg.atlassian.net/browse/CT-898

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
