### PR TITLE
Disable MySQL Binary Logging During Hour of Code

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -123,7 +123,7 @@
         # BEGIN: Static configuration settings.
         # WARNING - Changing these settings triggers restart of each database instance in the cluster during Stack Update.
 
-        binlog_format: 'ROW'
+        binlog_format: 'OFF'
         gtid-mode: 'ON'
         enforce_gtid_consistency: 'ON'
 

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -128,7 +128,7 @@
         enforce_gtid_consistency: 'ON'
 
         # Enable Enhanced Binary Logging to support Zero-ETL Integration with Redshift
-        aurora_enhanced_binlog: 1
+        aurora_enhanced_binlog: 0
         binlog_backup: 0
         binlog_replication_globaldb: 0
         binlog_row_image: full # This is actually a dynamic setting, but let's keep all these settings together.

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -123,14 +123,14 @@
         # BEGIN: Static configuration settings.
         # WARNING - Changing these settings triggers restart of each database instance in the cluster during Stack Update.
 
-        binlog_format: 'OFF'
+        binlog_format: 'OFF' # Disable binary logging during Hour of Code
         gtid-mode: 'ON'
         enforce_gtid_consistency: 'ON'
 
-        # Enable Enhanced Binary Logging to support Zero-ETL Integration with Redshift
+        # Disable Enhanced Binary Logging during Hour of Code
         aurora_enhanced_binlog: 0
-        binlog_backup: 0
-        binlog_replication_globaldb: 0
+        binlog_backup: 1
+        binlog_replication_globaldb: 1
         binlog_row_image: full # This is actually a dynamic setting, but let's keep all these settings together.
         binlog_row_metadata: full # Also dynamic.
 


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-1515

## Testing story

`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-disable-binary-logging DATABASE=yes`

## Deployment strategy

1. Merge this Pull Request. It will trigger a restart of all database instances in the cluster on each non-production environment
2. Release to production. The production database cluster ParameterGroup will be updated by the change will not take effect until the database instances are restarted.
3. Manually upgrade the database instances for Hour of Code. The restart carried out during this upgrade will apply this change.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
