### PR TITLE
Music: fix extra code generation

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -2,7 +2,7 @@ import * as GoogleBlockly from 'blockly/core';
 
 import {BLOCK_TYPES, Renderers} from '@cdo/apps/blockly/constants';
 import CdoDarkTheme from '@cdo/apps/blockly/themes/cdoDark';
-import {ProcedureBlock} from '@cdo/apps/blockly/types';
+import {ProcedureBlock, ExtendedBlock} from '@cdo/apps/blockly/types';
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {getAppOptionsEditBlocks} from '@cdo/apps/lab2/projects/utils';
@@ -205,6 +205,18 @@ export default class MusicBlocklyWorkspace {
     this.triggerIdToStartType = {};
 
     const topBlocks = workspace.getTopBlocks();
+
+    // Make sure that simple2 top-level blocks only generate their code once.
+    if (blockMode === BlockMode.SIMPLE2) {
+      topBlocks.forEach(block => {
+        if (
+          block.type === BlockTypes.WHEN_RUN_SIMPLE2 ||
+          block.type === BlockTypes.TRIGGERED_AT_SIMPLE2
+        ) {
+          (block as ExtendedBlock).skipNextBlockGeneration = true;
+        }
+      });
+    }
 
     topBlocks.forEach(block => {
       if (blockMode !== BlockMode.SIMPLE2) {

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -42,7 +42,6 @@ export const whenRunSimple2 = {
   generator: ctx => {
     const nextBlock = ctx.nextConnection && ctx.nextConnection.targetBlock();
     let handlerCode = Blockly.JavaScript.blockToCode(nextBlock, false);
-    ctx.skipNextBlockGeneration = true;
     return `
       if (__context == 'when_run') {
         Sequencer.newSequence();
@@ -88,7 +87,6 @@ export const triggeredAtSimple2 = {
     const id = ctx.getFieldValue(TRIGGER_FIELD);
     const nextBlock = ctx.nextConnection && ctx.nextConnection.targetBlock();
     let handlerCode = Blockly.JavaScript.blockToCode(nextBlock, false);
-    ctx.skipNextBlockGeneration = true;
     return `
       if (__context == "${id}") {
         Sequencer.newSequence(startPosition, true);


### PR DESCRIPTION
The very first compile of code in the `simple2` model would generate the code of the `when run` and trigger top-level blocks a second time.  This fixes that. 