### PR TITLE
Music: bump library version

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -12,7 +12,7 @@ import {Key} from '../utils/Notes';
 
 // This value can be modifed each time we know that there is an important new version
 // of the library on S3, to help bypass any caching of an older version.
-const requestVersion = 'launch2024-2';
+const requestVersion = 'launch2024-3';
 
 /**
  * Loads a sound library JSON file.


### PR DESCRIPTION
Bump the music library version for the updated library that will go live with the launch of **Music Lab: Jam Session** for **Hour of Code** 2024.
