### PR TITLE
P20-1273: Track user level progress with current locale

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -196,6 +196,7 @@ class ActivitiesController < ApplicationController
         submitted: params[:submitted] == 'true',
         level_source_id: @level_source.try(:id),
         pairing_user_ids: pairing_user_ids,
+        locale: locale,
         time_spent: time_since_last_milestone
       )
 
@@ -215,6 +216,7 @@ class ActivitiesController < ApplicationController
           submitted: false,
           level_source_id: nil,
           pairing_user_ids: pairing_user_ids,
+          locale: locale,
           time_spent: time_since_last_milestone
         )
       end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2080,7 +2080,18 @@ class User < ApplicationRecord
 
   # The synchronous handler for the track_level_progress helper.
   # @return [UserLevel]
-  def self.track_level_progress(user_id:, level_id:, script_id:, new_result:, submitted:, level_source_id:, pairing_user_ids: nil, is_navigator: false, time_spent: nil)
+  def self.track_level_progress(
+    user_id:,
+    level_id:,
+    script_id:,
+    new_result:,
+    submitted:,
+    level_source_id:,
+    pairing_user_ids: nil,
+    is_navigator: false,
+    time_spent: nil,
+    locale: nil
+  )
     new_level_completed = false
     new_csf_level_perfected = false
 
@@ -2126,6 +2137,8 @@ class User < ApplicationRecord
       total_time_spent = user_level.calculate_total_time_spent(time_spent)
       user_level.time_spent = total_time_spent if total_time_spent
 
+      user_level.locale = locale if locale
+
       user_level.atomic_save!
     end
 
@@ -2140,6 +2153,7 @@ class User < ApplicationRecord
           level_source_id: level_source_id,
           pairing_user_ids: nil,
           is_navigator: true,
+          locale: locale,
           time_spent: time_spent
         )
         Retryable.retryable on: [Mysql2::Error, ActiveRecord::RecordNotUnique], matching: /Duplicate entry/ do

--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -42,7 +42,7 @@ class UserLevel < ApplicationRecord
   after_save :after_submit, if: :submitted_or_resubmitted?
   before_save :before_unsubmit, if: ->(ul) {ul.submitted_changed? from: true, to: false}
 
-  validates :locale, inclusion: {in: I18n.available_locales.as_json}, allow_nil: true
+  validates :locale, inclusion: {in: I18n.available_locales.as_json}, allow_nil: true, if: :locale_changed?
 
   # TODO(asher): Consider making these scopes and the methods below more consistent, in tense and in
   # word choice.

--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -32,6 +32,8 @@ class UserLevel < ApplicationRecord
 
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
 
+  store_accessor :properties, %i[locale]
+
   belongs_to :user, optional: true
   belongs_to :level, optional: true
   belongs_to :script, class_name: 'Unit', optional: true
@@ -39,6 +41,8 @@ class UserLevel < ApplicationRecord
 
   after_save :after_submit, if: :submitted_or_resubmitted?
   before_save :before_unsubmit, if: ->(ul) {ul.submitted_changed? from: true, to: false}
+
+  validates :locale, inclusion: {in: I18n.available_locales.as_json}, allow_nil: true
 
   # TODO(asher): Consider making these scopes and the methods below more consistent, in tense and in
   # word choice.

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -558,6 +558,16 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert_equal false, UserLevel.where(user_id: @user.id, level: @level.id).first.submitted?
   end
 
+  test 'logged in milestone with current locale' do
+    current_locale = set_request_locale('uk-UA')
+
+    post :milestone, params: @milestone_params
+    assert_response :success
+
+    user_level = UserLevel.find_by(user_id: @user.id, level: @level.id)
+    assert_equal current_locale, user_level.locale
+  end
+
   test "Milestone with milestone posts disabled returns 503 status" do
     Gatekeeper.set('postMilestone', where: {script_name: @script.name}, value: false)
     post :milestone, params: @milestone_params
@@ -1136,18 +1146,22 @@ class ActivitiesControllerTest < ActionController::TestCase
       submitted: false
     }
 
+    current_locale = set_request_locale('uk-UA')
+
     post :milestone, params: milestone_params
     assert_response :success
 
     user_level = UserLevel.find_by(user: @user, level: sublevel1, script: script)
     refute_nil user_level
     assert_equal 100, user_level.best_result
+    assert_equal current_locale, user_level.locale
 
     assert_nil UserLevel.find_by(user: @user, level: sublevel2, script: script)
 
     parent_user_level = UserLevel.find_by(user: @user, level: bubble_choice, script: script)
     refute_nil parent_user_level
     assert_equal 100, parent_user_level.best_result
+    assert_equal current_locale, parent_user_level.locale
   end
 
   test 'milestone triggers AI rubric eval job' do

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -70,7 +70,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
-    assert_cached_queries(9) do
+    assert_cached_queries(10) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -87,7 +87,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
-    assert_cached_queries(7) do
+    assert_cached_queries(8) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3020,6 +3020,29 @@ class UserTest < ActiveSupport::TestCase
     ).level_source_id
   end
 
+  test 'track_level_progress stores locale when provided' do
+    user_level_params = {
+      user_id: @user.id,
+      level_id: @csf_script_level.level_id,
+      script_id: @csf_script_level.script_id,
+    }
+
+    level_progress_params = {
+      **user_level_params,
+      level_source_id: nil,
+      new_result: 100,
+      submitted: false,
+    }
+
+    User.track_level_progress(**level_progress_params)
+    refute_nil user_level = UserLevel.find_by(user_level_params)
+    assert_nil user_level.locale
+
+    current_locale = 'uk-UA'
+    User.track_level_progress(**level_progress_params.merge(locale: current_locale))
+    assert_equal current_locale, user_level.reload.locale
+  end
+
   test 'can create user with same name as deleted user' do
     create(:user, :deleted, name: 'Same Name')
     assert_creates(User) do

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -261,6 +261,10 @@ class ActiveSupport::TestCase
     end
   end
 
+  def set_request_locale(locale)
+    request.env['cdo.locale'] = locale
+  end
+
   def with_default_locale(locale)
     original_locale = I18n.default_locale
     request.env['cdo.locale'] = I18n.default_locale = locale


### PR DESCRIPTION
The RED team often wants to know which language a user selects after completing a level.
Currently, we only have the locale field in the users table, which records the user's first language selection site-wide. However, we need to track language preferences at the user-level granularity as different curricula are translated.

## Links
- JIRA task: [P20-1273](https://codedotorg.atlassian.net/browse/P20-1273)
- Migration PR: https://github.com/code-dot-org/code-dot-org/pull/62302