### PR TITLE
Fix RTL bug

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2979,7 +2979,7 @@ StudioApp.prototype.handleUsingBlockly_ = function (config) {
     showExampleTestButtons: utils.valueOr(config.showExampleTestButtons, false),
     valueTypeTabShapeMap: utils.valueOr(config.valueTypeTabShapeMap, {}),
     typeHints: utils.valueOr(config.level.showTypeHints, false),
-    isBlocklyRtl: getStore().getState().isRtl && isJigsaw, // disable RTL for blockly on jigsaw
+    isBlocklyRtl: getStore().getState().isRtl && !isJigsaw, // disable RTL for blockly on jigsaw
     isJigsaw,
     analyticsData: {
       appType: config.app,


### PR DESCRIPTION
Code was:

`getStore().getState().isRtl && config.levelGameName !== 'Jigsaw', // disable RTL for blockly on jigsaw`

(Checking that we're in RTL but not using Jigsaw)

Code became (https://github.com/code-dot-org/code-dot-org/pull/62479):

`getStore().getState().isRtl && isJigsaw, // disable RTL for blockly on jigsaw`

(Inadvertently only allowing RTL for Jigsaw - the opposite of what we wanted)
 
Code should have become:

`getStore().getState().isRtl && !isJigsaw, // disable RTL for blockly on jigsaw`


https://codedotorg.slack.com/archives/C0T0PNTM3/p1732221275018979?thread_ts=1732220885.300629&cid=C0T0PNTM3