### PR TITLE
[Codebridge] Remove file operations from readonly view

### DIFF
--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -57,44 +57,51 @@ const InnerFileBrowser = React.memo(
         {Object.values(folders)
           .filter(f => f.parentId === parentId)
           .sort((a, b) => a.name.localeCompare(b.name))
-          .map(f => (
-            <Droppable
-              data={{id: f.id}}
-              key={f.id + f.open}
-              Component="li"
-              className={classNames(moduleStyles.droppableArea, {
-                [moduleStyles.acceptingDrop]:
-                  f.id === dropData?.id && dragData?.parentId !== f.id,
-              })}
-            >
-              <Draggable
-                data={{id: f.id, type: DragType.FOLDER, parentId: f.parentId}}
+          .map(f => {
+            const MaybeDraggable = isReadOnly ? NotDraggable : Draggable;
+            return (
+              <Droppable
+                data={{id: f.id}}
+                key={f.id + f.open}
+                Component="li"
+                className={classNames(moduleStyles.droppableArea, {
+                  [moduleStyles.acceptingDrop]:
+                    f.id === dropData?.id && dragData?.parentId !== f.id,
+                })}
               >
-                <FolderRow item={f} enableMenu={!isReadOnly && !dragData?.id} />
-                {f.open && (
-                  <ul>
-                    <InnerFileBrowser
-                      folders={folders}
-                      parentId={f.id}
-                      files={files}
-                      setFileType={setFileType}
-                      appName={appName}
-                    />
-                  </ul>
-                )}
-              </Draggable>
-            </Droppable>
-          ))}
+                <MaybeDraggable
+                  data={{id: f.id, type: DragType.FOLDER, parentId: f.parentId}}
+                >
+                  <FolderRow
+                    item={f}
+                    enableMenu={!isReadOnly && !dragData?.id}
+                  />
+                  {f.open && (
+                    <ul>
+                      <InnerFileBrowser
+                        folders={folders}
+                        parentId={f.id}
+                        files={files}
+                        setFileType={setFileType}
+                        appName={appName}
+                      />
+                    </ul>
+                  )}
+                </MaybeDraggable>
+              </Droppable>
+            );
+          })}
         {Object.values(files)
           .filter(f => f.folderId === parentId && shouldShowFile(f))
           .sort((a, b) => a.name.localeCompare(b.name))
           .map(f => {
             const isDraggingLocked =
-              !isStartMode && f.type === ProjectFileType.LOCKED_STARTER;
+              isReadOnly ||
+              (!isStartMode && f.type === ProjectFileType.LOCKED_STARTER);
             const fileRowProps: FileRowProps = {
               item: f,
               hasValidationFile,
-              enableMenu: !dragData?.id || isDraggingLocked,
+              enableMenu: !isReadOnly && (!dragData?.id || isDraggingLocked),
             };
             const MaybeDraggable = isDraggingLocked ? NotDraggable : Draggable;
             return (


### PR DESCRIPTION
I noticed you could do a couple things in readonly mode in codebridge still:
- open the dropdown for an individual file and rename/delete/move a file
- drag and drop files and folders
These changes would not persist to the actual project because we don't save in readonly mode, but it is confusing to have them there given the rest of the view is readonly. This PR removes these options for readonly mode.

This PR is best viewed with whitespace hidden.

## Links

- jira ticket: [CT-902](https://codedotorg.atlassian.net/browse/CT-902)


## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
