### PR TITLE
Adding new url to redirect musiclab to tools/musiclab

### DIFF
--- a/pegasus/sites.v3/code.org/public/musiclab.redirect
+++ b/pegasus/sites.v3/code.org/public/musiclab.redirect
@@ -1,0 +1,1 @@
+/tools/musiclab


### PR DESCRIPTION
Adds one new redirect link to ensure the new url code.org/musiclab redirects to code.org/tools/musiclab as seen below:


https://github.com/user-attachments/assets/75fd208d-dc6f-4e48-b462-450bb1feed84




## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2783

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
