### PR TITLE
Adds conditional asterisks to school data inputs for required AB test

### DIFF
--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -220,7 +220,11 @@ const FinishTeacherAccount: React.FunctionComponent<{
               </BodyThreeText>
             )}
           </div>
-          <SchoolDataInputs {...schoolInfo} includeHeaders={false} />
+          <SchoolDataInputs
+            {...schoolInfo}
+            includeHeaders={false}
+            markFieldsAsRequired={isInSchoolRequiredExperiment}
+          />
           {showGDPR && (
             <div>
               <BodyThreeText

--- a/apps/src/templates/SchoolDataInputs.jsx
+++ b/apps/src/templates/SchoolDataInputs.jsx
@@ -38,6 +38,7 @@ export default function SchoolDataInputs({
   setSchoolZip,
   usIp,
   includeHeaders = true,
+  markFieldsAsRequired = false,
   fieldNames = {
     country: 'user[school_info_attributes][country]',
     ncesSchoolId: 'user[school_info_attributes][school_id]',
@@ -88,8 +89,12 @@ export default function SchoolDataInputs({
 
   const labelClassName = schoolZipIsValid ? '' : style.disabledLabel;
 
+  const computedStyleClass = classNames(style.schoolAssociationWrapper, {
+    [style.requiredLabel]: markFieldsAsRequired,
+  });
+
   return (
-    <div className={style.schoolAssociationWrapper}>
+    <div className={computedStyleClass}>
       {includeHeaders && (
         <div className={style.headerContainer}>
           <Heading2>{i18n.censusHeading()}</Heading2>
@@ -205,6 +210,7 @@ export default function SchoolDataInputs({
 
 SchoolDataInputs.propTypes = {
   includeHeaders: PropTypes.bool,
+  markFieldsAsRequired: PropTypes.bool,
   fieldNames: PropTypes.object,
   schoolId: PropTypes.string.isRequired,
   country: PropTypes.string.isRequired,

--- a/apps/src/templates/school-association.module.scss
+++ b/apps/src/templates/school-association.module.scss
@@ -52,6 +52,12 @@
   gap: 1.125rem;
 }
 
+.schoolAssociationWrapper.requiredLabel label {
+  span::after {
+    content: '*';
+  }
+}
+
 .disabledLabel {
   span {
     color: $light_gray_300 !important;


### PR DESCRIPTION
This PR adds the asterisks to the labels of the school data input fields when the user is in the 'School association required' AB test!

Before:
<img width="711" alt="Screenshot 2024-11-27 at 10 41 27 AM" src="https://github.com/user-attachments/assets/1f6f285c-ab3c-4433-b0f2-4fa2adfcbf79">

After (when in test group):
<img width="746" alt="Screenshot 2024-11-27 at 11 18 34 AM" src="https://github.com/user-attachments/assets/5c38ec4e-4ddc-43b0-ab1d-12cdff57c484">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2829

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
