### PR TITLE
Update project submit and submission_status actions and include unexpected error reports

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -202,8 +202,6 @@ class ProjectsController < ApplicationController
     PROJECT_SUBMISSION_STATUS[:PROJECT_TOO_NEW] => "Submission disabled because project has not existed for required time period."
   }
 
-  SIGN_IN_TO_SUBMIT_PROJECT_MESSAGE = 'To be able to submit your project, you must be signed in.'
-
   # GET /projects/:tab_name
   # Where a valid :tab_name is (nil|public|libraries)
   def index
@@ -528,8 +526,7 @@ class ProjectsController < ApplicationController
     begin
       authorize! :submission_status, project
     rescue CanCan::AccessDenied => exception
-      error = current_user ? exception.message : SIGN_IN_TO_SUBMIT_PROJECT_MESSAGE
-      return render status: :forbidden, json: {error: error}
+      return render status: :forbidden, json: {error: exception.message}
     end
     status = project.submission_status
     render(status: :ok, json: {status: status})
@@ -552,8 +549,7 @@ class ProjectsController < ApplicationController
           message:  "Project submission failed due to unauthorized submission status - user unexpectedly bypassed submission_status restriction in the share dialog and attempted to submit project."
         }
       )
-      error = current_user ? PROJECT_SUBMISSION_ERROR_MAP[project.submission_status] : SIGN_IN_TO_SUBMIT_PROJECT_MESSAGE
-      return render status: :forbidden, json: {error: error}
+      return render status: :forbidden, json: {error: PROJECT_SUBMISSION_ERROR_MAP[project.submission_status]}
     end
     # Publish the project, i.e., make it public.
     begin

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -557,7 +557,8 @@ class ProjectsController < ApplicationController
     end
     # Publish the project, i.e., make it public.
     begin
-      Projects.new(get_storage_id).publish(channel_id, project_type, current_user)
+      storage_id, _ = storage_decrypt_channel_id(channel_id)
+      Projects.new(storage_id).publish(channel_id, project_type, current_user)
     rescue Projects::PublishError => exception
       Honeybadger.notify(
         exception.message,

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/hash/indifferent_access'
 require 'cdo/firehose'
 
 class ProjectsController < ApplicationController
-  before_action :authenticate_user!, except: [:load, :create_new, :show, :edit, :readonly, :redirect_legacy, :public, :index, :export_config, :weblab_footer, :get_or_create_for_level, :can_publish_age_status]
+  before_action :authenticate_user!, except: [:load, :create_new, :show, :edit, :readonly, :redirect_legacy, :public, :index, :export_config, :weblab_footer, :get_or_create_for_level, :can_publish_age_status, :submission_status, :submit]
   before_action :redirect_admin_from_labs, only: [:load, :create_new, :show, :edit, :remix]
   before_action :authorize_load_project!, only: [:load, :create_new, :edit, :remix]
   before_action :set_level, only: [:load, :create_new, :show, :edit, :readonly, :remix, :export_config, :export_create_channel]
@@ -201,6 +201,8 @@ class ProjectsController < ApplicationController
     PROJECT_SUBMISSION_STATUS[:OWNER_TOO_NEW] => "Submission disabled because user's account has not existed for required time period.",
     PROJECT_SUBMISSION_STATUS[:PROJECT_TOO_NEW] => "Submission disabled because project has not existed for required time period."
   }
+
+  SIGN_IN_TO_SUBMIT_PROJECT_MESSAGE = 'To be able to submit your project, you must be signed in.'
 
   # GET /projects/:tab_name
   # Where a valid :tab_name is (nil|public|libraries)
@@ -523,6 +525,12 @@ class ProjectsController < ApplicationController
   def submission_status
     _, project_id = storage_decrypt_channel_id(params[:channel_id])
     project = Project.find_by(id: project_id)
+    begin
+      authorize! :submission_status, project
+    rescue CanCan::AccessDenied => exception
+      error = current_user ? exception.message : SIGN_IN_TO_SUBMIT_PROJECT_MESSAGE
+      return render status: :forbidden, json: {error: error}
+    end
     status = project.submission_status
     render(status: :ok, json: {status: status})
   end
@@ -537,13 +545,26 @@ class ProjectsController < ApplicationController
     project = Project.find_by(id: project_id)
     begin
       authorize! :submit, project
-    rescue CanCan::AccessDenied
-      return render status: :forbidden, json: {error: PROJECT_SUBMISSION_ERROR_MAP[project.submission_status]}
+    rescue CanCan::AccessDenied => exception
+      Honeybadger.notify(
+        "Project submission error: #{exception.message}",
+        context: {
+          message:  "Project submission failed due to unauthorized submission status - user unexpectedly bypassed submission_status restriction in the share dialog and attempted to submit project."
+        }
+      )
+      error = current_user ? PROJECT_SUBMISSION_ERROR_MAP[project.submission_status] : SIGN_IN_TO_SUBMIT_PROJECT_MESSAGE
+      return render status: :forbidden, json: {error: error}
     end
     # Publish the project, i.e., make it public.
     begin
       Projects.new(get_storage_id).publish(channel_id, project_type, current_user)
     rescue Projects::PublishError => exception
+      Honeybadger.notify(
+        exception.message,
+        context: {
+          message: "Project publish failed - user unexpectedly bypassed submission_status restriction in the share dialog and project submit authorization restrictions and attempted to publish project."
+        }
+      )
       return render(status: :forbidden, json: {error: exception.message})
     end
     # TODO: Store submission_description in our database.

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -105,8 +105,12 @@ class Ability
         project_owner.id == user.id || can?(:code_review, project_owner)
       end
 
+      can :submission_status, Project do |project|
+        project.owner_id == user.id
+      end
+
       can :submit, Project do |project|
-        project.submission_status == SharedConstants::PROJECT_SUBMISSION_STATUS[:CAN_SUBMIT]
+        project.owner_id == user.id && project.submission_status == SharedConstants::PROJECT_SUBMISSION_STATUS[:CAN_SUBMIT]
       end
 
       can :create, CodeReview do |code_review, project|

--- a/dashboard/app/models/project.rb
+++ b/dashboard/app/models/project.rb
@@ -81,7 +81,6 @@ class Project < ApplicationRecord
   def submission_status
     return SharedConstants::PROJECT_SUBMISSION_STATUS[:ALREADY_SUBMITTED] if published_at
     return SharedConstants::PROJECT_SUBMISSION_STATUS[:PROJECT_TYPE_NOT_ALLOWED] unless SharedConstants::ALL_PUBLISHABLE_PROJECT_TYPES.include?(project_type)
