### PR TITLE
Music: execute code after load

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -503,6 +503,10 @@ export default class MusicBlocklyWorkspace {
     }
     this.workspace.clearUndo();
 
+    // Clear the record of the last executed code so that if the new code
+    // happens to match it, we actually execute it.
+    this.lastExecutedEvents = {};
+
     // Ensure that we have an extensible object for Blockly.
     const codeCopy = JSON.parse(JSON.stringify(code));
 


### PR DESCRIPTION
This fixes an issue in which switching to a new level which happened to have the same code as the last-loaded level would result in execution of the new code being skipped, leading to an empty timeline when it should have had events.  

Now, after loading code, we clear the record of the last executed code, so that the new code is always executed. 
