### PR TITLE
Change primary cta destination to /reset for music-tutorial-2024

### DIFF
--- a/pegasus/sites.v3/code.org/views/music/music_lab_tutorials.haml
+++ b/pegasus/sites.v3/code.org/views/music/music_lab_tutorials.haml
@@ -14,7 +14,7 @@
       title: hoc_s("music_lab.jam_session.block.title"),
       image: "/images/action-blocks/action-block-music-lab-tutorial.png",
       desc: hoc_s("music_lab.jam_session.block.desc"),
-      url: CDO.studio_url("s/music-tutorial-2024"),
+      url: CDO.studio_url("s/music-tutorial-2024/reset"),
       button_label: hoc_s("music_lab.tutorial.button")
     },
   ]


### PR DESCRIPTION
On code.org/music, the primary CTA for activity tile for Music Tutorial 2024 goes to the lesson overview page. Instead, it should go to the first level of the progression.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
![image](https://github.com/user-attachments/assets/3be3975e-13f7-42d0-8a51-9771d2205c46)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
In a separate PR, we will be looking to add links to the lesson plan as a secondary CTA

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
