### PR TITLE
[Google Blockly] quick fixes - v11 prep

### DIFF
--- a/apps/src/blockly/addons/cdoBlockFlyout.ts
+++ b/apps/src/blockly/addons/cdoBlockFlyout.ts
@@ -210,8 +210,7 @@ export default class CdoBlockFlyout extends GoogleBlockly.HorizontalFlyout {
    *     area.
    * @override
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  wouldDelete(_element: GoogleBlockly.IDraggable, _couldConnect: boolean) {
+  wouldDelete(_element: GoogleBlockly.IDraggable) {
     return false;
   }
 

--- a/apps/src/blockly/addons/cdoGesture.js
+++ b/apps/src/blockly/addons/cdoGesture.js
@@ -37,6 +37,7 @@ export function overrideHandleTouchMove(blocklyWrapper) {
     // If the gesture already went through a bubble, don't set the start block.
     if (!this.startBlock && !this.startBubble) {
       this.startBlock = block;
+      Blockly.common.setSelected(this.startBlock);
 
       // Begin Customization
       // Set up duplication of shadow argument_reporter blocks.

--- a/apps/src/blockly/addons/cdoTrashcan.ts
+++ b/apps/src/blockly/addons/cdoTrashcan.ts
@@ -351,7 +351,10 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
    *   dragged.
    */
   onDragEnter(_dragElement: GoogleBlockly.IDraggable) {
-    this.setLidOpen(_dragElement.isDeletable());
+    // BlockSvgs and Bubbles are both draggable elements, but we only care about blocks.
+    if (_dragElement instanceof GoogleBlockly.BlockSvg) {
+      this.setLidOpen(_dragElement.isDeletable());
+    }
   }
 
   /**


### PR DESCRIPTION
This is one of several tasks that should help to unblock the Blockly v11 bump. A draft of this project is collected here:
- https://github.com/code-dot-org/code-dot-org/pull/62301/commits

A couple quick fixes that will be required for v11 but are safe to do now:

1. Remove unused `_couldConnect` parameter from `wouldDelete` (https://github.com/google/blockly/pull/7968)
This parameter has been removed in v11. We weren't using this parameter in our override any way.

2. Change gesture override to select block when dragging (https://github.com/google/blockly/pull/7991)
We have a monkey patch for this class in order to fix a multi-touch drag bug and to support advanced parameters in Music Lab. This just brings the affected method up to date so that it won't break with v11.

3. Check that elements are blocks before determining whether they can be deleted.
v11 has better type assertions so `isDeleteable()` isn't always present on an `IDraggable` element. `BlockSvg` is an extension of `IDraggable`.

This prevents 3 breaking changes for v11 which will make the actual bump a smaller difference.
When testing v11 locally, this resolves errors related to the deleted properties. When testing this branch against staging, no regressions are found. 

## Links

https://codedotorg.atlassian.net/browse/CT-898

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
