### PR TITLE
Lab2: fix standalone video fallback

### DIFF
--- a/apps/src/standaloneVideo/Video.tsx
+++ b/apps/src/standaloneVideo/Video.tsx
@@ -74,10 +74,14 @@ const Video: React.FunctionComponent<VideoProps> = ({
   const [videoChoice, setVideoChoice] = useState<VideoChoiceType>(undefined);
 
   useEffect(() => {
-    testYouTubeAvailable(available =>
-      setVideoChoice(available ? 'youtube' : 'fallback')
-    );
-  }, [setVideoChoice]);
+    if (src) {
+      const noCookie = src.includes('youtube-nocookie.com');
+
+      testYouTubeAvailable(noCookie, available =>
+        setVideoChoice(available ? 'youtube' : 'fallback')
+      );
+    }
+  }, [src]);
 
   const videoJsOptions = {
     autoplay: true,

--- a/apps/src/standaloneVideo/testYouTubeAvailable.ts
+++ b/apps/src/standaloneVideo/testYouTubeAvailable.ts
@@ -2,10 +2,11 @@ import testImageAccess from '@cdo/apps/code-studio/url_test';
 import youTubeAvailabilityEndpointURL from '@cdo/apps/code-studio/youTubeAvailabilityEndpointURL';
 
 export default function testYouTubeAvailable(
+  noCookie: boolean,
   callback: (result: boolean) => void
 ) {
   testImageAccess(
-    youTubeAvailabilityEndpointURL(false) + '?' + Math.random(),
+    youTubeAvailabilityEndpointURL(noCookie) + '?' + Math.random(),
     // Called when YouTube availability check succeeds.
     () => callback(true),
     // Called when YouTube availability check fails.


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/60903.  This fixes two issues preventing the fallback video player in Lab2 levels from starting properly:

- we weren't checking availability of `youtube-nocookie.com` when the video would come from there.
- we weren't waiting until we had a video URL before starting the availability check, which could lead to competing checks running.
