### PR TITLE
CMS prep - Clean up .redirect and .moved files batch 1

### DIFF
--- a/pegasus/sites.v3/code.org/public/CSDiscoveriesFacilitatorMap.moved
+++ b/pegasus/sites.v3/code.org/public/CSDiscoveriesFacilitatorMap.moved
@@ -1,1 +1,0 @@
-/files/CSD Facilitator Training Workshop Assignments.pdf

--- a/pegasus/sites.v3/code.org/public/CSDiscoveriesTeacherCon.moved
+++ b/pegasus/sites.v3/code.org/public/CSDiscoveriesTeacherCon.moved
@@ -1,1 +1,0 @@
-/files/TeacherCon Assignments.pdf

--- a/pegasus/sites.v3/code.org/public/CSPrinciplesFacilitatorMap.moved
+++ b/pegasus/sites.v3/code.org/public/CSPrinciplesFacilitatorMap.moved
@@ -1,1 +1,0 @@
-/files/CSP TeacherCon and Facilitator in Training Assignments.pdf

--- a/pegasus/sites.v3/code.org/public/act.redirect
+++ b/pegasus/sites.v3/code.org/public/act.redirect
@@ -1,1 +1,0 @@
-https://www.change.org/computerscience

--- a/pegasus/sites.v3/code.org/public/applab/tempdocs.redirect
+++ b/pegasus/sites.v3/code.org/public/applab/tempdocs.redirect
@@ -1,1 +1,0 @@
-https://studio.code.org/docs/ide/applab

--- a/pegasus/sites.v3/code.org/public/athome/csd.redirect
+++ b/pegasus/sites.v3/code.org/public/athome/csd.redirect
@@ -1,1 +1,0 @@
-https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms-csd/33007

--- a/pegasus/sites.v3/code.org/public/athome/csf.redirect
+++ b/pegasus/sites.v3/code.org/public/athome/csf.redirect
@@ -1,1 +1,0 @@
-https://forum.code.org/t/modifications-for-virtual-and-socially-distanced-classrooms-csf/33082

--- a/pegasus/sites.v3/code.org/public/athome/csp.redirect
+++ b/pegasus/sites.v3/code.org/public/athome/csp.redirect
@@ -1,1 +1,0 @@
-https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005

--- a/pegasus/sites.v3/code.org/public/blurbs.moved
+++ b/pegasus/sites.v3/code.org/public/blurbs.moved
@@ -1,1 +1,0 @@
-/educate/blurbs

--- a/pegasus/sites.v3/code.org/public/california.moved
+++ b/pegasus/sites.v3/code.org/public/california.moved
@@ -1,1 +1,0 @@
-/educate/california

--- a/pegasus/sites.v3/code.org/public/cert.moved
+++ b/pegasus/sites.v3/code.org/public/cert.moved
@@ -1,1 +1,0 @@
-/certificates

--- a/pegasus/sites.v3/code.org/public/certs.moved
+++ b/pegasus/sites.v3/code.org/public/certs.moved
@@ -1,1 +1,0 @@
-/certificates

--- a/pegasus/sites.v3/code.org/public/classgraphics.moved
+++ b/pegasus/sites.v3/code.org/public/classgraphics.moved
@@ -1,1 +1,0 @@
-/educate/marketingkit#classgraphics

--- a/pegasus/sites.v3/code.org/public/codebreaknow.redirect
+++ b/pegasus/sites.v3/code.org/public/codebreaknow.redirect
@@ -1,1 +1,0 @@
-https://code.org/break

--- a/pegasus/sites.v3/code.org/public/codelikeagirlshirt.redirect
+++ b/pegasus/sites.v3/code.org/public/codelikeagirlshirt.redirect
@@ -1,1 +1,0 @@
-http://www.ps.ppa.org/92616-50816

--- a/pegasus/sites.v3/code.org/public/codeplay.redirect
+++ b/pegasus/sites.v3/code.org/public/codeplay.redirect
@@ -1,1 +1,0 @@
-/coldplay

