### PR TITLE
Offload Section Lookup to Read Replica Database

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -103,7 +103,9 @@ class ScriptLevelsController < ApplicationController
     end
 
     # will be true if the user is in any unarchived section where tts autoplay is enabled
-    @tts_autoplay_enabled = current_user&.sections_as_student&.where({hidden: false})&.map(&:tts_autoplay_enabled)&.reduce(false, :|)
+    ActiveRecord::Base.connected_to(role: :reading) do
+      @tts_autoplay_enabled = current_user&.sections_as_student&.where({hidden: false})&.map(&:tts_autoplay_enabled)&.reduce(false, :|)
+    end
 
     @public_caching = configure_caching(@script)
 


### PR DESCRIPTION
We execute this query about 1500 times per second during peak usage on a normal school day. Execute this query on the read replica database instance to reduce load on the writer database.

## Testing story

Successfully provisioned a full stack adhoc (the only type of environment that does read splitting).

## Deployment strategy

## Follow-up work

Potentially modify the underlying `User.sections_as_student` method to use the read replica database.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
