### PR TITLE
Change usState to snake case in Statsig metric names

### DIFF
--- a/apps/src/sites/studio/pages/policy_compliance/parental_permission/_modal.js
+++ b/apps/src/sites/studio/pages/policy_compliance/parental_permission/_modal.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const defaultEventParams = (parentalPermissionRequest = {}) => ({
         consentStatus: parentalPermissionRequest?.consent_status,
-        usState: currentUser?.usStateCode,
+        us_state: currentUser?.usStateCode,
       });
 
       const reportEvent = (eventName, payload = {}) => {
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       reportEvent(EVENTS.CAP_PARENT_EMAIL_MODAL_SHOWN, {
         consentStatus: currentUser?.childAccountComplianceState,
-        usState: currentUser?.usStateCode,
+        us_state: currentUser?.usStateCode,
       });
 
       return (

--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsBanner.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsBanner.tsx
@@ -34,7 +34,7 @@ export const AgeGatedStudentsBanner: React.FC<Props> = ({
     reportEvent(EVENTS.CAP_AGE_GATED_BANNER_SHOWN, {
       user_id: currentUser.userId,
       number_of_gateable_students: ageGatedStudentsCount,
-      usState: ageGatedStudentsUsState,
+      us_state: ageGatedStudentsUsState,
     });
   }, [currentUser.userId, ageGatedStudentsCount, ageGatedStudentsUsState]);
 

--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
@@ -47,7 +47,7 @@ const AgeGatedStudentsModal: React.FC<Props> = ({
     reportEvent(EVENTS.CAP_STUDENT_WARNING_LINK_CLICKED, {
       user_id: currentUser.userId,
       number_of_gateable_students: ageGatedStudentsCount,
-      usState: ageGatedStudentsUsState,
+      us_state: ageGatedStudentsUsState,
     });
   };
 
@@ -55,7 +55,7 @@ const AgeGatedStudentsModal: React.FC<Props> = ({
     reportEvent(EVENTS.CAP_AGE_GATED_MODAL_CLOSED, {
       user_id: currentUser.userId,
       number_of_gateable_students: ageGatedStudentsCount,
-      usState: ageGatedStudentsUsState,
+      us_state: ageGatedStudentsUsState,
     });
     onClose();
   };
@@ -64,7 +64,7 @@ const AgeGatedStudentsModal: React.FC<Props> = ({
     reportEvent(EVENTS.CAP_AGE_GATED_MODAL_SHOWN, {
       user_id: currentUser.userId,
       number_of_gateable_students: ageGatedStudentsCount,
-      usState: ageGatedStudentsUsState,
+      us_state: ageGatedStudentsUsState,
     });
   }, [currentUser.userId, ageGatedStudentsCount, ageGatedStudentsUsState]);
   return (

--- a/apps/src/templates/policy_compliance/ChildAccountConsent/index.tsx
+++ b/apps/src/templates/policy_compliance/ChildAccountConsent/index.tsx
@@ -83,10 +83,16 @@ const ChildAccountConsent: React.FC<ChildAccountConsentProps> = ({
   usState,
 }) => {
   if (permissionGranted && permissionGrantedDate) {
-    reportEvent(EVENTS.CAP_PARENT_CONSENT_GRANTED, {studentId, usState});
+    reportEvent(EVENTS.CAP_PARENT_CONSENT_GRANTED, {
+      studentId,
+      us_state: usState,
+    });
     return permissionGrantedMessage(permissionGrantedDate);
   } else {
-    reportEvent(EVENTS.CAP_PARENT_CONSENT_EXPIRED, {studentId, usState});
+    reportEvent(EVENTS.CAP_PARENT_CONSENT_EXPIRED, {
+      studentId,
+      us_state: usState,
+    });
     return expiredTokenMessage();
   }
 };

--- a/apps/src/templates/policy_compliance/LockoutLinkedAccounts.jsx
+++ b/apps/src/templates/policy_compliance/LockoutLinkedAccounts.jsx
@@ -68,7 +68,7 @@ export default function LockoutLinkedAccounts(props) {
       providers: props.providers,
       inSection: props.inSection,
       consentStatus: props.permissionStatus,
-      usState: props.usState,
+      us_state: props.usState,
     });
   }, [props]);
 
@@ -88,21 +88,21 @@ export default function LockoutLinkedAccounts(props) {
         providers: props.providers,
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
-        usState: props.usState,
+        us_state: props.usState,
       });
     } else if (parentalPermissionRequest.parent_email === prevPendingEmail) {
       reportEvent(EVENTS.CAP_SETTINGS_EMAIL_RESEND, {
         providers: props.providers,
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
-        usState: props.usState,
+        us_state: props.usState,
       });
     } else {
       reportEvent(EVENTS.CAP_SETTINGS_EMAIL_UPDATED, {
         providers: props.providers,
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
-        usState: props.usState,
+        us_state: props.usState,
       });
     }
   }, [action, prevPendingEmail, parentalPermissionRequest, props]);