--- a/pegasus/sites.v3/code.org/public/csd-teachercon-pre-survey.redirect
+++ b/pegasus/sites.v3/code.org/public/csd-teachercon-pre-survey.redirect
@@ -1,1 +1,0 @@
-https://docs.google.com/forms/d/e/1FAIpQLScB7VsGqdJbCVn4ID2kz7oDZ3-PNvlsG_hP6eFCGbttQLxiQA/formResponse

--- a/pegasus/sites.v3/code.org/public/csd/standards.moved
+++ b/pegasus/sites.v3/code.org/public/csd/standards.moved
@@ -1,1 +1,0 @@
-/educate/csd/standards

--- a/pegasus/sites.v3/code.org/public/csp-syllabus.moved
+++ b/pegasus/sites.v3/code.org/public/csp-syllabus.moved
@@ -1,1 +1,0 @@
-/files/CSPSyllabusJan2016.pdf

--- a/pegasus/sites.v3/code.org/public/csp-teachercon-pre-survey.redirect
+++ b/pegasus/sites.v3/code.org/public/csp-teachercon-pre-survey.redirect
@@ -1,1 +1,0 @@
-https://docs.google.com/forms/d/e/1FAIpQLScN0GfvvKTcre2TUizC9nqPTJIEFGIpVMw8M6A_M0R_REFNZQ/viewform

--- a/pegasus/sites.v3/code.org/public/ecs-alignment.redirect
+++ b/pegasus/sites.v3/code.org/public/ecs-alignment.redirect
@@ -1,1 +1,0 @@
-http://pact.sri.com/mappings.html

--- a/pegasus/sites.v3/code.org/public/ecs-at-a-glance.moved
+++ b/pegasus/sites.v3/code.org/public/ecs-at-a-glance.moved
@@ -1,1 +1,0 @@
-/files/ECSonepager.pdf

--- a/pegasus/sites.v3/code.org/public/ecs-supplies.moved
+++ b/pegasus/sites.v3/code.org/public/ecs-supplies.moved
@@ -1,1 +1,0 @@
-/files/ECSsupplies.pdf

--- a/pegasus/sites.v3/code.org/public/ecs.redirect
+++ b/pegasus/sites.v3/code.org/public/ecs.redirect
@@ -1,1 +1,0 @@
-https://web.archive.org/web/20150423124112/http://www.exploringcs.org/wp-content/uploads/2014/02/ExploringComputerScience-v5.0.pdf

--- a/pegasus/sites.v3/code.org/public/ecs_alignment.redirect
+++ b/pegasus/sites.v3/code.org/public/ecs_alignment.redirect
@@ -1,1 +1,0 @@
-http://pact.sri.com/?page_id=1096

--- a/pegasus/sites.v3/code.org/public/ecsvideo.moved
+++ b/pegasus/sites.v3/code.org/public/ecsvideo.moved
@@ -1,1 +1,0 @@
-http://www.youtube.com/watch?v=juXqFtaPmNk

--- a/pegasus/sites.v3/code.org/public/educate/csd/pilot/terms.moved
+++ b/pegasus/sites.v3/code.org/public/educate/csd/pilot/terms.moved
@@ -1,1 +1,0 @@
-/educate/csd/pilot/CSDiscoveriesPilotTermsSheet.pdf

--- a/pegasus/sites.v3/code.org/public/educate/csd/status.moved
+++ b/pegasus/sites.v3/code.org/public/educate/csd/status.moved
@@ -1,1 +1,0 @@
-/educate/csd/status_signup

--- a/pegasus/sites.v3/code.org/public/educate/csp/aboutTheWidgets.moved
+++ b/pegasus/sites.v3/code.org/public/educate/csp/aboutTheWidgets.moved
@@ -1,1 +1,0 @@
-/widgets

