### PR TITLE
Music: retry loading if cookies have expired

### DIFF
--- a/apps/src/music/player/SoundCache.ts
+++ b/apps/src/music/player/SoundCache.ts
@@ -1,6 +1,6 @@
 import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
-import HttpClient from '@cdo/apps/util/HttpClient';
+import HttpClient, {isNetworkError} from '@cdo/apps/util/HttpClient';
 import {fetchSignedCookies} from '@cdo/apps/utils';
 
 import {baseAssetUrlRestricted} from '../constants';
@@ -16,17 +16,14 @@ class SoundCache {
     return SoundCache.instance;
   }
 
-  private readonly audioContext: AudioContext;
-  private readonly metricsReporter: LabMetricsReporter;
   private audioBuffers: {[id: string]: AudioBuffer};
   private hasLoadedSignedCookies: boolean;
 
-  private constructor(
-    audioContext: AudioContext = new AudioContext(),
-    metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter()
+  constructor(
+    private readonly audioContext: AudioContext = new AudioContext(),
+    private readonly metricsReporter: LabMetricsReporter = Lab2Registry.getInstance().getMetricsReporter(),
+    private readonly httpClient: typeof HttpClient = HttpClient
   ) {
-    this.audioContext = audioContext;
-    this.metricsReporter = metricsReporter;
     this.audioBuffers = {};
     this.hasLoadedSignedCookies = false;
   }
@@ -123,13 +120,15 @@ class SoundCache {
     }
     const startTime = Date.now();
 
-    const verified = await this.verifyUrl(url);
-    if (!verified) {
-      // Error is logged below
-      return;
+    // Fetch signed cookies if necessary
+    if (
+      url.startsWith(baseAssetUrlRestricted) &&
+      !this.hasLoadedSignedCookies
+    ) {
+      await this.refreshSignedCookies();
     }
 
-    const response = await HttpClient.get(url);
+    const response = await this.fetchSoundFromUrl(url);
     const arrayBuffer = await response.arrayBuffer();
     const audioBuffer = await this.audioContext.decodeAudioData(arrayBuffer);
     this.audioBuffers[url] = audioBuffer;
@@ -145,30 +144,29 @@ class SoundCache {
     this.audioBuffers = {};
   }
 
-  private async verifyUrl(path: string): Promise<boolean | null> {
-    const restricted = path.startsWith(baseAssetUrlRestricted);
-
-    let canLoadRestrictedContent = this.hasLoadedSignedCookies;
-    if (restricted && !this.hasLoadedSignedCookies) {
-      try {
-        const response = await fetchSignedCookies();
-        if (response.ok) {
-          canLoadRestrictedContent = true;
-          this.hasLoadedSignedCookies = true;
-        }
-      } catch (error) {
-        this.metricsReporter.logError(
-          'Error loading signed cookies',
-          error as Error
-        );
+  private async fetchSoundFromUrl(url: string) {
+    try {
+      const response = await this.httpClient.get(url);
+      return response;
+    } catch (error) {
+      if (isNetworkError(error) && error.response.status === 403) {
+        // Cloudfront cookies may have expired. Try refreshing and fetch again.
+        // If this fails, the error will be caught and logged.
+        await this.refreshSignedCookies();
+        return this.httpClient.get(url);
+      } else {
+        throw error;
       }
     }
+  }
 
-    if (restricted && !canLoadRestrictedContent) {
-      return false;
+  private async refreshSignedCookies(): Promise<void> {
+    const response = await fetchSignedCookies();
+    if (response.ok) {
+      this.hasLoadedSignedCookies = true;
+    } else {
+      throw new Error(`Failed to refresh signed cookies: ${response.status}`);
     }
-
-    return true;
   }
 }
 

--- a/apps/src/util/HttpClient.ts
+++ b/apps/src/util/HttpClient.ts
@@ -12,6 +12,11 @@ export type GetResponse<ResponseType> = {
   response: Response;
 };
 
+// Narrow the type of an error to NetworkError
+export function isNetworkError(error: unknown): error is NetworkError {
+  return error instanceof NetworkError;
+}
+
 /**
  * Error thrown by these functions when the response is not ok, which includes a
  * reference to the response object.

--- a/apps/test/unit/music/player/SoundCacheTest.ts
+++ b/apps/test/unit/music/player/SoundCacheTest.ts
@@ -1,0 +1,163 @@
+import LabMetricsReporter from '@cdo/apps/lab2/Lab2MetricsReporter';
+import SoundCache from '@cdo/apps/music/player/SoundCache';
+import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
+import {fetchSignedCookies} from '@cdo/apps/utils';
+import '@testing-library/jest-dom';
+
+jest.mock('@cdo/apps/utils');
+
+const UNRESTRICTED_SOUND = 'sound.mp3';
+const RESTRICTED_SOUND = '/restricted/musiclab/restricted.mp3';
+
+describe('SoundCache', () => {
+  let audioBuffer: AudioBuffer;
+  let arrayBuffer: ArrayBuffer;
+  let validResponse: Response;
+  let soundCache: SoundCache;
+  let audioContext: jest.Mocked<AudioContext>;
+  let metricsReporter: jest.Mocked<LabMetricsReporter>;
+  let httpClient: jest.Mocked<typeof HttpClient>;
+  let fetchSignedCookiesMock: jest.MockedFunction<typeof fetchSignedCookies>;
+
+  beforeEach(() => {
+    audioBuffer = {} as AudioBuffer;
+    arrayBuffer = new ArrayBuffer(0);
+    validResponse = new Response(arrayBuffer);
+
+    audioContext = {
+      decodeAudioData: jest.fn(),
+    } as unknown as jest.Mocked<AudioContext>;
+
+    metricsReporter = {
+      logError: jest.fn(),
+      publishMetric: jest.fn(),
+      reportLoadTime: jest.fn(),
+    } as unknown as jest.Mocked<LabMetricsReporter>;
+
+    httpClient = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<typeof HttpClient>;
+
+    fetchSignedCookiesMock = jest.mocked(fetchSignedCookies);
+    fetchSignedCookiesMock.mockResolvedValue(new Response(null, {status: 200}));
+
+    httpClient.get.mockResolvedValue(validResponse);
+    audioContext.decodeAudioData.mockResolvedValue(audioBuffer);
+
+    soundCache = new SoundCache(audioContext, metricsReporter, httpClient);
+  });
+
+  describe('loadSound', () => {
+    it('loads non-restricted sound from URL', async () => {
+      expect(await soundCache.loadSound(UNRESTRICTED_SOUND)).toBe(audioBuffer);
+
+      expect(fetchSignedCookiesMock).not.toHaveBeenCalled();
+      expect(httpClient.get).toHaveBeenCalledWith(UNRESTRICTED_SOUND);
+      expect(audioContext.decodeAudioData).toHaveBeenCalledWith(arrayBuffer);
+      expect(metricsReporter.reportLoadTime).toHaveBeenCalledWith(
+        'SoundCache.SingleSoundLoadTime',
+        expect.any(Number)
+      );
+    });
+
+    it('returns sound from cache if already loaded', async () => {
+      // Load sound into cache
+      expect(await soundCache.loadSound(UNRESTRICTED_SOUND)).toBe(audioBuffer);
+      expect(httpClient.get).toHaveBeenCalled();
+
+      // Clear mocks
+      httpClient.get.mockClear();
+      // Load again
+      expect(await soundCache.loadSound(UNRESTRICTED_SOUND)).toBe(audioBuffer);
+      expect(httpClient.get).not.toHaveBeenCalled();
+    });
+
+    it('fetches signed cookies for restricted sound', async () => {
+      expect(await soundCache.loadSound(RESTRICTED_SOUND)).toBe(audioBuffer);
+
+      expect(fetchSignedCookiesMock).toHaveBeenCalled();
+      expect(httpClient.get).toHaveBeenCalledWith(RESTRICTED_SOUND);
+      expect(audioContext.decodeAudioData).toHaveBeenCalledWith(arrayBuffer);
+    });
+
+    it('does not fetch signed cookies if already loaded', async () => {
+      // Load restricted sound
+      expect(await soundCache.loadSound(RESTRICTED_SOUND)).toBe(audioBuffer);
+      expect(fetchSignedCookiesMock).toHaveBeenCalled();
+
+      // Clear mocks
+      fetchSignedCookiesMock.mockClear();
+      // Load again
+      expect(await soundCache.loadSound(RESTRICTED_SOUND)).toBe(audioBuffer);
+      expect(fetchSignedCookiesMock).not.toHaveBeenCalled();
+    });
+
+    it('retries fetching restricted sound if cookies expire', async () => {
+      httpClient.get
+        .mockRejectedValueOnce(
+          new NetworkError('Forbidden', new Response(null, {status: 403}))
+        )
+        .mockResolvedValueOnce(validResponse);
+
+      expect(await soundCache.loadSound(RESTRICTED_SOUND)).toBe(audioBuffer);
+
+      expect(fetchSignedCookiesMock).toHaveBeenCalledTimes(2);
+      expect(httpClient.get).toHaveBeenCalledTimes(2);
+      expect(audioContext.decodeAudioData).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws an error if fetching signed cookies fails', async () => {
+      fetchSignedCookiesMock.mockResolvedValue(
+        new Response(null, {status: 500})
+      );
+
+      await expect(soundCache.loadSound(RESTRICTED_SOUND)).rejects.toThrow(
+        'Failed to refresh signed cookies: 500'
+      );
+
+      expect(fetchSignedCookiesMock).toHaveBeenCalled();
+      expect(httpClient.get).not.toHaveBeenCalled();
+      expect(audioContext.decodeAudioData).not.toHaveBeenCalled();
+    });
+
+    it('throw an error if fetching signed cookies throws an error', async () => {
+      fetchSignedCookiesMock.mockRejectedValue(
+        new TypeError('Failed to fetch')
+      );
+
+      await expect(soundCache.loadSound(RESTRICTED_SOUND)).rejects.toThrow(
+        'Failed to fetch'
+      );
+
+      expect(fetchSignedCookiesMock).toHaveBeenCalled();
+      expect(httpClient.get).not.toHaveBeenCalled();
+      expect(audioContext.decodeAudioData).not.toHaveBeenCalled();
+    });
+
+    it('throws an error if fetching sound fails with a non-403 error', async () => {
+      httpClient.get.mockRejectedValue(
+        new NetworkError('Internal Error', new Response(null, {status: 500}))
+      );
+
+      await expect(soundCache.loadSound(UNRESTRICTED_SOUND)).rejects.toThrow(
+        'Internal Error'
+      );
+
+      expect(httpClient.get).toHaveBeenCalled();
+      expect(audioContext.decodeAudioData).not.toHaveBeenCalled();
+    });
+
+    it('throws an error if decoding audio data fails', async () => {
+      audioContext.decodeAudioData.mockRejectedValue(
+        new DOMException('Decoding Error')
+      );
+
+      await expect(soundCache.loadSound(UNRESTRICTED_SOUND)).rejects.toThrow(
+        'Decoding Error'
+      );
+
+      expect(httpClient.get).toHaveBeenCalled();
+      expect(audioContext.decodeAudioData).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
I reviewed our sound load error logs after https://github.com/code-dot-org/code-dot-org/pull/62595 was released and found that ~1/2 of all the errors are a "403 Forbidden" of some kind. This led me to realize that unlike Dance Party (another lab where we fetch licensed content), Music Lab does not currently have a mechanism to refresh Cloudfront cookies if they've expired during a session, which could very well happen if students are on the same lesson for more than an hour. This change adds that, along with some minor code refactors and unit tests. While I'm not 100% certain this is the cause of the 403 errors, I'm hopefully that this should help drive down errors by a decent amount.

## Testing story

Tested locally by manually invalidating cookies after starting the HOC progression, and confirmed that cookies are re-fetched and sounds are successfully downloaded on later levels. Also added unit tests as this does make some changes in fairly critical code, close to Hour of Code.
