### PR TITLE
Panels Analytics: handle missing key error

### DIFF
--- a/apps/src/panels/PanelsLabView.tsx
+++ b/apps/src/panels/PanelsLabView.tsx
@@ -47,8 +47,13 @@ const sendAnalyticsEvent = async (event: string, data?: object) => {
   // We use the Music Analytics reporter so that analytics for the
   // HOC progression are reported to the same project, and to avoid
   // API key issues.
-  await MusicAnalyticsReporter.initialize();
-  track(event, data);
+  try {
+    await MusicAnalyticsReporter.initialize();
+    track(event, data);
+  } catch (error) {
+    // Expected on local environments.
+    console.warn(error);
+  }
 };
 const updateAnalyticsProperty = (key: string, value: string) => {
   if (!window.location.pathname.includes(HOC_2024_SCRIPT_NAME)) {


### PR DESCRIPTION
Catch and handle the missing Amplitude analytics key error as it's expected on environments where the key isn't defined (i.e. localhost). This is already handled on Music levels but was not handled on Panels levels when we recently added analytics reporting.