--- a/pegasus/sites.v3/code.org/public/educate/csp/aboutTheWidgets2.moved
+++ b/pegasus/sites.v3/code.org/public/educate/csp/aboutTheWidgets2.moved
@@ -1,1 +1,0 @@
-/widgets

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/courses.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/courses.redirect
@@ -1,1 +1,0 @@
-/administrators

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/cs-fundamentals-pilot.moved
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/cs-fundamentals-pilot.moved
@@ -1,1 +1,0 @@
-/educate/curriculum/cs-fundamentals-a-f

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/administrator.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/administrator.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/advocacy.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/advocacy.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/communications.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/communications.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/community.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/community.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/curriculum.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/curriculum.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/data.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/data.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/directory.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/directory.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/facilitator-support.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/facilitator-support.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/faq.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/faq.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/funding.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/funding.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/legacy.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/legacy.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/ordering-supplies.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/ordering-supplies.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/payments.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/payments.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/professional-development-deep-dive.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/professional-development-deep-dive.redirect
@@ -1,1 +1,0 @@
-https://code.org/professional-development-workshops

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/reporting-and-evaluations.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/reporting-and-evaluations.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/teacher-recruitment.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/teacher-recruitment.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/timeline.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/timeline.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/training-materials.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/training-materials.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/workshops-pl.redirect
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/workshops-pl.redirect
@@ -1,1 +1,0 @@
-/educate/regional-partner/playbook

--- a/pegasus/sites.v3/code.org/public/elementary.moved
+++ b/pegasus/sites.v3/code.org/public/elementary.moved
@@ -1,1 +1,0 @@
-/educate/es

--- a/pegasus/sites.v3/code.org/public/engineer.redirect
+++ b/pegasus/sites.v3/code.org/public/engineer.redirect
@@ -1,1 +1,0 @@
-/volunteer/engineer

--- a/pegasus/sites.v3/code.org/public/engineers.redirect
+++ b/pegasus/sites.v3/code.org/public/engineers.redirect
@@ -1,1 +1,0 @@
-/volunteer/engineer

--- a/pegasus/sites.v3/code.org/public/facilitator-development-plan.moved
+++ b/pegasus/sites.v3/code.org/public/facilitator-development-plan.moved
@@ -1,1 +1,0 @@
-/files/Code.orgFacilitatorDevelopmentProgram2017-18 (1).pdf

--- a/pegasus/sites.v3/code.org/public/facilitator.moved
+++ b/pegasus/sites.v3/code.org/public/facilitator.moved
@@ -1,1 +1,0 @@
-/professional-learning

--- a/pegasus/sites.v3/code.org/public/facilitator/csd.redirect
+++ b/pegasus/sites.v3/code.org/public/facilitator/csd.redirect
@@ -1,1 +1,0 @@
-http://curriculum.code.org/plcsd/

--- a/pegasus/sites.v3/code.org/public/facilitator/csf.redirect
+++ b/pegasus/sites.v3/code.org/public/facilitator/csf.redirect
@@ -1,1 +1,0 @@
-https://curriculum.code.org/plcsf/

--- a/pegasus/sites.v3/code.org/public/facilitator/csp.redirect
+++ b/pegasus/sites.v3/code.org/public/facilitator/csp.redirect
@@ -1,1 +1,0 @@
-http://curriculum.code.org/plcsp/

--- a/pegasus/sites.v3/code.org/public/files/2018-19_APCal.pdf.redirect
+++ b/pegasus/sites.v3/code.org/public/files/2018-19_APCal.pdf.redirect
@@ -1,1 +1,0 @@
-https://docs.google.com/document/d/e/2PACX-1vTl6EcEkYjhGXs3t3OvdXg2fNd5D9zD5FMWFeFIfaxIUiZtYyxw1XC1l-KOGnh1R4qQFpDf4OE88Z1z/pub

--- a/pegasus/sites.v3/code.org/public/gong.redirect
+++ b/pegasus/sites.v3/code.org/public/gong.redirect
@@ -1,1 +1,0 @@
-https://studio.code.org/projects/applab/fJxCbI7MSl-o8GTGjiaL6A

