### PR TITLE
chore(nvm): add .nvmrc for `frontend`

### DIFF
--- a/frontend/.nvmrc
+++ b/frontend/.nvmrc
@@ -1,0 +1,3 @@
+# To view valid code names, run `nvm ls`.
+# node 22's code name is 'jod'
+lts/jod


### PR DESCRIPTION
The latest long term supported version of node is 22 which will become end of life in Oct 2026.

To lessen the maintenance burden, the latest LTS was selected.