### PR TITLE
Update blocklyLocaleImports.js to fix fa-IR block translations.

### DIFF
--- a/apps/src/sites/studio/pages/blocklyLocaleImports.js
+++ b/apps/src/sites/studio/pages/blocklyLocaleImports.js
@@ -15,7 +15,7 @@ export const blocklyLocaleMap = {
   'es-mx': require('blockly/msg/es'),
   'et-ee': require('blockly/msg/et'),
   'eu-es': require('blockly/msg/eu'),
-  'fa-is': require('blockly/msg/fa'),
+  'fa-ir': require('blockly/msg/fa'),
   'fi-fi': require('blockly/msg/fi'),
   'fil-ph': require('blockly/msg/en'), // English provided as broader alternative for Filipino
   'fr-fr': require('blockly/msg/fr'),


### PR DESCRIPTION
A recent typo from this [commit](https://github.com/code-dot-org/code-dot-org/commit/99900535c5a11ccce848baad4313710593f0d2a5#diff-8a305fedde053e7165c919a7798c54e3488d905748a4d3d7fb4d0e0575f9d787R18) caused a regression in the translation of some common blocks:

Broken:

![image](https://github.com/user-attachments/assets/386a02a1-2d4d-4bba-9a61-31e25fd0e42a)

With fix:

![image](https://github.com/user-attachments/assets/fb637caa-18a5-4a7b-b116-0ec48711ccf2)

## Links

- jira ticket: [P20-1298](https://codedotorg.atlassian.net/browse/P20-1298)

## Testing story

Manually patched the affected data structure and saw the page render in production with, at least, an appropriate translation.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