--- a/pegasus/sites.v3/code.org/public/idaho.moved
+++ b/pegasus/sites.v3/code.org/public/idaho.moved
@@ -1,1 +1,0 @@
-/educate/idaho

--- a/pegasus/sites.v3/code.org/public/jerrybrown.moved
+++ b/pegasus/sites.v3/code.org/public/jerrybrown.moved
@@ -1,1 +1,0 @@
-/action/brown-letter

--- a/pegasus/sites.v3/code.org/public/k5workshop.moved
+++ b/pegasus/sites.v3/code.org/public/k5workshop.moved
@@ -1,1 +1,0 @@
-https://docs.google.com/forms/d/1QoWzKV5n2Fxx-W90LmmMWxY7qndMo1IE0QWZcxY9OTI/viewform

--- a/pegasus/sites.v3/code.org/public/k5workshops.moved
+++ b/pegasus/sites.v3/code.org/public/k5workshops.moved
@@ -1,1 +1,0 @@
-https://docs.google.com/forms/d/1QoWzKV5n2Fxx-W90LmmMWxY7qndMo1IE0QWZcxY9OTI/viewform

--- a/pegasus/sites.v3/code.org/public/marketingkit.moved
+++ b/pegasus/sites.v3/code.org/public/marketingkit.moved
@@ -1,1 +1,0 @@
-/educate/marketingkit

--- a/pegasus/sites.v3/code.org/public/maryland.moved
+++ b/pegasus/sites.v3/code.org/public/maryland.moved
@@ -1,1 +1,0 @@
-/educate/maryland

--- a/pegasus/sites.v3/code.org/public/mss-brief.moved
+++ b/pegasus/sites.v3/code.org/public/mss-brief.moved
@@ -1,1 +1,0 @@
-/curriculum/mss/files/Code.org_MS_Science_Program_two_pager.pdf

--- a/pegasus/sites.v3/code.org/public/mss-details.moved
+++ b/pegasus/sites.v3/code.org/public/mss-details.moved
@@ -1,1 +1,0 @@
-http://code.org/curriculum/mss/files/Code.org_MS_Science_Program_four_pager.pdf

--- a/pegasus/sites.v3/code.org/public/nyc.moved
+++ b/pegasus/sites.v3/code.org/public/nyc.moved
@@ -1,1 +1,0 @@
-/educate/nyc

--- a/pegasus/sites.v3/code.org/public/puzzlechallenge.moved
+++ b/pegasus/sites.v3/code.org/public/puzzlechallenge.moved
@@ -1,1 +1,0 @@
-/educate/puzzlechallenge

--- a/pegasus/sites.v3/code.org/public/sites/default/files/images/code-infographic-4-23.png.moved
+++ b/pegasus/sites.v3/code.org/public/sites/default/files/images/code-infographic-4-23.png.moved
@@ -1,1 +1,0 @@
-/sites/default/files/images/code.orginfographic.png

--- a/pegasus/sites.v3/code.org/public/slp-administrators.redirect
+++ b/pegasus/sites.v3/code.org/public/slp-administrators.redirect
@@ -1,1 +1,0 @@
-/administrators

--- a/pegasus/sites.v3/code.org/public/slp-counselors.redirect
+++ b/pegasus/sites.v3/code.org/public/slp-counselors.redirect
@@ -1,1 +1,0 @@
-/administrators

--- a/pegasus/sites.v3/code.org/public/slp-home.redirect
+++ b/pegasus/sites.v3/code.org/public/slp-home.redirect
@@ -1,1 +1,0 @@
-/administrators

