### PR TITLE
Add enable micro:bit checkbox to pythonlab level edit page

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -97,6 +97,7 @@ class Level < ApplicationRecord
     ai_tutor_available
     offer_browser_tts
     use_secondary_finish_button
+    enable_micro_bit
   )
 
   # Fix STI routing http://stackoverflow.com/a/9463495

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -97,7 +97,6 @@ class Level < ApplicationRecord
     ai_tutor_available
     offer_browser_tts
     use_secondary_finish_button
-    enable_micro_bit
   )
 
   # Fix STI routing http://stackoverflow.com/a/9463495

--- a/dashboard/app/models/levels/pythonlab.rb
+++ b/dashboard/app/models/levels/pythonlab.rb
@@ -34,6 +34,7 @@ class Pythonlab < Level
     starter_assets
     predict_settings
     validation_file
+    enable_micro_bit
   )
 
   validate :has_correct_multiple_choice_answer?

--- a/dashboard/app/views/levels/editors/_pythonlab.html.haml
+++ b/dashboard/app/views/levels/editors/_pythonlab.html.haml
@@ -7,5 +7,6 @@
 = render partial: 'levels/editors/fields/predict_settings', locals: {f: f}
 = render partial: 'levels/editors/fields/aitutor_fields', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
+= render partial: 'levels/editors/fields/enable_micro_bit', locals: {f: f}
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_enable_micro_bit.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_enable_micro_bit.html.haml
@@ -1,0 +1,7 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#enable_micro_bit"}}
+  Enable micro:bit
+#enable_micro_bit.in.collapse
+  = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :enable_micro_bit, description: "Enable micro:bit"}
+  %p
+    If checked, the pythonlab level will display a 'Send to micro:bit' header button.
+    When the button is clicked, the user's code will be flashed to the connected micro:bit.


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds an 'Enable micro:bit' checkbox to the pythonlab level edit page so that content editors can enable micro:bit on pythonlab levels.

When checked, pythonlab level will display a 'Send to micro:bit' header button. When the button is clicked, the user's code will be flashed to the connected micro:bit.



## After update

Screenshot of 'Enable micro:bit' checkbox on level edit page:
![Screenshot 2024-12-04 at 10 51 44 AM](https://github.com/user-attachments/assets/4f2da7bd-2c05-4643-b9fb-5ab34bf0dee8)


Screencast video of a user with levelbuilder permission. When the levelbuilder checks the box and saves the level, the 'Send to micro:bit' button is displayed in the workspace header. When the levelbuilder unchecks the box and saves, the button is no longer displayed. Note that this is on a branch that is forked from https://github.com/code-dot-org/code-dot-org/pull/62790 for testing purposes.

https://github.com/user-attachments/assets/6f1bf039-1009-47c2-9a43-feb61b9891a6




## Links
[jira](https://codedotorg.atlassian.net/browse/CT-913)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally and saw the pythonlab .level file was updated when checking/unchecking the enable micro:bit button. As seen in screencast video above, on a different branch forked from https://github.com/code-dot-org/code-dot-org/pull/62790, I was able to see the 'Send to micro:bit' button displayed as expected when the checkbox is checked.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
