### PR TITLE
P20-1180: Fix Global Edition region switch confirmation on Pegasus

### DIFF
--- a/apps/src/globalEdition/regionSwitchConfirm.js
+++ b/apps/src/globalEdition/regionSwitchConfirm.js
@@ -7,8 +7,8 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 document.addEventListener('DOMContentLoaded', () => {
   ReactDOM.render(
     <GlobalEditionRegionSwitchConfirm
-      country={getScriptData('country')}
-      region={getScriptData('region')}
+      code={getScriptData('code')}
+      name={getScriptData('name')}
     />,
     document.getElementById('global-edition-region-switch-confirm-container')
   );

--- a/apps/src/templates/globalEdition/RegionSwitchConfirm/index.story.tsx
+++ b/apps/src/templates/globalEdition/RegionSwitchConfirm/index.story.tsx
@@ -8,11 +8,7 @@ export default {
 } as Meta;
 
 const Template: StoryFn<typeof RegionSwitchConfirm> = args => (
-  <RegionSwitchConfirm
-    {...args}
-    country="IR"
-    region={{code: 'fa', name: 'Farsi', href: '#'}}
-  />
+  <RegionSwitchConfirm {...args} code="fa" name="Farsi" />
 );
 
 export const Default = Template.bind({});

--- a/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
+++ b/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
@@ -1,4 +1,3 @@
-@skip
 @no_mobile
 Feature: Global Edition - Region Switch Confirm Modal
 

--- a/shared/haml/global_edition/region_switch_confirm.haml
+++ b/shared/haml/global_edition/region_switch_confirm.haml
@@ -2,19 +2,12 @@
   require 'cdo/global_edition'
   return unless DCDO.get('global_edition_enabled', false)
 
-  country_code = request.country_code
-  ge_region = Cdo::GlobalEdition.country_region(country_code)
+  ge_region = Cdo::GlobalEdition.country_region(request.country_code)
   return if ge_region.nil? || ge_region == request.ge_region
 
   enabled_regions = DCDO.get('global_edition_region_switch_confirm_enabled_in', [])
   return unless enabled_regions.include?('all') || enabled_regions.include?(ge_region)
 
-  region_data = {
-    code: ge_region,
-    name: I18n.t(ge_region, scope: %i[global_edition regions]),
-    href: Cdo::GlobalEdition.region_change_url(request.fullpath, ge_region),
-  }
-
 #global-edition-region-switch-confirm-container
   %script{src: webpack_asset_path('js/global_edition/region_switch_confirm.js'),
-          data: {country: country_code.to_json, region: region_data.to_json}}
+          data: {code: ge_region.to_json, name: I18n.t(ge_region, scope: %i[global_edition regions]).to_json}}


### PR DESCRIPTION
```
And I wait until I am on "http://code.org/global/fa"
features/step_definitions/steps.rb:361
Timeout: I am not on https://test.code.org/global/fa like I want.
         I am on https://test.code.org/?ge_region=fa instead.
timed out after 120 seconds (Selenium::WebDriver::Error::TimeoutError)
./features/step_definitions/steps.rb:8:in `wait_until'
./features/step_definitions/steps.rb:367:in `/^I wait until I am on "([^"]*)"$/'
./features/support/hooks.rb:28:in `block in '
features/platform/global_edition/region_switch_confirm.feature:41:in `And I wait until I am on "http://code.org/global/fa"'

def wait_until(timeout = DEFAULT_WAIT_TIMEOUT)
  Selenium::WebDriver::Wait.new(timeout: timeout).until do
    yield
    rescue Selenium::WebDriver::Error::UnknownError => exception
# gem install syntax to get syntax highlighting
```

## Links
- JIRA task: [P20-1180](https://codedotorg.atlassian.net/browse/P20-1180)
- Original PR: https://github.com/code-dot-org/code-dot-org/pull/61631
- Log on S3: https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_platform_global_edition_region_switch_confirm_output.html?versionId=54U88tRX6XNV_6JQdkPSE_6F91juWs7C