### PR TITLE
Python Lab: speculative fix for system code error

### DIFF
--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -21,22 +21,25 @@ async function loadPyodideAndPackages() {
     // which does serve the unhashed files. We need to serve the unhashed files because
     // pyodide controls adding the filenames to the url we provide here.
     indexURL: `/blockly/js/pyodide/${version}/`,
-    // pre-load numpy as it will frequently be used, our custom setup package, and matplotlib
-    // which our custom setup package patches.
-    packages: [
-      'numpy',
-      'matplotlib',
-      // These are custom packages that we have built. They are defined in this repo:
-      // https://github.com/code-dot-org/pythonlab-packages
-      `/blockly/js/pyodide/${version}/unittest_runner-0.1.0-py3-none-any.whl`,
-      `/blockly/js/pyodide/${version}/pythonlab_setup-0.1.0-py3-none-any.whl`,
-    ],
     env: {
       HOME: `/${HOME_FOLDER}/`,
     },
   });
   pyodide.setStdout(getStreamHandlerOptions('sysout'));
   pyodide.setStderr(getStreamHandlerOptions('syserr'));
+
+  // Pre-load our custom packages (unittest_runner and pythonlab_setup), as well as
+  // matplotlib, which pythonlab_setup depends on, and numpy,
+  // which will frequently be used. We have seen issues with loading these via
+  // loadPyodide, so we load them here to ensure they are available.
+  await pyodide.loadPackage([
+    'numpy',
+    'matplotlib',
+    // These are custom packages that we have built. They are defined in this repo:
+    // https://github.com/code-dot-org/pythonlab-packages
+    `/blockly/js/pyodide/${version}/unittest_runner-0.1.0-py3-none-any.whl`,
+    `/blockly/js/pyodide/${version}/pythonlab_setup-0.1.0-py3-none-any.whl`,
+  ]);
   // Warm up the pyodide environment by running setup code.
   await runInternalCode(SETUP_CODE, -1);
 }


### PR DESCRIPTION
We had 87 instances of essentially the same error with our setup code in the last two weeks in Python Lab. The errors were all around not having loaded a dependent package (either matplotlib or a package it depends on) when we run the setup code. We _should_ have loaded matplotlib because it is loaded as part of `loadPyodide` (we include a list of packages to load in that method call). The [documentation is unclear](https://pyodide.org/en/stable/usage/api/js-api.html#globalThis.loadPyodide) on whether it is guaranteed that the packages will be loaded once that method returns though. So to be safe, I moved the package loading to a separate call which is specifically [documented](https://pyodide.org/en/stable/usage/api/js-api.html#pyodide.loadPackage) as returning after the packages have loaded.

It is possible this was failing due to a bad network, but it seemed like a reasonable change to make. It also did not add any time to the load time for pyodide, so I didn't see any downside.

## Links

- [Cloudwatch logs](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-1209600~timeType~'RELATIVE~tz~'UTC~unit~'seconds~editorString~'fields*20*40message*0a*7c*20filter*20level*20*3d*20*22SEVERE*22*20and*20message.appName*20*3d*20*27pythonlab*27*20and*20message.errorMessage*20*3d*20*22Python*20Lab*20System*20Code*20Error*22*0a*23*7c*20limit*2030~queryId~'6957d30a-f0f1-4c37-86d3-cce284b3a3ee~source~(~'production-browser-events)~lang~'CWLI))

## Testing story
Tested locally that setup code still runs as expected with this change.

## Follow-up work
This won't be deployed until post-hoc, but I will look again at the logs after it goes in to see if the error goes away.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
