### PR TITLE
NAV - change redirect for no students

### DIFF
--- a/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
+++ b/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
@@ -59,7 +59,7 @@ const ElementOrEmptyPage: React.FC<ElementOrEmptyPageProps> = ({
       return (
         <NavLink
           key={TEACHER_NAVIGATION_PATHS.roster}
-          to={TEACHER_NAVIGATION_PATHS.roster}
+          to={'../' + TEACHER_NAVIGATION_PATHS.roster}
           className={styles.navLink}
         >
           {i18n.addStudents()}


### PR DESCRIPTION
Changes redirect for no students in section.  Note that this is different than the component used on the V1 of the teacher dashboard.  I checked that the V1 and V2 versions redirected correctly locally.

BEFORE:

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/7460b98b-7762-4bd9-af53-a1f24ce65ce3">

Note hover shows that it redirects to an incorrect relative link.

## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65)