### PR TITLE
[Levelbuilder] Show BPM and measure count in Music Level Data section

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditLibrarySounds.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditLibrarySounds.tsx
@@ -2,7 +2,11 @@ import React, {useCallback} from 'react';
 
 import {Button} from '@cdo/apps/componentLibrary/button';
 import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
-import {BodyTwoText, StrongText} from '@cdo/apps/componentLibrary/typography';
+import {
+  BodyFourText,
+  BodyTwoText,
+  StrongText,
+} from '@cdo/apps/componentLibrary/typography';
 import MusicLibrary, {Sounds} from '@cdo/apps/music/player/MusicLibrary';
 import CollapsibleSection from '@cdo/apps/templates/CollapsibleSection';
 
@@ -116,6 +120,12 @@ const EditLibrarySounds: React.FunctionComponent<EditLibrarySoundsProps> = ({
                 </BodyTwoText>
               }
             >
+              <BodyFourText>
+                <i>
+                  Numbers in square brackets indicate the length of the sound in
+                  measures.
+                </i>
+              </BodyFourText>
               <div className={moduleStyles.indentedContainer}>
                 <Checkbox
                   name={pack.name + '-select-all'}
@@ -132,7 +142,7 @@ const EditLibrarySounds: React.FunctionComponent<EditLibrarySoundsProps> = ({
                     <Checkbox
                       key={sound.src}
                       name={sound.src}
-                      label={sound.name}
+                      label={`${sound.name} [${sound.length}]`}
                       checked={
                         (currentlySelected &&
                           currentlySelected.includes(sound.src)) ||

--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -88,10 +88,15 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
             ? a.artist.localeCompare(b.artist) || a.name.localeCompare(b.name)
             : 0
         )
-        ?.map(({name, id, artist, bpm}) => ({
-          value: id,
-          text: `[${bpm || DEFAULT_BPM}] ${artist} - ${name}`,
-        })),
+        ?.map(({name, id, artist, bpm, sounds}) => {
+          // Use the pack bpm if present, or the bpm of the first sound that has one.
+          const packTempo =
+            bpm || sounds?.find(sound => sound.bpm)?.bpm || DEFAULT_BPM;
+          return {
+            value: id,
+            text: `[${packTempo}] ${artist} - ${name}`,
+          };
+        }),
     [levelData.library, loadedLibraries]
   );
 

--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -4,10 +4,12 @@ import React, {useEffect, useMemo, useState} from 'react';
 import Alert from '@cdo/apps/componentLibrary/alert/Alert';
 import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
+import {BodyFourText} from '@cdo/apps/componentLibrary/typography';
 import {installFunctionBlocks} from '@cdo/apps/music/blockly/blockUtils';
 import {setUpBlocklyForMusicLab} from '@cdo/apps/music/blockly/setup';
 import {
   BlockMode,
+  DEFAULT_BPM,
   DEFAULT_LIBRARY,
   DEFAULT_PACK,
 } from '@cdo/apps/music/constants';
@@ -86,9 +88,9 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
             ? a.artist.localeCompare(b.artist) || a.name.localeCompare(b.name)
             : 0
         )
-        ?.map(({name, id, artist}) => ({
+        ?.map(({name, id, artist, bpm}) => ({
           value: id,
-          text: `${artist} - ${name}`,
+          text: `[${bpm || DEFAULT_BPM}] ${artist} - ${name}`,
         })),
     [levelData.library, loadedLibraries]
   );
@@ -138,7 +140,10 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
                 size="s"
                 items={[
                   {value: 'none', text: '(none)'},
-                  {value: DEFAULT_PACK, text: 'Code.org (Default)'},
+                  {
+                    value: DEFAULT_PACK,
+                    text: `[${DEFAULT_BPM}] Code.org (Default)`,
+                  },
                   ...restrictedPackOptions,
                 ]}
                 selectedValue={levelData.packId}
@@ -162,6 +167,9 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
                   setLevelData({...levelData, packId, sounds});
                 }}
               />
+              <BodyFourText>
+                <i>Numbers in square brackets indicate the pack tempo (BPM).</i>
+              </BodyFourText>
             </div>
           )}
           {levelData.library && loadedLibraries[levelData.library] ? (


### PR DESCRIPTION
Two improvements for the curriculum-authoring experience for Music Lab levels, coming as a direct request from the curriculum team:

- Add temp info to artist pack in the Artist Pack selector
- Add # of measures to to the sound selector list

<img width="665" alt="image" src="https://github.com/user-attachments/assets/7afd8c0f-de76-4895-8436-c46f3d6c65b3">

![image (250)](https://github.com/user-attachments/assets/643e4de3-8e32-4428-ba9b-d078cdf73666)

Seeing the BPM for a song is important to the curriculum team. Because we essentially stretch other CDO sounds to keep things in sync, our in-house sounds can sound "too slow" or a bit distorted if the selected pack has a much slower tempo.

Seeing the measure count of each allowed sound will allow the curriculum team to more rapidly iterate on levels, especially where having specific measure counts is critical for introducing concepts like loops in the Simple2 model.

## Links

https://codedotorg.slack.com/archives/C04TH8400AU/p1733244034158299

https://codedotorg.slack.com/archives/C04TH8400AU/p1733245419897019

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Follow-up work

Katie has also made the following request:
> Create a document of all artists and sounds for a quick glance of what is available.

To help with this, @dancodedotorg create the following tool: https://musiclab-song-search.glitch.me/

@dju90 to determine next steps for this request.

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Deployment Strategy

This can be merged into `staging-next` as the team is not currently blocked and this doesn't address any bugs.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
