### PR TITLE
[Dance] Add commands names to Blockly reserved words list

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -459,6 +459,14 @@ Dance.prototype.afterInject_ = function () {
     logger: danceMetricsReporter,
   });
 
+  // Add command names from the Dance Party API to the Blockly generator's
+  // reservered words. This prevents students from overriding commands
+  // with functions.
+  const reservedWords = Object.getOwnPropertyNames(
+    Object.getPrototypeOf(this.nativeAPI)
+  );
+  Blockly.JavaScript.addReservedWords(reservedWords.join());
+
   // Expose an interface for testing
   // Composes the nativeAPI getPerformanceData with our own performance data.
   const nativeAPITestInterface = this.nativeAPI.getTestInterface();


### PR DESCRIPTION
Similar to:
- https://github.com/code-dot-org/code-dot-org/pull/62667
- https://github.com/code-dot-org/code-dot-org/pull/62668

This fixes an issue where students can effectively override commands from the Dance Party API with their own functions:

![image (249)](https://github.com/user-attachments/assets/a3de3100-9044-462b-bda1-fadb4811170a)

By passing these command names to the Blockly generator as a reserved words list, students are free to use these names as function/variable names without clobbering our lab commands:

<img width="881" alt="image" src="https://github.com/user-attachments/assets/ad6f61a0-9f8d-485e-84f2-3e8bc6923477">


## Links

https://codedotorg.slack.com/archives/C05DMS18MEX/p1732569286899509?thread_ts=1732566133.037889&cid=C05DMS18MEX
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
