### PR TITLE
[Google Blockly] Prep fields for v11

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -177,6 +177,7 @@
     "@amplitude/analytics-browser": "^1.5.4",
     "@blockly/block-shareable-procedures": "~4.0.5",
     "@blockly/field-bitmap": "^4.1.0",
+    "@blockly/field-colour": "^5.0.9",
     "@blockly/field-grid-dropdown": "~4.0.9",
     "@blockly/keyboard-navigation": "~0.5.6",
     "@blockly/plugin-cross-tab-copy-paste": "~5.0.4",

--- a/apps/src/Globals.d.ts
+++ b/apps/src/Globals.d.ts
@@ -37,4 +37,5 @@ declare module '@blockly/plugin-scroll-options';
 declare module '@blockly/keyboard-navigation';
 declare module '@blockly/field-angle';
 declare module '@blockly/field-bitmap';
+declare module '@blockly/field-colour';
 declare module '@cdo/locale';

--- a/apps/src/blockly/addons/cdoFieldBitmap.ts
+++ b/apps/src/blockly/addons/cdoFieldBitmap.ts
@@ -17,17 +17,17 @@ interface FieldBitmapFromJsonConfig extends GoogleBlockly.FieldConfig {
 export class CdoFieldBitmap extends FieldBitmap {
   /**
    * Constructs a new instance of CdoFieldBitmap.
-   * @param {number[][] | ypeof Blockly.Field.SKIP_SETUP} value - The initial value of the field, represented
+   * @param {number[][] | typeof Blockly.Field.SKIP_SETUP} value - The initial value of the field, represented
    * as a 2D array of any length, or undefined.
-   * @param {object | null} options - The options for the field, can be an object or null/undefined.
+   * @param {object | null} validator - The options for the field, can be an object or null/undefined.
    * @param {object | null} config - Additional configuration options, can be an object or null/undefined.
    */
   constructor(
     value: number[][] | typeof GoogleBlockly.Field.SKIP_SETUP,
-    options?: GoogleBlockly.FieldValidator<number[][]>,
+    validator?: GoogleBlockly.FieldValidator<number[][]>,
     config?: FieldBitmapFromJsonConfig
   ) {
-    super(value, options, config);
+    super(value, validator, config);
   }
 
   /**

--- a/apps/src/blockly/addons/cdoFieldBitmap.ts
+++ b/apps/src/blockly/addons/cdoFieldBitmap.ts
@@ -19,7 +19,7 @@ export class CdoFieldBitmap extends FieldBitmap {
    * Constructs a new instance of CdoFieldBitmap.
    * @param {number[][] | typeof Blockly.Field.SKIP_SETUP} value - The initial value of the field, represented
    * as a 2D array of any length, or undefined.
-   * @param {object | null} validator - The options for the field, can be an object or null/undefined.
+   * @param {object | null} validator - A function that is called to validate a new field value or null/undefined.
    * @param {object | null} config - Additional configuration options, can be an object or null/undefined.
    */
   constructor(

--- a/apps/src/blockly/addons/cdoFieldColour.ts
+++ b/apps/src/blockly/addons/cdoFieldColour.ts
@@ -1,11 +1,24 @@
+import {FieldColour} from '@blockly/field-colour';
 import * as GoogleBlockly from 'blockly/core';
 
-export default class CdoFieldColour extends GoogleBlockly.FieldColour {
+import {COLOURS} from '../constants';
+
+interface FieldColourConfig extends GoogleBlockly.FieldConfig {
+  colourOptions?: string[];
+  colourTitles?: string[];
+  columns?: number;
+}
+
+interface FieldColourFromJsonConfig extends FieldColourConfig {
+  colour?: string;
+}
+
+export default class CdoFieldColour extends FieldColour {
   // The colours and columns properties are both private in the parent class, so we create
   // additional properties to track the config values.
   private coloursConfig: string[] | null = null;
   private columnsConfig: number = 0;
-  static COLOURS: string[] = GoogleBlockly.FieldColour.COLOURS;
+  static COLOURS: string[] = COLOURS;
   static TITLES: string[] = [];
   static COLUMNS: number = 7;
   static K1_HEIGHT: number = 35;
@@ -26,9 +39,9 @@ export default class CdoFieldColour extends GoogleBlockly.FieldColour {
    * for a list of properties this parameter supports.
    */
   constructor(
-    value?: string | typeof Blockly.Field.SKIP_SETUP,
-    validator?: GoogleBlockly.FieldColourValidator,
-    config?: GoogleBlockly.FieldColourConfig,
+    value?: string | typeof GoogleBlockly.Field.SKIP_SETUP,
+    validator?: GoogleBlockly.FieldValidator,
+    config?: FieldColourConfig,
     isK1?: boolean
   ) {
     super(value, validator, config);
@@ -48,12 +61,11 @@ export default class CdoFieldColour extends GoogleBlockly.FieldColour {
    * class to manually increase the size of the field.
    * @override
    * */
-  protected override showEditor_() {
+  protected showEditor_() {
     this.setColours(this.coloursConfig || CdoFieldColour.COLOURS);
     this.setColumns(this.columnsConfig || CdoFieldColour.COLUMNS);
     super.showEditor_();
     if (this.isK1) {
-      // @ts-expect-error: Accessing private member 'picker'
       Blockly.utils.dom.addClass(this.picker, 'k1ColourDropdown');
     }
   }
@@ -77,5 +89,10 @@ export default class CdoFieldColour extends GoogleBlockly.FieldColour {
     }
 
     this.positionBorderRect_();
+  }
+
+  static fromJson(_options: GoogleBlockly.FieldConfig) {
+    const options = _options as FieldColourFromJsonConfig;
+    return new CdoFieldColour(options.colour, undefined, options);
   }
 }

--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -257,3 +257,81 @@ export const SETTABLE_PROPERTIES = [
   'typeHints',
   'valueTypeTabShapeMap',
 ];
+
+/**
+ * An array of colour strings for the palette.
+ * Copied from goog.ui.ColorPicker.SIMPLE_GRID_COLORS
+ */
+export const COLOURS: string[] = [
+  // grays
+  '#ffffff',
+  '#cccccc',
+  '#c0c0c0',
+  '#999999',
+  '#666666',
+  '#333333',
+  '#000000', // reds
+  '#ffcccc',
+  '#ff6666',
+  '#ff0000',
+  '#cc0000',
+  '#990000',
+  '#660000',
+  '#330000', // oranges
+  '#ffcc99',
+  '#ff9966',
+  '#ff9900',
+  '#ff6600',
+  '#cc6600',
+  '#993300',
+  '#663300', // yellows
+  '#ffff99',
+  '#ffff66',
+  '#ffcc66',
+  '#ffcc33',
+  '#cc9933',
+  '#996633',
+  '#663333', // olives
+  '#ffffcc',
+  '#ffff33',
+  '#ffff00',
+  '#ffcc00',
+  '#999900',
+  '#666600',
+  '#333300', // greens
+  '#99ff99',
+  '#66ff99',
+  '#33ff33',
+  '#33cc00',
+  '#009900',
+  '#006600',
+  '#003300', // turquoises
+  '#99ffff',
+  '#33ffff',
+  '#66cccc',
+  '#00cccc',
+  '#339999',
+  '#336666',
+  '#003333', // blues
+  '#ccffff',
+  '#66ffff',
+  '#33ccff',
+  '#3366ff',
+  '#3333ff',
+  '#000099',
+  '#000066', // purples
+  '#ccccff',
+  '#9999ff',
+  '#6666cc',
+  '#6633ff',
+  '#6600cc',
+  '#333399',
+  '#330099', // violets
+  '#ffccff',
+  '#ff99ff',
+  '#cc66cc',
+  '#cc33cc',
+  '#993399',
+  '#663366',
+  '#330033',
+];

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -273,7 +273,7 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.wrapReadOnlyProperty(prop);
   });
 
-  type registrableFieldType = GoogleBlockly.fieldRegistry.RegistrableField;
+  type registrableFieldType = Pick<typeof GoogleBlockly.Field, 'prototype'>;
   // elements in this list should be structured as follows:
   // [field registry name for field, class name of field being overridden, class to use as override]
   const fieldOverrides: [string, string, registrableFieldType][] = [

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -273,26 +273,24 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyWrapper.wrapReadOnlyProperty(prop);
   });
 
+  type registrableFieldType = GoogleBlockly.fieldRegistry.RegistrableField;
   // elements in this list should be structured as follows:
   // [field registry name for field, class name of field being overridden, class to use as override]
-  const fieldOverrides: [
-    string,
-    string,
-    Pick<typeof GoogleBlockly.Field, 'prototype'>
-  ][] = [
+  const fieldOverrides: [string, string, registrableFieldType][] = [
     ['field_variable', 'FieldVariable', CdoFieldVariable],
     ['field_dropdown', 'FieldDropdown', CdoFieldDropdown],
-    ['field_colour', 'FieldColour', CdoFieldColour],
     ['field_number', 'FieldNumber', CdoFieldNumber],
-    // CdoFieldBitmap extends from a JavaScript class without typing.
-    // We know it's a field, so it's safe to cast as unknown.
+    // CdoFieldBitmap and CdoFieldColour extend from plugins.
+    // We know they're fields, so it's safe to cast as unknown.
     [
       'field_bitmap',
       'FieldBitmap',
-      CdoFieldBitmap as unknown as Pick<
-        typeof GoogleBlockly.Field,
-        'prototype'
-      >,
+      CdoFieldBitmap as unknown as registrableFieldType,
+    ],
+    [
+      'field_colour',
+      'FieldColour',
+      CdoFieldColour as unknown as registrableFieldType,
     ],
     ['field_label', 'FieldLabel', CdoFieldLabel],
     ['field_parameter', 'FieldParameter', CdoFieldParameter],

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -3,6 +3,7 @@ import {
   ObservableProcedureModel,
   ObservableParameterModel,
 } from '@blockly/block-shareable-procedures';
+import {installAllBlocks as installFieldColourBlocks} from '@blockly/field-colour';
 import {LineCursor, NavigationController} from '@blockly/keyboard-navigation';
 import {CrossTabCopyPaste} from '@blockly/plugin-cross-tab-copy-paste';
 import {
@@ -272,6 +273,10 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   READ_ONLY_PROPERTIES.forEach(prop => {
     blocklyWrapper.wrapReadOnlyProperty(prop);
   });
+
+  // Installs colour_picker, colour_rgb, colour_random, and colour_blend blocks.
+  // These are exclusively provided via the FieldColour plugin as of Blockly v11.
+  installFieldColourBlocks({javascript: javascriptGenerator});
 
   type registrableFieldType = Pick<typeof GoogleBlockly.Field, 'prototype'>;
   // elements in this list should be structured as follows:

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -140,7 +140,7 @@ export interface BlocklyWrapperType extends GoogleBlocklyType {
   wrapReadOnlyProperty: (propertyName: string) => void;
   wrapSettableProperty: (propertyName: string) => void;
   overrideFields: (
-    overrides: [string, string, Pick<typeof GoogleBlockly.Field, 'prototype'>][]
+    overrides: [string, string, GoogleBlockly.fieldRegistry.RegistrableField][]
   ) => void;
   setInfiniteLoopTrap: () => void;
   clearInfiniteLoopTrap: () => void;

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -2,6 +2,7 @@ import {
   ObservableParameterModel,
   ObservableProcedureModel,
 } from '@blockly/block-shareable-procedures';
+import {FieldColour} from '@blockly/field-colour';
 import * as GoogleBlockly from 'blockly/core';
 import {javascriptGenerator} from 'blockly/javascript';
 
@@ -14,7 +15,6 @@ import CdoFieldAnimationDropdown from './addons/cdoFieldAnimationDropdown';
 import CdoFieldBehaviorPicker from './addons/cdoFieldBehaviorPicker';
 import {CdoFieldBitmap} from './addons/cdoFieldBitmap';
 import CdoFieldButton from './addons/cdoFieldButton';
-import CdoFieldColour from './addons/cdoFieldColour';
 import CdoFieldFlyout from './addons/cdoFieldFlyout';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
 import CdoFieldParameter from './addons/cdoFieldParameter';
@@ -109,7 +109,7 @@ export interface BlocklyWrapperType extends GoogleBlocklyType {
   FieldToggle: typeof CdoFieldToggle;
   FieldFlyout: typeof CdoFieldFlyout;
   FieldBitmap: typeof CdoFieldBitmap;
-  FieldColour: typeof CdoFieldColour;
+  FieldColour: typeof FieldColour;
   FieldVariable: typeof CdoFieldVariable;
   FieldParameter: typeof CdoFieldParameter;
   JavaScript: JavascriptGeneratorType;

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -140,7 +140,7 @@ export interface BlocklyWrapperType extends GoogleBlocklyType {
   wrapReadOnlyProperty: (propertyName: string) => void;
   wrapSettableProperty: (propertyName: string) => void;
   overrideFields: (
-    overrides: [string, string, GoogleBlockly.fieldRegistry.RegistrableField][]
+    overrides: [string, string, Pick<typeof GoogleBlockly.Field, 'prototype'>][]
   ) => void;
   setInfiniteLoopTrap: () => void;
   clearInfiniteLoopTrap: () => void;

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -48,6 +48,7 @@ const nodeModulesToTranspile = [
   '@blockly/plugin-scroll-options',
   '@blockly/field-angle',
   '@blockly/field-bitmap',
+  '@blockly/field-colour',
   'blockly',
   '@code-dot-org/dance-party',
   '@code-dot-org/johnny-five',

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3664,6 +3664,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@blockly/field-colour@npm:^5.0.9":
+  version: 5.0.9
+  resolution: "@blockly/field-colour@npm:5.0.9"
+  peerDependencies:
+    blockly: ^11.0.0
+  checksum: b0f487b6532f67cc1f409018075b3d7242bfb630f452f527e41d4d4ffd37efad9962c82be1a1521e6656336715e1ca35397d0a7019c7633121fefa2a29de20d9
+  languageName: node
+  linkType: hard
+
 "@blockly/field-grid-dropdown@npm:~4.0.9":
   version: 4.0.10
   resolution: "@blockly/field-grid-dropdown@npm:4.0.10"
@@ -9980,6 +9989,7 @@ __metadata:
     "@babel/preset-react": ^7.25.9
     "@blockly/block-shareable-procedures": ~4.0.5
     "@blockly/field-bitmap": ^4.1.0
+    "@blockly/field-colour": ^5.0.9
     "@blockly/field-grid-dropdown": ~4.0.9
     "@blockly/keyboard-navigation": ~0.5.6
     "@blockly/plugin-cross-tab-copy-paste": ~5.0.4


### PR DESCRIPTION
This is one of several tasks that should help to unblock the Blockly v11 bump. A draft of this project is collected here:
- https://github.com/code-dot-org/code-dot-org/pull/62301/commits

This branch prepares custom fields, particularly for bitmaps and colors, for v11. `CdoFieldBitmap` is a customization of a plugin field class. `FieldColour` is being deleted from core with v11, so we will also need to move to the plugin for that.

**Changes**
- The default set of colors has been copied into our `constants.ts` file. This is because the base `FieldColour` no longer has a static `COLOURS` value. Note that we need this value primarily so that Artist/Frozen can override it with their own colour palettes. This something that would be great to clean up later as those custom colors should ideally be passed in as a configuration option instead.
- A `fromJson` method was added to `CdoFieldColour` to make it compliant with an upcoming `RegistrableField` type. See: https://github.com/google/blockly/pull/8062
- Colour field blocks that are currently installed with Core Blockly are now explicitly installed from the plugin. Starting with v11, these blocks will no longer be provided with Core. It's safe to add these definitions for all labs, so I've chosen to install them right when initialize the wrapper.
- New types are used our field overrides. I created a local version of the registrable field type that will become available with v11. See: https://github.com/google/blockly/pull/8062

**Screenshots**
New expected warnings related to re-installed blocks. These will go away once we're on v11, because we'll _only_ be installing them from the plugin:
<img width="511" alt="image" src="https://github.com/user-attachments/assets/c216272b-a014-4eb5-baea-d0ec72b6c9a8">

Colour fields with default/custom palettes, demonstrating no regressions...

Default colour palette in standard colour picker block:
<img width="304" alt="image" src="https://github.com/user-attachments/assets/77062e97-0f82-4f9b-8f47-df5ef2bdfec3">

Custom palettes and column count for Frozen/Artist/K-1 artist:
<img width="160" alt="image" src="https://github.com/user-attachments/assets/c51c9ca1-1ba5-4edf-bac3-6872b6a69166"><img width="179" alt="image" src="https://github.com/user-attachments/assets/10b9a8bd-c6fd-40f5-98e1-6421f850b997"><img width="237" alt="image" src="https://github.com/user-attachments/assets/8db96c93-c811-4e04-b13f-ab083e80fb72">


When testing v11 locally, this resolves errors related to the deleted properties. When testing this branch against staging, no regressions are found. 

## Links

https://codedotorg.atlassian.net/browse/CT-898

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
