### PR TITLE
add us_state to CAP teacher banner metrics

### DIFF
--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsBanner.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsBanner.tsx
@@ -16,12 +16,14 @@ interface Props {
   toggleModal: () => void;
   modalOpen: boolean;
   ageGatedStudentsCount?: number;
+  ageGatedStudentsUsState?: string;
 }
 
 export const AgeGatedStudentsBanner: React.FC<Props> = ({
   toggleModal,
   modalOpen,
   ageGatedStudentsCount = 0,
+  ageGatedStudentsUsState,
 }) => {
   const currentUser = useSelector((state: RootState) => state.currentUser);
   const reportEvent = (eventName: string, payload: object = {}) => {
@@ -32,8 +34,9 @@ export const AgeGatedStudentsBanner: React.FC<Props> = ({
     reportEvent(EVENTS.CAP_AGE_GATED_BANNER_SHOWN, {
       user_id: currentUser.userId,
       number_of_gateable_students: ageGatedStudentsCount,
+      usState: ageGatedStudentsUsState,
     });
-  }, [currentUser.userId, ageGatedStudentsCount]);
+  }, [currentUser.userId, ageGatedStudentsCount, ageGatedStudentsUsState]);
 
   return (
     <div id="uitest-age-gated-banner">
@@ -51,6 +54,7 @@ export const AgeGatedStudentsBanner: React.FC<Props> = ({
           isOpen={modalOpen}
           onClose={toggleModal}
           ageGatedStudentsCount={ageGatedStudentsCount}
+          ageGatedStudentsUsState={ageGatedStudentsUsState}
         />
       )}
     </div>

--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
@@ -25,6 +25,7 @@ interface Props {
   isOpen: boolean;
   isLoadingStudents: boolean;
   ageGatedStudentsCount?: number;
+  ageGatedStudentsUsState?: string;
 }
 
 const AgeGatedStudentsModal: React.FC<Props> = ({
@@ -32,6 +33,7 @@ const AgeGatedStudentsModal: React.FC<Props> = ({
   isOpen,
   onClose,
   ageGatedStudentsCount = 0,
+  ageGatedStudentsUsState,
 }) => {
   const currentUser = useSelector((state: RootState) => state.currentUser);
   const reportEvent = (eventName: string, payload: object = {}) => {
@@ -45,6 +47,7 @@ const AgeGatedStudentsModal: React.FC<Props> = ({
     reportEvent(EVENTS.CAP_STUDENT_WARNING_LINK_CLICKED, {
       user_id: currentUser.userId,
       number_of_gateable_students: ageGatedStudentsCount,
+      usState: ageGatedStudentsUsState,
     });
   };
 
@@ -52,6 +55,7 @@ const AgeGatedStudentsModal: React.FC<Props> = ({
     reportEvent(EVENTS.CAP_AGE_GATED_MODAL_CLOSED, {
       user_id: currentUser.userId,
       number_of_gateable_students: ageGatedStudentsCount,
+      usState: ageGatedStudentsUsState,
     });
     onClose();
   };
@@ -60,8 +64,9 @@ const AgeGatedStudentsModal: React.FC<Props> = ({
     reportEvent(EVENTS.CAP_AGE_GATED_MODAL_SHOWN, {
       user_id: currentUser.userId,
       number_of_gateable_students: ageGatedStudentsCount,
+      usState: ageGatedStudentsUsState,
     });
-  }, [currentUser.userId, ageGatedStudentsCount]);
+  }, [currentUser.userId, ageGatedStudentsCount, ageGatedStudentsUsState]);
   return (
     <BaseDialog
       isOpen={isOpen}

--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -112,6 +112,19 @@ function TeacherDashboardHeader({
     return '/sections/' + sectionId + '/edit';
   };
 
+  const getAgeGatedStudentsUsState = () => {
+    if (ageGatedStudentsCount > 0) {
+      const ageGatedStudents = filterAgeGatedStudents(
+        convertStudentDataToArray(
+          getStore().getState().manageStudents.studentData
+        )
+      );
+      return ageGatedStudents[0].usState;
+    }
+
+    return null;
+  };
+
   return (
     <div className={dashboardStyles.headerContainer}>
       <div className={dashboardStyles.headerLink}>
@@ -140,6 +153,7 @@ function TeacherDashboardHeader({
           toggleModal={toggleModal}
           modalOpen={modalOpen}
           ageGatedStudentsCount={ageGatedStudentsCount}
+          ageGatedStudentsUsState={getAgeGatedStudentsUsState()}
         />
       )}
       <div className={dashboardStyles.header}>


### PR DESCRIPTION
Adds us_state to the events on the CAP warning banner on the section page of the teacher dashboard:

- `CAP_AGE_GATED_MODAL_SHOWN`
- `CAP_AGE_GATED_MODAL_CLOSED`
- `CAP_STUDENT_WARNING_LINK_CLICKED`
- `CAP_AGE_GATED_BANNER_SHOWN`

<img width="776" alt="Screenshot 2024-11-20 at 12 59 56 PM" src="https://github.com/user-attachments/assets/5196021b-1dc6-4740-bc73-fa7fbac2e185">


## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1191)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
