### PR TITLE
Fix test eyes tests

### DIFF
--- a/apps/src/aiDifferentiation/ai-differentiation.module.scss
+++ b/apps/src/aiDifferentiation/ai-differentiation.module.scss
@@ -1,6 +1,6 @@
 @import 'color';
 @import 'font';
-@import 'typography';
+@import '@cdo/apps/componentLibrary/typography/typography.module';
 @import '@cdo/apps/componentLibrary/common/styles/mixins';
 
 @keyframes pulse {


### PR DESCRIPTION
Eyes tests showed differences due to fonts being changed.

We tracked this to the inclusion of `@import 'typography';` in [this](https://github.com/code-dot-org/code-dot-org/pull/62456) PR

This PR fixes by using the correct typography file.

## Links
[Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1731696010883329)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
See video where fonts change immediately after yarn hotfixes the change:

https://github.com/user-attachments/assets/c49f1d09-bdf0-4d29-8adc-72269dfa3cb4


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
