### PR TITLE
Switch progress feature flag default to enabled

### DIFF
--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -93,7 +93,7 @@ function SectionProgressSelector({
     progressTableV2ClosedBeta;
   const allowSelection =
     experiments.isEnabled(experiments.SECTION_PROGRESS_V2) ||
-    DCDO.get('progress-table-v2-enabled', false) ||
+    DCDO.get('progress-table-v2-enabled', true) ||
     isInClosedBeta;
   if (!allowSelection) {
     return <SectionProgress />;

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -37,7 +37,7 @@ class DCDOBase < DynamicConfigBase
       gender: DCDO.get('gender', false),
       'amplitude-event-sample-rates': DCDO.get('amplitude-event-sample-rates', {}),
       # Whether to allow the user to toggle between the v1 and v2 progress tables.
-      'progress-table-v2-enabled': DCDO.get('progress-table-v2-enabled', false),
+      'progress-table-v2-enabled': DCDO.get('progress-table-v2-enabled', true),
       # Whether to show the v1 or v2 progress table by default.
       'progress-table-v2-default-v2': DCDO.get('progress-table-v2-default-v2', false),
       # Whether to allow users with `progress_table_v2_closed_beta` user preference to toggle between v1 and v2.


### PR DESCRIPTION
The flag has been on on production for multiple months. The only thing this should effect is adhoc defaults and test.

The main reason for this change is to make adhocs and test more closely align with production

## Links
https://codedotorg.atlassian.net/browse/TEACH-1461
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
This will most likely cause eyes diffs. because the toggle between v1 and v2 will be shown.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
