### PR TITLE
[Music] Add Sequencer to reserved words

### DIFF
--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -60,6 +60,8 @@ export function setUpBlocklyForMusicLab() {
     Blockly.JavaScript.forBlock[blockType] = blockConfig.generator;
   }
 
+  Blockly.JavaScript.addReservedWords('Sequencer');
+
   Blockly.fieldRegistry.register(FIELD_SOUNDS_TYPE, FieldSounds);
   Blockly.fieldRegistry.register(FIELD_PATTERN_TYPE, FieldPattern);
   Blockly.fieldRegistry.register(FIELD_PATTERN_AI_TYPE, FieldPatternAi);


### PR DESCRIPTION
https://codedotorg.slack.com/archives/C05DMS18MEX/p1732566133037889

@breville shared an [issue](https://codeorg.zendesk.com/agent/tickets/516725) where sounds weren’t playing in a student’s Sprite Lab project. Evidently, it was because the student had a function playSound which was effectively no-opping the actual Sprite Lab command with the same name. A similar issue exists in Music Lab if a student creates a function using the should-be-reserved name `Sequencer`:

https://github.com/user-attachments/assets/15e0e8d7-e3b1-499f-aac0-574da55bff57

By adding this to the list of reserved words, Blockly will simply call this function `Sequencer2` behind the scenes and carry on without issue.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
