### PR TITLE
cloudformation/README.md: general "howto deploy"

### DIFF
--- a/aws/cloudformation/README.md
+++ b/aws/cloudformation/README.md
@@ -14,6 +14,37 @@ This directory contains CloudFormation stack templates, associated Custom Resour
 - [`Cdo::CloudFormation::StackTemplate`](../../lib/cdo/cloud_formation/stack_template.rb) - Controller class providing the ERB binding context for CloudFormation stack templates.
 - [`Cdo::CloudFormation::CdoApp`](../../lib/cdo/cloud_formation/cdo_app.rb) - Stack-template controller specific to the monolithic Code.org application stack.
 
+## Testing Out CloudFormation Templates Old and New
+
+So you've changed a cloudformation template, call it 'template.yml', or created a new one. How do you test your changes without affecting production services?
+
+First, consult [Specific Template/Stack Notes](#specific-template-stack-notes) to see if there are any for your stack of interest.
+
+### If you have a .yml.erb file
+
+If you're dealing with a .yml.erb file, you'll need to search for the right ruby/rake code to either render it to a template .yml, or directly deploy it. Good places to start your search would be the `lib/rake/stack.rake` file, or there may be a ruby script nearby the file.
+
+### If you have a .yml file
+
+Most .yml files (see Exceptions below) are straight forward to deploy and test :
+
+- Login to the __codeorg-dev__ AWS account
+- Select your region, Oregon suggested
+- Go to CloudFormation->Stacks
+- Click Create Stack->With New Resources
+- Select the "Upload a template file" option
+- Upload a template file: click "Choose File" button and select your template.yml file
+- Click the Next button to go to the Parameters page
+- Set "Stack name" to a unique descriptive name for your deploy (a branch?)
+- Fill in any other parameters as appropriate and specific to your particular template which defines them. Some of the params may require research to figure out.
+- Click "Next" a few times then "Submit" to start your stack creating
+
+#### Exceptions
+
+Incomplete list of .yml files may require a script to regenerate or test:
+
+- access_logs.yml
+
 ## Specific Template/Stack Notes
 
 ### IAM

--- a/aws/cloudformation/README.md
+++ b/aws/cloudformation/README.md
@@ -37,7 +37,9 @@ Most .yml files (see Exceptions below) are straight forward to deploy and test :
 - Click the Next button to go to the Parameters page
 - Set "Stack name" to a unique descriptive name for your deploy (a branch?)
 - Fill in any other parameters as appropriate and specific to your particular template which defines them. Some of the params may require research to figure out.
+- Add the tag "created_by" with your email as the value
 - Click "Next" a few times then "Submit" to start your stack creating
+- Remember to come back and delete the stack when you're finished testing
 
 #### Exceptions
 


### PR DESCRIPTION
General documentation on roughly how one might deploy (for dev and testing purposes) resources found in the `aws/cloudformation`.