### PR TITLE
Add Panels analytics for HOC 2024

### DIFF
--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -3,20 +3,62 @@
 // This is a React client for a panels level.  Note that this is
 // only used for levels that use Lab2.
 
-import React, {useCallback} from 'react';
+import {
+  Identify,
+  identify,
+  setSessionId,
+  track,
+} from '@amplitude/analytics-browser';
+import React, {useCallback, useEffect, useRef} from 'react';
 
 import continueOrFinishLesson from '@cdo/apps/lab2/progress/continueOrFinishLesson';
 import {useDialogControl, DialogType} from '@cdo/apps/lab2/views/dialogs';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import {sendSuccessReport} from '../code-studio/progressRedux';
+import {getCurrentLevel} from '../code-studio/progressReduxSelectors';
 import {queryParams} from '../code-studio/utils';
+import useLifecycleNotifier from '../lab2/hooks/useLifecycleNotifier';
+import {LifecycleEvent} from '../lab2/utils';
+import MusicAnalyticsReporter from '../music/analytics/AnalyticsReporter';
 import useWindowSize from '../util/hooks/useWindowSize';
 
 import PanelsView from './PanelsView';
 import {PanelsLevelProperties} from './types';
 
 const appName = 'panels';
+
+// Temporary solution for sending analytics for Hour of Code 2024.
+// TODO: Remove/consolidate reporters after HOC 2024.
+const HOC_2024_SCRIPT_NAME = 'music-jam-2024';
+const resetAnalyticsSession = () => {
+  if (!window.location.pathname.includes(HOC_2024_SCRIPT_NAME)) {
+    return;
+  }
+
+  setSessionId(Date.now());
+};
+const sendAnalyticsEvent = async (event: string, data?: object) => {
+  // Checking the script name to keep this scoped to HOC 2024 only.
+  if (!window.location.pathname.includes(HOC_2024_SCRIPT_NAME)) {
+    return;
+  }
+
+  // We use the Music Analytics reporter so that analytics for the
+  // HOC progression are reported to the same project, and to avoid
+  // API key issues.
+  await MusicAnalyticsReporter.initialize();
+  track(event, data);
+};
+const updateAnalyticsProperty = (key: string, value: string) => {
+  if (!window.location.pathname.includes(HOC_2024_SCRIPT_NAME)) {
+    return;
+  }
+
+  const identifyEvent = new Identify();
+  identifyEvent.set(key, value);
+  identify(identifyEvent);
+};
 
 const PanelsLabView: React.FunctionComponent = () => {
   const dispatch = useAppDispatch();
@@ -63,6 +105,55 @@ const PanelsLabView: React.FunctionComponent = () => {
     }
   }, [dialogControl, skipUrl]);
 
+  const startTime = useRef<number | null>(null);
+  useEffect(() => {
+    resetAnalyticsSession();
+    sendAnalyticsEvent('Panels Level Started');
+    startTime.current = Date.now();
+  }, [panels]);
+
+  useLifecycleNotifier(LifecycleEvent.LevelChangeRequested, () => {
+    if (startTime.current) {
+      sendAnalyticsEvent('Panels Level Completed', {
+        timeSpentSeconds: (Date.now() - startTime.current) / 1000,
+      });
+      startTime.current = null;
+    }
+  });
+
+  const onChangePanel = (
+    source: 'button' | 'bubble',
+    currentPanel: number,
+    nextPanel: number,
+    timeSpentOnPanelSeconds: number
+  ) => {
+    sendAnalyticsEvent(
+      source === 'button'
+        ? 'Panels Next Button Clicked'
+        : 'Panels Bubble Clicked',
+      {
+        currentPanel,
+        nextPanel,
+        timeSpentOnPanelSeconds,
+      }
+    );
+  };
+
+  const onClickContinue = (
+    currentPanel: number,
+    timeSpentOnPanelSeconds: number
+  ) => {
+    sendAnalyticsEvent('Panels Continue Button Clicked', {
+      currentPanel,
+      timeSpentOnPanelSeconds,
+    });
+  };
+
+  const levelPath = useAppSelector(state => getCurrentLevel(state)?.path);
+  useEffect(() => {
+    updateAnalyticsProperty('levelPath', levelPath);
+  }, [levelPath]);
+
   const [windowWidth, windowHeight] = useWindowSize();
 
   if (!panels || currentAppName !== appName) {
@@ -78,6 +169,8 @@ const PanelsLabView: React.FunctionComponent = () => {
       targetHeight={windowHeight}
       offerBrowserTts={offerBrowserTts}
       levelId={currentLevelId}
+      onChangePanel={onChangePanel}
+      onClickContinue={onClickContinue}
     />
   );
 };


