### PR TITLE
[Google Blockly] Add deprecated align values to wrapper

### DIFF
--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -157,9 +157,6 @@ export const WORKSPACE_EVENTS = {
 };
 
 export const READ_ONLY_PROPERTIES = [
-  'ALIGN_CENTRE',
-  'ALIGN_LEFT',
-  'ALIGN_RIGHT',
   'applab_locale',
   'BasicCursor',
   'Block',

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -241,6 +241,9 @@ export const READ_ONLY_PROPERTIES = [
 ];
 
 export const SETTABLE_PROPERTIES = [
+  'ALIGN_CENTRE',
+  'ALIGN_LEFT',
+  'ALIGN_RIGHT',
   'assetUrl',
   'behaviorEditor',
   'BROKEN_CONTROL_POINTS',

--- a/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/spritelabBlocks.ts
@@ -121,7 +121,7 @@ export const blocks = {
     // We set the inputs to align left so that if the flyout is larger than the
     // inputs will be aligned with the left edge of the block.
     this.inputList.forEach(input => {
-      input.setAlign(Blockly.Input.Align.LEFT);
+      input.setAlign(Blockly.ALIGN_LEFT);
     });
 
     // Insert the toggle field at the beginning for the first input row.

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -208,6 +208,10 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyInstance
   ) as BlocklyWrapperType;
 
+  blocklyWrapper.ALIGN_CENTRE = blocklyInstance.inputs.Align.CENTRE;
+  blocklyWrapper.ALIGN_LEFT = blocklyInstance.inputs.Align.LEFT;
+  blocklyWrapper.ALIGN_RIGHT = blocklyInstance.inputs.Align.RIGHT;
+
   blocklyWrapper.setInfiniteLoopTrap = function () {
     Blockly.JavaScript.INFINITE_LOOP_TRAP = INFINITE_LOOP_TRAP;
   };

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -68,6 +68,9 @@ type GoogleBlocklyType = typeof GoogleBlockly;
 
 // Type for the Blockly instance created and modified by googleBlocklyWrapper.
 export interface BlocklyWrapperType extends GoogleBlocklyType {
+  ALIGN_CENTRE: GoogleBlockly.inputs.Align.CENTRE;
+  ALIGN_LEFT: GoogleBlockly.inputs.Align.LEFT;
+  ALIGN_RIGHT: GoogleBlockly.inputs.Align.RIGHT;
   analyticsData: AnalyticsData;
   showUnusedBlocks: boolean | undefined;
   BlockFieldHelper: {[fieldHelper: string]: string};

--- a/apps/src/music/blockly/extensions.js
+++ b/apps/src/music/blockly/extensions.js
@@ -38,7 +38,7 @@ export const playMultiMutator = {
     const shadowBlockXml = `<shadow type="${BlockTypes.VALUE_SAMPLE}"/>`;
     this.appendValueInput(EXTRA_SOUND_INPUT_PREFIX + this.extraSoundInputCount_)
       .setShadowDom(Blockly.Xml.textToDom(shadowBlockXml))
-      .setAlign(Blockly.Input.Align.RIGHT)
+      .setAlign(Blockly.ALIGN_RIGHT)
       .setCheck(SOUND_VALUE_TYPE)
       .appendField('and');
 


### PR DESCRIPTION
This is one of several tasks that should help to unblock the Blockly v11 bump. A draft of this project is collected here:
- https://github.com/code-dot-org/code-dot-org/pull/62301/commits

Since the beginning of (Blockly) time, we have used properties like `Blockly.ALIGN_RIGHT` to set the alignment of block inputs. These values are currently deprecated and were removed with v11:
https://github.com/google/blockly/pull/7732/files#diff-b0eef723c99dc1228104b3187ab5ff8c524198db8a12994fcbe099f9bef4b010L244-L264

The newer `Input.Align` is also deprecated: https://github.com/google/blockly/pull/7732/files#diff-d2452865ee29274f173594ba31093a2b8845c47113f7223ca0df1933e4b3de85L309-L322

![image](https://github.com/user-attachments/assets/374af181-3b4e-40e6-90cb-af6c17caccbb)![image](https://github.com/user-attachments/assets/44c3e727-8d8e-4181-a435-e7ec7e14fb4a)


To handle this, we could consider updating every instance where we would access one of these values, but given how many there are, and that some are in unmigrated labs, that's not a great solution. Instead, we can simply adding them to the wrapper directly. Previously, these were wrapped as read-only properties from the imported Google Blockly instance when initializing the wrapper (see `wrapReadOnlyProperty`). Now, they are settable properties that directly match the v11 alternatives. This way, existing code will continue to work once we get to v11, including before and after migrating Play Lab.

When testing v11 locally, this resolves errors related to the deleted properties. When testing this branch against staging, no regressions are found. 

## Links

https://codedotorg.atlassian.net/browse/CT-898

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
