### PR TITLE
Simplify Session Store `pool_size` Config

### DIFF
--- a/dashboard/config/initializers/session_store.rb
+++ b/dashboard/config/initializers/session_store.rb
@@ -11,7 +11,7 @@ Dashboard::Application.config.session_store Middlewares::RedisSessionStore,
   # Users who interact with the site at least once a month will remain logged in.
   expire_after: 40.days,
 
-  # Enable pooling by specifying a pool size; we aribtrarily use the value this
+  # Enable pooling by specifying a pool size; we arbitrarily use the value this
   # would default to anyway, for simplicity. In practice, we run with enough
   # parallel worker processes in production that we only use an average of
   # ~1.34 connections per pool, so this could be reduced if desired.

--- a/dashboard/config/initializers/session_store.rb
+++ b/dashboard/config/initializers/session_store.rb
@@ -11,18 +11,8 @@ Dashboard::Application.config.session_store Middlewares::RedisSessionStore,
   # Users who interact with the site at least once a month will remain logged in.
   expire_after: 40.days,
 
-  # At 4 connections per thread, up to 5 threads per worker, and 48 workers per
-  # server, we expect 960 connections per server for each instance of this
-  # session store. AWS enforces an absolute maximum of 65k connections per
-  # cluster and we initialize more than one instance, so this number is our
-  # primary bottleneck for being able to scale the session store.
-  #
-  # TODO infra: determine if this limit can be further reduced without
-  # negatively impacting the performance of our web application servers.
-  pool_size: 4,
-
-  # In the interest of minimizing total connections per server and because the
-  # secondary instance of the session store we initialize for Pegasus has lower
-  # traffic than the one used by Dashboard, we specify a lower pool limit for
-  # that instance; see lib/cdo/rack/request.rb for example usage.
-  secondary_pool_size: 2
+  # Enable pooling by specifying a pool size; we aribtrarily use the value this
+  # would default to anyway, for simplicity. In practice, we run with enough
+  # parallel worker processes in production that we only use an average of
+  # ~1.34 connections per pool, so this could be reduced if desired.
+  pool_size: 5

--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -143,16 +143,10 @@ module Cdo
     # Initialize a private instance of the SessionStore used in Dashboard, so
     # we can access data stored there (ie, the id of the current user).
     private def dashboard_session_store
-      @@dashboard_session_store ||=
-        begin
-          # Configure this instance exactly the same as the primary instance, with one
-          # exception: the number of connections per thread we allow it to maintain.
-          # See dashboard/config/initializers/session_store.rb for more details.
-          options = Dashboard::Application.config.session_options.merge(
-            pool_size: Dashboard::Application.config.session_options.fetch(:secondary_pool_size)
-          )
-          Dashboard::Application.config.session_store.new(Dashboard::Application, options)
-        end
+      @@dashboard_session_store ||= Dashboard::Application.config.session_store.new(
+        Dashboard::Application,
+        Dashboard::Application.config.session_options.merge
+      )
     end
   end
 end

--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -145,7 +145,7 @@ module Cdo
     private def dashboard_session_store
       @@dashboard_session_store ||= Dashboard::Application.config.session_store.new(
         Dashboard::Application,
-        Dashboard::Application.config.session_options.merge
+        Dashboard::Application.config.session_options
       )
     end
   end


### PR DESCRIPTION
As a follow-up to https://github.com/code-dot-org/code-dot-org/pull/62635, this PR removes some of the earlier and less effective attempts at bringing our connection count down, restoring us to the default configuration.



## Links

The specific PRs this one effectively reverts:
- https://github.com/code-dot-org/code-dot-org/pull/62580
- https://github.com/code-dot-org/code-dot-org/pull/62394

[The CloudWatch metrics I examined](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~(expression~'m1*2fm2~label~'ConnectionsPerInstance~id~'e1~stat~'Maximum~period~300~yAxis~'right))~(~(expression~'e1*2f*2848*2b24*29~label~'ConnectionsPerPool~id~'e2~yAxis~'left))~(~'AWS*2fElastiCache~'CurrConnections~'CacheClusterId~'ausxf3ubdbzebgu-001~'CacheNodeId~'0001~(id~'m1~visible~false))~(~'AWS*2fAutoScaling~'GroupInServiceInstances~'AutoScalingGroupName~'Frontends-autoscale-prod~(id~'m2~yAxis~'left~visible~false)))~region~'us-east-1~title~'Current*20Connections~stat~'Maximum~view~'timeSeries~start~'-PT12H~end~'P0D~period~300)&query=~'*7bAWS*2fAutoScaling*2cAutoScalingGroupName*7d*20instances)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
