### PR TITLE
P20-1277/Add metrics for password reset

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1185,6 +1185,11 @@ class User < ApplicationRecord
     login = conditions.delete(:login)
     if login.present?
       return nil if login.size > max_credential_size || login.utf8mb4?
+      Cdo::Metrics.put(
+        'User', 'LoginByUsername', 1, {
+          Environment: CDO.rack_env
+        }
+      )
       # TODO: multi-auth (@eric, before merge!) have to handle this path, and make sure that whatever
       # indexing problems bit us on the users table don't affect the multi-auth table
       ignore_deleted_at_index.where(
@@ -1195,6 +1200,11 @@ class User < ApplicationRecord
       ).first
     elsif (hashed_email = conditions.delete(:hashed_email))
       return nil if hashed_email.size > max_credential_size || hashed_email.utf8mb4?
+      Cdo::Metrics.put(
+        'User', 'LoginByEmail', 1, {
+          Environment: CDO.rack_env
+        }
+      )
       return find_by_hashed_email(hashed_email)
     else
       nil

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1185,11 +1185,7 @@ class User < ApplicationRecord
     login = conditions.delete(:login)
     if login.present?
       return nil if login.size > max_credential_size || login.utf8mb4?
-      Cdo::Metrics.put(
-        'User', 'LoginByUsername', 1, {
-          Environment: CDO.rack_env
-        }
-      )
+      Cdo::Metrics.put('User', 'LoginByUsername', 1, {Environment: CDO.rack_env})
       # TODO: multi-auth (@eric, before merge!) have to handle this path, and make sure that whatever
       # indexing problems bit us on the users table don't affect the multi-auth table
       ignore_deleted_at_index.where(
@@ -1200,11 +1196,7 @@ class User < ApplicationRecord
       ).first
     elsif (hashed_email = conditions.delete(:hashed_email))
       return nil if hashed_email.size > max_credential_size || hashed_email.utf8mb4?
-      Cdo::Metrics.put(
-        'User', 'LoginByEmail', 1, {
-          Environment: CDO.rack_env
-        }
-      )
+      Cdo::Metrics.put('User', 'LoginByEmail', 1, {Environment: CDO.rack_env})
       return find_by_hashed_email(hashed_email)
     else
       nil

--- a/dashboard/lib/services/user/password_resetter_by_email.rb
+++ b/dashboard/lib/services/user/password_resetter_by_email.rb
@@ -11,20 +11,12 @@ module Services
         return user if user.errors.present?
 
         if user.new_record?
-          Cdo::Metrics.put(
-            'User', 'PasswordResetUserNotFound', 1, {
-              Environment: CDO.rack_env
-            }
-          )
+          log_user_metric('PasswordResetUserNotFound')
           # Only send if the user has an email auth option OR if the user is unmigrated and has a password login
         elsif user.authentication_options.any?(&:email?) || user.provider.nil?
           user.raw_token = send_reset_password_instructions
         else
-          Cdo::Metrics.put(
-            'User', 'PasswordResetEmailAuthNotFound', 1, {
-              Environment: CDO.rack_env
-            }
-          )
+          log_user_metric('PasswordResetEmailAuthNotFound')
         end
         user
       end
@@ -45,16 +37,16 @@ module Services
       private def send_reset_password_instructions
         raw = user.send(:set_reset_password_token)
         user.send(:send_devise_notification, :reset_password_instructions, raw, {to: email})
-        Cdo::Metrics.put(
-          'User', 'PasswordResetEmailSuccessful', 1, {
-            Environment: CDO.rack_env
-          }
-        )
+        log_user_metric('PasswordResetEmailSuccessful')
         raw
       rescue ArgumentError
         user.errors.add :base, I18n.t('password.reset_errors.invalid_email')
         user.send(:clear_reset_password_token)
         nil
+      end
+
+      private def log_user_metric(metric_name)
+        Cdo::Metrics.put('User', metric_name, 1, {Environment: CDO.rack_env})
       end
     end
   end

