### PR TITLE
Remove hidden/archived sections from course and unit overview dropdowns

### DIFF
--- a/apps/src/templates/teacherDashboard/teacherSectionsReduxSelectors.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsReduxSelectors.js
@@ -318,15 +318,17 @@ export function sectionsForDropdown(
   courseVersionId,
   unitId
 ) {
-  return sortedSectionsList(state.sections).map(section => ({
-    ...section,
-    isAssigned:
-      (unitId !== null && section.unitId === unitId) ||
-      (courseOfferingId !== null &&
-        section.courseOfferingId === courseOfferingId &&
-        courseVersionId !== null &&
-        section.courseVersionId === courseVersionId),
-  }));
+  return sortedSectionsList(state.sections)
+    .filter(section => !section.hidden)
+    .map(section => ({
+      ...section,
+      isAssigned:
+        (unitId !== null && section.unitId === unitId) ||
+        (courseOfferingId !== null &&
+          section.courseOfferingId === courseOfferingId &&
+          courseVersionId !== null &&
+          section.courseVersionId === courseVersionId),
+    }));
 }
 
 /**


### PR DESCRIPTION
Hidden and archived sections are [removed](https://github.com/code-dot-org/code-dot-org/pull/62321) from the BE call for unit and course overview endpoint. This already means they are not included in dropdowns on those pages. When moving to the teacher_dashboard, those hidden sections are not removed. This PR filters out all hidden sections from those dropdowns.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1459
