### PR TITLE
HoC 2024 - Add new videos

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -62,6 +62,9 @@
       v2:
         title: "One Hour: Ignite. Inspire. Code."
         desc: "Bring what your children love to life! Start the fun with an activity."
+    video_caption:
+      visible: "One Hour Can Make The Invisible Visible"
+      in_a_world: "Hour of Code: Make The Invisible Visible | Official Trailer"
 
   hoc2023_header: "Creativity with AI"
   hoc2023_hero_desc_homepage: "Join millions across the globe in organizing an hour of coding, with or without AI and learning how AI works. Anyone, anywhere can do it. No experience needed."

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -64,7 +64,7 @@
         desc: "Bring what your children love to life! Start the fun with an activity."
     video_caption:
       visible: "One Hour Can Make The Invisible Visible"
-      in_a_world: "Hour of Code: Make The Invisible Visible | Official Trailer"
+      in_a_world: "Make The Invisible Visible | Official Trailer"
 
   hoc2023_header: "Creativity with AI"
   hoc2023_hero_desc_homepage: "Join millions across the globe in organizing an hour of coding, with or without AI and learning how AI works. Anyone, anywhere can do it. No experience needed."

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -68,10 +68,10 @@ layout: wide_index
             =hoc_s("hoc_homepage.host.desc")
           %a.link-button{href: resolve_url('/events')}
             =hoc_s("hoc_homepage.host.button")
-        .flex-1
-          %figure.video-responsive
+        .flex-1{style: "width: 100%"}
+          %figure.video-responsive{style: "max-width: unset"}
             %div
-              %iframe{allowfullscreen: "true", frameborder: "0", referrerpolicy: "strict-origin-when-cross-origin", src: "https://www.youtube-nocookie.com/embed/sypjpycrR7k", width: "560", height: "315"}
+              %iframe{allowfullscreen: "true", frameborder: "0", referrerpolicy: "strict-origin-when-cross-origin", src: "https://www.youtube-nocookie.com/embed/sypjpycrR7k"}
           .video-caption.flex-container.justify-space-between.wrap{style: "margin-top: 0.5rem;"}
             %figcaption.no-margin-top.no-margin-bottom
               =hoc_s("hoc_2024.video_caption.visible")

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -68,8 +68,17 @@ layout: wide_index
             =hoc_s("hoc_homepage.host.desc")
           %a.link-button{href: resolve_url('/events')}
             =hoc_s("hoc_homepage.host.button")
-        %figure.flex-1
-          %img.rounded-corners{src: "/images/homepage-students-computer.png", alt: "", style: "width: 100%"}
+        .flex-1
+          %figure.video-responsive
+            %div
+              %iframe{allowfullscreen: "true", frameborder: "0", referrerpolicy: "strict-origin-when-cross-origin", src: "https://www.youtube-nocookie.com/embed/sypjpycrR7k", width: "560", height: "315"}
+          .video-caption.flex-container.justify-space-between.wrap{style: "margin-top: 0.5rem;"}
+            %figcaption.no-margin-top.no-margin-bottom
+              =hoc_s("hoc_2024.video_caption.visible")
+            %p.no-margin-bottom
+              %i{class: "fa-solid fa-download", style: "color: var(--brand_secondary_default);"}
+              %a{href: "//videos.code.org/hour-of-code-2024.mp4"}
+                =hoc_s(:call_to_action_download_video)
 
   -# Resources
   %section

--- a/pegasus/sites.v3/hourofcode.com/views/resources/resources_videos.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/resources/resources_videos.haml
@@ -47,8 +47,8 @@
 .carousel-wrapper.video-carousel
   %swiper-container.videos{navigation: "true", "navigation-next-el": ".nav-next-videos", "navigation-prev-el": ".nav-prev-videos", pagination: "true", init: "false", "allow-touch-move": "false"}
     - videos.each do |video|
-      -# Show playlist link for the second video
-      - if video == videos[1]
+      -# Show playlist link for the third video
+      - if video == videos[2]
         %swiper-slide
           %a{href: "https://www.youtube.com/playlist?list=PLzdnOPI1iJNcXMS80NRhQd0NA3po1swJf", target: "_blank", rel: "noopener noreferrer"}
             %figure

--- a/pegasus/sites.v3/hourofcode.com/views/resources/resources_videos.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/resources/resources_videos.haml
@@ -1,6 +1,16 @@
 :ruby
   videos = [
     {
+      youtube_code: 'sypjpycrR7k',
+      caption: hoc_s("hoc_2024.video_caption.visible"),
+      download_link: "//videos.code.org/hour-of-code-2024.mp4",
+    },
+    {
+      youtube_code: '7EuMEcFQfWc',
+      caption: hoc_s("hoc_2024.video_caption.in_a_world"),
+      download_link: "//videos.code.org/hour-of-code-2024-in-a-world.mp4",
+    },
+    {
       youtube_code: 'VYqHGIR7a_k',
       caption: hoc_s(:videos_creativity),
       download_link: "//videos.code.org/social/creativity-is.mp4",


### PR DESCRIPTION
Adds two new videos to the video carousel on https://hourofcode.com/resources and replaces an image with the first video on https://hourofcode.com homepage. Backup download videos have been added to S3. 

## Links
Jira ticket: [ACQ-2712](https://codedotorg.atlassian.net/browse/ACQ-2712)

## Testing story
Tested locally that downloads work

----

## hourofcode.com homepage
<img width="1275" alt="Screenshot 2024-11-19 at 11 34 52 AM" src="https://github.com/user-attachments/assets/d287fc5e-93ce-453d-b746-9019f47134b0">

## hourofcode.com/resources
<img width="1275" alt="Screenshot 2024-11-19 at 11 15 26 AM" src="https://github.com/user-attachments/assets/f32b31a6-267e-4b16-8d91-b50c3f44a1be">
