### PR TITLE
Restore Formerly-Broken Commented-Out Assert

### DIFF
--- a/dashboard/legacy/test/middleware/test_sources.rb
+++ b/dashboard/legacy/test/middleware/test_sources.rb
@@ -312,8 +312,7 @@ class SourcesTest < FilesApiTestBase
     assert successful?
     response = JSON.parse(last_response.body)
     timestamp1 = response['timestamp'].to_s
-    # this assert passes locally but fails on circle
-    # assert_equal timestamp1, Time.now.to_s
+    assert_equal timestamp1, Time.now.to_s
     version1 = response['versionId']
 
     Timecop.travel 1


### PR DESCRIPTION
This is a speculative change, just to see if the assert which a comment indicates was broken on circle is still broken on drone.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
