### PR TITLE
Add feedback link to the congrats dialog for signed-in users

### DIFF
--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -23,8 +23,10 @@ import i18n from '@cdo/locale';
 
 import moduleStyles from './share-dialog.module.scss';
 
-const TEACHER_FEEDBACK_LINK = 'https://docs.google.com/forms/d/e/1FAIpQLSflGeMmY_ff1QllJfpTsWGZdn_xv6dKpPba_evTMwfbvG3FTA/viewform';
-const STUDENT_FEEDBACK_LINK = 'https://docs.google.com/forms/d/e/1FAIpQLSeZGNgX4wDvA29stId_Q2toofJN-r12zSP8yBMZ-E9KW5XPWg/viewform';
+const TEACHER_FEEDBACK_LINK =
+  'https://docs.google.com/forms/d/e/1FAIpQLSflGeMmY_ff1QllJfpTsWGZdn_xv6dKpPba_evTMwfbvG3FTA/viewform';
+const STUDENT_FEEDBACK_LINK =
+  'https://docs.google.com/forms/d/e/1FAIpQLSeZGNgX4wDvA29stId_Q2toofJN-r12zSP8yBMZ-E9KW5XPWg/viewform';
 
 const CopyToClipboardButton: React.FunctionComponent<{
   shareUrl: string;

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -15,7 +15,7 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {SubmissionStatusType} from '@cdo/apps/templates/projects/submitProjectDialog/submitProjectApi';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
-import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
+import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import trackEvent from '@cdo/apps/util/trackEvent';
 import {ProjectSubmissionStatus} from '@cdo/generated-scripts/sharedConstants';
 import i18n from '@cdo/locale';

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -17,9 +17,14 @@ import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import trackEvent from '@cdo/apps/util/trackEvent';
 import {ProjectSubmissionStatus} from '@cdo/generated-scripts/sharedConstants';
+import {SignInState} from '@cdo/apps/templates/currentUserRedux';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import moduleStyles from './share-dialog.module.scss';
+
+const TEACHER_FEEDBACK_LINK = 'https://docs.google.com/forms/d/e/1FAIpQLSflGeMmY_ff1QllJfpTsWGZdn_xv6dKpPba_evTMwfbvG3FTA/viewform';
+const STUDENT_FEEDBACK_LINK = 'https://docs.google.com/forms/d/e/1FAIpQLSeZGNgX4wDvA29stId_Q2toofJN-r12zSP8yBMZ-E9KW5XPWg/viewform';
 
 const CopyToClipboardButton: React.FunctionComponent<{
   shareUrl: string;
@@ -165,6 +170,14 @@ const ShareDialog: React.FunctionComponent<{
     );
   }, [channelId, dispatch, projectType]);
 
+  const feedbackLink = useAppSelector(state => {
+    const {userType, signInState} = state.currentUser;
+    if (signInState !== SignInState.SignedIn) return undefined;
+    return userType === 'teacher'
+      ? TEACHER_FEEDBACK_LINK
+      : STUDENT_FEEDBACK_LINK;
+  });
+
   return (
     <FocusLock>
       <div className={moduleStyles.dialogContainer}>
@@ -217,36 +230,49 @@ const ShareDialog: React.FunctionComponent<{
             )}
           </div>
           <div className={moduleStyles.bottom}>
