### PR TITLE
Lab2: dialog close icon color

### DIFF
--- a/apps/src/lab2/views/dialogs/share-dialog.module.scss
+++ b/apps/src/lab2/views/dialogs/share-dialog.module.scss
@@ -98,6 +98,7 @@
       position: absolute;
       top: 0;
       right: 0;
+      color: $neutral_dark30;
 
       &Icon {
         font-size: 24px;


### PR DESCRIPTION
Update the close icon color in the Lab2 share dialog (used for sharing in Music Lab and Python Lab, and for congrats in Music Lab).