### PR TITLE
Add educator_type to User serialized_attrs

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -168,6 +168,7 @@ class User < ApplicationRecord
     has_seen_ai_assessments_announcement
     seen_ta_scores_map
     roster_synced
+    educator_type
   )
 
   attr_accessor(

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -168,7 +168,7 @@ class User < ApplicationRecord
     has_seen_ai_assessments_announcement
     seen_ta_scores_map
     roster_synced
-    educator_type
+    educator_role
   )
 
   attr_accessor(

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -117,6 +117,7 @@ class User < ApplicationRecord
   #     brute-force password attempts
   #   roster_synced: Indicates if the user was created during a roster sync operation from an LMS. Implies that the user
   #     is a school-managed account.
+  #   educator_role: Indicates the role of the educator, e.g. 'teacher', 'school_admin', 'district_admin', etc.
   serialized_attrs %w(
     ops_first_name
     ops_last_name

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -1,4 +1,11 @@
 class Policies::User
+  ALLOWED_EDUCATOR_TYPES = Set[
+    "teacher".freeze,
+    "school_admin".freeze,
+    "district_admin".freeze,
+    "librarian".freeze,
+  ].freeze
+
   # Returns the user.attributes along with the attributes of select
   # associations.
   def self.user_attributes(user)

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -1,5 +1,5 @@
 class Policies::User
-  ALLOWED_EDUCATOR_TYPES = Set[
+  ALLOWED_EDUCATOR_ROLES = Set[
     "teacher".freeze,
     "school_admin".freeze,
     "district_admin".freeze,


### PR DESCRIPTION
This PR adds the key `educator_role` to the `serialized_attrs` object in user.rb, as well as a set of expected educator types in the user policies which should be used to validate the input. This is to enable capturing different types of educators during the new sign-up flow. NOTE: The set of expected educator types is not complete, and should be finalized/updated before merging this PR.

This new value will only need to be accessed via a single user instance. It does not need to be an index as it won't be part of a query.

### Example Usage
Values in `serialized_attrs` behave as if they were column names when interacting with a user. Example:

Assigning a value:
```
user = ::User.new
user.educator_type = params[:educator_type]
```

Reading a value:
```
puts user.educator_type
# teacher
```

Example of validating an input against the ALLOWED_EDUCATOR_TYPES set
```
educator_type = params[:educator_type]
user.educator_type = educator_type if Policies::User::ALLOWED_EDUCATOR_TYPES.includes? educator_type
```
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
