### PR TITLE
Lab2: don't attempt level switch if the level ID is the same

### DIFF
--- a/apps/src/code-studio/progressRedux.ts
+++ b/apps/src/code-studio/progressRedux.ts
@@ -330,6 +330,10 @@ export function navigateToLevelId(levelId: string): ProgressThunkAction {
     const currentLevel = getCurrentLevel(getState());
 
     if (canChangeLevelInPage(currentLevel, newLevel)) {
+      // If the requested level is the same as the current level, don't do anything.
+      if (state.currentLevelId === levelId) {
+        return;
+      }
       updateBrowserForLevelNavigation(state, newLevel.path, levelId);
       // Notify the Lab2 system that the level is changing.
       notifyLevelChange(currentLevel.id, levelId);


### PR DESCRIPTION
Fix for https://codedotorg.atlassian.net/browse/LABS-1269. Another lifecycle-adjacent issue, though this was mostly just a miss on my part - when clicking the same bubble in a lab2 progression, we were attempting to go through the level switch flow which meant dispatching the `LevelChangeRequested` event; however since the level ID doesn't actually change, none of the other level loading occurs and in the case of Music Lab, we end up ending our analytics session and clearing out the blockly workspace without re-initializing it. Fix here is just to not attempt the level switch if the requested level ID is the same as the current level ID.

## Links

https://codedotorg.atlassian.net/browse/LABS-1269

## Testing story

Tested locally on Music HOC script, and Lab2 allthethings levels