### PR TITLE
Adding a few new values for curriculum umbrella, content area and topic tags.

### DIFF
--- a/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -136,7 +136,7 @@ describe('UnitEditor', () => {
       renderDefault({initialTopicTags: ['music_lab', 'ai']});
       // eslint-disable-next-line no-restricted-properties
       const topicTags = screen.getByTestId('chips-unit-editor-topic-tags');
-      expect(within(topicTags).getAllByRole('checkbox').length).to.equal(3);
+      expect(within(topicTags).getAllByRole('checkbox').length).to.equal(5);
 
       expect(within(topicTags).getByLabelText('Music lab').checked).to.equal(
         true
@@ -153,7 +153,7 @@ describe('UnitEditor', () => {
       renderDefault({initialTopicTags: ['music_lab', 'ai']});
       // eslint-disable-next-line no-restricted-properties
       const topicTags = screen.getByTestId('chips-unit-editor-topic-tags');
-      expect(within(topicTags).getAllByRole('checkbox').length).to.equal(3);
+      expect(within(topicTags).getAllByRole('checkbox').length).to.equal(5);
 
       expect(within(topicTags).getByLabelText('Maker').checked).to.equal(false);
 
@@ -167,7 +167,7 @@ describe('UnitEditor', () => {
       renderDefault({initialContentArea: 'self_paced_pl_k_5'});
 
       const contentArea = screen.getByLabelText('Content Area');
-      expect(within(contentArea).getAllByRole('option').length).to.equal(11);
+      expect(within(contentArea).getAllByRole('option').length).to.equal(12);
       expect(
         within(contentArea).getByText('K-5 self-paced PL').selected
       ).to.equal(true);
@@ -224,8 +224,8 @@ describe('UnitEditor', () => {
       });
 
       // To update based on the list of topic tags
-      expect(wrapper.find('input').length).to.equal(27);
-      expect(wrapper.find('input[type="checkbox"]').length).to.equal(14);
+      expect(wrapper.find('input').length).to.equal(29);
+      expect(wrapper.find('input[type="checkbox"]').length).to.equal(16);
       expect(wrapper.find('textarea').length).to.equal(4);
       expect(wrapper.find('select').length).to.equal(6);
       expect(wrapper.find('CollapsibleEditorSection').length).to.equal(11);

--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -77,7 +77,6 @@ module Curriculum
         pedagogy_special_topics_selfpaced_pl: 'Pedagogy special topics selfpaced pl',
         cs_basics_selfpaced_pl: 'CS Basics selfpaced pl',
         pd_for_facilitators: 'PD for Facilitators',
-        pl_workshop_activities: 'PL Workshop activities',
         other: 'Other'
       }
     ).freeze

--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -75,7 +75,9 @@ module Curriculum
         special_topics_curriculum_selfpaced_pl_6_8: '6-8 Special topics curriculum selfpaced pl',
         special_topics_curriculum_selfpaced_pl_9_12: '9-12 Special topics curriculum selfpaced pl',
         pedagogy_special_topics_selfpaced_pl: 'Pedagogy special topics selfpaced pl',
-        cs_basics_selfpaced_pl: 'CS Basics selfpaced pl'
+        cs_basics_selfpaced_pl: 'CS Basics selfpaced pl',
+        pd_for_facilitators: 'PD for Facilitators',
+        pl_workshop_activities: 'PL Workshop activities'
       }
     ).freeze
 
@@ -84,7 +86,9 @@ module Curriculum
       {
         ai: 'AI',
         maker: 'Maker',
-        music_lab: 'Music lab'
+        music_lab: 'Music lab',
+        survey: 'Survey',
+        data_science: 'Data Science'
       }
     ).freeze
 
@@ -100,6 +104,7 @@ module Curriculum
         self_paced_pl_6_8: '6-8 self-paced PL',
         self_paced_pl_9_12: '9-12 self-paced PL',
         skills_focused_self_paced_pl: 'Skills-focused self-paced PL',
+        pd_for_facilitators: 'PD for Facilitators',
         other: 'Other'
       }
     ).freeze

--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -77,7 +77,8 @@ module Curriculum
         pedagogy_special_topics_selfpaced_pl: 'Pedagogy special topics selfpaced pl',
         cs_basics_selfpaced_pl: 'CS Basics selfpaced pl',
         pd_for_facilitators: 'PD for Facilitators',
-        pl_workshop_activities: 'PL Workshop activities'
+        pl_workshop_activities: 'PL Workshop activities',
+        other: 'Other'
       }
     ).freeze
 


### PR DESCRIPTION
Adding a few new values to the allow list for the three fields used to categorize curriculum.

## Testing story

Manual through local deployment and unit tests

## Deployment strategy

Regular DTP

## Follow-up work

Once there are in production, will run the backfill script which will utilize some values from the new list

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