-    return SharedConstants::PROJECT_SUBMISSION_STATUS[:NOT_PROJECT_OWNER] unless owner
     return SharedConstants::PROJECT_SUBMISSION_STATUS[:SHARING_DISABLED] if owner.sharing_disabled? && SharedConstants::CONDITIONALLY_PUBLISHABLE_PROJECT_TYPES.include?(project_type)
     return SharedConstants::PROJECT_SUBMISSION_STATUS[:RESTRICTED_SHARE_MODE] if Projects.in_restricted_share_mode(channel_id, project_type)
     return SharedConstants::PROJECT_SUBMISSION_STATUS[:OWNER_TOO_NEW] unless owner_existed_long_enough_to_publish?

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -568,6 +568,8 @@ class ProjectsControllerTest < ActionController::TestCase
     Project.stubs(:find_by).returns(@test_project)
     get :submission_status, params: {project_type: 'music', channel_id: @channel_id}
     assert_response :forbidden
+    error_msg = JSON.parse(@response.body)["error"]
+    assert_equal error_msg, "You are not authorized to access this page."
   end
 
   test 'submission_status returns forbidden for signed-out user' do
@@ -575,6 +577,8 @@ class ProjectsControllerTest < ActionController::TestCase
     Project.stubs(:find_by).returns(@test_project)
     post :submission_status, params: {project_type: 'music', channel_id: @channel_id}
     assert_response :forbidden
+    error_msg = JSON.parse(@response.body)["error"]
+    assert_equal error_msg, "To be able to submit your project, you must be signed in."
   end
 
   test 'submit project returns bad_request if no submission description' do
@@ -586,6 +590,7 @@ class ProjectsControllerTest < ActionController::TestCase
   test 'submit project returns forbidden for non-project owner' do
     submission_description = 'test description'
     sign_in_with_request @non_project_owner
+    Project.stubs(:find_by).returns(@test_project)
     post :submit, params: {project_type: 'music', channel_id: @channel_id, submissionDescription: submission_description}
     assert_response :forbidden
   end
@@ -595,6 +600,8 @@ class ProjectsControllerTest < ActionController::TestCase
     sign_out :user
     post :submit, params: {project_type: 'music', channel_id: @channel_id, submissionDescription: submission_description}
     assert_response :forbidden
+    error_msg = JSON.parse(@response.body)["error"]
+    assert_equal error_msg, "To be able to submit your project, you must be signed in."
   end
 
   test 'submit project returns forbidden if project already submitted' do
@@ -605,16 +612,16 @@ class ProjectsControllerTest < ActionController::TestCase
     Projects.any_instance.stubs(:publish).returns({published_at: Time.now})
     post :submit, params: {project_type: 'music', channel_id: @channel_id, submissionDescription: submission_description}
     assert_response :forbidden
+    error_msg = JSON.parse(@response.body)["error"]
+    assert_equal error_msg, "Once submitted, a project cannot be submitted again."
   end
 
   test 'submit project returns success if project passes all restrictions' do
     submission_description = 'this project rocks'
     sign_in_with_request @project_owner
-    Project.stubs(:find_by).returns(@test_project)
-    @controller.stubs(:send_project_submission).returns(:success)
-    Projects.any_instance.stubs(:publish).returns({published_at: Time.now})
     @test_project.stubs(:submission_status).returns(SharedConstants::PROJECT_SUBMISSION_STATUS[:CAN_SUBMIT])
-    sign_in_with_request @project_owner
+    Project.stubs(:find_by).returns(@test_project)
+    Projects.any_instance.stubs(:publish).returns({published_at: Time.now})
     post :submit, params: {project_type: 'music', channel_id: @channel_id, submissionDescription: submission_description}
     assert_response :success
   end

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -568,8 +568,6 @@ class ProjectsControllerTest < ActionController::TestCase
     Project.stubs(:find_by).returns(@test_project)
     get :submission_status, params: {project_type: 'music', channel_id: @channel_id}
     assert_response :forbidden
-    error_msg = JSON.parse(@response.body)["error"]
-    assert_equal error_msg, "You are not authorized to access this page."
   end
 
   test 'submission_status returns forbidden for signed-out user' do
@@ -577,8 +575,6 @@ class ProjectsControllerTest < ActionController::TestCase
     Project.stubs(:find_by).returns(@test_project)
     post :submission_status, params: {project_type: 'music', channel_id: @channel_id}
     assert_response :forbidden
-    error_msg = JSON.parse(@response.body)["error"]
-    assert_equal error_msg, "To be able to submit your project, you must be signed in."
   end
 
   test 'submit project returns bad_request if no submission description' do
@@ -600,8 +596,6 @@ class ProjectsControllerTest < ActionController::TestCase
     sign_out :user
     post :submit, params: {project_type: 'music', channel_id: @channel_id, submissionDescription: submission_description}
     assert_response :forbidden
-    error_msg = JSON.parse(@response.body)["error"]
-    assert_equal error_msg, "To be able to submit your project, you must be signed in."
   end
 
   test 'submit project returns forbidden if project already submitted' do

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -44,6 +44,510 @@ class ProjectsControllerTest < ActionController::TestCase
     AzureTextToSpeech.unstub(:get_voices)
   end
 
