### PR TITLE
Panels: editing fix

### DIFF
--- a/apps/src/lab2/levelEditors/panels/edit-panels.module.scss
+++ b/apps/src/lab2/levelEditors/panels/edit-panels.module.scss
@@ -31,7 +31,6 @@ $full-height: 1080px;
   border-radius: 4px;
   margin-bottom: 25px;
   resize: vertical;
-  height: 300px;
   background-color: rgba($neutral_dark10, 0.5);
 }
 

--- a/dashboard/app/views/levels/editors/fields/_panels.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_panels.html.haml
@@ -1,7 +1,7 @@
-%h1.control-legend{data: {toggle: "collapse", target: "#panels-container"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#panels-outer-container"}}
   Panels
 
-#panels-container.in.collapse
+#panels-outer-container.in.collapse
   #panels-editor
 
 - content_for :body_scripts do


### PR DESCRIPTION
This is a mitigation for a bug in the Panels editing page, though the core issue is not yet root-caused.

### before

The bug is that if we scroll down inside the `300px`-high div that contains the stack of panel editors, then click the new "typing" checkbox added in https://github.com/code-dot-org/code-dot-org/pull/62253, then the panels preview collapses in height.  It can be restored by collapsing and expanding the "Panels" section again.

https://github.com/user-attachments/assets/519fa9b4-70d8-4c9a-99a2-880d0d06d37d

The issue does seem to be caused by the use of Bootstrap 2.3.2's collapse system.  The issue occurs even if the checkbox's `onChange` handler does nothing, but doesn't occur if we turn off the collapse support for the "Panels" section.  However, none of the obvious collapse functions seem to be fired when the checkbox is clicked.

### potential

An alternate solution was to turn off collapse support for the "Panels" section, but that leads to another layout issue:

https://github.com/user-attachments/assets/77493f92-bae0-49d2-b4b9-ea6e50e796ee

### after

This is how things look with this fix.  

https://github.com/user-attachments/assets/772e204f-5e25-4e3a-9884-55307a103159

### future

It would be great to revisit this and root-cause the issue.  If nothing else, it's a great mystery!