### PR TITLE
Fixing text overflow in GeneratedCode modal

### DIFF
--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1223,10 +1223,10 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
     }
 
     .generated-code-container {
-      margin: 25px 10px 25px -80px;
+      margin: 25px 10px 25px 0;
 
       html[dir="rtl"] & {
-        margin: 25px -80px 25px 10px;
+        margin: 25px 0 25px 10px;
       }
     }
   }


### PR DESCRIPTION
When viewing the GeneratedCode modal in a Right-to-Left (RTL) language, the text is overflowing outside the modal. This is due to a -80px right margin. The LTR languages were not having this issue because there was a different CSS attribute overriding the left-margin to be 0px. The -80px might be an artifact from an old version of this modal. This PR updates the CSS of the component to match the current expectations.

Before | After
---|---
![image](https://github.com/user-attachments/assets/8394d81d-9cbf-4ca1-bda8-7ff4e1731188)|![Screenshot 2024-11-26 at 2 06 35 PM](https://github.com/user-attachments/assets/cb1af615-1456-4828-acbc-8692e10b3fbb)


## Links
* [Jira](https://codedotorg.atlassian.net/issues/P20-1313)

## Testing story
* Manually tested on http://localhost-studio.code.org:3000/s/coursed-2022/lessons/13/levels/1/lang/fa

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

