### PR TITLE
Disable signup button if parent email is invalid

### DIFF
--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -387,7 +387,7 @@ const FinishStudentAccount: React.FunctionComponent<{
               name === '' ||
               age === '' ||
               (usIp && state === '') ||
-              (isParent && parentEmail === '') ||
+              (isParent && (parentEmail === '' || showParentEmailError)) ||
               !gdprValid
             }
             isPending={isSubmitting}

--- a/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
@@ -308,15 +308,53 @@ describe('FinishStudentAccount', () => {
     expect(screen.queryByText(locale.email_error_message())).toBe(null);
     expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
 
-    // Enter state
+    // Enter parent email
     fireEvent.change(parentEmailInput, {target: {value: 'parent@email.com'}});
 
     // Error does not show and button is enabled when email is entered
     expect(screen.queryByText(locale.email_error_message())).toBe(null);
     expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
 
-    // Clear state
+    // Clear parent email
     fireEvent.change(parentEmailInput, {target: {value: ''}});
+
+    // Error shows and button is disabled with empty email
+    screen.getByText(locale.email_error_message());
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('parentEmail error shows if parent checkbox is selected and parentEmail is an invalid email', async () => {
+    renderDefault();
+    await waitFor(() => {
+      expect(fetchStub.calledOnce).toBe(true);
+    });
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
+
+    // Set other required fields
+    const displayNameInput = screen.getAllByDisplayValue('')[1];
+    const stateInput = screen.getAllByRole('combobox')[1];
+    const ageInput = screen.getAllByRole('combobox')[0];
+    fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
+    fireEvent.change(stateInput, {target: {value: 'WA'}});
+    fireEvent.change(ageInput, {target: {value: '6'}});
+
+    // Button is enabled after required fields are filled before parent checkbox is checked
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
+
+    // Check parent checkbox
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+
+    // Error message doesn't show and button is disabled after parent checkbox is checked
+    const parentEmailInput = screen.getAllByDisplayValue('')[1];
+    expect(screen.queryByText(locale.email_error_message())).toBe(null);
+    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+
+    // Enter parent email
+    fireEvent.change(parentEmailInput, {
+      target: {value: '@invalidparentemail'},
+    });
 
     // Error shows and button is disabled with empty email
     screen.getByText(locale.email_error_message());

--- a/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
@@ -1,4 +1,5 @@
 import {render, screen, fireEvent, act, waitFor} from '@testing-library/react';
+import '@testing-library/jest-dom';
 import React from 'react';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
@@ -153,7 +154,7 @@ describe('FinishStudentAccount', () => {
     const finishSignUpButton = screen.getByRole('button', {
       name: locale.go_to_my_account(),
     });
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
   });
 
   it('leaving the displayName field empty shows error message and disabled submit button until display name is entered', async () => {
@@ -174,21 +175,21 @@ describe('FinishStudentAccount', () => {
 
     // Error message doesn't show and button is disabled by default
     expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
 
     // Enter display name
     fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
 
     // Error does not show and button is enabled when display name is entered
     expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
+    expect(finishSignUpButton).not.toBeDisabled();
 
     // Clear display name
     fireEvent.change(displayNameInput, {target: {value: ''}});
 
     // Error shows and button is disabled with empty display name
     screen.getByText(locale.display_name_error_message());
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
   });
 
   it('leaving the age field empty shows error message and disabled submit button until age is entered', async () => {
@@ -209,21 +210,21 @@ describe('FinishStudentAccount', () => {
 
     // Error message doesn't show and button is disabled by default
     expect(screen.queryByText(locale.age_error_message())).toBe(null);
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
 
     // Enter age
     fireEvent.change(ageInput, {target: {value: '6'}});
 
     // Error does not show and button is enabled when age is entered
     expect(screen.queryByText(locale.age_error_message())).toBe(null);
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
+    expect(finishSignUpButton).not.toBeDisabled();
 
     // Clear age
     fireEvent.change(ageInput, {target: {value: ''}});
 
     // Error shows and button is disabled with empty age
     screen.getByText(locale.age_error_message());
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
   });
 
   it('leaving the state field empty shows error message and disabled submit button until state is entered for US users', async () => {
@@ -244,21 +245,21 @@ describe('FinishStudentAccount', () => {
 
     // Error message doesn't show and button is disabled by default
     expect(screen.queryByText(locale.state_error_message())).toBe(null);
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
 
     // Enter state
     fireEvent.change(stateInput, {target: {value: 'WA'}});
 
     // Error does not show and button is enabled when state is entered
     expect(screen.queryByText(locale.state_error_message())).toBe(null);
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
+    expect(finishSignUpButton).not.toBeDisabled();
 
     // Clear state
     fireEvent.change(stateInput, {target: {value: ''}});
 
     // Error shows and button is disabled with empty state
     screen.getByText(locale.state_error_message());
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
   });
 
   it('state field is not required if user is not detected in the U.S.', async () => {
@@ -277,7 +278,7 @@ describe('FinishStudentAccount', () => {
     fireEvent.change(ageInput, {target: {value: '6'}});
 
     // Button is enabled without having to enter anything for 'state'
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
+    expect(finishSignUpButton).not.toBeDisabled();
   });
 
   it('parentEmail error shows if parent checkbox is selected and parentEmail is selected then cleared', async () => {
@@ -298,7 +299,7 @@ describe('FinishStudentAccount', () => {
     fireEvent.change(ageInput, {target: {value: '6'}});
 
     // Button is enabled after required fields are filled before parent checkbox is checked
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
+    expect(finishSignUpButton).not.toBeDisabled();
 
     // Check parent checkbox
     fireEvent.click(screen.getAllByRole('checkbox')[0]);
@@ -306,21 +307,21 @@ describe('FinishStudentAccount', () => {
     // Error message doesn't show and button is disabled after parent checkbox is checked
     const parentEmailInput = screen.getAllByDisplayValue('')[1];
     expect(screen.queryByText(locale.email_error_message())).toBe(null);
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
 
     // Enter parent email
     fireEvent.change(parentEmailInput, {target: {value: 'parent@email.com'}});
 
     // Error does not show and button is enabled when email is entered
     expect(screen.queryByText(locale.email_error_message())).toBe(null);
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
+    expect(finishSignUpButton).not.toBeDisabled();
 
     // Clear parent email
     fireEvent.change(parentEmailInput, {target: {value: ''}});
 
     // Error shows and button is disabled with empty email
     screen.getByText(locale.email_error_message());
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
   });
 
   it('parentEmail error shows if parent checkbox is selected and parentEmail is an invalid email', async () => {
@@ -341,7 +342,7 @@ describe('FinishStudentAccount', () => {
     fireEvent.change(ageInput, {target: {value: '6'}});
 
     // Button is enabled after required fields are filled before parent checkbox is checked
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
+    expect(finishSignUpButton).not.toBeDisabled();
 
     // Check parent checkbox
     fireEvent.click(screen.getAllByRole('checkbox')[0]);
@@ -349,7 +350,7 @@ describe('FinishStudentAccount', () => {
     // Error message doesn't show and button is disabled after parent checkbox is checked
     const parentEmailInput = screen.getAllByDisplayValue('')[1];
     expect(screen.queryByText(locale.email_error_message())).toBe(null);
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
 
     // Enter parent email
     fireEvent.change(parentEmailInput, {
@@ -358,7 +359,7 @@ describe('FinishStudentAccount', () => {
 
     // Error shows and button is disabled with empty email
     screen.getByText(locale.email_error_message());
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
   });
 
   it('GDPR has expected behavior if api call returns true', async () => {
@@ -386,9 +387,9 @@ describe('FinishStudentAccount', () => {
     const finishSignUpButton = screen.getByRole('button', {
       name: locale.go_to_my_account(),
     });
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
     fireEvent.click(screen.getAllByRole('checkbox')[1]);
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
+    expect(finishSignUpButton).not.toBeDisabled();
   });
 
   it('clicking finish sign up button triggers fetch call and shows error if backend error', async () => {

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -1,4 +1,5 @@
 import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import '@testing-library/jest-dom';
 import React from 'react';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
@@ -145,7 +146,7 @@ describe('FinishTeacherAccount', () => {
     const finishSignUpButton = screen.getByRole('button', {
       name: locale.go_to_my_account(),
     });
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
   });
 
   it('leaving the displayName field empty shows error message', () => {
@@ -186,9 +187,9 @@ describe('FinishTeacherAccount', () => {
     const finishSignUpButton = screen.getByRole('button', {
       name: locale.go_to_my_account(),
     });
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe('true');
+    expect(finishSignUpButton).toBeDisabled();
     fireEvent.click(screen.getAllByRole('checkbox')[0]);
-    expect(finishSignUpButton.getAttribute('aria-disabled')).toBe(null);
+    expect(finishSignUpButton).not.toBeDisabled();
 
     // Restore the original fetch implementation
     fetchStub.restore();


### PR DESCRIPTION
After the new signup flow A/B experiment was started, Bethany noticed that the "Go to my account" button on the finish student account page wasn't disabled when the parent email was invalid. This PR ensures the button is disabled while the parent email is invalid.

### Button is disabled when email is invalid
![Showsinvalidparent](https://github.com/user-attachments/assets/0fa802c9-7d1f-41d0-ba4e-a4df2b4d9c83)

### Button is enabled once email is valid
![parentvalid](https://github.com/user-attachments/assets/664f6c59-7c2c-4a9d-8167-59e295670133)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2770)

## Testing story
Local testing and adding a unit test.
