### PR TITLE
P20 1183/dashboard region switch

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -32,9 +32,11 @@ class HomeController < ApplicationController
     if params[:locale]
       redirect_uri = URI(redirect_path)
       redirect_params = URI.decode_www_form(redirect_uri.query.to_s).to_h
-      redirect_params[VarnishEnvironment::LOCALE_PARAM_KEY] = params[:locale]
+      lang, ge_region = params[:locale].split('|')
+      redirect_params[VarnishEnvironment::LOCALE_PARAM_KEY] = lang
       # Query parameter for browser cache to be avoided and load new locale
-      redirect_params['lang'] = params[:locale].split('|').first
+      redirect_params['lang'] = lang
+      redirect_params['ge_region'] = ge_region
       redirect_uri.query = URI.encode_www_form(redirect_params)
       redirect_path = redirect_uri.to_s
     end

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -40,12 +40,9 @@
         -# user input or to persist data without also updating it to enforce UTF-8
         = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do
           = hidden_field_tag :user_return_to, request.url
-          - options = Cdo::I18n.locale_options
-          - selected = locale
+          - options = Cdo::GlobalEdition.locale_options(request.ge_region)
+          - selected = Cdo::I18n.current_locale_option(request.ge_region)
           - if request.ge_region
-            - region_locales = Cdo::GlobalEdition.region_locales(request.ge_region)
-            - options = options.select {|_name, value| region_locales.include?(value)}
-            - options = options.map {|name, value| [name, value + "|#{request.ge_region}"]}
             -# Add the "escape" option to go out of the global edition
             - options << [I18n.t(:region_reset, scope: %i[global_edition]), "en-US"]
             - selected = "#{locale}|#{request.ge_region}"

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -45,7 +45,6 @@
           - if request.ge_region
             -# Add the "escape" option to go out of the global edition
             - options << [I18n.t(:region_reset, scope: %i[global_edition]), "en-US"]
-            - selected = "#{locale}|#{request.ge_region}"
           - options = options_for_select(options, selected)
           = select_tag :locale, options, { onchange: 'this.form.submit();', 'aria-label':  t('footer.locale_select', default: 'Select language') }
         %small.dim

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -40,7 +40,16 @@
         -# user input or to persist data without also updating it to enforce UTF-8
         = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do
           = hidden_field_tag :user_return_to, request.url
-          - options = options_for_select(Cdo::I18n.locale_options, locale)
+          - options = Cdo::I18n.locale_options
+          - selected = locale
+          - if request.ge_region
+            - region_locales = Cdo::GlobalEdition.region_locales(request.ge_region)
+            - options = options.select {|_name, value| region_locales.include?(value)}
+            - options = options.map {|name, value| [name, value + "|#{request.ge_region}"]}
+            -# Add the "escape" option to go out of the global edition
+            - options << [I18n.t(:region_reset, scope: %i[global_edition]), "en-US"]
+            - selected = "#{locale}|#{request.ge_region}"
+          - options = options_for_select(options, selected)
           = select_tag :locale, options, { onchange: 'this.form.submit();', 'aria-label':  t('footer.locale_select', default: 'Select language') }
         %small.dim
           !="&copy; Code.org, #{Time.now.year}"

--- a/dashboard/app/views/layouts/_small_footer.html.haml
+++ b/dashboard/app/views/layouts/_small_footer.html.haml
@@ -4,8 +4,8 @@
   reactProps = {
     i18nDropdownInBase: view_options[:has_i18n],
     localeUrl: locale_url,
-    currentLocale: locale,
-    localeOptions: Cdo::I18n.locale_options.map {|(text, value)| {text: text, value: value}},
+    currentLocale: Cdo::I18n.current_locale_option(locale, request.ge_region),
+    localeOptions: Cdo::GlobalEdition.locale_options(request.ge_region).map {|(text, value)| {text: text, value: value}},
     privacyPolicyInBase: true,
     copyrightInBase: true,
     baseMoreMenuString: I18n.t('footer.more'),

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1522,5 +1522,6 @@ en:
         resend_limit_reached: The limit for resend requests has been reached
   not_applicable_abbreviation: "N/A"
   global_edition:
+    region_reset: "Return to Full Site"
     regions:
       fa: Farsi

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -196,7 +196,7 @@ class HomeControllerTest < ActionController::TestCase
 
     get :set_locale, params: {user_return_to: "/blahblah", locale: "es-ES"}
 
-    assert_redirected_to 'http://studio.code.org/blahblah?set_locale=es-ES&lang=es-ES'
+    assert_redirected_to 'http://studio.code.org/blahblah?set_locale=es-ES&lang=es-ES&ge_region'
   end
 
   test "handle nonsense in user_return_to by returning to home" do
@@ -215,13 +215,13 @@ class HomeControllerTest < ActionController::TestCase
       user_return_to: "http://blah.com/blerg",
       locale: "es-ES"
     }
