### PR TITLE
test: wait until dropdown has value

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -51,4 +51,4 @@ Scenario: School Info Confirmation Dialog
   Then element "#uitest-country-dropdown" has value "US"
   Then element "#uitest-school-zip" has value "31513"
   # value is school_id for "Appling County High School"
-  Then element "#uitest-school-dropdown" has value "130006000010"
+  Then I wait until element "#uitest-school-dropdown" has value "130006000010"

--- a/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/acquisition_products/school_info_confirmation_dialog.feature
@@ -51,4 +51,4 @@ Scenario: School Info Confirmation Dialog
   Then element "#uitest-country-dropdown" has value "US"
   Then element "#uitest-school-zip" has value "31513"
   # value is school_id for "Appling County High School"
-  Then I wait until element "#uitest-school-dropdown" has value "130006000010"
+  Then I wait until element "#uitest-school-dropdown" has the value "130006000010"

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -54,7 +54,7 @@ And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?$/) do |
   # Hopefully fixes many of the issues with font wiggle due to lazily loading
   # alternative fonts for symbols and localized glyphs.
   wait_until do
-    @browser.execute_script('return !!(await document.fonts.ready)') == true
+    @browser.execute_script('return document.fonts.ready.then(() => true)') == true
   end
 
   if stitch_mode == "none"

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -54,7 +54,7 @@ And(/^I see no difference for "([^"]*)"(?: using stitch mode "([^"]*)")?$/) do |
   # Hopefully fixes many of the issues with font wiggle due to lazily loading
   # alternative fonts for symbols and localized glyphs.
   wait_until do
-    @browser.execute_script('return document.fonts.ready.then(() => true)') == true
+    @browser.execute_script('return document.fonts.status === "loaded"') == true
   end
 
   if stitch_mode == "none"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
I was seeing a js error when `I see no difference` step was run `Failed: SyntaxError: missing ) in parenthetical`
![Screenshot 2024-11-15 at 8 59 53 AM](https://github.com/user-attachments/assets/fd659d4f-5b09-4411-a048-24b24a7ecb31)


This was due to `await` being used outside of an `async` function. However, the `wait_until` method is actually polling for results, so it wasn't capable of handling the promise anyway. luckily there's a `document.fonts.status` property we can poll for, which is either `loading` or `loaded` https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