+  test "index" do
+    get :index
+    assert_response :success
+  end
+
+  test "index/libraries" do
+    get :index, params: {tab_name: 'libraries'}
+    assert_response :success
+  end
+
+  test "index/public" do
+    get :index, params: {tab_name: 'public'}
+    assert_response :success
+  end
+
+  test "index: redirect to public tab if no user" do
+    sign_out :user
+
+    get :index
+    assert_redirected_to '/projects/public'
+
+    get :index, params: {tab_name: 'libraries'}
+    assert_redirected_to '/projects/public'
+
+    # Don't redirect if we're already on /projects/public
+    get :index, params: {tab_name: 'public'}
+    assert_response :success
+  end
+
+  test "index: redirect admins to root" do
+    sign_in create(:admin)
+
+    get :index
+    assert_redirected_to root_path
+
+    get :index, params: {tab_name: 'libraries'}
+    assert_redirected_to root_path
+
+    # Don't redirect if we're already on /projects/public
+    get :index, params: {tab_name: 'public'}
+    assert_response :success
+  end
+
+  test 'artist project level has sharing meta tags' do
+    channel = 'fake-channel'
+    get :show, params: {key: 'artist', channel_id: channel, share: true}
+
+    assert_response :success
+    assert_sharing_meta_tags(
+      url: "http://test.host/projects/artist/#{channel}",
+      image_url: "https://test-studio.code.org/v3/files/#{channel}/.metadata/thumbnail.png",
+      image_width: 400,
+      image_height: 400,
+      small_thumbnail: true
+    )
+  end
+
+  test 'spritelab project level has sharing meta tags' do
+    spritelab_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:spritelab][:name])
+    # populate level with correct game
+    spritelab_level.update(game: Game.create(app: Game::SPRITELAB))
+
+    channel = 'fake-channel'
+    get :show, params: {key: 'spritelab', channel_id: channel, share: true}
+
+    assert_response :success
+    assert_sharing_meta_tags(
+      url: "http://test.host/projects/spritelab/#{channel}",
+      image_url: "https://test-studio.code.org/v3/files/#{channel}/.metadata/thumbnail.png",
+      image_width: 400,
+      image_height: 400
+    )
+  end
+
+  test 'poetry_hoc project level has sharing meta tags' do
+    poetry_hoc_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:poetry_hoc][:name])
+    # populate level with correct game
+    poetry_hoc_level.update(game: Game.create(app: Game::POETRY))
+
+    channel = 'fake-channel'
+    get :show, params: {key: 'poetry_hoc', channel_id: channel, share: true}
+
+    assert_response :success
+    assert_sharing_meta_tags(
+      url: "http://test.host/projects/poetry_hoc/#{channel}",
+      image_url: "https://test-studio.code.org/v3/files/#{channel}/.metadata/thumbnail.png",
+      image_width: 400,
+      image_height: 400
+    )
+  end
+
+  test 'applab project level has sharing meta tags' do
+    applab_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:applab][:name])
+    # populate level with correct game
+    applab_level.update(game: Game.create(app: Game::APPLAB))
+    channel = 'fake-channel'
+
+    ProjectsController.view_context_class.any_instance.stubs(:meta_image_url).returns('http://test.host/assets/applab_sharing_drawing.png')
+
+    get :show, params: {key: 'applab', channel_id: channel, share: true}
+
+    assert_response :success
+
+    assert_sharing_meta_tags(
+      url: "http://test.host/projects/applab/#{channel}",
+      image_url: 'http://test.host/assets/applab_sharing_drawing.png',
+      image_width: 400,
+      image_height: 400,
+      apple_mobile_web_app: true
+    )
+  end
+
+  test 'playlab project level has sharing meta tags' do
+    playlab_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:playlab][:name])
+    # populate level with correct game
+    playlab_level.update(game: Game.create(app: Game::PLAYLAB))
+
+    channel = 'fake-channel'
+
+    ProjectsController.view_context_class.any_instance.stubs(:meta_image_url).returns('http://test.host/assets/studio_sharing_drawing.png')
+
+    get :show, params: {key: 'playlab', channel_id: channel, share: true}
+
+    assert_response :success
+
+    assert_sharing_meta_tags(
+      url: "http://test.host/projects/playlab/#{channel}",
+      image_url: 'http://test.host/assets/studio_sharing_drawing.png',
+      image_width: 400,
+      image_height: 400,
+      apple_mobile_web_app: true
+    )
+  end
+
+  test 'legacy /p/:key links redirect to /projects/:key' do
+    get :redirect_legacy, params: {key: ProjectsController::STANDALONE_PROJECTS[:artist][:name]}
+    assert_template 'projects/redirect_legacy'
+  end
+
+  test 'send to phone' do
+    get :edit, params: {key: 'playlab', channel_id: 'my_channel_id'}
+    assert_includes(@response.body, '"send_to_phone_url":"http://test.host/sms/send"')
+  end
+
+  test 'applab and gamelab edit gets redirected if under 13' do
+    sign_in_with_request create(:young_student)
+
+    %w(applab gamelab).each do |lab|
+      get :edit, params: {key: lab, channel_id: 'my_channel_id'}
+
+      assert_redirected_to '/'
+    end
+  end
+
+  test 'applab and gamelab remix gets redirected if under 13' do
+    sign_in_with_request create(:young_student)
+
+    %w(applab gamelab).each do |lab|
+      get :remix, params: {key: lab, channel_id: 'my_channel_id'}
+
+      assert_redirected_to '/'
+    end
+  end
+
+  test 'applab and gamelab project level gets redirected if under 13' do
+    sign_in_with_request create(:young_student)
+
+    %w(applab gamelab).each do |lab|
+      get :load, params: {key: lab}
+
+      assert_redirected_to '/'
+    end
+  end
+
+  test 'applab and gamelab project level gets redirected to edit if over 13' do
+    sign_in_with_request create(:student)
+
+    %w(applab gamelab).each do |lab|
+      get :load, params: {key: lab}
+
+      assert @response.headers['Location'].ends_with? '/edit'
+    end
+  end
+
+  test 'applab and gamelab project levels gets redirected to edit if under 13 with tos teacher' do
+    sign_in_with_request create(:young_student_with_tos_teacher)
+
+    %w(applab gamelab).each do |lab|
+      get :load, params: {key: lab}
+
+      assert @response.headers['Location'].ends_with? '/edit'
+    end
+  end
+
+  test 'applab and gamelab project levels get redirected if under 13 with over 13 pair' do
+    @driver.update(age: 10)
+    @navigator.update(age: 18)
+    sign_in_with_request @driver
+    @controller.send :pairings=, {pairings: [@navigator], section_id: @section.id}
+
+    %w(applab gamelab).each do |lab|
+      get :load, params: {key: lab}
+
+      assert_redirected_to '/'
+    end
+  end
+
+  test 'applab and gamelab project levels get redirected if over 13 with under 13 pair' do
+    @driver.update(age: 18)
+    @navigator.update(age: 10)
+    sign_in_with_request @driver
+    @controller.send :pairings=, {pairings: [@navigator], section_id: @section.id}
+
+    %w(applab gamelab).each do |lab|
+      get :load, params: {key: lab}
+
+      assert_redirected_to '/'
+    end
+  end
+
+  test 'applab and gamelab project levels gets redirected to edit if over 13 with under 13 with tos teacher pair' do
+    @driver.update(age: 18)
+    @navigator.update(age: 10)
+    create :follower, user: (create :terms_of_service_teacher), student_user: @navigator
+    sign_in_with_request @driver
+    @controller.send :pairings=, {pairings: [@navigator], section_id: @section.id}
+
+    %w(applab gamelab).each do |lab|
+      get :load, params: {key: lab}
+
+      assert @response.headers['Location'].ends_with? '/edit'
+    end
+  end
+
+  test 'shared applab project does not get redirected if under 13' do
+    sign_in_with_request create(:young_student)
+
+    get :show, params: {key: 'applab', share: true, channel_id: 'my_channel_id'}
+
+    assert_response :success
+  end
+
+  test 'shared applab project does not get redirected if over 13' do
+    sign_in_with_request create(:student)
+
+    # We can't make successful requests for both applab and gamelab within the
+    # same test case, or we'll get an error about view_options already being
+    # frozen.
+
+    get :show, params: {key: 'applab', share: true, channel_id: 'my_channel_id'}
+
+    assert_response :success
+  end
+
+  test 'shared applab and gamelab project level gets redirected to edit if under 13 with tos teacher' do
+    sign_in_with_request create(:young_student_with_tos_teacher)
+
+    %w(applab gamelab).each do |lab|
+      get :load, params: {key: lab}
+
+      assert @response.headers['Location'].ends_with? '/edit'
+    end
+  end
+
+  test 'applab and gamelab project level redirects to login if not signed in' do
+    sign_out :user
+    %w(applab gamelab).each do |lab|
+      get :load, params: {key: lab}
+      assert_redirected_to_sign_in
+    end
+  end
+
+  test 'admins get redirected away' do
+    sign_in_with_request create(:admin)
+
+    get :index
+    assert_redirected_to root_path
+
+    %w(applab gamelab).each do |lab|
+      get :load, params: {key: lab}
+      assert_redirected_to root_path
+    end
+
+    %w(applab gamelab).each do |lab|
+      get :show, params: {key: lab, share: true, channel_id: 'fake_channel_id'}
+      assert_redirected_to root_path
+    end
+  end
+
+  test 'applab project level goes to edit if teacher' do
+    sign_in_with_request create(:teacher)
+    get :load, params: {key: 'applab'}
+    assert @response.headers['Location'].ends_with? '/edit'
+  end
+
+  test 'applab project level goes to edit if student without admin teacher' do
+    sign_in_with_request create(:student)
+    get :load, params: {key: 'applab'}
+    assert @response.headers['Location'].ends_with? '/edit'
+  end
+
+  test 'gamelab project level redirects to login if not signed in' do
+    sign_out :user
+    get :load, params: {key: 'gamelab'}
+    assert_redirected_to_sign_in
+  end
+
+  test 'project validators can go to /featured' do
+    @project_validator = create :teacher
+    @project_validator.permission = UserPermission::PROJECT_VALIDATOR
+    sign_in @project_validator
+    get :featured
+    assert_response :success
+  end
+
+  test '/featured gets redirected to /public if not project validator' do
+    get :featured
+    assert_redirected_to '/projects/public'
+  end
+
+  test '/featured get redirected to sign in if signed out' do
+    sign_out :user
+    get :featured
+    assert_redirected_to '/users/sign_in'
+  end
+
+  test '/applab/new creates a channel and redirects to /applab/<channel>/edit' do
+    get :create_new, params: {key: 'applab'}
+    assert_response :redirect
+    assert @response.headers['Location'].ends_with? '/edit'
+  end
+
+  test '/applab/new with enableMaker param preserves param in redirect' do
+    get :create_new, params: {key: 'applab', enableMaker: 'true'}
+    assert_response :redirect
+    assert @response.headers['Location'].ends_with? '/edit?enableMaker=true'
+  end
+
+  test 'get_or_create_for_level without script creates new channel if none exists' do
+    level = create(:level, :blockly)
+    get :get_or_create_for_level, params: {level_id: level.id}
+    assert_response :success
+    refute_nil @response.body['channel']
+  end
+
+  test 'get_or_create_for_level without script returns existing channel' do
+    level = create(:level, :blockly)
+    get :get_or_create_for_level, params: {level_id: level.id}
+    assert_response :success
+    channel_id = @response.body['channel']
+    refute_nil channel_id
+
+    get :get_or_create_for_level, params: {level_id: level.id}
+    assert_response :success
+    assert_equal channel_id, @response.body['channel']
+  end
+
+  test 'get_or_create_for_level with script creates new channel if none exists' do
+    script = create(:script)
+    level = create(:level, :blockly)
+    create(:script_level, script: script, levels: [level])
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id}
+    assert_response :success
+    refute_nil @response.body['channel']
+  end
+
+  test 'get_or_create_for_level with script restricts usage for young students in app lab' do
+    sign_in_with_request create(:young_student)
+    script = create(:script)
+    level = create(:applab)
+    create(:script_level, script: script, levels: [level])
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id}
+    assert_response :forbidden
+  end
+
+  test 'get_or_create_for_level with script allows usage for young students with tos teacher in app lab' do
+    sign_in_with_request create(:young_student_with_tos_teacher)
+    script = create(:script)
+    level = create(:applab)
+    create(:script_level, script: script, levels: [level])
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id}
+    assert_response :success
+    refute_nil @response.body['channel']
+  end
+
+  test 'get_or_create_for_level with user returns forbiddden if not teacher of student' do
+    student = create :user
+    script = create(:script)
+    level = create(:level, :blockly)
+    create(:script_level, script: script, levels: [level])
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id, user_id: student.id}
+    assert_response :forbidden
+  end
+
+  test 'get_or_create_for_level with user returns not started if student has not started' do
+    teacher = create(:teacher)
+    section = create(:section, user: teacher, login_type: 'word')
+    student = create :user
+    create(:follower, section: section, student_user: student)
+    sign_in teacher
+
+    script = create(:script)
+    level = create(:level, :blockly)
+    create(:script_level, script: script, levels: [level])
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id, user_id: student.id}
+    assert_response :success
+    body = JSON.parse(@response.body)
+    assert_equal body['started'], false
+  end
+
+  test 'get_or_create_for_level with user returns channel' do
+    teacher = create(:teacher)
+    section = create(:section, user: teacher, login_type: 'word')
+    student = create :user
+    create(:follower, section: section, student_user: student)
+
+    # The student should do some work.
+    sign_in_with_request(student)
+    script = create(:script)
+    level = create(:level, :blockly)
+    create(:script_level, script: script, levels: [level])
+    create :user_level, level: level, user: student, script: script
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id}
+    assert_response :success
+    refute_nil @response.body['channel']
+    sign_out student
+
+    # Now that the channel has been created, check that the teacher can retrieve it for their student.
+    sign_in teacher
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id, user_id: student.id}
+    assert_response :success
+    refute_nil @response.body['channel']
+  end
+
+  test 'get_or_create_for_level with user uses script level ID if provided' do
+    teacher = create(:teacher)
+    section = create(:section, user: teacher, login_type: 'word')
+    student = create :user
+    other_student = create :user
+    create(:follower, section: section, student_user: student)
+    sign_in teacher
+
+    script = create(:script)
+    sublevel = create(:level, :blockly)
+    parent_level = create(:bubble_choice_level, sublevels: [sublevel])
+    script_level = create(:script_level, script: script, levels: [parent_level])
+
+    # Teacher should be able to get the channel for the given sublevel for the student.
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: sublevel.id, script_level_id: script_level.id, user_id: student.id}
+    assert_response :success
+
+    # Teacher should be able to get the channel for the parent level for the student since it matches the script level ID.
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: parent_level.id, script_level_id: script_level.id, user_id: student.id}
+    assert_response :success
+
+    # Teacher should not be able to get the channel for the given sublevel for a student not in their section.
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: sublevel.id, script_level_id: script_level.id, user_id: other_student.id}
+    assert_response :forbidden
+  end
+
+  test 'get_or_create_for_level with user returns forbidden if script level ID does not match level ID' do
+    teacher = create(:teacher)
+    section = create(:section, user: teacher, login_type: 'word')
+    student = create :user
+    create(:follower, section: section, student_user: student)
+    sign_in teacher
+
+    script = create(:script)
+    sublevel = create(:level, :blockly)
+    other_level = create(:level, :blockly)
+    script_level = create(:script_level, script: script, levels: [other_level])
+
+    # Teacher should not be able to get the channel for the given sublevel since the provided level ID does not match the script level ID.
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: sublevel.id, script_level_id: script_level.id, user_id: student.id}
+    assert_response :forbidden
+  end
+
+  test 'on lab2 levels navigating to /view redirects to /edit if user is project owner' do
+    channel_id = '12345'
+    Projects.any_instance.stubs(:get).returns({isOwner: true})
+
+    get :show, params: {path: "/projects/music/#{channel_id}/view", key: 'music', channel_id: channel_id, readonly: true}
+    assert_response :redirect
+    assert_redirected_to "/projects/music/#{channel_id}/edit"
+  end
+
+  test 'on lab2 levels navigating to /edit redirects to /view if user is not project owner' do
+    channel_id = '12345'
+    Projects.any_instance.stubs(:get).returns({isOwner: false})
+
+    get :edit, params: {path: "/projects/music/#{channel_id}/edit", key: 'music', channel_id: channel_id}
+    assert_response :redirect
+    assert_redirected_to "/projects/music/#{channel_id}/view"
+  end
+
+  test 'on lab2 levels navigating to /edit redirects to /view if project is frozen' do
+    channel_id = '12345'
+    Projects.any_instance.stubs(:get).returns({isFrozen: true})
+
+    get :edit, params: {path: "/projects/music/#{channel_id}/edit", key: 'music', channel_id: channel_id}
+    assert_response :redirect
+    assert_redirected_to "/projects/music/#{channel_id}/view"
+  end
+
   test 'submission status returns appropriate status' do
     sign_in_with_request @project_owner
     Project.stubs(:find_by).returns(@test_project)

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -10,10 +10,6 @@ class ProjectsControllerTest < ActionController::TestCase
     ActionDispatch::TestRequest.any_instance.stubs(:user_id).returns(user.id)
   end
 
