### PR TITLE
add UI tests and touch up logic for TA dismissible alert

### DIFF
--- a/apps/src/templates/rubrics/RubricContainer.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.jsx
@@ -42,7 +42,7 @@ function RubricContainer({
   rubric,
   studentLevelInfo,
   teacherHasEnabledAi,
-  currentLevelName,
+  onLevelForEvaluation,
   reportingData,
   open,
   closeRubric,
@@ -50,7 +50,6 @@ function RubricContainer({
   loadAllTeacherEvaluationData,
   loadAiEvalStatusForAll,
 }) {
-  const onLevelForEvaluation = currentLevelName === rubric.level.name;
   const canProvideFeedback = !!studentLevelInfo && onLevelForEvaluation;
   const rubricTabSessionKey = 'rubricFABTabSessionKey';
   const rubricPositionX = 'rubricFABPositionX';
@@ -398,7 +397,7 @@ RubricContainer.propTypes = {
   reportingData: reportingDataShape,
   studentLevelInfo: studentLevelInfoShape,
   teacherHasEnabledAi: PropTypes.bool,
-  currentLevelName: PropTypes.string,
+  onLevelForEvaluation: PropTypes.bool,
   closeRubric: PropTypes.func,
   open: PropTypes.bool,
   sectionId: PropTypes.number,

--- a/apps/src/templates/rubrics/RubricContainer.story.jsx
+++ b/apps/src/templates/rubrics/RubricContainer.story.jsx
@@ -111,7 +111,7 @@ const Template = args => (
       rubric={defaultRubric}
       teacherHasEnabledAi={false}
       studentLevelInfo={defaultStudentLevelInfo}
-      currentLevelName={rubricLevelName}
+      onLevelForEvaluation={true}
       open
       {...args}
     />
@@ -136,7 +136,7 @@ export const ViewingStudentWorkOnNonAssessmentLevelAiEnabled = Template.bind(
 ViewingStudentWorkOnNonAssessmentLevelAiEnabled.args = {
   studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
   teacherHasEnabledAi: true,
-  currentLevelName: 'not_free_play_level',
+  onLevelForEvaluation: false,
 };
 
 export const ViewingStudentWorkOnNonAssessmentLevelAiDisabled = Template.bind(
@@ -145,7 +145,7 @@ export const ViewingStudentWorkOnNonAssessmentLevelAiDisabled = Template.bind(
 ViewingStudentWorkOnNonAssessmentLevelAiDisabled.args = {
   studentLevelInfo: {...defaultStudentLevelInfo, submitted: true},
   teacherHasEnabledAi: false,
-  currentLevelName: 'not_free_play_level',
+  onLevelForEvaluation: false,
 };
 
 export const ViewingStudentWorkOnAssessmentLevelAiEnabled = Template.bind({});

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -220,7 +220,9 @@ function RubricFloatingActionButton({
       </button>
       {showCountBubble ? (
         <>
-          <div className={style.countOverlay}>
+          <div
+            className={classnames(style.countOverlay, 'uitest-count-bubble')}
+          >
             <BodyFourText className={style.countText}>
               <StrongText>
                 <span aria-label={i18n.aiEvaluationsToReview()}>

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -118,7 +118,7 @@ function RubricFloatingActionButton({
       ? EVENTS.TA_RUBRIC_CLOSED_FROM_FAB_EVENT
       : EVENTS.TA_RUBRIC_OPENED_FROM_FAB_EVENT;
     analyticsReporter.sendEvent(eventName, eventData);
-    if (!isOpen) {
+    if (!isOpen && showCountBubble) {
       setSeenTaScores();
     }
     setIsOpen(!isOpen);

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -100,7 +100,10 @@ function RubricFloatingActionButton({
   const readyStudentCount = useAppSelector(selectReadyStudentCount);
   const hasLoadedStudentStatus = useAppSelector(selectHasLoadedStudentStatus);
   const showCountBubble =
-    notificationsEnabled && hasLoadedStudentStatus && readyStudentCount > 0;
+    onLevelForEvaluation &&
+    notificationsEnabled &&
+    hasLoadedStudentStatus &&
+    readyStudentCount > 0;
 
   const eventData = useMemo(() => {
     return {

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -128,6 +128,8 @@ function RubricFloatingActionButton({
   const showScoresAlert =
     canShowTaScoresAlert && !hasSeenAlert && showCountBubble;
 
+  const [dismissConfirmed, setDismissConfirmed] = useState(false);
+
   const setSeenTaScores = useCallback(() => {
     setHasSeenAlert(true);
 
@@ -135,9 +137,13 @@ function RubricFloatingActionButton({
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({lesson_id: rubric.lesson.id}),
-    }).catch(error => {
-      console.error('Error setting seen TA scores:', error);
-    });
+    })
+      .then(response => {
+        setDismissConfirmed(true);
+      })
+      .catch(error => {
+        console.error('Error setting seen TA scores:', error);
+      });
   }, [rubric.lesson.id]);
 
   const viewScores = () => {
@@ -226,7 +232,11 @@ function RubricFloatingActionButton({
       {showCountBubble ? (
         <>
           <div
-            className={classnames(style.countOverlay, 'uitest-count-bubble')}
+            className={classnames(
+              style.countOverlay,
+              'uitest-count-bubble',
+              dismissConfirmed && 'uitest-dismiss-confirmed'
+            )}
           >
             <BodyFourText className={style.countText}>
               <StrongText>

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -95,6 +95,8 @@ function RubricFloatingActionButton({
 
   const [internalError, setInternalError] = useState(null);
 
+  const onLevelForEvaluation = currentLevelName === rubric.level.name;
+
   const readyStudentCount = useAppSelector(selectReadyStudentCount);
   const hasLoadedStudentStatus = useAppSelector(selectHasLoadedStudentStatus);
   const showCountBubble =
@@ -265,7 +267,7 @@ function RubricFloatingActionButton({
           rubric={rubric}
           studentLevelInfo={studentLevelInfo}
           reportingData={reportingData}
-          currentLevelName={currentLevelName}
+          onLevelForEvaluation={onLevelForEvaluation}
           teacherHasEnabledAi={aiEnabled}
           open={isOpen}
           closeRubric={handleClick}

--- a/apps/src/templates/rubrics/StudentScoresAlert.jsx
+++ b/apps/src/templates/rubrics/StudentScoresAlert.jsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -22,7 +23,9 @@ export default function StudentScoresAlert({closeAlert, viewScores}) {
   }
 
   return (
-    <div className={style.dismissableAlert}>
+    <div
+      className={classnames(style.dismissableAlert, 'uitest-dismissible-alert')}
+    >
       <span className={style.dismissableAlertText}>
         <BodyThreeText>
           {i18n.rubricStudentScoresAlert({studentCount, sectionName})}

--- a/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricContainerTest.jsx
@@ -121,7 +121,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={{}}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -175,7 +175,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -199,7 +199,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={false}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -227,7 +227,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           sectionId={42}
           open
@@ -263,7 +263,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           sectionId={42}
           open
@@ -301,7 +301,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           sectionId={42}
           open
@@ -349,7 +349,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           sectionId={42}
           open
@@ -462,7 +462,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           sectionId={42}
           open
@@ -506,7 +506,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           sectionId={42}
           open
@@ -547,7 +547,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           sectionId={42}
           open
@@ -591,7 +591,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           sectionId={42}
           open
@@ -635,7 +635,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           sectionId={42}
           reportingData={{}}
           open
@@ -677,7 +677,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           sectionId={42}
           open
@@ -719,7 +719,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           sectionId={42}
           open
@@ -763,7 +763,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           sectionId={42}
           open
@@ -800,7 +800,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -839,7 +839,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -882,7 +882,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={{name: 'Grace Hopper'}}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -906,7 +906,7 @@ describe('RubricContainer', () => {
         <RubricContainer
           rubric={defaultRubric}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           canProvideFeedback
           open
@@ -931,7 +931,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={{name: 'Grace Hopper'}}
           teacherHasEnabledAi={true}
-          currentLevelName={'different_level'}
+          onLevelForEvaluation={false}
           reportingData={{}}
           canProvideFeedback
           open
@@ -956,7 +956,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -985,7 +985,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -1013,7 +1013,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'non-assessment-level'}
+          onLevelForEvaluation={false}
           reportingData={{}}
           open
         />
@@ -1041,7 +1041,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={false}
-          currentLevelName={'test-level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -1069,7 +1069,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -1099,7 +1099,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -1147,7 +1147,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -1184,7 +1184,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />
@@ -1232,7 +1232,7 @@ describe('RubricContainer', () => {
           rubric={defaultRubric}
           studentLevelInfo={defaultStudentInfo}
           teacherHasEnabledAi={true}
-          currentLevelName={'test_level'}
+          onLevelForEvaluation={true}
           reportingData={{}}
           open
         />

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -396,7 +396,7 @@ describe('RubricFloatingActionButton', () => {
 
       await wait();
 
-      screen.getByText(alertMessage).closest('div');
+      screen.getByText(alertMessage);
       const fab = screen.getByRole('button', {
         name: i18n.openOrCloseTeachingAssistant(),
       });
@@ -409,6 +409,37 @@ describe('RubricFloatingActionButton', () => {
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({lesson_id: 33}),
       });
+    });
+
+    it('does not dismiss alert on fab click on non assessment level', async () => {
+      stubFetch({
+        evalStatusForAll: successJsonAll,
+        teacherEvals: noEvals,
+      });
+
+      render(
+        <Provider store={store}>
+          <RubricFloatingActionButton
+            {...defaultProps}
+            sectionId={sectionId}
+            currentLevelName="non-assessment-level"
+          />
+        </Provider>
+      );
+
+      await wait();
+
+      expect(screen.queryByText(alertMessage)).not.toBeInTheDocument();
+
+      const fab = screen.getByRole('button', {
+        name: i18n.openOrCloseTeachingAssistant(),
+      });
+      fireEvent.click(fab);
+
+      expect(fetch).not.toHaveBeenCalledWith(
+        '/api/v1/users/set_seen_ta_scores',
+        expect.anything()
+      );
     });
 
     it('dismisses alert when fab is open initially', async () => {

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -227,6 +227,30 @@ describe('RubricFloatingActionButton', () => {
         screen.queryByLabelText(i18n.aiEvaluationsToReview())
       ).not.toBeInTheDocument();
     });
+
+    it('does not render count bubble on non-assessment level', async () => {
+      stubFetch({
+        evalStatusForAll: successJsonAll,
+        teacherEvals: noEvals,
+      });
+
+      render(
+        <Provider store={store}>
+          <RubricFloatingActionButton
+            {...defaultProps}
+            sectionId={sectionId}
+            currentLevelName="non-assessment-level"
+          />
+        </Provider>
+      );
+
+      await wait();
+
+      expect(screen.getByRole('img', {name: 'TA overlay'})).toBeVisible();
+      expect(
+        screen.queryByLabelText(i18n.aiEvaluationsToReview())
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('student scores alert', () => {

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -634,7 +634,7 @@ class ScriptLevelsController < ApplicationController
   end
 
   private def can_show_ta_scores_alert?
-    return false if LearningGoalTeacherEvaluation.exists?(teacher_id: current_user.id)
+    return false if LearningGoalTeacherEvaluation.where(teacher_id: current_user.id).where.not(understanding: nil).exists?
     seen_ta_scores_map = current_user&.seen_ta_scores_map || {}
     return false if seen_ta_scores_map.keys.length >= MAX_SHOW_TA_SCORES_ALERT
     !seen_ta_scores_map[@script_level.lesson.id.to_s]

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -634,6 +634,7 @@ class ScriptLevelsController < ApplicationController
   end
 
   private def can_show_ta_scores_alert?
+    return false if LearningGoalTeacherEvaluation.exists?(teacher_id: current_user.id)
     seen_ta_scores_map = current_user&.seen_ta_scores_map || {}
     return false if seen_ta_scores_map.keys.length >= MAX_SHOW_TA_SCORES_ALERT
     !seen_ta_scores_map[@script_level.lesson.id.to_s]

--- a/dashboard/test/integration/rubrics_test.rb
+++ b/dashboard/test/integration/rubrics_test.rb
@@ -9,7 +9,7 @@ class RubricsTest < ActionDispatch::IntegrationTest
 
     @unit = create :script, :with_levels, lessons_count: 4, name: 'test-unit'
     @first_script_level = @unit.script_levels.first
-    create :rubric, lesson: @first_script_level.lesson, level: @first_script_level.levels.first
+    @rubric = create :rubric, :with_learning_goals, lesson: @first_script_level.lesson, level: @first_script_level.levels.first
     @last_script_level = @unit.script_levels.last
     create :rubric, lesson: @last_script_level.lesson, level: @last_script_level.levels.first
   end
@@ -19,6 +19,20 @@ class RubricsTest < ActionDispatch::IntegrationTest
     assert_response :success
     rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
     assert rubric_data['canShowTaScoresAlert']
+  end
+
+  test 'canShowTaScoresAlert is false after teacher submits feedback' do
+    create :learning_goal_teacher_evaluation, learning_goal: @rubric.learning_goals.first, teacher: @teacher
+
+    get build_script_level_path(@first_script_level)
+    assert_response :success
+    rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
+    refute rubric_data['canShowTaScoresAlert']
+
+    get build_script_level_path(@last_script_level)
+    assert_response :success
+    rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
+    refute rubric_data['canShowTaScoresAlert']
   end
 
   test 'set_seen_ta_scores sets canShowTaScoresAlert to false' do

--- a/dashboard/test/integration/rubrics_test.rb
+++ b/dashboard/test/integration/rubrics_test.rb
@@ -22,13 +22,17 @@ class RubricsTest < ActionDispatch::IntegrationTest
   end
 
   test 'canShowTaScoresAlert is false after teacher submits feedback' do
-    create :learning_goal_teacher_evaluation, learning_goal: @rubric.learning_goals.first, teacher: @teacher
+    learning_goal = create :learning_goal_teacher_evaluation, learning_goal: @rubric.learning_goals.first, teacher: @teacher, understanding: nil
 
-    get build_script_level_path(@first_script_level)
+    # ignore learning goal without understanding
+    get build_script_level_path(@last_script_level)
     assert_response :success
     rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)
-    refute rubric_data['canShowTaScoresAlert']
+    assert rubric_data['canShowTaScoresAlert']
 
+    learning_goal.update!(understanding: 1)
+
+    # can show alert after understanding is set
     get build_script_level_path(@last_script_level)
     assert_response :success
     rubric_data = JSON.parse(css_select('script[data-rubricdata]').first.attribute('data-rubricdata').to_s)

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -195,7 +195,8 @@ Feature: Evaluate student code against rubrics using AI
 
     # Teacher dismisses alert
     When I click selector ".uitest-dismissible-alert .fa-close"
-    And I wait until element ".uitest-dismissible-alert" is not visible
+    And I wait until element ".uitest-dismiss-confirmed" is visible
+    And element ".uitest-dismissible-alert" is not visible
 
     # dismissed alert does not come back on page reload
     When I reload the page

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -195,7 +195,6 @@ Feature: Evaluate student code against rubrics using AI
 
     # Teacher dismisses alert
     When I click selector ".uitest-dismissible-alert .fa-close"
-    And I wait until element "#uitest-rubric-content" is visible
     And I wait until element ".uitest-dismissible-alert" is not visible
 
     # dismissed alert does not come back on page reload

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -27,7 +27,7 @@ Feature: Evaluate student code against rubrics using AI
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
-    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
+    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2?enableExperiments=taNotifications"
     And I wait for the lab page to fully load
     And element ".teacher-panel td:eq(1)" contains text "Aiden"
     And I click selector ".teacher-panel td:eq(1)" to load a new page
@@ -36,12 +36,15 @@ Feature: Evaluate student code against rubrics using AI
     And I click selector ".introjs-skipbutton" once I see it
     Then I verify progress in the header of the current page is "perfect_assessment" for level 2
     And element "#ui-floatingActionButton" is visible
+    And I wait until element ".uitest-count-bubble" is visible
+    And element ".uitest-dismissible-alert" is visible
 
     # Teacher views AI evaluation status in rubric header
     When I click selector "#ui-floatingActionButton"
     And I wait until element "#uitest-rubric-content" is visible
     And element ".uitest-run-ai-assessment" is disabled
     Then I wait until element ".uitest-rubric-tab-buttons .__react_component_tooltip" contains text "AI analysis already completed for this project."
+    And I wait until element ".uitest-dismissible-alert" is not visible
 
     # Teacher views AI evaluation results in rubric
     And I wait until element "#uitest-next-goal" is visible
@@ -51,6 +54,12 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element ".uitest-ai-assessment" is visible
     Then element ".uitest-ai-assessment" contains text "Aiden has achieved Extensive or Convincing Evidence"
     And element ".uitest-student-progress-status" contains text "Ready to review"
+
+    # dismissed alert does not come back on page reload
+    When I reload the page
+    And I wait until element "#ui-floatingActionButton" is visible
+    And I wait until element ".uitest-count-bubble" is visible
+    And element ".uitest-dismissible-alert" is not visible
 
   Scenario: Student code is evaluated by AI when teacher requests individual evaluation
     Given I create an authorized teacher-associated student named "Aiden"

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -27,7 +27,7 @@ Feature: Evaluate student code against rubrics using AI
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
-    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2?enableExperiments=taNotifications"
+    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
     And element ".teacher-panel td:eq(1)" contains text "Aiden"
     And I click selector ".teacher-panel td:eq(1)" to load a new page
@@ -36,15 +36,12 @@ Feature: Evaluate student code against rubrics using AI
     And I click selector ".introjs-skipbutton" once I see it
     Then I verify progress in the header of the current page is "perfect_assessment" for level 2
     And element "#ui-floatingActionButton" is visible
-    And I wait until element ".uitest-count-bubble" is visible
-    And element ".uitest-dismissible-alert" is visible
 
     # Teacher views AI evaluation status in rubric header
     When I click selector "#ui-floatingActionButton"
     And I wait until element "#uitest-rubric-content" is visible
     And element ".uitest-run-ai-assessment" is disabled
     Then I wait until element ".uitest-rubric-tab-buttons .__react_component_tooltip" contains text "AI analysis already completed for this project."
-    And I wait until element ".uitest-dismissible-alert" is not visible
 
     # Teacher views AI evaluation results in rubric
     And I wait until element "#uitest-next-goal" is visible
@@ -54,12 +51,6 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element ".uitest-ai-assessment" is visible
     Then element ".uitest-ai-assessment" contains text "Aiden has achieved Extensive or Convincing Evidence"
     And element ".uitest-student-progress-status" contains text "Ready to review"
-
-    # dismissed alert does not come back on page reload
-    When I reload the page
-    And I wait until element "#ui-floatingActionButton" is visible
-    And I wait until element ".uitest-count-bubble" is visible
-    And element ".uitest-dismissible-alert" is not visible
 
   Scenario: Student code is evaluated by AI when teacher requests individual evaluation
     Given I create an authorized teacher-associated student named "Aiden"
@@ -171,3 +162,45 @@ Feature: Evaluate student code against rubrics using AI
     And I wait until element ".uitest-ai-assessment" is visible
     Then element ".uitest-ai-assessment" contains text "Aiden has achieved Extensive or Convincing Evidence"
     And element ".uitest-student-progress-status" contains text "Ready to review"
+
+  Scenario: Alerts are shown when AI scores are available to review
+    Given I create an authorized teacher-associated student named "Aiden"
+    And I get debug info for the current user
+    And I am on "http://studio.code.org/home"
+    And I wait until element "#homepage-container" is visible
+    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
+    And I wait for the lab page to fully load
+    And I verify progress in the header of the current page is "not_tried" for level 2
+
+    # Student submits code
+    When I ensure droplet is in text mode
+    And I append text to droplet "// the quick brown fox jumped over the lazy dog.\n"
+    And I submit this gamelab level
+
+    # Teacher views floating action button on assessment level
+    When I sign in as "Teacher_Aiden"
+    And I am on "http://studio.code.org/home"
+    And I wait until element "#homepage-container" is visible
+    And element "#sign_in_or_user" contains text "Teacher_Aiden"
+    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2?enableExperiments=taNotifications"
+    And I wait for the lab page to fully load
+    And element ".teacher-panel td:eq(1)" contains text "Aiden"
+    And I click selector ".teacher-panel td:eq(1)" to load a new page
+    And I wait for the lab page to fully load
+    And I wait until element "#ui-floatingActionButton" is visible
+    And I click selector ".introjs-skipbutton" once I see it
+    And element "#ui-floatingActionButton" is visible
+    And I wait until element ".uitest-count-bubble" is visible
+    And element ".uitest-dismissible-alert" is visible
+
+    # Teacher dismisses alert
+    When I click selector ".uitest-dismissible-alert .fa-close"
+    And I wait until element "#uitest-rubric-content" is visible
+    And I wait until element ".uitest-dismissible-alert" is not visible
+
+    # dismissed alert does not come back on page reload
+    When I reload the page
+    And I wait until element "#ui-floatingActionButton" is visible
+    And I wait until element ".uitest-count-bubble" is visible
+    And element ".uitest-dismissible-alert" is not visible
+


### PR DESCRIPTION
Softly depends on https://github.com/code-dot-org/code-dot-org/pull/62494, which adds a DB index needed for looking up LearningGoalTeacherEvaluations efficiently.

Continues https://codedotorg.atlassian.net/browse/AITT-816 by tightening up some logic for showing bubble count and dismissible alert:
* only ever show bubble count or dismissible alert on the assessment level (see screenshots)
* on non-assessment level, do not mark the alert as seen when the fab is used to open the TA window (on assessment levels, this dismisses the alert)
* if the teacher submits feedback (represented by `LearningGoalTeacherEvaluation` objects) for any student, the alert should never be shown again on any lesson. however, the autosave feature creates LGTE objects even when the teacher does not submit, and we want to ignore these. we do this by only looking for LGTEs with non-nil `understanding`.

this PR also adds a basic UI test for verifying the dismiss logic is working end to end.

## screenshots
only show bubble count or dismissible alert on assessment level
![Screenshot 2024-11-15 at 12 37 25 PM](https://github.com/user-attachments/assets/a3402ee8-268f-4b73-9868-3987d8129486)



## Testing story

* each logic update is accompanied by new unit test
* new UI test covering dismissal stickiness end to end

## Follow-up work

the only known remaining work is to launch the experiment 