### PR TITLE
chore(eslint): move ts-eslint to base config

### DIFF
--- a/frontend/packages/lint-config/eslint/base.mjs
+++ b/frontend/packages/lint-config/eslint/base.mjs
@@ -1,8 +1,10 @@
 import importPlugin from 'eslint-plugin-import-x';
+import {configs as tseslintConfig} from 'typescript-eslint';
 import js from '@eslint/js';
 
 export default [
   js.configs.recommended,
+  ...tseslintConfig.recommended,
   importPlugin.flatConfigs.recommended,
   importPlugin.flatConfigs.typescript,
   {

--- a/frontend/packages/lint-config/eslint/react.mjs
+++ b/frontend/packages/lint-config/eslint/react.mjs
@@ -1,6 +1,5 @@
 import globals from 'globals';
 import cdoBase from './base.mjs';
-import {configs as tseslintConfig} from 'typescript-eslint';
 import pluginReact from 'eslint-plugin-react';
 
 /** @type {import('eslint').Linter.Config[]} */
@@ -8,7 +7,6 @@ export default [
   {files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}']},
   {languageOptions: {globals: {...globals.node, ...globals.browser}}},
   ...cdoBase,
-  ...tseslintConfig.recommended,
   {
     ...pluginReact.configs.flat['jsx-runtime'],
     settings: {react: {version: 'detect'}},


### PR DESCRIPTION
Previously, the ts-eslint recommended linter was only added to the react config. However, it makes more sense to have it in the base config as Code.org node libraries will use Typescript.

We will re-review this when the standards working group meets.