-  setup_all do
-    @test_project = create :project
-  end
-
   setup do
     sign_in_with_request create :user
     Geocoder.stubs(:search).returns([OpenStruct.new(country_code: 'US')])
@@ -38,523 +34,23 @@ class ProjectsControllerTest < ActionController::TestCase
     @section = create :section
     @section.add_student @driver
     @section.add_student @navigator
+
+    @project_owner = create :student
+    @test_project = create :project, owner: @project_owner
+    @channel_id = @test_project.channel_id
   end
 
   teardown do
     AzureTextToSpeech.unstub(:get_voices)
   end
 
-  test "index" do
-    get :index
-    assert_response :success
-  end
-
-  test "index/libraries" do
-    get :index, params: {tab_name: 'libraries'}
-    assert_response :success
-  end
-
-  test "index/public" do
-    get :index, params: {tab_name: 'public'}
-    assert_response :success
-  end
-
-  test "index: redirect to public tab if no user" do
-    sign_out :user
-
-    get :index
-    assert_redirected_to '/projects/public'
-
-    get :index, params: {tab_name: 'libraries'}
-    assert_redirected_to '/projects/public'
-
-    # Don't redirect if we're already on /projects/public
-    get :index, params: {tab_name: 'public'}
-    assert_response :success
-  end
-
-  test "index: redirect admins to root" do
-    sign_in create(:admin)
-
-    get :index
-    assert_redirected_to root_path
-
-    get :index, params: {tab_name: 'libraries'}
-    assert_redirected_to root_path
-
-    # Don't redirect if we're already on /projects/public
-    get :index, params: {tab_name: 'public'}
-    assert_response :success
-  end
-
-  test 'artist project level has sharing meta tags' do
-    channel = 'fake-channel'
-    get :show, params: {key: 'artist', channel_id: channel, share: true}
-
-    assert_response :success
-    assert_sharing_meta_tags(
-      url: "http://test.host/projects/artist/#{channel}",
-      image_url: "https://test-studio.code.org/v3/files/#{channel}/.metadata/thumbnail.png",
-      image_width: 400,
-      image_height: 400,
-      small_thumbnail: true
-    )
-  end
-
-  test 'spritelab project level has sharing meta tags' do
-    spritelab_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:spritelab][:name])
-    # populate level with correct game
-    spritelab_level.update(game: Game.create(app: Game::SPRITELAB))
-
-    channel = 'fake-channel'
-    get :show, params: {key: 'spritelab', channel_id: channel, share: true}
-
-    assert_response :success
-    assert_sharing_meta_tags(
-      url: "http://test.host/projects/spritelab/#{channel}",
-      image_url: "https://test-studio.code.org/v3/files/#{channel}/.metadata/thumbnail.png",
-      image_width: 400,
-      image_height: 400
-    )
-  end
-
-  test 'poetry_hoc project level has sharing meta tags' do
-    poetry_hoc_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:poetry_hoc][:name])
-    # populate level with correct game
-    poetry_hoc_level.update(game: Game.create(app: Game::POETRY))
-
-    channel = 'fake-channel'
-    get :show, params: {key: 'poetry_hoc', channel_id: channel, share: true}
-
-    assert_response :success
-    assert_sharing_meta_tags(
-      url: "http://test.host/projects/poetry_hoc/#{channel}",
-      image_url: "https://test-studio.code.org/v3/files/#{channel}/.metadata/thumbnail.png",
-      image_width: 400,
-      image_height: 400
-    )
-  end
-
-  test 'applab project level has sharing meta tags' do
-    applab_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:applab][:name])
-    # populate level with correct game
-    applab_level.update(game: Game.create(app: Game::APPLAB))
-    channel = 'fake-channel'
-
-    ProjectsController.view_context_class.any_instance.stubs(:meta_image_url).returns('http://test.host/assets/applab_sharing_drawing.png')
-
-    get :show, params: {key: 'applab', channel_id: channel, share: true}
-
-    assert_response :success
-
-    assert_sharing_meta_tags(
-      url: "http://test.host/projects/applab/#{channel}",
-      image_url: 'http://test.host/assets/applab_sharing_drawing.png',
-      image_width: 400,
-      image_height: 400,
-      apple_mobile_web_app: true
-    )
-  end
-
-  test 'playlab project level has sharing meta tags' do
-    playlab_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:playlab][:name])
-    # populate level with correct game
-    playlab_level.update(game: Game.create(app: Game::PLAYLAB))
-
-    channel = 'fake-channel'
-
-    ProjectsController.view_context_class.any_instance.stubs(:meta_image_url).returns('http://test.host/assets/studio_sharing_drawing.png')
-
-    get :show, params: {key: 'playlab', channel_id: channel, share: true}
-
-    assert_response :success
-
-    assert_sharing_meta_tags(
-      url: "http://test.host/projects/playlab/#{channel}",
-      image_url: 'http://test.host/assets/studio_sharing_drawing.png',
-      image_width: 400,
-      image_height: 400,
-      apple_mobile_web_app: true
-    )
-  end
-
-  test 'legacy /p/:key links redirect to /projects/:key' do
-    get :redirect_legacy, params: {key: ProjectsController::STANDALONE_PROJECTS[:artist][:name]}
-    assert_template 'projects/redirect_legacy'
-  end
-
-  test 'send to phone' do
-    get :edit, params: {key: 'playlab', channel_id: 'my_channel_id'}
-    assert_includes(@response.body, '"send_to_phone_url":"http://test.host/sms/send"')
-  end
-
-  test 'applab and gamelab edit gets redirected if under 13' do
-    sign_in_with_request create(:young_student)
-
-    %w(applab gamelab).each do |lab|
-      get :edit, params: {key: lab, channel_id: 'my_channel_id'}
-
-      assert_redirected_to '/'
-    end
-  end
-
-  test 'applab and gamelab remix gets redirected if under 13' do
-    sign_in_with_request create(:young_student)
-
-    %w(applab gamelab).each do |lab|
-      get :remix, params: {key: lab, channel_id: 'my_channel_id'}
-
-      assert_redirected_to '/'
-    end
-  end
-
-  test 'applab and gamelab project level gets redirected if under 13' do
-    sign_in_with_request create(:young_student)
-
-    %w(applab gamelab).each do |lab|
-      get :load, params: {key: lab}
-
-      assert_redirected_to '/'
-    end
-  end
-
-  test 'applab and gamelab project level gets redirected to edit if over 13' do
-    sign_in_with_request create(:student)
-
-    %w(applab gamelab).each do |lab|
-      get :load, params: {key: lab}
-
-      assert @response.headers['Location'].ends_with? '/edit'
-    end
-  end
-
-  test 'applab and gamelab project levels gets redirected to edit if under 13 with tos teacher' do
-    sign_in_with_request create(:young_student_with_tos_teacher)
-
-    %w(applab gamelab).each do |lab|
-      get :load, params: {key: lab}
-
-      assert @response.headers['Location'].ends_with? '/edit'
-    end
-  end
-
-  test 'applab and gamelab project levels get redirected if under 13 with over 13 pair' do
-    @driver.update(age: 10)
-    @navigator.update(age: 18)
-    sign_in_with_request @driver
-    @controller.send :pairings=, {pairings: [@navigator], section_id: @section.id}
-
-    %w(applab gamelab).each do |lab|
-      get :load, params: {key: lab}
-
-      assert_redirected_to '/'
-    end
-  end
-
-  test 'applab and gamelab project levels get redirected if over 13 with under 13 pair' do
-    @driver.update(age: 18)
-    @navigator.update(age: 10)
-    sign_in_with_request @driver
-    @controller.send :pairings=, {pairings: [@navigator], section_id: @section.id}
-
-    %w(applab gamelab).each do |lab|
-      get :load, params: {key: lab}
-
-      assert_redirected_to '/'
-    end
-  end
-
-  test 'applab and gamelab project levels gets redirected to edit if over 13 with under 13 with tos teacher pair' do
-    @driver.update(age: 18)
-    @navigator.update(age: 10)
-    create :follower, user: (create :terms_of_service_teacher), student_user: @navigator
-    sign_in_with_request @driver
-    @controller.send :pairings=, {pairings: [@navigator], section_id: @section.id}
-
-    %w(applab gamelab).each do |lab|
-      get :load, params: {key: lab}
-
-      assert @response.headers['Location'].ends_with? '/edit'
-    end
-  end
-
-  test 'shared applab project does not get redirected if under 13' do
-    sign_in_with_request create(:young_student)
-
-    get :show, params: {key: 'applab', share: true, channel_id: 'my_channel_id'}
-
-    assert_response :success
-  end
-
-  test 'shared applab project does not get redirected if over 13' do
-    sign_in_with_request create(:student)
-
-    # We can't make successful requests for both applab and gamelab within the
-    # same test case, or we'll get an error about view_options already being
-    # frozen.
-
-    get :show, params: {key: 'applab', share: true, channel_id: 'my_channel_id'}
-
-    assert_response :success
-  end
-
-  test 'shared applab and gamelab project level gets redirected to edit if under 13 with tos teacher' do
-    sign_in_with_request create(:young_student_with_tos_teacher)
-
-    %w(applab gamelab).each do |lab|
-      get :load, params: {key: lab}
-
-      assert @response.headers['Location'].ends_with? '/edit'
-    end
-  end
-
-  test 'applab and gamelab project level redirects to login if not signed in' do
-    sign_out :user
-    %w(applab gamelab).each do |lab|
-      get :load, params: {key: lab}
-      assert_redirected_to_sign_in
-    end
-  end
-
-  test 'admins get redirected away' do
-    sign_in_with_request create(:admin)
-
-    get :index
-    assert_redirected_to root_path
-
-    %w(applab gamelab).each do |lab|
-      get :load, params: {key: lab}
-      assert_redirected_to root_path
-    end
-
-    %w(applab gamelab).each do |lab|
-      get :show, params: {key: lab, share: true, channel_id: 'fake_channel_id'}
-      assert_redirected_to root_path
-    end
-  end
-
-  test 'applab project level goes to edit if teacher' do
-    sign_in_with_request create(:teacher)
-    get :load, params: {key: 'applab'}
-    assert @response.headers['Location'].ends_with? '/edit'
-  end
-
-  test 'applab project level goes to edit if student without admin teacher' do
-    sign_in_with_request create(:student)
-    get :load, params: {key: 'applab'}
-    assert @response.headers['Location'].ends_with? '/edit'
-  end
-
-  test 'gamelab project level redirects to login if not signed in' do
-    sign_out :user
-    get :load, params: {key: 'gamelab'}
-    assert_redirected_to_sign_in
-  end
-
-  test 'project validators can go to /featured' do
-    @project_validator = create :teacher
-    @project_validator.permission = UserPermission::PROJECT_VALIDATOR
-    sign_in @project_validator
-    get :featured
-    assert_response :success
-  end
-
-  test '/featured gets redirected to /public if not project validator' do
-    get :featured
-    assert_redirected_to '/projects/public'
-  end
-
-  test '/featured get redirected to sign in if signed out' do
-    sign_out :user
-    get :featured
-    assert_redirected_to '/users/sign_in'
-  end
-
-  test '/applab/new creates a channel and redirects to /applab/<channel>/edit' do
-    get :create_new, params: {key: 'applab'}
-    assert_response :redirect
-    assert @response.headers['Location'].ends_with? '/edit'
-  end
-
-  test '/applab/new with enableMaker param preserves param in redirect' do
-    get :create_new, params: {key: 'applab', enableMaker: 'true'}
-    assert_response :redirect
-    assert @response.headers['Location'].ends_with? '/edit?enableMaker=true'
-  end
-
-  test 'get_or_create_for_level without script creates new channel if none exists' do
-    level = create(:level, :blockly)
-    get :get_or_create_for_level, params: {level_id: level.id}
-    assert_response :success
-    refute_nil @response.body['channel']
-  end
-
-  test 'get_or_create_for_level without script returns existing channel' do
-    level = create(:level, :blockly)
-    get :get_or_create_for_level, params: {level_id: level.id}
-    assert_response :success
-    channel_id = @response.body['channel']
-    refute_nil channel_id
-
-    get :get_or_create_for_level, params: {level_id: level.id}
-    assert_response :success
-    assert_equal channel_id, @response.body['channel']
-  end
-
-  test 'get_or_create_for_level with script creates new channel if none exists' do
-    script = create(:script)
-    level = create(:level, :blockly)
-    create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id}
-    assert_response :success
-    refute_nil @response.body['channel']
-  end
-
-  test 'get_or_create_for_level with script restricts usage for young students in app lab' do
-    sign_in_with_request create(:young_student)
-    script = create(:script)
-    level = create(:applab)
-    create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id}
-    assert_response :forbidden
-  end
-
-  test 'get_or_create_for_level with script allows usage for young students with tos teacher in app lab' do
-    sign_in_with_request create(:young_student_with_tos_teacher)
-    script = create(:script)
-    level = create(:applab)
-    create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id}
-    assert_response :success
-    refute_nil @response.body['channel']
-  end
-
-  test 'get_or_create_for_level with user returns forbiddden if not teacher of student' do
-    student = create :user
-    script = create(:script)
-    level = create(:level, :blockly)
-    create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id, user_id: student.id}
-    assert_response :forbidden
-  end
-
-  test 'get_or_create_for_level with user returns not started if student has not started' do
-    teacher = create(:teacher)
-    section = create(:section, user: teacher, login_type: 'word')
-    student = create :user
-    create(:follower, section: section, student_user: student)
-    sign_in teacher
-
-    script = create(:script)
-    level = create(:level, :blockly)
-    create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id, user_id: student.id}
-    assert_response :success
-    body = JSON.parse(@response.body)
-    assert_equal body['started'], false
-  end
-
-  test 'get_or_create_for_level with user returns channel' do
-    teacher = create(:teacher)
-    section = create(:section, user: teacher, login_type: 'word')
-    student = create :user
-    create(:follower, section: section, student_user: student)
-
-    # The student should do some work.
-    sign_in_with_request(student)
-    script = create(:script)
-    level = create(:level, :blockly)
-    create(:script_level, script: script, levels: [level])
-    create :user_level, level: level, user: student, script: script
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id}
-    assert_response :success
-    refute_nil @response.body['channel']
-    sign_out student
-
-    # Now that the channel has been created, check that the teacher can retrieve it for their student.
-    sign_in teacher
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id, user_id: student.id}
-    assert_response :success
-    refute_nil @response.body['channel']
-  end
-
-  test 'get_or_create_for_level with user uses script level ID if provided' do
-    teacher = create(:teacher)
-    section = create(:section, user: teacher, login_type: 'word')
-    student = create :user
-    other_student = create :user
-    create(:follower, section: section, student_user: student)
-    sign_in teacher
-
-    script = create(:script)
-    sublevel = create(:level, :blockly)
-    parent_level = create(:bubble_choice_level, sublevels: [sublevel])
-    script_level = create(:script_level, script: script, levels: [parent_level])
-
-    # Teacher should be able to get the channel for the given sublevel for the student.
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: sublevel.id, script_level_id: script_level.id, user_id: student.id}
-    assert_response :success
-
-    # Teacher should be able to get the channel for the parent level for the student since it matches the script level ID.
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: parent_level.id, script_level_id: script_level.id, user_id: student.id}
-    assert_response :success
-
-    # Teacher should not be able to get the channel for the given sublevel for a student not in their section.
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: sublevel.id, script_level_id: script_level.id, user_id: other_student.id}
-    assert_response :forbidden
-  end
-
-  test 'get_or_create_for_level with user returns forbidden if script level ID does not match level ID' do
-    teacher = create(:teacher)
-    section = create(:section, user: teacher, login_type: 'word')
-    student = create :user
-    create(:follower, section: section, student_user: student)
-    sign_in teacher
-
-    script = create(:script)
-    sublevel = create(:level, :blockly)
-    other_level = create(:level, :blockly)
-    script_level = create(:script_level, script: script, levels: [other_level])
-
-    # Teacher should not be able to get the channel for the given sublevel since the provided level ID does not match the script level ID.
-    get :get_or_create_for_level, params: {script_id: script.id, level_id: sublevel.id, script_level_id: script_level.id, user_id: student.id}
-    assert_response :forbidden
-  end
-
-  test 'on lab2 levels navigating to /view redirects to /edit if user is project owner' do
-    channel_id = '12345'
-    Projects.any_instance.stubs(:get).returns({isOwner: true})
-
-    get :show, params: {path: "/projects/music/#{channel_id}/view", key: 'music', channel_id: channel_id, readonly: true}
-    assert_response :redirect
-    assert_redirected_to "/projects/music/#{channel_id}/edit"
-  end
-
-  test 'on lab2 levels navigating to /edit redirects to /view if user is not project owner' do
-    channel_id = '12345'
-    Projects.any_instance.stubs(:get).returns({isOwner: false})
-
-    get :edit, params: {path: "/projects/music/#{channel_id}/edit", key: 'music', channel_id: channel_id}
-    assert_response :redirect
-    assert_redirected_to "/projects/music/#{channel_id}/view"
-  end
-
-  test 'on lab2 levels navigating to /edit redirects to /view if project is frozen' do
-    channel_id = '12345'
-    Projects.any_instance.stubs(:get).returns({isFrozen: true})
-
-    get :edit, params: {path: "/projects/music/#{channel_id}/edit", key: 'music', channel_id: channel_id}
-    assert_response :redirect
-    assert_redirected_to "/projects/music/#{channel_id}/view"
-  end
-
   test 'submission status returns appropriate status' do
