### PR TITLE
Panels: list styling

### DIFF
--- a/apps/src/panels/panelsView.module.scss
+++ b/apps/src/panels/panelsView.module.scss
@@ -108,6 +108,17 @@ $text-horizontal-padding: 2.6cqw;
         }
       }
 
+      ol, ul {
+        font-size: 1.6cqw;
+        line-height: 0;
+        margin: 0 0 1.1cqw 2.2cqw;
+
+        li {
+          margin-bottom: 1.1cqw;
+          line-height: 1.4em;
+        }
+      }
+
       .invisiblePlaceholder {
         opacity: 0;
       }

--- a/apps/src/panels/panelsView.module.scss
+++ b/apps/src/panels/panelsView.module.scss
@@ -110,7 +110,6 @@ $text-horizontal-padding: 2.6cqw;
 
       ol, ul {
         font-size: 1.6cqw;
-        line-height: 0;
         margin: 0 0 1.1cqw 2.2cqw;
 
         li {


### PR DESCRIPTION
This adds some styling for lists in panels levels.

### before

<img width="573" alt="Screenshot 2024-11-21 at 8 48 50 PM" src="https://github.com/user-attachments/assets/8889f60c-6eb3-46a6-aa11-3fc1fc5d3125">

### after

<img width="573" alt="Screenshot 2024-11-21 at 8 44 06 PM" src="https://github.com/user-attachments/assets/d27daa72-39fb-4368-80b0-d544843c0dba">

### future

It's based on the list styling used in Lab2 [instructions](https://github.com/code-dot-org/code-dot-org/blob/5b4add1f33a357ea64026b98eb74b6d3daf07fbb/apps/src/lab2/views/components/instructions.module.scss#L176-L185), though some outer styling differences means it's not quite identical.  In the future it might be good to unify these components and their styling.
