### PR TITLE
Add swiper partial to state promote pages

### DIFF
--- a/pegasus/sites.v3/code.org/public/promote/splat.haml
+++ b/pegasus/sites.v3/code.org/public/promote/splat.haml
@@ -68,6 +68,8 @@ theme: responsive
 
 = view 'popup_window.js'
 
+= view :swiper_page_promote
+
 :javascript
   var petition;
   $(document).ready(function() {


### PR DESCRIPTION
Fixes an issue on the state-specific promote pages where the carousels weren't loading correctly.

In production:


https://github.com/user-attachments/assets/97941a43-b042-4ea0-8ab5-72e410429e1a

With this change:


https://github.com/user-attachments/assets/4611ff36-c7ec-45c1-bb70-849c8300cb80



