### PR TITLE
Music: TTS UI color

### DIFF
--- a/apps/src/lab2/views/components/TextToSpeech.module.scss
+++ b/apps/src/lab2/views/components/TextToSpeech.module.scss
@@ -10,6 +10,7 @@
   opacity: 35%;
   cursor: pointer;
   transition: opacity 0.2s ease;
+  color: $neutral_dark;
 
   &Playing {
     opacity: 100%;

--- a/apps/src/panels/panelsView.module.scss
+++ b/apps/src/panels/panelsView.module.scss
@@ -73,6 +73,7 @@ $text-horizontal-padding: 2.6cqw;
 
     .text {
       background-color: $neutral_light;
+      color: $neutral_dark;
       border-radius: 5px;
       width: 40%;
       position: absolute;


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/62224. 

Adjusts the text-to-speech icon to be the same color as the instructions text.

And actually adjusts the panel text to also be this color.
