### PR TITLE
Skipping flaky test in pl_landing_page.feature

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pl_landing_page.feature
+++ b/dashboard/test/ui/features/acquisition_products/pl_landing_page.feature
@@ -62,6 +62,9 @@ Feature: Professional Learning landing page
     # Sees Instructor Professional Learning Sections section
     And I wait until element "button:contains(Create a section)" is visible
 
+  # This test has been flaky due to the page render timing out. Skipping until
+  # a fix can be addressed
+  @skip
   Scenario: Regional Partner sees relevant content sections
     Given I am a program manager with a started course
     And I am on "http://studio.code.org/my-professional-learning"


### PR DESCRIPTION
This PR skips a flaky UI test in pl_landing_page.feature.

[Slack thread for context](https://codedotorg.slack.com/archives/C0T0PNTM3/p1732254035093599?thread_ts=1732225049.120379&cid=C0T0PNTM3)
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
