### PR TITLE
Ensures browser is properly maximized to avoid flaky result

### DIFF
--- a/dashboard/test/ui/features/step_definitions/browser_control.rb
+++ b/dashboard/test/ui/features/step_definitions/browser_control.rb
@@ -3,9 +3,7 @@ And(/^I change the browser window size to (\d+) by (\d+)$/) do |length, height|
 end
 
 And(/^I maximize the browser window$/) do
-  max_width, max_height = @browser.execute_script('return [window.screen.availWidth, window.screen.availHeight];')
-  @browser.manage.window.position = Selenium::WebDriver::Point.new(0, 0)
-  @browser.manage.window.resize_to(max_width, max_height)
+  @browser.manage.window.maximize
 end
 
 # for explanation of js function, see

--- a/dashboard/test/ui/features/step_definitions/browser_control.rb
+++ b/dashboard/test/ui/features/step_definitions/browser_control.rb
@@ -4,6 +4,7 @@ end
 
 And(/^I maximize the browser window$/) do
   max_width, max_height = @browser.execute_script('return [window.screen.availWidth, window.screen.availHeight];')
+  @browser.manage.window.position = Selenium::WebDriver::Point.new(0, 0)
   @browser.manage.window.resize_to(max_width, max_height)
 end
 


### PR DESCRIPTION
The header / hamburger tests need to resize the window to test the truncation of menu items. However, since they are single session, they do not return the window to normal size.

A prior attempt to fix this told it to resize the window to the full available size, which is what our test runner usually does between test sessions. However, the original window size is "maximized" and just resizing the window to the screen dimensions does not work. For one, it may be offset from the top-left corner. Telling it to move to the corner was ineffective.

Therefore, a rule to "maximize" was updated to just properly maximize the window to match its behavior at the start of the test session.

## Links

- jira ticket: [P20-1257](https://codedotorg.atlassian.net/browse/P20-1257)
- jira ticket: [P20-1258](https://codedotorg.atlassian.net/browse/P20-1258)

## Testing story

Tested via the Drone CI and viewed the video of the selenium run on SauceLabs. It showed to returning to normal size after the test that resizes the window. This should solve our problem.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
