### PR TITLE
Nav - fix redirect for manage students

### DIFF
--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -234,6 +234,16 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
               />
             }
           />
+          {/* /manage_students is the legacy url for /roster. Redirect to /roster so that old bookmarks continue to work */}
+          <Route
+            path={'manage_students'}
+            element={
+              <Navigate
+                to={'../' + TEACHER_NAVIGATION_PATHS.roster}
+                replace={true}
+              />
+            }
+          />
           {showAITutorTab && (
             <Route
               path={TEACHER_NAVIGATION_PATHS.aiTutorChatMessages}
@@ -249,16 +259,6 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
             />
           )}
         </Route>
-        {/* /manage_students is the legacy url for /roster. Redirect to /roster so that old bookmarks continue to work */}
-        <Route
-          path={'manage_students'}
-          element={
-            <Navigate
-              to={'../' + TEACHER_NAVIGATION_PATHS.roster}
-              replace={true}
-            />
-          }
-        />
       </Route>
     ),
     [


### PR DESCRIPTION
Redirects manage_students to go to roster.

https://github.com/user-attachments/assets/94e068e7-cc6e-4f37-8510-094e87f0d7f0




## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1454)

Note: I found the redirect from the teacher dashboard to work fine. 

## Testing story

Tested locally - see video