### PR TITLE
Music: share buttons

### DIFF
--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -233,7 +233,6 @@ const ShareDialog: React.FunctionComponent<{
                   type="primary"
                   color="white"
                   size="m"
-                  className={moduleStyles.doneButton}
                 />
               </div>
             ) : (
@@ -244,7 +243,6 @@ const ShareDialog: React.FunctionComponent<{
                 color="white"
                 size="m"
                 onClick={handleClose}
-                className={moduleStyles.doneButton}
               />
             )}
           </div>

--- a/apps/src/lab2/views/dialogs/share-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/share-dialog.module.scss
@@ -91,10 +91,6 @@
       }
     }
 
-    .doneButton {
-      margin-left: auto;
-    }
-
     .closeButton {
       background-color: initial;
       box-shadow: initial;
@@ -111,7 +107,10 @@
 
   .bottom {
     display: flex;
-    justify-content: space-between;
+    flex-direction: row;
+    justify-content: end;
+    gap: 14px;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
This updates the layout of the bottom buttons in the share dialog, both for the congrats and share cases.

## before

### congrats

#### LTR

<img width="735" alt="Screenshot 2024-11-09 at 2 33 36 PM" src="https://github.com/user-attachments/assets/e6baa04b-32f9-4dd8-83f7-4b333a41d341">

#### RTL

<img width="735" alt="Screenshot 2024-11-09 at 2 17 32 PM" src="https://github.com/user-attachments/assets/711a0b32-f041-402d-b492-52dc0e0ff744">

### share

#### LTR

<img width="735" alt="Screenshot 2024-11-09 at 2 39 29 PM" src="https://github.com/user-attachments/assets/4cbd4612-ef5e-4547-b3ff-e75527832d7b">

#### RTL

<img width="735" alt="Screenshot 2024-11-09 at 2 39 26 PM" src="https://github.com/user-attachments/assets/f9a737e5-82e9-40f1-9d00-dd3433afcc04">

## after

### congrats

#### LTR

<img width="735" alt="Screenshot 2024-11-09 at 2 31 00 PM" src="https://github.com/user-attachments/assets/860ef1ee-3e22-45d0-8bfb-b784e557e971">

#### RTL

<img width="735" alt="Screenshot 2024-11-09 at 2 28 03 PM" src="https://github.com/user-attachments/assets/a8875ed3-50b3-4abf-b246-cc76a360b8bd">

### share

#### LTR

<img width="735" alt="Screenshot 2024-11-09 at 2 38 17 PM" src="https://github.com/user-attachments/assets/fb5734b7-0110-4940-8a37-ef43d9ad8e74">

#### RTL

<img width="735" alt="Screenshot 2024-11-09 at 2 38 21 PM" src="https://github.com/user-attachments/assets/8d1dec0b-7082-4cca-95a9-6990fe1cc4d1">
