### PR TITLE
Add index on school_infos for country, school_name, and school_type, based off staging this time

### DIFF
--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -20,8 +20,9 @@
 #
 # Indexes
 #
-#  fk_rails_951bceb7e3              (school_district_id)
-#  index_school_infos_on_school_id  (school_id)
+#  fk_rails_951bceb7e3                                            (school_district_id)
+#  index_school_infos_on_school_id                                (school_id)
+#  index_school_infos_on_school_name_and_country_and_school_type  (school_name,country,school_type)
 #
 
 class SchoolInfo < ApplicationRecord

--- a/dashboard/db/migrate/20241203163649_add_index_to_school_infos_country_and_school_name_and_school_type.rb
+++ b/dashboard/db/migrate/20241203163649_add_index_to_school_infos_country_and_school_name_and_school_type.rb
@@ -1,0 +1,5 @@
+class AddIndexToSchoolInfosCountryAndSchoolNameAndSchoolType < ActiveRecord::Migration[6.1]
+  def change
+    add_index :school_infos, [:school_name, :country, :school_type]
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_11_25_202219) do
+ActiveRecord::Schema.define(version: 2024_12_03_163649) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1880,6 +1880,7 @@ ActiveRecord::Schema.define(version: 2024_11_25_202219) do
     t.string "validation_type", default: "full", null: false
     t.index ["school_district_id"], name: "fk_rails_951bceb7e3"
     t.index ["school_id"], name: "index_school_infos_on_school_id"
+    t.index ["school_name", "country", "school_type"], name: "index_school_infos_on_school_name_and_country_and_school_type"
   end
 
   create_table "school_stats_by_years", primary_key: ["school_id", "school_year"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

a query that checks for existing `school_infos` entries was impacting performance on the production db. the slow query was searching for an existing record matching the `country` and `school_name` columns. at the moment, a school_info record will either have a `school_id` (nces school) which already has an index, or it will have a `country` and either a `school_name` or a `school_type`. so the thought was to add an index on those three columns (`country, `school_name` and `school_type`). after creating a production db clone and connecting to it, I was able to analyze the query with and without an index.

BEFORE ADDING INDEX:
```
-> Limit: 1 row(s)  (cost=2763.80 rows=0.5) (actual time=2784.514..2784.514 rows=0 loops=1)
    -> Filter: ((school_infos.country = 'ID') and (school_infos.state is null) and (school_infos.zip is null) and (school_infos.school_name is null) and (school_infos.validation_type = 'none') and (school_infos.school_type = 'noSchoolSetting') and (school_infos.school_district_other is null) and (school_infos.school_district_name is null) and (school_infos.school_id is null) and (school_infos.school_other is null) and (school_infos.full_address is null))  (cost=2763.80 rows=0.5) (actual time=2784.513..2784.513 rows=0 loops=1)
        -> Index lookup on school_infos using fk_rails_951bceb7e3 (school_district_id=NULL), with index condition: (school_infos.school_district_id is null)  (cost=2763.80 rows=325394) (actual time=0.215..2690.459 rows=841890 loops=1)
```

AFTER ADDING INDEX:
```
-> Limit: 1 row(s)  (cost=0.26 rows=0.05) (actual time=0.021..0.021 rows=0 loops=1)
    -> Filter: ((school_infos.state is null) and (school_infos.zip is null) and (school_infos.validation_type = 'none') and (school_infos.school_district_id is null) and (school_infos.school_district_other is null) and (school_infos.school_district_name is null) and (school_infos.school_id is null) and (school_infos.school_other is null) and (school_infos.full_address is null))  (cost=0.26 rows=0.05) (actual time=0.020..0.020 rows=0 loops=1)
        -> Index lookup on school_infos using idx_school_infos_name_country_type (school_name=NULL, country='ID', school_type='noSchoolSetting'), with index condition: (school_infos.school_name is null)  (cost=0.26 rows=1) (actual time=0.020..0.020 rows=0 loops=1)

```


## Links

[slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1733162798362609)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

tested manually on a clone of the production `school_infos` table

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

adding the index to the cloned production db took a little over 6 seconds

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