+    sign_in_with_request @project_owner
+    Project.stubs(:find_by).returns(@test_project)
     channel_id = '123456'
     @controller.stubs(:storage_decrypt_channel_id).returns([123, 456])
-    test_project = {}
-    Project.stubs(:find_by).returns(test_project)
     SharedConstants::PROJECT_SUBMISSION_STATUS.each_value do |status|
-      test_project.stubs(:submission_status).returns(status)
+      @test_project.stubs(:submission_status).returns(status)
       get :submission_status, params: {project_type: 'music', channel_id: channel_id}
       assert_response :success
       response_status = JSON.parse(@response.body)["status"]
@@ -563,31 +59,30 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   test 'submit project returns bad_request if no submission description' do
-    channel_id = '123456'
     submission_description = ''
-    post :submit, params: {project_type: 'music', channel_id: channel_id, submissionDescription: submission_description}
+    post :submit, params: {project_type: 'music', channel_id: @channel_id, submissionDescription: submission_description}
     assert_response :bad_request
   end
 
-  test 'submit project returns success if project passes all restrictions' do
-    channel_id = '123456'
-    @controller.stubs(:storage_decrypt_channel_id).returns([123, 456])
-    submission_description = 'this project rocks'
-    @test_project.stubs(:submission_status).returns(SharedConstants::PROJECT_SUBMISSION_STATUS[:CAN_SUBMIT])
-    Project.stubs(:find_by).returns(@test_project)
-    Projects.any_instance.stubs(:publish).returns({})
-    post :submit, params: {project_type: 'music', channel_id: channel_id, submissionDescription: submission_description}
-    assert_response :success
-  end
-
   test 'submit project returns forbidden if project already submitted' do
