### PR TITLE
Proposal: rework lab2 data loading

### DIFF
--- a/apps/src/lab2/views/Lab2Wrapper2.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper2.tsx
@@ -76,9 +76,10 @@ const Lab2Wrapper2: React.FC<Lab2WrapperProps> = (/* ... props ... */) => {
 
   // Use lab2EntryPoints to lazy load the lab view, i.e.:
   // const LabView = lab2EntryPoints[labData.levelProperties.appName].view;
+  // const labProps = {...labData, ...props};
   // return (
   //   <Suspense fallback={<Loading isLoading={true} />}>
-  //     <LabView />
+  //     <LabView {...labProps} />
   //   </Suspense>
   // );
   return null;

--- a/apps/src/lab2/views/Lab2Wrapper2.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper2.tsx
@@ -1,0 +1,87 @@
+import React, {useEffect, useState} from 'react';
+import {useSelector} from 'react-redux';
+
+import {getLevelPropertiesPath} from '@cdo/apps/code-studio/progressReduxSelectors';
+
+import {LevelProperties, ProjectSources} from '../types';
+
+import Loading from './Loading';
+
+/**
+ * These are the top-level parameters provided to the Lab2 system.
+ * Generally, these *don't* change between levels in a lab and
+ * are only fetched on initial page load.
+ *
+ * This is primarily just App Options/App Options-derived data
+ * (pretty much just PartialAppOptions in utils.ts).
+ */
+interface Lab2WrapperProps {
+  standaloneProjectId?: string;
+  appOptionsLevelId?: number;
+  editBlocks?: 'start_sources';
+  // ... etc
+}
+
+/**
+ * This is the data provided to individual labs as props.
+ * These will change between levels in a lab and are fetched
+ * whenever the level changes or resets.
+ */
+interface LabData {
+  levelProperties: LevelProperties; // Might be a fancy TS way to make this lab-specific
+  startSources?: ProjectSources; // Optional because not all labs are project-backed
+}
+
+/**
+ * We can use this type in lab2EntryPoints.ts to enforce that LabViews can accept
+ * these props.
+ */
+export type LabProps = Lab2WrapperProps & LabData;
+
+const Lab2Wrapper2: React.FC<Lab2WrapperProps> = (/* ... props ... */) => {
+  // 1. We store the current lab's data as internal state and NOT in Redux.
+  // This way, the Lab2 wrapper controls how and when labs access their data,
+  // to ensure it's always loaded and ready before mounting the lab view.
+  // If undefined, no lab has loaded and we can show a loading screen.
+  const [labData, setLabData] = useState<LabData | undefined>();
+
+  const loadLabData = async (levelPropertiesPath: string): Promise<LabData> => {
+    // This would be mostly the same as what we currently do in lab2Redux (maybe in a separate file)
+    // except that we will save data to our local state instead of dispatching redux updates.
+    // const levelProperties = await fetchLevelProperties(levelPropertiesPath);
+    // ...
+    return {} as unknown as LabData;
+  };
+
+  // 2. Similar to ProjectContainer; when the current level ID changes,
+  // we load the lab's data, except here we will set it in internal state,
+  // and make sure to clear it out before loading the next lab.
+
+  const levelPropertiesPath = useSelector(getLevelPropertiesPath);
+  useEffect(() => {
+    if (!levelPropertiesPath) {
+      return;
+    }
+
+    setLabData(undefined);
+    loadLabData(levelPropertiesPath).then(labData => setLabData(labData));
+  }, [levelPropertiesPath]);
+
+  // 3. Render based on the current lab data. If lab data is undefined, show a loading screen.
+  // Otherwise, render the appropriate lab view.
+
+  if (!labData) {
+    return <Loading isLoading={true} />;
+  }
+
+  // Use lab2EntryPoints to lazy load the lab view, i.e.:
+  // const LabView = lab2EntryPoints[labData.levelProperties.appName].view;
+  // return (
+  //   <Suspense fallback={<Loading isLoading={true} />}>
+  //     <LabView />
+  //   </Suspense>
+  // );
+  return null;
+};
+
+export default Lab2Wrapper2;


### PR DESCRIPTION
This is a pseudo-code/skeleton writeup for a potential proposal to rework the data fetching and lab loading lifecycle in Lab2. It's not a huge change; this doesn't really change any of the actual loading logic, but instead changes how that data is fetched and how it's provided to individual labs.

### Motivation/Background

Currently, the Lab2 system does a pretty good job of managing level transitions and loading level/project data for each new lab view, to minimize the work individual labs have to do to manage their data. However, as the number of labs and features have grown, we've run into some edge cases around labs needing to respond to certain lifecycle events, and needing to know when specific pieces of data have been updated as opposed to others. The LifecycleListener/useLifecycleListener hook were added to mitigate this partially, but these still have the issue that individual labs need to register callbacks which can only happen once their views have been mounted; and labs need to specifically know the order in which lifecycle events occur alongside other redux updates. In other words, the concerns I'm attempting to address are:
1) Labs can't always make safe assumptions about when they will or will not receive lifecycle callbacks
2) Labs can't always make safe assumptions about order in which essential pieces of data will be updated in redux (i.e. level ID vs level properties vs sources, etc)
3) Labs can't be 100% sure that they will only be rendered when they're supposed to be for the given level (this is primarily only a problem for Music Lab today because it's rendered in the background, but does affect other labs because of the brief window between navigating to a new level and loading the data for the new level, which is ultimately what updates the view).

There have been a few recent bugs/issues that have brought this to light for me, but one particular case was https://github.com/code-dot-org/code-dot-org/pull/62418 - Music Lab uses both the `LevelLoadCompleted` lifecycle event as well as the React `componentDidMount` callback to load it's level data, which meant that in some cases we were reloading lab data twice, leading to issues. However, I found that I couldn't simply remove one or the other, because of inconsistencies in how these events were fired in standalone projects vs levels.

### Proposal
Instead of updating and storing core lab data (level properties, sources) in redux, the idea here is to provide them as **top level props** to the lab view. Additionally, in this proposal we always unmount the lab view while fetching data, and only mount the lab view once data has fully loaded for the level. This way, data is provided in a unidirectional, single entrypoint, and labs can be confident that if they are mounted, then all the data they need is available and ready.

Relatedly, this also attempts to logically organize data by how it gets updatec; any data that remains constant for whole progression and that's fetched only once per page load (i.e. app options) is provided as top level props for the entire Lab2 system, while data that changes for each lab is stored as internal state by the Lab2 wrapper, and provided as props the individual lab views.

Goals:
1) Labs are only mounted once their data is fully loaded
2) Lab views receive their server-provided data as props (instead of through redux).
3) Lab views are dismounted when transitioning to a new lab

Of course, this is still untested pseudo-code, and I'm sure there a lot of edge cases to still talk through (for example, other server-provided fields like predict level data, etc). We'd also still need to be careful to enforce that lab views access data in the right way (i.e. try to limit reading from the progress redux store when possible, use lab props instead). But the idea is that we'd have more consistency and reliability with our level transition and data fetching lifecycle.