### PR TITLE
Add a More info link next to the code.org initiative selector in unit edit page

### DIFF
--- a/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
@@ -34,6 +34,7 @@ import HelpTip from '@cdo/apps/sharedComponents/HelpTip';
 import MultiCheckboxSelector from '@cdo/apps/templates/MultiCheckboxSelector';
 import color from '@cdo/apps/util/color';
 import {linkWithQueryParams, navigateToHref} from '@cdo/apps/utils';
+import Link from '@cdo/apps/componentLibrary/link/Link';
 
 import {lessonGroupShape} from './shapes';
 
@@ -719,6 +720,12 @@ class UnitEditor extends React.Component {
                     blocks and there will be information about CSTA Standards.
                   </p>
                 </HelpTip>
+                <Link
+                  href="https://github.com/code-dot-org/code-dot-org/wiki/Updating-Publish-State-of-Scripts-or-Courses"
+                  openInNewTab={true}
+                >
+                  More info
+                </Link>
               </label>
               <label>
                 Content Area

--- a/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 
 import {announcementShape} from '@cdo/apps/code-studio/announcementsRedux';
 import {Chips} from '@cdo/apps/componentLibrary/chips';
+import Link from '@cdo/apps/componentLibrary/link/Link';
 import {
   InstructionType,
   PublishedState,
@@ -34,7 +35,6 @@ import HelpTip from '@cdo/apps/sharedComponents/HelpTip';
 import MultiCheckboxSelector from '@cdo/apps/templates/MultiCheckboxSelector';
 import color from '@cdo/apps/util/color';
 import {linkWithQueryParams, navigateToHref} from '@cdo/apps/utils';
-import Link from '@cdo/apps/componentLibrary/link/Link';
 
 import {lessonGroupShape} from './shapes';
 


### PR DESCRIPTION
This change is to address an ask from RED team to more easily provide details about the various new fields that are added for categorizing our curriculum. 

### Ask
Include a "More info" link (similar to the one highlighted below) to "https://github.com/code-dot-org/code-dot-org/wiki/Updating-Publish-State-of-Scripts-or-Courses" where marked in red below.
![image](https://github.com/user-attachments/assets/9b67b5ce-6441-4770-9a64-c19c1cc9570d)

### Screen shot from local
![image](https://github.com/user-attachments/assets/303e9e99-773c-4c6d-8d5d-5ee79454366c)

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1441

## Testing story

- Validated manually locally
- Drone

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