--- a/pegasus/sites.v3/code.org/public/translate/aquatic.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/aquatic.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/course-catalog.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/course-catalog.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/curriculum.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/curriculum.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/dance-landing.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/dance-landing.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/dance.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/dance.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/frozen.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/frozen.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/guidelines.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/guidelines.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/hero.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/hero.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/hoc-activities.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/hoc-activities.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/hoc-overview.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/hoc-overview.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/homepage.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/homepage.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/hourofcode.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/hourofcode.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/leadt.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/leadt.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/mc.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/mc.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/minecraft-landing.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/minecraft-landing.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/minecraft.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/minecraft.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/projects.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/projects.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/sports.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/sports.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/starwars.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/starwars.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/supported.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/supported.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/tutorials.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/tutorials.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/translate/videos.redirect
+++ b/pegasus/sites.v3/code.org/public/translate/videos.redirect
@@ -1,1 +1,0 @@
-/translate

--- a/pegasus/sites.v3/code.org/public/tuesdayHW.moved
+++ b/pegasus/sites.v3/code.org/public/tuesdayHW.moved
@@ -1,1 +1,0 @@
-https://docs.google.com/document/d/16TjB4hwTebLQ3wBAoxWX9OXH36huJ_nO-AkepGClcZc/edit

--- a/pegasus/sites.v3/code.org/public/volunteer/engineer/index.moved
+++ b/pegasus/sites.v3/code.org/public/volunteer/engineer/index.moved
@@ -1,1 +1,0 @@
-/volunteer

--- a/pegasus/sites.v3/code.org/public/welcome-algebra.moved
+++ b/pegasus/sites.v3/code.org/public/welcome-algebra.moved
@@ -1,1 +1,0 @@
-/files/CSinAlgebraTeacherWelcomeKit.pdf

--- a/pegasus/sites.v3/code.org/public/welcome-csp.moved
+++ b/pegasus/sites.v3/code.org/public/welcome-csp.moved
@@ -1,1 +1,0 @@
-/files/CSPTeacherWelcomeKit.pdf

--- a/pegasus/sites.v3/code.org/public/welcome-ecs.moved
+++ b/pegasus/sites.v3/code.org/public/welcome-ecs.moved
@@ -1,1 +1,0 @@
-/files/ECSTeacherWelcomeKit.pdf

--- a/pegasus/sites.v3/code.org/public/welcome-science.moved
+++ b/pegasus/sites.v3/code.org/public/welcome-science.moved
@@ -1,1 +1,0 @@
-/files/CSinScienceTeacherWelcomeKit.pdf

--- a/pegasus/sites.v3/code.org/public/what_is_ecs.moved
+++ b/pegasus/sites.v3/code.org/public/what_is_ecs.moved
@@ -1,1 +1,0 @@
-/files/what_is_ecs.pdf

--- a/pegasus/sites.v3/code.org/public/youthlogoshirt.redirect
+++ b/pegasus/sites.v3/code.org/public/youthlogoshirt.redirect
@@ -1,1 +1,0 @@
-http://www.ps.ppa.org/101016-50882

--- a/pegasus/sites.v3/hourofcode.com/public/teacher-led.moved
+++ b/pegasus/sites.v3/hourofcode.com/public/teacher-led.moved
@@ -1,1 +1,0 @@
-https://code.org/teacher-led


### PR DESCRIPTION
Removes outdated/unneeded `.redirect` and `.moved` files in preparation for the move to the CMS.

## Links
Jira ticket: [ACQ-2780](https://codedotorg.atlassian.net/browse/ACQ-2780)
Gsheet: [here](https://docs.google.com/spreadsheets/d/1Wwes9eF375MRNyGAx83KpVspbmDGbDsU-bBMwUV-WCc/edit?gid=2130082972#gid=2130082972&range=266:266)

## Testing story
Tested a handful locally to see if they produce a 404, and also checked the gsheet row number vs. what's in the PR, both equal 106:

<img width="873" alt="388298730-2b6b2dab-7b52-4f07-8754-dd4173f1f04a" src="https://github.com/user-attachments/assets/a082fa8b-032d-4dd6-8087-8291bb35e07d">