--- a/dashboard/lib/services/user/password_resetter_by_email.rb
+++ b/dashboard/lib/services/user/password_resetter_by_email.rb
@@ -45,6 +45,11 @@ module Services
       private def send_reset_password_instructions
         raw = user.send(:set_reset_password_token)
         user.send(:send_devise_notification, :reset_password_instructions, raw, {to: email})
+        Cdo::Metrics.put(
+          'User', 'PasswordResetEmailSuccessful', 1, {
+            Environment: CDO.rack_env
+          }
+        )
         raw
       rescue ArgumentError
         user.errors.add :base, I18n.t('password.reset_errors.invalid_email')

--- a/dashboard/test/lib/services/user/password_resetter_by_email_test.rb
+++ b/dashboard/test/lib/services/user/password_resetter_by_email_test.rb
@@ -11,6 +11,12 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
     let(:mail) {ActionMailer::Base.deliveries.first}
     let!(:user) {create(:user, email: email)}
 
+    let(:cdo_rack_env) {'expected_cdo_rack_env'}
+
+    before do
+      CDO.stubs(:rack_env).returns(cdo_rack_env)
+    end
+
     it 'returns user with generated reset password tokens' do
       _reset_password.must_equal user
       _(reset_password.reset_password_token).wont_be_nil
@@ -26,12 +32,9 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
     end
 
     it 'tracks PasswordResetEmailSuccessful metric' do
-      expected_env = 'expected_env'
-
-      CDO.expects(:rack_env).returns(expected_env)
       Cdo::Metrics.
         expects(:put).
-        with('User', 'PasswordResetEmailSuccessful', 1, {Environment: expected_env}).
+        with('User', 'PasswordResetEmailSuccessful', 1, {Environment: cdo_rack_env}).
         once
 
       reset_password
@@ -55,12 +58,9 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
       end
 
       it 'tracks PasswordResetEmailSuccessful metric' do
-        expected_env = 'expected_env'
-
-        CDO.expects(:rack_env).returns(expected_env)
         Cdo::Metrics.
           expects(:put).
-          with('User', 'PasswordResetEmailSuccessful', 1, {Environment: expected_env}).
+          with('User', 'PasswordResetEmailSuccessful', 1, {Environment: cdo_rack_env}).
           once
 
         reset_password
@@ -74,12 +74,9 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
 
       context 'when account does not have email authentication' do
         it 'tracks PasswordResetEmailAuthNotFound metric' do
-          expected_env = 'expected_env'
-
-          CDO.expects(:rack_env).returns(expected_env)
           Cdo::Metrics.
             expects(:put).
-            with('User', 'PasswordResetEmailAuthNotFound', 1, {Environment: expected_env}).
+            with('User', 'PasswordResetEmailAuthNotFound', 1, {Environment: cdo_rack_env}).
             once
 
           reset_password
@@ -120,12 +117,9 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
         end
 
         it 'tracks PasswordResetEmailSuccessful metric' do
-          expected_env = 'expected_env'
-
-          CDO.expects(:rack_env).returns(expected_env)
           Cdo::Metrics.
             expects(:put).
-            with('User', 'PasswordResetEmailSuccessful', 1, {Environment: expected_env}).
+            with('User', 'PasswordResetEmailSuccessful', 1, {Environment: cdo_rack_env}).
             once
 
           reset_password
@@ -142,12 +136,9 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
         end
 
         it 'tracks PasswordResetEmailAuthNotFound metric' do
-          expected_env = 'expected_env'
-
-          CDO.expects(:rack_env).returns(expected_env)
           Cdo::Metrics.
             expects(:put).
-            with('User', 'PasswordResetEmailAuthNotFound', 1, {Environment: expected_env}).
+            with('User', 'PasswordResetEmailAuthNotFound', 1, {Environment: cdo_rack_env}).
             once
 
           reset_password
@@ -182,12 +173,9 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
         end
 
         it 'tracks PasswordResetEmailSuccessful metric' do
-          expected_env = 'expected_env'
-
-          CDO.expects(:rack_env).returns(expected_env)
           Cdo::Metrics.
             expects(:put).
-            with('User', 'PasswordResetEmailSuccessful', 1, {Environment: expected_env}).
+            with('User', 'PasswordResetEmailSuccessful', 1, {Environment: cdo_rack_env}).
             once
 
           reset_password
