### PR TITLE
[Google Blockly] Use setSelected to select block

### DIFF
--- a/dashboard/test/ui/features/step_definitions/angleHelper.rb
+++ b/dashboard/test/ui/features/step_definitions/angleHelper.rb
@@ -4,7 +4,7 @@ When(/^I show the editor of field "([^"]*)" of block "([^"]*)"$/) do |field, blo
     var workspace = Blockly.getMainWorkspace();
     workspace.hideChaff();
     var selectedBlock = workspace.getBlockById('#{block_id}');
-    selectedBlock.select();
+    Blockly.common.setSelected(selectedBlock);
     selectedBlock.getField('#{field}').showEditor();
   JS
   @browser.execute_script(script)


### PR DESCRIPTION
The v11 test branch has a failure in the Angle Picker scenarios for Artist:
https://drone.cdn-code.org/code-dot-org/code-dot-org/19254/2/6
https://app.saucelabs.com/tests/61d67d9c336144c689b33eaa7b20ab5d#18
<img width="1216" alt="image" src="https://github.com/user-attachments/assets/c356e707-adc5-47b5-98ef-baaa2856b268">

In these scenarios, we are unable to change a field value because `Blockly.selected` is null. We have been selecting the block with `.select()`, which no longer works.

According to https://github.com/google/blockly/pull/7991 
> This reverses the responsibility of the `Blockly.common.setSelected` and the `someElement.select` methods. If you were calling `select` or `unselect` you should instead call `Blockly.common.setSelected(some element)` and `Blockly.common.setSelected(null)` respectively.

In fact, you can see that `select()` used to call `common.setSelected` but no longer does:
https://github.com/google/blockly/commit/ed403d0b77eaeba8939c8fd8ffeef48721257ffc#diff-bb0de0069443e7577f62ffa96e6b51c5fafd06703f50c3eed6eb616ac87467bfL254-L274

According to the updated descriptions of `select()` and `unselect()` these block methods now just handle visual highlighting, but it no longer fire events related to tracking the single selected block. We call use these methods in Music Lab as well as older labs (Maze/Artist/Play Lab) in order to highlight blocks as their code is executed in real-time, which continues to work:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/18aa491b-2fe5-4118-b74d-83e214abbe75">

I could not find any other times, outside of this UI test step where we attempt to read `Blockly.selected` after using `block.select()`, so I think this could be the only change needed. The only implication of this change is that the when the UI test runs there isn't a visual indication of the highlighting, but that's not important in terms of the purpose of the test.

The block most recently clicked by a user is still tracked by `Blockly.selected`.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
