### PR TITLE
P20-1284/Disable LTI account unlinking when no other auth options exist

### DIFF
--- a/apps/src/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/accounts/ManageLinkedAccounts.jsx
@@ -74,6 +74,16 @@ class ManageLinkedAccounts extends React.Component {
     );
   };
 
+  cannotDisconnectLti = authOption => {
+    return (
+      authOption.credentialType === SingleSignOnProviders.lti_v1 &&
+      _.every(this.props.authenticationOptions, [
+        'credentialType',
+        SingleSignOnProviders.lti_v1,
+      ])
+    );
+  };
+
   // Given an array of authentication options, returns a boolean indicating whether or not the user can log in
   userHasLoginOption = authOptions => {
     // If it's the user's last authentication option or all of the user's authentication options are email addresses,
@@ -106,6 +116,10 @@ class ManageLinkedAccounts extends React.Component {
       this.cannotDisconnectClever(authOption)
     ) {
       return DISCONNECT_DISABLED_STATUS.ROSTER_SECTION;
+    }
+
+    if (this.cannotDisconnectLti(authOption)) {
+      return DISCONNECT_DISABLED_STATUS.NO_LOGIN_OPTIONS;
     }
 
     // Make sure user has another way to log in if authOption is disconnected

--- a/apps/test/unit/accounts/ManageLinkedAccountsTest.jsx
+++ b/apps/test/unit/accounts/ManageLinkedAccountsTest.jsx
@@ -252,6 +252,36 @@ describe('ManageLinkedAccounts', () => {
     expect(googleConnectButton).to.have.attr('disabled');
   });
 
+  describe('LTI Account Unlinking', () => {
+    it('disables disconnecting from lti if user only has lti auth', () => {
+      const authOptions = {1: {id: 1, credentialType: 'lti_v1'}};
+      const wrapper = mount(
+        <ManageLinkedAccounts
+          {...DEFAULT_PROPS}
+          userHasPassword={true} // Should disable disconnecting from lti even if the user has a password attached to their account
+          authenticationOptions={authOptions}
+        />
+      );
+      const ltiConnectButton = wrapper.find('BootstrapButton').at(4);
+      expect(ltiConnectButton).to.have.attr('disabled');
+    });
+
+    it('does not disable disconnecting from lti if the user has another authentication option', () => {
+      const authOptions = {
+        1: {id: 1, credentialType: 'google_oauth2'},
+        2: {id: 2, credentialType: 'lti_v1'},
+      };
+      const wrapper = mount(
+        <ManageLinkedAccounts
+          {...DEFAULT_PROPS}
+          authenticationOptions={authOptions}
+        />
+      );
+      const ltiConnectButton = wrapper.find('BootstrapButton').at(4);
+      expect(ltiConnectButton).to.not.have.attr('disabled');
+    });
+  });
+
   describe('CPA lockout to prevent students from connecting oauth accounts without parent permission', () => {
     it('disables the connect buttons when personal account linking is disabled', () => {
       const wrapper = mount(


### PR DESCRIPTION
Currently, LTI unlinking is allowed when a password is added to their account. However, adding a password does not add an email authentication option, so unlinking errors out because there is not an alternate authentication option. 

To avoid confusion, this PR disallows LTI account unlinking when there are no other authentication options for that account.


## Links
Jira: [P20-1284](https://codedotorg.atlassian.net/browse/P20-1284)

## Testing story

Tests added to `ManageLinkedAccountsTests.jsx`
