### PR TITLE
Prevent user aidiff message while waiting for AI response

### DIFF
--- a/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
+++ b/apps/src/aiDifferentiation/AiDiffChatFooter.tsx
@@ -14,18 +14,20 @@ interface AiDiffChatFooterProps {
   onSubmit: (msg: string) => void;
   onSuggestPrompts: () => void;
   messages: ChatItem[];
+  waiting: boolean;
 }
 
 const AiDiffChatFooter: React.FC<AiDiffChatFooterProps> = ({
   onSubmit,
   onSuggestPrompts,
   messages,
+  waiting,
 }) => {
   return (
     <div className={style.chatFooter}>
       <UserMessageEditor
         onSubmit={onSubmit}
-        disabled={false}
+        disabled={waiting}
         customPlaceholder={commonI18n.aiDifferentiation_write_message()}
       />
       <div className={style.chatFooterButtons}>

--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -271,6 +271,7 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
             onSubmit={onMessageSend}
             onSuggestPrompts={onSuggestPrompts}
             messages={messageHistory}
+            waiting={isWaitingForResponse}
           />
         </div>
       </div>

--- a/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
+++ b/apps/test/unit/aiDifferentiation/AiDiffContainerTest.jsx
@@ -166,6 +166,10 @@ describe('AiDiffContainer', () => {
     expect(submit_btn).toBeEnabled();
     fireEvent.click(submit_btn);
 
+    //After click, but before server response, user message editor should be disabled
+    expect(submit_btn).not.toBeEnabled();
+    expect(textbox).not.toBeEnabled();
+
     const responseEventData = {
       lessonId: 2,
       lessonName: 'test_lesson',
@@ -220,6 +224,9 @@ describe('AiDiffContainer', () => {
     expect(
       screen.getAllByLabelText(i18n.aiChatMessageBot())[1]
     ).toHaveTextContent("Beep boop I'm a bot");
+
+    //User message editor should be enabled once we have a server response
+    expect(submit_btn).not.toBeEnabled();
   });
 
   it('Selecting a prompt does nothing if there are more recent messages', async () => {


### PR DESCRIPTION
Small change to disable the user message editor while waiting for a response from bedrock. AWS bedrock throws an error if there are multiple retrieve_and_generate requests on the same sessionID, i.e. sending a multiple chats in a row.

<img width="514" alt="Screenshot 2024-11-27 at 1 49 47 PM" src="https://github.com/user-attachments/assets/3adfef5f-96dc-4db9-9af1-d6f2721102d1">


## Links

Jira ticket: https://codedotorg.atlassian.net/browse/AITT-870

## Testing story

Modified apps unit test to test this change


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
