### PR TITLE
Add us_state to parent permission events

### DIFF
--- a/apps/src/sites/studio/pages/policy_compliance/child_account_consent.js
+++ b/apps/src/sites/studio/pages/policy_compliance/child_account_consent.js
@@ -14,11 +14,13 @@ $(document).ready(function () {
     ? new Date(permissionGrantedDateString)
     : undefined;
   const studentId = element.getAttribute('data-student-id');
+  const usState = element.getAttribute('data-us-state');
   ReactDOM.render(
     <ChildAccountConsent
       permissionGranted={permissionGranted}
       permissionGrantedDate={permissionGrantedDate}
       studentId={studentId}
+      usState={usState}
     />,
     element
   );

--- a/apps/src/templates/policy_compliance/ChildAccountConsent/index.tsx
+++ b/apps/src/templates/policy_compliance/ChildAccountConsent/index.tsx
@@ -73,18 +73,20 @@ export interface ChildAccountConsentProps {
   permissionGranted?: boolean;
   permissionGrantedDate?: Date;
   studentId?: number;
+  usState?: string;
 }
 
 const ChildAccountConsent: React.FC<ChildAccountConsentProps> = ({
   permissionGranted,
   permissionGrantedDate,
   studentId,
+  usState,
 }) => {
   if (permissionGranted && permissionGrantedDate) {
-    reportEvent(EVENTS.CAP_PARENT_CONSENT_GRANTED, {studentId: studentId});
+    reportEvent(EVENTS.CAP_PARENT_CONSENT_GRANTED, {studentId, usState});
     return permissionGrantedMessage(permissionGrantedDate);
   } else {
-    reportEvent(EVENTS.CAP_PARENT_CONSENT_EXPIRED);
+    reportEvent(EVENTS.CAP_PARENT_CONSENT_EXPIRED, {studentId, usState});
     return expiredTokenMessage();
   }
 };

--- a/apps/test/unit/templates/policy_compliance/ChildAccountConsentTest.tsx
+++ b/apps/test/unit/templates/policy_compliance/ChildAccountConsentTest.tsx
@@ -45,6 +45,7 @@ describe('ChildAccountConsent', () => {
       permissionGranted: true,
       permissionGrantedDate: permissionGrantedDate,
       studentId: 12345,
+      usState: 'CA',
     };
     const dateOptions: Intl.DateTimeFormatOptions = {
       year: 'numeric',
@@ -68,6 +69,7 @@ describe('ChildAccountConsent', () => {
       expect(sendEventSpy).to.be.calledOnce;
       expect(sendEventSpy).calledWith('CAP Parent Consent Granted', {
         studentId: props.studentId,
+        usState: props.usState,
       });
     });
   });

--- a/dashboard/app/controllers/policy_compliance_controller.rb
+++ b/dashboard/app/controllers/policy_compliance_controller.rb
@@ -25,6 +25,7 @@ class PolicyComplianceController < ApplicationController
     user = permission_request.user
     @permission_granted_date = user.cap_status_date
     @student_id = user.id
+    @us_state = user.us_state
   end
 
   # GET /policy_compliance/pending_permission_request

--- a/dashboard/app/views/policy_compliance/child_account_consent.html.haml
+++ b/dashboard/app/views/policy_compliance/child_account_consent.html.haml
@@ -2,6 +2,7 @@
   :"data-permission-granted" => @permission_granted,
   :"data-permission-granted-date" => @permission_granted_date,
   :"data-student-id" => @student_id,
+  :"data-us-state" => @us_state,
 }
 
 - content_for(:head) do


### PR DESCRIPTION
Adds the US State value to the following events:
- `CAP_PARENT_CONSENT_EXPIRED`
- `CAP_PARENT_CONSENT_GRANTED`

Also adds the user ID to `CAP_PARENT_CONSENT_EXPIRED` since it was missing.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1187)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
