### PR TITLE
index levels on type

### DIFF
--- a/dashboard/app/models/levels/aichat.rb
+++ b/dashboard/app/models/levels/aichat.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Aichat < Level

--- a/dashboard/app/models/levels/ailab.rb
+++ b/dashboard/app/models/levels/ailab.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Ailab < Level

--- a/dashboard/app/models/levels/applab.rb
+++ b/dashboard/app/models/levels/applab.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 require 'cdo/shared_constants'

--- a/dashboard/app/models/levels/artist.rb
+++ b/dashboard/app/models/levels/artist.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Artist < Blockly

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 require 'nokogiri'

--- a/dashboard/app/models/levels/bounce.rb
+++ b/dashboard/app/models/levels/bounce.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Bounce < Grid

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class BubbleChoice < DSLDefined

--- a/dashboard/app/models/levels/calc.rb
+++ b/dashboard/app/models/levels/calc.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Calc < Blockly

--- a/dashboard/app/models/levels/contract_match.rb
+++ b/dashboard/app/models/levels/contract_match.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 # Contract Match type.

--- a/dashboard/app/models/levels/craft.rb
+++ b/dashboard/app/models/levels/craft.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 require "csv"

--- a/dashboard/app/models/levels/curriculum_reference.rb
+++ b/dashboard/app/models/levels/curriculum_reference.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class CurriculumReference < Level

--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Dancelab < GamelabJr

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 # Levels defined using a text-based ruby DSL syntax.

--- a/dashboard/app/models/levels/eval.rb
+++ b/dashboard/app/models/levels/eval.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Eval < Blockly

--- a/dashboard/app/models/levels/evaluation_multi.rb
+++ b/dashboard/app/models/levels/evaluation_multi.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class EvaluationMulti < Multi

--- a/dashboard/app/models/levels/external.rb
+++ b/dashboard/app/models/levels/external.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class External < DSLDefined

--- a/dashboard/app/models/levels/external_link.rb
+++ b/dashboard/app/models/levels/external_link.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class ExternalLink < Level

--- a/dashboard/app/models/levels/fish.rb
+++ b/dashboard/app/models/levels/fish.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Fish < Level

--- a/dashboard/app/models/levels/flappy.rb
+++ b/dashboard/app/models/levels/flappy.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Flappy < Blockly

--- a/dashboard/app/models/levels/free_response.rb
+++ b/dashboard/app/models/levels/free_response.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class FreeResponse < Level

--- a/dashboard/app/models/levels/frequency_analysis.rb
+++ b/dashboard/app/models/levels/frequency_analysis.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class FrequencyAnalysis < Widget

--- a/dashboard/app/models/levels/gamelab.rb
+++ b/dashboard/app/models/levels/gamelab.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 require 'cdo/shared_constants'

--- a/dashboard/app/models/levels/gamelab_jr.rb
+++ b/dashboard/app/models/levels/gamelab_jr.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class GamelabJr < Gamelab

--- a/dashboard/app/models/levels/grid.rb
+++ b/dashboard/app/models/levels/grid.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 require "csv"

--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Javalab < Level

--- a/dashboard/app/models/levels/karel.rb
+++ b/dashboard/app/models/levels/karel.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Karel < Maze

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 require 'cdo/shared_constants'

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class LevelGroup < DSLDefined

--- a/dashboard/app/models/levels/map.rb
+++ b/dashboard/app/models/levels/map.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Map < CurriculumReference

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Match < DSLDefined

--- a/dashboard/app/models/levels/maze.rb
+++ b/dashboard/app/models/levels/maze.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Maze < Grid

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 require "csv"

--- a/dashboard/app/models/levels/music.rb
+++ b/dashboard/app/models/levels/music.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 # Music uses level_data, which is actual JSON in each .level file, and

--- a/dashboard/app/models/levels/net_sim.rb
+++ b/dashboard/app/models/levels/net_sim.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class NetSim < Blockly

--- a/dashboard/app/models/levels/odometer.rb
+++ b/dashboard/app/models/levels/odometer.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Odometer < Widget

