### PR TITLE
Update GenAI alarm descriptions with next steps

### DIFF
--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
@@ -16,8 +16,11 @@ const modelIds = modelDescriptions.map((model: {id: string}) => model.id);
 
 export const openaiSafetyHighFailureRateConfiguration: PutMetricAlarmInput = {
   AlarmName: 'genai_openai_safety_high_failure_rate',
-  AlarmDescription:
-    'Alarms when OpenAI safety checks are experiencing a high failure rate.',
+  AlarmDescription: `OpenAI safety checks are experiencing a high failure rate.
+
+*Next Steps*:
+- Check the [GenAICurriculum Dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/GenAICurriculum)
+- Check HoneyBadger for "AichatRequestChatCompletionJob" errors`,
   ActionsEnabled: true,
   OKActions: [],
   AlarmActions: [SNS_TOPIC],
@@ -72,8 +75,11 @@ const failureMetrics = modelIds.map((modelId, index) => ({
 export const chatCompletionJobExecutionHighFailureRateConfiguration: PutMetricAlarmInput =
   {
     AlarmName: 'genai_chat_completion_job_execution_high_failure_rate',
-    AlarmDescription:
-      'Alarms when chat completion jobs are experiencing a high failure rate.',
+    AlarmDescription: `Chat completion jobs are experiencing a high failure rate.
+    
+*Next Steps*:
+- Check the [GenAICurriculum Dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/GenAICurriculum)
+- Check HoneyBadger for "AichatRequestChatCompletionJob" errors`,
     ActionsEnabled: true,
     OKActions: [],
     AlarmActions: [SNS_TOPIC],
@@ -113,8 +119,13 @@ const browserIndices = BROWSERS.map((_, i) => i + 1);
 export const chatCompletionHighBrowserFailureRateConfiguration: PutMetricAlarmInput =
   {
     AlarmName: 'genai_chat_completion_high_browser_failure_rate',
-    AlarmDescription:
-      'Alarms when browser are experiencing a high failure rate attempting chat completion requests.',
+    AlarmDescription: `Browsers are experiencing a high failure rate attempting chat completion requests.
+
+*Next Steps:*
+- Check the [GenAICurriculum Dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/GenAICurriculum)
+- Check [browser logs](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/production-browser-events/log-events/production) in Cloudwatch
+- If chat completion job failure rates and/or OpenAI failure rates are also elevated, check HoneyBadger for "AichatRequestChatCompletionJob" errors.
+- If not, this is likely a browser-specific and/or ActiveJob related issue. Check the [ActiveJob dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/ActiveJob_DelayedJob).`,
     ActionsEnabled: true,
     OKActions: [],
     AlarmActions: [SNS_TOPIC],

--- a/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
+++ b/aws/cloudformation/standalone/gen_ai_curriculum/monitoring/alarms/alarmConfigurations.ts
@@ -12,6 +12,9 @@ import {
   createOpenaiMetricStat,
 } from './alarmHelpers';
 
+const SL_HANDBOOK_LINK =
+  'https://docs.google.com/document/d/1T0Vwwg22isdgsf66mYiRtUZVKaSxHo1PW89HAnW_twk/edit?tab=t.0#heading=h.npwykn5tc2b4';
+
 const modelIds = modelDescriptions.map((model: {id: string}) => model.id);
 
 export const openaiSafetyHighFailureRateConfiguration: PutMetricAlarmInput = {
@@ -20,7 +23,8 @@ export const openaiSafetyHighFailureRateConfiguration: PutMetricAlarmInput = {
 
 *Next Steps*:
 - Check the [GenAICurriculum Dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/GenAICurriculum)
-- Check HoneyBadger for "AichatRequestChatCompletionJob" errors`,
+- Check HoneyBadger for **AichatRequestChatCompletionJob** errors
+- Check [Student Learning Tips & Tricks](${SL_HANDBOOK_LINK}) for more details.`,
   ActionsEnabled: true,
   OKActions: [],
   AlarmActions: [SNS_TOPIC],
@@ -79,7 +83,8 @@ export const chatCompletionJobExecutionHighFailureRateConfiguration: PutMetricAl
     
 *Next Steps*:
 - Check the [GenAICurriculum Dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/GenAICurriculum)
-- Check HoneyBadger for "AichatRequestChatCompletionJob" errors`,
+- Check HoneyBadger for **AichatRequestChatCompletionJob** errors
+- Check [Student Learning Tips & Tricks](${SL_HANDBOOK_LINK}) for more details.`,
     ActionsEnabled: true,
     OKActions: [],
     AlarmActions: [SNS_TOPIC],
@@ -123,9 +128,10 @@ export const chatCompletionHighBrowserFailureRateConfiguration: PutMetricAlarmIn
 
 *Next Steps:*
 - Check the [GenAICurriculum Dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/GenAICurriculum)
-- Check [browser logs](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/production-browser-events/log-events/production) in Cloudwatch
-- If chat completion job failure rates and/or OpenAI failure rates are also elevated, check HoneyBadger for "AichatRequestChatCompletionJob" errors.
-- If not, this is likely a browser-specific and/or ActiveJob related issue. Check the [ActiveJob dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/ActiveJob_DelayedJob).`,
+- Check [browser logs](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/production-browser-events/log-events/production) in Cloudwatch (filter by **appName: 'aichat'**)
+- If chat completion job failure rates and/or OpenAI failure rates are also elevated, check HoneyBadger for **AichatRequestChatCompletionJob** errors.
+- If not, this is likely a browser-specific and/or ActiveJob related issue. Check the [ActiveJob dashboard](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards/dashboard/ActiveJob_DelayedJob).
+- Check [Student Learning Tips & Tricks](${SL_HANDBOOK_LINK}) for more details.`,
     ActionsEnabled: true,
     OKActions: [],
     AlarmActions: [SNS_TOPIC],


### PR DESCRIPTION
Update GenAI alarm descriptions with some more details and next steps that the SL on call can follow. Very much open to feedback on how to make these more useful or clearer!

Example on how this shows up in Cloudwatch
<img width="458" alt="Screenshot 2024-12-06 at 11 00 55 AM" src="https://github.com/user-attachments/assets/a334f80c-7ef8-431e-8388-9a14e5ec2eba">
