### PR TITLE
P20-1314/Clean up lti_account_unlinking dcdo flag

### DIFF
--- a/apps/src/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/accounts/ManageLinkedAccounts.jsx
@@ -13,7 +13,6 @@ import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {tableLayoutStyles} from '@cdo/apps/templates/tables/tableConstants';
 import color from '@cdo/apps/util/color';
-import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
 
 import RailsAuthenticityToken from '../lib/util/RailsAuthenticityToken';
@@ -172,8 +171,7 @@ class ManageLinkedAccounts extends React.Component {
     Object.values(SingleSignOnProviders).forEach(provider => {
       if (
         provider === SingleSignOnProviders.lti_v1 &&
-        (!optionsByProvider[provider] ||
-          !experiments.isEnabled(experiments.LTI_ACCOUNT_UNLINKING))
+        !optionsByProvider[provider]
       ) {
         return;
       }

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -59,8 +59,6 @@ experiments.BIG_PLAYSPACE = 'bigPlayspace';
 experiments.NEW_SIGN_UP_FLOW = 'new_sign_up_flow';
 // Allows user to view the new version of the teacher navigation
 experiments.TEACHER_LOCAL_NAV_V2 = 'teacher-local-nav-v2';
-// Enables LTI account disconnect buttons on the Account Settings page
-experiments.LTI_ACCOUNT_UNLINKING = 'lti_account_unlinking';
 // Shows 'check my code' button in App Lab for validation via AI
 experiments.CSP_VALIDATION_VIA_AI = 'csp_validation_via_ai';
 

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -54,7 +54,6 @@ class DCDOBase < DynamicConfigBase
       'cfu-pin-hide-enabled': DCDO.get('cfu-pin-hide-enabled', false),
       'teacher-local-nav-v2': DCDO.get('teacher-local-nav-v2', false),
       'best-of-stem-2024': DCDO.get('best-of-stem-2024', false),
-      lti_account_unlinking: DCDO.get('lti_account_unlinking', false),
       # TODO ACQ-2556 - Remove this after the 2024 HOC sweepstakes is over
       'hoc-2024-sweepstakes': DCDO.get('hoc-2024-sweepstakes', false),
       # TODO ACQ-2556 - Remove this after the 2024 HOC launch


### PR DESCRIPTION
This experiment flag is no longer needed and can be removed.

## Links
Jira: [P20-1314](https://codedotorg.atlassian.net/browse/P20-1314)