-    channel_id = '123456'
-    @controller.stubs(:storage_decrypt_channel_id).returns([123, 456])
     submission_description = 'this project rocks'
+    sign_in_with_request @project_owner
     @test_project.stubs(:submission_status).returns(SharedConstants::PROJECT_SUBMISSION_STATUS[:ALREADY_SUBMITTED])
     Project.stubs(:find_by).returns(@test_project)
     Projects.any_instance.stubs(:publish).returns({published_at: Time.now})
-    post :submit, params: {project_type: 'music', channel_id: channel_id, submissionDescription: submission_description}
+    post :submit, params: {project_type: 'music', channel_id: @channel_id, submissionDescription: submission_description}
     assert_response :forbidden
+  end
+
+  test 'submit project returns success if project passes all restrictions' do
+    submission_description = 'this project rocks'
+    sign_in_with_request @project_owner
+    Project.stubs(:find_by).returns(@test_project)
+    @controller.stubs(:send_project_submission).returns(:success)
+    Projects.any_instance.stubs(:publish).returns({published_at: Time.now})
+    @test_project.stubs(:submission_status).returns(SharedConstants::PROJECT_SUBMISSION_STATUS[:CAN_SUBMIT])
+    sign_in_with_request @project_owner
+    post :submit, params: {project_type: 'music', channel_id: @channel_id, submissionDescription: submission_description}
+    assert_response :success
   end
 end

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -36,6 +36,7 @@ class ProjectsControllerTest < ActionController::TestCase
     @section.add_student @navigator
 
     @project_owner = create :student
