### PR TITLE
[Play Lab] make setScoreText instantaneous

### DIFF
--- a/apps/src/studio/api.js
+++ b/apps/src/studio/api.js
@@ -329,7 +329,13 @@ exports.showDebugInfo = function (value) {
 };
 
 exports.setScoreText = function (id, text) {
-  Studio.queueCmd(id, 'setScoreText', {text: text});
+  if (typeof text === 'number') {
+    Studio.playerScore = text;
+    Studio.scoreText = null;
+  } else {
+    Studio.scoreText = text;
+  }
+  Studio.queueCmd(id, 'displayScore', {});
 };
 
 exports.showCoordinates = function (id) {

--- a/apps/src/studio/api.js
+++ b/apps/src/studio/api.js
@@ -330,8 +330,10 @@ exports.showDebugInfo = function (value) {
 
 exports.setScoreText = function (id, text) {
   if (typeof text === 'number') {
-    Studio.playerScore = text;
+    // Resetting the scoreText ensures the new score player score
+    // is used when displayScore updates the play area.
     Studio.scoreText = null;
+    Studio.playerScore = text;
   } else {
     Studio.scoreText = text;
   }

--- a/apps/src/studio/apiJavascript.js
+++ b/apps/src/studio/apiJavascript.js
@@ -281,16 +281,6 @@ exports.showDebugInfo = function (value) {
   });
 };
 
-/*
-exports.setScoreText = function(text) {
-  Studio.queueCmd(null, 'setScoreText', {'text': text});
-};
-
-exports.showCoordinates = function() {
-  Studio.queueCmd(null, 'showCoordinates', {});
-};
-*/
-
 exports.vanish = function (spriteIndex) {
   Studio.queueCmd(null, 'vanish', {spriteIndex: spriteIndex});
 };

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -5433,6 +5433,8 @@ Studio.paramAsNumber = function (value) {
 };
 
 Studio.adjustScore = function (value) {
+  // Resetting the scoreText ensures the new score player score
+  // is used when displayScore updates the play area.
   Studio.scoreText = null;
   Studio.playerScore += value;
 

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -5433,6 +5433,7 @@ Studio.paramAsNumber = function (value) {
 };
 
 Studio.adjustScore = function (value) {
+  Studio.scoreText = null;
   Studio.playerScore += value;
 
   Studio.displayFloatingScore(value);


### PR DESCRIPTION
@molly-moen reported an issue from ZenDesk:

Here is [the sample project](https://studio.code.org/projects/playlab/Eln8ML0HNVYi_pFLD5tDQIeTHchHbivxfH1FkaL5QWs/view) which is supposed to remove a point and end the game either as a win or a loss, based on an if/else, but it never does.

![image](https://github.com/user-attachments/assets/eae146a3-bbfa-4b71-ab86-4cecc4702bd1)

The reason the game never ends is because neither condition evaluates to true. The reasons are complicated. Play Lab actually tracks two values that are both treated as "score": `Studio.scoreText` and `Studio.playerScore`.  

`scoreText`:
- Can either be a string, a number, or null if unset
- if set, is always displayed at the top of the play area
- set using the "set score" block

![image](https://github.com/user-attachments/assets/7c9cc637-a627-4416-ab05-bbf03f443932)

`playerScore`:
- A number, 0 is default
- If no `scoreText` has been set, it is displayed as `"Score: {playerScore}"`
- Manipulated with blocks like "add/remove points"
- Can be read using the purple `score` block 

![image](https://github.com/user-attachments/assets/7f14ebda-48dd-43d4-a5d8-0e0963fe6d18)

Essentially, what this means for the user's program is that the `scoreText` is always `3`, which is displayed at the top. The `playerScore` is initially `0` then `-1`, which is why neither conditional evaluates as expected.

I believe that if a user says "set score to 3", they are expecting that we would set the same score that could be read and manipulated with other blocks. However, it makes (a sort of) sense that if they "set score to bananas" that this might not necessarily break the other game elements of their program. 

With this in mind, I propose changing what `setScoreText` does. When setting a score with a "set score" block, we will continue to set `scoreText` only if the new value isn't a number. Otherwise, we reset to null and instead set `playerScore`. This will change what is displayed as we'll now use the same `"Score: {playerScore}"` template string:
![image](https://github.com/user-attachments/assets/62041240-2ac6-4164-b699-48847a1b1a11)

The second issue that exists has to do with how Play Lab executes student code. When a student presses "Run", we interpret all of Blockly's generated code. When we encounter API commands (from `apps/src/studio/api.js`), we typically queue them up for execution. You'll notice that most of these commands queue up a command with the same name: https://github.com/code-dot-org/code-dot-org/blob/a3139a3e8e50a1acaf7157522b2036758f7085d3/apps/src/studio/api.js

When the queued command is called, we use these `Studio` commands, beginning at this line: https://github.com/code-dot-org/code-dot-org/blob/a3139a3e8e50a1acaf7157522b2036758f7085d3/apps/src/studio/studio.js#L4107

This is different from how a tool like Sprite Lab works, where all commands are executed instantly, and it's how Play Lab can teach sequencing. While commands for sprites and such are queued for sequential execution, other commands, particularly commands related to the game score, are executed immediately. This creates a unintuitive situation where the order of the blocks does not necessarily map to the order of execution. For example, if we tell a sprite to say `score`, we get the score value at the time that we are queueing commands, not at the time of actual execution. If a queued command would change the score, a lower block in the stack will be unaware of that change because it hasn't happened yet. This means other queued commands might be using a stale score value.

![image](https://github.com/user-attachments/assets/eae146a3-bbfa-4b71-ab86-4cecc4702bd1)

If we look at the submitted user project again, we can trace things. What this program actually does, in order:

1. The first “set score” block queues a `setScoreText` command with value 3. [[🔗](https://github.com/code-dot-org/code-dot-org/blob/a8e05d25a0434b0f7f4c854f439713e76d7d379c/apps/src/studio/api.js#L331-L333)]
2. The second “remove points” block immediately removes a point from the default start score (0 becomes -1). This is because queued commands have not run yet. This also queues a `displayScore` command. [[🔗](https://github.com/code-dot-org/code-dot-org/blob/a3139a3e8e50a1acaf7157522b2036758f7085d3/apps/src/studio/api.js#L271-L274)]
3. The `if` blocks are interpreted. Because `playerScore` is currently -1, no `endGame` commands are queued
4. First queued command (`setScoreText`) runs, updating the score text to 3 and displaying it. [[🔗](https://github.com/code-dot-org/code-dot-org/blob/a8e05d25a0434b0f7f4c854f439713e76d7d379c/apps/src/studio/studio.js#L5445-L5448)]
5. The queued `displayScore` command runs, which is effectively redundant. [[🔗](https://github.com/code-dot-org/code-dot-org/blob/a3139a3e8e50a1acaf7157522b2036758f7085d3/apps/src/studio/studio.js#L4356-L4366)]

 Molly and I noticed that if you use "add 3 points" instead of "set score 3" at the start of the program, it works as expected:
![image (251)](https://github.com/user-attachments/assets/c78461a1-0fb8-4670-a86a-97b80f1f1c2e)

Let's explore what this program actually does:

1. The first “add points” block immediately adds points to the default start score (0 becomes 3). This also queues a `displayScore` command. [[🔗](https://github.com/code-dot-org/code-dot-org/blob/a3139a3e8e50a1acaf7157522b2036758f7085d3/apps/src/studio/api.js#L271-L274)]
2. The second “remove points” block immediately removes a point (3 becomes 2). This also queues a `displayScore` command. (Same command as step 1)
3. The `if` blocks are interpreted next. 
4. The player score is not 3, so the first “end game as win” block is ignored.
5. The player score is 3, so an `endGame` command is queued (as a loss). [[🔗](https://github.com/code-dot-org/code-dot-org/blob/a3139a3e8e50a1acaf7157522b2036758f7085d3/apps/src/studio/api.js#L14-L16)]
6. Two  queued `displayScore` commands are called. [[🔗](https://github.com/code-dot-org/code-dot-org/blob/a3139a3e8e50a1acaf7157522b2036758f7085d3/apps/src/studio/studio.js#L4356-L4366)]
7. The queued `endGame` command is called and the game ends as a loss. [[🔗](https://github.com/code-dot-org/code-dot-org/blob/a3139a3e8e50a1acaf7157522b2036758f7085d3/apps/src/studio/studio.js#L5456-L5474)]

The key difference is that "add points" executes immediately while "set score" is queued/delayed. Even if we change what the (delayed) `Studio.setScoreText` command does (with respect to `scoreText` and `playerScore`, outlined higher up), the first program still won't work as expected.
Instead, I looked at the api command `setScoreText` (which has been responsible for queueing `Studio.setScoreText`). Instead of queueing, it now immediately sets the score (either `scoreText` or `playerScore` depending on the value's type), and just queues `displayScore`. 

This adds consistency to the program flow such that all score commands will not execute right away. This means that that blocks lower down can get the updated score and use it for their own queued commands. 

With both of these changes, we're now able to use "set score" blocks to set the `playerScore` value. We do this immediately so that it can be read by other blocks that need that value for the commands that they would queue. 

Now the user's program follows a much more expected flow:

![image (252)](https://github.com/user-attachments/assets/471ed157-a841-4d5d-b067-c4d2059541e0)

(Task failed successfully?)


## Links
https://codedotorg.slack.com/archives/C03DBDN67B7/p1733331124857989
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
