### PR TITLE
Music: tweak sound load error metrics

### DIFF
--- a/apps/src/lab2/Lab2MetricsReporter.ts
+++ b/apps/src/lab2/Lab2MetricsReporter.ts
@@ -1,5 +1,5 @@
 import MetricsReporter from '@cdo/apps/metrics/MetricsReporter';
-import {MetricDimension} from '@cdo/apps/metrics/types';
+import {MetricDimension, MetricUnit} from '@cdo/apps/metrics/types';
 
 /**
  * Properties that this metric reporter will add to log payloads.
@@ -54,6 +54,18 @@ export default class LabMetricsReporter {
     dimensions: MetricDimension[] = []
   ) {
     MetricsReporter.publishMetric(metricName, loadTimeMs, 'Milliseconds', [
+      ...dimensions,
+      ...this.getCommonDimensions(),
+    ]);
+  }
+
+  public publishMetric(
+    name: string,
+    value: number,
+    unit: MetricUnit,
+    dimensions: MetricDimension[] = []
+  ) {
+    MetricsReporter.publishMetric(name, value, unit, [
       ...dimensions,
       ...this.getCommonDimensions(),
     ]);

--- a/apps/src/music/player/SoundCache.ts
+++ b/apps/src/music/player/SoundCache.ts
@@ -64,7 +64,11 @@ class SoundCache {
     const loadPromises: Promise<void>[] = [];
 
     if (paths.length > 0) {
-      this.metricsReporter.incrementCounter('SoundCache.LoadSoundsAttempt');
+      this.metricsReporter.publishMetric(
+        'SoundCache.LoadSoundsCount',
+        paths.length,
+        'Count'
+      );
     }
 
     for (const path of paths) {
@@ -100,7 +104,11 @@ class SoundCache {
         count: failedSounds.length,
         failedSounds,
       });
-      this.metricsReporter.incrementCounter('SoundCache.LoadSoundsError');
+      this.metricsReporter.publishMetric(
+        'SoundCache.FailedSoundsCount',
+        failedSounds.length,
+        'Count'
+      );
     }
   }
 


### PR DESCRIPTION
Small change to sound load error metrics to help better understand the nature and impact of load failures. Instead of simply logging an attempt when we start loading sounds and when we finish, we'll report the total number of sounds attempted and the total number failed. Using these two values we can get a simple aggregation of what proportion of sounds are failing across all projects and better understand the impact. Additionally, we can still use the `SampleCount` statistic as a proxy for calculating which % of load attempts had 1 or more sound fail, which is what we track today.

This is accompanied by some updates to our [Music Lab dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/MusicLab?start=PT168H&end=null)  which should help us better drill down and root cause sound load errors.

## Links

https://codedotorg.atlassian.net/browse/LABS-761

## Testing story

Tested locally with Cloudwatch