### PR TITLE
[DESIGN2-216-Typography] Typography Component - DSCO - Update color variables

### DIFF
--- a/apps/src/componentLibrary/typography/CHANGELOG.md
+++ b/apps/src/componentLibrary/typography/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this component will be documented in this file.
 
+## [2.0.2](https://github.com/code-dot-org/code-dot-org/pull/62837)
+* updated color variables to use primitiveColors.css
+
 ## [2.0.1](https://github.com/code-dot-org/code-dot-org/pull/53337)
 * add ```ExtraStrong``` typography element
 

--- a/apps/src/componentLibrary/typography/CHANGELOG.md
+++ b/apps/src/componentLibrary/typography/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this component will be documented in this file.
 
 ## [2.0.2](https://github.com/code-dot-org/code-dot-org/pull/62837)
-* updated color variables to use primitiveColors.css
+* updated color variables to use `primitiveColors.css`
 
 ## [2.0.1](https://github.com/code-dot-org/code-dot-org/pull/53337)
 * add ```ExtraStrong``` typography element

--- a/apps/src/componentLibrary/typography/typography.module.scss
+++ b/apps/src/componentLibrary/typography/typography.module.scss
@@ -1,4 +1,5 @@
-@import "color", "font";
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
+@import "font";
 
 /* This file is being copied and adopted to shared/css/typography.scss
    Updating styles in this file will require a manual sync of the that file.
@@ -87,7 +88,7 @@ html {
 */
 
 @mixin heading-common {
-  color: $neutral-dark;
+  color: var(--neutral-base-black);
   margin: 0 0 0.5em 0;
 }
 
@@ -136,7 +137,7 @@ html {
 // Paragraph styles
 @mixin paragraph-common {
   @include main-font-regular;
-  color: $neutral-dark;
+  color: var(--neutral-base-black);
   margin-bottom: 1em;
 }
 


### PR DESCRIPTION
Swaps out color variables from `shared/color.scss` with Primitive colors from `primitiveColors.css` on the Typography component. 

👀 **DOTD note:** there might be Eyes diffs with this.

## Links
Jira ticket: [DESIGN2-216](https://codedotorg.atlassian.net/browse/DESIGN2-216)

## Testing story
Tested locally in Storybook

----

## Before - using `shared/colors.scss`
<img width="987" alt="Before" src="https://github.com/user-attachments/assets/56a4adca-8a20-4965-8afd-4ca6563d1066">

## After - using `primitiveColors.css`
<img width="987" alt="After" src="https://github.com/user-attachments/assets/b60c0c8e-3684-48bf-ae07-3432fd1b0e9d">