### PR DESCRIPTION
Add Amplitude analytics events to Panels levels, specifically for the Hour of Code 2024 progression. This is meant to be a very temporary, HOC-specific implementation just so we have analytics for Panels level in the HOC progression (for internal analytics and external partners). Here is the list of new events with data if present:

- "Panels Level Started"
  - <img width="1064" alt="Screenshot 2024-11-12 at 6 58 30 PM" src="https://github.com/user-attachments/assets/6a3ab8c3-5ce1-4f63-9614-d352f18356f3">

- "Panels Next Button Clicked"
  - `currentPanel`: index of the current panel (0-based)
  - `nextPanel`: index of the panel the user is going to
  - `timeSpentOnPanelSeconds`: seconds spent on the current panel before clicking next
  - <img width="1052" alt="Screenshot 2024-11-12 at 6 59 45 PM" src="https://github.com/user-attachments/assets/14023153-2061-41ad-b0f6-f373ce91c66d">

- "Panels Bubble Clicked"
  - same fields as above
  - <img width="1053" alt="Screenshot 2024-11-12 at 6 58 39 PM" src="https://github.com/user-attachments/assets/94da65f4-b824-4be7-a1bc-6c96560ca78a">

- "Panels Continue Button Clicked" (last button - continues to next level)
  - `currentPanel`: index of the current panel (last panel)
  - `timeSpentOnPanelSeconds`: same as above
  - <img width="1053" alt="Screenshot 2024-11-12 at 6 58 53 PM" src="https://github.com/user-attachments/assets/7ba6836e-94f1-4693-a994-b7cb3aeea034">

- "Panels Level Completed"
  - `timeSpentSeconds`: total time in seconds spent on the ENTIRE panels level (through all panels)
  - <img width="1064" alt="Screenshot 2024-11-12 at 6 59 01 PM" src="https://github.com/user-attachments/assets/446fc5b9-c200-423d-a78b-9ed9f85efa70">

#### Engineering Background

The reason this is implemented in this very scoped/hardcoded manner is because we currently have two pathways to report analytics to Amplitude: 1) The Music Lab AnalyticsReporter which reports to a "Music Lab"-specific project in Amplitude (that was implemented before the team fully onboarded onto Amplitude) and 2) a generic AnalyticsReporter that reports to a "Code.org - Development/Staging/Production"-specific project (depending on environment). When the Amplitude client is initialized, it'll use whatever API key it was last initialized with to determine which project to write to. I initially tried to use the generic AnalyticsReporter for Panels levels since they're not Music Lab-specific, but found that after loading a Music Lab level, events started getting forwarded to the Music Lab project since the API key was updated in the Music Lab level. I also noticed in a few instances where Music Lab events would get forwarded to the non-Music Lab project due to race conditions between API key initializations - this felt especially dangerous with Music Lab marketing launch so close, and I wanted to de-risk losing any Music Lab data.

After consulting with @breville, we decided to make this a very intentionally scoped and one-off solution for Music Lab where we would report to the Music Lab project but only if the current URL contains the HOC 2024 tutorial name. That way all events get forwarded to one project, and we don't have any risk of API keys overwriting each other, but we also don't send any analytics for other Panels levels in other scripts. As part of post-HOC tech debt cleanup, we will definitely revisit this and remove in favor of a more consolidated reporting approach.

## Links

https://codedotorg.atlassian.net/browse/LABS-1219

## Testing story

Tested locally with Amplitude.