### PR TITLE
HoC 2024 - Update OpenGraph for November launch

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -59,6 +59,9 @@
     social:
       title: "Register your event for Hour of Code!"
       desc: "Explore how computer science can bring your favorite things to life."
+      v2:
+        title: "One Hour: Ignite. Inspire. Code."
+        desc: "Bring what your children love to life! Start the fun with an activity."
 
   hoc2023_header: "Creativity with AI"
   hoc2023_hero_desc_homepage: "Join millions across the globe in organizing an hour of coding, with or without AI and learning how AI works. Anyone, anywhere can do it. No experience needed."

--- a/pegasus/src/social_metadata.rb
+++ b/pegasus/src/social_metadata.rb
@@ -1,7 +1,6 @@
 # Centralized social metadata for a few key pages:
 #
 #   code.org/
-#   code.org/challenge
 #   code.org/dance
 #   code.org/minecraft
 #   code.org/hourofcode/overview
@@ -12,67 +11,32 @@
 #   code.org/ai/pl/101
 #   code.org/ai/how-ai-works
 #   code.org/videos
-#   code.org/10years
 #   code.org/youngwomen
 #   code.org/music
 #   code.org/lms
 #
-#   hourofcode.com/
-#   hourofcode.com/learn
-#   hourofcode.com/how-to
-#   hourofcode.com/how-to/events
-#   hourofcode.com/resources
-#   hourofcode.com/events
-#   hourofcode.com/faq
+#   hourofcode.com site-wide
 
 def get_social_metadata_for_page(request)
-  # Not currently used, but left here for reference in case we want to use videos again.
-  # rubocop:disable Lint/UselessAssignment
-  videos = {
-    what_most_schools_dont_teach: {youtube_key: "nKIu9yen5nc", width: 640, height: 360},
-    computer_science_is_changing_everything: {youtube_key: "QvyTEx1wyOY", width: 640, height: 360},
-    hour_of_code_worldwide: {youtube_key: "ybBUd9-0ZJQ", width: 640, height: 360},
-    creativity_is: {youtube_key: "VYqHGIR7a_k", width: 640, height: 640}
-  }
-  # rubocop:enable Lint/UselessAssignment
-
   images = {
     kids_with_ipads: {path: "/images/default-og-image.png", width: 1220, height: 640},
-    celeb_challenge: {path: "/images/fit-1220/social-media/celeb-challenge.png", width: 1220, height: 640},
-    creativity: {path: "/images/social-media/code-2018-creativity.png", width: 1200, height: 630},
-    cs_is_everything_thumbnail: {path: "/images/cs-is-everything-thumbnail.png", width: 1200, height: 627},
-    hoc_2018_creativity: {path: "/images/social-media/hoc-2018-creativity.png", width: 1200, height: 630},
-    hoc_student_challenge: {path: "/images/fit-1920/social-media/hoc-student-challenge.png", width: 1920, height: 1080},
-    hoc_student_challenge_new: {path: "/images/fit-1920/social-media/hoc-student-challenge.png", width: 1920, height: 1080},
-    mc_social_2017: {path: "/images/mc/mc_social_2017.png", width: 1200, height: 630},
     mc_social_2018: {path: "/images/social-media/mc-social-2018.png", width: 1200, height: 630},
-    dance_2018: {path: "/images/social-media/dance-social-2018.png", width: 1200, height: 630},
-    dance_2019: {path: "/images/social-media/dance-social-2019.png", width: 1200, height: 630},
-    dance_2022: {path: "/images/social-media/dance-social-2022.png", width: 1200, height: 630},
     dance_2023: {path: "/images/social-media/dance-social-2023-spring.png", width: 1200, height: 630},
     dance_2023_hoc: {path: "/images/social-media/dance-social-2023-hoc.png", width: 1200, height: 630},
-    hoc_2019_social: {path: "/shared/images/social-media/hoc2019_social.png", width: 1200, height: 630},
-    codeorg2019_social: {path: "/shared/images/social-media/codeorg2019_social.png", width: 1200, height: 630},
-    codeorg2020_social: {path: "/shared/images/social-media/codeorg2020_social.png", width: 1200, height: 630},
-    hoc_2020_social: {path: "/shared/images/social-media/hoc2020_social.png", width: 1200, height: 630},
-    hoc_cse_social: {path: "/shared/images/social-media/hoc_cse_social.png", width: 1200, height: 630},
-    hoc_2022_social: {path: "/shared/images/social-media/hoc2022_social.png", width: 1200, height: 630},
     maker_physical_computing: {path: "/shared/images/social-media/maker_social.png", width: 1200, height: 630},
     blockchain: {path: "/shared/images/social-media/blockchain-social.png", width: 1200, height: 630},
     ai: {path: "/shared/images/social-media/ai-social.png", width: 1200, height: 630},
     ai_101: {path: "/shared/images/social-media/ai-101-social.png", width: 1200, height: 630},
     ai_how_ai_works: {path: "/shared/images/social-media/ai-how-ai-works-social.png", width: 1200, height: 630},
-    hoc_2023_social: {path: "/shared/images/social-media/hoc2023_social.png", width: 1200, height: 630},
     hoc_2024_social: {path: "/shared/images/social-media/hoc2024_social.png", width: 1200, height: 630},
     videos_page: {path: "/shared/images/social-media/videos-page.png", width: 1200, height: 630},
-    ten_years: {path: "/shared/images/social-media/10years-social.png", width: 1200, height: 630},
     young_women_in_cs: {path: "/shared/images/social-media/young-women-social.png", width: 1200, height: 630},
     music_lab: {path: "/shared/images/social-media/music-lab.png", width: 1200, height: 630},
+    music_lab_jam: {path: "/shared/images/social-media/music-lab-jam.png", width: 1200, height: 630},
     lms: {path: "/shared/images/social-media/lms.png", width: 1200, height: 630},
   }
 
   # Important:
