### PR TITLE
Update color variables on DSCO Breadcrumbs component

### DIFF
--- a/apps/src/componentLibrary/breadcrumbs/CHANGELOG.md
+++ b/apps/src/componentLibrary/breadcrumbs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1](https://github.com/code-dot-org/code-dot-org/pull/X)
+
+* updated color variables to use primitiveColors.css
+
 ## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/61009)
 
 * implemented component

--- a/apps/src/componentLibrary/breadcrumbs/CHANGELOG.md
+++ b/apps/src/componentLibrary/breadcrumbs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.1](https://github.com/code-dot-org/code-dot-org/pull/X)
+## [0.2.1](https://github.com/code-dot-org/code-dot-org/pull/62813)
 
 * updated color variables to use primitiveColors.css
 

--- a/apps/src/componentLibrary/breadcrumbs/breadcrumbs.module.scss
+++ b/apps/src/componentLibrary/breadcrumbs/breadcrumbs.module.scss
@@ -1,4 +1,4 @@
-@import "color.scss";
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 @import "font.scss";
 @import "@cdo/apps/componentLibrary/common/styles/mixins";
 @import "@cdo/apps/componentLibrary/typography/typography.module";
@@ -13,28 +13,28 @@
     justify-content: center;
     align-items: center;
     gap: 10px;
-    color: $light-black;
+    color: var(--neutral-base-black);
     font-feature-settings: 'liga' off, 'clig' off;
     text-decoration: none;
     border-radius: 4px;
 
     // Current location styles
     &:last-child {
-      color: $light_primary_500;
+      color: var(--brand-teal-50);
       cursor: default;
     }
 
     // Hover, Pressed, Visited styles
     &:hover, :active, :visited {
       &:not(:last-child) {
-        color: $light_gray_800;
+        color: var(--neutral-gray-80);
       }
     }
 
     // Focus styles
     &:focus-visible {
-      color: $light_black;
-      outline: 2px solid $light_primary_500;
+      color: var(--neutral-base-black);
+      outline: 2px solid var(--brand-teal-50);
       outline-offset: 2px;
     }
   }
@@ -45,7 +45,7 @@
     justify-content: center;
     align-items: center;
 
-    color: $light_black_opacity-70;
+    color: var(--neutral-black-alpha-70);
   }
 
 }


### PR DESCRIPTION
Swaps out color variables from `shared/color.scss` with Primitive colors from `primitiveColors.css` on the Breadcrumbs component. 

👀 **DOTD note:** there might be Eyes diffs with this.

## Links
Jira ticket: [DESIGN2-199](https://codedotorg.atlassian.net/browse/DESIGN2-199)

## Testing story
Tested locally in Storybook

----

## Before - using `shared/colors.scss`
<img width="988" alt="Before" src="https://github.com/user-attachments/assets/5b8098dd-c74a-4a5e-bd21-e5ad70304382">

## After - using `primitiveColors.css`
<img width="988" alt="After" src="https://github.com/user-attachments/assets/7e9f03b7-433f-44ed-b5e1-5796add47ff1">