### PR TITLE
Hotfix: restart ActiveJob workers from a shell script

### DIFF
--- a/bin/restart-active-job-workers
+++ b/bin/restart-active-job-workers
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+require_relative '../deployment'
+require 'cdo/active_job_backend'
+
+# (Re)start dashboard workers with a rolling deploy.
+Cdo::ActiveJobBackend.restart_workers

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -45,11 +45,6 @@ namespace :build do
     end
   end
 
-  desc 'Starts Active Job workers, restarts existing workers (if any) in a rolling fashion to avoid downtime'
-  timed_task_with_logging :start_active_job_workers do
-    Cdo::ActiveJobBackend.restart_workers
-  end
-
   desc 'Builds dashboard (install gems, migrate/seed db, compile assets).'
   timed_task_with_logging dashboard: :package do
     Dir.chdir(dashboard_dir) do
@@ -137,9 +132,7 @@ namespace :build do
         # that may arise when that best practice is not followed.
         unless rack_env?(:development)
           ChatClient.log 'Restarting <b>dashboard</b> Active Job worker(s).'
-          Dir.chdir(deploy_dir) do
-            RakeUtils.rake_stream_output 'build:start_active_job_workers'
-          end
+          RakeUtils.system_stream_output 'bundle', 'exec', bin_dir('restart-active-job-workers')
         end
       end
 

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -142,10 +142,11 @@ use_my_apps: true
 # invoke Python via PyCall. These will SEGV if run with the default async
 # adapter, because it uses threads instead of processes.
 #
-# If you enable `delayed_job`, you will need to manually run `bundle exec rake build:start_active_job_workers`
+# If you enable `delayed_job`, you will need to manually run `bin/restart-active-job-workers`
+# to start (or restart) delayed_job workers.
 #
 # active_job_queue_adapter: :delayed_job
 #
-# Number of workers to start when running `rake build:start_active_job_workers`:
+# Number of workers to start when running `bin/restart-active-job-workers`:
 # active_job_backend_n_workers_to_start: 2
 # active_job_backend_rolling_restart_in_n_batches: 1


### PR DESCRIPTION
This PR switches `Cdo::ActiveJobBackend.restart_workers` to being invoked by new shell script `bin/restart-active-job-workers` (rather than being invoked by a `rake build:` target).

Why? Invoking from rake build resulted in production-daemon downtime due to an out-of-memory condition:

1. initializers/script_preload.rb ([github](https://github.com/code-dot-org/code-dot-org/blob/7f068669cf0869c599c54a3be40e2545978617f4/dashboard/config/initializers/script_preload.rb/#L6-L8)) does not preload scripts into memory if `File.basename($0) == 'rake'`.
2. As a result, when invoked from a rake task `Cdo::ActiveJobBackend.restart_workers` does NOT preload the script cache before forking individual workers, which results in each of 150 workers on production-daemon having their own copy.
3. This resulted in an outage today, as the extra RAM usage filled production-daemon's RAM to the point it was hard to even kill the delayed_job processes.