### PR TITLE
Return student locked out boolean in PUT /users response

### DIFF
--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -60,6 +60,8 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
     useState(false);
   const [showEmailUpdateSuccess, setShowEmailUpdateSuccess] = useState(false);
   const [errors, setErrors] = useState<Record<string, string[]>>({});
+  const [studentLockedOut, setStudentLockedOut] =
+    useState(studentInLockoutFlow);
 
   const displayNameHelperMessage = useMemo(
     () =>
@@ -82,10 +84,10 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
 
   const lockedOutStudentMessage = useMemo(
     () =>
-      studentInLockoutFlow
+      studentLockedOut
         ? i18n.accountInformation_updateFieldParentPermissionRequired()
         : undefined,
-    [studentInLockoutFlow]
+    [studentLockedOut]
   );
 
   const handleSubmitAccountSettingsUpdate = async () => {
@@ -115,6 +117,8 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
     });
 
     if (response.ok) {
+      const result = await response.json();
+      setStudentLockedOut(result.student_in_lockout_flow);
       setShowAccountUpdateSuccess(true);
     } else {
       const validationErrors = await response.json();
@@ -376,7 +380,7 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
                   value: String(value),
                   text: String(value),
                 }))}
-                disabled={studentInLockoutFlow}
+                disabled={studentLockedOut}
                 dropdownTextThickness="thin"
                 className={commonStyles.input}
                 helperMessage={lockedOutStudentMessage}
@@ -408,7 +412,7 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
                     clearError('us_state');
                   }}
                   items={usStateOptions}
-                  disabled={studentInLockoutFlow}
+                  disabled={studentLockedOut}
                   dropdownTextThickness="thin"
                   className={commonStyles.input}
                   helperMessage={lockedOutStudentMessage}

--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -116,13 +116,12 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
       }),
     });
 
+    const result = await response.json();
     if (response.ok) {
-      const result = await response.json();
       setStudentLockedOut(result.student_in_lockout_flow);
       setShowAccountUpdateSuccess(true);
     } else {
-      const validationErrors = await response.json();
-      setErrors(validationErrors);
+      setErrors(result);
     }
   };
 

--- a/apps/test/unit/accounts/AccountInformationTest.jsx
+++ b/apps/test/unit/accounts/AccountInformationTest.jsx
@@ -92,6 +92,10 @@ describe('AccountInformation', () => {
   it('submits form with updated information and displays success alert', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
+      json: () =>
+        Promise.resolve({
+          student_in_lockout_flow: false,
+        }),
     });
 
     render(<AccountInformation {...defaultProps} />);
@@ -189,5 +193,35 @@ describe('AccountInformation', () => {
     );
     expect(screen.getByLabelText(/age/i)).toBeDisabled();
     expect(screen.getByLabelText(/state/i)).toBeDisabled();
+  });
+
+  it('disables student-specific fields when user update response puts student in lock out flow', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          student_in_lockout_flow: true,
+        }),
+    });
+    render(
+      <AccountInformation
+        {...defaultProps}
+        isStudent={true}
+        userType={'student'}
+        studentInLockoutFlow={false}
+      />
+    );
+
+    expect(screen.getByLabelText(/age/i)).toBeEnabled();
+    expect(screen.getByLabelText(/state/i)).toBeEnabled();
+
+    fireEvent.click(
+      screen.getByRole('button', {name: /update account information/i})
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/age/i)).toBeDisabled();
+      expect(screen.getByLabelText(/state/i)).toBeDisabled();
+    });
   });
 });

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -210,6 +210,11 @@ class Policies::ChildAccount
     ((student_birthday + student_age.years > today) ? (student_age - 1) : student_age) <= policy[:max_age]
   end
 
+  def self.student_in_lockout?(user)
+    # The student is in a 'lockout' flow if they are underage and not unlocked
+    underage?(user) && !Policies::ChildAccount::ComplianceState.permission_granted?(user)
+  end
+
   # Whether or not the user can create/link new personal logins
   def self.can_link_new_personal_account?(user)
     return true unless user.student?


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
when a student makes an update to their account that would put them in the lock out flow, we need the ui to update immediately, disabling the fields they need permission to edit. I added a function that returns a boolean for the user's lockout status, so it can be used both in the server side data passed to the haml file, as well as the api response for updating account info. the locked out ui state is then set based on the response.




## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
