### PR TITLE
chore(stub): add sample storybook test runner test

### DIFF
--- a/frontend/packages/dsco/src/stub/stories/Stub.story.tsx
+++ b/frontend/packages/dsco/src/stub/stories/Stub.story.tsx
@@ -1,4 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
+import { fn , userEvent, within, expect } from '@storybook/test';
 
 import {Stub} from '../Stub';
 
@@ -18,5 +19,12 @@ export const Empty: Story = {
   args: {
     label: 'Hello World!',
     backgroundColor: 'white',
+    onClick: fn()
   },
+  play: async ({args, canvasElement}) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByText(args.label);
+    await userEvent.click(button);
+    await expect(args.onClick).toHaveBeenCalled();
+  }
 };


### PR DESCRIPTION
This PR reimplements a missing test case for the Stub component. This was previously implemented in `Button` but was removed when `Stub` was implemented.

[Screencast From 2024-12-04 15-23-18.webm](https://github.com/user-attachments/assets/7ef32842-8c97-4585-a7fc-96a12c118953)


