### PR TITLE
TEACH-1415 Units not appearing on course edit page

### DIFF
--- a/apps/src/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/levelbuilder/course-editor/CourseEditor.js
@@ -416,8 +416,7 @@ class CourseEditor extends Component {
             <div>
               The dropdown(s) below represent the ordered set of units in this
               course. To remove a unit, just set the dropdown to the default
-              (first) value. Please referesh the page after every edit to get
-              the most uptodate list of units.
+              (first) value.
             </div>
             <CourseUnitsEditor
               inputStyle={styles.input}

--- a/apps/src/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/levelbuilder/course-editor/CourseEditor.js
@@ -416,7 +416,8 @@ class CourseEditor extends Component {
             <div>
               The dropdown(s) below represent the ordered set of units in this
               course. To remove a unit, just set the dropdown to the default
-              (first) value.
+              (first) value. Please referesh the page after every edit to get
+              the most uptodate list of units.
             </div>
             <CourseUnitsEditor
               inputStyle={styles.input}

--- a/apps/src/levelbuilder/course-editor/CourseUnitsEditor.js
+++ b/apps/src/levelbuilder/course-editor/CourseUnitsEditor.js
@@ -49,9 +49,11 @@ export default class CourseUnitsEditor extends Component {
                 {name}
               </option>
             ))}
-            <option key={unitNames.length} value={selectedUnit}>
-              {selectedUnit}
-            </option>
+            {this.props.unitsInCourse.map((courseUnitName, index) => (
+              <option key={unitNames.length + index} value={courseUnitName}>
+                {courseUnitName}
+              </option>
+            ))}
           </select>
         ))}
       </div>

--- a/apps/src/levelbuilder/course-editor/CourseUnitsEditor.js
+++ b/apps/src/levelbuilder/course-editor/CourseUnitsEditor.js
@@ -49,6 +49,9 @@ export default class CourseUnitsEditor extends Component {
                 {name}
               </option>
             ))}
+            <option key={unitNames.length} value={selectedUnit}>
+              {selectedUnit}
+            </option>
           </select>
         ))}
       </div>

--- a/apps/src/levelbuilder/course-editor/CourseUnitsEditor.js
+++ b/apps/src/levelbuilder/course-editor/CourseUnitsEditor.js
@@ -49,7 +49,7 @@ export default class CourseUnitsEditor extends Component {
                 {name}
               </option>
             ))}
