### PR TITLE
Music: readonly header pack

### DIFF
--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -153,7 +153,7 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
 
   return (
     <div className={moduleStyles.container}>
-      {!readOnlyWorkspace && (
+      {
         <div className={moduleStyles.subContainer}>
           {!allowPackSelection && packFolder && (
             <button
@@ -168,66 +168,70 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
               <CurrentPack packFolder={packFolder} noRightPadding={true} />
             </button>
           )}
-          <button
-            onClick={onClickStartOver}
-            type="button"
-            className={classNames(
-              moduleStyles.button,
-              allowPackSelection && packFolder && moduleStyles.buttonWide
-            )}
-          >
-            {allowPackSelection && packFolder && (
-              <CurrentPack packFolder={packFolder} noRightPadding={false} />
-            )}
-            <FontAwesome
-              title={musicI18n.startOver()}
-              icon="refresh"
-              className={'icon'}
-            />
-          </button>
-          <button
-            onClick={() => onClickUndoRedo('undo')}
-            type="button"
-            className={classNames(
-              moduleStyles.button,
-              !canUndo && moduleStyles.buttonDisabled
-            )}
-            disabled={!canUndo}
-          >
-            <FontAwesome
-              title={musicI18n.undo()}
-              icon="undo"
-              className={'icon'}
-            />
-          </button>
-          <button
-            onClick={() => onClickUndoRedo('redo')}
-            type="button"
-            className={classNames(
-              moduleStyles.button,
-              !canRedo && moduleStyles.buttonDisabled
-            )}
-            disabled={!canRedo}
-          >
-            <FontAwesome
-              title={musicI18n.redo()}
-              icon="redo"
-              className={'icon'}
-            />
-          </button>
+          {!readOnlyWorkspace && (
+            <>
+              <button
+                onClick={onClickStartOver}
+                type="button"
+                className={classNames(
+                  moduleStyles.button,
+                  allowPackSelection && packFolder && moduleStyles.buttonWide
+                )}
+              >
+                {allowPackSelection && packFolder && (
+                  <CurrentPack packFolder={packFolder} noRightPadding={false} />
+                )}
+                <FontAwesome
+                  title={musicI18n.startOver()}
+                  icon="refresh"
+                  className={'icon'}
+                />
+              </button>
+              <button
+                onClick={() => onClickUndoRedo('undo')}
+                type="button"
+                className={classNames(
+                  moduleStyles.button,
+                  !canUndo && moduleStyles.buttonDisabled
+                )}
+                disabled={!canUndo}
+              >
+                <FontAwesome
+                  title={musicI18n.undo()}
+                  icon="undo"
+                  className={'icon'}
+                />
+              </button>
+              <button
+                onClick={() => onClickUndoRedo('redo')}
+                type="button"
+                className={classNames(
+                  moduleStyles.button,
+                  !canRedo && moduleStyles.buttonDisabled
+                )}
+                disabled={!canRedo}
+              >
+                <FontAwesome
+                  title={musicI18n.redo()}
+                  icon="redo"
+                  className={'icon'}
+                />
+              </button>
+              <button
+                onClick={onFeedbackClicked}
+                type="button"
+                className={classNames(moduleStyles.button)}
+              >
+                <FontAwesome
+                  title={musicI18n.feedback()}
+                  icon="commenting"
+                  className={'icon'}
+                />
+              </button>
+            </>
+          )}
         </div>
-      )}
-      <button
-        onClick={onFeedbackClicked}
-        type="button"
-        className={classNames(moduleStyles.button)}
-      >
-        <FontAwesome
-          title={musicI18n.feedback()}
-          icon="commenting"
-          className={'icon'}
-        />
-      </button>
+      }
       {skipUrl && (
         <button
           onClick={onClickSkip}

--- a/apps/src/music/views/HeaderButtons.tsx
+++ b/apps/src/music/views/HeaderButtons.tsx
@@ -153,85 +153,83 @@ const HeaderButtons: React.FunctionComponent<HeaderButtonsProps> = ({
 
   return (
     <div className={moduleStyles.container}>
-      {
-        <div className={moduleStyles.subContainer}>
-          {!allowPackSelection && packFolder && (
+      <div className={moduleStyles.subContainer}>
+        {!allowPackSelection && packFolder && (
+          <button
+            type="button"
+            className={classNames(
+              moduleStyles.button,
+              moduleStyles.buttonWide,
+              moduleStyles.buttonInteractionDisabled
+            )}
+            disabled={true}
+          >
+            <CurrentPack packFolder={packFolder} noRightPadding={true} />
+          </button>
+        )}
+        {!readOnlyWorkspace && (
+          <>
             <button
+              onClick={onClickStartOver}
               type="button"
               className={classNames(
                 moduleStyles.button,
-                moduleStyles.buttonWide,
-                moduleStyles.buttonInteractionDisabled
+                allowPackSelection && packFolder && moduleStyles.buttonWide
               )}
-              disabled={true}
             >
-              <CurrentPack packFolder={packFolder} noRightPadding={true} />
+              {allowPackSelection && packFolder && (
+                <CurrentPack packFolder={packFolder} noRightPadding={false} />
+              )}
+              <FontAwesome
+                title={musicI18n.startOver()}
+                icon="refresh"
+                className={'icon'}
+              />
             </button>
-          )}
-          {!readOnlyWorkspace && (
-            <>
-              <button
-                onClick={onClickStartOver}
-                type="button"
-                className={classNames(
-                  moduleStyles.button,
-                  allowPackSelection && packFolder && moduleStyles.buttonWide
-                )}
-              >
-                {allowPackSelection && packFolder && (
-                  <CurrentPack packFolder={packFolder} noRightPadding={false} />
-                )}
-                <FontAwesome
-                  title={musicI18n.startOver()}
-                  icon="refresh"
-                  className={'icon'}
-                />
-              </button>
-              <button
-                onClick={() => onClickUndoRedo('undo')}
-                type="button"
-                className={classNames(
-                  moduleStyles.button,
-                  !canUndo && moduleStyles.buttonDisabled
-                )}
-                disabled={!canUndo}
-              >
-                <FontAwesome
-                  title={musicI18n.undo()}
-                  icon="undo"
-                  className={'icon'}
-                />
-              </button>
-              <button
-                onClick={() => onClickUndoRedo('redo')}
-                type="button"
-                className={classNames(
-                  moduleStyles.button,
-                  !canRedo && moduleStyles.buttonDisabled
-                )}
-                disabled={!canRedo}
-              >
-                <FontAwesome
-                  title={musicI18n.redo()}
-                  icon="redo"
-                  className={'icon'}
-                />
-              </button>
-              <button
-                onClick={onFeedbackClicked}
-                type="button"
-                className={classNames(moduleStyles.button)}
-              >
-                <FontAwesome
-                  title={musicI18n.feedback()}
-                  icon="commenting"
-                  className={'icon'}
-                />
-              </button>
-            </>
-          )}
-        </div>
-      }
+            <button
+              onClick={() => onClickUndoRedo('undo')}
+              type="button"
+              className={classNames(
+                moduleStyles.button,
+                !canUndo && moduleStyles.buttonDisabled
+              )}
+              disabled={!canUndo}
+            >
+              <FontAwesome
+                title={musicI18n.undo()}
+                icon="undo"
+                className={'icon'}
+              />
+            </button>
+            <button
+              onClick={() => onClickUndoRedo('redo')}
+              type="button"
+              className={classNames(
+                moduleStyles.button,
+                !canRedo && moduleStyles.buttonDisabled
+              )}
+              disabled={!canRedo}
+            >
+              <FontAwesome
+                title={musicI18n.redo()}
+                icon="redo"
+                className={'icon'}
+              />
+            </button>
+            <button
+              onClick={onFeedbackClicked}
+              type="button"
+              className={classNames(moduleStyles.button)}
+            >
+              <FontAwesome
+                title={musicI18n.feedback()}
+                icon="commenting"
+                className={'icon'}
+              />
+            </button>
+          </>
+        )}
+      </div>
       {skipUrl && (
         <button
           onClick={onClickSkip}

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -749,7 +749,8 @@ class UnconnectedMusicView extends React.Component {
           player={this.player}
           allowPackSelection={
             this.library?.getHasRestrictedPacks() &&
-            !this.props.levelProperties?.levelData?.packId
+            !this.props.levelProperties?.levelData?.packId &&
+            !this.props.isReadOnlyWorkspace
           }
           analyticsReporter={this.analyticsReporter}
           blocklyWorkspace={this.musicBlocklyWorkspace}


### PR DESCRIPTION
With this change, when viewing another user's shared Music Lab project, the chosen pack is shown and the feedback icon is not.  Previously, the chosen pack was not shown, but the feedback icon was.

#### Another user's project (before)

![Screenshot 2024-11-19 at 12 30 36 PM](https://github.com/user-attachments/assets/b2188082-4adf-4da2-834d-fb67832d6c66)

#### Another user's project (after)

![Screenshot 2024-11-19 at 12 26 43 PM](https://github.com/user-attachments/assets/42e8f44c-f1a2-46b4-adfe-3908eaca222c)

#### a level in /s/music-intro-2024 (unchanged)
 
![Screenshot 2024-11-19 at 12 26 15 PM](https://github.com/user-attachments/assets/7aa6849f-8716-4f26-b61f-80a8bd7a0ee3)

#### a level in /s/music-jam-2024 (unchanged)

![Screenshot 2024-11-19 at 12 26 36 PM](https://github.com/user-attachments/assets/292bdb35-5b0c-4434-b79a-185178dd9e42)

#### the final level in /s/music-jam-2024 (unchanged)

![Screenshot 2024-11-19 at 12 26 20 PM](https://github.com/user-attachments/assets/07d6c499-b976-471f-b76e-07807195ebe6)
