### PR TITLE
chore(node): use node 20 for `frontend`

### DIFF
--- a/.devcontainer/frontend/Dockerfile
+++ b/.devcontainer/frontend/Dockerfile
@@ -3,7 +3,7 @@
 # syntax=docker.io/docker/dockerfile:1
 
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
-ARG VARIANT=1-22-bookworm
+ARG VARIANT=1-20-bookworm
 FROM mcr.microsoft.com/devcontainers/typescript-node:${VARIANT}
 
 # Install additional OS packages.

--- a/frontend/.nvmrc
+++ b/frontend/.nvmrc
@@ -1,3 +1,1 @@
-# To view valid code names, run `nvm ls`.
-# node 22's code name is 'jod'
-lts/jod
+20

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,6 @@
   },
   "packageManager": "yarn@4.5.1",
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   }
 }

--- a/frontend/packages/dsco/package.json
+++ b/frontend/packages/dsco/package.json
@@ -78,7 +78,7 @@
     "react-dom": ">=16"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"


### PR DESCRIPTION
Code.org `apps` currently uses node 20 in the ci build. Technically, it uses node 18 as defined in the `.nvmrc` file, however ci actually uses node 20. Since node 18 is EOL and security is EOL in April, and ci already uses node 20, it does seem to make sense to use node 20 to start with.