### PR TITLE
Music: toggling drum notes during preview freezes preview

### DIFF
--- a/apps/src/music/views/PatternAiPanel.tsx
+++ b/apps/src/music/views/PatternAiPanel.tsx
@@ -277,6 +277,18 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
   }, [availableKits, currentValue.instrument]);
   const [currentPreviewTick, setCurrentPreviewTick] = useState(0);
 
+  const previewNote = useCallback(
+    (note: number) => {
+      // Don't preview the note if we're previewing the whole pattern
+      if (currentPreviewTick > 0) {
+        return;
+      }
+
+      MusicRegistry.player.previewNote(note, currentValue.instrument);
+    },
+    [currentValue.instrument, currentPreviewTick]
+  );
+
   const toggleEvent = useCallback(
     (tick: number, note: number) => {
       const index = currentValue.events.findIndex(
@@ -288,12 +300,12 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
       } else {
         // Not found, so add.
         currentValue.events.push({tick, note});
-        MusicRegistry.player.previewNote(note, currentValue.instrument);
+        previewNote(note);
       }
 
       onChange(currentValue);
     },
-    [onChange, currentValue]
+    [onChange, currentValue, previewNote]
   );
 
   const hasEvent = (note: number, tick: number) => {
@@ -591,12 +603,7 @@ const PatternAiPanel: React.FunctionComponent<PatternAiPanelProps> = ({
                     <div className={styles.nameContainer}>
                       <span
                         className={styles.name}
-                        onClick={() =>
-                          MusicRegistry.player.previewNote(
-                            note || index,
-                            currentValue.instrument
-                          )
-                        }
+                        onClick={() => previewNote(note || index)}
                       >
                         {name}
                       </span>

--- a/apps/src/music/views/PatternPanel.tsx
+++ b/apps/src/music/views/PatternPanel.tsx
@@ -54,6 +54,18 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
   }, [availableKits, currentValue.instrument]);
   const [currentPreviewTick, setCurrentPreviewTick] = useState(0);
 
+  const previewNote = useCallback(
+    (note: number) => {
+      // Don't preview the note if we're previewing the whole pattern
+      if (currentPreviewTick > 0) {
+        return;
+      }
+
+      MusicRegistry.player.previewNote(note, currentValue.instrument);
+    },
+    [currentValue.instrument, currentPreviewTick]
+  );
+
   const toggleEvent = useCallback(
     (tick: number, note: number) => {
       const index = currentValue.events.findIndex(
@@ -65,12 +77,12 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
       } else {
         // Not found, so add.
         currentValue.events.push({tick, note});
-        MusicRegistry.player.previewNote(note, currentValue.instrument);
+        previewNote(note);
       }
 
       onChange(currentValue);
     },
-    [onChange, currentValue]
+    [onChange, currentValue, previewNote]
   );
 
   const hasEvent = (note: number, tick: number) => {
@@ -156,12 +168,7 @@ const PatternPanel: React.FunctionComponent<PatternPanelProps> = ({
             <div className={styles.nameContainer}>
               <span
                 className={styles.name}
-                onClick={() =>
-                  MusicRegistry.player.previewNote(
-                    note || index,
-                    currentValue.instrument
-                  )
-                }
+                onClick={() => previewNote(note || index)}
               >
                 {name}
               </span>


### PR DESCRIPTION
Fixes a bug where toggling on a note during drum preview playback (in both the AI and regular blocks) would cause the preview to freeze. Our preview system is designed to only preview one sequence or note at a time, so toggling on a note during a preview would cancel the current preview and just preview the single note. The fix here is just to disable the single note preview if a full pattern preview is in progress.

Before:

https://github.com/user-attachments/assets/941bdc11-e240-4078-be6b-b231fd15d0dd

After:

https://github.com/user-attachments/assets/55ff742d-9d3d-4d15-b40a-a26b9b4304dd