### PR TITLE
[Sprite Lab] Add command names to reserved words list.

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1067,6 +1067,11 @@ export default class P5Lab {
 
       if (this.isBlockly) {
         this.library = this.createLibrary({p5: this.p5Wrapper.p5});
+        // Add each command name to the Blockly generator's reserved word list.
+        // This prevents students from overriding commands with their functions.
+        Object.keys(this.library.commands).forEach(commandName => {
+          Blockly.JavaScript.nameDB_.reservedWords.add(commandName);
+        });
 
         const libraryCommands = this.library.commands;
         for (const command in libraryCommands) {

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -70,12 +70,6 @@ export default class CoreLibrary {
       },
       ...commands,
     };
-
-    // Add each command name to the Blockly generator's reserved word list.
-    // This prevents students from overriding commands with their functions.
-    Object.keys(this.commands).forEach(commandName => {
-      Blockly.JavaScript.nameDB_.reservedWords.add(commandName);
-    });
   }
 
   isPreviewFrame() {

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -70,6 +70,12 @@ export default class CoreLibrary {
       },
       ...commands,
     };
+
+    // Add each command name to the Blockly generator's reserved word list.
+    // This prevents students from overriding commands with their functions.
+    Object.keys(this.commands).forEach(commandName => {
+      Blockly.JavaScript.nameDB_.reservedWords.add(commandName);
+    });
   }
 
   isPreviewFrame() {


### PR DESCRIPTION
https://codedotorg.slack.com/archives/C05DMS18MEX/p1732566133037889

@breville shared an [issue](https://codeorg.zendesk.com/agent/tickets/516725) where sounds weren’t playing in a student’s Sprite Lab project. Evidently, it was because the student had a function `playSound` which was effectively no-opping the actual Sprite Lab command with the same name. This can leads to all kinds of strange possibilities, such as what’s shown in this video:

https://github.com/user-attachments/assets/e1a1e1f2-fe60-408a-baec-a0b0d5f52721

Blockly manages a database of names for variables and functions, including a list of programming-language-specific reserved words. We can prevent this issue by adding all command names (such as `playSound` and `makeNewSpriteAnon`) to this list. Now, if a user does this, Blockly will append a `2` to the name of the function when it comes time to actually generate code for it.


https://github.com/user-attachments/assets/5623cddf-732d-45dc-b76a-3df8b7d1fe6e


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
