### PR TITLE
P20-1180: Skip region_switch_confirm.feature

### DIFF
--- a/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
+++ b/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
@@ -1,3 +1,4 @@
+@skip
 @no_mobile
 Feature: Global Edition - Region Switch Confirm Modal
 


### PR DESCRIPTION
```
And I wait until I am on "http://code.org/global/fa"
features/step_definitions/steps.rb:361
Timeout: I am not on https://test.code.org/global/fa like I want.
         I am on https://test.code.org/?ge_region=fa instead.
timed out after 120 seconds (Selenium::WebDriver::Error::TimeoutError)
./features/step_definitions/steps.rb:8:in `wait_until'
./features/step_definitions/steps.rb:367:in `/^I wait until I am on "([^"]*)"$/'
./features/support/hooks.rb:28:in `block in '
features/platform/global_edition/region_switch_confirm.feature:41:in `And I wait until I am on "http://code.org/global/fa"'

def wait_until(timeout = DEFAULT_WAIT_TIMEOUT)
  Selenium::WebDriver::Wait.new(timeout: timeout).until do
    yield
    rescue Selenium::WebDriver::Error::UnknownError => exception
# gem install syntax to get syntax highlighting
```

## Links
- JIRA task: [P20-1180](https://codedotorg.atlassian.net/browse/P20-1180)
- Original PR: https://github.com/code-dot-org/code-dot-org/pull/61631
- Log on S3: https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_platform_global_edition_region_switch_confirm_output.html?versionId=54U88tRX6XNV_6JQdkPSE_6F91juWs7C