### PR TITLE
Evaluate Student Learning: check if most recent message is from assistant and tweak system prompt 

### DIFF
--- a/apps/src/applab/ValidationResultsModal.tsx
+++ b/apps/src/applab/ValidationResultsModal.tsx
@@ -10,18 +10,18 @@ import Spinner from '@cdo/apps/sharedComponents/Spinner';
 
 export interface ValidationResultsModalProps {
   onClose: () => void;
-  results: string | undefined;
+  aiResponse: string | undefined;
 }
 
 const ValidationResultsModal: React.FunctionComponent<
   ValidationResultsModalProps
-> = ({onClose, results}) => {
+> = ({onClose, aiResponse}) => {
   return (
     <AccessibleDialog onClose={onClose}>
       <div>
         <Heading3>Results</Heading3>
-        {!results && <Spinner />}
-        {results && <p>{results}</p>}
+        {!aiResponse && <Spinner />}
+        {aiResponse && <p>{aiResponse}</p>}
       </div>
       <hr />
     </AccessibleDialog>


### PR DESCRIPTION
General [doc](https://docs.google.com/document/d/1GYd88TYZfvefrYoBrZqaM-67YYI1yGMxSmFKhJ3fkwE/edit?tab=t.0) tracking my thinking on ways to validate App Lab levels. 

Two small changes as we continue to prepare for more thoroughly testing this: 

- I updated the system prompt to give one sentence explaining its evaluation in all 3 outcomes (yes, no and partial) in hopes that we can get a little more insight as we consider whether this direction is viable or not 

- I updated the Results modal to only show the most recent chat message if it's from the assistant rather than the user. Previously this would cause a little glitch when the "Check my code" button was clicked multiple times because we would briefly show the user's most recent message rather than the spinner. 