@@ -198,12 +186,9 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
       let(:user) {nil}
 
       it 'tracks PasswordResetUserNotFound metric' do
-        expected_env = 'expected_env'
-
-        CDO.expects(:rack_env).returns(expected_env)
         Cdo::Metrics.
           expects(:put).
-          with('User', 'PasswordResetUserNotFound', 1, {Environment: expected_env}).
+          with('User', 'PasswordResetUserNotFound', 1, {Environment: cdo_rack_env}).
           once
 
         reset_password

--- a/dashboard/test/lib/services/user/password_resetter_by_email_test.rb
+++ b/dashboard/test/lib/services/user/password_resetter_by_email_test.rb
@@ -25,6 +25,18 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
       _(mail.subject).must_equal 'Code.org reset password instructions'
     end
 
+    it 'tracks PasswordResetEmailSuccessful metric' do
+      expected_env = 'expected_env'
+
+      CDO.expects(:rack_env).returns(expected_env)
+      Cdo::Metrics.
+        expects(:put).
+        with('User', 'PasswordResetEmailSuccessful', 1, {Environment: expected_env}).
+        once
+
+      reset_password
+    end
+
     context 'when account is unmigrated' do
       let!(:user) {create(:user, :demigrated, email: email)}
 
@@ -40,6 +52,18 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
         _(mail).wont_be_nil
         _(mail.to).must_equal [email]
         _(mail.subject).must_equal 'Code.org reset password instructions'
+      end
+
+      it 'tracks PasswordResetEmailSuccessful metric' do
+        expected_env = 'expected_env'
+
+        CDO.expects(:rack_env).returns(expected_env)
+        Cdo::Metrics.
+          expects(:put).
+          with('User', 'PasswordResetEmailSuccessful', 1, {Environment: expected_env}).
+          once
+
+        reset_password
       end
     end
 
@@ -94,6 +118,18 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
           _(mail.to).must_equal [email]
           _(mail.subject).must_equal 'Code.org reset password instructions'
         end
+
+        it 'tracks PasswordResetEmailSuccessful metric' do
+          expected_env = 'expected_env'
+
+          CDO.expects(:rack_env).returns(expected_env)
+          Cdo::Metrics.
+            expects(:put).
+            with('User', 'PasswordResetEmailSuccessful', 1, {Environment: expected_env}).
+            once
+
+          reset_password
+        end
       end
     end
 
@@ -143,6 +179,18 @@ class Services::User::PasswordResetterByEmailTest < ActiveSupport::TestCase
           _(mail).wont_be_nil
           _(mail.to).must_equal [email]
           _(mail.subject).must_equal 'Code.org reset password instructions'
+        end
+
+        it 'tracks PasswordResetEmailSuccessful metric' do
+          expected_env = 'expected_env'
+
+          CDO.expects(:rack_env).returns(expected_env)
+          Cdo::Metrics.
+            expects(:put).
+            with('User', 'PasswordResetEmailSuccessful', 1, {Environment: expected_env}).
+            once
+
+          reset_password
         end
       end
     end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -908,10 +908,18 @@ class UserTest < ActiveSupport::TestCase
     # login by username still works
     user = create :user
     assert_equal user, User.find_for_authentication(login: user.username)
+    Cdo::Metrics.
+      expects(:put).
+      with('User', 'LoginByUsername', 1, includes(:Environment)).
+      once
 
     # login by email still works
     email_user = create :user, email: 'not@an.email'
     assert_equal email_user, User.find_for_authentication(login: 'not@an.email')
+    Cdo::Metrics.
+      expects(:put).
+      with('User', 'LoginByEmail', 1, includes(:Environment)).
+      once
 
     # login by hashed email
     hashed_email_user = create :user, age: 4


### PR DESCRIPTION
This PR adds metrics to monitor the use of password resets and logging in via username rather than email.

## Links
Jira: [P20-1277](https://codedotorg.atlassian.net/browse/P20-1277)

## Testing story
Tests added to`password_resetter_by_email_test.rb` and `user_test.rb` to ensure logging is taking place