### PR TITLE
Lab2: Enable/disable TTS button by locale

### DIFF
--- a/apps/src/lab2/views/components/TextToSpeech.tsx
+++ b/apps/src/lab2/views/components/TextToSpeech.tsx
@@ -5,6 +5,7 @@ import {queryParams} from '@cdo/apps/code-studio/utils';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import DCDO from '@cdo/apps/dcdo';
 import {useBrowserTextToSpeech} from '@cdo/apps/sharedComponents/BrowserTextToSpeechWrapper';
+import currentLocale from '@cdo/apps/util/currentLocale';
 
 import moduleStyles from './TextToSpeech.module.scss';
 
@@ -15,10 +16,13 @@ interface TextToSpeechProps {
 const usePause = queryParams('tts-play-pause') === 'true';
 const playIcon = (queryParams('tts-play-icon') as string) || 'volume';
 const stopIcon = (queryParams('tts-stop-icon') as string) || 'circle-stop';
-const ttsButtonEnabled = DCDO.get(
-  'browser-tts-button-enabled',
-  true
-) as boolean;
+// If the list of enabled locales is set to true, enable all locales.
+const enabledLocales = DCDO.get('browser-tts-button-enabled-locales', []) as
+  | string[]
+  | boolean;
+const ttsButtonEnabled =
+  enabledLocales === true ||
+  (Array.isArray(enabledLocales) && enabledLocales.includes(currentLocale()));
 
 /**
  * TextToSpeech play button.

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -60,7 +60,8 @@ class DCDOBase < DynamicConfigBase
       'hoc-2024-sweepstakes': DCDO.get('hoc-2024-sweepstakes', false),
       # TODO ACQ-2556 - Remove this after the 2024 HOC launch
       'hoc-2024-nov-launch': DCDO.get('hoc-2024-nov-launch', false),
-      'browser-tts-button-enabled': DCDO.get('browser-tts-button-enabled', true),
+      # Enabled locales for browser text to speech. Set to an empty array to disable all languages, or true to enable all.
+      'browser-tts-button-enabled-locales': DCDO.get('browser-tts-button-enabled-locales', ['en-US']),
     }
   end
 end


### PR DESCRIPTION
If a string is missing translations in a given locale, the browser text to speech will attempt to read the fallback English string in the locale-specific voice, leading to a broken experience. This updates the browser TTS DCDO flag to instead store a list of enabled locales, so that TTS can be turned on a per-locale basis after we're confident in the quality of translations. Setting the flag to `true` will enable all locales.

## Links

https://codedotorg.atlassian.net/browse/LABS-1217

## Testing story

Tested locally with a variety of language / flag combinations.