### PR TITLE
Reenabling enter button on login type page new sign up

### DIFF
--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -71,6 +71,24 @@ const LoginTypeSelection: React.FunctionComponent = () => {
   }, []);
 
   useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        const button = document.getElementById(
+          'createAccountButton'
+        ) as HTMLButtonElement;
+        if (button && !button.disabled) {
+          button.click();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
+  useEffect(() => {
     if (
       passwordIcon === CHECK_ICON &&
       !showConfirmPasswordError &&

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -70,23 +70,11 @@ const LoginTypeSelection: React.FunctionComponent = () => {
     getToken();
   }, []);
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Enter') {
-        const button = document.getElementById(
-          'createAccountButton'
-        ) as HTMLButtonElement;
-        if (button && !button.disabled) {
-          button.click();
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, []);
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' && !createAccountButtonDisabled) {
+      submitLoginType();
+    }
+  };
 
   useEffect(() => {
     if (
@@ -320,6 +308,7 @@ const LoginTypeSelection: React.FunctionComponent = () => {
                 onChange={handleEmailChange}
                 name="emailInput"
                 id="uitest-email"
+                onKeyDown={handleKeyDown}
               />
               {showEmailError && (
                 <div className={style.validationMessage}>
@@ -341,6 +330,7 @@ const LoginTypeSelection: React.FunctionComponent = () => {
                 name="passwordInput"
                 id="uitest-password"
                 inputType="password"
+                onKeyDown={handleKeyDown}
               />
               <div className={style.validationMessage}>
                 <FontAwesomeV6Icon
@@ -358,6 +348,7 @@ const LoginTypeSelection: React.FunctionComponent = () => {
                 name="confirmPasswordInput"
                 inputType="password"
                 id="uitest-confirm-password"
+                onKeyDown={handleKeyDown}
               />
               {showConfirmPasswordError && (
                 <div className={style.validationMessage}>

--- a/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
+++ b/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
@@ -300,6 +300,81 @@ describe('LoginTypeSelection', () => {
     fetchSpy.restore();
   });
 
+  it('clicks the create account button when Enter is pressed if the button is enabled', async () => {
+    const fetchSpy = sinon.stub(window, 'fetch');
+    fetchSpy.returns(Promise.resolve(new Response()));
+
+    await waitFor(() => {
+      renderDefault();
+    });
+
+    const email = 'myrandomemail@gmail.com';
+    const password = 'password';
+    const emailInput = screen.getByLabelText(locale.email_address());
+    const passwordInput = screen.getByLabelText(locale.password());
+    const confirmPasswordInput = screen.getByLabelText(
+      locale.confirm_password()
+    );
+    const beginSignUpParams = {
+      new_sign_up: true,
+      user: {
+        email: email,
+        password: password,
+        password_confirmation: password,
+      },
+    };
+
+    // Set up create account button onClick jest function
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.create_my_account(),
+    }) as HTMLButtonElement;
+    const handleClick = jest.fn();
+    finishSignUpButton.onclick = handleClick;
+
+    // Simulate pressing Enter when button is not enabled
+    fireEvent.keyDown(document, {key: 'Enter', code: 'Enter', charCode: 13});
+
+    // Verify the button's click handler was never called
+    await waitFor(() => {
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    // Ensure the button is enabled
+    fireEvent.change(emailInput, {
+      target: {value: email},
+    });
+    fireEvent.change(passwordInput, {target: {value: password}});
+    fireEvent.change(passwordInput, {target: {value: password}});
+    fireEvent.change(confirmPasswordInput, {target: {value: password}});
+
+    await waitFor(() => {
+      expect(finishSignUpButton).not.toBeDisabled();
+    });
+
+    // Simulate pressing Enter
+    fireEvent.keyDown(document, {key: 'Enter', code: 'Enter', charCode: 13});
+
+    await waitFor(() => {
+      // Verify the button's click handler was called
+      expect(handleClick).toHaveBeenCalled();
+
+      // Verify the button's fetch method was called
+      expect(fetchSpy).toHaveBeenCalled;
+      const fetchCall = fetchSpy.getCall(0);
+      expect(fetchCall.args[0]).toEqual('/users/begin_sign_up');
+      expect(fetchCall.args[1]?.body).toEqual(
+        JSON.stringify(beginSignUpParams)
+      );
+
+      // Verify the user is redirected to the finish sign up page
+      expect(navigateToHrefMock).toHaveBeenCalledWith(
+        '/users/new_sign_up/finish_student_account'
+      );
+    });
+
+    fetchSpy.restore();
+  });
+
   it('if user selected student then finish sign up button sends user to finish student page', async () => {
     await waitFor(() => {
       renderDefault('student');

--- a/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
+++ b/apps/test/unit/signUpFlow/LoginTypeSelectionTest.tsx
@@ -328,15 +328,19 @@ describe('LoginTypeSelection', () => {
     const finishSignUpButton = screen.getByRole('button', {
       name: locale.create_my_account(),
     }) as HTMLButtonElement;
-    const handleClick = jest.fn();
-    finishSignUpButton.onclick = handleClick;
 
+    // Set focus on the password input field
+    confirmPasswordInput.focus();
     // Simulate pressing Enter when button is not enabled
-    fireEvent.keyDown(document, {key: 'Enter', code: 'Enter', charCode: 13});
+    fireEvent.keyDown(confirmPasswordInput, {
+      key: 'Enter',
+      code: 'Enter',
+      charCode: 13,
+    });
 
-    // Verify the button's click handler was never called
+    // Verify the submit function was never called
     await waitFor(() => {
-      expect(handleClick).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
 
     // Ensure the button is enabled
@@ -351,13 +355,16 @@ describe('LoginTypeSelection', () => {
       expect(finishSignUpButton).not.toBeDisabled();
     });
 
+    // Set focus on the password input field
+    confirmPasswordInput.focus();
     // Simulate pressing Enter
-    fireEvent.keyDown(document, {key: 'Enter', code: 'Enter', charCode: 13});
+    fireEvent.keyDown(confirmPasswordInput, {
+      key: 'Enter',
+      code: 'Enter',
+      charCode: 13,
+    });
 
     await waitFor(() => {
-      // Verify the button's click handler was called
-      expect(handleClick).toHaveBeenCalled();
-
       // Verify the button's fetch method was called
       expect(fetchSpy).toHaveBeenCalled;
       const fetchCall = fetchSpy.getCall(0);


### PR DESCRIPTION
I mistakenly believed that updating the button to be of type 'submit' in [this pr](https://github.com/code-dot-org/code-dot-org/pull/62202) would mean that the keyboard functionality would be maintained. However, I've since realized that the submit type only works if the focus state is already on the button. 

This pr is largely a revert of that one, while keeping the proper submit type. I was also able to refactor the approach a bit now that Denys has enabled onKeyDown for inputs. Thanks @drizco for the tip!

Here is a video to show that the accessible experience still works (after the first click into the email field so I didn't have to show the whole header tabbing, I tabbed between fields and pressed enter to submit). 


https://github.com/user-attachments/assets/41d2b3cf-df1a-42df-8f6c-0c2717866c55



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2700

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
