### PR TITLE
TeacherSectionsWarningJob will now send warning emails sequentially

### DIFF
--- a/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
+++ b/dashboard/app/jobs/cap/teacher_sections_warning_job.rb
@@ -3,6 +3,7 @@
 module CAP
   class TeacherSectionsWarningJob < ApplicationJob
     EVENT_NAME = 'cap_teacher_sections_warning'
+    MAILJET_RETRY_LIMIT = 5
 
     rescue_from StandardError, with: :report_exception
 
@@ -21,14 +22,7 @@ module CAP
           }
         end
 
-        MailjetDeliveryJob.perform_later(
-          :cap_section_warning,
-          teacher.email,
-          teacher.name,
-          vars: {
-            capSections: email_cap_sections,
-          }
-        )
+        send_warning_email(teacher.email, teacher.name, email_cap_sections)
 
         Metrics::Events.log_event(
           event_name: EVENT_NAME,
@@ -49,6 +43,23 @@ module CAP
 
     private def teachers
       @teachers ||= User.where(id: cap_affected_sections.select(:user_id))
+    end
+
+    private def send_warning_email(email, name, cap_sections)
+      Retryable.retryable(
+        on: RestClient::TooManyRequests,
+        tries: MAILJET_RETRY_LIMIT,
+        sleep: ->(n) {2 ** n}
+      ) do
+        MailJet.send_email(
+          :cap_section_warning,
+          email,
+          name,
+          vars: {
+            capSections: cap_sections,
+          }
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Once a week, we query for all the teachers who have sections affected by our Child Account Policy and send them a warning email. This was first designed to have one ActiveJob query for all the teachers, and then schedule a single job for each teacher to send an email using MailJet. However, this resulted in use overwhelming the MailJet API because we were calling the API too quickly across many workers running in parallel. 

This PR makes it so the job which queries for all the teachers then sends the email sequentially. This will make it so we won't overwhelm the MailJet API because we have retries with exponential backoff.

## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1305)

## Testing story
* Unit tests

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
Once it is deployed to prod, I will manually trigger the job to verify it works.