--- a/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
+++ b/apps/src/templates/policy_compliance/ParentalPermissionBanner/index.tsx
@@ -39,7 +39,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
   ) => {
     return {
       inSection: currentUser.inSection,
-      usState: currentUser.usStateCode,
+      us_state: currentUser.usStateCode,
       consentStatus: parentalPermissionRequest.consent_status,
     };
   };
@@ -53,7 +53,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
       reportEvent(EVENTS.CAP_PARENT_EMAIL_BANNER_SHOWN, {
         inSection: currentUser.inSection,
         consentStatus: currentUser.childAccountComplianceState,
-        usState: currentUser.usStateCode,
+        us_state: currentUser.usStateCode,
       });
     }
   }, [
@@ -69,7 +69,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
     reportEvent(EVENTS.CAP_PARENT_EMAIL_BANNER_CLICKED, {
       inSection: currentUser.inSection,
       consentStatus: currentUser.childAccountComplianceState,
-      usState: currentUser.usStateCode,
+      us_state: currentUser.usStateCode,
     });
   };
 
@@ -84,7 +84,7 @@ const ParentalPermissionBanner: React.FC<ParentalPermissionBannerProps> = ({
 
     reportEvent(EVENTS.CAP_PARENT_EMAIL_MODAL_CLOSED, {
       inSection: currentUser.inSection,
-      usState: currentUser.usStateCode,
+      us_state: currentUser.usStateCode,
       consentStatus,
     });
   };

--- a/apps/src/templates/sessions/LockoutPanel.tsx
+++ b/apps/src/templates/sessions/LockoutPanel.tsx
@@ -90,7 +90,7 @@ const LockoutPanel: React.FC<LockoutPanelProps> = props => {
         inSection: props.inSection,
         consentStatus: props.permissionStatus,
         requestSent: !!props.pendingEmail,
-        usState: currentUser.usStateCode,
+        us_state: currentUser.usStateCode,
       });
     }
   }, [
@@ -116,19 +116,19 @@ const LockoutPanel: React.FC<LockoutPanelProps> = props => {
       reportEvent(EVENTS.CAP_LOCKOUT_EMAIL_SUBMITTED, {
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
-        usState: currentUser.usStateCode,
+        us_state: currentUser.usStateCode,
       });
     } else if (parentalPermissionRequest.parent_email === prevPendingEmail) {
       reportEvent(EVENTS.CAP_LOCKOUT_EMAIL_RESEND, {
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
-        usState: currentUser.usStateCode,
+        us_state: currentUser.usStateCode,
       });
     } else {
       reportEvent(EVENTS.CAP_LOCKOUT_EMAIL_UPDATED, {
         inSection: props.inSection,
         consentStatus: parentalPermissionRequest.consent_status,
-        usState: currentUser.usStateCode,
+        us_state: currentUser.usStateCode,
       });
     }
   }, [
@@ -169,7 +169,7 @@ const LockoutPanel: React.FC<LockoutPanelProps> = props => {
     reportEvent(EVENTS.CAP_LOCKOUT_SIGN_OUT, {
       inSection: props.inSection,
       consentStatus: status,
-      usState: currentUser.usStateCode,
+      us_state: currentUser.usStateCode,
     });
   };
 

--- a/apps/test/unit/templates/policy_compliance/ChildAccountConsentTest.tsx
+++ b/apps/test/unit/templates/policy_compliance/ChildAccountConsentTest.tsx
@@ -69,7 +69,7 @@ describe('ChildAccountConsent', () => {
       expect(sendEventSpy).to.be.calledOnce;
       expect(sendEventSpy).calledWith('CAP Parent Consent Granted', {
         studentId: props.studentId,
-        usState: props.usState,
+        us_state: props.usState,
       });
     });
   });


### PR DESCRIPTION
I recently added the `usState` property to a bunch of front-end CAP metrics, but the naming should have been snake case to match the `us_state` naming from backend events. This PR changes the names of all the bad properties.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
