### PR TITLE
enable logging for delayed job

### DIFF
--- a/dashboard/config/initializers/delayed_job_config.rb
+++ b/dashboard/config/initializers/delayed_job_config.rb
@@ -8,3 +8,5 @@ Delayed::Worker.destroy_failed_jobs = false
 # retry_on method, and second from delayed_job, which is controlled by the
 # max_attempts variable.
 Delayed::Worker.max_attempts = 1
+
+Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))


### PR DESCRIPTION
Increase our ability to debug delayed job issues, in response to this [live site issue](https://codedotorg.slack.com/archives/C0T0PNTM3/p1732334823803929).

docs: https://github.com/collectiveidea/delayed_job#:~:text=Delayed%3A%3AWorker.logger