### PR TITLE
Fix ProgressV2 section selection

### DIFF
--- a/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressV2.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
+import {useParams} from 'react-router-dom';
 
 import {Heading1, Heading6} from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
@@ -13,6 +14,7 @@ import {
   getCurrentUnitData,
   loadExpandedLessonsFromLocalStorage,
 } from '../sectionProgress/sectionProgressRedux';
+import {showV2TeacherDashboard} from '../teacherNavigation/TeacherNavFlagUtils';
 import UnitSelectorV2 from '../UnitSelectorV2';
 
 import IconKey from './IconKey';
@@ -33,6 +35,7 @@ function SectionProgressV2({
   loadExpandedLessonsFromLocalStorage,
   hideTopHeading,
 }) {
+  const params = useParams();
   React.useEffect(() => {
     loadExpandedLessonsFromLocalStorage(scriptId, sectionId);
     analyticsReporter.sendEvent(EVENTS.PROGRESS_V2_VIEW, {
@@ -56,6 +59,7 @@ function SectionProgressV2({
   });
 
   React.useEffect(() => {
+    let isMounted = true;
     if (
       (!unitData || unitData.id !== scriptId) &&
       (scriptId !== loadedData.scriptId ||
@@ -63,12 +67,16 @@ function SectionProgressV2({
       !isLoadingProgress &&
       !isRefreshingProgress &&
       sectionId &&
-      scriptId
+      scriptId &&
+      isMounted // only update loaded data if component is still mounted.
     ) {
       loadUnitProgress(scriptId, sectionId).then(() =>
         setLoadedData({scriptId, sectionId})
       );
     }
+    return () => {
+      isMounted = false;
+    };
   }, [
     scriptId,
     sectionId,
@@ -84,6 +92,27 @@ function SectionProgressV2({
       .filter(lesson => expandedLessonIds.includes(lesson.id))
       .some(lesson => lesson.levels.some(level => level.isValidated));
   }, [expandedLessonIds, unitData]);
+
+  const isLoading = React.useMemo(() => {
+    if (showV2TeacherDashboard() && parseInt(params.sectionId) !== sectionId) {
+      // If we're in the V2 teacher dashboard, we want to show a loading state if the
+      // redux section does not yet match the URL section.
+      return true;
+    }
+    return (
+      !levelDataInitialized ||
+      isLoadingSectionData ||
+      isLoadingProgress ||
+      isRefreshingProgress
+    );
+  }, [
+    levelDataInitialized,
+    isLoadingSectionData,
+    isLoadingProgress,
+    isRefreshingProgress,
+    params.sectionId,
+    sectionId,
+  ]);
 
   return (
     // eslint-disable-next-line react/forbid-dom-props
@@ -103,14 +132,7 @@ function SectionProgressV2({
           <MoreOptionsDropdown />
         </Heading6>
       </div>
-      <ProgressTableV2
-        isSkeleton={
-          !levelDataInitialized ||
-          isLoadingSectionData ||
-          isLoadingProgress ||
-          isRefreshingProgress
-        }
-      />
+      <ProgressTableV2 isSkeleton={isLoading} />
     </div>
   );
 }

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -18,12 +18,32 @@ class TeacherDashboardController < ApplicationController
     view_options(full_width: true, no_padding_container: true)
   end
 
-  def redirect_to_newest_section
+  def redirect_to_newest_section_progress
     if current_user.sections_instructed.empty?
       redirect_to "https://support.code.org/hc/en-us/articles/25195525766669-Getting-Started-New-Progress-View"
     else
       section_id = current_user.sections_instructed.order(created_at: :desc).first.id
       redirect_to "/teacher_dashboard/sections/#{section_id}/progress?view=v2"
+    end
+  end
+
+  def enable_experiments
+    if current_user.sections_instructed.empty?
+      redirect_to "/home"
+    else
+
+      section_id = current_user.sections_instructed.order(created_at: :desc).first.id
+      redirect_to "/teacher_dashboard/sections/#{section_id}/progress?enableExperiments=teacher-local-nav-v2"
+    end
+  end
+
+  def disable_experiments
+    if current_user.sections_instructed.empty?
+      redirect_to "/home"
+    else
+
+      section_id = current_user.sections_instructed.order(created_at: :desc).first.id
+      redirect_to "/teacher_dashboard/sections/#{section_id}/progress?disableExperiments=teacher-local-nav-v2"
     end
   end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -8,7 +8,11 @@ Dashboard::Application.routes.draw do
   get "/courses", to: redirect(CDO.code_org_url("/students"))
 
   # Redirect studio.code.org/sections/teacher_dashboard/first_section_progress to most recent section
-  get '/teacher_dashboard/sections/first_section_progress', to: "teacher_dashboard#redirect_to_newest_section"
+  get '/teacher_dashboard/sections/first_section_progress', to: "teacher_dashboard#redirect_to_newest_section_progress"
+
+  # Redirect enable and disable experiments to most recent section
+  get '/teacher_dashboard/sections/enable_experiments', to: "teacher_dashboard#enable_experiments"
+  get '/teacher_dashboard/sections/disable_experiments', to: "teacher_dashboard#disable_experiments"
 
   constraints host: CDO.codeprojects_hostname do
     # Routes needed for the footer on weblab share links on codeprojects

--- a/dashboard/test/controllers/teacher_dashboard_controller_test.rb
+++ b/dashboard/test/controllers/teacher_dashboard_controller_test.rb
@@ -62,7 +62,7 @@ class TeacherDashboardControllerTest < ActionController::TestCase
     other_teacher = create(:teacher)
     sign_in other_teacher
 
-    get :redirect_to_newest_section
+    get :redirect_to_newest_section_progress
 
     assert_redirected_to 'https://support.code.org/hc/en-us/articles/25195525766669-Getting-Started-New-Progress-View'
   end
@@ -72,8 +72,46 @@ class TeacherDashboardControllerTest < ActionController::TestCase
 
     section = create :section, user: @section_owner, created_at: 2.days.from_now
 
-    get :redirect_to_newest_section
+    get :redirect_to_newest_section_progress
 
     assert_redirected_to "/teacher_dashboard/sections/#{section.id}/progress?view=v2"
+  end
+
+  test 'enable_experiments: redirects to home if no sections' do
+    other_teacher = create(:teacher)
+    sign_in other_teacher
+
+    get :enable_experiments
+
+    assert_redirected_to '/home'
+  end
+
+  test 'enable_experiments: redirects to newest section with flags' do
+    sign_in @section_owner
+
+    section = create :section, user: @section_owner, created_at: 2.days.from_now
+
+    get :enable_experiments
+
+    assert_redirected_to "/teacher_dashboard/sections/#{section.id}/progress?enableExperiments=teacher-local-nav-v2"
+  end
+
+  test 'disable_experiments: redirects to home if no sections' do
+    other_teacher = create(:teacher)
+    sign_in other_teacher
+
+    get :disable_experiments
+
+    assert_redirected_to '/home'
+  end
+
+  test 'disable_experiments: redirects to newest section with flags' do
+    sign_in @section_owner
+
+    section = create :section, user: @section_owner, created_at: 2.days.from_now
+
+    get :disable_experiments
+
+    assert_redirected_to "/teacher_dashboard/sections/#{section.id}/progress?disableExperiments=teacher-local-nav-v2"
   end
 end


### PR DESCRIPTION
Switching selected sections on the progress table would fail when selecting a section that has students from a section that does not have students.

This is because there is a bit of time between when the url section changes and the selected section is selected in redux. This PR fixes that issue by adding additional logic to show the loading state appropriately

Progress page v1 still needs to be fixed in a FLUP PR
## Links
https://codedotorg.atlassian.net/browse/TEACH-1456
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
