### PR TITLE
Fixes the header menus for RTL languages.

### DIFF
--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -71,7 +71,7 @@
 %link{:href=>'/shared/css/hamburger.css', :rel=>'stylesheet'}
 
 %div{class: header_class}
-  .navbar-static-top.header{dir: "ltr"}
+  .navbar-static-top.header
     .container{style: "width: 100%; display: flex; justify-content: space-between; height: 50px;"}
       .header_left
         .header_logo

--- a/pegasus/sites.v3/code.org/styles_min/040-page.css
+++ b/pegasus/sites.v3/code.org/styles_min/040-page.css
@@ -656,6 +656,11 @@ nav.main #hamburger #hamburger-contents {
   right: -3px;
 }
 
+html[dir="rtl"] nav.main #hamburger #hamburger-contents {
+  right: unset;
+  left: -3px;
+}
+
 /* Do not show hamburger links that are hidden until the
  * width becomes a certain size.
  */

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -143,9 +143,15 @@
     text-align: left;
     white-space: nowrap;
     padding: 0;
-    right: 0px;
+    right: 0;
     &[dir = 'rtl']  a {
       text-align: right;
+      left: 0;
+      right: unset;
+    }
+    html[dir = 'rtl'] & {
+      left: 0;
+      right: unset;
     }
     a {
       display: block;


### PR DESCRIPTION
This adjusts the styling of the dropdown menus in Pegasus and Dashboard such that they render correctly when using a right-to-left language. Before, the menus on Pegasus were running off the screen and were mostly unusable.

On dashboard, the header was forced to render left-to-right, which prevented a fix since you would fix the menu in Pegasus only to have it now broken on dashboard. This removes the forcing of the LTR header.

Before: (Pegasus only... Dashboard just always renders the header left-to-right, which is also wrong)

![image](https://github.com/user-attachments/assets/a8a98a73-e2a9-4fbd-a711-3271335ce9ea)

Global Farsi Edition:

![image](https://github.com/user-attachments/assets/eba601a3-7030-4579-be96-a58eae9c23f5)

Studio (English):

![image](https://github.com/user-attachments/assets/ef3b5d58-6a8e-42d9-82df-79b2b9357e2d)

![image](https://github.com/user-attachments/assets/e07cb2eb-6ab7-4633-8a9c-f60e9ef74cac)

Studio (Hebrew):

![image](https://github.com/user-attachments/assets/9ee4b432-b9b4-45d8-a3d9-54877990355e)

![image](https://github.com/user-attachments/assets/c20f4ac5-7146-47fb-8d99-0c2a0112e02c)

Pegasus (English):

![image](https://github.com/user-attachments/assets/800e677c-949b-41fd-8d12-552e822a50d0)

![image](https://github.com/user-attachments/assets/741ee9a2-454b-4740-a9ec-790447f077ad)

Pegasus (Hebrew):

![image](https://github.com/user-attachments/assets/6f32e102-2470-4d39-a63f-a84fa07d8a9c)

![image](https://github.com/user-attachments/assets/6e93d308-6c0a-4c4a-a1f1-19997cdd2950)

## Links

- jira ticket: [P20-1300](https://codedotorg.atlassian.net/browse/P20-1300)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
