### PR TITLE
[Dance Party] Fast-follow to also remove oldtownroadremix_lilnasx_long

### DIFF
--- a/apps/src/code-studio/dancePartySongArtistTags.js
+++ b/apps/src/code-studio/dancePartySongArtistTags.js
@@ -31,7 +31,6 @@ export const SongTitlesToArtistTwitterHandle = {
   highhopes_panicatthedisco: 'PanicAtTheDisco',
   ificanthaveyou_shawnmendes: 'ShawnMendes',
   introtoshamstep_47SOUL: '47soulofficial',
-  oldtownroadremix_lilnasx_long: 'LilNasX',
   starships_nickiminaj: 'NICKIMINAJ',
   sucker_jonasbrothers: 'JonasBrothers',
   // 2020 Songs

--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -24,6 +24,7 @@ const DEPRECATED_SONGS = [
   'neverreallyover_katyperry',
   'occidentalview_francescogabbani',
   'oldtownroadremix_lilnasx',
+  'oldtownroadremix_lilnasx_long',
 ];
 
 /**

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -719,7 +719,7 @@ module SharedConstants
   # Current song manifest file name for Dance Party. Note that different manifests
   # can be tested using query params (?manifest=...), but once this value is updated
   # the default manifest will change for all users.
-  DANCE_SONG_MANIFEST_FILENAME = 'songManifest2024_v3.json'
+  DANCE_SONG_MANIFEST_FILENAME = 'songManifest2024_v4.json'
 
   # We should always specify a version for the LLM so the results don't unexpectedly change.
   # reference: https://platform.openai.com/docs/models/gpt-3-5


### PR DESCRIPTION
Fast follow to https://github.com/code-dot-org/code-dot-org/pull/62271 to include the Old Town Road remix per https://codedotorg.slack.com/archives/C05DMS18MEX/p1731013990555959?thread_ts=1730837473.667409&cid=C05DMS18MEX. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<img width="1282" alt="Screenshot 2024-11-08 at 9 16 57 AM" src="https://github.com/user-attachments/assets/b57d960a-a7f2-4c6a-8fe2-6e12c3fff2bc">

Confirmed a project using the Old Town Road Remix falls back to a different song and displays a banner. No levels were using the remix as their default song, so there's nothing to test there. 

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

- @code-dot-org/acquisition-products-team is tracking the need to remove Lil Nas X from https://code.org/dance#artist-list.
- No levels need to be updated. 

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
