### PR TITLE
Set 'Cross-Origin-Embedder-Policy' on assets

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -388,6 +388,18 @@ Resources:
       DistributionConfig: <%= cloudfront_config(app) %>
 <%   end -%>
 
+<%   if cdn_enabled -%>
+  CredentiallessCrossOriginEmbedderPolicy:
+    Type: AWS::CloudFront::ResponseHeadersPolicy
+    Properties:
+      ResponseHeadersPolicyConfig:
+        Name: CredentiallessCrossOriginEmbedderPolicy
+        CustomHeadersConfig:
+          Items:
+            - Header: "Cross-Origin-Embedder-Policy"
+              Value: "credentialless"
+<%   end -%>
+
 <%   if cdn_enabled && app == 'Pegasus' -%>
 <%=    component 'www_redirect', app: app -%>
 <%  end -%>

--- a/dashboard/config/initializers/add_headers_to_sprockets.rb
+++ b/dashboard/config/initializers/add_headers_to_sprockets.rb
@@ -1,0 +1,15 @@
+require 'cdo/http_cache'
+
+# Monkeypatch Sprockets::Server to add headers to assets
+# Required to use SharedArrayBuffer, see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements
+module Sprockets
+  module Server
+    alias_method :original_headers, :headers
+
+    def headers(env, asset, length)
+      original_headers(env, asset, length).merge(
+        HttpCache::ASSETS_CROSS_ORIGIN_POLICY_HEADERS,
+      )
+    end
+  end
+end

--- a/dashboard/config/initializers/add_headers_to_sprockets.rb
+++ b/dashboard/config/initializers/add_headers_to_sprockets.rb
@@ -7,9 +7,10 @@ module Sprockets
     alias_method :original_headers, :headers
 
     def headers(env, asset, length)
-      original_headers(env, asset, length).merge(
-        HttpCache::ASSETS_CROSS_ORIGIN_POLICY_HEADERS,
-      )
+      assets_coep_headers = {
+        'Cross-Origin-Embedder-Policy' => 'credentialless'
+      }
+      original_headers(env, asset, length).merge(assets_coep_headers)
     end
   end
 end

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -293,6 +293,7 @@ module AWS
         ViewerProtocolPolicy: 'redirect-to-https'
       }.tap do |behavior|
         behavior[:PathPattern] = path if path
+        behavior[:ResponseHeadersPolicyId] = '!Ref CredentiallessCrossOriginEmbedderPolicy' if behavior_config[:credentialless_cross_origin_embedder_policy]
         behavior[:RealtimeLogConfigArn] = {'Fn::ImportValue': 'AccessLogs-Config'}
       end
     end

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -51,6 +51,8 @@ class HttpCache
   ACCEPT_HEADER = %w(Accept).freeze
   ALLOWLISTED_HEADERS = LANGUAGE_HEADER + COUNTRY_HEADER + ACCEPT_HEADER
 
+  # Cross Origin Policy headers to add to all /assets responses, required to use some
+  # "high security" javascript features like SharedArrayBuffer.
   ASSETS_CROSS_ORIGIN_POLICY_HEADERS = {
     'Cross-Origin-Embedder-Policy' => 'credentialless',
   }
@@ -249,7 +251,9 @@ class HttpCache
             #
             path: '/assets/*',
             proxy: 'cdo-assets',
-            headers: [],
+            headers: [
+              *ASSETS_CROSS_ORIGIN_POLICY_HEADERS.keys
+            ],
             cookies: 'none'
           },
           {

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -51,12 +51,6 @@ class HttpCache
   ACCEPT_HEADER = %w(Accept).freeze
   ALLOWLISTED_HEADERS = LANGUAGE_HEADER + COUNTRY_HEADER + ACCEPT_HEADER
 
-  # Cross Origin Policy headers to add to all /assets responses, required to use some
-  # "high security" javascript features like SharedArrayBuffer.
-  ASSETS_CROSS_ORIGIN_POLICY_HEADERS = {
-    'Cross-Origin-Embedder-Policy' => 'credentialless',
-  }
-
   DEFAULT_COOKIES = [
     # Language drop-down selection.
     'language_',
@@ -251,9 +245,8 @@ class HttpCache
             #
             path: '/assets/*',
             proxy: 'cdo-assets',
-            headers: [
-              *ASSETS_CROSS_ORIGIN_POLICY_HEADERS.keys
-            ],
+            headers: [],
+            credentialless_cross_origin_embedder_policy: true,
             cookies: 'none'
           },
           {

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -51,6 +51,10 @@ class HttpCache
   ACCEPT_HEADER = %w(Accept).freeze
   ALLOWLISTED_HEADERS = LANGUAGE_HEADER + COUNTRY_HEADER + ACCEPT_HEADER
 
+  ASSETS_CROSS_ORIGIN_POLICY_HEADERS = {
+    'Cross-Origin-Embedder-Policy' => 'credentialless',
+  }
+
   DEFAULT_COOKIES = [
     # Language drop-down selection.
     'language_',


### PR DESCRIPTION
Sets HTTP header 'Cross-Origin-Embedder-Policy: credentialless' on assets, both in cloudformation setups and when serving assets straight from rails using Sprockets::Server (e.g. in dev).

This header is required to use [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements) which in turn is required to communicate with Pyodide running in a webworker.