### PR TITLE
Music: reduce compiles

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -465,6 +465,14 @@ class UnconnectedMusicView extends React.Component {
       return;
     }
 
+    // Skip this pair of events to avoid extra compiles when dragging a block out of the toolbox.
+    if (
+      e.type === Blockly.Events.TOOLBOX_ITEM_SELECT ||
+      e.type === Blockly.Events.CREATE
+    ) {
+      return;
+    }
+
     if (e.type === Blockly.Events.CHANGE) {
       if (e.element === 'field' && e.name === TRIGGER_FIELD) {
         this.props.setSelectedTriggerId(


### PR DESCRIPTION
Dragging a block out of the toolbox was causing a small UI hitch due to two events triggering compile & executes as the drag was begun.  Now, these two events are ignored.

#### Note

Interestingly, when a block was first dragged out and `TOOLBOX_ITEM_SELECT` was fired, the generated JS had the block's code (just a as a standalone call, since it wasn't attached to anything at the beginning of the drag), and when `CREATE` was fired immediately afterward, the block's code was gone again.