### PR TITLE
Update font sizes across sites to fix lowercase "i" issue on PCs

### DIFF
--- a/apps/src/componentLibrary/typography/CHANGELOG.md
+++ b/apps/src/componentLibrary/typography/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this component will be documented in this file.
 
+## [2.0.2](https://github.com/code-dot-org/code-dot-org/pull/62481)
+* update `@mixin body-three` font-size to 15px/0.938rem
+
 ## [2.0.1](https://github.com/code-dot-org/code-dot-org/pull/53337)
 * add ```ExtraStrong``` typography element
 

--- a/apps/src/componentLibrary/typography/typography.module.scss
+++ b/apps/src/componentLibrary/typography/typography.module.scss
@@ -154,7 +154,7 @@ html {
 
 @mixin body-three {
   @include paragraph-common;
-  font-size: 0.875rem;
+  font-size: 0.938rem;
   line-height: 1.54;
 }
 

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -68,7 +68,7 @@ body {
   font-family: var(--main-font);
   font-weight: var(--regular-font-weight);
   font-style: normal;
-  font-size: 14px;
+  font-size: 15px;
   color: var(--neutral_dark);
   margin: 0;
 }
@@ -166,7 +166,7 @@ p {
 }
 
 .body-three {
-  font-size: 0.875rem;
+  font-size: 0.938rem;
   line-height: 1.54;
   margin-bottom: 1em;
 }

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -172,7 +172,7 @@ p {
 }
 
 .body-four {
-  font-size: 0.75rem;
+  font-size: 0.813rem;
   line-height: 1.64;
   margin-bottom: 1em;
 }

--- a/pegasus/sites.v3/hourofcode.com/styles/040-page.css
+++ b/pegasus/sites.v3/hourofcode.com/styles/040-page.css
@@ -145,7 +145,7 @@ p {
 }
 
 .body-four {
-  font-size: 0.75rem;
+  font-size: 0.813rem;
   line-height: 1.64;
   margin-bottom: 1em;
 }

--- a/pegasus/sites.v3/hourofcode.com/styles/040-page.css
+++ b/pegasus/sites.v3/hourofcode.com/styles/040-page.css
@@ -53,7 +53,7 @@ body {
   font-family: var(--main-font);
   font-weight: var(--regular-font-weight);
   font-style: normal;
-  font-size: 14px;
+  font-size: 15px;
   color: var(--neutral_dark);
   margin: 0;
 }

--- a/shared/css/typography.scss
+++ b/shared/css/typography.scss
@@ -132,7 +132,7 @@
 
 @mixin body-three {
   @include paragraph-common;
-  font-size: 0.875rem;
+  font-size: 0.938rem;
   line-height: 1.54;
 }
 


### PR DESCRIPTION
Updates `12px`/`0.75rem` and `14px`/`0.875rem` font sizes to `13px`/`0.813rem` and `15px`/`0.938rem` respectively to prevent an issue with the lowercase "i" looking like a lowercase "l" (el) when the font size is small, or when the default font size is bold on a link. This issue only affects PC computers, and lowercase "i"s look as expected on Macs.

**These are the places that have been updated:**
- `shared/css/typography.scss` - shared across code.org and studio.code.org
- `apps/src/componentLibrary/typography/typography.module.scss` - studio.code.org
- `pegasus/sites.v3/code.org/styles_min/040-page.css` - code.org
- `pegasus/sites.v3/hourofcode.com/styles/040-page.css` - hourofcode.com

🚨 **Note for DOTD:** this will likely cause lots of Eyes diffs.

## Links
Jira ticket: [ACQ-2592](https://codedotorg.atlassian.net/browse/ACQ-2592) - see ticket for more context

----

## `body` font-size update to `15px` on code.org
<img width="1706" alt="Screenshot 2024-11-18 at 9 54 45 AM" src="https://github.com/user-attachments/assets/997244c3-7a92-4bdd-8458-4621ffcdc539">


## `.body-four` font-size update to `13px` on code.org
<img width="1032" alt="Screenshot 2024-11-15 at 2 00 03 PM" src="https://github.com/user-attachments/assets/f2e971e9-0825-44cc-87d3-58a6fc9b3da1">
