### PR TITLE
Fix Puma Worker Boot Metric

### DIFF
--- a/lib/cdo/app_server_hooks.rb
+++ b/lib/cdo/app_server_hooks.rb
@@ -28,7 +28,7 @@ module Cdo
 
     def self.after_fork(host:)
       require 'cdo/aws/metrics'
-      Cdo::Metrics.put('App Server', 'WorkerBoot', 1, Host: host)
+      Cdo::Metrics.put('App Server', 'WorkerBoot', 1, {Host: host})
 
       # Statsig is initialized here for managed environments. For development, it is
       # intialized in config/initializers/statsig.rb


### PR DESCRIPTION
We see these errors in production puma logs (`/dashboard/logs/puma_stdout.log`):

```
[1102] PumaWorkerKiller: Rolling Restart. 48 workers consuming total: 279149.0703125 mb. Sending TERM to pid 4059.
[1400826] WARNING hook before_worker_boot failed with exception (ArgumentError) wrong number of arguments (given 3, expected 4)
[1102] - Worker 33 (PID: 1400826) booted in 0.01s, phase: 0
I, [2024-11-12T02:09:05.191493 #1400826]  INFO -- : Fork detected, re-connecting child process...
I, [2024-11-12T02:09:05.218012 #1400826]  INFO -- : Fork detected, re-connecting child process...
```

And we haven't seen a `WorkerBoot` metric being published to CloudWatch [in more than a year](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~'App*20Server~'WorkerBoot~'Host~'code.org~(id~'m7~yAxis~'right~region~'us-east-1~label~'HTTP*20Worker*20Boot*20-*20Pegasus))~(~'...~'studio.code.org~(id~'m8~yAxis~'right~region~'us-east-1~label~'HTTP*20Worker*20Boot*20-*20Dashboard))~(~'CWAgent~'mem_used_percent~'AutoScalingGroupName~'Frontends-autoscale-prod~(id~'max~label~'Memory*20Utilization*20-*20Max~stat~'Maximum~region~'us-east-1~visible~false))~(~'...~(id~'avg~label~'Memory*20Utilization*20-*20Avg~stat~'Average~region~'us-east-1~visible~false))~(~'...~(id~'min~label~'Memory*20Utilization*20-*20Min~stat~'Minimum~region~'us-east-1~visible~false)))~view~'timeSeries~stacked~false~region~'us-east-1~yAxis~(left~(min~0~max~100)~right~(min~0))~title~'Memory*20Utilization*20*26*20Process*20Starts~period~86400~stat~'Sum~start~'-PT10800H~end~'P0D)).

We now need to explicitly pass the `Dimensions` argument in a Hash, like we do elsewhere ([example](https://github.com/code-dot-org/code-dot-org/blob/7cf74703a9a553155a03adecf322ba18f4bee352/dashboard/lib/services/user/password_resetter_by_username.rb#L14-L18))?

## Testing story

We don't use puma and child workers in development nor continuous integration environments. Provision an adhoc and confirm the metrics are being published and that errors about incorrect number of arguments in the puma logs no longer appear. 

The puma logs (`dashboard/logs/puma_stdout.log`) show that child worker restarts no longer raise an error invoking our `Cdo::Metrics` helper:

```
[152038] - Worker 1 (PID: 181749) booted in 0.01s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14919.6171875 mb. Sending TERM to pid 178081.
Statsig already initialized.
[152038] - Worker 6 (PID: 181801) booted in 0.03s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14919.6171875 mb. Sending TERM to pid 177712.
Statsig already initialized.
[152038] - Worker 3 (PID: 181901) booted in 0.01s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14919.6171875 mb. Sending TERM to pid 178026.
Statsig already initialized.
[152038] - Worker 4 (PID: 181963) booted in 0.01s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14919.6171875 mb. Sending TERM to pid 177608.
Statsig already initialized.
[152038] - Worker 7 (PID: 182010) booted in 0.01s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14919.6171875 mb. Sending TERM to pid 177866.
Statsig already initialized.
[152038] - Worker 2 (PID: 182063) booted in 0.01s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14919.6171875 mb. Sending TERM to pid 177815.
Statsig already initialized.
[152038] - Worker 0 (PID: 182111) booted in 0.01s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14638.57421875 mb. Sending TERM to pid 182010.
Statsig already initialized.
[152038] - Worker 7 (PID: 185632) booted in 0.01s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14638.57421875 mb. Sending TERM to pid 182111.
Statsig already initialized.
[152038] - Worker 0 (PID: 185740) booted in 0.01s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14638.57421875 mb. Sending TERM to pid 181901.
Statsig already initialized.
[152038] - Worker 3 (PID: 185796) booted in 0.01s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14638.57421875 mb. Sending TERM to pid 181749.
Statsig already initialized.
[152038] - Worker 1 (PID: 185843) booted in 0.01s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14638.57421875 mb. Sending TERM to pid 182063.
Statsig already initialized.
[152038] - Worker 2 (PID: 185896) booted in 0.02s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14638.57421875 mb. Sending TERM to pid 181963.
Statsig already initialized.
[152038] - Worker 4 (PID: 185943) booted in 0.02s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14638.57421875 mb. Sending TERM to pid 181801.
Statsig already initialized.
[152038] - Worker 6 (PID: 186052) booted in 0.01s, phase: 0
[152038] PumaWorkerKiller: Rolling Restart. 8 workers consuming total: 14638.57421875 mb. Sending TERM to pid 181698.
```

And the `WorkerBoot` Metric is being successfully published to CloudWatch for this adhoc
<img width="1626" alt="image" src="https://github.com/user-attachments/assets/ef28d3f1-447e-4dd3-b2e1-bc91a6fe8332">


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
