### PR TITLE
add us_state to LockoutLinkedAccounts events

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/edit.js
+++ b/apps/src/sites/studio/pages/devise/registrations/edit.js
@@ -150,6 +150,7 @@ $(document).ready(() => {
         providers={JSON.parse(
           lockoutLinkedAccountsMountPoint.getAttribute('data-providers')
         )}
+        usState={lockoutLinkedAccountsMountPoint.getAttribute('data-us-state')}
       />,
       lockoutLinkedAccountsMountPoint
     );

--- a/apps/src/templates/policy_compliance/LockoutLinkedAccounts.jsx
+++ b/apps/src/templates/policy_compliance/LockoutLinkedAccounts.jsx
@@ -68,6 +68,7 @@ export default function LockoutLinkedAccounts(props) {
       providers: props.providers,
       inSection: props.inSection,
       consentStatus: props.permissionStatus,
+      usState: props.usState,
     });
   }, [props]);
 
@@ -87,18 +88,21 @@ export default function LockoutLinkedAccounts(props) {
         providers: props.providers,
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
+        usState: props.usState,
       });
     } else if (parentalPermissionRequest.parent_email === prevPendingEmail) {
       reportEvent(EVENTS.CAP_SETTINGS_EMAIL_RESEND, {
         providers: props.providers,
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
+        usState: props.usState,
       });
     } else {
       reportEvent(EVENTS.CAP_SETTINGS_EMAIL_UPDATED, {
         providers: props.providers,
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
+        usState: props.usState,
       });
     }
   }, [action, prevPendingEmail, parentalPermissionRequest, props]);
@@ -303,6 +307,7 @@ LockoutLinkedAccounts.propTypes = {
   userEmail: PropTypes.string,
   inSection: PropTypes.bool,
   providers: PropTypes.arrayOf(PropTypes.string),
+  usState: PropTypes.string,
 };
 
 const styles = {

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -81,6 +81,7 @@
       user_email: current_user.hashed_email,
       in_section: JSON.dump(current_user.student? ? current_user.sections_as_student.present? : nil),
       providers: JSON.dump(current_user.providers.filter_map(&:presence)),
+      us_state: current_user.us_state,
     },
   }
 


### PR DESCRIPTION
Adds us_state to the CAP events in the LockoutLinkedAccounts component:

- `CAP_SETTINGS_SHOWN`
- `CAP_SETTINGS_EMAIL_SUBMITTED`
- `CAP_SETTINGS_EMAIL_UPDATED`
- `CAP_SETTINGS_EMAIL_RESEND`



## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1191)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
