### PR TITLE
Music: timeouts

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -44,6 +44,11 @@ export default class MusicBlocklyWorkspace {
       return;
     }
     setUpBlocklyForMusicLab();
+
+    if (blockMode !== BlockMode.SIMPLE2) {
+      Blockly.setInfiniteLoopTrap();
+    }
+
     this.isBlocklyEnvironmentSetup = true;
   }
 
@@ -221,6 +226,8 @@ export default class MusicBlocklyWorkspace {
           this.compiledEvents.whenRunButton = {
             code:
               'var __context = "when_run";\n' +
+              'var __functionCallsCount = 0;\n' +
+              'var __loopIterationsCount = 0;\n' +
               Blockly.JavaScript.workspaceToCode(workspace),
           };
         }
@@ -252,10 +259,14 @@ export default class MusicBlocklyWorkspace {
         ).includes(block.type)
       ) {
         const id = block.getFieldValue(TRIGGER_FIELD);
+        let code = `var __context = "${id}";\n`;
+        if (block.type === BlockTypes.TRIGGERED_AT_SIMPLE2) {
+          code +=
+            'var __functionCallsCount = 0;\n' +
+            'var __loopIterationsCount = 0;\n';
+        }
         this.compiledEvents[triggerIdToEvent(id)] = {
-          code:
-            `var __context = "${id}";\n` +
-            Blockly.JavaScript.workspaceToCode(workspace),
+          code: code + Blockly.JavaScript.workspaceToCode(workspace),
           args: ['startPosition'],
         };
         // Also save the value of the trigger start field at compile time so we can
@@ -309,6 +320,7 @@ export default class MusicBlocklyWorkspace {
       return;
     }
 
+    const startTime = Date.now();
     console.log('Executing compiled song.');
 
     if (this.codeHooks.whenRunButton) {
@@ -324,6 +336,8 @@ export default class MusicBlocklyWorkspace {
     });
 
     this.lastExecutedEvents = this.compiledEvents;
+
+    console.log('Execution time: ', Date.now() - startTime);
   }
 
   /**

--- a/apps/src/music/blockly/blockUtils.js
+++ b/apps/src/music/blockly/blockUtils.js
@@ -1,6 +1,6 @@
 import {BLOCK_TYPES} from '@cdo/apps/blockly/constants';
 
-import {BlockMode} from '../constants';
+import {BlockMode, MAX_FUNCTION_CALLS_COUNT} from '../constants';
 
 import {BlockTypes} from './blockTypes';
 import {DOCS_BASE_URL} from './constants';
@@ -137,11 +137,13 @@ function restoreBlockDefinitions() {
 // A helper function to generate the code for a function call to play sounds sequentially.
 function simple2FunctionCallGenerator(functionName, functionCallBllockId) {
   return `
-    Sequencer.startFunctionContext('${functionName}', '${functionCallBllockId}');
-    Sequencer.playSequential();
-    ${functionName}();
-    Sequencer.endSequential();
-    Sequencer.endFunctionContext();
+    if (__functionCallsCount++ < ${MAX_FUNCTION_CALLS_COUNT}) {
+      Sequencer.startFunctionContext('${functionName}', '${functionCallBllockId}');
+      Sequencer.playSequential();
+      ${functionName}();
+      Sequencer.endSequential();
+      Sequencer.endFunctionContext();
+    }
   `;
 }
 

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -1,3 +1,4 @@
+import {MAX_LOOP_ITERATIONS_COUNT} from '../../constants';
 import musicI18n from '../../locale';
 import {BlockTypes} from '../blockTypes';
 import {getCodeForSingleBlock} from '../blockUtils';
@@ -397,19 +398,12 @@ export const repeatSimple2 = {
       'repeat_end',
       Blockly.Names.NameType.VARIABLE
     );
-    code += 'var ' + endVar + ' = ' + repeats + ';\n';
-    code +=
-      'for (var ' +
-      loopVar +
-      ' = 0; ' +
-      loopVar +
-      ' < ' +
-      endVar +
-      '; ' +
-      loopVar +
-      '++) {\n' +
-      branch +
-      '}\n';
+    code += `
+      var ${endVar} = ${repeats};
+      for (var ${loopVar} = 0; ${loopVar} < ${endVar} && __loopIterationsCount < ${MAX_LOOP_ITERATIONS_COUNT}; ${loopVar}++, __loopIterationsCount++) {
+        ${branch}
+      }
+    `;
 
     return `
       Sequencer.playSequential();

--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -32,7 +32,6 @@ import {BlockConfig} from './types';
  * Set up the global Blockly environment for Music Lab. This should
  * only be called once per page load, as it configures the global
  * Blockly state.
- * @param {string} blockMode - The block mode to determine whether advanced blocks should be registered.
  */
 export function setUpBlocklyForMusicLab() {
   backupFunctionDefinitons();
@@ -69,6 +68,4 @@ export function setUpBlocklyForMusicLab() {
   // Rename the new function placeholder text for Music Lab specifically.
   Blockly.Msg['PROCEDURES_DEFNORETURN_PROCEDURE'] =
     musicI18n.blockly_functionNamePlaceholder();
-
-  Blockly.setInfiniteLoopTrap();
 }

--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -48,6 +48,8 @@ export const DEFAULT_PATTERN_LENGTH = 1;
 export const DEFAULT_PATTERN_AI_LENGTH = 2;
 export const DEFAULT_CHORD_LENGTH = 1;
 export const DEFAULT_TUNE_LENGTH = 1;
+export const MAX_FUNCTION_CALLS_COUNT = 400;
+export const MAX_LOOP_ITERATIONS_COUNT = 1000;
 
 export const DEFAULT_PATTERN: InstrumentEventValue = {
   instrument: 'drums',

--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -48,7 +48,7 @@ export const DEFAULT_PATTERN_LENGTH = 1;
 export const DEFAULT_PATTERN_AI_LENGTH = 2;
 export const DEFAULT_CHORD_LENGTH = 1;
 export const DEFAULT_TUNE_LENGTH = 1;
-export const MAX_FUNCTION_CALLS_COUNT = 400;
+export const MAX_FUNCTION_CALLS_COUNT = 100;
 export const MAX_LOOP_ITERATIONS_COUNT = 1000;
 
 export const DEFAULT_PATTERN: InstrumentEventValue = {


### PR DESCRIPTION
This change implements a new system for handling excessive looping or recursion in the Music Lab `simple2` model.

### Before

Until now, we were using an existing "infinite loop trap" to stop execution when programs had excessive looping or recursion.    This system ([1](https://github.com/code-dot-org/code-dot-org/blob/eba177ac37efb59d15eef8bd293c4ed578c71d1c/apps/src/blockly/cdoBlocklyWrapper.js#L175-L177), [2](https://github.com/code-dot-org/code-dot-org/blob/eba177ac37efb59d15eef8bd293c4ed578c71d1c/apps/src/blockly/utils.ts#L165-L166)) had a couple issues.  

Firstly, it was throwing an [exception](https://github.com/code-dot-org/code-dot-org/blob/eba177ac37efb59d15eef8bd293c4ed578c71d1c/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js#L10) inside the interpreter when it reached the threshold, which seemed to get some of the system into an unusual state (`Invalid state: no current function ID`, not diagnosed further).  

Secondly, the system would only [reset](https://github.com/code-dot-org/code-dot-org/blob/eba177ac37efb59d15eef8bd293c4ed578c71d1c/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js#L7) its count when the code was re-compiled, rather than re-executed.  Because Music Lab can execute multiple times for a single compile, this would lead to events showing on the timeline at first, but then vanishing.

### After

The solution proposed here is for Music Lab to do its own management of excessive looping or recursion.  The interpreted code simply maintains two distinct counts of how many loop iterations it has executed, and how many function calls it has executed, and stops doing either when it hits its respective limit.

With this change in place, the user can see and play the events on the timeline that are placed before thresholds are reached, and the system stays in a regular state.

To limit the scope of this change, this new system is only applied to the `simple2` model for now.
