### PR TITLE
Create embeddable census map

### DIFF
--- a/apps/src/sites/code.org/pages/public/embeddable_census_map.js
+++ b/apps/src/sites/code.org/pages/public/embeddable_census_map.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import CensusMap from '@cdo/apps/templates/census/CensusMap';
+import getScriptData from '@cdo/apps/util/getScriptData';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tileset = getScriptData('tileset');
+  const mapElement = document.getElementById('census-map');
+  if (mapElement) {
+    ReactDOM.render(<CensusMap tileset={tileset} />, mapElement);
+  }
+});

--- a/apps/src/templates/census/CensusMap.jsx
+++ b/apps/src/templates/census/CensusMap.jsx
@@ -7,7 +7,7 @@ import i18n from '@cdo/locale';
 
 class CensusMapInfoWindow extends Component {
   static propTypes = {
-    onTakeSurveyClick: PropTypes.func.isRequired,
+    onTakeSurveyClick: PropTypes.func,
     schoolId: PropTypes.string.isRequired,
     schoolName: PropTypes.string.isRequired,
     city: PropTypes.string.isRequired,
@@ -75,21 +75,23 @@ class CensusMapInfoWindow extends Component {
           <div className={colorClass} />
           {censusMessage}
         </div>
-        <div className="button-container">
-          <div className="button-link-div">
-            <a
-              onClick={() =>
-                this.props.onTakeSurveyClick(schoolDropdownOption, false)
-              }
-            >
-              <div className="button">
-                <div className="button-text">
-                  Take the survey for this school
+        {this.props.onTakeSurveyClick && (
+          <div className="button-container">
+            <div className="button-link-div">
+              <a
+                onClick={() =>
+                  this.props.onTakeSurveyClick(schoolDropdownOption, false)
+                }
+              >
+                <div className="button">
+                  <div className="button-text">
+                    Take the survey for this school
+                  </div>
                 </div>
-              </div>
-            </a>
+              </a>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     );
   }
@@ -97,7 +99,7 @@ class CensusMapInfoWindow extends Component {
 
 export default class CensusMap extends Component {
   static propTypes = {
-    onTakeSurveyClick: PropTypes.func.isRequired,
+    onTakeSurveyClick: PropTypes.func,
     school: PropTypes.object,
     tileset: PropTypes.string.isRequired,
   };

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -225,6 +225,7 @@ const PEGASUS_ENTRIES = {
   'code.org/public/teach': './src/sites/code.org/pages/public/teach.js',
   'code.org/public/students': './src/sites/code.org/pages/public/students.js',
   'code.org/public/cms-demo': './src/sites/code.org/pages/public/cms-demo.js',
+  'code.org/public/embeddable_census_map': './src/sites/code.org/pages/public/embeddable_census_map.js',
 
   // hourofcode.com
   'hourofcode.com/views/theme_common_head_after': './src/sites/hourofcode.com/pages/views/theme_common_head_after.js',

--- a/pegasus/sites.v3/code.org/public/embeddable_census_map.haml
+++ b/pegasus/sites.v3/code.org/public/embeddable_census_map.haml
@@ -1,0 +1,19 @@
+---
+theme: responsive
+no_header: true
+no_footer: true
+embeddable: true
+english_only: true
+---
+
+- js_locale = request.locale.to_s.downcase.tr('-', '_')
+%script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
+%link{rel: "stylesheet", href: "https://api.tiles.mapbox.com/mapbox-gl-js/v1.1.1/mapbox-gl.css"}
+%link{rel: "stylesheet", type: "text/css", href: "/css/census-map.css"}
+%script{src: webpack_asset_path('js/code.org/public/embeddable_census_map.js'), data: {tileset: CDO.mapbox_access_tileset.to_json}}
+
+#census-map
+
+%script{type: "text/javascript", src: "https://api.tiles.mapbox.com/mapbox-gl-js/v1.1.1/mapbox-gl.js"}
+:javascript
+  mapboxgl.accessToken = "#{CDO.mapbox_access_token}";


### PR DESCRIPTION
Makes an embeddable version of the census map, similar to what I did in https://github.com/code-dot-org/code-dot-org/pull/62144. I did not update styles here or provide a way to allow marketing to do so -- I think that will need to be done by an engineer in a follow-up. 

![Screenshot 2024-11-19 at 9 55 09 AM](https://github.com/user-attachments/assets/1980c66e-4f9c-4b68-8666-2a869e0e6ac5)

This exists on Pegasus as-is. I considered putting it on Dashboard, as we want to move /yourschool to Dashboard at some point, but that didn't feel "right" for just the map. In fact, I think we need to decide where we want custom JS "widgets" to live once we move to the CMS, but for now I've left it on Pegasus. I don't believe this would block us moving /yourschool to Dashboard.