### PR TITLE
Fix school info name bugs

### DIFF
--- a/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
+++ b/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
@@ -62,10 +62,10 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
 
   const detectedSchoolName = useMemo(
     () =>
-      initialState.schoolName ||
+      (initialState.schoolId ? '' : initialState.schoolName) ||
       sessionStorage.getItem(SCHOOL_NAME_SESSION_KEY) ||
       '',
-    [initialState.schoolName]
+    [initialState.schoolName, initialState.schoolId]
   );
 
   const [state, setState] = useState<{
@@ -83,23 +83,69 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
 
   // State hooks
   const setCountry = (value: string) => {
+    analyticsReporter.sendEvent(
+      EVENTS.COUNTRY_SELECTED,
+      {country: value},
+      PLATFORMS.BOTH
+    );
     setState(prevState => ({
       ...prevState,
       country: value,
+      schoolZip: '',
+      schoolName: '',
+      schoolId:
+        value === US_COUNTRY_CODE
+          ? NonSchoolOptions.SELECT_A_SCHOOL
+          : NonSchoolOptions.CLICK_TO_ADD,
     }));
   };
+
   const setSchoolId = (value: string) => {
+    if (value === NonSchoolOptions.NO_SCHOOL_SETTING) {
+      analyticsReporter.sendEvent(
+        EVENTS.DO_NOT_TEACH_AT_SCHOOL_CLICKED,
+        {},
+        PLATFORMS.BOTH
+      );
+    } else if (value === NonSchoolOptions.CLICK_TO_ADD) {
+      analyticsReporter.sendEvent(
+        EVENTS.ADD_MANUALLY_CLICKED,
+        {},
+        PLATFORMS.BOTH
+      );
+    } else {
+      analyticsReporter.sendEvent(
+        EVENTS.SCHOOL_SELECTED_FROM_LIST,
+        {
+          'nces Id': value,
+        },
+        PLATFORMS.BOTH
+      );
+    }
     setState(prevState => ({
       ...prevState,
       schoolId: value,
+      schoolName: '',
     }));
   };
+
   const setSchoolZip = (value: string) => {
+    if (ZIP_REGEX.test(value)) {
+      analyticsReporter.sendEvent(
+        EVENTS.ZIP_CODE_ENTERED,
+        {zip: value},
+        PLATFORMS.BOTH
+      );
+    }
+
     setState(prevState => ({
       ...prevState,
       schoolZip: value,
+      schoolName: '',
+      schoolId: NonSchoolOptions.SELECT_A_SCHOOL,
     }));
   };
+
   const setSchoolName = (value: string) => {
     setState(prevState => ({
       ...prevState,
@@ -127,16 +173,9 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     []
   );
 
-  const handleSessionStorage = (
-    key: string,
-    value: string,
-    callback?: () => void
-  ) => {
+  const handleSessionStorage = (key: string, value: string) => {
     if (sessionStorage.getItem(key) !== value) {
       sessionStorage.setItem(key, value);
-      if (callback) {
-        callback();
-      }
     }
   };
 
@@ -144,13 +183,7 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
 
   // Handle country changes
   useEffect(() => {
-    handleSessionStorage(SCHOOL_COUNTRY_SESSION_KEY, country, () => {
-      analyticsReporter.sendEvent(
-        EVENTS.COUNTRY_SELECTED,
-        {country},
-        PLATFORMS.BOTH
-      );
-    });
+    handleSessionStorage(SCHOOL_COUNTRY_SESSION_KEY, country);
   }, [country]);
 
   // Handle schoolZip changes
@@ -161,13 +194,7 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
       return;
     }
 
-    handleSessionStorage(SCHOOL_ZIP_SESSION_KEY, schoolZip, () => {
-      analyticsReporter.sendEvent(
-        EVENTS.ZIP_CODE_ENTERED,
-        {zip: schoolZip},
-        PLATFORMS.BOTH
-      );
-    });
+    handleSessionStorage(SCHOOL_ZIP_SESSION_KEY, schoolZip);
 
     fetchSchools(schoolZip, data => {
       if (!mounted.current) return;
@@ -177,48 +204,13 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
         .sort((a, b) => a.text.localeCompare(b.text));
 
       setSchoolsList(schools);
-
-      // this will auto select the school from the fetched list of schools if the user is updating their school info
-      if (schools.some(school => school.value === detectedSchoolId)) {
-        setSchoolId(detectedSchoolId);
-      }
     });
-  }, [schoolZip, detectedSchoolId, fetchSchools]);
+  }, [schoolZip, fetchSchools]);
 
   // Handle schoolId changes
   useEffect(() => {
-    handleSessionStorage(SCHOOL_ID_SESSION_KEY, schoolId, () => {
-      if (schoolId === NonSchoolOptions.NO_SCHOOL_SETTING) {
-        setSchoolName('');
-        analyticsReporter.sendEvent(
-          EVENTS.DO_NOT_TEACH_AT_SCHOOL_CLICKED,
-          {},
-          PLATFORMS.BOTH
-        );
-      } else if (schoolId === NonSchoolOptions.CLICK_TO_ADD) {
-        setSchoolName('');
-        analyticsReporter.sendEvent(
-          EVENTS.ADD_MANUALLY_CLICKED,
-          {},
-          PLATFORMS.BOTH
-        );
-      } else {
-        const name = schoolsList.find(
-          school => school.value === schoolId
-        )?.text;
-        if (name) {
-          setSchoolName(name);
-        }
-        analyticsReporter.sendEvent(
-          EVENTS.SCHOOL_SELECTED_FROM_LIST,
-          {
-            'nces Id': schoolId,
-          },
-          PLATFORMS.BOTH
-        );
-      }
-    });
-  }, [schoolId, schoolsList]);
+    handleSessionStorage(SCHOOL_ID_SESSION_KEY, schoolId);
+  }, [schoolId]);
 
   // Handle schoolName changes
   useEffect(() => {

--- a/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
+++ b/apps/src/schoolInfo/hooks/useSchoolInfo.tsx
@@ -62,9 +62,11 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
 
   const detectedSchoolName = useMemo(
     () =>
-      (initialState.schoolId ? '' : initialState.schoolName) ||
-      sessionStorage.getItem(SCHOOL_NAME_SESSION_KEY) ||
-      '',
+      initialState.schoolId
+        ? ''
+        : initialState.schoolName ||
+          sessionStorage.getItem(SCHOOL_NAME_SESSION_KEY) ||
+          '',
     [initialState.schoolName, initialState.schoolId]
   );
 
@@ -91,12 +93,6 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     setState(prevState => ({
       ...prevState,
       country: value,
-      schoolZip: '',
-      schoolName: '',
-      schoolId:
-        value === US_COUNTRY_CODE
-          ? NonSchoolOptions.SELECT_A_SCHOOL
-          : NonSchoolOptions.CLICK_TO_ADD,
     }));
   };
 
@@ -125,7 +121,6 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     setState(prevState => ({
       ...prevState,
       schoolId: value,
-      schoolName: '',
     }));
   };
 
