### PR TITLE
Music: prevent multiple concurrent library loads

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -160,6 +160,8 @@ class UnconnectedMusicView extends React.Component {
       hasLoadedInitialSounds: false,
     };
 
+    this.isLevelLoadInProgress = false;
+
     MusicBlocklyWorkspace.setupBlocklyEnvironment(this.props.blockMode);
   }
 
@@ -230,6 +232,12 @@ class UnconnectedMusicView extends React.Component {
   }
 
   async onLevelLoad(levelData, initialSources) {
+    if (this.isLevelLoadInProgress) {
+      // Don't attempt to setup the level if a load is already in progress.
+      return;
+    }
+    this.isLevelLoadInProgress = true;
+
     // Stop playback if needed.
     this.stopSong();
 
@@ -339,6 +347,7 @@ class UnconnectedMusicView extends React.Component {
       AppConfig.getValue('show-ai-generate-again-help') === 'true';
 
     this.props.setStartingPlayheadPosition(1);
+    this.isLevelLoadInProgress = false;
   }
 
   // Load the library and initialize the music player, if not already loaded.


### PR DESCRIPTION
We noticed a late-breaking bug where certain levels in the Music Lab HOC progression that used licensed songs were having their samples played back at the wrong BPM and key. The root cause here was that as an unintentional side effect of https://github.com/code-dot-org/code-dot-org/pull/62250, we were loading the music library twice when first mounting (once on `componentDidMount` and again after the lifecycle event fired). As a result, the BPM and key got reset to the defaults (120/C) after the second load completed but didn't change back to the pack-specific values since the pack ID had already been updated by the first load. The fix here is just to add a flag to prevent multiple loads, which should handle the immediate problem cases for HOC. 

Longer term though - I do think this is a symptom of a larger issue which we've seen for some time, which is that the Lab2 data updating and lifecycle is somewhat inconsistent. Labs don't have a strict guarantee of when pieces of data will arrive or in what state of the lifecycle they're in when specific updates occur. We tried to mitigate this somewhat with the LifecycleListener and corresponding hooks, but I do think it's worth a more wholesale look at simplifying and streamlining the data updating and mounting lifecycle post HOC (I have some ideas here 🙂)

## Testing story

Tested this on the full HOC progression, and tried refreshing each page for a fresh library load. Also verified standalone projects and share view.