### PR TITLE
HoC 2024 - Add image for Quorum Penguin tutorial

### DIFF
--- a/pegasus/sites.v3/code.org/public/images/tutorials/hoc2024/quorum_penguin.png
+++ b/pegasus/sites.v3/code.org/public/images/tutorials/hoc2024/quorum_penguin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2411b6be34ef17e69429b7308ce714efe27e131390ac86af0eaedb1d0cbf5f8f
+size 247042


### PR DESCRIPTION
Adds image for the "Penguins: Accessible Data Science with Quorum Blocks" tutorial.

## Links
Jira ticket: [ACQ-2857](https://codedotorg.atlassian.net/browse/ACQ-2857)