### PR TITLE
Remove Student experience filter from /learn

### DIFF
--- a/apps/src/tutorialExplorer/filterHeader.jsx
+++ b/apps/src/tutorialExplorer/filterHeader.jsx
@@ -42,13 +42,9 @@ export default class FilterHeader extends React.Component {
     // There are two filters which can appear in this header at desktop width.
     // Check explicitly for each.
     let filterGroupGrade = null;
-    let filterGroupHeaderStudentExperience = null;
     if (!this.props.mobileLayout) {
       filterGroupGrade = this.props.filterGroups.find(
         item => item.name === 'grade'
-      );
-      filterGroupHeaderStudentExperience = this.props.filterGroups.find(
-        item => item.name === 'student_experience'
       );
     }
 
@@ -73,16 +69,6 @@ export default class FilterHeader extends React.Component {
                       containerStyle={styles.filterGroupGradeContainer}
                       filterGroup={filterGroupGrade}
                       selection={this.props.selection['grade']}
-                      onUserInput={this.props.onUserInputFilter}
-                    />
-                  )}
-                  {filterGroupHeaderStudentExperience && (
-                    <FilterGroupHeaderSelection
-                      containerStyle={
-                        styles.filterGroupStudentExperienceContainer
-                      }
-                      filterGroup={filterGroupHeaderStudentExperience}
-                      selection={this.props.selection['student_experience']}
                       onUserInput={this.props.onUserInputFilter}
                     />
                   )}

--- a/apps/src/tutorialExplorer/tutorialExplorer.js
+++ b/apps/src/tutorialExplorer/tutorialExplorer.js
@@ -659,16 +659,6 @@ function getFilters({mobile}) {
       ],
     },
     {
-      name: 'student_experience',
-      text: i18n.filterStudentExperience(),
-      headerOnDesktop: true,
-      singleEntry: true,
-      entries: [
-        {name: 'beginner', text: i18n.filterStudentExperienceBeginner()},
-        {name: 'comfortable', text: i18n.filterStudentExperienceComfortable()},
-      ],
-    },
-    {
       name: 'platform',
       text: i18n.filterPlatform(),
       entries: [
@@ -742,7 +732,6 @@ function getFilters({mobile}) {
   ];
 
   const initialFilters = {
-    student_experience: ['beginner'],
     grade: ['all'],
   };
 


### PR DESCRIPTION
Removes the "Student experience" filter as there is only 1 (soon 2) comfortable tutorials.

https://github.com/user-attachments/assets/4729038b-37d2-4c67-8232-bd61cd531a82

"Advanced Scratch Coding" is the only "Comfortable" tutorial currently listed on /learn, so I simply checked for that as a test.

The filter is also gone in mobile:


https://github.com/user-attachments/assets/fd8a5db4-0c31-4d64-9c19-6263d2bd99f6

Jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2695




