### PR TITLE
[Maze] Add reserved words

### DIFF
--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -146,6 +146,12 @@ module.exports = class Maze {
         Blockly.HSV_SATURATION = 0.6;
 
         Blockly.SNAP_RADIUS *= this.scale.snapRadius;
+
+        // Add API name and local variable to generator reserved words list.
+        // This prevents students from overriding these with their own
+        // functions/variables.
+        Blockly.JavaScript.addReservedWords('Maze,code');
+
         Blockly.setInfiniteLoopTrap();
       }
 


### PR DESCRIPTION
Similar to:

- https://github.com/code-dot-org/code-dot-org/pull/62667
- https://github.com/code-dot-org/code-dot-org/pull/62668
- https://github.com/code-dot-org/code-dot-org/pull/62689

This fixes an issue where students can can break Maze levels by creating a function called `Maze`.

<img width="866" alt="image" src="https://github.com/user-attachments/assets/6877f35f-e2e3-495e-8f13-537f7b53aac6">

For this branch, I followed the pattern I found where this work was already done for Artist, which includes reserving the local variable `code`:
https://github.com/code-dot-org/code-dot-org/blob/mike/maze-reserved-words/apps/src/turtle/artist.js#L551

With these changes, if students define functions or variables named `Maze` or `code`, the code we will actually execute for them will consist of `Maze2` and `code2`, respectively.

After:

<img width="877" alt="image" src="https://github.com/user-attachments/assets/2c5ffc8c-9dc9-4927-9ccd-e5b297b42326">

Above, `Maze` is an empty function. We know this is working as expected because the bee moved forward one step and there were no errors.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
