### PR TITLE
Add an eyes test for teacher dashboard v2

### DIFF
--- a/apps/src/templates/sectionProgressV2/ItemType.jsx
+++ b/apps/src/templates/sectionProgressV2/ItemType.jsx
@@ -3,74 +3,51 @@ import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
-const makeObjectType = (title, icon, color, iconUiTestId) => ({
+const makeObjectType = (title, icon, color) => ({
   title,
   icon,
   color,
-  iconUiTestId,
 });
 
 export const ITEM_TYPE = Object.freeze({
-  VIEWED: makeObjectType(i18n.viewed(), undefined, undefined, undefined),
-  NEEDS_FEEDBACK: makeObjectType(
-    i18n.needsFeedback(),
-    undefined,
-    undefined,
-    undefined
-  ),
-  FEEDBACK_GIVEN: makeObjectType(
-    i18n.feedbackGiven(),
-    undefined,
-    undefined,
-    undefined
-  ),
-  NO_PROGRESS: makeObjectType(
-    i18n.noProgress(),
-    undefined,
-    undefined,
-    undefined
-  ),
+  VIEWED: makeObjectType(i18n.viewed(), undefined, undefined),
+  NEEDS_FEEDBACK: makeObjectType(i18n.needsFeedback(), undefined, undefined),
+  FEEDBACK_GIVEN: makeObjectType(i18n.feedbackGiven(), undefined, undefined),
+  NO_PROGRESS: makeObjectType(i18n.noProgress(), undefined, undefined),
   ASSESSMENT_LEVEL: makeObjectType(
     i18n.assessmentLevel(),
     'star',
-    color.neutral_dark,
-    'ui-test-assessment-level'
+    color.neutral_dark
   ),
   CHOICE_LEVEL: makeObjectType(
     i18n.choiceLevel(),
     'split',
-    color.neutral_dark60,
-    'ui-test-choice-level'
+    color.neutral_dark60
   ),
   KEEP_WORKING: makeObjectType(
     i18n.markedAsKeepWorking(),
     'rotate-left',
-    color.neutral_dark,
-    'ui-test-keep-working'
+    color.neutral_dark
   ),
   NO_ONLINE_WORK: makeObjectType(
     i18n.noOnlineWork(),
     'dash',
-    color.neutral_dark,
-    'ui-test-no-online-work'
+    color.neutral_dark
   ),
   IN_PROGRESS: makeObjectType(
     i18n.inProgress(),
     'circle-o',
-    color.product_affirmative_default,
-    'ui-test-in-progress'
+    color.product_affirmative_default
   ),
   SUBMITTED: makeObjectType(
     i18n.submitted(),
     'circle',
-    color.product_affirmative_default,
-    'ui-test-submitted'
+    color.product_affirmative_default
   ),
   VALIDATED: makeObjectType(
     i18n.validated(),
     'circle-check',
-    color.product_affirmative_default,
-    'ui-test-validated'
+    color.product_affirmative_default
   ),
 });
 

--- a/apps/src/templates/sectionProgressV2/ItemType.jsx
+++ b/apps/src/templates/sectionProgressV2/ItemType.jsx
@@ -3,51 +3,74 @@ import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 
-const makeObjectType = (title, icon, color) => ({
+const makeObjectType = (title, icon, color, iconUiTestId) => ({
   title,
   icon,
   color,
+  iconUiTestId,
 });
 
 export const ITEM_TYPE = Object.freeze({
-  VIEWED: makeObjectType(i18n.viewed(), undefined, undefined),
-  NEEDS_FEEDBACK: makeObjectType(i18n.needsFeedback(), undefined, undefined),
-  FEEDBACK_GIVEN: makeObjectType(i18n.feedbackGiven(), undefined, undefined),
-  NO_PROGRESS: makeObjectType(i18n.noProgress(), undefined, undefined),
+  VIEWED: makeObjectType(i18n.viewed(), undefined, undefined, undefined),
+  NEEDS_FEEDBACK: makeObjectType(
+    i18n.needsFeedback(),
+    undefined,
+    undefined,
+    undefined
+  ),
+  FEEDBACK_GIVEN: makeObjectType(
+    i18n.feedbackGiven(),
+    undefined,
+    undefined,
+    undefined
+  ),
+  NO_PROGRESS: makeObjectType(
+    i18n.noProgress(),
+    undefined,
+    undefined,
+    undefined
+  ),
   ASSESSMENT_LEVEL: makeObjectType(
     i18n.assessmentLevel(),
     'star',
-    color.neutral_dark
+    color.neutral_dark,
+    'ui-test-assessment-level'
   ),
   CHOICE_LEVEL: makeObjectType(
     i18n.choiceLevel(),
     'split',
-    color.neutral_dark60
+    color.neutral_dark60,
+    'ui-test-choice-level'
   ),
   KEEP_WORKING: makeObjectType(
     i18n.markedAsKeepWorking(),
     'rotate-left',
-    color.neutral_dark
+    color.neutral_dark,
+    'ui-test-keep-working'
   ),
   NO_ONLINE_WORK: makeObjectType(
     i18n.noOnlineWork(),
     'dash',
-    color.neutral_dark
+    color.neutral_dark,
+    'ui-test-no-online-work'
   ),
   IN_PROGRESS: makeObjectType(
     i18n.inProgress(),
     'circle-o',
-    color.product_affirmative_default
+    color.product_affirmative_default,
+    'ui-test-in-progress'
   ),
   SUBMITTED: makeObjectType(
     i18n.submitted(),
     'circle',
-    color.product_affirmative_default
+    color.product_affirmative_default,
+    'ui-test-submitted'
   ),
   VALIDATED: makeObjectType(
     i18n.validated(),
     'circle-check',
-    color.product_affirmative_default
+    color.product_affirmative_default,
+    'ui-test-validated'
   ),
 });
 

--- a/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
@@ -30,7 +30,7 @@ export default function ProgressIcon({itemType}) {
 
   return (
     // eslint-disable-next-line react/forbid-dom-props
-    <div data-testid="progress-icon" id={itemType['iconUiTestId']}>
+    <div data-testid="progress-icon">
       {itemType['icon'] !== undefined && (
         <FontAwesome
           id={'uitest-' + itemType['icon']}

--- a/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
+++ b/apps/src/templates/sectionProgressV2/ProgressIcon.jsx
@@ -30,7 +30,7 @@ export default function ProgressIcon({itemType}) {
 
   return (
     // eslint-disable-next-line react/forbid-dom-props
-    <div data-testid="progress-icon">
+    <div data-testid="progress-icon" id={itemType['iconUiTestId']}>
       {itemType['icon'] !== undefined && (
         <FontAwesome
           id={'uitest-' + itemType['icon']}

--- a/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
+++ b/apps/src/templates/sectionProgressV2/SkeletonProgressDataColumn.jsx
@@ -56,7 +56,7 @@ function SkeletonProgressDataColumn({
   expandedMetadataStudentIds,
 }) {
   return (
-    <div className={styles.lessonColumn}>
+    <div className={styles.lessonColumn} id="ui-test-skeleton-progress-column">
       <LessonProgressColumnHeader
         lesson={lesson}
         addExpandedLesson={() => {}}

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -172,7 +172,7 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
   );
 
   return (
-    <nav className={styles.sidebarContainer}>
+    <nav className={styles.sidebarContainer} id="ui-test-teacher-sidebar">
       <div className={styles.sidebarContent}>
         <Typography
           semanticTag={'h2'}

--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -12,6 +12,14 @@ PUZZLE_SOLUTIONS = {
     And I drag block "turnRight" to block "moveForward"
     And I drag block "moveForward" to block "turnRight"
   },
+  "http://studio.code.org/s/allthethings/lessons/10/levels/1" => %{
+    Then I wait for 3 seconds
+    And I wait until element ".submitButton" is visible
+    And I press ".answerbutton[index=1]" using jQuery
+    And I press ".answerbutton[index=0]" using jQuery
+    And I press ".submitButton:first" using jQuery
+    And I wait to see ".modal"
+  },
 }
 
 def append_noautoplay(url_string)
@@ -26,6 +34,7 @@ Then /^I complete the level on "([^"]*)"$/ do |puzzle_url|
   steps %{
     And I am on "#{append_noautoplay(puzzle_url)}"
     And I wait for the lab page to fully load
+    And I close the instructions overlay if it exists
   }
   steps PUZZLE_SOLUTIONS[puzzle_url]
   steps %{

--- a/dashboard/test/ui/features/step_definitions/solutions.rb
+++ b/dashboard/test/ui/features/step_definitions/solutions.rb
@@ -12,14 +12,6 @@ PUZZLE_SOLUTIONS = {
     And I drag block "turnRight" to block "moveForward"
     And I drag block "moveForward" to block "turnRight"
   },
-  "http://studio.code.org/s/allthethings/lessons/10/levels/1" => %{
-    Then I wait for 3 seconds
-    And I wait until element ".submitButton" is visible
-    And I press ".answerbutton[index=1]" using jQuery
-    And I press ".answerbutton[index=0]" using jQuery
-    And I press ".submitButton:first" using jQuery
-    And I wait to see ".modal"
-  },
 }
 
 def append_noautoplay(url_string)
@@ -34,7 +26,6 @@ Then /^I complete the level on "([^"]*)"$/ do |puzzle_url|
   steps %{
     And I am on "#{append_noautoplay(puzzle_url)}"
     And I wait for the lab page to fully load
-    And I close the instructions overlay if it exists
   }
   steps PUZZLE_SOLUTIONS[puzzle_url]
   steps %{

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
@@ -4,12 +4,22 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
   Scenario: Teacher can see the local navigation
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    And I am on "http://studio.code.org/s/allthethings/lessons/2/levels/1?noautoplay=true"
+    And I close the instructions overlay if it exists
+    And I wait to see "#runButton"
+    And I press "runButton"
+    And I wait to see "#resetButton"
 
     When I sign in as "Teacher_Sally" and go home
+    And I get levelbuilder access
     Given I use a cookie to mock the DCDO key "teacher-local-nav-v2" as "true"
     Given I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
 
     When I click selector "a:contains(Untitled Section)" once I see it to load a new page
 
     Then I wait until element "#ui-test-teacher-sidebar" is visible
+
+    And I wait until element "h6:contains(Icon Key)" is visible
+    And I wait until element "#ui-test-progress-table-v2" is visible
+
+    And I wait until element "#ui-test-skeleton-progress-column" is not visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
@@ -1,7 +1,9 @@
 @no_mobile
+@eyes
 Feature: Using the V2 teacher dashboard local navigation - Eyes
 
   Scenario: Teacher can see the local navigation
+    When I open my eyes to test "teacher local nav v2"
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
 
@@ -26,5 +28,8 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
     And I wait until element "#ui-test-progress-table-v2" is visible
 
     And I wait until element "#ui-test-skeleton-progress-column" is not visible
+    And I scroll to "#ui-test-lesson-header-10"
 
-    And I wait until element "#ui-test-not" is visible
+    And I see no difference for "progress v2"
+
+    And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
@@ -4,10 +4,14 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
   Scenario: Teacher can see the local navigation
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
-    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
-    And I wait for 15 seconds
 
-#    And I complete the level on "http://studio.code.org/s/allthethings/lessons/10/levels/1"
+    And I am on "http://studio.code.org/s/allthethings/lessons/10/levels/1?noautoplay=true"
+    Then I wait for 3 seconds
+    And I wait until element ".submitButton" is visible
+    And I press ".answerbutton[index=1]" using jQuery
+    And I press ".answerbutton[index=0]" using jQuery
+    And I press ".submitButton:first" using jQuery
+    And I wait to see ".modal"
 
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
@@ -4,11 +4,10 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
   Scenario: Teacher can see the local navigation
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
-    And I am on "http://studio.code.org/s/allthethings/lessons/2/levels/1?noautoplay=true"
-    And I close the instructions overlay if it exists
-    And I wait to see "#runButton"
-    And I press "runButton"
-    And I wait to see "#resetButton"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+    And I wait for 15 seconds
+
+#    And I complete the level on "http://studio.code.org/s/allthethings/lessons/10/levels/1"
 
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
@@ -23,3 +22,5 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
     And I wait until element "#ui-test-progress-table-v2" is visible
 
     And I wait until element "#ui-test-skeleton-progress-column" is not visible
+
+    And I wait until element "#ui-test-not" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
@@ -1,0 +1,15 @@
+@no_mobile
+Feature: Using the V2 teacher dashboard local navigation - Eyes
+
+  Scenario: Teacher can see the local navigation
+    Given I use a cookie to mock the DCDO key "teacher-local-nav-v2" as "true"
+    Given I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
+
+    Given I create an authorized teacher-associated student named "Sally"
+    Given I am assigned to unit "allthethings"
+    And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
+
+    When I sign in as "Teacher_Sally" and go home
+    When I click selector "a:contains(Untitled Section)" once I see it to load a new page
+
+    Then I wait until element "#ui-test-teacher-sidebar" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
@@ -2,14 +2,14 @@
 Feature: Using the V2 teacher dashboard local navigation - Eyes
 
   Scenario: Teacher can see the local navigation
-    Given I use a cookie to mock the DCDO key "teacher-local-nav-v2" as "true"
-    Given I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
-
     Given I create an authorized teacher-associated student named "Sally"
     Given I am assigned to unit "allthethings"
     And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
 
     When I sign in as "Teacher_Sally" and go home
+    Given I use a cookie to mock the DCDO key "teacher-local-nav-v2" as "true"
+    Given I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
+
     When I click selector "a:contains(Untitled Section)" once I see it to load a new page
 
     Then I wait until element "#ui-test-teacher-sidebar" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
@@ -1,5 +1,5 @@
 @no_mobile
-Feature: Using the V2 teacher dashboard
+Feature: Using the V2 progress page
 
 Scenario: Teacher can open and close Icon Key and details
   Given I create an authorized teacher-associated student named "Sally"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
@@ -133,7 +133,13 @@ Scenario: Teacher can view lesson progress for when students have completed a le
   And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
 
   # Student completes all the levels in lesson 10 (there is only one level)
-  And I complete the level on "http://studio.code.org/s/allthethings/lessons/10/levels/1"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/10/levels/1?noautoplay=true"
+  Then I wait for 3 seconds
+  And I wait until element ".submitButton" is visible
+  And I press ".answerbutton[index=1]" using jQuery
+  And I press ".answerbutton[index=0]" using jQuery
+  And I press ".submitButton:first" using jQuery
+  And I wait to see ".modal"
 
   When I sign in as "Teacher_Sally" and go home
   And I get levelbuilder access

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_progress_v2.feature
@@ -133,13 +133,7 @@ Scenario: Teacher can view lesson progress for when students have completed a le
   And I complete the level on "http://studio.code.org/s/allthethings/lessons/2/levels/1"
 
   # Student completes all the levels in lesson 10 (there is only one level)
-  Given I am on "http://studio.code.org/s/allthethings/lessons/10/levels/1?noautoplay=true"
-  Then I wait for 3 seconds
-  And I wait until element ".submitButton" is visible
-  And I press ".answerbutton[index=1]" using jQuery
-  And I press ".answerbutton[index=0]" using jQuery
-  And I press ".submitButton:first" using jQuery
-  And I wait to see ".modal"
+  And I complete the level on "http://studio.code.org/s/allthethings/lessons/10/levels/1"
 
   When I sign in as "Teacher_Sally" and go home
   And I get levelbuilder access


### PR DESCRIPTION
Adds a simple eyes test that makes some progress on a lesson and checks for differences on the progress v2 page. This test checks for the sidebar and page header with the new local teacher navigation

Successful test run locally (other users may not have access): https://app.saucelabs.com/tests/2d0ebeba7aff422896f5c541953d0fe8#119
![Screenshot 2024-12-03 at 1 47 34 PM](https://github.com/user-attachments/assets/d15a9cb2-895c-48eb-841e-587485c86fb0)


## Links
https://codedotorg.atlassian.net/browse/TEACH-1351
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Ran test locally - ensure that eyes checks are run and it passes.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