-  #   - image should always come before video
   #   - description should always come before description_twitter
   #   - to apply an image that shows up specifically on Twitter,
   #     use the "image_twitter" key after the "image" key
@@ -86,47 +50,15 @@ def get_social_metadata_for_page(request)
     },
     "hourofcode.com" => {
       "default" => {
-        title: hoc_s("hoc_2024.social.title"),
-        description: hoc_s("hoc_2024.social.desc"),
+        title: hoc_s("hoc_2024.social.v2.title"),
+        description: hoc_s("hoc_2024.social.v2.desc"),
         image: images[:hoc_2024_social]
       }
     },
-    "challenge" => {
-      "soon-hoc" => {
-        title: "Celebrity Challenge",
-        description: "Win a celebrity video chat for your class!",
-        image: images[:hoc_student_challenge]
-      },
-      "actual-hoc" => {
-        title: "Celebrity Challenge",
-        description: "Win a celebrity video chat for your class!",
-        image: images[:celeb_challenge]
-      },
-      "default" => {
-        title: "Celebrity Challenge",
-        description: "Win a celebrity video chat for your class!",
-        image: images[:celeb_challenge]
-      }
-    },
     "minecraft" => {
-      "soon-hoc" => {
-        title: hoc_s(:tutorial_mchoc_name),
-        description: hoc_s(:social_hoc2018_mc),
-        image: images[:mc_social_2017]
-      },
-      "soon-hoc-mc" => {
-        title: hoc_s(:tutorial_mchoc_name),
-        description: hoc_s(:social_hoc2018_mc_creativity),
-        image: images[:mc_social_2018]
-      },
-      "soon-hoc-dance" => {
-        title: hoc_s(:tutorial_mchoc_name),
-        description: hoc_s(:social_hoc2018_mc_creativity),
-        image: images[:mc_social_2018]
-      },
       "default" => {
         title: hoc_s(:tutorial_mchoc_name),
-        description: hoc_s(:social_hoc2018_mc_creativity),
+        description: hoc_s("hoc_page.activities.minecraft.desc"),
         image: images[:mc_social_2018]
       }
     },
@@ -135,13 +67,6 @@ def get_social_metadata_for_page(request)
         title: hoc_s(:social_hoc2018_dance_party),
         description: hoc_s(:social_hoc2023_dance_v2),
         image: images[:dance_2023_hoc]
-      }
-    },
-    "hoc-default" => {
-      "default" => {
-        title: hoc_s("hoc_2024.social.title"),
-        description: hoc_s("hoc_2024.social.desc"),
-        image: images[:hoc_2024_social]
       }
     },
     "hoc-overview" => {
@@ -193,13 +118,6 @@ def get_social_metadata_for_page(request)
         image: images[:videos_page]
       }
     },