+    @non_project_owner = create :student
     @test_project = create :project, owner: @project_owner
     @channel_id = @test_project.channel_id
   end
@@ -562,10 +563,38 @@ class ProjectsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'submission status returns forbidden for non-project owner' do
+    sign_in_with_request @non_project_owner
+    Project.stubs(:find_by).returns(@test_project)
+    get :submission_status, params: {project_type: 'music', channel_id: @channel_id}
+    assert_response :forbidden
+  end
+
+  test 'submission_status returns forbidden for signed-out user' do
+    sign_out :user
+    Project.stubs(:find_by).returns(@test_project)
+    post :submission_status, params: {project_type: 'music', channel_id: @channel_id}
+    assert_response :forbidden
+  end
+
   test 'submit project returns bad_request if no submission description' do
     submission_description = ''
     post :submit, params: {project_type: 'music', channel_id: @channel_id, submissionDescription: submission_description}
     assert_response :bad_request
+  end
+
+  test 'submit project returns forbidden for non-project owner' do
+    submission_description = 'test description'
+    sign_in_with_request @non_project_owner
+    post :submit, params: {project_type: 'music', channel_id: @channel_id, submissionDescription: submission_description}
+    assert_response :forbidden
+  end
+
+  test 'submit project returns forbidden for signed-out user' do
+    submission_description = 'test description'
+    sign_out :user
+    post :submit, params: {project_type: 'music', channel_id: @channel_id, submissionDescription: submission_description}
+    assert_response :forbidden
   end
 
   test 'submit project returns forbidden if project already submitted' do

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -798,7 +798,6 @@ module SharedConstants
     PROJECT_TYPE_NOT_ALLOWED: 'project_type_not_allowed',
     RESTRICTED_SHARE_MODE: 'restricted_share_mode',
     SHARING_DISABLED: 'sharing_disabled',
