### PR TITLE
Update comment for music lab mini-player channel id retrieval

### DIFF
--- a/dashboard/app/controllers/musiclab_controller.rb
+++ b/dashboard/app/controllers/musiclab_controller.rb
@@ -2,8 +2,8 @@ class MusiclabController < ApplicationController
   ANALYTICS_KEY = CDO.amplitude_api_key
   NUM_MINI_PLAYER_PROJECTS = 5
   # The hard-coded list of channel IDs for the mini player if the 'get_channel_ids_from_featured_projects_gallery'
-  # DCDO flag is set to `false`. The default for the DCDO flag is `true` so that the channel IDs are retrieved
-  # from the active music lab featured projects by default. See lines 64-69 below.
+  # DCDO flag is set to `false`. If the DCDO flag is set to `true`, then the channel IDs are randomly selected from
+  # the set of active music lab featured projects. See get_selected_channel_ids below.
   CHANNELS = %w(
     RSDgNPmToACl-JRTVYAcTCbF46lyXXPRWOsHISyu3kc
     q0wDQmka3QRjS0EIH46XtSIQ_zJfhayM71YEqOAahao

--- a/dashboard/app/controllers/musiclab_controller.rb
+++ b/dashboard/app/controllers/musiclab_controller.rb
@@ -1,7 +1,9 @@
 class MusiclabController < ApplicationController
   ANALYTICS_KEY = CDO.amplitude_api_key
   NUM_MINI_PLAYER_PROJECTS = 5
-  # Hard-coded list of channel IDs for the mini player if DCDO flag is set to `true`
+  # The hard-coded list of channel IDs for the mini player if the 'get_channel_ids_from_featured_projects_gallery'
+  # DCDO flag is set to `false`. The default for the DCDO flag is `true` so that the channel IDs are retrieved
+  # from the active music lab featured projects by default. See lines 64-69 below.
   CHANNELS = %w(
     RSDgNPmToACl-JRTVYAcTCbF46lyXXPRWOsHISyu3kc
     q0wDQmka3QRjS0EIH46XtSIQ_zJfhayM71YEqOAahao


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR updates the comment that discusses the retrieval of music lab channel ids for the mini-player so that it is more accurate. Thanks @breville for pointing this out!


## Links
https://github.com/code-dot-org/code-dot-org/pull/59077/files#r1860197723

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
