### PR TITLE
HoC 2024 - Remove Lil Nas X from code.org/dance and add Beyoncé

### DIFF
--- a/pegasus/sites.v3/code.org/public/images/dance-hoc/dance-party-artist-beyonce.png
+++ b/pegasus/sites.v3/code.org/public/images/dance-hoc/dance-party-artist-beyonce.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ae93c502e7e98c5dc28447fa953fd1699da9efbddd1d1ab3c7aedc7c6864349
+size 71738

--- a/pegasus/sites.v3/code.org/views/dance/dance_party_featured_artists.haml
+++ b/pegasus/sites.v3/code.org/views/dance/dance_party_featured_artists.haml
@@ -1,8 +1,8 @@
 - artist_index = 6
 
-- artist_photo = ["/images/dance-hoc/dance-party-artist-miley-cyrus.png", "/images/dance-hoc/dance-party-artist-bts.png", "/images/dance-hoc/dance-party-artist-lil-nas-x.png", "/images/dance-hoc/dance-party-artist-harry-styles.png", "/images/dance-hoc/dance-party-artist-nicki-minaj.png", "/images/dance-hoc/dance-party-artist-rosalia.png"]
+- artist_photo = ["/images/dance-hoc/dance-party-artist-beyonce.png", "/images/dance-hoc/dance-party-artist-miley-cyrus.png", "/images/dance-hoc/dance-party-artist-bts.png", "/images/dance-hoc/dance-party-artist-harry-styles.png", "/images/dance-hoc/dance-party-artist-nicki-minaj.png", "/images/dance-hoc/dance-party-artist-rosalia.png"]
 
-- artist_alt_text = ["Miley Cyrus", "BTS", "Lil Nas X", "Harry Styles", "Nicki Minaj", "Rosalia"]
+- artist_alt_text = ["Beyoncé", "Miley Cyrus", "BTS", "Harry Styles", "Nicki Minaj", "Rosalia"]
 
 %ul.featured-artists.clear-styles.flex-container.justify-space-between.wrap
   - artist_index.times do |index|
@@ -10,7 +10,7 @@
       %img{src: artist_photo[index], alt: artist_alt_text[index]}
 
 %p.heading-sm
-  Miley Cyrus, BTS, Lil Nas X, Harry Styles, Nicki Minaj, Rosalía
+  Beyoncé, Miley Cyrus, BTS, Harry Styles, Nicki Minaj, Rosalía
   %a{href: "#artist-list"}
     %span.and-more
       =hoc_s(:dance_and_more)


### PR DESCRIPTION
Removes Lil Nas X from https://code.org/dance and adds Beyoncé.

## Links
Jira ticket: [ACQ-2688](https://codedotorg.atlassian.net/browse/ACQ-2688)
Slack convo: [here](https://codedotorg.slack.com/archives/C05DMS18MEX/p1731427059958449?thread_ts=1730837473.667409&cid=C05DMS18MEX)

----

## Before

<img width="1187" alt="Before" src="https://github.com/user-attachments/assets/6fb26f1b-7241-4d8b-90e3-b9d10107b166">

## After

<img width="1187" alt="After" src="https://github.com/user-attachments/assets/d3dea278-a611-46e3-9d25-b0fdd3048345">
