### PR TITLE
[Google Blockly] Set ALIGN values after wrapping inputs

### DIFF
--- a/apps/src/blockly/constants.ts
+++ b/apps/src/blockly/constants.ts
@@ -204,6 +204,7 @@ export const READ_ONLY_PROPERTIES = [
   'hasCategories',
   'html',
   'Input',
+  'inputs',
   'INPUT_VALUE',
   'js',
   'MenuItem',

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -209,10 +209,6 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     blocklyInstance
   ) as BlocklyWrapperType;
 
-  blocklyWrapper.ALIGN_CENTRE = blocklyInstance.inputs.Align.CENTRE;
-  blocklyWrapper.ALIGN_LEFT = blocklyInstance.inputs.Align.LEFT;
-  blocklyWrapper.ALIGN_RIGHT = blocklyInstance.inputs.Align.RIGHT;
-
   blocklyWrapper.setInfiniteLoopTrap = function () {
     Blockly.JavaScript.INFINITE_LOOP_TRAP = INFINITE_LOOP_TRAP;
   };
@@ -409,6 +405,10 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
   SETTABLE_PROPERTIES.forEach(property =>
     blocklyWrapper.wrapSettableProperty(property)
   );
+
+  blocklyWrapper.ALIGN_CENTRE = blocklyWrapper.inputs.Align.CENTRE;
+  blocklyWrapper.ALIGN_LEFT = blocklyWrapper.inputs.Align.LEFT;
+  blocklyWrapper.ALIGN_RIGHT = blocklyWrapper.inputs.Align.RIGHT;
 
   // Allows for dynamically setting the workspace theme with workspace.setTheme()
   blocklyWrapper.themes = {


### PR DESCRIPTION
Follow up to:
- https://github.com/code-dot-org/code-dot-org/pull/62312

Once flipping to v11 in a new test branch (https://github.com/code-dot-org/code-dot-org/pull/62440), new UI failures were cropping up due to values like `Blockly.ALIGN_RIGHT` being undefined. This caused blocks to fail to be installed correctly, which resulted in unknown blocks and various null errors:

https://drone.cdn-code.org/code-dot-org/code-dot-org/19191/2/6

The solution here is to wrap the `inputs` object from the Blockly instance, and move the declaration of `Blockly.ALIGN_` values to after this has happened.

Drone passing here as well as the test branch linked above are an indicator that this works in v10 and v11. To cut down on any potential churn, I'll hold off on merging until I have confirmation that it works in both places.