### PR TITLE
Fixes issue with section creation.

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -63,7 +63,7 @@ export default function CurriculumQuickAssign({
     const filterOfferings = data => {
       const languageFilter = courseFilters?.language;
 
-      if (languageFilter) {
+      if (languageFilter && data) {
         // Crawl data and remove any courses / versions that are not available
         // in the requested language.
         for (const levelInfo of Object.values(data)) {


### PR DESCRIPTION
Apparently when creating a section, the course listing data can be null for a small window of time.

Cause: (as seen on production, reproduced locally)

![image](https://github.com/user-attachments/assets/688817cf-0f38-4453-b1c3-c659d7c80606)

Just by guarding `data` for that initial render works just fine. Works when tested locally with the fix.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
