### PR TITLE
Another async fix for school info ui test

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -49,6 +49,7 @@ Scenario: School Info Confirmation Dialog
   And element ".modal-body" is visible
   Then I press "#update-button" using jQuery
   And element ".modal" is visible
-  Then I wait to see a modal containing text "United States"
+  Then element "#uitest-country-dropdown" has value "US"
   Then element "#uitest-school-zip" has value "31513"
-  Then I wait until element "#uitest-school-dropdown" contains text "Appling County High School"
+  # value is school_id for "Appling County High School"
+  Then element "#uitest-school-dropdown" has value "130006000010"

--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -51,4 +51,4 @@ Scenario: School Info Confirmation Dialog
   And element ".modal" is visible
   Then I wait to see a modal containing text "United States"
   Then element "#uitest-school-zip" has value "31513"
-  Then I wait to see a modal containing text "Appling County High School"
+  Then I wait until element "#uitest-school-dropdown" contains text "Appling County High School"


### PR DESCRIPTION
things were going so well... until this..
![Screenshot 2024-11-13 at 2 17 12 PM](https://github.com/user-attachments/assets/ad6cc84e-427f-4901-befe-2d03b622eacc)

the failed run on chrome indicated that the school name text was not visible in the modal, but the video showed the text eventually loaded 🤔 

the 'wait to see modal containing text' step is a little deceptive. the 'wait' is on the modal to appear, whereas we expected it to wait for the text to appear. instead of waiting for the zip code api request, we can check the input's value, which is fetched prior to the modal appearing. this test is intended to check the user's saved value, and not the zip code search, which is already tested in a previous step

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[jira](https://codedotorg.atlassian.net/browse/ACQ-2535)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
