### PR TITLE
Panels: fix fades

### DIFF
--- a/apps/src/panels/panelsView.module.scss
+++ b/apps/src/panels/panelsView.module.scss
@@ -69,6 +69,10 @@ $text-horizontal-padding: 2.6cqw;
         animation: 0.5s ease 0s fade-in;
         animation-fill-mode: both;
       }
+
+      &Invisible {
+        opacity: 0;
+      }
     }
 
     .text {


### PR DESCRIPTION
This improves the fades between panels in a couple ways:

- the next image is preloaded so that's it's more likely ready to show once the user navigates to it, preventing a fade from being "wasted" as it fades in a non-loaded image. 
- when the panel is set to fade in over the previous one, the value of the previous image is now more stable.  (`usePrevious` was giving us a value from the previous render, and we can get multiple renders fairly quickly after switching to a new panel.)

