### PR TITLE
ProjectManager: include error message if save failed

### DIFF
--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -364,7 +364,13 @@ export default class ProjectManager {
           forceNewVersion
         );
       } catch (error) {
-        this.onSaveFail('Error saving sources', error as Error);
+        let errorToReport: Error;
+        if (error instanceof Error) {
+          errorToReport = error as Error;
+        } else {
+          errorToReport = new Error('Unknown error occurred');
+        }
+        this.onSaveFail('Error saving sources', errorToReport);
         return;
       }
       this.lastSource = JSON.stringify(this.sourcesToSave);
@@ -425,8 +431,10 @@ export default class ProjectManager {
       this.metricsReporter.logWarning(`${error.message}. Reloading page.`);
       reload();
     } else {
-      // Otherwise, we log the error.
-      this.metricsReporter.logError(errorMessage, error);
+      // Otherwise, we log the error, including the message as details.
+      this.metricsReporter.logError(errorMessage, error, {
+        message: error.message,
+      });
     }
   }
 


### PR DESCRIPTION
Python Lab had a case of a user hitting a save error over and over, but we couldn't diagnose further because all we had was a minified stack trace. This updates the "error saving sources" error to also pass on the error message, to hopefully give us more insight if this happens again. To be safe, I also added a check that the error we are catching is actually of type `Error`, and create an `unknown` error otherwise.

## Links

- jira ticket: [CT-903](https://codedotorg.atlassian.net/browse/CT-903)

## Testing story
Tested locally. When I manually threw an error from `sourcestore.save` locally I see a minified stack trace, and with this change I can at least also see a message passed through.

## Follow-up work
I will be keeping an eye on the [Python Lab dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/PythonLab?start=PT72H&end=null) to see if the same issue happens again.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
