### PR TITLE
GenAI: update SNS topic + add browser alarm

### DIFF
--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
@@ -1,8 +1,11 @@
-import {ComparisonOperator} from '@aws-sdk/client-cloudwatch';
+import {
+  ComparisonOperator,
+  PutMetricAlarmInput,
+} from '@aws-sdk/client-cloudwatch';
 
 // TODO: Replace with dependency on shared_constants.rb.
 import modelDescriptions from '../../../../../../apps/static/aichat/modelDescriptions.json';
-import {SNS_TOPIC} from '../constants';
+import {BROWSERS, SNS_TOPIC} from '../constants';
 
 import {
   createJobExecutionMetricStat,
@@ -11,9 +14,10 @@ import {
 
 const modelIds = modelDescriptions.map((model: {id: string}) => model.id);
 
-export const openaiSafetyHighFailureRateConfiguration = {
+export const openaiSafetyHighFailureRateConfiguration: PutMetricAlarmInput = {
   AlarmName: 'genai_openai_safety_high_failure_rate',
-  AlarmDescription: 'genai_openai_safety_high_failure_rate',
+  AlarmDescription:
+    'Alarms when OpenAI safety checks are experiencing a high failure rate.',
   ActionsEnabled: true,
   OKActions: [],
   AlarmActions: [SNS_TOPIC],
@@ -65,38 +69,103 @@ const failureMetrics = modelIds.map((modelId, index) => ({
   ),
 }));
 
-export const chatCompletionJobExecutionHighFailureRateConfiguration = {
-  AlarmName: 'genai_chat_completion_job_execution_high_failure_rate',
-  AlarmDescription: 'genai_chat_completion_job_execution_high_failure_rate',
-  ActionsEnabled: true,
-  OKActions: [],
-  AlarmActions: [SNS_TOPIC],
-  InsufficientDataActions: [],
-  EvaluationPeriods: 5,
-  DatapointsToAlarm: 5,
-  Threshold: 10,
-  ComparisonOperator: ComparisonOperator.GreaterThanThreshold,
-  TreatMissingData: 'missing',
-  Metrics: [
-    {
-      Id: 'failure_rate',
-      Label: 'failure_rate',
-      ReturnData: true,
-      Expression: '100*(failures/total)',
-    },
-    {
-      Id: 'failures',
-      Label: 'failures',
-      ReturnData: false,
-      Expression: 'SUM([m6, m7, m8, m9, m10])',
-    },
-    ...failureMetrics,
-    {
-      Id: 'total',
-      Label: 'total_jobs',
-      ReturnData: false,
-      Expression: 'SUM([m1, m2, m3, m4, m5])',
-    },
-    ...startMetrics,
-  ],
-};
+export const chatCompletionJobExecutionHighFailureRateConfiguration: PutMetricAlarmInput =
+  {
+    AlarmName: 'genai_chat_completion_job_execution_high_failure_rate',
+    AlarmDescription:
+      'Alarms when chat completion jobs are experiencing a high failure rate.',
+    ActionsEnabled: true,
+    OKActions: [],
+    AlarmActions: [SNS_TOPIC],
+    InsufficientDataActions: [],
+    EvaluationPeriods: 5,
+    DatapointsToAlarm: 5,
+    Threshold: 10,
+    ComparisonOperator: ComparisonOperator.GreaterThanThreshold,
+    TreatMissingData: 'missing',
+    Metrics: [
+      {
+        Id: 'failure_rate',
+        Label: 'failure_rate',
+        ReturnData: true,
+        Expression: '100*(failures/total)',
+      },
+      {
+        Id: 'failures',
+        Label: 'failures',
+        ReturnData: false,
+        Expression: 'SUM([m6, m7, m8, m9, m10])',
+      },
+      ...failureMetrics,
+      {
+        Id: 'total',
+        Label: 'total_jobs',
+        ReturnData: false,
+        Expression: 'SUM([m1, m2, m3, m4, m5])',
+      },
+      ...startMetrics,
+    ],
+  };
+
+const browserIndices = BROWSERS.map((_, i) => i + 1);
+
+// TODO: Unify this code with dashboard metrics if possible
+export const chatCompletionHighBrowserFailureRateConfiguration: PutMetricAlarmInput =
+  {
+    AlarmName: 'genai_chat_completion_high_browser_failure_rate',
+    AlarmDescription:
+      'Alarms when browser are experiencing a high failure rate attempting chat completion requests.',
+    ActionsEnabled: true,
+    OKActions: [],
+    AlarmActions: [SNS_TOPIC],
+    InsufficientDataActions: [],
+    EvaluationPeriods: 5,
+    DatapointsToAlarm: 5,
+    Threshold: 10,
+    ComparisonOperator: ComparisonOperator.GreaterThanThreshold,
+    TreatMissingData: 'missing',
+    Metrics: [
+      ...['ChatCompletionRequestInitiated', 'ChatCompletionErrorUnhandled']
+        .map((metric, i) =>
+          BROWSERS.map((browser, j) => ({
+            Id: `m${i + 1}${j + 1}`,
+            MetricStat: {
+              Metric: {
+                Namespace: 'production-browser-metrics',
+                MetricName: `Aichat.${metric}`,
+                Dimensions: [
+                  {
+                    Name: 'Hostname',
+                    Value: 'studio.code.org',
+                  },
+                  {
+                    Name: 'AppName',
+                    Value: 'aichat',
+                  },
+                  {
+                    Name: 'Browser',
+                    Value: browser,
+                  },
+                ],
+              },
+              Period: 300,
+              Stat: 'Sum',
+            },
+            ReturnData: false,
+          }))
+        )
+        .flat(),
+      {
+        Expression: browserIndices.map(i => `m1${i}`).join('+'),
+        Label: 'Request Count',
+        Id: 'e1',
+        ReturnData: false,
+      },
+      {
+        Expression: `(${browserIndices.map(i => `m2${i}`).join('+')})/e1 * 100`,
+        Label: 'Error Rate (%)',
+        Id: 'e2',
+        ReturnData: true,
+      },
+    ],
+  };

--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/createAlarms.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/createAlarms.ts
@@ -8,6 +8,7 @@ import {REGION} from '../constants';
 import {
   openaiSafetyHighFailureRateConfiguration,
   chatCompletionJobExecutionHighFailureRateConfiguration,
+  chatCompletionHighBrowserFailureRateConfiguration,
 } from './alarmConfigurations';
 
 // Initialize the CloudWatch client.
@@ -17,6 +18,7 @@ const cloudwatch = new CloudWatchClient({region: REGION});
 const alarmConfigurations = [
   openaiSafetyHighFailureRateConfiguration,
   chatCompletionJobExecutionHighFailureRateConfiguration,
+  chatCompletionHighBrowserFailureRateConfiguration,
 ];
 
 const createMetricAlarms = async () => {

--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/constants.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/constants.ts
@@ -1,7 +1,7 @@
 export const ENDPOINT_VARIANT = 'AllTraffic';
 export const REGION = 'us-east-1';
 export const SNS_TOPIC =
-  'arn:aws:sns:us-east-1:475661607190:javabuilder-low-urgency'; // This will be updated to a team-based SNS topic.
+  'arn:aws:sns:us-east-1:475661607190:autoscale-prod-StudentLearningWorkdayUrgent-hd8WmLbmPdIU';
 
 export const commonGraphProps = {
   width: 6,
@@ -37,3 +37,5 @@ export const ERROR_COLOR = '#d62728';
 export const WARNING_COLOR = '#ff7f0e';
 
 export const DASHBOARD_NAME = 'GenAICurriculum';
+
+export const BROWSERS = ['Chrome', 'Firefox', 'Safari'];

--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/dashboard/createDashboard.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/dashboard/createDashboard.ts
@@ -6,7 +6,7 @@ import {Dashboard} from 'cloudwatch-dashboard-types';
 import {exit} from 'process';
 
 import modelDescriptions from '../../../../../../apps/static/aichat/modelDescriptions.json';
-import {DASHBOARD_NAME, REGION} from '../constants';
+import {BROWSERS, DASHBOARD_NAME, REGION} from '../constants';
 
 import {
   createActiveJobGraph,
@@ -29,8 +29,6 @@ import {
   createOverallSavePerformanceGraph,
 } from './widgetCreators';
 
-const browsers = ['Chrome', 'Firefox', 'Safari'];
-
 function createDashboard(environment = 'production'): Dashboard {
   const modelWidgets = modelDescriptions
     .map(({name, id}) => [
@@ -47,14 +45,12 @@ function createDashboard(environment = 'production'): Dashboard {
     ])
     .flat();
 
-  const browserMetrics = browsers
-    .map(browser => [
-      createTitleWidget(browser, 'h2'),
-      createBrowserChatPerformanceGraph(environment, browser),
-      createBrowserSavePerformanceGraph(environment, browser),
-      createBrowserLatencyByModelGraph(modelDescriptions, environment, browser),
-    ])
-    .flat();
+  const browserMetrics = BROWSERS.map(browser => [
+    createTitleWidget(browser, 'h2'),
+    createBrowserChatPerformanceGraph(environment, browser),
+    createBrowserSavePerformanceGraph(environment, browser),
+    createBrowserLatencyByModelGraph(modelDescriptions, environment, browser),
+  ]).flat();
 
   return {
     widgets: [
@@ -69,8 +65,8 @@ function createDashboard(environment = 'production'): Dashboard {
       ),
       createTitleWidget('Performance', 'h2'),
       createJobPerformanceGraph(environment),
-      createOverallChatPerformanceGraph(environment, browsers),
-      createOverallSavePerformanceGraph(environment, browsers),
+      createOverallChatPerformanceGraph(environment, BROWSERS),
+      createOverallSavePerformanceGraph(environment, BROWSERS),
       createExecutionCountGraph(modelDescriptions, environment, {
         width: 6,
         height: 12,
@@ -79,10 +75,10 @@ function createDashboard(environment = 'production'): Dashboard {
       createLogTable('warning', environment),
       // -- Latency Overview
       createTitleWidget('Latency', 'h2'),
-      createBrowserLatencyComparisonGraph(browsers, environment),
+      createBrowserLatencyComparisonGraph(BROWSERS, environment),
       createActiveJobGraph(environment),
       createLatencyComparisonGraph(modelDescriptions, environment),
-      createBrowserLatencyComparisonGraph(browsers, environment, 'gauge', {
+      createBrowserLatencyComparisonGraph(BROWSERS, environment, 'gauge', {
         width: 24,
         height: 5,
       }),


### PR DESCRIPTION
Updates the SNS topic for the GenAI alarms to the "Student Learning Workday Urgent" topic, and adds a new alarm that tracks browser failure rates (now that we can replace SEARCH queries with https://github.com/code-dot-org/code-dot-org/pull/62095). Note that the SNS topic is not yet hooked into to any integrations; this may need to be manually configured in the console, so will look into that as a separate task.

## Links

https://codedotorg.atlassian.net/browse/LABS-1170

## Testing story

Confirmed that alarms appear in Cloudwatch: https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarmsV2:alarm/genai_chat_completion_high_browser_failure_rate

## Follow-up work

Add Slack integration to SNS topic.