@@ -141,8 +136,6 @@ export function useSchoolInfo(initialState: SchoolInfoInitialState) {
     setState(prevState => ({
       ...prevState,
       schoolZip: value,
-      schoolName: '',
-      schoolId: NonSchoolOptions.SELECT_A_SCHOOL,
     }));
   };
 

--- a/apps/src/templates/census/CensusTeacherBanner.jsx
+++ b/apps/src/templates/census/CensusTeacherBanner.jsx
@@ -36,12 +36,12 @@ export default function CensusTeacherBanner({
   const [showCensusUnknownError, setShowCensusUnknownError] = useState(false);
 
   const schoolInfo = useSchoolInfo({
-    schoolId: existingSchoolInfo.id,
-    country: existingSchoolInfo.country,
-    schoolName: existingSchoolInfo.name,
+    schoolId: existingSchoolInfo?.id,
+    country: existingSchoolInfo?.country,
+    schoolName: existingSchoolInfo?.name,
 
-    schoolZip: existingSchoolInfo.zip,
-    schoolType: existingSchoolInfo.type,
+    schoolZip: existingSchoolInfo?.zip,
+    schoolType: existingSchoolInfo?.type,
   });
 
   const hideSchoolInfoForm = () => {
@@ -256,12 +256,12 @@ export default function CensusTeacherBanner({
       );
     }
 
-    if (schoolInfo.schoolName) {
+    if (existingSchoolInfo?.name) {
       return (
         <div>
           <div style={styles.header}>
             <h2 style={styles.title}>
-              Add {schoolInfo.schoolName} to our map!
+              Add {existingSchoolInfo?.name} to our map!
             </h2>
             <p style={styles.updateSchool}>
               Not teaching at this school anymore?&ensp;

--- a/apps/test/unit/schoolInfo/SchoolInfoInterstitialTest.jsx
+++ b/apps/test/unit/schoolInfo/SchoolInfoInterstitialTest.jsx
@@ -100,7 +100,8 @@ describe('SchoolInfoInterstitial', () => {
       expect(mockUpdateSchoolInfo).toHaveBeenCalledWith({
         schoolId: '1',
         country: 'US',
-        schoolName: 'Test School',
+        // schoolName is empty when schoolId is passed to useSchoolInfo, regardless of initial state
+        schoolName: '',
         schoolZip: '12345',
       });
 

--- a/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
+++ b/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
@@ -64,10 +64,10 @@ describe('useSchoolInfo', () => {
   });
 
   it('should use initialState instead of sessionStorage if passed', async () => {
-    sessionStorage.setItem(SCHOOL_COUNTRY_SESSION_KEY, 'CA');
-    sessionStorage.setItem(SCHOOL_ID_SESSION_KEY, '');
-    sessionStorage.setItem(SCHOOL_NAME_SESSION_KEY, 'Stored School');
-    sessionStorage.setItem(SCHOOL_ZIP_SESSION_KEY, '');
+    sessionStorage.setItem(SCHOOL_COUNTRY_SESSION_KEY, 'US');
+    sessionStorage.setItem(SCHOOL_ID_SESSION_KEY, '2');
+    sessionStorage.setItem(SCHOOL_NAME_SESSION_KEY, '');
+    sessionStorage.setItem(SCHOOL_ZIP_SESSION_KEY, '12345');
 
     const {result, waitForNextUpdate} = renderHook(() =>
       useSchoolInfo(initialState)
@@ -78,7 +78,7 @@ describe('useSchoolInfo', () => {
 
     expect(result.current.country).toBe(initialState.country);
     expect(result.current.schoolId).toBe(initialState.schoolId);
-    expect(result.current.schoolName).toBe(initialState.schoolName);
+    expect(result.current.schoolName).toBe('');
     expect(result.current.schoolZip).toBe(initialState.schoolZip);
   });
 
@@ -127,7 +127,7 @@ describe('useSchoolInfo', () => {
         hook.current.reset();
       });
       expect(hook.current.schoolZip).toBe(initialState.schoolZip);
-      expect(hook.current.schoolName).toBe(initialState.schoolName);
+      expect(hook.current.schoolName).toBe('');
       expect(hook.current.schoolId).toBe(initialState.schoolId);
       expect(hook.current.country).toBe(initialState.country);
     });
@@ -150,11 +150,11 @@ describe('useSchoolInfo', () => {
         expect(schoolCountrySessionStorageCalls[1][1]).toBe('CA');
       });
 
-      it('should retain schoolZip, schoolId, and schoolName on country changes', () => {
+      it('should reset schoolZip, schoolId, and schoolName on country changes', async () => {
         expect(hook.current.country).toBe(initialState.country);
         expect(hook.current.schoolId).toBe(initialState.schoolId);
         expect(hook.current.schoolZip).toBe(initialState.schoolZip);
-        expect(hook.current.schoolName).toBe(initialState.schoolName);
+        expect(hook.current.schoolName).toBe('');
         expect(hook.current.schoolsList).toEqual([
           {value: initialState.schoolId, text: initialState.schoolName},
           {value: '2', text: 'Other School'},
@@ -165,13 +165,10 @@ describe('useSchoolInfo', () => {
         });
 
         expect(hook.current.country).toBe('CA');
-        expect(hook.current.schoolId).toBe(initialState.schoolId);
-        expect(hook.current.schoolZip).toBe(initialState.schoolZip);
-        expect(hook.current.schoolName).toBe(initialState.schoolName);
-        expect(hook.current.schoolsList).toEqual([
-          {value: initialState.schoolId, text: initialState.schoolName},
-          {value: '2', text: 'Other School'},
-        ]);
+        expect(hook.current.schoolId).toBe(NonSchoolOptions.CLICK_TO_ADD);
+        expect(hook.current.schoolZip).toBe('');
+        expect(hook.current.schoolName).toBe('');
+        expect(hook.current.schoolsList).toEqual([]);
       });
 
       it('should send an analytics event', () => {
@@ -220,9 +217,9 @@ describe('useSchoolInfo', () => {
         expect(schoolZipSessionStorageCalls[1][1]).toBe('');
       });
 
-      it('should retain schoolId and schoolName if the schoolZip changes', async () => {
+      it('should reset schoolId and schoolName if the schoolZip changes', async () => {
         expect(hook.current.schoolId).toBe(initialState.schoolId);
-        expect(hook.current.schoolName).toBe(initialState.schoolName);
+        expect(hook.current.schoolName).toBe('');
         expect(hook.current.schoolsList).toEqual([
           {value: initialState.schoolId, text: initialState.schoolName},
           {value: '2', text: 'Other School'},
@@ -233,8 +230,8 @@ describe('useSchoolInfo', () => {
         });
 
         expect(hook.current.schoolZip).toBe('90210');
-        expect(hook.current.schoolId).toBe(initialState.schoolId);
-        expect(hook.current.schoolName).toBe(initialState.schoolName);
+        expect(hook.current.schoolId).toBe(NonSchoolOptions.SELECT_A_SCHOOL);
+        expect(hook.current.schoolName).toBe('');
         expect(hook.current.schoolsList).toEqual([
           {value: initialState.schoolId, text: initialState.schoolName},
           {value: '2', text: 'Other School'},
@@ -317,9 +314,9 @@ describe('useSchoolInfo', () => {
 
       it('should clear the school name when CLICK_TO_ADD or NO_SCHOOL_SETTING are selected', () => {
         act(() => {
-          hook.current.setSchoolId('2');
+          hook.current.setSchoolName('Super Cool School');
         });
-        expect(hook.current.schoolName).toBe('Other School');
+        expect(hook.current.schoolName).toBe('Super Cool School');
 
         act(() => {
           hook.current.setSchoolId(NonSchoolOptions.CLICK_TO_ADD);
@@ -327,9 +324,9 @@ describe('useSchoolInfo', () => {
         expect(hook.current.schoolName).toBe('');
 
         act(() => {
-          hook.current.setSchoolId('1');
+          hook.current.setSchoolName('Another Cool School');
         });
-        expect(hook.current.schoolName).toBe('Cool School');
+        expect(hook.current.schoolName).toBe('Another Cool School');
 
         act(() => {
           hook.current.setSchoolId(NonSchoolOptions.NO_SCHOOL_SETTING);
@@ -349,9 +346,7 @@ describe('useSchoolInfo', () => {
             ([key]) => key === SCHOOL_NAME_SESSION_KEY
           );
         expect(schoolNameSessionStorageCalls).toHaveLength(2);
-        expect(schoolNameSessionStorageCalls[0][1]).toBe(
-          initialState.schoolName
-        );
+        expect(schoolNameSessionStorageCalls[0][1]).toBe('');
         expect(schoolNameSessionStorageCalls[1][1]).toBe('Super Cool School');
       });
     });

--- a/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
+++ b/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
@@ -64,10 +64,10 @@ describe('useSchoolInfo', () => {
   });
 
   it('should use initialState instead of sessionStorage if passed', async () => {
-    sessionStorage.setItem(SCHOOL_COUNTRY_SESSION_KEY, 'US');
-    sessionStorage.setItem(SCHOOL_ID_SESSION_KEY, '2');
-    sessionStorage.setItem(SCHOOL_NAME_SESSION_KEY, 'Other School');
-    sessionStorage.setItem(SCHOOL_ZIP_SESSION_KEY, '12345');
+    sessionStorage.setItem(SCHOOL_COUNTRY_SESSION_KEY, 'CA');
+    sessionStorage.setItem(SCHOOL_ID_SESSION_KEY, '');
+    sessionStorage.setItem(SCHOOL_NAME_SESSION_KEY, 'Stored School');
+    sessionStorage.setItem(SCHOOL_ZIP_SESSION_KEY, '');
 
     const {result, waitForNextUpdate} = renderHook(() =>
       useSchoolInfo(initialState)
@@ -78,6 +78,7 @@ describe('useSchoolInfo', () => {
 
     expect(result.current.country).toBe(initialState.country);
     expect(result.current.schoolId).toBe(initialState.schoolId);
+    // initial state has schoolId, so schoolName is empty
     expect(result.current.schoolName).toBe('');
     expect(result.current.schoolZip).toBe(initialState.schoolZip);
   });

--- a/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
+++ b/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
@@ -66,7 +66,7 @@ describe('useSchoolInfo', () => {
   it('should use initialState instead of sessionStorage if passed', async () => {
     sessionStorage.setItem(SCHOOL_COUNTRY_SESSION_KEY, 'US');
     sessionStorage.setItem(SCHOOL_ID_SESSION_KEY, '2');
-    sessionStorage.setItem(SCHOOL_NAME_SESSION_KEY, '');
+    sessionStorage.setItem(SCHOOL_NAME_SESSION_KEY, 'Other School');
     sessionStorage.setItem(SCHOOL_ZIP_SESSION_KEY, '12345');
 
     const {result, waitForNextUpdate} = renderHook(() =>
@@ -96,6 +96,27 @@ describe('useSchoolInfo', () => {
     expect(result.current.schoolId).toBe(NonSchoolOptions.SELECT_A_SCHOOL);
     expect(result.current.schoolName).toBe('Stored School');
     expect(result.current.schoolZip).toBe('');
+  });
+
+  it('should return a schoolName if no schoolId is passed', async () => {
+    const {result, waitForNextUpdate} = renderHook(() =>
+      useSchoolInfo({
+        ...initialState,
+        schoolId: '',
+      })
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.schoolName).toBe(initialState.schoolName);
+  });
+
+  it('should not return a schoolName if schoolId is passed', async () => {
+    const {result, waitForNextUpdate} = renderHook(() =>
+      useSchoolInfo(initialState)
+    );
+    await waitForNextUpdate();
+
+    expect(result.current.schoolName).toBe('');
   });
 
   describe('hook state updates', () => {
@@ -150,7 +171,7 @@ describe('useSchoolInfo', () => {
         expect(schoolCountrySessionStorageCalls[1][1]).toBe('CA');
       });
 
-      it('should reset schoolZip, schoolId, and schoolName on country changes', async () => {
+      it('should retain schoolZip, schoolId, and schoolName on country changes', async () => {
         expect(hook.current.country).toBe(initialState.country);
         expect(hook.current.schoolId).toBe(initialState.schoolId);
         expect(hook.current.schoolZip).toBe(initialState.schoolZip);
@@ -161,14 +182,21 @@ describe('useSchoolInfo', () => {
         ]);
 
         act(() => {
+          hook.current.setSchoolName('Another School');
+        });
+
+        act(() => {
           hook.current.setCountry('CA');
         });
 
         expect(hook.current.country).toBe('CA');
-        expect(hook.current.schoolId).toBe(NonSchoolOptions.CLICK_TO_ADD);
-        expect(hook.current.schoolZip).toBe('');
-        expect(hook.current.schoolName).toBe('');
-        expect(hook.current.schoolsList).toEqual([]);
+        expect(hook.current.schoolId).toBe(initialState.schoolId);
+        expect(hook.current.schoolZip).toBe(initialState.schoolZip);
+        expect(hook.current.schoolName).toBe('Another School');
+        expect(hook.current.schoolsList).toEqual([
+          {value: initialState.schoolId, text: initialState.schoolName},
+          {value: '2', text: 'Other School'},
+        ]);
       });
 
       it('should send an analytics event', () => {
@@ -217,7 +245,7 @@ describe('useSchoolInfo', () => {
         expect(schoolZipSessionStorageCalls[1][1]).toBe('');
       });
 
-      it('should reset schoolId and schoolName if the schoolZip changes', async () => {
+      it('should retain schoolId and schoolName if the schoolZip changes', async () => {
         expect(hook.current.schoolId).toBe(initialState.schoolId);
         expect(hook.current.schoolName).toBe('');
         expect(hook.current.schoolsList).toEqual([
@@ -225,13 +253,17 @@ describe('useSchoolInfo', () => {
           {value: '2', text: 'Other School'},
         ]);
 
+        act(() => {
+          hook.current.setSchoolName('Another School');
+        });
+
         await act(async () => {
           hook.current.setSchoolZip('90210');
         });
 
         expect(hook.current.schoolZip).toBe('90210');
-        expect(hook.current.schoolId).toBe(NonSchoolOptions.SELECT_A_SCHOOL);
-        expect(hook.current.schoolName).toBe('');
+        expect(hook.current.schoolId).toBe(initialState.schoolId);
+        expect(hook.current.schoolName).toBe('Another School');
         expect(hook.current.schoolsList).toEqual([
           {value: initialState.schoolId, text: initialState.schoolName},
           {value: '2', text: 'Other School'},
@@ -310,28 +342,6 @@ describe('useSchoolInfo', () => {
           {'nces Id': '2'},
           PLATFORMS.BOTH
         );
-      });
-
-      it('should clear the school name when CLICK_TO_ADD or NO_SCHOOL_SETTING are selected', () => {
-        act(() => {
-          hook.current.setSchoolName('Super Cool School');
-        });
-        expect(hook.current.schoolName).toBe('Super Cool School');
-
-        act(() => {
-          hook.current.setSchoolId(NonSchoolOptions.CLICK_TO_ADD);
-        });
-        expect(hook.current.schoolName).toBe('');
-
-        act(() => {
-          hook.current.setSchoolName('Another Cool School');
-        });
-        expect(hook.current.schoolName).toBe('Another Cool School');
-
-        act(() => {
-          hook.current.setSchoolId(NonSchoolOptions.NO_SCHOOL_SETTING);
-        });
-        expect(hook.current.schoolName).toBe('');
       });
     });
 

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -215,19 +215,19 @@ class HomeController < ApplicationController
       @homepage_data[:showIncubatorBanner] = show_incubator_banner?
 
       if show_census_banner
-        teachers_school = current_user.school_info.school
-        school_stats = SchoolStatsByYear.where(school_id: teachers_school.id).order(school_year: :desc).first
+        teachers_school = Queries::SchoolInfo.current_school(current_user)
+        school_stats = SchoolStatsByYear.where(school_id: teachers_school[:school_id]).order(school_year: :desc).first
 
         @homepage_data[:censusQuestion] = school_stats.try(:has_high_school_grades?) ? "how_many_20_hours" : "how_many_10_hours"
         @homepage_data[:currentSchoolYear] = current_census_year
         @homepage_data[:existingSchoolInfo] = {
-          id: teachers_school.id,
-          name: teachers_school.name,
+          id: teachers_school[:school_id],
+          name: teachers_school[:school_name],
           country: 'US',
-          zip: teachers_school.zip,
-          type: teachers_school.school_type,
+          zip: teachers_school[:school_zip],
+          type: teachers_school[:school_type],
         }
-        @homepage_data[:ncesSchoolId] = teachers_school.id
+        @homepage_data[:ncesSchoolId] = teachers_school[:school_id]
         @homepage_data[:teacherName] = current_user.name
         @homepage_data[:teacherId] = current_user.id
         @homepage_data[:teacherEmail] = current_user.email

--- a/dashboard/lib/queries/school_info.rb
+++ b/dashboard/lib/queries/school_info.rb
@@ -13,7 +13,7 @@ class Queries::SchoolInfo
     if existing_school_info.school
       # Return data directly from the associated school if it exists
       {
-        school_name: existing_school_info.school.name,
+        school_name: existing_school_info.school.name.titleize,
         school_type: existing_school_info.school.school_type,
         school_id: existing_school_info.school.id,
         school_zip: existing_school_info.school.zip,

--- a/dashboard/test/lib/queries/school_info_test.rb
+++ b/dashboard/test/lib/queries/school_info_test.rb
@@ -6,7 +6,7 @@ class Queries::SchoolInfoTest < ActiveSupport::TestCase
   end
 
   test 'when school_info exists with an associated school' do
-    school = create(:school, name: 'Test School', school_type: 'public', id: '1', zip: '12345')
+    school = create(:school, name: 'TEST SCHOOL', school_type: 'public', id: '1', zip: '12345')
     school_info = create(:school_info, school: school)
     user_school_info = create(:user_school_info, user: @user, school_info: school_info)
 
@@ -15,6 +15,7 @@ class Queries::SchoolInfoTest < ActiveSupport::TestCase
     result = Queries::SchoolInfo.current_school(@user)
 
     expected_result = {
+      # nces school name converted from uppercase to titlecase
       school_name: 'Test School',
       school_type: 'public',
       school_id: '1',


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This pr fixes some bugs in `useSchoolInfo` caused by complex state management. The core issue stemmed from using the results from the user's current school to pre-fill the form state. Specifically, `current_school` returns the nces school name, however the form state should not be pre-filled with the existing nces school name because that state should be reserved for users entering their school name into the form manually. it _should_ be pre-filled if the school is not an nces school. By checking for the existence of `initialState.schoolId` we're able to determine the form state for `schoolName`

This simple fix means we can delete code that cleared state in certain scenarios, like when changing from an nces school to a non-US country, the nces school name should not pre-fill the school name input.

To further clean things up, I decided to move the analytics event calls to the event handlers rather than the useEffects. it was getting complicated to skip the analytics event when the form is first hydrated with the user's existing school info. Since we moved from state setting functions to event handlers, it made sense to make this change as well. The existing useEffects are still used for handling session storage and fetching the schoolsList.

I also have a small update to the `current_school` method to title-case the nces school name, the same as it is in the zip code search results.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
