### PR TITLE
HoC 2024 - Update imagi platforms string

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -9258,7 +9258,7 @@
   tutorial_carnegiesensabot_string_platforms: "All modern browsers"
   tutorial_robotical4_string_platforms: "All modern browsers"
   tutorial_kinderadd_string_platforms: "Unplugged"
-  tutorial_imagipython_string_platforms: "Chrome, Firefox, Android tablet, iPad, iPhone"
+  tutorial_imagipython_string_platforms: "All modern browsers, Android tablet, iPad, iPhone"
   tutorial_robotical2_string_platforms: "Unplugged"
   tutorial_robotical3_string_platforms: "All modern browsers"
   tutorial_blockscadvirus_string_platforms: "All modern browsers"


### PR DESCRIPTION
Updates the string for the "Creative Coding in Python" tutorial. This string is overriding the string from cdo-tutorials so updating them all to match.