### PR TITLE
Blockly: orphan fix

### DIFF
--- a/apps/src/blockly/eventHandlers.ts
+++ b/apps/src/blockly/eventHandlers.ts
@@ -39,6 +39,7 @@ export function disableOrphans(event: GoogleBlockly.Events.Abstract) {
   if (
     event.type !== Blockly.Events.BLOCK_CHANGE &&
     event.type !== Blockly.Events.BLOCK_MOVE &&
+    event.type !== Blockly.Events.BLOCK_DRAG &&
     event.type !== Blockly.Events.BLOCK_CREATE
   ) {
     return;
@@ -67,11 +68,8 @@ export function disableOrphans(event: GoogleBlockly.Events.Abstract) {
     if (block) {
       updateBlockEnabled(block);
     }
-  }
-
-  if (
-    (blockEvent.type === Blockly.Events.BLOCK_DRAG ||
-      blockEvent.type === Blockly.Events.BLOCK_MOVE) &&
+  } else if (
+    blockEvent.type === Blockly.Events.BLOCK_DRAG &&
     block &&
     block.type === BLOCK_TYPES.procedureDefinition &&
     eventWorkspace

--- a/apps/src/blockly/eventHandlers.ts
+++ b/apps/src/blockly/eventHandlers.ts
@@ -67,8 +67,11 @@ export function disableOrphans(event: GoogleBlockly.Events.Abstract) {
     if (block) {
       updateBlockEnabled(block);
     }
-  } else if (
-    blockEvent.type === Blockly.Events.BLOCK_DRAG &&
+  }
+
+  if (
+    (blockEvent.type === Blockly.Events.BLOCK_DRAG ||
+      blockEvent.type === Blockly.Events.BLOCK_MOVE) &&
     block &&
     block.type === BLOCK_TYPES.procedureDefinition &&
     eventWorkspace


### PR DESCRIPTION
This is an attempt to fix an issue in which an "orphan" function call block is being reenabled when the matching function definition is dragged.  