### PR TITLE
Fix switching sections on course/unit overview page

### DIFF
--- a/apps/src/templates/courseOverview/TeacherCourseOverview.tsx
+++ b/apps/src/templates/courseOverview/TeacherCourseOverview.tsx
@@ -116,7 +116,11 @@ const TeacherCourseOverview: React.FC = () => {
   const selectedSection = useAppSelector(selectedSectionSelector);
 
   React.useEffect(() => {
-    if (!selectedSection || !selectedSection?.courseVersionName) {
+    if (
+      !selectedSection ||
+      !selectedSection?.courseVersionName ||
+      parseInt(params.sectionId || '-1') !== selectedSection.id
+    ) {
       return;
     }
     if (!selectedSection.courseId && selectedSection.unitName) {
@@ -168,6 +172,7 @@ const TeacherCourseOverview: React.FC = () => {
     setCourseSummary,
     setIsVerifiedInstructor,
     setHiddenScripts,
+    params.sectionId,
   ]);
 
   const userId = useSelector(

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -19,7 +19,10 @@ import i18n from '@cdo/locale';
 import {selectedSectionSelector} from '../teacherDashboard/teacherSectionsReduxSelectors';
 
 import {asyncLoadSelectedSection} from './selectedSectionLoader';
-import {LABELED_TEACHER_NAVIGATION_PATHS} from './TeacherNavigationPaths';
+import {
+  LABELED_TEACHER_NAVIGATION_PATHS,
+  TEACHER_NAVIGATION_PATHS,
+} from './TeacherNavigationPaths';
 
 import styles from './teacher-navigation.module.scss';
 
@@ -103,13 +106,29 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
 
   const navigateToDifferentSection = (sectionId: number) => {
     if (currentPathObject?.absoluteUrl) {
-      navigate(
-        generatePath(currentPathObject.absoluteUrl, {
-          sectionId: sectionId,
-          courseVersionName: sections[sectionId]?.courseVersionName,
-          unitName: sections[sectionId]?.unitName,
-        })
-      );
+      if (
+        currentPathObject.url === TEACHER_NAVIGATION_PATHS.courseOverview ||
+        currentPathObject.url === TEACHER_NAVIGATION_PATHS.unitOverview
+      ) {
+        const overviewUrl = sections[sectionId]?.unitName
+          ? LABELED_TEACHER_NAVIGATION_PATHS.unitOverview.absoluteUrl
+          : LABELED_TEACHER_NAVIGATION_PATHS.courseOverview.absoluteUrl;
+        navigate(
+          generatePath(overviewUrl, {
+            sectionId: sectionId,
+            courseVersionName: sections[sectionId]?.courseVersionName,
+            unitName: sections[sectionId]?.unitName,
+          })
+        );
+      } else {
+        navigate(
+          generatePath(currentPathObject.absoluteUrl, {
+            sectionId: sectionId,
+            courseVersionName: sections[sectionId]?.courseVersionName,
+            unitName: sections[sectionId]?.unitName,
+          })
+        );
+      }
 
       analyticsReporter.sendEvent(EVENTS.NAVIGATE_TO_SECTION, {
         sectionId: sectionId,


### PR DESCRIPTION
Switching sections on the unit overview page to a section that did not have a unit assigned would not redirect correctly.

This PR also switches between unit and course overview pages when switching sections.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1463