### PR TITLE
Rescue from error trying to find nonexistent contained levels

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -82,14 +82,6 @@ def main
   end
 
   Level.find_each do |level|
-    begin
-    # The RecordNotFound exception happens when a Level does not belong to any ScriptLevel.
-    # The NoMethodError exception happens when a ScriptLevel does not have a Script.
-    # TODO(asher): Fix the corrupt data on staging, eliminating the need for this rescue clause.
-    rescue ActiveRecord::RecordNotFound, NoMethodError
-      next
-    end
-
     level.contained_levels.each_with_index do |contained_level, index|
       next unless contained_level.type == 'Multi'
 
@@ -113,6 +105,12 @@ def main
         }
       end
     end
+  rescue ActiveRecord::RecordNotFound => exception
+    Honeybadger.notify(
+      exception,
+      error_message: "Error reading level for rollup tables."
+    )
+    next
   end
 
   contained_levels.map {|row| row[:contained_level_id]}.each do |contained_level_id|

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -108,7 +108,7 @@ def main
   rescue ActiveRecord::RecordNotFound => exception
     Honeybadger.notify(
       exception,
-      error_message: "Error reading level for rollup tables."
+      error_message: "Error reading level '#{level.name}' for rollup tables."
     )
     next
   end


### PR DESCRIPTION
The `create_rollup_tables` cronjob had been [crashing](https://app.honeybadger.io/projects/45435/faults/110299882?q=contained_levels) consistently. Last successful run was in March, just before a [level referring to a non-existent contained level](https://github.com/code-dot-org/code-dot-org/blob/9fc76302e844ef5dc684d306e57ce1655e14232b/dashboard/config/levels/custom/javalab/CSA%20U1%20Nested%20Iteration%20-L1_2025.level#L10) was committed to staging.

This change rescues the `RecordNotFound` error so that the script can proceed to write data related to the valid levels. It also removes a begin/rescue block that has been empty since [this commit](https://github.com/code-dot-org/code-dot-org/commit/bf040b9bd2e6ccad4a98cfc59c8777ef2e9c21c7) three years ago.

## Links
[Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1715098215080409) about the stale data in the table and problems for RED team.

## Testing story

Tested the script locally. Before the change it failed on that same level as in production. Afterward it succeeded.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
