### PR TITLE
Updating sign up flow statsig only events and adding page load events

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -24,6 +24,7 @@ const EVENTS = {
     'Curriculum Free Dialog Button Clicked',
   LMS_INFORMATION_BUTTON_CLICKED: 'LMS Information Button Clicked',
   PARENT_OR_GUARDIAN_SIGN_UP_CLICKED: 'Parent or Guardian Sign Up Clicked',
+  FINISH_ACCOUNT_PAGE_LOADED: 'Finish Account Page Loaded',
 
   // School Association
   // Update School Info Dialog

--- a/apps/src/signUpFlow/AccountType.tsx
+++ b/apps/src/signUpFlow/AccountType.tsx
@@ -37,7 +37,7 @@ const AccountType: React.FunctionComponent = () => {
     analyticsReporter.sendEvent(
       EVENTS.SIGN_UP_STARTED_EVENT,
       {},
-      PLATFORMS.STATSIG
+      PLATFORMS.BOTH
     );
   }, []);
 
@@ -47,7 +47,7 @@ const AccountType: React.FunctionComponent = () => {
       {
         'account type': accountType,
       },
-      PLATFORMS.STATSIG
+      PLATFORMS.BOTH
     );
     sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, accountType);
     navigateToHref(studio('/users/new_sign_up/login_type'));
@@ -57,7 +57,7 @@ const AccountType: React.FunctionComponent = () => {
     analyticsReporter.sendEvent(
       EVENTS.CURRICULUM_FREE_DIALOG_BUTTON_CLICKED,
       {},
-      PLATFORMS.STATSIG
+      PLATFORMS.BOTH
     );
   };
 

--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -78,6 +78,12 @@ const FinishStudentAccount: React.FunctionComponent<{
       navigateToHref('/users/new_sign_up/login_type');
     }
 
+    analyticsReporter.sendEvent(
+      EVENTS.FINISH_ACCOUNT_PAGE_LOADED,
+      {},
+      PLATFORMS.BOTH
+    );
+
     const fetchGdprData = async () => {
       const urlParams = new URLSearchParams(window.location.search);
       const forceInEu = urlParams.get('force_in_eu');
@@ -120,7 +126,7 @@ const FinishStudentAccount: React.FunctionComponent<{
     analyticsReporter.sendEvent(
       EVENTS.PARENT_OR_GUARDIAN_SIGN_UP_CLICKED,
       {},
-      PLATFORMS.STATSIG
+      PLATFORMS.BOTH
     );
     const newIsParentCheckedChoice = !isParent;
     setIsParent(newIsParentCheckedChoice);

--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -80,7 +80,7 @@ const FinishStudentAccount: React.FunctionComponent<{
 
     analyticsReporter.sendEvent(
       EVENTS.FINISH_ACCOUNT_PAGE_LOADED,
-      {},
+      {'user type': 'student'},
       PLATFORMS.BOTH
     );
 

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -73,6 +73,12 @@ const FinishTeacherAccount: React.FunctionComponent<{
       navigateToHref('/users/new_sign_up/login_type');
     }
 
+    analyticsReporter.sendEvent(
+      EVENTS.FINISH_ACCOUNT_PAGE_LOADED,
+      {},
+      PLATFORMS.BOTH
+    );
+
     const fetchGdprData = async () => {
       const urlParams = new URLSearchParams(window.location.search);
       const forceInEu = urlParams.get('force_in_eu');

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -75,7 +75,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
 
     analyticsReporter.sendEvent(
       EVENTS.FINISH_ACCOUNT_PAGE_LOADED,
-      {},
+      {'user type': 'teacher'},
       PLATFORMS.BOTH
     );
 

--- a/apps/src/signUpFlow/LoginTypeSelection.tsx
+++ b/apps/src/signUpFlow/LoginTypeSelection.tsx
@@ -158,7 +158,7 @@ const LoginTypeSelection: React.FunctionComponent = () => {
     analyticsReporter.sendEvent(
       EVENTS.LMS_INFORMATION_BUTTON_CLICKED,
       {},
-      PLATFORMS.STATSIG
+      PLATFORMS.BOTH
     );
   };
 
@@ -168,7 +168,7 @@ const LoginTypeSelection: React.FunctionComponent = () => {
       {
         'user login type': loginType,
       },
-      PLATFORMS.STATSIG
+      PLATFORMS.BOTH
     );
   }
 

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -41,6 +41,11 @@ let userInRegionalPartnerVariant = experiments.isEnabled(
 );
 
 $(document).ready(() => {
+  analyticsReporter.sendEvent(
+    EVENTS.FINISH_ACCOUNT_PAGE_LOADED,
+    {},
+    PLATFORMS.BOTH
+  );
   const schoolInfoMountPoint = document.getElementById('school-info-inputs');
   let user_type = $('#user_user_type').val();
   init();

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -41,11 +41,6 @@ let userInRegionalPartnerVariant = experiments.isEnabled(
 );
 
 $(document).ready(() => {
-  analyticsReporter.sendEvent(
-    EVENTS.FINISH_ACCOUNT_PAGE_LOADED,
-    {},
-    PLATFORMS.BOTH
-  );
   const schoolInfoMountPoint = document.getElementById('school-info-inputs');
   let user_type = $('#user_user_type').val();
   init();

--- a/apps/src/sites/studio/pages/followers/student_user_new.js
+++ b/apps/src/sites/studio/pages/followers/student_user_new.js
@@ -7,7 +7,7 @@ $(document).ready(() => {
   analyticsReporter.sendEvent(
     EVENTS.SIGN_UP_STARTED_EVENT,
     {source: 'section code sign up form'},
-    PLATFORMS.STATSIG
+    PLATFORMS.BOTH
   );
 
   document
@@ -21,7 +21,7 @@ $(document).ready(() => {
           'has school': false,
           'has marketing value selected': true,
         },
-        PLATFORMS.STATSIG
+        PLATFORMS.BOTH
       );
     });
 });


### PR DESCRIPTION
I was able to test the different pages: the new flow finish student sign up, and the new flow finish teacher sign up. 

I was also able to update some of the sign up events to send to Amplitude as well as statsig so we can take advantage of the superior analytics for the additional year we have it:)

(The two pages look the same, with different metadata)

<img width="584" alt="Screenshot 2024-12-05 at 10 25 28 AM" src="https://github.com/user-attachments/assets/d9ae7d9b-c705-42f2-85d6-961c8cd7ed46">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2859
- https://codedotorg.atlassian.net/browse/ACQ-2865

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
