### PR TITLE
Fixes some bin/* commands that fail on production.

### DIFF
--- a/lib/cdo/rack/global_edition.rb
+++ b/lib/cdo/rack/global_edition.rb
@@ -2,6 +2,7 @@
 
 require 'request_store'
 require 'cdo/global_edition'
+require 'active_support/core_ext/string/filters'
 
 module Rack
   class GlobalEdition


### PR DESCRIPTION
Adds active_support require to allow String.remove to be used.

Found by a failing `bin/flush_cloudfront_aws` command. (Slack message [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1731536395012839?thread_ts=1731097253.855389&cid=C0T0PNTM3))

```
/.../lib/cdo/rack/global_edition.rb:17:in `<class:RouteHandler>': undefined method `remove' for "^(?<ge_prefix>\\n  /global/\\n  (?<ge_region>en|fa|root)\\n)\\n(?<main_path>/.*|$)\\n":String (NoMethodError)
	from /.../lib/cdo/rack/global_edition.rb:11:in `<class:GlobalEdition>'
	from /.../lib/cdo/rack/global_edition.rb:7:in `<module:Rack>'
	from /.../lib/cdo/rack/global_edition.rb:6:in `<top (required)>'
	from /.../lib/cdo/http_cache.rb:153:in `require'
	from /.../lib/cdo/http_cache.rb:153:in `config'
	from /.../lib/cdo/aws/cloudfront.rb:27:in `<class:CloudFront>'
	from /.../lib/cdo/aws/cloudfront.rb:10:in `<module:AWS>'
	from /.../lib/cdo/aws/cloudfront.rb:9:in `<top (required)>'
	from bin/flush_cloudfront_aws:4:in `require'
	from bin/flush_cloudfront_aws:4:in `<main>'
```

## Testing story

Tested by trying to require the rack component without anything else being loaded. It failed with this error, reproducing the error. Added the require, and the file could be loaded in.

Interestingly, the `bin/flush_cloudwatch_aws` command actually runs successfully in `development` likely due to something else loading `active_support` beforehand, unlike production.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
