### PR TITLE
add us_state to parent email modal events

### DIFF
--- a/apps/src/sites/studio/pages/policy_compliance/parental_permission/_modal.js
+++ b/apps/src/sites/studio/pages/policy_compliance/parental_permission/_modal.js
@@ -16,40 +16,50 @@ document.addEventListener('DOMContentLoaded', () => {
   const renderModal = () => {
     // eslint-disable-next-line react/prop-types
     const Modal = ({lockoutDate, inSection}) => {
+      const currentUser = useSelector(state => state.currentUser);
+      if (!currentUser?.userId) return null;
+
+      const defaultEventParams = (parentalPermissionRequest = {}) => ({
+        consentStatus: parentalPermissionRequest?.consent_status,
+        usState: currentUser?.usStateCode,
+      });
+
       const reportEvent = (eventName, payload = {}) => {
         payload.inSection = inSection;
         analyticsReporter.sendEvent(eventName, payload);
       };
 
       const handleClose = parentalPermissionRequest => {
-        reportEvent(EVENTS.CAP_PARENT_EMAIL_MODAL_CLOSED, {
-          consentStatus: parentalPermissionRequest?.consent_status,
-        });
+        reportEvent(
+          EVENTS.CAP_PARENT_EMAIL_MODAL_CLOSED,
+          defaultEventParams(parentalPermissionRequest)
+        );
       };
 
       const handleSubmit = parentalPermissionRequest => {
-        reportEvent(EVENTS.CAP_PARENT_EMAIL_SUBMITTED, {
-          consentStatus: parentalPermissionRequest.consent_status,
-        });
+        reportEvent(
+          EVENTS.CAP_PARENT_EMAIL_SUBMITTED,
+          defaultEventParams(parentalPermissionRequest)
+        );
       };
 
       const handleResend = parentalPermissionRequest => {
-        reportEvent(EVENTS.CAP_PARENT_EMAIL_RESEND, {
-          consentStatus: parentalPermissionRequest.consent_status,
-        });
+        reportEvent(
+          EVENTS.CAP_PARENT_EMAIL_RESEND,
+          defaultEventParams(parentalPermissionRequest)
+        );
       };
 
       const handleUpdate = parentalPermissionRequest => {
-        reportEvent(EVENTS.CAP_PARENT_EMAIL_UPDATED, {
-          consentStatus: parentalPermissionRequest.consent_status,
-        });
+        reportEvent(
+          EVENTS.CAP_PARENT_EMAIL_UPDATED,
+          defaultEventParams(parentalPermissionRequest)
+        );
       };
-
-      const currentUser = useSelector(state => state.currentUser);
-      if (!currentUser?.userId) return null;
 
       reportEvent(EVENTS.CAP_PARENT_EMAIL_MODAL_SHOWN, {
         consentStatus: currentUser?.childAccountComplianceState,
+        usState: currentUser?.usStateCode,
       });
 
       return (

--- a/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
+++ b/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
@@ -67,6 +67,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
 
     reportEvent(EVENTS.CAP_PARENT_EMAIL_MODAL_CLOSED, {
       inSection: currentUser.inSection,
+      usState: currentUser.usStateCode,
       consentStatus,
     });
   };
@@ -76,6 +77,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
   ) => {
     reportEvent(EVENTS.CAP_PARENT_EMAIL_SUBMITTED, {
       inSection: currentUser.inSection,
+      usState: currentUser.usStateCode,
       consentStatus: parentalPermissionRequest.consent_status,
     });
   };
@@ -85,6 +87,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
   ) => {
     reportEvent(EVENTS.CAP_PARENT_EMAIL_RESEND, {
       inSection: currentUser.inSection,
+      usState: currentUser.usStateCode,
       consentStatus: parentalPermissionRequest.consent_status,
     });
   };
@@ -94,6 +97,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
   ) => {
     reportEvent(EVENTS.CAP_PARENT_EMAIL_UPDATED, {
       inSection: currentUser.inSection,
+      usState: currentUser.usStateCode,
       consentStatus: parentalPermissionRequest.consent_status,
     });
   };

--- a/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
+++ b/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
@@ -34,6 +34,16 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
     analyticsReporter.sendEvent(eventName, payload);
   };
 
+  const defaultEventParams = (
+    parentalPermissionRequest: ParentalPermissionRequest
+  ) => {
+    return {
+      inSection: currentUser.inSection,
+      usState: currentUser.usStateCode,
+      consentStatus: parentalPermissionRequest.consent_status,
+    };
+  };
+
   useEffect(() => {
     currentUser.userId && setShow(true);
   }, [currentUser.userId]);
@@ -75,31 +85,28 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
   const handleModalSubmit = (
     parentalPermissionRequest: ParentalPermissionRequest
   ) => {
-    reportEvent(EVENTS.CAP_PARENT_EMAIL_SUBMITTED, {
-      inSection: currentUser.inSection,
-      usState: currentUser.usStateCode,
-      consentStatus: parentalPermissionRequest.consent_status,
-    });
+    reportEvent(
+      EVENTS.CAP_PARENT_EMAIL_SUBMITTED,
+      defaultEventParams(parentalPermissionRequest)
+    );
   };
 
   const handleModalResend = (
     parentalPermissionRequest: ParentalPermissionRequest
   ) => {
-    reportEvent(EVENTS.CAP_PARENT_EMAIL_RESEND, {
-      inSection: currentUser.inSection,
-      usState: currentUser.usStateCode,
-      consentStatus: parentalPermissionRequest.consent_status,
-    });
+    reportEvent(
+      EVENTS.CAP_PARENT_EMAIL_RESEND,
+      defaultEventParams(parentalPermissionRequest)
+    );
   };
 
   const handleModalUpdate = (
     parentalPermissionRequest: ParentalPermissionRequest
   ) => {
-    reportEvent(EVENTS.CAP_PARENT_EMAIL_UPDATED, {
-      inSection: currentUser.inSection,
-      usState: currentUser.usStateCode,
-      consentStatus: parentalPermissionRequest.consent_status,
-    });
+    reportEvent(
+      EVENTS.CAP_PARENT_EMAIL_UPDATED,
+      defaultEventParams(parentalPermissionRequest)
+    );
   };
 
   return (


### PR DESCRIPTION
Adds us_state to the following events in the parent email modal:

- `CAP_PARENT_EMAIL_MODAL_SHOWN`
- `CAP_PARENT_EMAIL_MODAL_CLOSED`
- `CAP_PARENT_EMAIL_SUBMITTED`
- `CAP_PARENT_EMAIL_UPDATED`
- `CAP_PARENT_EMAIL_RESEND`


## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1191)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