--- a/dashboard/app/models/levels/panels.rb
+++ b/dashboard/app/models/levels/panels.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 class Panels < Level
   serialized_attrs %w(

--- a/dashboard/app/models/levels/pixelation.rb
+++ b/dashboard/app/models/levels/pixelation.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Pixelation < Widget

--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Poetry < GamelabJr

--- a/dashboard/app/models/levels/public_key_cryptography.rb
+++ b/dashboard/app/models/levels/public_key_cryptography.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 # Level type for standalone widget teaching public key cryptography

--- a/dashboard/app/models/levels/pythonlab.rb
+++ b/dashboard/app/models/levels/pythonlab.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 class Pythonlab < Level
   serialized_attrs %w(

--- a/dashboard/app/models/levels/standalone_video.rb
+++ b/dashboard/app/models/levels/standalone_video.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class StandaloneVideo < Level

--- a/dashboard/app/models/levels/star_wars_grid.rb
+++ b/dashboard/app/models/levels/star_wars_grid.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class StarWarsGrid < Studio

--- a/dashboard/app/models/levels/studio.rb
+++ b/dashboard/app/models/levels/studio.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Studio < Grid

--- a/dashboard/app/models/levels/studio_ec.rb
+++ b/dashboard/app/models/levels/studio_ec.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class StudioEC < Studio

--- a/dashboard/app/models/levels/text_compression.rb
+++ b/dashboard/app/models/levels/text_compression.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class TextCompression < Widget

--- a/dashboard/app/models/levels/text_match.rb
+++ b/dashboard/app/models/levels/text_match.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 # Text Match type.

--- a/dashboard/app/models/levels/unplugged.rb
+++ b/dashboard/app/models/levels/unplugged.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Unplugged < Level

--- a/dashboard/app/models/levels/vigenere.rb
+++ b/dashboard/app/models/levels/vigenere.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Vigenere < Widget

--- a/dashboard/app/models/levels/weblab.rb
+++ b/dashboard/app/models/levels/weblab.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Weblab < Level

--- a/dashboard/app/models/levels/weblab2.rb
+++ b/dashboard/app/models/levels/weblab2.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 class Weblab2 < Level
   serialized_attrs %w(

--- a/dashboard/app/models/levels/widget.rb
+++ b/dashboard/app/models/levels/widget.rb
@@ -22,6 +22,7 @@
 #  index_levels_on_game_id    (game_id)
 #  index_levels_on_level_num  (level_num)
 #  index_levels_on_name       (name)
+#  index_levels_on_type       (type)
 #
 
 class Widget < Level

--- a/dashboard/db/migrate/20241120192448_index_levels_on_type.rb
+++ b/dashboard/db/migrate/20241120192448_index_levels_on_type.rb
@@ -1,0 +1,5 @@
+class IndexLevelsOnType < ActiveRecord::Migration[6.1]
+  def change
+    add_index :levels, :type
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_11_16_044924) do
+ActiveRecord::Schema.define(version: 2024_11_20_192448) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -918,6 +918,7 @@ ActiveRecord::Schema.define(version: 2024_11_16_044924) do
     t.index ["game_id"], name: "index_levels_on_game_id"
     t.index ["level_num"], name: "index_levels_on_level_num"
     t.index ["name"], name: "index_levels_on_name"
+    t.index ["type"], name: "index_levels_on_type"
   end
 
   create_table "levels_script_levels", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Potential fix for adhoc issue ([slack](https://codedotorg.slack.com/archives/C03CK49G9/p1732128594362279?thread_ts=1727971169.516589&cid=C03CK49G9)). 

The problem is a slow query during seeding:
```
SELECT `levels`.`name`, `levels`.`md5` FROM `levels` WHERE `levels`.`type` IN ('DSLDefined', 'Match', 'Multi', 'EvaluationMulti', 'TextMatch', 'External', 'LevelGroup', 'BubbleChoice')
```

This query has been observed to take anywhere from 8 seconds to 2.5 minutes on adhocs.

## Testing story

On my local machine, adding this index reduces query time from `2.21 sec` to `0.17 sec`.
