### PR TITLE
[Levelbuilder] Block editor - Add prompt to save button if name has changed

### DIFF
--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -20,6 +20,8 @@ const INVALID_COLOR = '#d00';
 let poolField, nameField, helperEditor, configEditor, validationDiv;
 let hasLintingErrors = false;
 let isValidBlockConfig = false;
+let originalBlockName;
+let saveButton;
 
 $(document).ready(() => {
   registerReducers({animationList: animationList});
@@ -37,6 +39,9 @@ function initializeEditPage(defaultSprites) {
 
   poolField = document.getElementById('block_pool');
   nameField = document.getElementById('block_name');
+  saveButton = document.getElementById('block_submit');
+  originalBlockName = nameField.value;
+
   Blockly.inject(document.getElementById('blockly-container'), {
     assetUrl,
     valueTypeTabShapeMap: valueTypeTabShapeMap(Blockly),
@@ -150,6 +155,7 @@ function updateBlockPreview() {
     parsedConfig.func || parsedConfig.name,
     poolField.value
   );
+  checkBlockNameChanges(blockName);
   nameField.value = blockName;
   // Calling this function just so that we can catch and show errors (if any)
   installCustomBlocks({
@@ -174,4 +180,16 @@ function updateBlockPreview() {
 function onBlockSpaceChange() {
   document.getElementById('code-preview').innerText =
     Blockly.getWorkspaceCode();
+}
+
+function checkBlockNameChanges(blockName) {
+  // Add a prompt to the "Update Block" button if the user has changed the block name or pool.
+  if (originalBlockName && blockName !== originalBlockName) {
+    saveButton.setAttribute(
+      'data-confirm',
+      `Are you sure you want to update ${originalBlockName}?\n\n` +
+        `This will affect everywhere that this block is used.\n\n` +
+        `If you change the block pool or block name, this could break existing levels or projects.`
+    );
+  }
 }


### PR DESCRIPTION
@breville [shared](https://codedotorg.slack.com/archives/C05DMS18MEX/p1732507940073009) an issue where a level was failing to load due to a custom block being deleted from a block pool:

> Zendesk [ticket](https://codeorg.zendesk.com/agent/tickets/516167): the penultimate [level](https://studio.code.org/s/hello-world-space-2022/lessons/1/levels/10) of Hello World: Space indeed fails to load.
`Invalid block definition for type: gamelab_playSoundOptionsSpace`

This has apparently been broken for about 3.5 months, since a new sound picker block was created on levelbuilder for a new tutorial:
https://github.com/code-dot-org/code-dot-org/commit/30d016ca08c2e0ddbd1ea7cf2e7501f1aa40d826

Evidently, the levelbuilder user who created the new block used the space sounds block as a template, but then **updated** it instead of cloning. This effectively deleted the old block.

Full page view of block editor follows, for reference:
![image](https://github.com/user-attachments/assets/4def7d06-507f-4d46-9662-5751b93aca84)


I reverted the deleted block manually on levelbuilder which should fix the level with tomorrow's deploy.

To prevent future mistakes like this, I proposed adding a prompt if we detect that the block name has changed. @samantha-code agreed, saying:
> I think we should add a prompt (the more documentation for levelbuilders the better) and an extra acknowledgement for any destructive action in level builder as a rule, so adding it here makes a ton of sense. I dont think we should remove Update as an option all together because there is a valid option (spelling error etc.) to want to update and change.

This adds a barebones browser prompt to the save button if we detect that the block's name has changed. The full block name also includes the pool name as a prefix, so we are also effectively checking for a change in pool. (The incident that caused the reported issue was due to changing to a new pool and shortening the name of the block itself.)

![image](https://github.com/user-attachments/assets/9481dae6-89f2-426f-8d2b-ed75ec3df554)

This new prompt will show when the user clicks "Update Block" at any point after we detect a change in the block name. New blocks created from scratch are unaffected as there is no original name to compare against.

This prompt is obviously lacking in design/polish, but matches the experience for deleting a block from the same page.

![image](https://github.com/user-attachments/assets/36133820-9888-41cd-be65-2ca7dae080a2)

This is intended to be a quick win to prevent our internal users from accidentally making the same mistake.

## Links

https://codedotorg.slack.com/archives/C05DMS18MEX/p1732507940073009
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Manually tested updating a block after changing various config values, block names, and block pool.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
