### PR TITLE
[GenAI - Teacher Flagging] Migration to track request_id from aichat_events table as a foreign key.

### DIFF
--- a/dashboard/app/models/aichat_event.rb
+++ b/dashboard/app/models/aichat_event.rb
@@ -10,10 +10,12 @@
 #  aichat_event :json
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  request_id   :bigint
 #
 # Indexes
 #
-#  index_ace_user_level_script  (user_id,level_id,script_id)
+#  index_ace_user_level_script        (user_id,level_id,script_id)
+#  index_aichat_events_on_request_id  (request_id)
 #
 class AichatEvent < ApplicationRecord
   belongs_to :user

--- a/dashboard/db/migrate/20241121225506_add_foreign_key_from_aichat_events_to_aichat_requests.rb
+++ b/dashboard/db/migrate/20241121225506_add_foreign_key_from_aichat_events_to_aichat_requests.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyFromAichatEventsToAichatRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :aichat_events, :request, index: true, foreign_key: {to_table: :aichat_requests}, null: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_11_25_202219) do
+ActiveRecord::Schema.define(version: 2024_11_21_225506) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -78,6 +78,8 @@ ActiveRecord::Schema.define(version: 2024_11_25_202219) do
     t.json "aichat_event"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "request_id"
+    t.index ["request_id"], name: "index_aichat_events_on_request_id"
     t.index ["user_id", "level_id", "script_id"], name: "index_ace_user_level_script"
   end
 
@@ -2506,6 +2508,7 @@ ActiveRecord::Schema.define(version: 2024_11_25_202219) do
 
   add_foreign_key "ai_tutor_interaction_feedbacks", "ai_tutor_interactions"
   add_foreign_key "ai_tutor_interaction_feedbacks", "users"
+  add_foreign_key "aichat_events", "aichat_requests", column: "request_id"
   add_foreign_key "cap_user_events", "users"
   add_foreign_key "census_submission_form_maps", "census_submissions"
   add_foreign_key "census_summaries", "schools"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

NOTE: #62737 is dependent on this PR. If this PR is reverted, #62737 must be reverted also.

We want to allow teachers to flag messages from the UI, which will be stored in aichat_events. The other metadata about why things get flagged by the safety layer lives in aichat_requests which we can export via a script.  If we want to join that data for export, we will need a link between the aichat_events and the aichat_requests.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- [Add and populate a foreign key between aichat _requests and aichat_events](https://codedotorg.atlassian.net/browse/LABS-1287)

## Testing story

Tested locally that migration adds the appropriate column and foreign key constraint.

Tested #62737 on top of this change

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Merge into staging-next to be deployed after HOC along with its dependent change #62737
 
## Follow-up work

 - #62737
 - [Update aichat_requests_to_csv script to include teacher flagging info](https://codedotorg.atlassian.net/browse/LABS-1286) 
 - [Allow teachers to flag a message as inappropriate (both student input and chatbot response)](https://codedotorg.atlassian.net/browse/LABS-1105) 
