### PR TITLE
Adding more logging and isolating failures between different student/script ID execution

### DIFF
--- a/bin/oneoff/reset_student_progress_in_bulk/delete_user_progress_by_unit.rb
+++ b/bin/oneoff/reset_student_progress_in_bulk/delete_user_progress_by_unit.rb
@@ -61,9 +61,13 @@ rows.each do |row|
   raise "missing script_id for row #{row}" unless script_id
   if follower_ids.include?(student_id)
     if do_dry_run
-      puts "can remove student data with id " + student_id.to_s
+      puts "Can remove student data with id " + student_id.to_s + " for unit with ID " + script_id.to_s
     else
-      User.delete_progress_for_unit(user_id: student_id, script_id: script_id)
+      begin
+        User.delete_progress_for_unit(user_id: student_id, script_id: script_id)
+      rescue
+        puts "Error deleting progress for student " + student_id.to_s + " for unit with ID " + script_id.to_s
+      end
     end
   else
     puts "Student with id " + student_id.to_s + " is not in teacher " + teacher_id.to_s +


### PR DESCRIPTION
Minor updates to the progress deletion script

1. Include the unit ID along with student ID to make it easier to follow dry run in cases where the script is used to delete progress across multiple units
2. Handle exceptions when resetting progress fails for a subset of input, so that doesn't block overall execution.

## Links

Following up after executing Zendesk https://codedotorg.atlassian.net/browse/TEACH-1444

## Testing story

Manually validated
- Dry run scenario
- Failure in actual execution doesn't fully fail the script

## Deployment strategy

DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