-            {finishUrl ? (
-              <div className={moduleStyles.contents}>
+            {feedbackLink && (
+              <a
+                href={feedbackLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={moduleStyles.feedbackLink}
+                aria-label={i18n.feedbackHeader()}
+              >
+                {i18n.feedbackHeader()}
+              </a>
+            )}
+            <div className={moduleStyles.buttonGroup}>
+              {finishUrl ? (
+                <div className={moduleStyles.contents}>
+                  <Button
+                    ariaLabel={i18n.keepPlaying()}
+                    text={i18n.keepPlaying()}
+                    type="secondary"
+                    color="white"
+                    size="m"
+                    onClick={handleClose}
+                    className={moduleStyles.keepPlayingButton}
+                  />
+                  <LinkButton
+                    ariaLabel={i18n.finish()}
+                    href={finishUrl}
+                    text={i18n.finish()}
+                    type="primary"
+                    color="white"
+                    size="m"
+                  />
+                </div>
+              ) : (
                 <Button
-                  ariaLabel={i18n.keepPlaying()}
-                  text={i18n.keepPlaying()}
-                  type="secondary"
-                  color="white"
-                  size="m"
-                  onClick={handleClose}
-                  className={moduleStyles.keepPlayingButton}
-                />
-                <LinkButton
-                  ariaLabel={i18n.finish()}
-                  href={finishUrl}
-                  text={i18n.finish()}
+                  ariaLabel={i18n.done()}
+                  text={i18n.done()}
                   type="primary"
                   color="white"
                   size="m"
+                  onClick={handleClose}
                 />
-              </div>
-            ) : (
-              <Button
-                ariaLabel={i18n.done()}
-                text={i18n.done()}
-                type="primary"
-                color="white"
-                size="m"
-                onClick={handleClose}
-              />
-            )}
+              )}
+            </div>
           </div>
           <button
             type="button"

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -12,13 +12,12 @@ import DCDO from '@cdo/apps/dcdo';
 import {ProjectType} from '@cdo/apps/lab2/types';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {SubmissionStatusType} from '@cdo/apps/templates/projects/submitProjectDialog/submitProjectApi';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import {useAppDispatch} from '@cdo/apps/util/reduxHooks';
 import trackEvent from '@cdo/apps/util/trackEvent';
 import {ProjectSubmissionStatus} from '@cdo/generated-scripts/sharedConstants';
-import {SignInState} from '@cdo/apps/templates/currentUserRedux';
-import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import moduleStyles from './share-dialog.module.scss';

--- a/apps/src/lab2/views/dialogs/ShareDialog.tsx
+++ b/apps/src/lab2/views/dialogs/ShareDialog.tsx
@@ -232,7 +232,7 @@ const ShareDialog: React.FunctionComponent<{
             )}
           </div>
           <div className={moduleStyles.bottom}>
-            {feedbackLink && (
+            {feedbackLink && finishUrl && (
               <a
                 href={feedbackLink}
                 target="_blank"

--- a/apps/src/lab2/views/dialogs/share-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/share-dialog.module.scss
@@ -124,6 +124,7 @@
     .buttonGroup {
       display: flex;
       gap: 14px;
+      margin-left: auto;
     }
   }
 }

--- a/apps/src/lab2/views/dialogs/share-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/share-dialog.module.scss
@@ -107,24 +107,18 @@
 
   .bottom {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    flex-direction: row;
-    gap: 14px;
-    width: 100%;
 
     .feedbackLink {
       display: flex;
-      align-items: center;
       color: $neutral_light;
       text-decoration: underline;
-      font-size: 14px;
     }
 
     .buttonGroup {
       display: flex;
       gap: 14px;
-      margin-left: auto;
+      margin-inline-start: auto;
     }
   }
 }

--- a/apps/src/lab2/views/dialogs/share-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/share-dialog.module.scss
@@ -107,10 +107,24 @@
 
   .bottom {
     display: flex;
+    justify-content: space-between;
+    align-items: center;
     flex-direction: row;
-    justify-content: end;
     gap: 14px;
     width: 100%;
+
+    .feedbackLink {
+      display: flex;
+      align-items: center;
+      color: $neutral_light;
+      text-decoration: underline;
+      font-size: 14px;
+    }
+
+    .buttonGroup {
+      display: flex;
+      gap: 14px;
+    }
   }
 }
 


### PR DESCRIPTION
To collect specific feedback during Hour of Code, we want to surface the same form links as are available in the top right of the Music Lab IDE (dialog button), but in a more intentional, visible location. Signed out users will not see the feedback link. Signed in teachers will get a link to one form, while signed in students will get a link to another.

## Testing story
Tested locally, on Edge, Chrome, and Firefox

_Signed out, English_
![image](https://github.com/user-attachments/assets/f4fb7734-d06c-4317-8e22-df2c54fff5cf)

_Signed out, Arabic_
![image](https://github.com/user-attachments/assets/f5389166-cc8a-4993-bbba-e027b7741af0)

_Signed in, English_
![image](https://github.com/user-attachments/assets/841bd068-5d95-4c26-9a1d-3bb14b465a22)

_Signed in, Arabic_
![image](https://github.com/user-attachments/assets/f8fe4516-03f4-45a9-9ee1-c5fc529dd8c5)

_Signed in student gets one link_
![image](https://github.com/user-attachments/assets/70ed55a7-4fc3-492e-9aa1-96264ba77f55)

_Signed in teacher gets another link_
![image](https://github.com/user-attachments/assets/ce761575-db1c-40c5-838b-8ed51bc0512d)

_Share dialog (no change)_
![image](https://github.com/user-attachments/assets/3a05bcf5-c132-4762-bc5f-cd287945a558)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
Will test extensively on staging

## Follow-up work
- Could consolidate form links into one place, since they are used both here and in apps/src/music/views/HeaderButtons.tsx.
- Need to change dialog "x" button to light and fix for RTL

## Privacy
Forms collect no PII by design (but does have free text fields).

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
