### PR TITLE
Ensure LoginTypePicker modal scrolls the full height of content

### DIFF
--- a/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
@@ -124,8 +124,9 @@ const AddSectionDialog = ({
         useUpdatedStyles
         fixedWidth={1010}
         isOpen={isOpen}
-        overflow="hidden"
+        overflow="auto"
         uncloseable
+        style={{overflow: 'hidden'}}
       >
         <PadAndCenter>{getDialogContent()}</PadAndCenter>
       </BaseDialog>


### PR DESCRIPTION
Platform recently [added cards with LMS documentation links](https://github.com/code-dot-org/code-dot-org/pull/60410) to the bottom of the LoginTypePicker modal. This significantly increased the height of content in the modal, especially if the user has their logins configured in a way that causes lots of cards to show up. The modal has many divs, some of which are set to scroll, but the important one wasn't. When the user resizes the window to the point where the content no longer fits, no scroll bar appears.

This changes the correct div to the scrollable. It also changes a different div to `overflow: hidden` to avoid a double scroll bar. This looks odd in the code, but that seems to just be the way this component is set up. It's super old.

Video of the modal now scrolling all the way top to bottom, even with the window made small:

https://github.com/user-attachments/assets/1068745a-4bb1-49ee-8bf8-4e23816ce00f

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1317)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
