### PR TITLE
Adding Delware CAP config

### DIFF
--- a/dashboard/lib/policies/child_account/state_policies.rb
+++ b/dashboard/lib/policies/child_account/state_policies.rb
@@ -14,7 +14,14 @@ module Policies::ChildAccount::StatePolicies
         grace_period_duration: 14.days.seconds,
         lockout_date: DateTime.parse('2024-07-01T00:00:00MDT'),
         start_date: DateTime.parse('2023-07-05T23:15:00+00:00'),
-      }
+      },
+      'DE' => {
+        name: 'DPDPA',
+        max_age: 12,
+        grace_period_duration: 14.days.seconds,
+        lockout_date: DateTime.parse('2025-01-01T00:00:00-05:00'),
+        start_date: DateTime.parse('2025-01-01T00:00:00-05:00'),
+      },
     }
 
     # Override the configured dates for testing purposes

--- a/dashboard/test/lib/policies/child_account/state_policies_test.rb
+++ b/dashboard/test/lib/policies/child_account/state_policies_test.rb
@@ -33,5 +33,31 @@ class Policies::ChildAccount::StatePoliciesTest < ActiveSupport::TestCase
         _(co_state_policy[:lockout_date]).must_equal default_lockout_date
       end
     end
+
+    describe 'for Delaware' do
+      let(:co_state_policy) {state_policies['DE']}
+      let(:default_start_date) {DateTime.parse('2025-01-01T00:00:00-05:00')}
+      let(:default_lockout_date) {DateTime.parse('2025-01-01T00:00:00-05:00')}
+
+      it 'contains expected max age' do
+        _(co_state_policy[:max_age]).must_equal 12
+      end
+
+      it 'contains expected name' do
+        _(co_state_policy[:name]).must_equal 'DPDPA'
+      end
+
+      it 'contains expected grace_period_duration' do
+        _(co_state_policy[:grace_period_duration]).must_equal 14.days
+      end
+
+      it 'contains expected default start_date' do
+        _(co_state_policy[:start_date]).must_equal default_start_date
+      end
+
+      it 'contains expected default lockout_date' do
+        _(co_state_policy[:lockout_date]).must_equal default_lockout_date
+      end
+    end
   end
 end


### PR DESCRIPTION
Add the ChildAccountPolicy Delaware configuration. When this is in productions, students and teachers in Delaware will start to see warnings about the upcoming lockout date.

## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1312)

## Testing story
* Unit tests
* Bug bash

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
This will be merged on Monday before the DTP. When the DTP on Monday completes, students and teachers in Delaware will start to see the warning banners.

