### PR TITLE
Various attempts to fix flaky school confirmation dialog tests

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -31,10 +31,12 @@ Scenario: School Info Confirmation Dialog
   # Teacher completes school info interstitial
   And I select the "United States" option in dropdown "uitest-country-dropdown"
   And I press keys "31513" for element "#uitest-school-zip"
+  Then I wait until element "#uitest-school-dropdown" contains text "Appling County High School"
   And I select the "Appling County High School" option in dropdown "uitest-school-dropdown"
   And I open my eyes to test "School Association"
   And I see no difference for "School Association: all fields"
   Then I press "#save-button" using jQuery
+  And I wait until element ".modal" is gone
 
   # One week later, the teacher does not see the prompt
   And eight days pass for user "Teacher_Chuba"

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -298,7 +298,7 @@ And(/^eight days pass for user "([^"]*)"$/) do |name|
 end
 
 And(/^one year passes for user "([^"]*)"$/) do |name|
-  pass_time_for_user name, 1.year.ago
+  pass_time_for_user name, 1.year.ago - 1.day
 end
 
 def pass_time_for_user(name, amount_of_time)
@@ -307,7 +307,8 @@ def pass_time_for_user(name, amount_of_time)
   user.created_at = amount_of_time
   user.last_seen_school_info_interstitial = amount_of_time if user.last_seen_school_info_interstitial
   user.save!
-  user.user_school_infos.each do |info|
+  info = user.user_school_infos.where(end_date: nil).order(id: :desc).first
+  if info
     info.last_confirmation_date = amount_of_time
     info.save!
   end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Attempts to fix flaky test include:

- adding steps to wait for a ui change that is contingent on an async request finishing
  - wait for the school zip search to complete
  - wait for the modal to close after the update
- make the step for waiting a year actually a little over a year, by subtracting a day from `1.year.ago`
  - I haven't seen it fail this way during the deploy but it consistently failed locally for me and this fixes that at least 🤷 
- query the most recent `user_school_infos` instead of updating all of them
  - probably no point to this as I don't think there's ever more than one, but giving it a whirl

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-2535)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
