### PR TITLE
Music: curriculum library editor support

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -23,7 +23,7 @@ import RawJsonEditor from './RawJsonEditor';
 
 import moduleStyles from './edit-music-level-data.module.scss';
 
-const VALID_LIBRARIES = [DEFAULT_LIBRARY, 'launch2024'];
+const VALID_LIBRARIES = [DEFAULT_LIBRARY, 'launch2024', 'curriculum2024'];
 const RECOMMENDED_LIBRARY = 'launch2024';
 
 const JSON_FIELDS = [['startSources', 'Start Sources']] as const;


### PR DESCRIPTION
This adds level editor support for an upcoming `curriculum2024` library, which will initially feature a single pack of in-house sounds that are each 1-measure long, to assist in developing K-5 curriculum.

<img width="776" alt="Screenshot 2024-11-25 at 10 17 50 PM" src="https://github.com/user-attachments/assets/4e437370-8817-43b7-8943-3cc45e5c1847">
