### PR TITLE
Music: use HttpClient for fetching sounds

### DIFF
--- a/apps/src/music/player/SoundCache.ts
+++ b/apps/src/music/player/SoundCache.ts
@@ -1,5 +1,6 @@
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
+import HttpClient from '@cdo/apps/util/HttpClient';
 import {fetchSignedCookies} from '@cdo/apps/utils';
 
 import {baseAssetUrlRestricted} from '../constants';
@@ -128,7 +129,7 @@ class SoundCache {
       return;
     }
 
-    const response = await fetch(url);
+    const response = await HttpClient.get(url);
     const arrayBuffer = await response.arrayBuffer();
     const audioBuffer = await this.audioContext.decodeAudioData(arrayBuffer);
     this.audioBuffers[url] = audioBuffer;

--- a/apps/src/util/HttpClient.ts
+++ b/apps/src/util/HttpClient.ts
@@ -103,6 +103,18 @@ async function sendRequest(
   return response;
 }
 
+/**
+ * Performs a GET request to the given endpoint. Use {@link fetchJson}
+ * to automatically unwrap the response JSON as a typed object.
+ */
+async function get(
+  endpoint: string,
+  useAuthenticityToken = false,
+  headers: Record<string, string> = {}
+): Promise<Response> {
+  return sendRequest('GET', endpoint, undefined, useAuthenticityToken, headers);
+}
+
 async function put(
   endpoint: string,
   body?: string,
@@ -140,4 +152,5 @@ export default {
   fetchJson,
   post,
   put,
+  get,
 };


### PR DESCRIPTION
Another fix to help root cause sound load errors. I realized we were using the browser `fetch` API to load sounds, which meant that if the request failed with an HTTP error code (e.g. 404), we would still try to decode the buffer from response, leading to a vague "Unable to decode audio data" error. Instead, we now use our `HttpClient` module which wraps `fetch` but also throws an error on any non-`ok` response, which means that we should see the actual network error appear in our logs.

Before:
<img width="927" alt="Screenshot 2024-11-21 at 10 38 10 AM" src="https://github.com/user-attachments/assets/4a1e9c08-f52c-46d9-aa27-9bbda9e704eb">

After:
<img width="934" alt="Screenshot 2024-11-21 at 10 38 28 AM" src="https://github.com/user-attachments/assets/55a773f6-ebc4-4a56-a8ac-8da7b9ccb599">

## Testing story

Tested locally by manually changing URLs.