### PR TITLE
Teacher nav course overview redirect

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -30,6 +30,16 @@ class CoursesController < ApplicationController
   end
 
   def show
+    if experiment.enabled?(current_user, nil, 'teacher-local-nav-v2')
+      if !params[:section_id] && current_user&.last_section_id
+        redirect_to "/teacher_dashboard/sections/#{current_user.last_section_id}/courses/#{@unit_group.name}"
+        return
+      elsif params[:section_id]
+        redirect_to "/teacher_dashboard/sections/#{params[:section_id]}/courses/#{@unit_group.name}"
+        return
+      end
+    end
+
     if !params[:section_id] && current_user&.last_section_id
       redirect_to "#{request.path}?section_id=#{current_user.last_section_id}"
       return

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -30,7 +30,7 @@ class CoursesController < ApplicationController
   end
 
   def show
-    if experiment.enabled?(current_user, nil, 'teacher-local-nav-v2')
+    if Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') && current_user.sections_instructed.any? {|s| s.course_id == @unit_group.id}
       if !params[:section_id] && current_user&.last_section_id
         redirect_to "/teacher_dashboard/sections/#{current_user.last_section_id}/courses/#{@unit_group.name}"
         return

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -362,6 +362,18 @@ class CoursesControllerTest < ActionController::TestCase
     assert_response :ok
   end
 
+  test "show: teacher in teacher-local-nav-v2 experiment is redirected to teacher dashboard if course is in a section" do
+    experiment_course = create :unit_group, name: 'experiment-course', family_name: 'experiment-course', version_year: '2024', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    experiment_teacher = create :teacher
+    experiment_section = create :section, user: experiment_teacher, unit_group: experiment_course
+    SingleUserExperiment.find_or_create_by!(min_user_id: experiment_teacher.id, name: 'teacher-local-nav-v2')
+
+    sign_in experiment_teacher
+
+    get :show, params: {course_name: 'experiment-course'}
+    assert_redirected_to "/teacher_dashboard/sections/#{experiment_section.id}/courses/#{experiment_course.name}"
+  end
+
   no_access_msg = "You don&#39;t have access to this course."
 
   test_user_gets_response_for :show, response: :redirect, user: nil,


### PR DESCRIPTION
Adds redirect to course_controller that sends the teacher to the teacher dashboard course overview if they are in the teacher-local-nav-v2 experiment and have a section with that course.

## Links

[TEACH-1335](https://codedotorg.atlassian.net/browse/TEACH-1335)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Unit test added to test redirect

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
