### PR TITLE
Fix test_pegasus_documents unit test

### DIFF
--- a/pegasus/test/test_pegasus_documents.rb
+++ b/pegasus/test/test_pegasus_documents.rb
@@ -1,6 +1,7 @@
 require_relative './test_helper'
 require_relative '../router'
 require 'cdo/rack/request'
+require 'varnish_environment'
 require 'shared_resources'
 require 'parallel'
 require 'open3'


### PR DESCRIPTION
The Pegasus `test_pegasus_documents` systematically goes through every possible view based on directory structure.

However, it does not "require" modules that are specified in `pegasus/config.ru` such as `varnish_environment`. This inconsistency causes an error when no other mechanism includes it first. Apparently, though I do not know exactly the reason, the `test` environment for our `DTT` does not require `varnish_environment` preceding the test run for this unit test.

Somehow, the drone environment for our continuous integration does require this module before running these tests.

So, let's just require it in the test file. This matches it including things like `shared_resources`, which is in the `config.ru` and redundantly specified here to let it match server runtime behavior. Seems like a fragile pattern, but it is what it is for now. Pegasus has a shelf life and it is not worth making it that much better while the test suite is broken.

```
  test_render_pegasus_documents                                   FAIL (6.95s)
Minitest::Assertion:         Page rendering errors:
        [code.org/global/fa/about] Render failed:
        Error rendering /home/ubuntu/test/pegasus/sites.v3/code.org/layouts/default.haml: Error rendering /home/ubuntu/test/pegasus/sites.v3/code.org/views/global/fa/farsiheader.haml: uninitialized constant VarnishEnvironment
        /home/ubuntu/test/pegasus/router.rb:563:in `rescue in render_template'
        /home/ubuntu/test/pegasus/router.rb:559:in `render_template'
        /home/ubuntu/test/pegasus/router.rb:248:in `block in <class:Documents>'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1693:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1693:in `block in compile!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1078:in `block in process_route'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1076:in `catch'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1076:in `process_route'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1017:in `block in filter!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1016:in `each'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1016:in `filter!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1153:in `dispatch!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:956:in `block in call!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1119:in `block in invoke'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1119:in `catch'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1119:in `invoke'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:956:in `call!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:945:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1003:in `forward'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1095:in `route_missing'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1044:in `route!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1040:in `route!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1040:in `route!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1147:in `block in dispatch!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1119:in `block in invoke'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1119:in `catch'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1119:in `invoke'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1142:in `dispatch!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:956:in `block in call!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1119:in `block in invoke'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1119:in `catch'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:1119:in `invoke'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:956:in `call!'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:945:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/xss_header.rb:18:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/path_traversal.rb:16:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/json_csrf.rb:26:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/base.rb:50:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/base.rb:50:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/frame_options.rb:31:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-2.2.9/lib/rack/null_logger.rb:11:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-2.2.9/lib/rack/head.rb:12:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:218:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:2000:in `call'
        /home/ubuntu/test/lib/cdo/rack/process_html.rb:32:in `call'
        /home/ubuntu/test/lib/cdo/rack/upgrade_insecure_requests.rb:36:in `call'
        /home/ubuntu/test/lib/cdo/rack/deflater.rb:38:in `call'
        /home/ubuntu/test/lib/cdo/rack/locale.rb:17:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/xss_header.rb:18:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/path_traversal.rb:16:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/json_csrf.rb:26:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/base.rb:50:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/base.rb:50:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-protection-2.2.3/lib/rack/protection/frame_options.rb:31:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-2.2.9/lib/rack/null_logger.rb:11:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-2.2.9/lib/rack/head.rb:12:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:218:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/sinatra-2.2.3/lib/sinatra/base.rb:2000:in `call'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-test-2.0.2/lib/rack/test.rb:358:in `process_request'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-test-2.0.2/lib/rack/test.rb:165:in `custom_request'
        /usr/local/lib/ruby/gems/3.0.0/gems/rack-test-2.0.2/lib/rack/test.rb:114:in `get'
        /usr/local/lib/ruby/3.0.0/forwardable.rb:238:in `get'
        /home/ubuntu/test/pegasus/test/test_pegasus_documents.rb:106:in `block (3 levels) in test_render_pegasus_documents'
        /home/ubuntu/test/shared/test/capture_queries.rb:28:in `capture_queries'
        /home/ubuntu/test/pegasus/test/test_pegasus_documents.rb:106:in `block (2 levels) in test_render_pegasus_documents'
        /home/ubuntu/test/pegasus/test/test_pegasus_documents.rb:104:in `loop'
        /home/ubuntu/test/pegasus/test/test_pegasus_documents.rb:104:in `block in test_render_pegasus_documents'
```

## Links

[Slack thread](https://codedotorg.slack.com/archives/CFTFD6BPV/p1732566129565259)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
