### PR TITLE
Fix flaky python lab test

### DIFF
--- a/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
+++ b/dashboard/test/ui/features/code_tools/pythonlab/pythonlab_run.feature
@@ -33,9 +33,11 @@ Scenario: Continue button and progress status shows up correctly
   And I wait until current URL contains "http://studio.code.org/s/allthethings/lessons/50/levels/2"
   # Check that progress has been updated for the previous level
   Then I verify progress in the header of the current page is "perfect" for level 1
+  And I wait to see "#uitest-validate-button"
   And I wait until "#uitest-validate-button" is not disabled
   And I press "uitest-validate-button"
   And I wait until element "#instructions-navigation" is visible
   And element "#instructions-navigation" contains text "Continue"
+  And I wait for 2 seconds
   Then I verify progress in the header of the current page is "perfect" for level 2
   Then I sign out


### PR DESCRIPTION
The python lab test verifying progress/continue has been flaky. I found two points of failure in recent runs:
- We weren't always waiting for the next level to fully load before checking if a button was enabled
- We weren't always waiting long enough for progress to update.

The first one has a clear solution, which is to wait for the button to exist before checking if it's enabled. The second one is a little trickier, although I only saw it occur one time, all the other failures were the load not done yet. We already have a wait in the [progress check](https://github.com/code-dot-org/code-dot-org/blob/bc757c721bb2b2cbb87b4a4a13d4cf066d180785/dashboard/test/ui/features/step_definitions/progress.rb#L40-L45), so I added an additional wait to give us a bit more time. In the one failure I saw the progress did update 1 second after the check occurred.

## Links
- jira ticket: [LABS-1204](https://codedotorg.atlassian.net/browse/LABS-1204)


## Testing story
Tested against a saucelabs tunnel on Chrome and Firefox. I ran it 3 times for each browser and all passed.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
