### PR TITLE
Adds a wait_until to pause an eyes test snapshot until fonts are loaded.

### DIFF
--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -15,13 +15,6 @@ When(/^I open my eyes to test "([^"]*)"$/) do |test_name|
   next if CDO.disable_all_eyes_running
   ensure_eyes_available
 
-  # Wait until the fonts are fully loaded and rendering the page
-  # Hopefully fixes many of the issues with font wiggle due to lazily loading
-  # alternative fonts for symbols and localized glyphs.
-  wait_until do
-    @browser.execute_script('return !!(await document.fonts.ready)') == true
-  end
-
   batch = Applitools::BatchInfo.new(ENV.fetch('BATCH_NAME', nil))
   batch.id = ENV.fetch('BATCH_ID', nil)
   @eyes.batch = batch
@@ -56,6 +49,13 @@ end
 # A Feature can optionally specify the stitch mode ('css' or 'scroll') for Eyes to create the full screenshot.
 And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?$/) do |identifier, stitch_mode|
   next if CDO.disable_all_eyes_running
+
+  # Wait until the fonts are fully loaded and rendering the page
+  # Hopefully fixes many of the issues with font wiggle due to lazily loading
+  # alternative fonts for symbols and localized glyphs.
+  wait_until do
+    @browser.execute_script('return !!(await document.fonts.ready)') == true
+  end
 
   if stitch_mode == "none"
     @eyes.force_full_page_screenshot = false

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -15,6 +15,13 @@ When(/^I open my eyes to test "([^"]*)"$/) do |test_name|
   next if CDO.disable_all_eyes_running
   ensure_eyes_available
 
+  # Wait until the fonts are fully loaded and rendering the page
+  # Hopefully fixes many of the issues with font wiggle due to lazily loading
+  # alternative fonts for symbols and localized glyphs.
+  wait_until do
+    @browser.execute_script('return !!(await document.fonts.ready)') == true
+  end
+
   batch = Applitools::BatchInfo.new(ENV.fetch('BATCH_NAME', nil))
   batch.id = ENV.fetch('BATCH_ID', nil)
   @eyes.batch = batch


### PR DESCRIPTION
Attempts to tackle flaky eyes tests that cause the issues seen below where fonts are lazily loaded and not yet rendering some symbols.

This tells the driver to wait until `document.fonts.ready` is returning `true` before creating the snapshot, which is [described here](https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/ready).

This often causes a flaky eyes result in our footer since things like the copyright symbol are rendered from alternative fonts that haven't yet had the chance to load, and our font settings are set to do a `swap` instead of render nothing:

![image](https://github.com/user-attachments/assets/8af9f276-d947-4d6e-8908-cd595d4956b4)

## Links

- jira ticket: [P20-1280](https://codedotorg.atlassian.net/browse/P20-1280)

## Testing story

This needs to run on our `test` server as only that environment can actually take screenshots and coördinate with the eyes service. I'll need to run this on the `test` server while it is idle.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