-            {this.props.unitsInCourse.map((courseUnitName, index) => (
+            {this.props.initialUnitsInCourse.map((courseUnitName, index) => (
               <option key={unitNames.length + index} value={courseUnitName}>
                 {courseUnitName}
               </option>

--- a/apps/test/unit/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/levelbuilder/course-editor/CourseEditorTest.js
@@ -27,7 +27,7 @@ import {allowConsoleWarnings} from '../../../util/throwOnConsole';
 
 describe('CourseEditor', () => {
   let defaultProps, store;
-  
+
   beforeEach(() => {
     sinon.stub(utils, 'navigateToHref');
     stubRedux();
@@ -37,7 +37,7 @@ describe('CourseEditor', () => {
       studentResources: createResourcesReducer('studentResource'),
     });
     store = getStore();
-  
+
     defaultProps = {
       name: 'test-course',
       initialTitle: 'Computer Science Principles 2017',
@@ -91,15 +91,28 @@ describe('CourseEditor', () => {
   describe('Course Editor - RTL', () => {
     it('All units within the course are listed under Units header', () => {
       renderDefault();
-      expect(screen.getAllByDisplayValue('Select a unit to add to course').length).to.equal(1);
+      expect(
+        screen.getAllByDisplayValue('Select a unit to add to course').length
+      ).to.equal(1);
       expect(screen.getAllByDisplayValue('CSP Unit 1').length).to.equal(1);
       expect(screen.getAllByDisplayValue('CSP Unit 2').length).to.equal(1);
-      expect(screen.queryAllByDisplayValue('Unit Not Part of Course').length).to.equal(0);
+      expect(
+        screen.queryAllByDisplayValue('Unit Not Part of Course').length
+      ).to.equal(0);
 
-      expect(screen.getAllByRole('option', {name: 'Select a unit to add to course'}).length).to.equal(3);
-      expect(screen.getAllByRole('option', {name: 'CSP Unit 1'}).length).to.equal(1);
-      expect(screen.getAllByRole('option', {name: 'CSP Unit 2'}).length).to.equal(1);
-      expect(screen.getAllByRole('option', {name: 'Unit Not Part of Course'}).length).to.equal(3);
+      expect(
+        screen.getAllByRole('option', {name: 'Select a unit to add to course'})
+          .length
+      ).to.equal(3);
+      expect(
+        screen.getAllByRole('option', {name: 'CSP Unit 1'}).length
+      ).to.equal(1);
+      expect(
+        screen.getAllByRole('option', {name: 'CSP Unit 2'}).length
+      ).to.equal(1);
+      expect(
+        screen.getAllByRole('option', {name: 'Unit Not Part of Course'}).length
+      ).to.equal(3);
     });
   });
 
@@ -368,7 +381,9 @@ describe('CourseEditor', () => {
       expect(
         wrapper
           .find('.saveBar')
-          .contains('Error Saving: Please set both version year and family name.')
+          .contains(
+            'Error Saving: Please set both version year and family name.'
+          )
       ).to.be.true;
 
       $.ajax.restore();
@@ -401,7 +416,9 @@ describe('CourseEditor', () => {
       expect(
         wrapper
           .find('.saveBar')
-          .contains('Error Saving: Please set both version year and family name.')
+          .contains(
+            'Error Saving: Please set both version year and family name.'
+          )
       ).to.be.true;
 
       $.ajax.restore();
@@ -483,4 +500,3 @@ describe('CourseEditor', () => {
     });
   });
 });
-

--- a/apps/test/unit/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/levelbuilder/course-editor/CourseEditorTest.js
@@ -22,7 +22,7 @@ import {
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import * as utils from '@cdo/apps/utils';
 
-import {assert, expect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
+import {assert, expect as chaiExpect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 import {allowConsoleWarnings} from '../../../util/throwOnConsole';
 
 describe('CourseEditor', () => {
@@ -92,26 +92,26 @@ describe('CourseEditor', () => {
       renderDefault();
       expect(
         screen.getAllByDisplayValue('Select a unit to add to course').length
-      ).to.equal(1);
-      expect(screen.getAllByDisplayValue('CSP Unit 1').length).to.equal(1);
-      expect(screen.getAllByDisplayValue('CSP Unit 2').length).to.equal(1);
+      ).toEqual(1);
+      expect(screen.getAllByDisplayValue('CSP Unit 1').length).toEqual(1);
+      expect(screen.getAllByDisplayValue('CSP Unit 2').length).toEqual(1);
       expect(
         screen.queryAllByDisplayValue('Unit Not Part of Course').length
-      ).to.equal(0);
+      ).toEqual(0);
 
       expect(
         screen.getAllByRole('option', {name: 'Select a unit to add to course'})
           .length
-      ).to.equal(3);
+      ).toEqual(3);
       expect(
         screen.getAllByRole('option', {name: 'CSP Unit 1'}).length
-      ).to.equal(3);
+      ).toEqual(3);
       expect(
         screen.getAllByRole('option', {name: 'CSP Unit 2'}).length
-      ).to.equal(3);
+      ).toEqual(3);
       expect(
         screen.getAllByRole('option', {name: 'Unit Not Part of Course'}).length
-      ).to.equal(3);
+      ).toEqual(3);
     });
   });
 
@@ -130,7 +130,7 @@ describe('CourseEditor', () => {
             ]}
           />
         );
-        expect(wrapper.find('ResourcesEditor').first()).to.exist;
+        chaiExpect(wrapper.find('ResourcesEditor').first()).to.exist;
       });
     });
 
@@ -148,13 +148,15 @@ describe('CourseEditor', () => {
 
     it('has correct markdown for preview of course teacher and student description', () => {
       const wrapper = createWrapper({});
-      expect(wrapper.find('TextareaWithMarkdownPreview').length).to.equal(2);
-      expect(
+      chaiExpect(wrapper.find('TextareaWithMarkdownPreview').length).to.equal(
+        2
+      );
+      chaiExpect(
         wrapper.find('TextareaWithMarkdownPreview').at(0).prop('markdown')
       ).to.equal(
         '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
       );
-      expect(
+      chaiExpect(
         wrapper.find('TextareaWithMarkdownPreview').at(1).prop('markdown')
       ).to.equal(
         '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
@@ -192,13 +194,15 @@ describe('CourseEditor', () => {
         const saveBar = wrapper.find('SaveBar');
 
         const saveAndKeepEditingButton = saveBar.find('button').at(1);
-        expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-          .true;
+        chaiExpect(saveAndKeepEditingButton.contains('Save and Keep Editing'))
+          .to.be.true;
         saveAndKeepEditingButton.simulate('click');
 
         // check the the spinner is showing
-        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
-        expect(courseEditor.state().isSaving).to.equal(true);
+        chaiExpect(
+          wrapper.find('.saveBar').find('FontAwesome').length
+        ).to.equal(1);
+        chaiExpect(courseEditor.state().isSaving).to.equal(true);
 
         clock = sinon.useFakeTimers(new Date('2020-12-01'));
         const expectedLastSaved = Date.now();
@@ -206,12 +210,14 @@ describe('CourseEditor', () => {
         clock.tick(50);
 
         courseEditor.update();
-        expect(utils.navigateToHref).to.not.have.been.called;
-        expect(courseEditor.state().isSaving).to.equal(false);
-        expect(courseEditor.state().lastSaved).to.equal(expectedLastSaved);
-        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
+        chaiExpect(utils.navigateToHref).to.not.have.been.called;
+        chaiExpect(courseEditor.state().isSaving).to.equal(false);
+        chaiExpect(courseEditor.state().lastSaved).to.equal(expectedLastSaved);
+        chaiExpect(
+          wrapper.find('.saveBar').find('FontAwesome').length
+        ).to.equal(0);
         //check that last saved message is showing
-        expect(wrapper.find('.lastSavedMessage').length).to.equal(1);
+        chaiExpect(wrapper.find('.lastSavedMessage').length).to.equal(1);
       });
 
       it('shows error when save and keep editing has error saving', () => {
@@ -228,21 +234,25 @@ describe('CourseEditor', () => {
         const saveBar = wrapper.find('SaveBar');
 
         const saveAndKeepEditingButton = saveBar.find('button').at(1);
-        expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-          .true;
+        chaiExpect(saveAndKeepEditingButton.contains('Save and Keep Editing'))
+          .to.be.true;
         saveAndKeepEditingButton.simulate('click');
 
         // check the the spinner is showing
-        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
-        expect(courseEditor.state().isSaving).to.equal(true);
+        chaiExpect(
+          wrapper.find('.saveBar').find('FontAwesome').length
+        ).to.equal(1);
+        chaiExpect(courseEditor.state().isSaving).to.equal(true);
 
         server.respond();
         courseEditor.update();
-        expect(utils.navigateToHref).to.not.have.been.called;
-        expect(courseEditor.state().isSaving).to.equal(false);
-        expect(courseEditor.state().error).to.equal('There was an error');
-        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
-        expect(
+        chaiExpect(utils.navigateToHref).to.not.have.been.called;
+        chaiExpect(courseEditor.state().isSaving).to.equal(false);
+        chaiExpect(courseEditor.state().error).to.equal('There was an error');
+        chaiExpect(
+          wrapper.find('.saveBar').find('FontAwesome').length
+        ).to.equal(0);
+        chaiExpect(
           wrapper.find('.saveBar').contains('Error Saving: There was an error')
         ).to.be.true;
 
@@ -265,16 +275,18 @@ describe('CourseEditor', () => {
         const saveBar = wrapper.find('SaveBar');
 
         const saveAndCloseButton = saveBar.find('button').at(2);
-        expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
+        chaiExpect(saveAndCloseButton.contains('Save and Close')).to.be.true;
         saveAndCloseButton.simulate('click');
 
         // check the the spinner is showing
-        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
-        expect(courseEditor.state().isSaving).to.equal(true);
+        chaiExpect(
+          wrapper.find('.saveBar').find('FontAwesome').length
+        ).to.equal(1);
+        chaiExpect(courseEditor.state().isSaving).to.equal(true);
 
         server.respond();
         courseEditor.update();
-        expect(utils.navigateToHref).to.have.been.calledWith(
+        chaiExpect(utils.navigateToHref).to.have.been.calledWith(
           `/courses/test-course${window.location.search}`
         );
 
@@ -295,22 +307,26 @@ describe('CourseEditor', () => {
         const saveBar = wrapper.find('SaveBar');
 
         const saveAndCloseButton = saveBar.find('button').at(2);
-        expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
+        chaiExpect(saveAndCloseButton.contains('Save and Close')).to.be.true;
         saveAndCloseButton.simulate('click');
 
         // check the the spinner is showing
-        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
-        expect(courseEditor.state().isSaving).to.equal(true);
+        chaiExpect(
+          wrapper.find('.saveBar').find('FontAwesome').length
+        ).to.equal(1);
+        chaiExpect(courseEditor.state().isSaving).to.equal(true);
 
         server.respond();
 
         courseEditor.update();
-        expect(utils.navigateToHref).to.not.have.been.called;
+        chaiExpect(utils.navigateToHref).to.not.have.been.called;
 
-        expect(courseEditor.state().isSaving).to.equal(false);
-        expect(courseEditor.state().error).to.equal('There was an error');
-        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
-        expect(
+        chaiExpect(courseEditor.state().isSaving).to.equal(false);
+        chaiExpect(courseEditor.state().error).to.equal('There was an error');
+        chaiExpect(
+          wrapper.find('.saveBar').find('FontAwesome').length
+        ).to.equal(0);
+        chaiExpect(
           wrapper.find('.saveBar').contains('Error Saving: There was an error')
         ).to.be.true;
 
@@ -330,18 +346,18 @@ describe('CourseEditor', () => {
         const saveBar = wrapper.find('SaveBar');
 
         const saveAndKeepEditingButton = saveBar.find('button').at(1);
-        expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-          .true;
+        chaiExpect(saveAndKeepEditingButton.contains('Save and Keep Editing'))
+          .to.be.true;
         saveAndKeepEditingButton.simulate('click');
 
-        expect($.ajax).to.not.have.been.called;
+        chaiExpect($.ajax).to.not.have.been.called;
 
-        expect(courseEditor.state().isSaving).to.equal(false);
-        expect(courseEditor.state().error).to.equal(
+        chaiExpect(courseEditor.state().isSaving).to.equal(false);
+        chaiExpect(courseEditor.state().error).to.equal(
           'Please provide a pilot experiment in order to save with published state as pilot.'
         );
 
-        expect(
+        chaiExpect(
           wrapper
             .find('.saveBar')
             .contains(
@@ -366,18 +382,18 @@ describe('CourseEditor', () => {
       const saveBar = wrapper.find('SaveBar');
 
       const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
+      chaiExpect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to
+        .be.true;
       saveAndKeepEditingButton.simulate('click');
 
-      expect($.ajax).to.not.have.been.called;
+      chaiExpect($.ajax).to.not.have.been.called;
 
-      expect(courseEditor.state().isSaving).to.equal(false);
-      expect(courseEditor.state().error).to.equal(
+      chaiExpect(courseEditor.state().isSaving).to.equal(false);
+      chaiExpect(courseEditor.state().error).to.equal(
         'Please set both version year and family name.'
       );
 
-      expect(
+      chaiExpect(
         wrapper
           .find('.saveBar')
           .contains(
@@ -401,18 +417,18 @@ describe('CourseEditor', () => {
       const saveBar = wrapper.find('SaveBar');
 
       const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
+      chaiExpect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to
+        .be.true;
       saveAndKeepEditingButton.simulate('click');
 
-      expect($.ajax).to.not.have.been.called;
+      chaiExpect($.ajax).to.not.have.been.called;
 
-      expect(courseEditor.state().isSaving).to.equal(false);
-      expect(courseEditor.state().error).to.equal(
+      chaiExpect(courseEditor.state().isSaving).to.equal(false);
+      chaiExpect(courseEditor.state().error).to.equal(
         'Please set both version year and family name.'
       );
 
-      expect(
+      chaiExpect(
         wrapper
           .find('.saveBar')
           .contains(
@@ -438,18 +454,18 @@ describe('CourseEditor', () => {
       const saveBar = wrapper.find('SaveBar');
 
       const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
+      chaiExpect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to
+        .be.true;
       saveAndKeepEditingButton.simulate('click');
 
-      expect($.ajax).to.not.have.been.called;
+      chaiExpect($.ajax).to.not.have.been.called;
 
-      expect(courseEditor.state().isSaving).to.equal(false);
-      expect(courseEditor.state().error).to.equal(
+      chaiExpect(courseEditor.state().isSaving).to.equal(false);
+      chaiExpect(courseEditor.state().error).to.equal(
         'Please set all device compatibilities in order to save with published state as preview or stable.'
       );
 
-      expect(
+      chaiExpect(
         wrapper
           .find('.saveBar')
           .contains(
@@ -476,18 +492,18 @@ describe('CourseEditor', () => {
       const saveBar = wrapper.find('SaveBar');
 
       const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
+      chaiExpect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to
+        .be.true;
       saveAndKeepEditingButton.simulate('click');
 
-      expect($.ajax).to.not.have.been.called;
+      chaiExpect($.ajax).to.not.have.been.called;
 
-      expect(courseEditor.state().isSaving).to.equal(false);
-      expect(courseEditor.state().error).to.equal(
+      chaiExpect(courseEditor.state().isSaving).to.equal(false);
+      chaiExpect(courseEditor.state().error).to.equal(
         'Please set all device compatibilities in order to save with published state as preview or stable.'
       );
 
-      expect(
+      chaiExpect(
         wrapper
           .find('.saveBar')
           .contains(

--- a/apps/test/unit/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/levelbuilder/course-editor/CourseEditorTest.js
@@ -1,3 +1,4 @@
+import {render, screen} from '@testing-library/react';
 import {mount, shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import $ from 'jquery';
 import React from 'react';
@@ -24,37 +25,9 @@ import * as utils from '@cdo/apps/utils';
 import {assert, expect} from '../../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
 import {allowConsoleWarnings} from '../../../util/throwOnConsole';
 
-const defaultProps = {
-  name: 'test-course',
-  initialTitle: 'Computer Science Principles 2017',
-  initialFamilyName: 'CSP',
-  initialVersionYear: '2017',
-  initialPublishedState: 'beta',
-  initialDescriptionShort: 'Desc here',
-  initialDescriptionStudent:
-    '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
-  initialDescriptionTeacher:
-    '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
-  initialUnitsInCourse: ['CSP Unit 1', 'CSP Unit 2'],
-  unitNames: ['CSP Unit 1', 'CSP Unit 2'],
-  initialHasVerifiedResources: false,
-  initialHasNumberedUnits: false,
-  courseFamilies: ['CSP', 'CSD', 'CSF'],
-  versionYearOptions: ['2017', '2018', '2019'],
-  initialAnnouncements: [],
-  coursePath: '/courses/test-course',
-  initialInstructionType: InstructionType.teacher_led,
-  initialInstructorAudience: InstructorAudience.teacher,
-  initialParticipantAudience: ParticipantAudience.student,
-  teacherResources: [],
-  studentResources: [],
-};
-
 describe('CourseEditor', () => {
-  // Warnings allowed due to usage of deprecated componentWillReceiveProps
-  // lifecycle method.
-  allowConsoleWarnings();
-
+  let defaultProps, store;
+  
   beforeEach(() => {
     sinon.stub(utils, 'navigateToHref');
     stubRedux();
@@ -63,6 +36,33 @@ describe('CourseEditor', () => {
       resources: createResourcesReducer('teacherResource'),
       studentResources: createResourcesReducer('studentResource'),
     });
+    store = getStore();
+  
+    defaultProps = {
+      name: 'test-course',
+      initialTitle: 'Computer Science Principles 2017',
+      initialFamilyName: 'CSP',
+      initialVersionYear: '2017',
+      initialPublishedState: 'beta',
+      initialDescriptionShort: 'Desc here',
+      initialDescriptionStudent:
+        '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
+      initialDescriptionTeacher:
+        '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
+      initialUnitsInCourse: ['CSP Unit 1', 'CSP Unit 2'],
+      unitNames: ['Unit Not Part of Course'],
+      initialHasVerifiedResources: false,
+      initialHasNumberedUnits: false,
+      courseFamilies: ['CSP', 'CSD', 'CSF'],
+      versionYearOptions: ['2017', '2018', '2019'],
+      initialAnnouncements: [],
+      coursePath: '/courses/test-course',
+      initialInstructionType: InstructionType.teacher_led,
+      initialInstructorAudience: InstructorAudience.teacher,
+      initialParticipantAudience: ParticipantAudience.student,
+      teacherResources: [],
+      studentResources: [],
+    };
   });
 
   afterEach(() => {
@@ -73,217 +73,282 @@ describe('CourseEditor', () => {
   const createWrapper = overrideProps => {
     const combinedProps = {...defaultProps, ...overrideProps};
     return mount(
-      <Provider store={getStore()}>
+      <Provider store={store}>
         <CourseEditor {...combinedProps} />
       </Provider>
     );
   };
 
-  describe('Teacher Resources', () => {
-    it('uses the resource component for resources', () => {
-      const wrapper = shallow(
-        <CourseEditor
-          {...defaultProps}
-          teacherResources={[
-            {id: 1, key: 'curriculum', name: 'Curriculum', url: '/foo'},
-          ]}
-        />
-      );
-      expect(wrapper.find('ResourcesEditor').first()).to.exist;
-    });
-  });
-
-  it('renders full course editor page', () => {
-    const wrapper = createWrapper({});
-    assert.equal(wrapper.find('textarea').length, 3);
-    assert.equal(wrapper.find('CourseUnitsEditor').length, 1);
-    assert.equal(wrapper.find('ResourcesEditor').length, 2);
-    assert.equal(wrapper.find('ResourcesDropdown').length, 0);
-    assert.equal(wrapper.find('CollapsibleEditorSection').length, 6);
-    assert.equal(wrapper.find('AnnouncementsEditor').length, 1);
-    assert.equal(wrapper.find('CourseVersionPublishingEditor').length, 1);
-    assert.equal(wrapper.find('CourseTypeEditor').length, 1);
-  });
-
-  it('has correct markdown for preview of course teacher and student description', () => {
-    const wrapper = createWrapper({});
-    expect(wrapper.find('TextareaWithMarkdownPreview').length).to.equal(2);
-    expect(
-      wrapper.find('TextareaWithMarkdownPreview').at(0).prop('markdown')
-    ).to.equal(
-      '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
+  function renderDefault(overrideProps = {}) {
+    const combinedProps = {...defaultProps, ...overrideProps};
+    render(
+      <Provider store={store}>
+        <CourseEditor {...combinedProps} />
+      </Provider>
     );
-    expect(
-      wrapper.find('TextareaWithMarkdownPreview').at(1).prop('markdown')
-    ).to.equal(
-      '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
-    );
+  }
+
+  describe('Course Editor - RTL', () => {
+    it('All units within the course are listed under Units header', () => {
+      renderDefault();
+      expect(screen.getAllByDisplayValue('Select a unit to add to course').length).to.equal(1);
+      expect(screen.getAllByDisplayValue('CSP Unit 1').length).to.equal(1);
+      expect(screen.getAllByDisplayValue('CSP Unit 2').length).to.equal(1);
+      expect(screen.queryAllByDisplayValue('Unit Not Part of Course').length).to.equal(0);
+
+      expect(screen.getAllByRole('option', {name: 'Select a unit to add to course'}).length).to.equal(3);
+      expect(screen.getAllByRole('option', {name: 'CSP Unit 1'}).length).to.equal(3);
+      expect(screen.getAllByRole('option', {name: 'CSP Unit 2'}).length).to.equal(3);
+      expect(screen.getAllByRole('option', {name: 'Unit Not Part of Course'}).length).to.equal(3);
+    });
   });
 
-  describe('Saving Course Editor', () => {
-    let clock, server;
+  describe('CourseEditor - legacy enzyme', () => {
+    // Warnings allowed due to usage of deprecated componentWillReceiveProps
+    // lifecycle method.
+    allowConsoleWarnings();
 
-    beforeEach(() => {
-      server = sinon.fakeServer.create();
+    describe('Teacher Resources', () => {
+      it('uses the resource component for resources', () => {
+        const wrapper = shallow(
+          <CourseEditor
+            {...defaultProps}
+            teacherResources={[
+              {id: 1, key: 'curriculum', name: 'Curriculum', url: '/foo'},
+            ]}
+          />
+        );
+        expect(wrapper.find('ResourcesEditor').first()).to.exist;
+      });
     });
 
-    afterEach(() => {
-      if (clock) {
-        clock.restore();
-        clock = undefined;
-      }
-      server.restore();
-    });
-
-    it('can save and keep editing', () => {
+    it('renders full course editor page', () => {
       const wrapper = createWrapper({});
-      const courseEditor = wrapper.find('CourseEditor');
-
-      let returnData = {
-        coursePath: '/courses/test-course',
-      };
-      server.respondWith('PUT', `/courses/test-course`, [
-        200,
-        {'Content-Type': 'application/json'},
-        JSON.stringify(returnData),
-      ]);
-
-      const saveBar = wrapper.find('SaveBar');
-
-      const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
-      saveAndKeepEditingButton.simulate('click');
-
-      // check the the spinner is showing
-      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
-      expect(courseEditor.state().isSaving).to.equal(true);
-
-      clock = sinon.useFakeTimers(new Date('2020-12-01'));
-      const expectedLastSaved = Date.now();
-      server.respond();
-      clock.tick(50);
-
-      courseEditor.update();
-      expect(utils.navigateToHref).to.not.have.been.called;
-      expect(courseEditor.state().isSaving).to.equal(false);
-      expect(courseEditor.state().lastSaved).to.equal(expectedLastSaved);
-      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
-      //check that last saved message is showing
-      expect(wrapper.find('.lastSavedMessage').length).to.equal(1);
+      assert.equal(wrapper.find('textarea').length, 3);
+      assert.equal(wrapper.find('CourseUnitsEditor').length, 1);
+      assert.equal(wrapper.find('ResourcesEditor').length, 2);
+      assert.equal(wrapper.find('ResourcesDropdown').length, 0);
+      assert.equal(wrapper.find('CollapsibleEditorSection').length, 6);
+      assert.equal(wrapper.find('AnnouncementsEditor').length, 1);
+      assert.equal(wrapper.find('CourseVersionPublishingEditor').length, 1);
+      assert.equal(wrapper.find('CourseTypeEditor').length, 1);
     });
 
-    it('shows error when save and keep editing has error saving', () => {
+    it('has correct markdown for preview of course teacher and student description', () => {
       const wrapper = createWrapper({});
-      const courseEditor = wrapper.find('CourseEditor');
-
-      let returnData = 'There was an error';
-      server.respondWith('PUT', `/courses/test-course`, [
-        404,
-        {'Content-Type': 'application/json'},
-        returnData,
-      ]);
-
-      const saveBar = wrapper.find('SaveBar');
-
-      const saveAndKeepEditingButton = saveBar.find('button').at(1);
-      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-        .true;
-      saveAndKeepEditingButton.simulate('click');
-
-      // check the the spinner is showing
-      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
-      expect(courseEditor.state().isSaving).to.equal(true);
-
-      server.respond();
-      courseEditor.update();
-      expect(utils.navigateToHref).to.not.have.been.called;
-      expect(courseEditor.state().isSaving).to.equal(false);
-      expect(courseEditor.state().error).to.equal('There was an error');
-      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
+      expect(wrapper.find('TextareaWithMarkdownPreview').length).to.equal(2);
       expect(
-        wrapper.find('.saveBar').contains('Error Saving: There was an error')
-      ).to.be.true;
-
-      server.restore();
-    });
-
-    it('can save and close', () => {
-      const wrapper = createWrapper({});
-      const courseEditor = wrapper.find('CourseEditor');
-
-      let returnData = {
-        coursePath: '/courses/test-course',
-      };
-      server.respondWith('PUT', `/courses/test-course`, [
-        200,
-        {'Content-Type': 'application/json'},
-        JSON.stringify(returnData),
-      ]);
-
-      const saveBar = wrapper.find('SaveBar');
-
-      const saveAndCloseButton = saveBar.find('button').at(2);
-      expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
-      saveAndCloseButton.simulate('click');
-
-      // check the the spinner is showing
-      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
-      expect(courseEditor.state().isSaving).to.equal(true);
-
-      server.respond();
-      courseEditor.update();
-      expect(utils.navigateToHref).to.have.been.calledWith(
-        `/courses/test-course${window.location.search}`
+        wrapper.find('TextareaWithMarkdownPreview').at(0).prop('markdown')
+      ).to.equal(
+        '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
       );
-
-      server.restore();
-    });
-
-    it('shows error when save and keep editing has error saving', () => {
-      const wrapper = createWrapper({});
-      const courseEditor = wrapper.find('CourseEditor');
-
-      let returnData = 'There was an error';
-      server.respondWith('PUT', `/courses/test-course`, [
-        404,
-        {'Content-Type': 'application/json'},
-        returnData,
-      ]);
-
-      const saveBar = wrapper.find('SaveBar');
-
-      const saveAndCloseButton = saveBar.find('button').at(2);
-      expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
-      saveAndCloseButton.simulate('click');
-
-      // check the the spinner is showing
-      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
-      expect(courseEditor.state().isSaving).to.equal(true);
-
-      server.respond();
-
-      courseEditor.update();
-      expect(utils.navigateToHref).to.not.have.been.called;
-
-      expect(courseEditor.state().isSaving).to.equal(false);
-      expect(courseEditor.state().error).to.equal('There was an error');
-      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
       expect(
-        wrapper.find('.saveBar').contains('Error Saving: There was an error')
-      ).to.be.true;
-
-      server.restore();
+        wrapper.find('TextareaWithMarkdownPreview').at(1).prop('markdown')
+      ).to.equal(
+        '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
+      );
     });
 
-    it('shows error when published state is pilot but no pilot experiment given', () => {
+    describe('Saving Course Editor', () => {
+      let clock, server;
+
+      beforeEach(() => {
+        server = sinon.fakeServer.create();
+      });
+
+      afterEach(() => {
+        if (clock) {
+          clock.restore();
+          clock = undefined;
+        }
+        server.restore();
+      });
+
+      it('can save and keep editing', () => {
+        const wrapper = createWrapper({});
+        const courseEditor = wrapper.find('CourseEditor');
+
+        let returnData = {
+          coursePath: '/courses/test-course',
+        };
+        server.respondWith('PUT', `/courses/test-course`, [
+          200,
+          {'Content-Type': 'application/json'},
+          JSON.stringify(returnData),
+        ]);
+
+        const saveBar = wrapper.find('SaveBar');
+
+        const saveAndKeepEditingButton = saveBar.find('button').at(1);
+        expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+          .true;
+        saveAndKeepEditingButton.simulate('click');
+
+        // check the the spinner is showing
+        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
+        expect(courseEditor.state().isSaving).to.equal(true);
+
+        clock = sinon.useFakeTimers(new Date('2020-12-01'));
+        const expectedLastSaved = Date.now();
+        server.respond();
+        clock.tick(50);
+
+        courseEditor.update();
+        expect(utils.navigateToHref).to.not.have.been.called;
+        expect(courseEditor.state().isSaving).to.equal(false);
+        expect(courseEditor.state().lastSaved).to.equal(expectedLastSaved);
+        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
+        //check that last saved message is showing
+        expect(wrapper.find('.lastSavedMessage').length).to.equal(1);
+      });
+
+      it('shows error when save and keep editing has error saving', () => {
+        const wrapper = createWrapper({});
+        const courseEditor = wrapper.find('CourseEditor');
+
+        let returnData = 'There was an error';
+        server.respondWith('PUT', `/courses/test-course`, [
+          404,
+          {'Content-Type': 'application/json'},
+          returnData,
+        ]);
+
+        const saveBar = wrapper.find('SaveBar');
+
+        const saveAndKeepEditingButton = saveBar.find('button').at(1);
+        expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+          .true;
+        saveAndKeepEditingButton.simulate('click');
+
+        // check the the spinner is showing
+        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
+        expect(courseEditor.state().isSaving).to.equal(true);
+
+        server.respond();
+        courseEditor.update();
+        expect(utils.navigateToHref).to.not.have.been.called;
+        expect(courseEditor.state().isSaving).to.equal(false);
+        expect(courseEditor.state().error).to.equal('There was an error');
+        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
+        expect(
+          wrapper.find('.saveBar').contains('Error Saving: There was an error')
+        ).to.be.true;
+
+        server.restore();
+      });
+
+      it('can save and close', () => {
+        const wrapper = createWrapper({});
+        const courseEditor = wrapper.find('CourseEditor');
+
+        let returnData = {
+          coursePath: '/courses/test-course',
+        };
+        server.respondWith('PUT', `/courses/test-course`, [
+          200,
+          {'Content-Type': 'application/json'},
+          JSON.stringify(returnData),
+        ]);
+
+        const saveBar = wrapper.find('SaveBar');
+
+        const saveAndCloseButton = saveBar.find('button').at(2);
+        expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
+        saveAndCloseButton.simulate('click');
+
+        // check the the spinner is showing
+        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
+        expect(courseEditor.state().isSaving).to.equal(true);
+
+        server.respond();
+        courseEditor.update();
+        expect(utils.navigateToHref).to.have.been.calledWith(
+          `/courses/test-course${window.location.search}`
+        );
+
+        server.restore();
+      });
+
+      it('shows error when save and keep editing has error saving', () => {
+        const wrapper = createWrapper({});
+        const courseEditor = wrapper.find('CourseEditor');
+
+        let returnData = 'There was an error';
+        server.respondWith('PUT', `/courses/test-course`, [
+          404,
+          {'Content-Type': 'application/json'},
+          returnData,
+        ]);
+
+        const saveBar = wrapper.find('SaveBar');
+
+        const saveAndCloseButton = saveBar.find('button').at(2);
+        expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
+        saveAndCloseButton.simulate('click');
+
+        // check the the spinner is showing
+        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
+        expect(courseEditor.state().isSaving).to.equal(true);
+
+        server.respond();
+
+        courseEditor.update();
+        expect(utils.navigateToHref).to.not.have.been.called;
+
+        expect(courseEditor.state().isSaving).to.equal(false);
+        expect(courseEditor.state().error).to.equal('There was an error');
+        expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
+        expect(
+          wrapper.find('.saveBar').contains('Error Saving: There was an error')
+        ).to.be.true;
+
+        server.restore();
+      });
+
+      it('shows error when published state is pilot but no pilot experiment given', () => {
+        sinon.stub($, 'ajax');
+        const wrapper = createWrapper({});
+
+        const courseEditor = wrapper.find('CourseEditor');
+        courseEditor.setState({
+          publishedState: PublishedState.pilot,
+          pilotExperiment: '',
+        });
+
+        const saveBar = wrapper.find('SaveBar');
+
+        const saveAndKeepEditingButton = saveBar.find('button').at(1);
+        expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+          .true;
+        saveAndKeepEditingButton.simulate('click');
+
+        expect($.ajax).to.not.have.been.called;
+
+        expect(courseEditor.state().isSaving).to.equal(false);
+        expect(courseEditor.state().error).to.equal(
+          'Please provide a pilot experiment in order to save with published state as pilot.'
+        );
+
+        expect(
+          wrapper
+            .find('.saveBar')
+            .contains(
+              'Error Saving: Please provide a pilot experiment in order to save with published state as pilot.'
+            )
+        ).to.be.true;
+
+        $.ajax.restore();
+      });
+    });
+
+    it('shows error when version year is set but family name is not', () => {
       sinon.stub($, 'ajax');
       const wrapper = createWrapper({});
 
       const courseEditor = wrapper.find('CourseEditor');
       courseEditor.setState({
-        publishedState: PublishedState.pilot,
-        pilotExperiment: '',
+        versionYear: '1991',
+        familyName: '',
       });
 
       const saveBar = wrapper.find('SaveBar');
@@ -297,159 +362,125 @@ describe('CourseEditor', () => {
 
       expect(courseEditor.state().isSaving).to.equal(false);
       expect(courseEditor.state().error).to.equal(
-        'Please provide a pilot experiment in order to save with published state as pilot.'
+        'Please set both version year and family name.'
+      );
+
+      expect(
+        wrapper
+          .find('.saveBar')
+          .contains('Error Saving: Please set both version year and family name.')
+      ).to.be.true;
+
+      $.ajax.restore();
+    });
+
+    it('shows error when family name is set but version year is not', () => {
+      sinon.stub($, 'ajax');
+      const wrapper = createWrapper({});
+
+      const courseEditor = wrapper.find('CourseEditor');
+      courseEditor.setState({
+        versionYear: '',
+        familyName: 'new-family-name',
+      });
+
+      const saveBar = wrapper.find('SaveBar');
+
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
+      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+        .true;
+      saveAndKeepEditingButton.simulate('click');
+
+      expect($.ajax).to.not.have.been.called;
+
+      expect(courseEditor.state().isSaving).to.equal(false);
+      expect(courseEditor.state().error).to.equal(
+        'Please set both version year and family name.'
+      );
+
+      expect(
+        wrapper
+          .find('.saveBar')
+          .contains('Error Saving: Please set both version year and family name.')
+      ).to.be.true;
+
+      $.ajax.restore();
+    });
+
+    it('shows error when published state is preview or stable and device compatibility JSON is null', () => {
+      sinon.stub($, 'ajax');
+      const wrapper = createWrapper({
+        isMissingRequiredDeviceCompatibilities: true,
+      });
+
+      const courseEditor = wrapper.find('CourseEditor');
+      courseEditor.setState({
+        publishedState: PublishedState.preview,
+        courseOfferingDeviceCompatibilities: null,
+      });
+
+      const saveBar = wrapper.find('SaveBar');
+
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
+      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+        .true;
+      saveAndKeepEditingButton.simulate('click');
+
+      expect($.ajax).to.not.have.been.called;
+
+      expect(courseEditor.state().isSaving).to.equal(false);
+      expect(courseEditor.state().error).to.equal(
+        'Please set all device compatibilities in order to save with published state as preview or stable.'
       );
 
       expect(
         wrapper
           .find('.saveBar')
           .contains(
-            'Error Saving: Please provide a pilot experiment in order to save with published state as pilot.'
+            'Error Saving: Please set all device compatibilities in order to save with published state as preview or stable.'
+          )
+      ).to.be.true;
+
+      $.ajax.restore();
+    });
+
+    it('shows error when published state is preview or stable and at least one device compatibility is not set', () => {
+      sinon.stub($, 'ajax');
+      const wrapper = createWrapper({
+        isMissingRequiredDeviceCompatibilities: true,
+      });
+
+      const courseEditor = wrapper.find('CourseEditor');
+      courseEditor.setState({
+        publishedState: PublishedState.stable,
+        courseOfferingDeviceCompatibilities:
+          '{"computer":"","chromebook":"ideal","tablet":"ideal","mobile":"not_recommended","no_device":"incompatible"}',
+      });
+
+      const saveBar = wrapper.find('SaveBar');
+
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
+      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+        .true;
+      saveAndKeepEditingButton.simulate('click');
+
+      expect($.ajax).to.not.have.been.called;
+
+      expect(courseEditor.state().isSaving).to.equal(false);
+      expect(courseEditor.state().error).to.equal(
+        'Please set all device compatibilities in order to save with published state as preview or stable.'
+      );
+
+      expect(
+        wrapper
+          .find('.saveBar')
+          .contains(
+            'Error Saving: Please set all device compatibilities in order to save with published state as preview or stable.'
           )
       ).to.be.true;
 
       $.ajax.restore();
     });
   });
-
-  it('shows error when version year is set but family name is not', () => {
-    sinon.stub($, 'ajax');
-    const wrapper = createWrapper({});
-
-    const courseEditor = wrapper.find('CourseEditor');
-    courseEditor.setState({
-      versionYear: '1991',
-      familyName: '',
-    });
-
-    const saveBar = wrapper.find('SaveBar');
-
-    const saveAndKeepEditingButton = saveBar.find('button').at(1);
-    expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-      .true;
-    saveAndKeepEditingButton.simulate('click');
-
-    expect($.ajax).to.not.have.been.called;
-
-    expect(courseEditor.state().isSaving).to.equal(false);
-    expect(courseEditor.state().error).to.equal(
-      'Please set both version year and family name.'
-    );
-
-    expect(
-      wrapper
-        .find('.saveBar')
-        .contains('Error Saving: Please set both version year and family name.')
-    ).to.be.true;
-
-    $.ajax.restore();
-  });
-
-  it('shows error when family name is set but version year is not', () => {
-    sinon.stub($, 'ajax');
-    const wrapper = createWrapper({});
-
-    const courseEditor = wrapper.find('CourseEditor');
-    courseEditor.setState({
-      versionYear: '',
-      familyName: 'new-family-name',
-    });
-
-    const saveBar = wrapper.find('SaveBar');
-
-    const saveAndKeepEditingButton = saveBar.find('button').at(1);
-    expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-      .true;
-    saveAndKeepEditingButton.simulate('click');
-
-    expect($.ajax).to.not.have.been.called;
-
-    expect(courseEditor.state().isSaving).to.equal(false);
-    expect(courseEditor.state().error).to.equal(
-      'Please set both version year and family name.'
-    );
-
-    expect(
-      wrapper
-        .find('.saveBar')
-        .contains('Error Saving: Please set both version year and family name.')
-    ).to.be.true;
-
-    $.ajax.restore();
-  });
-
-  it('shows error when published state is preview or stable and device compatibility JSON is null', () => {
-    sinon.stub($, 'ajax');
-    const wrapper = createWrapper({
-      isMissingRequiredDeviceCompatibilities: true,
-    });
-
-    const courseEditor = wrapper.find('CourseEditor');
-    courseEditor.setState({
-      publishedState: PublishedState.preview,
-      courseOfferingDeviceCompatibilities: null,
-    });
-
-    const saveBar = wrapper.find('SaveBar');
-
-    const saveAndKeepEditingButton = saveBar.find('button').at(1);
-    expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-      .true;
-    saveAndKeepEditingButton.simulate('click');
-
-    expect($.ajax).to.not.have.been.called;
-
-    expect(courseEditor.state().isSaving).to.equal(false);
-    expect(courseEditor.state().error).to.equal(
-      'Please set all device compatibilities in order to save with published state as preview or stable.'
-    );
-
-    expect(
-      wrapper
-        .find('.saveBar')
-        .contains(
-          'Error Saving: Please set all device compatibilities in order to save with published state as preview or stable.'
-        )
-    ).to.be.true;
-
-    $.ajax.restore();
-  });
-
-  it('shows error when published state is preview or stable and at least one device compatibility is not set', () => {
-    sinon.stub($, 'ajax');
-    const wrapper = createWrapper({
-      isMissingRequiredDeviceCompatibilities: true,
-    });
-
-    const courseEditor = wrapper.find('CourseEditor');
-    courseEditor.setState({
-      publishedState: PublishedState.stable,
-      courseOfferingDeviceCompatibilities:
-        '{"computer":"","chromebook":"ideal","tablet":"ideal","mobile":"not_recommended","no_device":"incompatible"}',
-    });
-
-    const saveBar = wrapper.find('SaveBar');
-
-    const saveAndKeepEditingButton = saveBar.find('button').at(1);
-    expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
-      .true;
-    saveAndKeepEditingButton.simulate('click');
-
-    expect($.ajax).to.not.have.been.called;
-
-    expect(courseEditor.state().isSaving).to.equal(false);
-    expect(courseEditor.state().error).to.equal(
-      'Please set all device compatibilities in order to save with published state as preview or stable.'
-    );
-
-    expect(
-      wrapper
-        .find('.saveBar')
-        .contains(
-          'Error Saving: Please set all device compatibilities in order to save with published state as preview or stable.'
-        )
-    ).to.be.true;
-
-    $.ajax.restore();
-  });
 });
+

--- a/apps/test/unit/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/levelbuilder/course-editor/CourseEditorTest.js
@@ -26,7 +26,32 @@ import {assert, expect} from '../../../util/reconfiguredChai'; // eslint-disable
 import {allowConsoleWarnings} from '../../../util/throwOnConsole';
 
 describe('CourseEditor', () => {
-  let defaultProps, store;
+  let store;
+  const defaultProps = {
+    name: 'test-course',
+    initialTitle: 'Computer Science Principles 2017',
+    initialFamilyName: 'CSP',
+    initialVersionYear: '2017',
+    initialPublishedState: 'beta',
+    initialDescriptionShort: 'Desc here',
+    initialDescriptionStudent:
+      '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
+    initialDescriptionTeacher:
+      '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
+    initialUnitsInCourse: ['CSP Unit 1', 'CSP Unit 2'],
+    unitNames: ['Unit Not Part of Course'],
+    initialHasVerifiedResources: false,
+    initialHasNumberedUnits: false,
+    courseFamilies: ['CSP', 'CSD', 'CSF'],
+    versionYearOptions: ['2017', '2018', '2019'],
+    initialAnnouncements: [],
+    coursePath: '/courses/test-course',
+    initialInstructionType: InstructionType.teacher_led,
+    initialInstructorAudience: InstructorAudience.teacher,
+    initialParticipantAudience: ParticipantAudience.student,
+    teacherResources: [],
+    studentResources: [],
+  };
 
   beforeEach(() => {
     sinon.stub(utils, 'navigateToHref');
@@ -37,32 +62,6 @@ describe('CourseEditor', () => {
       studentResources: createResourcesReducer('studentResource'),
     });
     store = getStore();
-
-    defaultProps = {
-      name: 'test-course',
-      initialTitle: 'Computer Science Principles 2017',
-      initialFamilyName: 'CSP',
-      initialVersionYear: '2017',
-      initialPublishedState: 'beta',
-      initialDescriptionShort: 'Desc here',
-      initialDescriptionStudent:
-        '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
-      initialDescriptionTeacher:
-        '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
-      initialUnitsInCourse: ['CSP Unit 1', 'CSP Unit 2'],
-      unitNames: ['Unit Not Part of Course'],
-      initialHasVerifiedResources: false,
-      initialHasNumberedUnits: false,
-      courseFamilies: ['CSP', 'CSD', 'CSF'],
-      versionYearOptions: ['2017', '2018', '2019'],
-      initialAnnouncements: [],
-      coursePath: '/courses/test-course',
-      initialInstructionType: InstructionType.teacher_led,
-      initialInstructorAudience: InstructorAudience.teacher,
-      initialParticipantAudience: ParticipantAudience.student,
-      teacherResources: [],
-      studentResources: [],
-    };
   });
 
   afterEach(() => {
@@ -106,10 +105,10 @@ describe('CourseEditor', () => {
       ).to.equal(3);
       expect(
         screen.getAllByRole('option', {name: 'CSP Unit 1'}).length
-      ).to.equal(1);
+      ).to.equal(3);
       expect(
         screen.getAllByRole('option', {name: 'CSP Unit 2'}).length
-      ).to.equal(1);
+      ).to.equal(3);
       expect(
         screen.getAllByRole('option', {name: 'Unit Not Part of Course'}).length
       ).to.equal(3);

--- a/apps/test/unit/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/levelbuilder/course-editor/CourseEditorTest.js
@@ -97,8 +97,8 @@ describe('CourseEditor', () => {
       expect(screen.queryAllByDisplayValue('Unit Not Part of Course').length).to.equal(0);
 
       expect(screen.getAllByRole('option', {name: 'Select a unit to add to course'}).length).to.equal(3);
-      expect(screen.getAllByRole('option', {name: 'CSP Unit 1'}).length).to.equal(3);
-      expect(screen.getAllByRole('option', {name: 'CSP Unit 2'}).length).to.equal(3);
+      expect(screen.getAllByRole('option', {name: 'CSP Unit 1'}).length).to.equal(1);
+      expect(screen.getAllByRole('option', {name: 'CSP Unit 2'}).length).to.equal(1);
       expect(screen.getAllByRole('option', {name: 'Unit Not Part of Course'}).length).to.equal(3);
     });
   });


### PR DESCRIPTION
With the change (https://github.com/code-dot-org/code-dot-org/commit/04c7484c1c56b8894ea5dac8923c8db74820da59) to limit every unit can be part of only one unit group, the list that populates the drop down in the course edit page was filtered only to units that are not part of any unit groups. As a result, the dropdowns did not populate values that are part of the current unit as well. 

This change 
1. Fixes that by additionally adding the current unit in the list of options in the client side. 
2. Adds the new unit test for this change using RTL, which shows up as lot more changes than there actually are in the diff. 


## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1415

## Testing story

- Validated manually locally and new UTs
- Drone

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
