### PR TITLE
P20 1190/remove old cpa feature flags

### DIFF
--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -4,11 +4,9 @@ import {connect} from 'react-redux';
 
 import {disabledBubblesSupportArticle} from '@cdo/apps/code-studio/disabledBubbles';
 import Link from '@cdo/apps/componentLibrary/link';
-import DCDO from '@cdo/apps/dcdo';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import {getStore} from '@cdo/apps/redux';
 import {sectionShape} from '@cdo/apps/templates/teacherDashboard/shapes';
-import {isProductionEnvironment} from '@cdo/apps/utils';
 import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';
 
@@ -44,10 +42,7 @@ function TeacherDashboardHeader({
   const inUSA =
     ['US', 'RD'].includes(currentUser.countryCode) || !!currentUser.usStateCode;
   const showAgeGatedStudentsBanner =
-    inUSA &&
-    currentUser.isTeacher &&
-    ageGatedStudentsCount > 0 &&
-    DCDO.get('show-age-gated-students-banner', !isProductionEnvironment());
+    inUSA && currentUser.isTeacher && ageGatedStudentsCount > 0;
 
   const toggleModal = () => {
     setModalOpen(!modalOpen);

--- a/dashboard/app/helpers/child_account_helper.rb
+++ b/dashboard/app/helpers/child_account_helper.rb
@@ -10,7 +10,6 @@ module ChildAccountHelper
       student_lockout_date ||= Policies::ChildAccount::StatePolicies.state_policy(user)&.dig(:lockout_date)
     else
       return unless student_lockout_date
-      return unless DCDO.get('cap_student_warnings_enabled', false)
     end
 
     {
@@ -39,7 +38,6 @@ module ChildAccountHelper
       student_lockout_date ||= Policies::ChildAccount::StatePolicies.state_policy(user)&.dig(:lockout_date)
     else
       return unless student_lockout_date
-      return unless DCDO.get('cap_student_warnings_enabled', false)
       return if user.latest_parental_permission_request
     end
 

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -267,7 +267,7 @@ module UsersHelper
     # Therefore, we don't need to show the cap_user_info modal.
     return false if !Policies::ChildAccount.user_predates_state_collection?(user) && user.us_state.present?
     # Is the student a child and using a personal account to access code.org?
-    Policies::ChildAccount.show_cap_state_modal?(user) && user.under_13? && Policies::ChildAccount.personal_account?(user)
+    user.under_13? && Policies::ChildAccount.personal_account?(user)
   end
 
   def lti_user_info_required?(user)

--- a/dashboard/lib/policies/child_account.rb
+++ b/dashboard/lib/policies/child_account.rb
@@ -57,14 +57,6 @@ class Policies::ChildAccount
     user.created_at < StatePolicies.state_policies['CO'][:start_date]
   end
 
-  # 'cap-state-modal-rollout' should be a value in the range [0,100]
-  # If the value is 10, 10% of users will see the modal
-  # If the value is 50, 50% of users will see the modal
-  def self.show_cap_state_modal?(user)
-    return false unless user&.id
-    (user.id % 100) < DCDO.get('cap-state-modal-rollout', 0)
-  end
-
   # Checks if a user is affected by a state policy but was created prior to the
   # policy going into effect.
   def self.user_predates_policy?(user)

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -339,7 +339,6 @@ class HomeControllerTest < ActionController::TestCase
     refute student.us_state, "user should not have us_state, but value was #{student.us_state}"
     request.env['HTTP_CLOUDFRONT_VIEWER_COUNTRY'] = 'US'
     sign_in student
-    Policies::ChildAccount.stubs(:show_cap_state_modal?).with(student).returns(true)
     get :home
 
     assert_select '#student-information-modal', true
@@ -358,7 +357,6 @@ class HomeControllerTest < ActionController::TestCase
     assert student.age, 12
 
     sign_in student
-    Policies::ChildAccount.stubs(:show_cap_state_modal?).with(student).returns(true)
     get :home
 
     assert_select '#student-information-modal', true
@@ -375,7 +373,6 @@ class HomeControllerTest < ActionController::TestCase
     assert student.age, 12
 
     sign_in student
-    Policies::ChildAccount.stubs(:show_cap_state_modal?).with(student).returns(true)
     get :home
 
     assert_select '#student-information-modal', true
@@ -412,7 +409,6 @@ class HomeControllerTest < ActionController::TestCase
     student.update_attribute(:age, 11)
     request.env['HTTP_CLOUDFRONT_VIEWER_COUNTRY'] = 'US'
     sign_in student
-    Policies::ChildAccount.stubs(:show_cap_state_modal?).with(student).returns(true)
     get :home
     assert_select '#student-information-modal', false
   end

--- a/dashboard/test/lib/policies/child_account_test.rb
+++ b/dashboard/test/lib/policies/child_account_test.rb
@@ -54,27 +54,6 @@ class Policies::ChildAccountTest < ActiveSupport::TestCase
     assert failures.empty?, failures.join("\n")
   end
 
-  test 'show_cap_state_modal?' do
-    test_matrix = [
-      {rollout: 10, user_id: 9, expected: true},
-      {rollout: 10, user_id: 101, expected: true},
-      {rollout: 10, user_id: 109, expected: true},
-      {rollout: 10, user_id: 110, expected: false},
-      {rollout: 10, user_id: 199, expected: false},
-      {rollout: 20, user_id: 119, expected: true},
-      {rollout: 99, user_id: 198, expected: true},
-      {rollout: 99, user_id: 199, expected: false},
-      {rollout: 100, user_id: 99, expected: true},
-      {rollout: 100, user_id: 1099, expected: true},
-    ]
-    test_matrix.each do |test_case|
-      user = OpenStruct.new({id: test_case[:user_id]})
-      DCDO.stubs(:get).with('cap-state-modal-rollout', 0).returns(test_case[:rollout])
-      actual = Policies::ChildAccount.show_cap_state_modal? user
-      assert_equal test_case[:expected], actual, "Testcase #{test_case} failed"
-    end
-  end
-
   test 'user_predates_policy?' do
     # [User traits, Expected result from compliant?]
     test_matrix = [

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -50,7 +50,6 @@ class DCDOBase < DynamicConfigBase
       'music-lab-samples-report': DCDO.get('music-lab-samples-report', true),
       'disable-try-new-progress-view-modal': DCDO.get('disable-try-new-progress-view-modal', false),
       'music-lab-existing-projects-default-sounds': DCDO.get('music-lab-existing-projects-default-sounds', true),
-      'show-age-gated-students-banner': DCDO.get('show-age-gated-students-banner', true),
       'cfu-pin-hide-enabled': DCDO.get('cfu-pin-hide-enabled', false),
       'teacher-local-nav-v2': DCDO.get('teacher-local-nav-v2', false),
       'best-of-stem-2024': DCDO.get('best-of-stem-2024', false),


### PR DESCRIPTION
For the launch of our ChildAccountPolicy, we have used various DCDO feature flags to test features in production. Now that we are live, we can remove these flags.

DCDO flags no longer needed:
- cap_student_warnings_enabled
- cap-state-modal-rollout
- show-age-gated-students-banner

## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1190)


## Testing story
* Automated tests.
