### PR TITLE
Upgrade to Aurora Engine 3.08.0 to Prevent Production Database Restart Issue

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -295,7 +295,7 @@
       # Updating a Stack with a change to EngineVersion causes "Some Interruption".
       # Each Database Instance in the cluster is restarted.
       # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-engineversion
-      EngineVersion: 8.0.mysql_aurora.3.05.2
+      EngineVersion: 8.0.mysql_aurora.3.08.0
       MasterUsername: !Sub "{{resolve:secretsmanager:${DatabaseSecretAdmin}:SecretString:username}}"
       MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabaseSecretAdmin}:SecretString:password}}"
       EnableIAMDatabaseAuthentication: true


### PR DESCRIPTION
Upgrade to latest release of Aurora 3 / MySQL 8: `8.0.mysql_aurora.3.08.0` to prevent recurrence of the spontaneous production writer database instance restart that occurred Sunday Dec 1 ~7PM PST.

See Slack discussion: https://codedotorg.slack.com/archives/C0T0PNTM3/p1733108473316719

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.Updates.3080.html

This release specifically addresses the issue we encountered:

```
Fixed an issue that can cause a DB instance restart after disabling binary logging, when enhanced binlog was previously enabled.
```


## Testing story

Successfully provisioned an adhoc with this version:

`bundle exec rake adhoc:start RAILS_ENV=adhoc STACK_NAME=adhoc-upgrade-aurora-3-08-0 DATABASE=yes`

## Deployment strategy

1. Merge and verify managed test server passes all tests.
2. Manually release the good commit from the `test` branch to the levelbuilder environment to ensure all non-production environments are upgraded
3. Clone the production database cluster (~15 minutes) as a rollback option
4. Manually upgrade production cluster via the web console (~2 minutes of downtime as the writer and reader restart)

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
