### PR TITLE
add us state to parental permission banner

### DIFF
--- a/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
+++ b/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
@@ -43,6 +43,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
       reportEvent(EVENTS.CAP_PARENT_EMAIL_BANNER_SHOWN, {
         inSection: currentUser.inSection,
         consentStatus: currentUser.childAccountComplianceState,
+        usState: currentUser.usStateCode,
       });
     }
   }, [show, currentUser.inSection, currentUser.childAccountComplianceState]);
@@ -53,6 +54,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
     reportEvent(EVENTS.CAP_PARENT_EMAIL_BANNER_CLICKED, {
       inSection: currentUser.inSection,
       consentStatus: currentUser.childAccountComplianceState,
+      usState: currentUser.usStateCode,
     });
   };
 

--- a/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
+++ b/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
@@ -46,7 +46,12 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
         usState: currentUser.usStateCode,
       });
     }
-  }, [show, currentUser.inSection, currentUser.childAccountComplianceState]);
+  }, [
+    show,
+    currentUser.inSection,
+    currentUser.childAccountComplianceState,
+    currentUser.usStateCode,
+  ]);
 
   const handleModalShow = () => {
     setShowModal(true);


### PR DESCRIPTION
Adds us_state to the following events in the parent permission banner (banner for students)
- `CAP_PARENT_EMAIL_BANNER_SHOWN`
- `CAP_PARENT_EMAIL_BANNER_CLICKED`

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1191)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
