### PR TITLE
Fix bug where lesson visibility toggles are always shown

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -161,9 +161,11 @@ class UnitOverviewTopRow extends React.Component {
           </div>
         </div>
         <div style={styles.rightButtons}>
-          {unitAllowsHiddenLessons && (
-            <BulkLessonVisibilityToggle lessons={unitCalendarLessons} />
-          )}
+          {!deeperLearningCourse &&
+            viewAs === ViewType.Instructor &&
+            unitAllowsHiddenLessons && (
+              <BulkLessonVisibilityToggle lessons={unitCalendarLessons} />
+            )}
           <span style={styles.detailToggle}>
             <ProgressDetailToggle toggleStudyGroup="unit-overview" />
           </span>


### PR DESCRIPTION
Fixes a bug introduced in [this](https://github.com/code-dot-org/code-dot-org/pull/62160/files) PR where the BulkLessonVisibilityToggle is suddenly shown at times where it should not be. This code was recently changed and reordered. The BulkLessonVisibilityToggle should be in a conditional like [this](https://github.com/code-dot-org/code-dot-org/pull/62160/files#diff-480d9a19fb9e118049268f7c64d1c6239c16febd51cfa50e472bd71f9fb2ad17L249-L267) statement

This PR re-adds logic to hide the BulkLessonVisibilityToggle.

This was found in a UI test [here](https://eyes.applitools.com/app/test-results/00000251670695305318/00000251670695069110/steps/1?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor)

## Links
[
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->](https://codedotorg.slack.com/archives/C0T0PNTM3/p1731609946344069)
