### PR TITLE
Add cron script to demote old admins

### DIFF
--- a/bin/cron/demote_expired_admin_accounts
+++ b/bin/cron/demote_expired_admin_accounts
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+require 'optparse'
+require 'date'
+# delaying expensive requires until after Option Parser
+
+require_relative 'only_one'
+abort 'Script already running' unless only_one_running?(__FILE__)
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    Usage: #{File.basename(__FILE__)} [options]
+
+    This script locates accounts with admin privileges that have not been logged
+    into for more than 90 days and revokes admin privileges.
+
+    Options:
+  BANNER
+
+  opts.on('--dry-run', 'Report expected results without modifying anything') do |dry_run|
+    options[:dry_run] = dry_run
+  end
+
+  opts.on('-h', '--help', 'Print this help message') do
+    puts opts
+    exit
+  end
+end.parse!
+
+require_relative '../../dashboard/config/environment'
+require 'cdo/chat_client'
+
+begin
+  # Calculate the date 90 days ago
+  cutoff_date = 90.days.ago.to_date
+  expired_admins = User.where(admin: true).where('last_sign_in_at < ?', cutoff_date)
+
+  if options[:dry_run]
+    puts "Dry run: Found #{expired_admins.count} admin accounts eligible for privilege revocation."
+    expired_admins.each do |user|
+      puts "User ID: #{user.id}, Email: #{user.email}, Last Sign In: #{user.last_sign_in_at}"
+    end
+  else
+    # Revoke admin privileges
+    revoked_count = expired_admins.update_all(admin: false)
+    ChatClient.message('cron-daily', "Revoked admin privileges for #{revoked_count} accounts due to lack of use.")
+  end
+rescue => exception
+  ChatClient.message('cron-daily', "Error executing #{File.basename(__FILE__)}: #{exception.message}", color: 'red')
+  raise exception
+end


### PR DESCRIPTION
This adds a script which will remove admin privileges from any admins that have not logged in for 90 days. Re-adding admin privileges is trivial, and there are no side-effects of revoking and re-adding these privileges. This provides a backstop to ensure offboarded employees have permissions revoked, as well as automatically cleaning up people who either temporarily needed privileges, or who were granted excessive privileges during onboarding. It's not a replacement for proactive permissions management, but helps reduce surface area.

This PR adds the script. We can follow it up with the actual scheduling of the script in cron once we've validated it in Production.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
