### PR TITLE
P20-1180: Fix Global Edition region switch modal in Pegasus

### DIFF
--- a/apps/src/templates/globalEdition/RegionSwitchConfirm/index.tsx
+++ b/apps/src/templates/globalEdition/RegionSwitchConfirm/index.tsx
@@ -57,11 +57,11 @@ const RegionSwitchConfirm: React.FC<RegionSwitchConfirmProps> = ({
     }
   }, [show, region, reportEvent]);
 
-  const handleSwitch = () => {
+  const handleAccept = () => {
+    setShow(false);
     reportEvent(EVENTS.GLOBAL_EDITION_REGION_SWITCH_CONFIRM_ACCEPTED, {
       page: region.href,
     });
-    window.location.href = region.href;
   };
 
   const handleReject = () => {
@@ -90,16 +90,19 @@ const RegionSwitchConfirm: React.FC<RegionSwitchConfirmProps> = ({
           })}
         />
 
-        <Button
-          id="global-edition-region-switch-confirm-accept"
-          className="no-mc"
-          text={i18n.globalEdition_regionSwitchConfirm_accept({
-            region: region.name,
-          })}
-          type="primary"
-          size="l"
-          onClick={handleSwitch}
-        />
+        <form action={region.href} method="post">
+          <Button
+            id="global-edition-region-switch-confirm-accept"
+            className="no-mc"
+            text={i18n.globalEdition_regionSwitchConfirm_accept({
+              region: region.name,
+            })}
+            buttonTagTypeAttribute="submit"
+            type="primary"
+            size="l"
+            onClick={handleAccept}
+          />
+        </form>
 
         <Link
           id="global-edition-region-switch-confirm-reject"

--- a/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
+++ b/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
@@ -37,7 +37,8 @@ Feature: Global Edition - Region Switch Confirm Modal
     And I reload the page
     And I wait until element "#global-edition-region-switch-confirm.fade.in[role='dialog']" is visible
     When I press "global-edition-region-switch-confirm-accept"
-    Then check that I am on "http://code.org/global/fa"
+    Then I get redirected away from "http://code.org"
+    And I wait until I am on "http://code.org/global/fa"
     And element "#global-edition-region-switch-confirm" is not visible
 
   Scenario: The modal is shown on studio.code.org (Studio) domain


### PR DESCRIPTION
```
Then check that I am on "http://code.org/global/fa"
features/step_definitions/steps.rb:347
expected: "https://test.code.org/global/fa"
     got: "https://test.code.org/?ge_region=fa"

(compared using ==)
 (RSpec::Expectations::ExpectationNotMetError)
./features/step_definitions/steps.rb:349:in `/^check that I am on "([^"]*)"$/'
./features/support/hooks.rb:28:in `block in '
features/platform/global_edition/region_switch_confirm.feature:40:in `Then check that I am on "http://code.org/global/fa"'
Then /^check that I am on "([^"]*)"$/ do |url|
  url = replace_hostname(url)
  expect(@browser.current_url).to eq(url)
end

# gem install syntax to get syntax highlighting
```
## Links
- JIRA task: [P20-1180](https://codedotorg.atlassian.net/browse/P20-1180)
- Original PR: https://github.com/code-dot-org/code-dot-org/pull/61631
- Log on S3: https://cucumber-logs.s3.amazonaws.com/test/test/Firefox_platform_global_edition_region_switch_confirm_output.html?versionId=BxQZBYLHWT2VHMG6pzCKSCHfXdoSWd83