### PR TITLE
launch TA notifications by removing the experiment

### DIFF
--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -16,7 +16,6 @@ import instructions, {
   setTaRubric,
 } from '@cdo/apps/redux/instructions';
 import RubricFloatingActionButton from '@cdo/apps/templates/rubrics/RubricFloatingActionButton';
-import experiments from '@cdo/apps/util/experiments';
 import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 
 $(document).ready(initPage);
@@ -112,9 +111,6 @@ function initPage() {
           PLATFORMS.BOTH
         );
       }
-      const notificationsEnabled = experiments.isEnabled(
-        experiments.TA_NOTIFICATIONS
-      );
       ReactDOM.render(
         <Provider store={getStore()}>
           <RubricFloatingActionButton
@@ -123,7 +119,6 @@ function initPage() {
             reportingData={reportingData}
             currentLevelName={config.level_name}
             aiEnabled={rubric.learningGoals.some(lg => lg.aiEnabled)}
-            notificationsEnabled={notificationsEnabled}
             canShowTaScoresAlert={canShowTaScoresAlert}
           />
         </Provider>,

--- a/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
+++ b/apps/src/templates/rubrics/RubricFloatingActionButton.jsx
@@ -75,7 +75,6 @@ function RubricFloatingActionButton({
   reportingData,
   aiEnabled,
   sectionId,
-  notificationsEnabled,
   canShowTaScoresAlert,
 }) {
   const sessionStorageKey = 'RubricFabOpenStateKey';
@@ -100,10 +99,7 @@ function RubricFloatingActionButton({
   const readyStudentCount = useAppSelector(selectReadyStudentCount);
   const hasLoadedStudentStatus = useAppSelector(selectHasLoadedStudentStatus);
   const showCountBubble =
-    onLevelForEvaluation &&
-    notificationsEnabled &&
-    hasLoadedStudentStatus &&
-    readyStudentCount > 0;
+    onLevelForEvaluation && hasLoadedStudentStatus && readyStudentCount > 0;
 
   const eventData = useMemo(() => {
     return {
@@ -298,7 +294,6 @@ RubricFloatingActionButton.propTypes = {
   reportingData: reportingDataShape,
   aiEnabled: PropTypes.bool,
   sectionId: PropTypes.number,
-  notificationsEnabled: PropTypes.bool,
   canShowTaScoresAlert: PropTypes.bool,
 };
 

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -29,8 +29,6 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS =
   'teacher-dashboard-section-buttons';
 experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
   'teacher-dashboard-section-buttons-alternate-text';
-// Enables notifications in Teaching Assistant when new AI evaluations are ready to review
-experiments.TA_NOTIFICATIONS = 'taNotifications';
 experiments.FINISH_DIALOG_METRICS = 'finish-dialog-metrics';
 experiments.I18N_TRACKING = 'frontend-i18n-tracking';
 experiments.TIME_SPENT = 'time-spent';

--- a/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
+++ b/apps/test/unit/templates/rubrics/RubricFloatingActionButtonTest.jsx
@@ -56,7 +56,6 @@ const defaultProps = {
   rubric: defaultRubric,
   currentLevelName: 'test_level',
   studentLevelInfo: null,
-  notificationsEnabled: true,
 };
 
 describe('RubricFloatingActionButton', () => {
@@ -202,30 +201,6 @@ describe('RubricFloatingActionButton', () => {
       const countBubble = screen.getByLabelText(i18n.aiEvaluationsToReview());
       expect(countBubble).toBeVisible();
       expect(countBubble.textContent).toBe('1');
-    });
-
-    it('does not render count bubble when notifications are disabled', async () => {
-      stubFetch({
-        evalStatusForAll: successJsonAll,
-        teacherEvals: noEvals,
-      });
-
-      render(
-        <Provider store={store}>
-          <RubricFloatingActionButton
-            {...defaultProps}
-            sectionId={sectionId}
-            notificationsEnabled={false}
-          />
-        </Provider>
-      );
-
-      await wait();
-
-      expect(screen.getByRole('img', {name: 'TA overlay'})).toBeVisible();
-      expect(
-        screen.queryByLabelText(i18n.aiEvaluationsToReview())
-      ).not.toBeInTheDocument();
     });
 
     it('does not render count bubble on non-assessment level', async () => {

--- a/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
+++ b/dashboard/test/ui/features/teacher_tools/rubrics/ai_evaluate_student_code.feature
@@ -182,7 +182,7 @@ Feature: Evaluate student code against rubrics using AI
     And I am on "http://studio.code.org/home"
     And I wait until element "#homepage-container" is visible
     And element "#sign_in_or_user" contains text "Teacher_Aiden"
-    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2?enableExperiments=taNotifications"
+    And I am on "http://studio.code.org/s/allthethings/lessons/48/levels/2"
     And I wait for the lab page to fully load
     And element ".teacher-panel td:eq(1)" contains text "Aiden"
     And I click selector ".teacher-panel td:eq(1)" to load a new page


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-816. Teachers should now start seeing the 🔴 notification badge and ✖️ dismissible alert on AI-enabled lessons:

![Screenshot 2024-11-18 at 2 58 29 PM](https://github.com/user-attachments/assets/21bda174-cbe7-4374-b15f-b82a3a4b202b)

## Testing story

* updated UI test to ensure the feature actually launches
* existing unit tests to ensure I didn't break anything
* manual testing to ensure notification UI still works as expected locally