-    assert_redirected_to 'http://studio.code.org/blerg?set_locale=es-ES&lang=es-ES'
+    assert_redirected_to 'http://studio.code.org/blerg?set_locale=es-ES&lang=es-ES&ge_region'
   end
 
   test "if user_return_to in set_locale is nil redirects to homepage" do
     request.host = "studio.code.org"
     get :set_locale, params: {user_return_to: nil, locale: "es-ES"}
-    assert_redirected_to 'http://studio.code.org?set_locale=es-ES&lang=es-ES'
+    assert_redirected_to 'http://studio.code.org?set_locale=es-ES&lang=es-ES&ge_region'
   end
 
   test "should get index with edmodo header" do

--- a/lib/cdo/global_edition.rb
+++ b/lib/cdo/global_edition.rb
@@ -4,6 +4,8 @@ require 'request_store'
 require 'uri'
 require 'yaml'
 
+require 'cdo/i18n'
+
 module Cdo
   # Lazily loads global configurations for regional pages
   module GlobalEdition
@@ -76,6 +78,16 @@ module Cdo
         end
         region_locked_locales
       end.freeze
+    end
+
+    def self.locale_options(region = nil)
+      options = Cdo::I18n.locale_options
+      if region
+        region_locales = region_locales(region)
+        options = options.select {|_name, value| region_locales.include?(value)}
+        options = options.map {|name, value| [name, value + "|#{region}"]}
+      end
+      options
     end
 
     def self.region_change_url(url, region = nil)

--- a/lib/cdo/i18n.rb
+++ b/lib/cdo/i18n.rb
@@ -59,6 +59,10 @@ module Cdo
         end.sort_by(&:second).freeze
       end
 
+      def current_locale_option(locale, ge_region = nil)
+        ge_region.nil? || ge_region.empty? ? locale.to_s : "#{locale}|#{ge_region}"
+      end
+
       def locale_direction(locale)
         LOCALE_CONFIGS.dig(locale.to_s, :dir) || TEXT_DIRECTION_LTR
       end

--- a/lib/cdo/rack/global_edition.rb
+++ b/lib/cdo/rack/global_edition.rb
@@ -97,7 +97,7 @@ module Rack
 
       private def setup_region(region)
         # Resets the region if it's `nil` or sets it only if it's available.
-        return unless region.nil? || Cdo::GlobalEdition.region_available?(region)
+        return unless region.nil? || region.empty? || Cdo::GlobalEdition.region_available?(region)
 
         # Sets the request cookies to apply changes immediately without needing to reload the page.
         request.cookies[REGION_KEY] = region
@@ -144,9 +144,6 @@ module Rack
         site_locale = request.cookies[LOCALE_KEY]
 
         if Cdo::GlobalEdition.region_available?(region)
-          # Only Pegasus pages are available in all regional languages.
-          site_locale = Cdo::GlobalEdition.region_locked_locales.key(region) unless pegasus?
-
           region_locales = Cdo::GlobalEdition.region_locales(region)
           site_locale = Cdo::GlobalEdition.main_region_locale(region) unless region_locales.include?(site_locale)
         else


### PR DESCRIPTION
Unifies pegasus and dashboard language dropdowns.

Dashboard dropdowns now show english/farsi and an extra option to exit the global region. The small footer omits the ability to exit the global region for the sake of simplicity and to not make it too easy for young folks to drop out of the region... which would be very confusing.

**Footer**:

![image](https://github.com/user-attachments/assets/eac04d46-cdc5-4c96-92e2-5911414d721b)

**Small footer**:

![image](https://github.com/user-attachments/assets/8d75bf44-4957-46f8-8c59-3455afd7543c)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
