### PR TITLE
Revert "Evaluate Student Learning: log App Lab run and finish clicks to ULI"

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -15,9 +15,7 @@ import autogenerateML from '@cdo/apps/applab/ai';
 import * as aiConfig from '@cdo/apps/applab/ai/dropletConfig';
 import SmallFooter from '@cdo/apps/code-studio/components/SmallFooter';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
-import {logUserLevelInteraction} from '@cdo/apps/userLevelInteractionsLogger/userLevelInteractionsApi';
 import {workspace_running_background, white} from '@cdo/apps/util/color';
-import {UserLevelInteractions} from '@cdo/generated-scripts/sharedConstants';
 import commonMsg from '@cdo/locale';
 
 import annotationList from '../acemode/annotationList';
@@ -1102,13 +1100,6 @@ Applab.serializeAndSave = function (callback) {
  */
 // XXX This is the only method used by the templates!
 Applab.runButtonClick = function () {
-  const levelId = studioApp().config.serverLevelId;
-  const scriptId = studioApp().config.serverScriptId;
-  logUserLevelInteraction({
-    levelId: levelId,
-    scriptId: scriptId,
-    interaction: UserLevelInteractions.click_run,
-  });
   Sounds.getSingleton().unmuteURLs();
   studioApp().toggleRunReset('reset');
   if (studioApp().isUsingBlockly()) {
@@ -1299,13 +1290,6 @@ function onInterfaceModeChange(mode) {
 }
 
 Applab.onPuzzleFinish = function () {
-  const levelId = studioApp().config.serverLevelId;
-  const scriptId = studioApp().config.serverScriptId;
-  logUserLevelInteraction({
-    levelId: levelId,
-    scriptId: scriptId,
-    interaction: UserLevelInteractions.click_finish,
-  });
   Applab.onPuzzleComplete(false); // complete without submitting
 };
 

--- a/dashboard/app/controllers/user_level_interactions_controller.rb
+++ b/dashboard/app/controllers/user_level_interactions_controller.rb
@@ -48,7 +48,7 @@ class UserLevelInteractionsController < ApplicationController
     user_level_interaction_params[:user_id] = current_user.id
     user_level_interaction_params[:school_year] = school_year
     unit = Unit.find(user_level_interaction_params[:script_id])
-    version_year = unit.get_course_version&.key
+    version_year = unit.version_year
     level = Level.find(user_level_interaction_params[:level_id])
     project_data = get_project_and_version_id(user_level_interaction_params[:level_id], user_level_interaction_params[:script_id])
     user_level_interaction_params[:code_version] = project_data[:version_id]

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -45,8 +45,6 @@ module SharedConstants
   USER_LEVEL_INTERACTIONS = OpenStruct.new(
     {
       click_help_and_tips: "click_help_and_tips",
-      click_run: "click_run",
-      click_finish: "click_finish",
     }
   ).freeze
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#62586

I'm seeing failures as DOTD on both Chrome and Safari [teacher_tools/projects/applab_project.feature](https://github.com/code-dot-org/code-dot-org/blob/test/dashboard/test/ui/features/teacher_tools/projects/applab_project.feature) in the latest DTT. Of the [commits in that PR](https://github.com/code-dot-org/code-dot-org/pull/62697/files), mine seem most likely to be the culprit so I'm going to revert and see if that helps. 