### PR TITLE
Ensures test honeybadger notifications are flushed.

### DIFF
--- a/dashboard/test/integration/honeybadger_test.rb
+++ b/dashboard/test/integration/honeybadger_test.rb
@@ -39,6 +39,9 @@ class HoneybadgerTest < ActionDispatch::IntegrationTest
 
     get raise_error_path
 
+    # Ensure that the notifications hit the backend queue
+    Honeybadger.flush
+
     # Other tests running in parallel might have logged notices too, but we're only interested in notices about our test controller
     notice = Honeybadger::Backend::Test.notifications[:notices].find {|n| n.controller == "honeybadger_error"}
     refute_nil notice


### PR DESCRIPTION
Fixes a flaky integration test that checks the Honeybadger error log and notifications to ensure it filters sensitive data.

It was flaky because the Honeybadger backend simulates a buffering of notifications and one has to flush according to the API documentation: https://docs.honeybadger.io/lib/ruby/getting-started/tests-and-honeybadger/

## Links

Reported via [Slack](https://codedotorg.slack.com/archives/CFTFD6BPV/p1731528657997429).

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
