### PR TITLE
P20 1172/global mvp curriculum catalog

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -15,7 +15,7 @@ import React, {useState, useEffect} from 'react';
 import {Heading5, BodyTwoText} from '@cdo/apps/componentLibrary/typography';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import GlobalRegionWrapper from '@cdo/apps/templates/GlobalRegionWrapper';
+import GlobalEditionWrapper from '@cdo/apps/templates/GlobalEditionWrapper';
 import {
   getSimilarRecommendations,
   getStretchRecommendations,
@@ -350,7 +350,7 @@ CurriculumCatalog.propTypes = {
  * ```
  */
 const RegionalCurriculumCatalog = props => (
-  <GlobalRegionWrapper
+  <GlobalEditionWrapper
     component={CurriculumCatalog}
     componentId="CurriculumCatalog"
     props={props}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -15,6 +15,7 @@ import React, {useState, useEffect} from 'react';
 import {Heading5, BodyTwoText} from '@cdo/apps/componentLibrary/typography';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import GlobalRegionWrapper from '@cdo/apps/templates/GlobalRegionWrapper';
 import {
   getSimilarRecommendations,
   getStretchRecommendations,
@@ -39,6 +40,7 @@ const CurriculumCatalog = ({
   isSignedOut,
   isTeacher,
   curriculaTaught,
+  forceTranslated,
   ...props
 }) => {
   const [filteredCurricula, setFilteredCurricula] = useState(curriculaData);
@@ -309,6 +311,7 @@ const CurriculumCatalog = ({
         filteredCurricula={filteredCurricula}
         setFilteredCurricula={setFilteredCurricula}
         isEnglish={isEnglish}
+        forceTranslated={forceTranslated}
         languageNativeName={languageNativeName}
       />
       <div className={style.catalogContentContainer}>
@@ -326,6 +329,32 @@ CurriculumCatalog.propTypes = {
   isSignedOut: PropTypes.bool.isRequired,
   isTeacher: PropTypes.bool.isRequired,
   curriculaTaught: PropTypes.arrayOf(PropTypes.number),
+  forceTranslated: PropTypes.bool,
 };
 
-export default CurriculumCatalog;
+/**
+ * This is a version of the curriculum catalog that is overridable by a regional
+ * configuration.
+ *
+ * This is done via a configuration in, for instance, /config/global_editions/fa.yml
+ * via a paths rule such as:
+ *
+ * ```
+ * pages:
+ *   # Home dashboards
+ *   - path: /
+ *     components:
+ *       LtiFeedbackBanner: false
+ *       CurriculumCatalog:
+ *         forceTranslated: true
+ * ```
+ */
+const RegionalCurriculumCatalog = props => (
+  <GlobalRegionWrapper
+    component={CurriculumCatalog}
+    componentId="CurriculumCatalog"
+    props={props}
+  />
+);
+
+export default RegionalCurriculumCatalog;

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogFilters.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogFilters.jsx
@@ -56,8 +56,8 @@ const filterTypes = {
   },
 };
 
-const getEmptyFilters = () => {
-  let filters = {translated: false};
+const getEmptyFilters = (forceTranslated = false) => {
+  let filters = {translated: forceTranslated};
   Object.keys(filterTypes).forEach(filterKey => {
     filters[filterKey] = [];
   });
@@ -76,11 +76,11 @@ const getValidParamValues = (filterKey, paramValues) => {
 
 // Returns initial filter states based on URL parameters (returns empty filters if
 // no relevant parameters in the URL).
-const getInitialFilterStates = () => {
+const getInitialFilterStates = forceTranslated => {
   const filterTypeKeys = Object.keys(filterTypes);
   const urlParams = queryParams();
 
-  let filters = getEmptyFilters();
+  let filters = getEmptyFilters(forceTranslated);
   Object.keys(urlParams).forEach(paramKey => {
     if (filterTypeKeys.includes(paramKey)) {
       filters[paramKey] = getValidParamValues(paramKey, urlParams[paramKey]);
@@ -184,10 +184,11 @@ const CurriculumCatalogFilters = ({
   filteredCurricula,
   setFilteredCurricula,
   isEnglish,
+  forceTranslated,
   languageNativeName,
 }) => {
   const [appliedFilters, setAppliedFilters] = useState(
-    getInitialFilterStates()
+    getInitialFilterStates(forceTranslated)
   );
   const [numFilteredTranslatedCurricula, setNumFilteredTranslatedCurricula] =
     useState(
@@ -343,15 +344,17 @@ const CurriculumCatalogFilters = ({
               />
             </BodyTwoText>
           </div>
-          <Toggle
-            name="filterTranslatedToggle"
-            label={i18n.onlyShowCurriculaInLanguage({
-              language: languageNativeName,
-            })}
-            size="m"
-            checked={appliedFilters['translated']}
-            onChange={e => handleToggleLanguageFilter(e.target.checked)}
-          />
+          {!forceTranslated && (
+            <Toggle
+              name="filterTranslatedToggle"
+              label={i18n.onlyShowCurriculaInLanguage({
+                language: languageNativeName,
+              })}
+              size="m"
+              checked={appliedFilters['translated']}
+              onChange={e => handleToggleLanguageFilter(e.target.checked)}
+            />
+          )}
         </div>
       )}
     </div>
@@ -364,6 +367,7 @@ CurriculumCatalogFilters.propTypes = {
   setFilteredCurricula: PropTypes.func.isRequired,
   isEnglish: PropTypes.bool.isRequired,
   languageNativeName: PropTypes.string.isRequired,
+  forceTranslated: PropTypes.bool,
 };
 
 export default CurriculumCatalogFilters;

--- a/apps/src/templates/projects/StartNewProject.jsx
+++ b/apps/src/templates/projects/StartNewProject.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import fontConstants from '@cdo/apps/fontConstants';
+import GlobalRegionWrapper from '@cdo/apps/templates/GlobalRegionWrapper';
 import i18n from '@cdo/locale';
 
 import Button from '../../legacySharedComponents/Button';
@@ -9,7 +10,7 @@ import color from '../../util/color';
 
 import NewProjectButtons from './NewProjectButtons';
 
-export default class StartNewProject extends React.Component {
+export class StartNewProject extends React.Component {
   static propTypes = {
     projectTypes: PropTypes.arrayOf(PropTypes.string),
     canViewFullList: PropTypes.bool,
@@ -155,3 +156,30 @@ const styles = {
     width: '100%',
   },
 };
+
+/**
+ * This is a version of the new project selection that is overridable by a region
+ * configuration.
+ *
+ * This is done via a configuration in, for instance, /config/global_editions/fa.yml
+ * via a paths rule such as:
+ *
+ * ```
+ * pages:
+ *   # All pages
+ *   - path: /
+ *     components:
+ *       LtiFeedbackBanner: false
+ *       StartNewProject:
+ *         canViewFullList: false
+ * ```
+ */
+const RegionalStartNewProject = props => (
+  <GlobalRegionWrapper
+    component={StartNewProject}
+    componentId="StartNewProject"
+    props={props}
+  />
+);
+
+export default RegionalStartNewProject;

--- a/apps/src/templates/projects/StartNewProject.jsx
+++ b/apps/src/templates/projects/StartNewProject.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import fontConstants from '@cdo/apps/fontConstants';
-import GlobalRegionWrapper from '@cdo/apps/templates/GlobalRegionWrapper';
+import GlobalEditionWrapper from '@cdo/apps/templates/GlobalEditionWrapper';
 import i18n from '@cdo/locale';
 
 import Button from '../../legacySharedComponents/Button';
@@ -175,7 +175,7 @@ const styles = {
  * ```
  */
 const RegionalStartNewProject = props => (
-  <GlobalRegionWrapper
+  <GlobalEditionWrapper
     component={StartNewProject}
     componentId="StartNewProject"
     props={props}

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -18,7 +18,7 @@ import InfoHelpTip from '@cdo/apps/sharedComponents/InfoHelpTip';
 import Notification, {
   NotificationType,
 } from '@cdo/apps/sharedComponents/Notification';
-import GlobalRegionWrapper from '@cdo/apps/templates/GlobalRegionWrapper';
+import GlobalEditionWrapper from '@cdo/apps/templates/GlobalEditionWrapper';
 import CoteacherSettings from '@cdo/apps/templates/sectionsRefresh/coteacherSettings/CoteacherSettings';
 import {navigateToHref} from '@cdo/apps/utils';
 import {CapLinks} from '@cdo/generated-scripts/sharedConstants';
@@ -437,7 +437,7 @@ export default function SectionsSetUpContainer({
       />
 
       {/* Allow the curriculum quick assign region to be configured per-region */}
-      <GlobalRegionWrapper
+      <GlobalEditionWrapper
         component={CurriculumQuickAssign}
         componentId="CurriculumQuickAssign"
         props={{

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -18,6 +18,7 @@ import InfoHelpTip from '@cdo/apps/sharedComponents/InfoHelpTip';
 import Notification, {
   NotificationType,
 } from '@cdo/apps/sharedComponents/Notification';
+import GlobalRegionWrapper from '@cdo/apps/templates/GlobalRegionWrapper';
 import CoteacherSettings from '@cdo/apps/templates/sectionsRefresh/coteacherSettings/CoteacherSettings';
 import {navigateToHref} from '@cdo/apps/utils';
 import {CapLinks} from '@cdo/generated-scripts/sharedConstants';
@@ -435,12 +436,17 @@ export default function SectionsSetUpContainer({
         isNewSection={isNewSection}
       />
 
-      <CurriculumQuickAssign
-        id="uitest-curriculum-quick-assign"
-        isNewSection={isNewSection}
-        updateSection={(key, val) => updateSection(0, key, val)}
-        sectionCourse={sections[0].course || consolidatedCourseData()}
-        initialParticipantType={sections[0].participantType}
+      {/* Allow the curriculum quick assign region to be configured per-region */}
+      <GlobalRegionWrapper
+        component={CurriculumQuickAssign}
+        componentId="CurriculumQuickAssign"
+        props={{
+          id: 'uitest-curriculum-quick-assign',
+          isNewSection: isNewSection,
+          updateSection: (key, val) => updateSection(0, key, val),
+          sectionCourse: sections[0].course || consolidatedCourseData(),
+          initialParticipantType: sections[0].participantType,
+        }}
       />
 
       <div

--- a/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
@@ -1,8 +1,9 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 
 import fontConstants from '@cdo/apps/fontConstants';
+import GlobalRegionWrapper from '@cdo/apps/templates/GlobalRegionWrapper';
 import i18n from '@cdo/locale';
 
 import PopUpMenu, {STANDARD_PADDING} from '../../sharedComponents/PopUpMenu';
@@ -16,117 +17,136 @@ import {assignmentCourseVersionShape} from './shapes';
 const menuItemWidth = _(columnWidths).values().reduce(_.add);
 const menuWidth = menuItemWidth + 2 * STANDARD_PADDING;
 
-export default class AssignmentVersionSelector extends Component {
-  static propTypes = {
-    dropdownStyle: PropTypes.object,
-    onChangeVersion: PropTypes.func.isRequired,
-    selectedCourseVersionId: PropTypes.number,
-    courseVersions: PropTypes.objectOf(assignmentCourseVersionShape),
-    disabled: PropTypes.bool,
-    rightJustifiedPopupMenu: PropTypes.bool,
-  };
+export function AssignmentVersionSelector({
+  dropdownStyle,
+  onChangeVersion,
+  selectedCourseVersionId,
+  courseVersions,
+  courseFilters,
+  disabled,
+  rightJustifiedPopupMenu,
+}) {
+  const selectRef = useRef(null);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [targetPoint, setTargetPoint] = useState({top: 0, left: 0});
+  const [filteredVersions, setFilteredVersions] = useState([]);
 
-  state = {
-    isMenuOpen: false,
-    targetPoint: {top: 0, left: 0},
-  };
+  // Filter the offerings based on the filters provided
+  useEffect(() => {
+    const languageFilter = courseFilters?.language;
 
-  handleMouseDown = e => {
+    const data = courseVersions;
+
+    if (languageFilter) {
+      for (const [key, versionInfo] of Object.entries(data)) {
+        if (!versionInfo.locale_codes.includes(languageFilter)) {
+          delete data[key];
+        }
+      }
+    }
+
+    setFilteredVersions(data);
+  }, [courseVersions, courseFilters?.language]);
+
+  const handleMouseDown = e => {
     // Prevent the native dropdown menu from opening.
     e.preventDefault();
   };
 
-  handleClick = e => {
+  const handleClick = e => {
     e.stopPropagation();
-    if (!this.state.isMenuOpen) {
-      this.openMenu();
+    if (!isMenuOpen) {
+      openMenu();
     } else {
-      this.closeMenu();
+      closeMenu();
     }
   };
 
-  openMenu() {
-    const rect = this.select.getBoundingClientRect();
-    const targetPoint = {
+  const openMenu = () => {
+    const rect = selectRef.current.getBoundingClientRect();
+    const newTargetPoint = {
       top: rect.bottom + window.pageYOffset,
       left: rect.left + window.pageXOffset,
     };
-    this.setState({
-      isMenuOpen: true,
-      targetPoint,
-    });
-  }
+    setIsMenuOpen(true);
+    setTargetPoint(newTargetPoint);
+  };
 
-  closeMenu = () => this.setState({isMenuOpen: false});
+  const closeMenu = () => {
+    setIsMenuOpen(false);
+  };
 
-  handleNativeDropdownChange = event => {
+  const handleNativeDropdownChange = event => {
     const version = event.target.value;
-    this.props.onChangeVersion(version.id);
+    onChangeVersion(version.id);
   };
 
-  chooseMenuItem = version => {
-    this.props.onChangeVersion(version.id);
-    this.closeMenu();
+  const chooseMenuItem = version => {
+    onChangeVersion(version.id);
+    closeMenu();
   };
 
-  render() {
-    const {dropdownStyle, courseVersions, disabled, selectedCourseVersionId} =
-      this.props;
+  const popupMenuXOffset = rightJustifiedPopupMenu ? -menuWidth / 2 : 0;
+  const menuOffset = {
+    x: popupMenuXOffset,
+    y: 0,
+  };
 
-    const popupMenuXOffset = this.props.rightJustifiedPopupMenu
-      ? -menuWidth / 2
-      : 0;
-    const menuOffset = {
-      x: popupMenuXOffset,
-      y: 0,
-    };
+  const orderedCourseVersions = _.orderBy(filteredVersions, 'key', 'desc');
 
-    let orderedCourseVersions = _.orderBy(courseVersions, 'key', 'desc');
-
-    return (
-      <span style={styles.version} id="uitest-version-selector">
-        <label style={styles.dropdownLabel} htmlFor="assignment-version-year">
-          {i18n.assignmentSelectorVersion()}
-        </label>
-        <select
-          id="assignment-version-year"
-          value={selectedCourseVersionId}
-          onChange={this.handleNativeDropdownChange}
-          onMouseDown={this.handleMouseDown}
-          onClick={this.handleClick}
-          style={dropdownStyle}
-          disabled={disabled}
-          ref={select => (this.select = select)}
-        >
-          {Object.values(orderedCourseVersions).map(version => (
-            <option key={version.id} value={version.id}>
-              {version.is_recommended
-                ? `${version.version_year} (${i18n.recommended()})`
-                : version.version_year}
-            </option>
-          ))}
-        </select>
-        <PopUpMenu
-          isOpen={this.state.isMenuOpen}
-          targetPoint={this.state.targetPoint}
-          offset={menuOffset}
-          style={styles.popUpMenuStyle}
-          onClose={this.closeMenu}
-        >
-          <AssignmentVersionMenuHeader />
-          {Object.values(orderedCourseVersions).map(version => (
-            <AssignmentVersionMenuItem
-              selectedCourseVersionId={selectedCourseVersionId}
-              courseVersion={version}
-              onClick={() => this.chooseMenuItem(version)}
-              key={version.id}
-            />
-          ))}
-        </PopUpMenu>
-      </span>
-    );
-  }
+  return (
+    <span style={styles.version} id="uitest-version-selector">
+      <label style={styles.dropdownLabel} htmlFor="assignment-version-year">
+        {i18n.assignmentSelectorVersion()}
+      </label>
+      <select
+        id="assignment-version-year"
+        value={selectedCourseVersionId}
+        onChange={handleNativeDropdownChange}
+        onMouseDown={handleMouseDown}
+        onClick={handleClick}
+        style={dropdownStyle}
+        disabled={disabled}
+        ref={selectRef}
+      >
+        {Object.values(orderedCourseVersions).map(version => (
+          <option key={version.id} value={version.id}>
+            {version.is_recommended
+              ? `${version.version_year} (${i18n.recommended()})`
+              : version.version_year}
+          </option>
+        ))}
+      </select>
+      <PopUpMenu
+        isOpen={isMenuOpen}
+        targetPoint={targetPoint}
+        offset={menuOffset}
+        style={styles.popUpMenuStyle}
+        onClose={closeMenu}
+      >
+        <AssignmentVersionMenuHeader />
+        {Object.values(orderedCourseVersions).map(version => (
+          <AssignmentVersionMenuItem
+            selectedCourseVersionId={selectedCourseVersionId}
+            courseVersion={version}
+            onClick={() => chooseMenuItem(version)}
+            key={version.id}
+          />
+        ))}
+      </PopUpMenu>
+    </span>
+  );
 }
+
+AssignmentVersionSelector.propTypes = {
+  dropdownStyle: PropTypes.object,
+  onChangeVersion: PropTypes.func.isRequired,
+  selectedCourseVersionId: PropTypes.number,
+  courseVersions: PropTypes.objectOf(assignmentCourseVersionShape),
+  courseFilters: PropTypes.object,
+  disabled: PropTypes.bool,
+  rightJustifiedPopupMenu: PropTypes.bool,
+};
 
 const styles = {
   version: {
@@ -144,3 +164,31 @@ const styles = {
     width: menuWidth,
   },
 };
+
+/**
+ * This is a version of the course version dropdown that is overridable by a region
+ * configuration.
+ *
+ * This is done via a configuration in, for instance, /config/global_editions/fa.yml
+ * via a paths rule such as:
+ *
+ * ```
+ * pages:
+ *   # All pages
+ *   - path: /
+ *     components:
+ *       LtiFeedbackBanner: false
+ *       AssignmentVersionSelector:
+ *         courseFilters:
+ *         language: fa-IR
+ * ```
+ */
+const RegionalAssignmentVersionSelector = props => (
+  <GlobalRegionWrapper
+    component={AssignmentVersionSelector}
+    componentId="AssignmentVersionSelector"
+    props={props}
+  />
+);
+
+export default RegionalAssignmentVersionSelector;

--- a/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, {useState, useEffect, useRef} from 'react';
 
 import fontConstants from '@cdo/apps/fontConstants';
-import GlobalRegionWrapper from '@cdo/apps/templates/GlobalRegionWrapper';
+import GlobalEditionWrapper from '@cdo/apps/templates/GlobalEditionWrapper';
 import i18n from '@cdo/locale';
 
 import PopUpMenu, {STANDARD_PADDING} from '../../sharedComponents/PopUpMenu';
@@ -184,7 +184,7 @@ const styles = {
  * ```
  */
 const RegionalAssignmentVersionSelector = props => (
-  <GlobalRegionWrapper
+  <GlobalEditionWrapper
     component={AssignmentVersionSelector}
     componentId="AssignmentVersionSelector"
     props={props}

--- a/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
@@ -180,7 +180,7 @@ const styles = {
  *       LtiFeedbackBanner: false
  *       AssignmentVersionSelector:
  *         courseFilters:
- *         language: fa-IR
+ *           language: fa-IR
  * ```
  */
 const RegionalAssignmentVersionSelector = props => (

--- a/apps/src/templates/teacherDashboard/teacherDashboardTestHelpers.js
+++ b/apps/src/templates/teacherDashboard/teacherDashboardTestHelpers.js
@@ -50,6 +50,7 @@ export const courseOfferings = {
         type: 'Unit',
         is_stable: true,
         is_recommended: false,
+        locale_codes: ['fa-AF', 'cs-CZ', 'de-DE', 'en-US'],
         locales: ['العربية', 'Čeština', 'Deutsch', 'English'],
         units: {
           1: {
@@ -71,6 +72,7 @@ export const courseOfferings = {
         type: 'Unit',
         is_stable: true,
         is_recommended: true,
+        locale_codes: ['en-US', 'it-IT', 'sk-SK'],
         locales: ['English', 'Italiano', 'Slovenčina'],
         units: {
           2: {
@@ -100,6 +102,7 @@ export const courseOfferings = {
         type: 'UnitGroup',
         is_stable: true,
         is_recommended: false,
+        locale_codes: [],
         locales: [],
         units: {
           3: {
@@ -130,6 +133,7 @@ export const courseOfferings = {
         type: 'UnitGroup',
         is_stable: true,
         is_recommended: true,
+        locale_codes: [],
         locales: [],
         units: {
           5: {
@@ -168,6 +172,7 @@ export const courseOfferings = {
         type: 'UnitGroup',
         is_stable: true,
         is_recommended: true,
+        locale_codes: [],
         locales: [],
         units: {
           7: {
@@ -206,6 +211,7 @@ export const courseOfferings = {
         type: 'Unit',
         is_stable: true,
         is_recommended: false,
+        locale_codes: [],
         locales: [],
         units: {
           9: {
@@ -236,6 +242,7 @@ export const courseOfferings = {
         type: 'Unit',
         is_stable: true,
         is_recommended: true,
+        locale_codes: [],
         locales: [],
         units: {
           10: {
@@ -266,6 +273,7 @@ export const courseOfferings = {
         type: 'Unit',
         is_stable: true,
         is_recommended: true,
+        locale_codes: [],
         locales: [],
         units: {
           11: {
@@ -296,6 +304,7 @@ export const courseOfferings = {
         type: 'Unit',
         is_stable: true,
         is_recommended: true,
+        locale_codes: [],
         locales: [],
         units: {
           12: {
@@ -326,6 +335,7 @@ export const courseOfferings = {
         type: 'UnitGroup',
         is_stable: true,
         is_recommended: true,
+        locale_codes: [],
         locales: [],
         units: {
           13: {
@@ -364,6 +374,7 @@ export const courseOfferings = {
         type: 'Unit',
         is_stable: true,
         is_recommended: true,
+        locale_codes: [],
         locales: [],
         units: {
           15: {
@@ -386,6 +397,7 @@ export const courseOfferings = {
         type: 'Unit',
         is_stable: true,
         is_recommended: true,
+        locale_codes: [],
         locales: [],
         units: {
           16: {

--- a/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
@@ -45,7 +45,11 @@ describe('SectionsSetUpContainer', () => {
   it('renders curriculum quick assign', () => {
     const wrapper = shallow(<SectionsSetUpContainer {...DEFAULT_PROPS} />);
 
-    expect(wrapper.find('CurriculumQuickAssign').length).to.equal(1);
+    expect(
+      wrapper.find('GlobalEditionWrapper', {
+        componentId: 'CurriculumQuickAssign',
+      }).length
+    ).to.equal(1);
   });
 
   it('renders Child Account Policy Notice for US, student and email sections', () => {

--- a/apps/test/unit/templates/teacherDashboard/AssignmentVersionSelectorTest.js
+++ b/apps/test/unit/templates/teacherDashboard/AssignmentVersionSelectorTest.js
@@ -1,4 +1,4 @@
-import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {render, screen} from '@testing-library/react';
 import React from 'react';
 
 import AssignmentVersionSelector from '@cdo/apps/templates/teacherDashboard/AssignmentVersionSelector';
@@ -13,12 +13,12 @@ const defaultProps = {
 
 describe('AssignmentVersionSelector', () => {
   it('an option and AssignmentVersionMenuItem for each course version', () => {
-    const wrapper = shallow(<AssignmentVersionSelector {...defaultProps} />);
-    expect(wrapper.find('option').length).toEqual(2);
-    expect(wrapper.find('AssignmentVersionMenuItem').length).toEqual(2);
-    expect(wrapper.find('option').map(option => option.text())).toEqual([
-      '2018 (Recommended)',
-      '2017',
-    ]);
+    render(<AssignmentVersionSelector {...defaultProps} />);
+
+    // Renders all options
+    expect(screen.getByRole('option', {name: '2017'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {name: '2018 (Recommended)'})
+    ).toBeInTheDocument();
   });
 });

--- a/config/global_editions/fa.yml
+++ b/config/global_editions/fa.yml
@@ -144,12 +144,17 @@ footer:
 
 # Route matching to influence properties of components
 pages:
-  # Home dashboards
+  # All pages
   - path: /
     components:
       LtiFeedbackBanner: false
       CurriculumCatalog:
+        # Do not allow switching away from showing ONLY translated courses
         forceTranslated: true
+      StartNewProject:
+        # Do not show all project options, just the basic ones
+        canViewFullList: false
+  # Teacher dashboard
   - path: /teacher_dashboard
     components:
       DownloadParentLetterButton: false
@@ -159,6 +164,7 @@ pages:
       ProgressV1OrV2ToggleLink: false
       ProgressFeedbackBanner: false
       ParentLetterAndStudentPrivacyInfo: false
+  # Home dashboards
   - path: /home
     components:
       MarketingAnnouncementBanner: false

--- a/config/global_editions/fa.yml
+++ b/config/global_editions/fa.yml
@@ -154,6 +154,16 @@ pages:
       StartNewProject:
         # Do not show all project options, just the basic ones
         canViewFullList: false
+      CurriculumQuickAssign:
+        # For section setup, truncate the 'quick access' course listing to
+        # only items that are translated to Farsi
+        courseFilters:
+          language: fa-IR
+      AssignmentVersionSelector:
+        # When viewing a course, only populate the version selector with
+        # versions that are translated
+        courseFilters:
+          language: fa-IR
   # Teacher dashboard
   - path: /teacher_dashboard
     components:

--- a/config/global_editions/fa.yml
+++ b/config/global_editions/fa.yml
@@ -148,6 +148,8 @@ pages:
   - path: /
     components:
       LtiFeedbackBanner: false
+      CurriculumCatalog:
+        forceTranslated: true
   - path: /teacher_dashboard
     components:
       DownloadParentLetterButton: false

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -197,6 +197,7 @@ class CourseVersion < ApplicationRecord
         is_stable: stable?,
         is_recommended: recommended?(locale_code),
         locales: content_root.supported_locale_names,
+        locale_codes: content_root.supported_locale_codes,
         units: units.select {|u| u.course_assignable?(user)}.map(&:summarize_for_assignment_dropdown).to_h
       }
     ]


### PR DESCRIPTION
This adds regional configuration wrappers and edits to the curriculum lists and selections.

We want to, when viewing within a region, only show courses (and versions of the courses)  that are translated.

## Links

- jira ticket: [P20-1294](https://codedotorg.atlassian.net/browse/P20-1294)
- jira ticket: [P20-1295](https://codedotorg.atlassian.net/browse/P20-1295)

## Testing story

Tested via our adhoc and QA testers.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
