### PR TITLE
[Flaky ui test] stale element error not being rescued

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -42,6 +42,7 @@ rescue Selenium::WebDriver::Error::StaleElementReferenceError
   true
 rescue Selenium::WebDriver::Error::WebDriverError => exception
   return true if exception.message.include?('stale element reference') ||
+    exception.message.include?('is stale') ||
     exception.message.include?('no such element')
   puts "Unknown error: #{exception}"
   true


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

working on this failure:

![Screenshot 2024-11-15 at 10 59 01 AM](https://github.com/user-attachments/assets/c92bf360-250c-4b8f-9e0d-27fc22ceaddf)

after tracing back the steps, I believe this is happening in the `element_stale?` method, where the exception is caught but not handled. possibly the error message payload has changed? I'm trying `is stale` because I see that in the error message in the screenshot
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
