### PR TITLE
truncate aichat error message to 4MB

### DIFF
--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -41,7 +41,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
     # Report metrics for the failed job (after_perform doesn't run on failure)
     report_job_finish(request)
 
-    # Raise an exception to notify our system of the failed job.
+    # Raise an exception to notify our system of the failed job. Make sure not to exceed the delayed_jobs.last_error column size.
     raise "AichatRequestChatCompletionJob failed with unexpected error: #{exception.message}. Context: #{request.to_json[0..MAX_REQUEST_LOG_LENGTH]}"
   end
 

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -5,7 +5,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
 
   DEFAULT_TOXICITY_THRESHOLD_USER_INPUT = 0.2
   DEFAULT_TOXICITY_THRESHOLD_MODEL_OUTPUT = 0.6
-  MAX_ERROR_MESSAGE_LENGTH = 4 * 1024 * 1024
+  MAX_REQUEST_LOG_LENGTH = 4 * 1024 * 1024
 
   before_enqueue do |job|
     request = job.arguments.first[:request]
@@ -42,8 +42,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
     report_job_finish(request)
 
     # Raise an exception to notify our system of the failed job.
-    message = exception.message && exception.message[0..MAX_ERROR_MESSAGE_LENGTH]
-    raise "AichatRequestChatCompletionJob failed with unexpected error: #{message}. Context: #{request.to_json}"
+    raise "AichatRequestChatCompletionJob failed with unexpected error: #{exception.message}. Context: #{request.to_json[0..MAX_REQUEST_LOG_LENGTH]}"
   end
 
   def perform(request:, locale:)

--- a/dashboard/app/jobs/aichat_request_chat_completion_job.rb
+++ b/dashboard/app/jobs/aichat_request_chat_completion_job.rb
@@ -5,6 +5,7 @@ class AichatRequestChatCompletionJob < ApplicationJob
 
   DEFAULT_TOXICITY_THRESHOLD_USER_INPUT = 0.2
   DEFAULT_TOXICITY_THRESHOLD_MODEL_OUTPUT = 0.6
+  MAX_ERROR_MESSAGE_LENGTH = 4 * 1024 * 1024
 
   before_enqueue do |job|
     request = job.arguments.first[:request]
@@ -41,7 +42,8 @@ class AichatRequestChatCompletionJob < ApplicationJob
     report_job_finish(request)
 
     # Raise an exception to notify our system of the failed job.
-    raise "AichatRequestChatCompletionJob failed with unexpected error: #{exception.message}. Context: #{request.to_json}"
+    message = exception.message && exception.message[0..MAX_ERROR_MESSAGE_LENGTH]
+    raise "AichatRequestChatCompletionJob failed with unexpected error: #{message}. Context: #{request.to_json}"
   end
 
   def perform(request:, locale:)


### PR DESCRIPTION
fix to prevent a single large aichat message from killing all delayed job worker processes, taking down aichat and ai rubrics features. for background, see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1732583892096529?thread_ts=1732334823.803929&cid=C0T0PNTM3).

## Testing story

relying on existing test coverage to make sure nothing breaks