-    NOT_PROJECT_OWNER: 'not_project_owner',
     OWNER_TOO_NEW: 'owner_too_new',
     PROJECT_TOO_NEW: 'project_too_new',
   }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the `projects_controller` actions `submit` and `submission_status` following up https://github.com/code-dot-org/code-dot-org/pull/61974.

Changes include:
- Moving the check for non-project owner to `ability.rb` for both actions.
- Adding both actions to the list of exceptions for `:authenticate_user!` so that signed out users receive a `403` instead of a redirect.
- Adding Honeybadge error reports for unexpected `forbidden` errors in `submit` - the UI should prevent a user who does not have access to `submit` from making a `submit` request. See https://github.com/code-dot-org/code-dot-org/blob/0072da23d7b396bc589d37fb5f46d3eff9d46341/apps/src/lab2/views/dialogs/ShareDialog.tsx#L96-L127.
- Related dashboard unit tests in `projects_controller` were updated and tests for non-project owner and signed out users were added.

## Links
[jira](https://codedotorg.atlassian.net/browse/LABS-1184) - Check for non-project owner in ability.rb
[jira](https://codedotorg.atlassian.net/browse/LABS-1212) - Add error handling to project submission dialog

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Locally, I checked the Network tab and saw that a `403` status code was now returned for a signed out user.
<img width="697" alt="Screenshot 2024-11-08 at 2 27 58 PM" src="https://github.com/user-attachments/assets/2c447d85-e006-4154-8cb9-f1124bf68436">


Also updated dashboard unit tests and added new tests for signed out and non-project owner users.

<!--


  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