-    "ten_years" => {
-      "default" => {
-        title: hoc_s(:tenth_anniversary_top_heading),
-        description: hoc_s(:tenth_anniversary_top_desc),
-        image: images[:ten_years]
-      }
-    },
     "young_women_in_cs" => {
       "default" => {
         title: hoc_s(:yw_page_top_heading),
@@ -210,8 +128,8 @@ def get_social_metadata_for_page(request)
     "music_lab" => {
       "default" => {
         title: hoc_s("music_lab.opengraph_title", markdown: :inline, locals: {music_lab: "Music Lab"}),
-        description: hoc_s("music_lab.banner.desc"),
-        image: images[:music_lab]
+        description: hoc_s("music_lab.jam_session.banner.desc_01"),
+        image: images[:music_lab_jam]
       }
     },
     "lms" => {
@@ -223,26 +141,14 @@ def get_social_metadata_for_page(request)
     },
   }
 
-  if request.path == "/challenge" && request.site == "code.org"
-    page = "challenge"
+  if request.site == "hourofcode.com"
+    page = request.site
+  elsif request.path == "/" && request.site == "code.org"
+    page = request.site
   elsif request.path == "/minecraft" && request.site == "code.org"
     page = "minecraft"
   elsif request.path == "/dance" && request.site == "code.org"
     page = "dance"
-  elsif request.path == "/" && ["code.org", "hourofcode.com"].include?(request.site)
-    page = request.site
-  elsif request.path == "/learn" && request.site == "hourofcode.com"
-    page = "hoc-default"
-  elsif request.path == "/how-to" && request.site == "hourofcode.com"
-    page = "hoc-default"
-  elsif request.path == "/how-to/events" && request.site == "hourofcode.com"
-    page = "hoc-default"
-  elsif request.path == "/resources" && request.site == "hourofcode.com"
-    page = "hoc-default"
-  elsif request.path == "/events" && request.site == "hourofcode.com"
-    page = "hoc-default"
-  elsif request.path == "/faq" && request.site == "hourofcode.com"
-    page = "hoc-default"
   elsif request.path == "/hourofcode" && request.site == "code.org"
     page = "hoc-overview"
   elsif request.path == "/maker" && request.site == "code.org"
@@ -257,8 +163,6 @@ def get_social_metadata_for_page(request)
     page = "ai_how_ai_works"
   elsif request.path == "/educate/resources/videos" && request.site == "code.org"
     page = "videos_page"
-  elsif request.path == "/10years" && request.site == "code.org"
-    page = "ten_years"
   elsif request.path == "/youngwomen" && request.site == "code.org"
     page = "young_women_in_cs"
   elsif request.path == "/music" && request.site == "code.org"
@@ -269,26 +173,7 @@ def get_social_metadata_for_page(request)
     return {}
   end
 
-  hoc_mode = DCDO.get("hoc_mode", CDO.default_hoc_mode)
-
-  # For now, post-hoc, pre-hoc and false act as the default.
-  if ["post-hoc", "pre-hoc", false].include? hoc_mode
-    hoc_mode = "default"
-  end
-
-  # Additional hoc variants.
-  extension = ""
-  hoc_launch = DCDO.get("hoc_launch", CDO.default_hoc_launch)
-  case hoc_launch
-  when "mc"
-    extension = "-mc"
-  when "dance"
-    extension = "-dance"
-  end
-
   social_tag_set =
-    social_tags[page][hoc_mode + extension] ||
-    social_tags[page][hoc_mode] ||
     social_tags[page]["default"]
 
   output = {}

--- a/shared/images/social-media/music-lab-jam.png
+++ b/shared/images/social-media/music-lab-jam.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:395aab1b03d4441b19c2e5a90139f93b2785e34679c3391ff00f0f4d21a47fec
+size 122372


### PR DESCRIPTION
Updates the following OpenGraph tags:
- Title and description on https://hourofcode.com
  - Also applies OpenGraph site-wide!
- New Music Lab: Jam Session image and description on https://code.org/music
- Default generic description on https://code.org/minecraft

I also cleaned up `social_metadata.rb` by removing outdated entries and removed hoc_mode logic since it's not used. 

## Links
Jira ticket: [ACQ-2542](https://codedotorg.atlassian.net/browse/ACQ-2542) 

## Testing story
Tested locally