### PR TITLE
HoC 2024 - Music Lab: Jam Session updates on code.org/music

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/page/music-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/page/music-styles.scss
@@ -94,7 +94,8 @@ section.student-projects {
 
   .text-wrapper {
     background: var(--neutral_light);
-    padding: 2rem;
+    padding-block: calc(2rem + 8px);
+    padding-inline: 2rem;
   }
 }
 

--- a/pegasus/sites.v3/code.org/views/music/music_lab_featured_artists.haml
+++ b/pegasus/sites.v3/code.org/views/music/music_lab_featured_artists.haml
@@ -7,8 +7,8 @@
   ]
   hoc_nov_artists = [
     {image: '/images/music-lab/sabrina-carpenter.png', alt_text: 'Sabrina Carpenter'},
-    {image: '/images/music-lab/benson-boone.png', alt_text: 'Benson Boone'},
     {image: '/images/music-lab/shakira.png', alt_text: 'Shakira'},
+    {image: '/images/music-lab/benson-boone.png', alt_text: 'Benson Boone'},
     {image: '/images/music-lab/henry-moodie.png', alt_text: 'Henry Moodie'},
   ]
 

--- a/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
+++ b/pegasus/sites.v3/code.org/views/music/music_lab_student_projects.haml
@@ -5,7 +5,7 @@
   list_items = [hoc_s("music_lab.student_projects.list_create"), hoc_s("music_lab.student_projects.list_artist"),  hoc_s("music_lab.student_projects.list_share")]
 
 .grid-container.gap-2
-  %iframe.rounded-corners.box-shadow-primary{width: "100%", height: 300, src: embed_src}
+  %iframe.rounded-corners.box-shadow-primary{width: "100%", height: 315, src: embed_src}
   .text-wrapper.rounded-corners
     %h3.heading-sm
       =hoc_s("music_lab.student_projects.subheading")

--- a/pegasus/sites.v3/code.org/views/music/music_lab_tutorials.haml
+++ b/pegasus/sites.v3/code.org/views/music/music_lab_tutorials.haml
@@ -5,7 +5,7 @@
       title: hoc_s("music_lab.jam_session.name"),
       image: "/images/action-blocks/action-block-music-lab-jam-session.png",
       desc: hoc_s("music_lab.jam_session.banner.desc_03", locals: {artist_list: "Sabrina Carpenter, Lady Gaga", artist_name: "Shakira"}),
-      url: CDO.studio_url("/s/music-intro-2024/reset"),
+      url: CDO.studio_url("/s/music-jam-2024/reset"),
       button_label: hoc_s("music_lab.jam_session.button.start"),
       new: true
     },


### PR DESCRIPTION
Updates the following on https://code.org/music
- Swap Shakira and Benson Boone in the thumbnail order
- Update Music Lab: Jam Session tutorial tile link to `/s/music-jam-2024/reset`
- Adjust the Student Projects iframe to be 315px high to fix the vertical scrolling

## Links
Jira ticket: [ACQ-2661](https://codedotorg.atlassian.net/browse/ACQ-2661)
Slack convo: [here](https://codedotorg.slack.com/archives/C5V9YCXTR/p1731004402898159)