### PR TITLE
add us_state to lockout panel events

### DIFF
--- a/apps/src/templates/sessions/LockoutPanel.tsx
+++ b/apps/src/templates/sessions/LockoutPanel.tsx
@@ -90,6 +90,7 @@ const LockoutPanel: React.FC<LockoutPanelProps> = props => {
         inSection: props.inSection,
         consentStatus: props.permissionStatus,
         requestSent: !!props.pendingEmail,
+        usState: currentUser.usStateCode,
       });
     }
   }, [
@@ -97,6 +98,7 @@ const LockoutPanel: React.FC<LockoutPanelProps> = props => {
     props.permissionStatus,
     props.pendingEmail,
     currentUser.userId,
+    currentUser.usStateCode,
   ]);
 
   /**
@@ -114,19 +116,28 @@ const LockoutPanel: React.FC<LockoutPanelProps> = props => {
       reportEvent(EVENTS.CAP_LOCKOUT_EMAIL_SUBMITTED, {
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
+        usState: currentUser.usStateCode,
       });
     } else if (parentalPermissionRequest.parent_email === prevPendingEmail) {
       reportEvent(EVENTS.CAP_LOCKOUT_EMAIL_RESEND, {
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
+        usState: currentUser.usStateCode,
       });
     } else {
       reportEvent(EVENTS.CAP_LOCKOUT_EMAIL_UPDATED, {
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
+        usState: currentUser.usStateCode,
       });
     }
-  }, [action, prevPendingEmail, parentalPermissionRequest, props.inSection]);
+  }, [
+    action,
+    prevPendingEmail,
+    parentalPermissionRequest,
+    props.inSection,
+    currentUser.usStateCode,
+  ]);
 
   // This will set the email to the current pending email and fire off the
   // form as though they had typed in the same email again.
@@ -158,6 +169,7 @@ const LockoutPanel: React.FC<LockoutPanelProps> = props => {
     reportEvent(EVENTS.CAP_LOCKOUT_SIGN_OUT, {
       inSection: props.inSection,
       consentStatus: status,
+      usState: currentUser.usStateCode,
     });
   };
 


### PR DESCRIPTION
Adds us_state to the following events on the CAP lockout panel:

- `CAP_LOCKOUT_SHOWN`
- `CAP_LOCKOUT_SIGN_OUT`
- `CAP_LOCKOUT_EMAIL_SUBMITTED`
- `CAP_LOCKOUT_EMAIL_UPDATED`
- `CAP_LOCKOUT_EMAIL_RESEND`



## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1191)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
