### PR TITLE
Reload account settings page if student updates age or state

### DIFF
--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, {useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 
 import {hashEmail} from '@cdo/apps/code-studio/hashEmail';
 import Alert, {alertTypes} from '@cdo/apps/componentLibrary/alert/Alert';
@@ -17,6 +17,9 @@ import {AccountInformationProps} from './types';
 
 import styles from './style.module.scss';
 import commonStyles from '../common/common.styles.module.scss';
+
+const ACCOUNT_UPDATE_SUCCESS_PARAM = 'account-update-success';
+const SCROLL_POSITION_KEY = 'scrollPosition';
 
 export const AccountInformation: React.FC<AccountInformationProps> = ({
   verifiedTeacher,
@@ -88,6 +91,22 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
     [studentInLockoutFlow]
   );
 
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    if (searchParams?.has(ACCOUNT_UPDATE_SUCCESS_PARAM)) {
+      setShowAccountUpdateSuccess(true);
+      const url = new URL(window.location.href);
+      url.searchParams.delete(ACCOUNT_UPDATE_SUCCESS_PARAM);
+      window.history.replaceState({}, '', url.toString());
+      const scrollPositionString = sessionStorage.getItem(SCROLL_POSITION_KEY);
+      if (scrollPositionString) {
+        const scrollPosition = JSON.parse(scrollPositionString);
+        window.scrollTo(scrollPosition.left, scrollPosition.top);
+        sessionStorage.removeItem(SCROLL_POSITION_KEY);
+      }
+    }
+  }, []);
+
   const handleSubmitAccountSettingsUpdate = async () => {
     resetMessages();
     setErrors({});
@@ -116,9 +135,25 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
 
     if (response.ok) {
       setShowAccountUpdateSuccess(true);
+      handleReload();
     } else {
       const validationErrors = await response.json();
       setErrors(validationErrors);
+    }
+  };
+
+  const handleReload = () => {
+    if (
+      isStudent &&
+      (age !== userAge || usState !== userProperties?.us_state)
+    ) {
+      sessionStorage.setItem(
+        SCROLL_POSITION_KEY,
+        JSON.stringify({top: window.scrollY, left: window.scrollX})
+      );
+      const url = new URL(window.location.href);
+      url.searchParams.set(ACCOUNT_UPDATE_SUCCESS_PARAM, '');
+      window.location.href = url.toString();
     }
   };
 

--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -142,6 +142,12 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
     }
   };
 
+  /**
+   * Page must be reloaded if student updates their age or state.
+   * These values affect whether or not the student is locked out,
+   * which is passed down to the account settings page components
+   * through script data.
+   */
   const handleReload = () => {
     if (
       isStudent &&

--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -18,8 +18,7 @@ import {AccountInformationProps} from './types';
 import styles from './style.module.scss';
 import commonStyles from '../common/common.styles.module.scss';
 
-const ACCOUNT_UPDATE_SUCCESS_PARAM = 'account-update-success';
-const SCROLL_POSITION_KEY = 'scrollPosition';
+const ACCOUNT_UPDATE_SUCCESS = 'account-update-success';
 
 export const AccountInformation: React.FC<AccountInformationProps> = ({
   verifiedTeacher,
@@ -92,18 +91,11 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
   );
 
   useEffect(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-    if (searchParams?.has(ACCOUNT_UPDATE_SUCCESS_PARAM)) {
+    const accountUpdateSuccess =
+      sessionStorage.getItem(ACCOUNT_UPDATE_SUCCESS) === String(true);
+    if (accountUpdateSuccess) {
       setShowAccountUpdateSuccess(true);
-      const url = new URL(window.location.href);
-      url.searchParams.delete(ACCOUNT_UPDATE_SUCCESS_PARAM);
-      window.history.replaceState({}, '', url.toString());
-      const scrollPositionString = sessionStorage.getItem(SCROLL_POSITION_KEY);
-      if (scrollPositionString) {
-        const scrollPosition = JSON.parse(scrollPositionString);
-        window.scrollTo(scrollPosition.left, scrollPosition.top);
-        sessionStorage.removeItem(SCROLL_POSITION_KEY);
-      }
+      sessionStorage.removeItem(ACCOUNT_UPDATE_SUCCESS);
     }
   }, []);
 
@@ -153,13 +145,8 @@ export const AccountInformation: React.FC<AccountInformationProps> = ({
       isStudent &&
       (age !== userAge || usState !== userProperties?.us_state)
     ) {
-      sessionStorage.setItem(
-        SCROLL_POSITION_KEY,
-        JSON.stringify({top: window.scrollY, left: window.scrollX})
-      );
-      const url = new URL(window.location.href);
-      url.searchParams.set(ACCOUNT_UPDATE_SUCCESS_PARAM, '');
-      window.location.href = url.toString();
+      sessionStorage.setItem(ACCOUNT_UPDATE_SUCCESS, String(true));
+      window.location.reload();
     }
   };
 

--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -18,7 +18,7 @@ import {AccountInformationProps} from './types';
 import styles from './style.module.scss';
 import commonStyles from '../common/common.styles.module.scss';
 
-const ACCOUNT_UPDATE_SUCCESS = 'account-update-success';
+export const ACCOUNT_UPDATE_SUCCESS = 'account-update-success';
 
 export const AccountInformation: React.FC<AccountInformationProps> = ({
   verifiedTeacher,

--- a/apps/src/accounts/ChangeEmail/ChangeEmailForm.tsx
+++ b/apps/src/accounts/ChangeEmail/ChangeEmailForm.tsx
@@ -58,7 +58,7 @@ export const ChangeEmailForm: React.FC<ChangeEmailFormProps> = ({
   };
 
   return (
-    <form className={styles.form}>
+    <div className={styles.form}>
       <TextField
         inputType="email"
         name="user[email]"
@@ -125,6 +125,6 @@ export const ChangeEmailForm: React.FC<ChangeEmailFormProps> = ({
           </div>
         </div>
       )}
-    </form>
+    </div>
   );
 };

--- a/apps/src/accounts/ChangeEmail/formStyle.module.scss
+++ b/apps/src/accounts/ChangeEmail/formStyle.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.125rem;
+  margin-bottom: 1rem;
 
   input {
     width: 400px;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
when a student makes an update to their account that would put them in the lock out flow, we need the ui to update immediately, disabling the fields they need permission to edit. this pr reloads the page if the student updates their age or state, getting fresh data for all the account settings components.

BEFORE:

https://github.com/user-attachments/assets/ee0486ab-d009-4f8a-822b-65f4a04641e4



AFTER:

https://github.com/user-attachments/assets/f26d3de8-1fac-4e7d-b66d-bd477390050b



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
