### PR TITLE
change last_error column to utf8mb4 in delayed_jobs table

### DIFF
--- a/dashboard/db/migrate/20241125202219_convert_last_error_to_utf8mb4_in_delayed_jobs.rb
+++ b/dashboard/db/migrate/20241125202219_convert_last_error_to_utf8mb4_in_delayed_jobs.rb
@@ -1,0 +1,9 @@
+class ConvertLastErrorToUtf8mb4InDelayedJobs < ActiveRecord::Migration[6.1]
+  def up
+    execute 'alter table delayed_jobs modify last_error mediumtext charset utf8mb4 collate utf8mb4_unicode_ci'
+  end
+
+  def down
+    execute 'alter table delayed_jobs modify last_error mediumtext charset utf8 collate utf8_unicode_ci'
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_11_20_192448) do
+ActiveRecord::Schema.define(version: 2024_11_25_202219) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -568,7 +568,7 @@ ActiveRecord::Schema.define(version: 2024_11_20_192448) do
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
-    t.text "last_error", size: :medium
+    t.text "last_error", size: :medium, collation: "utf8mb4_unicode_ci"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"


### PR DESCRIPTION
See [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1732566016902319?thread_ts=1732334823.803929&cid=C0T0PNTM3). Fixes an issue causing problems for delayed_job workers, because user-entered text was being written to a column that did not support 4-byte emoji.

Ran migration locally and confirmed the column has been updated:
```
mysql> SELECT character_set_name FROM information_schema.`COLUMNS`  WHERE table_schema = "dashboard_development"   AND table_name = "delayed_jobs"   AND column_name = "last_error";
+--------------------+
| CHARACTER_SET_NAME |
+--------------------+
| utf8mb4            |
+--------------------+
```

There are < 3K rows in the delayed_jobs table. the same alter table command recently ran for the learning_goal_ai_evaluations table completing in under a second, which contains 750K rows.
