### PR TITLE
Organize the new RedisSessionStore Middleware into Modules

### DIFF
--- a/dashboard/lib/middlewares/redis_session_store.rb
+++ b/dashboard/lib/middlewares/redis_session_store.rb
@@ -91,7 +91,7 @@ module Middlewares
   end
 
   class RedisSessionStore < ActionDispatch::Session::RedisStore
-    include UnnecessarySessionWritePrevention
-    include DeletedSessionPreservation
+    prepend UnnecessarySessionWritePrevention
+    prepend DeletedSessionPreservation
   end
 end

--- a/dashboard/lib/middlewares/redis_session_store.rb
+++ b/dashboard/lib/middlewares/redis_session_store.rb
@@ -1,5 +1,10 @@
 module Middlewares
-  class RedisSessionStore < ActionDispatch::Session::RedisStore
+  # In the interests of reducing Redis traffic in general, we would like to
+  # reduce the number of unnecessary write operations we execute. To do so, we
+  # augment the session to keep track of whether or not it's been changed, and
+  # consider both that and whether or not the request is asynchronous before
+  # deciding whether to issue a write.
+  module UnnecessarySessionWritePrevention
     # Extends +ActionDispatch::Request::Session+ to allow identifying whether a session has been changed.
     module SessionExtension
       def changed?
@@ -18,11 +23,41 @@ module Middlewares
       super
     end
 
+    # Overrides +Rack::Session::Abstract::Persisted#commit_session?+ to skip
+    # committing a session that is unchanged for an AJAX request, reducing
+    # Redis traffic in general.
+    #
+    # @see https://github.com/rack/rack/blob/v2.2.9/lib/rack/session/abstract/id.rb#L342
+    private def commit_session?(req, session, options)
+      result = super
+
+      # If the session has not changed but still requires committing,
+      # it's likely due to the presence of options like +:max_age+ and +:expire_after+,
+      # which are intended to prolong the session.
+      # In this case, we can skip committing for AJAX requests to reduce Redis traffic.
+      # See: https://github.com/rack/rack/blob/v2.2.9/lib/rack/session/abstract/id.rb#L355-L357
+      result = !req.xhr? if result && !session.changed? && forced_session_update?(session, options)
+
+      result
+    end
+  end
+
+  # Rails sessions have a race condition which can result in a user's session
+  # reverting to an earlier state. One way this can manifest is when a user
+  # attempts to delete their session by logging out of the site, there is a
+  # chance that the race condition will log them back in again, potentially
+  # without them noticing.
+  #
+  # To prevent (or at least reduce the frequency of) that particular case, we
+  # explicitly flag deleted sessions and check before writing any session that
+  # we are not inadvertently restoring a recently-deleted session.
+  #
+  # @see http://web.archive.org/web/20201023020301/https://paulbutcher.com/2007/05/01/race-conditions-in-rails-sessions-and-how-to-fix-them/
+  module DeletedSessionPreservation
     # Overrides +Rack::Session::Redis#delete_session+ to temporarily mark the session as deleted,
     # allowing concurrent requests to identify that the session is being deleted and prevent its restoration.
     #
     # @see https://github.com/redis-store/redis-rack/blob/v3.0.0/lib/rack/session/redis.rb#L54
-    # @see http://web.archive.org/web/20201023020301/https://paulbutcher.com/2007/05/01/race-conditions-in-rails-sessions-and-how-to-fix-them/
     def delete_session(req, sid, ...)
       super
     ensure
@@ -38,20 +73,13 @@ module Middlewares
       req.session.options[:renew] = true
     end
 
-    # Overrides +Rack::Session::Abstract::Persisted#commit_session?+ to skip committing a session
-    # that is either unchanged for an AJAX request or has been deleted during a previous concurrent request,
-    # preventing the restoration of that session and reducing Redis traffic in general.
+    # Overrides +Rack::Session::Abstract::Persisted#commit_session?+ to skip
+    # committing a session that has been deleted during a previous concurrent
+    # request, preventing the restoration of that session.
     #
     # @see https://github.com/rack/rack/blob/v2.2.9/lib/rack/session/abstract/id.rb#L342
     private def commit_session?(req, session, options)
       result = super
-
-      # If the session has not changed but still requires committing,
-      # it's likely due to the presence of options like +:max_age+ and +:expire_after+,
-      # which are intended to prolong the session.
-      # In this case, we can skip committing for AJAX requests to reduce Redis traffic.
-      # See: https://github.com/rack/rack/blob/v2.2.9/lib/rack/session/abstract/id.rb#L355-L357
-      result = !req.xhr? if result && !session.changed? && forced_session_update?(session, options)
 
       if result && options[:renew].blank?
         store_session = load_session(req).second.stringify_keys
@@ -60,5 +88,10 @@ module Middlewares
 
       result
     end
+  end
+
+  class RedisSessionStore < ActionDispatch::Session::RedisStore
+    include UnnecessarySessionWritePrevention
+    include DeletedSessionPreservation
   end
 end


### PR DESCRIPTION
In order to make it more clear to future developers that `RedisSessionStore` currently contains two distinct (but related) customizations to the base functionality, I split our existing code up into two modules and also added a few explanatory comments. I'm very open to feedback, in particular on whether the comments are a useful addition and whether the module names are accurate and readable.

## Links

Based on (and will be merged into) https://github.com/code-dot-org/code-dot-org/pull/61815 rather than `staging`

## Testing story

Verified both that the existing unit test passes and that manually logging in and out repeatedly does not result in any sessions being unexpectedly restored

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
