### PR TITLE
Adding a new UI test for the colorado lockout scenario

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/new_sign_up.feature
+++ b/dashboard/test/ui/features/acquisition_products/new_sign_up.feature
@@ -40,6 +40,7 @@ Scenario: Student can create an account in the new sign up flow
 Scenario: 10yo student hits Colorado lockout
 
   Given I am on "http://studio.code.org/users/new_sign_up/account_type"
+  When I use a cookie to mock the DCDO key "cpa_experience" as "true"
   And I press the last button with text "Sign up as a student" to load a new page
   And I fill in the new sign up email field with a random email
   And I press keys "password" for element "#uitest-password"

--- a/dashboard/test/ui/features/acquisition_products/new_sign_up.feature
+++ b/dashboard/test/ui/features/acquisition_products/new_sign_up.feature
@@ -36,3 +36,19 @@ Scenario: Student can create an account in the new sign up flow
   And I see no difference for "Finish Sign Up Student"
   And I press the last button with text "Go to my account" to load a new page
   And I close my eyes
+
+Scenario: 10yo student hits Colorado lockout
+
+  Given I am on "http://studio.code.org/users/new_sign_up/account_type"
+  And I press the last button with text "Sign up as a student" to load a new page
+  And I fill in the new sign up email field with a random email
+  And I press keys "password" for element "#uitest-password"
+  And I press keys "password" for element "#uitest-confirm-password"
+  And I press the last button with text "Create my account" to load a new page
+  And I press keys "myDisplayName" for element "#uitest-display-name"
+  And I select the "10" option in dropdown "uitest-user-age"
+  And I select the "Colorado" option in dropdown "uitest-user-state"
+  And I press the last button with text "Go to my account" to load a new page
+  And I open my eyes to test "Colorado Lockout"
+  And I see no difference for "Colorado Lockout"
+  And I close my eyes


### PR DESCRIPTION
This Pr adds a new ui and eyes test for the colorado lockout scenario.

<img width="1158" alt="Screenshot 2024-11-08 at 3 05 12 PM" src="https://github.com/user-attachments/assets/59701c57-1b7e-471a-9270-fd34825e681a">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2663

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
