### PR TITLE
Add a way to toggle teacher dashboard experiments in a static link

### DIFF
--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -18,12 +18,32 @@ class TeacherDashboardController < ApplicationController
     view_options(full_width: true, no_padding_container: true)
   end
 
-  def redirect_to_newest_section
+  def redirect_to_newest_section_progress
     if current_user.sections_instructed.empty?
       redirect_to "https://support.code.org/hc/en-us/articles/25195525766669-Getting-Started-New-Progress-View"
     else
       section_id = current_user.sections_instructed.order(created_at: :desc).first.id
       redirect_to "/teacher_dashboard/sections/#{section_id}/progress?view=v2"
+    end
+  end
+
+  def enable_experiments
+    if current_user.sections_instructed.empty?
+      redirect_to "/home"
+    else
+
+      section_id = current_user.sections_instructed.order(created_at: :desc).first.id
+      redirect_to "/teacher_dashboard/sections/#{section_id}/progress?enableExperiments=teacher-local-nav-v2"
+    end
+  end
+
+  def disable_experiments
+    if current_user.sections_instructed.empty?
+      redirect_to "/home"
+    else
+
+      section_id = current_user.sections_instructed.order(created_at: :desc).first.id
+      redirect_to "/teacher_dashboard/sections/#{section_id}/progress?disableExperiments=teacher-local-nav-v2"
     end
   end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -8,7 +8,11 @@ Dashboard::Application.routes.draw do
   get "/courses", to: redirect(CDO.code_org_url("/students"))
 
   # Redirect studio.code.org/sections/teacher_dashboard/first_section_progress to most recent section
-  get '/teacher_dashboard/sections/first_section_progress', to: "teacher_dashboard#redirect_to_newest_section"
+  get '/teacher_dashboard/sections/first_section_progress', to: "teacher_dashboard#redirect_to_newest_section_progress"
+
+  # Redirect enable and disable experiments to most recent section
+  get '/teacher_dashboard/sections/enable_experiments', to: "teacher_dashboard#enable_experiments"
+  get '/teacher_dashboard/sections/disable_experiments', to: "teacher_dashboard#disable_experiments"
 
   constraints host: CDO.codeprojects_hostname do
     # Routes needed for the footer on weblab share links on codeprojects

--- a/dashboard/test/controllers/teacher_dashboard_controller_test.rb
+++ b/dashboard/test/controllers/teacher_dashboard_controller_test.rb
@@ -62,7 +62,7 @@ class TeacherDashboardControllerTest < ActionController::TestCase
     other_teacher = create(:teacher)
     sign_in other_teacher
 
-    get :redirect_to_newest_section
+    get :redirect_to_newest_section_progress
 
     assert_redirected_to 'https://support.code.org/hc/en-us/articles/25195525766669-Getting-Started-New-Progress-View'
   end
@@ -72,8 +72,46 @@ class TeacherDashboardControllerTest < ActionController::TestCase
 
     section = create :section, user: @section_owner, created_at: 2.days.from_now
 
-    get :redirect_to_newest_section
+    get :redirect_to_newest_section_progress
 
     assert_redirected_to "/teacher_dashboard/sections/#{section.id}/progress?view=v2"
+  end
+
+  test 'enable_experiments: redirects to home if no sections' do
+    other_teacher = create(:teacher)
+    sign_in other_teacher
+
+    get :enable_experiments
+
+    assert_redirected_to '/home'
+  end
+
+  test 'enable_experiments: redirects to newest section with flags' do
+    sign_in @section_owner
+
+    section = create :section, user: @section_owner, created_at: 2.days.from_now
+
+    get :enable_experiments
+
+    assert_redirected_to "/teacher_dashboard/sections/#{section.id}/progress?enableExperiments=teacher-local-nav-v2"
+  end
+
+  test 'disable_experiments: redirects to home if no sections' do
+    other_teacher = create(:teacher)
+    sign_in other_teacher
+
+    get :disable_experiments
+
+    assert_redirected_to '/home'
+  end
+
+  test 'disable_experiments: redirects to newest section with flags' do
+    sign_in @section_owner
+
+    section = create :section, user: @section_owner, created_at: 2.days.from_now
+
+    get :disable_experiments
+
+    assert_redirected_to "/teacher_dashboard/sections/#{section.id}/progress?disableExperiments=teacher-local-nav-v2"
   end
 end


### PR DESCRIPTION
We want a way to enable and disable the `teacher-local-nav-v2` experiment flag using a static link that is usable by all users. This does not currently work because the `?enableExperiments=teacher-local-nav-v2` url parameter does not work on the homepage (this is assumed to be because of caching). However, each teacher dashboard page --- the only other logical place to link the user --- requires a section id. 

This PR creates two new endpoints that will redirect the user to the first section in a user's list of sections AND apply all experiment flags. In this case just `teacher-local-nav-v2`. This is left generic enough that we can reuse this endpoint in the future just by changing the flags that are added in the endpoints.

Links will be 
`/teacher_dashboard/sections/disable_experiments`
`/teacher_dashboard/sections/enable_experiments`
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
https://codedotorg.atlassian.net/browse/TEACH-1452
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Manually tested that each endpoint redirects correctly and each experiment is enabled/disabled.

<!-- Ot