### PR TITLE
feat(marketing): add contentful experiences

### DIFF
--- a/frontend/apps/marketing/.env.example
+++ b/frontend/apps/marketing/.env.example
@@ -1,0 +1,31 @@
+####################################
+# Contentful Environment Variables #
+####################################
+
+# For values, see: https://www.contentful.com/developers/docs/references/authentication/
+
+# Contentful Space ID
+# Viewable in the Contentful web app under Settings > API keys
+# See: https://contentful.github.io/contentful.js/contentful/latest/interfaces/CreateClientParams.html#space
+CONTENTFUL_SPACE_ID=
+
+# Contentful Environment ID
+# Note: Production must only use the master environment
+# See: https://contentful.github.io/contentful.js/contentful/latest/interfaces/CreateClientParams.html#environment
+CONTENTFUL_ENV_ID=
+
+# For published & unpublished content, use preview.contentful.com
+# For published content only cdn.contentful.com
+# Note: User-accessible websites should only use published content
+# See: https://contentful.github.io/contentful.js/contentful/latest/interfaces/CreateClientParams.html#host
+CONTENTFUL_API_HOST=
+
+# If viewing unpublished & published content is suitable, use the "Contentful Preview API Token"
+# If only published content is suitable (such as Production), use the "Contentful Content Delivery API Token"
+# Viewable in the Contentful web app under Settings > API keys
+# See: https://contentful.github.io/contentful.js/contentful/latest/interfaces/CreateClientParams.html#accessToken
+CONTENTFUL_TOKEN=
+
+# The Contentful content type id for experience content
+# Viewable in the Contentful web app under Settings > Experiences > API Identifier
+CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID=

--- a/frontend/apps/marketing/README.md
+++ b/frontend/apps/marketing/README.md
@@ -2,6 +2,19 @@
 
 ## Getting Started
 
+### Secrets
+
+Contentful API Keys and other secrets will need to be populated for this application to run correctly.
+
+1. Copy `.env.example` to `.env`
+    ```bash
+    cp .env.example .env
+    ```
+2. For each entry in `.env`, see the instructions for how to obtain an API Key.
+
+**Note**: `.env` must not be committed to source. It is git ignored by default.
+
+### Developing
 First, run the development server:
 
 ```bash

--- a/frontend/apps/marketing/README.md
+++ b/frontend/apps/marketing/README.md
@@ -7,14 +7,15 @@
 Contentful API Keys and other secrets will need to be populated for this application to run correctly.
 
 1. Copy `.env.example` to `.env`
-    ```bash
-    cp .env.example .env
-    ```
+   ```bash
+   cp .env.example .env
+   ```
 2. For each entry in `.env`, see the instructions for how to obtain an API Key.
 
 **Note**: `.env` must not be committed to source. It is git ignored by default.
 
 ### Developing
+
 First, run the development server:
 
 ```bash
@@ -22,3 +23,17 @@ yarn dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## Creating New Components
+
+When creating a new component for the design system, setup the following structure. For this example, the `ExampleButton` component is to be created. Substitute this name for the component to be created.
+
+1. Create skeleton directories:
+   ```bash
+   yarn workspace @code-dot-org/dsco exec mkdir -p src/ExampleButton src/ExampleButton/__tests__ src/ExampleButton/stories
+   ```
+2. Create the `ExampleButton.tsx` file which will be your react component. See other components in `src` for examples.
+3. Create the `index.ts` file which will re-export `ExampleButton` and optionally define a [Contentful Component Defintiion](https://www.contentful.com/developers/docs/experiences/register-custom-components/). A definition is not needed if the component will not be used in Contentful Studio.
+4. Add `ExampleButton` exports in `package.json` under the `exports` field.
+5. Create `ExampleButton.test.tsx` in the `__tests__` directory and implement jest unit tests.
+6. Create `ExampleButton.story.tsx` using [Storybook Component Story Format](https://storybook.js.org/docs/api/csf) in the `stories` directory.

--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -26,6 +26,9 @@
   },
   "prettier": "@code-dot-org/lint-config/prettier/index.mjs",
   "dependencies": {
+    "@code-dot-org/dsco": "workspace:*",
+    "@contentful/experiences-sdk-react": "^1.24.0",
+    "contentful": "^11.2.5",
     "next": "^15.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -44,6 +44,6 @@
     "typescript": "^5"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   }
 }

--- a/frontend/apps/marketing/src/app/[locale]/[slug]/page.tsx
+++ b/frontend/apps/marketing/src/app/[locale]/[slug]/page.tsx
@@ -1,0 +1,37 @@
+import {detachExperienceStyles} from '@contentful/experiences-sdk-react';
+import {getExperience} from '@/contentful/get-experience';
+import ExperiencePageLoader from '@/contentful/components/ExperiencePageLoader';
+
+// Register custom components server-side
+import '@/contentful/register-custom-components';
+
+type ExperiencePageProps = {
+  params: Promise<{locale?: string; slug?: string; preview?: string}>;
+  searchParams: Promise<{[key: string]: string | string[] | undefined}>;
+};
+
+export default async function ExperiencePage({
+  params,
+  searchParams,
+}: ExperiencePageProps) {
+  const {locale = 'en-US', slug = 'home-page'} = (await params) || {};
+  const {expEditorMode} = await searchParams;
+  const editorMode = expEditorMode === 'true';
+  const {experience, error} = await getExperience(slug, locale, editorMode);
+
+  if (error) {
+    return <div>{error.message}</div>;
+  }
+
+  // extract the styles from the experience
+  const stylesheet = experience ? detachExperienceStyles(experience) : null;
+
+  // experience currently needs to be stringified manually to be passed to the component
+  const experienceJSON = experience ? JSON.stringify(experience) : null;
+  return (
+    <main style={{width: '100%'}}>
+      {stylesheet && <style>{stylesheet}</style>}
+      <ExperiencePageLoader experienceJSON={experienceJSON} locale={locale} />
+    </main>
+  );
+}

--- a/frontend/apps/marketing/src/app/globals.css
+++ b/frontend/apps/marketing/src/app/globals.css
@@ -1,42 +1,5 @@
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
-}
-
-body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
 }

--- a/frontend/apps/marketing/src/contentful/client.ts
+++ b/frontend/apps/marketing/src/contentful/client.ts
@@ -1,0 +1,12 @@
+import {createClient} from 'contentful';
+
+export default createClient({
+  // your space id
+  space: process.env.CONTENTFUL_SPACE_ID!,
+  // your environment id
+  environment: process.env.CONTENTFUL_ENV_ID,
+  // Supported values: 'preview.contentful.com' or 'cdn.contentful.com',
+  host: process.env.CONTENTFUL_API_HOST,
+  // needs to be access token if host = 'cdn.contentful.com' and preview token if 'preview.contentful.com'
+  accessToken: process.env.CONTENTFUL_TOKEN!,
+});

--- a/frontend/apps/marketing/src/contentful/components/ExperiencePageLoader.tsx
+++ b/frontend/apps/marketing/src/contentful/components/ExperiencePageLoader.tsx
@@ -1,0 +1,21 @@
+'use client';
+// Register custom components client-side
+import '@/contentful/register-custom-components';
+import {ExperienceRoot} from '@contentful/experiences-sdk-react';
+
+type ExperiencePageLoaderProps = {
+  experienceJSON: string | null;
+  locale: string;
+};
+
+/**
+ * This is a client-side component layer that registers Contentful custom components prior to the
+ * instantiation of the Contentful ExperienceRoot component. Custom components must be mapped client-side prior to ExperienceRoot
+ * being mounted.
+ */
+export default function ExperiencePageLoader({
+  experienceJSON,
+  locale,
+}: ExperiencePageLoaderProps) {
+  return <ExperienceRoot experience={experienceJSON} locale={locale} />;
+}

--- a/frontend/apps/marketing/src/contentful/get-experience.ts
+++ b/frontend/apps/marketing/src/contentful/get-experience.ts
@@ -1,0 +1,35 @@
+import {fetchBySlug} from '@contentful/experiences-sdk-react';
+import client from './client';
+
+/**
+ * Calls Contentful to retrieve the experience content record
+ * @param slug Page Slug
+ * @param localeCode The locale code to fetch from
+ * @param isEditorMode Whether the page is running in Experience Studio
+ * @returns Experience content record and error if any
+ */
+export const getExperience = async (
+  slug: string,
+  localeCode: string,
+  isEditorMode = false,
+) => {
+  // While in editor mode, the experience is passed to the ExperienceRoot
+  // component by the editor, so we don't fetch it here
+  if (isEditorMode) {
+    return {experience: undefined, error: undefined};
+  }
+
+  let experience: Awaited<ReturnType<typeof fetchBySlug>> | undefined;
+
+  try {
+    experience = await fetchBySlug({
+      client,
+      slug,
+      experienceTypeId: process.env.CONTENTFUL_EXPERIENCE_CONTENT_TYPE_ID!,
+      localeCode,
+    });
+  } catch (error) {
+    return {experience, error: error as Error};
+  }
+  return {experience, error: undefined};
+};

--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -1,5 +1,5 @@
 /**
- * This file is used to register custom react components with the Contentful SDK.
+ * This file is used to register custom react components for usage in Contentful Studio Experiences.
  *
  * Note: This file must be imported both server-side and client-side to ensure Contentful is able to map on both rendering modes.
  */

--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is used to register custom react components with the Contentful SDK.
+ *
+ * Note: This file must be imported both server-side and client-side to ensure Contentful is able to map on both rendering modes.
+ */
+import {defineComponents} from '@contentful/experiences-sdk-react';
+import {Stub, StubContentfulComponentDefinition} from '@code-dot-org/dsco/stub';
+import {
+  StubSection,
+  StubSectionContentfulComponentDefinition,
+} from '@code-dot-org/dsco/stub-section';
+
+defineComponents([
+  {
+    component: Stub,
+    definition: StubContentfulComponentDefinition,
+  },
+  {
+    component: StubSection,
+    definition: StubSectionContentfulComponentDefinition,
+  },
+]);

--- a/frontend/packages/dsco/clean-package.config.cjs
+++ b/frontend/packages/dsco/clean-package.config.cjs
@@ -1,26 +1,3 @@
-const glob = require('glob');
-const {basename, dirname} = require('path');
-
-const entryPoints = glob.sync('./src/**/index.ts', {
-  posix: true,
-  nodir: true,
-});
-
-const componentExports = {};
-
-for (const entryPoint of entryPoints) {
-  const componentName = basename(dirname(entryPoint));
-
-  componentExports[`./${componentName}`] = {
-    types: `./dist/${componentName}/index.d.ts`,
-    import: `./dist/${componentName}/index.mjs`,
-    require: `./dist/${componentName}/index.js`,
-  };
-
-  componentExports[`./${componentName}/index.css`] =
-    `./dist/${componentName}/index.css`;
-}
-
 module.exports = {
   remove: ['devDependencies'],
   replace: {
@@ -29,7 +6,6 @@ module.exports = {
     types: 'dist/index.d.ts',
     exports: {
       './package.json': './package.json',
-      ...componentExports,
     },
   },
 };

--- a/frontend/packages/dsco/package.json
+++ b/frontend/packages/dsco/package.json
@@ -17,6 +17,19 @@
   "license": "SEE LICENSE IN LICENSE",
   "sideEffects": false,
   "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    "./stub-section": {
+      "types": "./dist/stub-section/index.d.ts",
+      "import": "./dist/stub-section/index.js",
+      "require": "./dist/stub-section/index.cjs"
+    },
+    "./stub": {
+      "types": "./dist/stub/index.d.ts",
+      "import": "./dist/stub/index.js",
+      "require": "./dist/stub/index.cjs"
+    }
+  },
   "main": "components/index.ts",
   "files": [
     "dist"
@@ -43,6 +56,7 @@
   "devDependencies": {
     "@code-dot-org/legacy-css": "workspace:*",
     "@code-dot-org/lint-config": "workspace:*",
+    "@contentful/experiences-sdk-react": "^1.24.0",
     "@eslint/js": "^9.15.0",
     "@swc/core": "^1.9.3",
     "@swc/jest": "^0.2.37",

--- a/frontend/packages/dsco/src/stub-section/index.ts
+++ b/frontend/packages/dsco/src/stub-section/index.ts
@@ -1,2 +1,22 @@
+import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
 export {StubSection, StubSection as default} from './StubSection';
 export type {StubSectionProps} from './StubSection';
+
+export const StubSectionContentfulComponentDefinition: ComponentDefinition = {
+  id: 'stubSection',
+  name: 'StubSection',
+  category: 'Custom Components',
+  variables: {
+    backgroundColor: {
+      displayName: 'Background Color',
+      type: 'Text',
+      defaultValue: 'white',
+    },
+    label: {
+      displayName: 'Label',
+      type: 'Text',
+      defaultValue: 'Enter text here',
+    },
+  },
+};

--- a/frontend/packages/dsco/src/stub/index.ts
+++ b/frontend/packages/dsco/src/stub/index.ts
@@ -1,2 +1,21 @@
 export {Stub, Stub as default} from './Stub';
 export type {StubProps} from './Stub';
+import type {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
+export const StubContentfulComponentDefinition: ComponentDefinition = {
+  id: 'stub',
+  name: 'Stub',
+  category: 'Custom Components',
+  variables: {
+    backgroundColor: {
+      displayName: 'Background Color',
+      type: 'Text',
+      defaultValue: 'white',
+    },
+    label: {
+      displayName: 'Label',
+      type: 'Text',
+      defaultValue: 'Enter text here',
+    },
+  },
+};

--- a/frontend/packages/dsco/src/stub/stories/Stub.story.tsx
+++ b/frontend/packages/dsco/src/stub/stories/Stub.story.tsx
@@ -1,5 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import { fn , userEvent, within, expect } from '@storybook/test';
+import {fn, userEvent, within, expect} from '@storybook/test';
 
 import {Stub} from '../Stub';
 
@@ -19,12 +19,12 @@ export const Empty: Story = {
   args: {
     label: 'Hello World!',
     backgroundColor: 'white',
-    onClick: fn()
+    onClick: fn(),
   },
   play: async ({args, canvasElement}) => {
     const canvas = within(canvasElement);
     const button = canvas.getByText(args.label);
     await userEvent.click(button);
     await expect(args.onClick).toHaveBeenCalled();
-  }
+  },
 };

--- a/frontend/packages/dsco/tsup.config.ts
+++ b/frontend/packages/dsco/tsup.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
   clean: true,
   target: 'es2019',
   format: ['cjs', 'esm'],
-  banner: {js: '"use client";'},
   external: [
     '/fonts/barlowSemiCondensed/BarlowSemiCondensed-Medium.ttf',
     '/fonts/barlowSemiCondensed/BarlowSemiCondensed-SemiBold.ttf',

--- a/frontend/packages/lint-config/eslint/base.mjs
+++ b/frontend/packages/lint-config/eslint/base.mjs
@@ -10,6 +10,7 @@ export default [
   {
     rules: {
       'import-x/no-cycle': 'error',
+      'import-x/no-unresolved': 'off', // https://codedotorg.atlassian.net/browse/ACQ-2875
     },
   },
 ];

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -714,7 +714,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.24.1, @babel/runtime@npm:^7.24.7, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.26.0
   resolution: "@babel/runtime@npm:7.26.0"
   dependencies:
@@ -794,12 +794,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@code-dot-org/dsco@workspace:packages/dsco":
+"@code-dot-org/dsco@workspace:*, @code-dot-org/dsco@workspace:packages/dsco":
   version: 0.0.0-use.local
   resolution: "@code-dot-org/dsco@workspace:packages/dsco"
   dependencies:
     "@code-dot-org/legacy-css": "workspace:*"
     "@code-dot-org/lint-config": "workspace:*"
+    "@contentful/experiences-sdk-react": "npm:^1.24.0"
     "@eslint/js": "npm:^9.15.0"
     "@swc/core": "npm:^1.9.3"
     "@swc/jest": "npm:^0.2.37"
@@ -877,10 +878,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@code-dot-org/marketing@workspace:apps/marketing"
   dependencies:
+    "@code-dot-org/dsco": "workspace:*"
+    "@contentful/experiences-sdk-react": "npm:^1.24.0"
     "@next/eslint-plugin-next": "npm:^15.0.3"
     "@types/node": "npm:^20"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
+    contentful: "npm:^11.2.5"
     eslint: "npm:^9.16.0"
     eslint-plugin-jest: "npm:^28.9.0"
     next: "npm:^15.0.3"
@@ -890,6 +894,118 @@ __metadata:
     typescript: "npm:^5"
   languageName: unknown
   linkType: soft
+
+"@contentful/content-source-maps@npm:^0.11.0, @contentful/content-source-maps@npm:^0.11.6":
+  version: 0.11.6
+  resolution: "@contentful/content-source-maps@npm:0.11.6"
+  dependencies:
+    "@vercel/stega": "npm:^0.1.2"
+    json-pointer: "npm:^0.6.2"
+  checksum: 10c0/10cd0ef4f8c4df03c3760ef9e0e018c1b22942c849f419921d5ce15beec24448816b5e69763c975c414f2638f98322321782a99c750f5e22f6813b0155e257c5
+  languageName: node
+  linkType: hard
+
+"@contentful/experiences-components-react@npm:1.24.0":
+  version: 1.24.0
+  resolution: "@contentful/experiences-components-react@npm:1.24.0"
+  dependencies:
+    "@contentful/experiences-core": "npm:1.24.0"
+    "@contentful/rich-text-react-renderer": "npm:^15.17.2"
+    postcss-import: "npm:^16.0.1"
+    style-inject: "npm:^0.3.0"
+  peerDependencies:
+    react: ">=17.0.0"
+    react-dom: ">=17.0.0"
+  checksum: 10c0/712f97de7fd486eabca259920a2d9571cc32a123bc4ff547425e99fd599d84294b177966b8d295663b5a921d06a68cfb59279330b6f9f5723af380a92aa58fad
+  languageName: node
+  linkType: hard
+
+"@contentful/experiences-core@npm:1.24.0":
+  version: 1.24.0
+  resolution: "@contentful/experiences-core@npm:1.24.0"
+  dependencies:
+    "@contentful/experiences-validators": "npm:1.24.0"
+    "@contentful/rich-text-types": "npm:^16.3.0"
+  peerDependencies:
+    contentful: ">=10.6.0"
+  checksum: 10c0/9cf3b3846b742d3121799ddf90938bfa24598aea4e257bfce2be4478f38316f5d726b55838e5bf8f44aeb4e147686ba801194db1334aa01ec14c959663ac5666
+  languageName: node
+  linkType: hard
+
+"@contentful/experiences-sdk-react@npm:^1.24.0":
+  version: 1.24.0
+  resolution: "@contentful/experiences-sdk-react@npm:1.24.0"
+  dependencies:
+    "@contentful/experiences-components-react": "npm:1.24.0"
+    "@contentful/experiences-core": "npm:1.24.0"
+    "@contentful/experiences-validators": "npm:1.24.0"
+    "@contentful/experiences-visual-editor-react": "npm:1.24.0"
+    "@contentful/rich-text-types": "npm:^16.2.1"
+    classnames: "npm:^2.3.2"
+    csstype: "npm:^3.1.2"
+    immer: "npm:^10.0.3"
+    lodash-es: "npm:^4.17.21"
+    md5: "npm:^2.3.0"
+    style-inject: "npm:^0.3.0"
+    vite-plugin-css-injected-by-js: "npm:^3.1.1"
+  peerDependencies:
+    contentful: ">=10.6.0"
+    react: ">=16.0.0"
+    react-dom: ">=16.0.0"
+  checksum: 10c0/1d99da7fa3272f277e0430638cbd37fc536934070f51ae1d5e624625f4f938e1b0438f0db253f08df20d1566e8e32687b16138003beae14ae4d59a1017e5e190
+  languageName: node
+  linkType: hard
+
+"@contentful/experiences-validators@npm:1.24.0":
+  version: 1.24.0
+  resolution: "@contentful/experiences-validators@npm:1.24.0"
+  dependencies:
+    zod: "npm:^3.22.4"
+  checksum: 10c0/52b996d7236afbfc0559f1ca26572592efb59d773641af19ce9b5f04aeddc691c4d7d36666f95d4b146f3bccc35f01ce5e81d4d7d38d05fc25fb9567da6c9a86
+  languageName: node
+  linkType: hard
+
+"@contentful/experiences-visual-editor-react@npm:1.24.0":
+  version: 1.24.0
+  resolution: "@contentful/experiences-visual-editor-react@npm:1.24.0"
+  dependencies:
+    "@contentful/experiences-components-react": "npm:1.24.0"
+    "@contentful/experiences-core": "npm:1.24.0"
+    "@hello-pangea/dnd": "npm:^16.3.0"
+    classnames: "npm:^2.3.2"
+    contentful: "npm:^10.6.14"
+    immer: "npm:^10.0.3"
+    lodash-es: "npm:^4.17.21"
+    md5: "npm:^2.3.0"
+    style-inject: "npm:^0.3.0"
+    use-debounce: "npm:^10.0.0"
+    uuid: "npm:^9.0.1"
+    zustand: "npm:^4.4.7"
+  peerDependencies:
+    react: ">=17.0.0"
+    react-dom: ">=17.0.0"
+  checksum: 10c0/0ff2f60c455609afa32c6f84adad38fcf9a7ac83d7af5ec0e5576ad8205ae64648519d9a3e58ea4a1b951ad2eac0acb51f2aa542fb1de1b6a2559c3e9a83a0e7
+  languageName: node
+  linkType: hard
+
+"@contentful/rich-text-react-renderer@npm:^15.17.2":
+  version: 15.22.11
+  resolution: "@contentful/rich-text-react-renderer@npm:15.22.11"
+  dependencies:
+    "@contentful/rich-text-types": "npm:^16.8.5"
+  peerDependencies:
+    react: ^16.8.6 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/4422ce9f0e93865226012e4551726dec6bb996127c8298c3b9b0011289872fe362e5dabef5b6d7146a1de5145021a0d9ec240ef961c523c5a7748b2f2ca3e3ec
+  languageName: node
+  linkType: hard
+
+"@contentful/rich-text-types@npm:^16.0.2, @contentful/rich-text-types@npm:^16.2.1, @contentful/rich-text-types@npm:^16.3.0, @contentful/rich-text-types@npm:^16.6.1, @contentful/rich-text-types@npm:^16.8.5":
+  version: 16.8.5
+  resolution: "@contentful/rich-text-types@npm:16.8.5"
+  checksum: 10c0/0af82d501bb26d854fa3bc68136db1f0738428135066876062370637f219cd51f10abecf8e02a72c2cf9eb012523add21f4a3f72af4981a7ad4c95a9bbcb237f
+  languageName: node
+  linkType: hard
 
 "@dotenv-run/cli@npm:^1.3.6":
   version: 1.3.6
@@ -1226,6 +1342,24 @@ __metadata:
   dependencies:
     "@hapi/hoek": "npm:^9.0.0"
   checksum: 10c0/b16b06d9357947149e032bdf10151eb71aea8057c79c4046bf32393cb89d0d0f7ca501c40c0f7534a5ceca078de0700d2257ac855c15e59fe4e00bba2f25c86f
+  languageName: node
+  linkType: hard
+
+"@hello-pangea/dnd@npm:^16.3.0":
+  version: 16.6.0
+  resolution: "@hello-pangea/dnd@npm:16.6.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.24.1"
+    css-box-model: "npm:^1.2.1"
+    memoize-one: "npm:^6.0.0"
+    raf-schd: "npm:^4.0.3"
+    react-redux: "npm:^8.1.3"
+    redux: "npm:^4.2.1"
+    use-memo-one: "npm:^1.1.3"
+  peerDependencies:
+    react: ^16.8.5 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/ef43ba21f063f6497f399b457452d45be456b1f28405b148d9683d2ca65e5f77e2685a0b7e9998aaca4f8676b1642ba2c277fc78643ea59fd6b9f71a56ffc5e0
   languageName: node
   linkType: hard
 
@@ -2226,6 +2360,13 @@ __metadata:
 "@rollup/rollup-linux-x64-gnu@npm:4.27.3":
   version: 4.27.3
   resolution: "@rollup/rollup-linux-x64-gnu@npm:4.27.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:^4.18.0":
+  version: 4.28.0
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.28.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3384,6 +3525,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hoist-non-react-statics@npm:^3.3.1":
+  version: 3.3.6
+  resolution: "@types/hoist-non-react-statics@npm:3.3.6"
+  dependencies:
+    "@types/react": "npm:*"
+    hoist-non-react-statics: "npm:^3.3.0"
+  checksum: 10c0/149a4c217d81f21f8a1e152160a59d5b99b6a9aa6d354385d5f5bc02760cbf1e170a8442ba92eb653befff44b0c5bc2234bb77ce33e0d11a65f779e8bab5c321
+  languageName: node
+  linkType: hard
+
 "@types/html-minifier-terser@npm:^6.0.0":
   version: 6.1.0
   resolution: "@types/html-minifier-terser@npm:6.1.0"
@@ -3607,6 +3758,13 @@ __metadata:
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
   checksum: 10c0/68c6921721a3dcb40451543db2174a145ef915bc8bcbe7ad4e59194a0238e776e782b896c7a59f4b93ac6acefca9161fccb31d1ce3b3445cb6faa467297fb473
+  languageName: node
+  linkType: hard
+
+"@types/use-sync-external-store@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@types/use-sync-external-store@npm:0.0.3"
+  checksum: 10c0/82824c1051ba40a00e3d47964cdf4546a224e95f172e15a9c62aa3f118acee1c7518b627a34f3aa87298a2039f982e8509f92bfcc18bea7c255c189c293ba547
   languageName: node
   linkType: hard
 
@@ -3848,6 +4006,13 @@ __metadata:
     "@typescript-eslint/types": "npm:8.17.0"
     eslint-visitor-keys: "npm:^4.2.0"
   checksum: 10c0/9144c4e4a63034fb2031a0ee1fc77e80594f30cab3faafa9a1f7f83782695774dd32fac8986f260698b4e150b4dd52444f2611c07e4c101501f08353eb47c82c
+  languageName: node
+  linkType: hard
+
+"@vercel/stega@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@vercel/stega@npm:0.1.2"
+  checksum: 10c0/66eb80f286d46806004a2eacd215af80ad3cd443e7a96a6070d390dbb3f4d1f6e063013ec0d196c7fe852721d5dbe62e23b44c32975e36b18cda30e5e0728e04
   languageName: node
   linkType: hard
 
@@ -4672,6 +4837,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.7.4":
+  version: 1.7.9
+  resolution: "axios@npm:1.7.9"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.0"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/b7a41e24b59fee5f0f26c1fc844b45b17442832eb3a0fb42dd4f1430eb4abc571fe168e67913e8a1d91c993232bd1d1ab03e20e4d1fee8c6147649b576fc1b0b
+  languageName: node
+  linkType: hard
+
 "axios@npm:^1.7.7":
   version: 1.7.8
   resolution: "axios@npm:1.7.8"
@@ -5214,6 +5390,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"charenc@npm:0.0.2":
+  version: 0.0.2
+  resolution: "charenc@npm:0.0.2"
+  checksum: 10c0/a45ec39363a16799d0f9365c8dd0c78e711415113c6f14787a22462ef451f5013efae8a28f1c058f81fc01f2a6a16955f7a5fd0cd56247ce94a45349c89877d8
+  languageName: node
+  linkType: hard
+
 "check-error@npm:^2.1.1":
   version: 2.1.1
   resolution: "check-error@npm:2.1.1"
@@ -5555,6 +5738,75 @@ __metadata:
   languageName: node
   linkType: hard
 
+"contentful-resolve-response@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "contentful-resolve-response@npm:1.9.0"
+  dependencies:
+    fast-copy: "npm:^2.1.7"
+  checksum: 10c0/0b2cb07cd0457aebdc28a06ac65b5a892a47eb6f95d2f563ac4f7b85745331fa4be6895ae0d5a14ea3ca6960ad47f4a188e0b06edd94062ef304919095b14872
+  languageName: node
+  linkType: hard
+
+"contentful-sdk-core@npm:^8.3.1":
+  version: 8.3.2
+  resolution: "contentful-sdk-core@npm:8.3.2"
+  dependencies:
+    fast-copy: "npm:^2.1.7"
+    lodash.isplainobject: "npm:^4.0.6"
+    lodash.isstring: "npm:^4.0.1"
+    p-throttle: "npm:^4.1.1"
+    qs: "npm:^6.11.2"
+  checksum: 10c0/f0623dc8b1ed8df8dd3adf8bc2ddef81d36ce697519a8ff5351a70f3497ee7b403b8b23a9c438a9a4d9ee51afad0bb83d3cae370de2b481566cca699f1a98c80
+  languageName: node
+  linkType: hard
+
+"contentful-sdk-core@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "contentful-sdk-core@npm:9.0.1"
+  dependencies:
+    "@rollup/rollup-linux-x64-gnu": "npm:^4.18.0"
+    fast-copy: "npm:^3.0.2"
+    lodash: "npm:^4.17.21"
+    p-throttle: "npm:^6.1.0"
+    process: "npm:^0.11.10"
+    qs: "npm:^6.12.3"
+  dependenciesMeta:
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+  checksum: 10c0/9de88d147ddb45134a62b984a98e6011c339864d57fbde8b56cf70263fd755b7743b3e43ac33e0bc907fc0cbd4276afe96a117679d04be9a65c27256333c8cd6
+  languageName: node
+  linkType: hard
+
+"contentful@npm:^10.6.14":
+  version: 10.15.1
+  resolution: "contentful@npm:10.15.1"
+  dependencies:
+    "@contentful/content-source-maps": "npm:^0.11.0"
+    "@contentful/rich-text-types": "npm:^16.0.2"
+    axios: "npm:^1.7.4"
+    contentful-resolve-response: "npm:^1.9.0"
+    contentful-sdk-core: "npm:^8.3.1"
+    json-stringify-safe: "npm:^5.0.1"
+    type-fest: "npm:^4.0.0"
+  checksum: 10c0/09c399b33482c3c1b5c12da9bcba6a1a90707b2f26909dd681a5ad380ae7825ab5c7d07a472081c7ff726d7a2b35382d8c139a0240aacf8bc626e2572b765b1f
+  languageName: node
+  linkType: hard
+
+"contentful@npm:^11.2.5":
+  version: 11.2.5
+  resolution: "contentful@npm:11.2.5"
+  dependencies:
+    "@contentful/content-source-maps": "npm:^0.11.6"
+    "@contentful/rich-text-types": "npm:^16.6.1"
+    axios: "npm:^1.7.4"
+    contentful-resolve-response: "npm:^1.9.0"
+    contentful-sdk-core: "npm:^9.0.1"
+    json-stringify-safe: "npm:^5.0.1"
+    type-fest: "npm:^4.0.0"
+  checksum: 10c0/467fad1610f1f6de8acb61e9aa5d6efedfe1232c98d2d60e56f4e44e49a0e28be51ad3028cb02a5d4345b764ad997bdf6a17d82118cb2036f4c70051e2d271f5
+  languageName: node
+  linkType: hard
+
 "convert-source-map@npm:^1.7.0":
   version: 1.9.0
   resolution: "convert-source-map@npm:1.9.0"
@@ -5641,6 +5893,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"crypt@npm:0.0.2":
+  version: 0.0.2
+  resolution: "crypt@npm:0.0.2"
+  checksum: 10c0/adbf263441dd801665d5425f044647533f39f4612544071b1471962209d235042fb703c27eea2795c7c53e1dfc242405173003f83cf4f4761a633d11f9653f18
+  languageName: node
+  linkType: hard
+
+"css-box-model@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "css-box-model@npm:1.2.1"
+  dependencies:
+    tiny-invariant: "npm:^1.0.6"
+  checksum: 10c0/611e56d76b16e4e21956ed9fa53f1936fbbfaccd378659587e9c929f342037fc6c062f8af9447226e11fe7c95e31e6c007a37e592f9bff4c2d40e6915553104a
+  languageName: node
+  linkType: hard
+
 "css-loader@npm:^6.7.1":
   version: 6.11.0
   resolution: "css-loader@npm:6.11.0"
@@ -5724,7 +5992,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2":
+"csstype@npm:^3.0.2, csstype@npm:^3.1.2":
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 10c0/80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
@@ -7099,6 +7367,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-copy@npm:^2.1.7":
+  version: 2.1.7
+  resolution: "fast-copy@npm:2.1.7"
+  checksum: 10c0/1fa3c6f21305fa49581d543812f0c96429c0748b97c074b1aca5d2d6d43520ff1452a8021b4051f5a894c0fdbcac463797b5660e0813399054914dd91e7f27f5
+  languageName: node
+  linkType: hard
+
+"fast-copy@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "fast-copy@npm:3.0.2"
+  checksum: 10c0/02e8b9fd03c8c024d2987760ce126456a0e17470850b51e11a1c3254eed6832e4733ded2d93316c82bc0b36aeb991ad1ff48d1ba95effe7add7c3ab8d8eb554a
+  languageName: node
+  linkType: hard
+
 "fast-decode-uri-component@npm:^1.0.1":
   version: 1.0.1
   resolution: "fast-decode-uri-component@npm:1.0.1"
@@ -7428,6 +7710,13 @@ __metadata:
   dependencies:
     is-callable: "npm:^1.1.3"
   checksum: 10c0/22330d8a2db728dbf003ec9182c2d421fbcd2969b02b4f97ec288721cda63eb28f2c08585ddccd0f77cb2930af8d958005c9e72f47141dc51816127a118f39aa
+  languageName: node
+  linkType: hard
+
+"foreach@npm:^2.0.4":
+  version: 2.0.6
+  resolution: "foreach@npm:2.0.6"
+  checksum: 10c0/dc79f83997ac986dadbc95b4035ce8b86699fb654eb85446b0ad779fe69d567fc9894075e460243ca8bc20adb8fd178ad203aef66dc3c620ac78b18a4cb7059c
   languageName: node
   linkType: hard
 
@@ -7998,6 +8287,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: "npm:^16.7.0"
+  checksum: 10c0/fe0889169e845d738b59b64badf5e55fa3cf20454f9203d1eb088df322d49d4318df774828e789898dcb280e8a5521bb59b3203385662ca5e9218a6ca5820e74
+  languageName: node
+  linkType: hard
+
 "homedir-polyfill@npm:^1.0.0":
   version: 1.0.3
   resolution: "homedir-polyfill@npm:1.0.3"
@@ -8225,6 +8523,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immer@npm:^10.0.3":
+  version: 10.1.1
+  resolution: "immer@npm:10.1.1"
+  checksum: 10c0/b749e10d137ccae91788f41bd57e9387f32ea6d6ea8fd7eb47b23fd7766681575efc7f86ceef7fe24c3bc9d61e38ff5d2f49c2663b2b0c056e280a4510923653
+  languageName: node
+  linkType: hard
+
 "immutable@npm:^5.0.2":
   version: 5.0.3
   resolution: "immutable@npm:5.0.3"
@@ -8404,6 +8709,13 @@ __metadata:
     call-bind: "npm:^1.0.2"
     has-tostringtag: "npm:^1.0.0"
   checksum: 10c0/6090587f8a8a8534c0f816da868bc94f32810f08807aa72fa7e79f7e11c466d281486ffe7a788178809c2aa71fe3e700b167fe80dd96dad68026bfff8ebf39f7
+  languageName: node
+  linkType: hard
+
+"is-buffer@npm:~1.1.6":
+  version: 1.1.6
+  resolution: "is-buffer@npm:1.1.6"
+  checksum: 10c0/ae18aa0b6e113d6c490ad1db5e8df9bdb57758382b313f5a22c9c61084875c6396d50bbf49315f5b1926d142d74dfb8d31b40d993a383e0a158b15fea7a82234
   languageName: node
   linkType: hard
 
@@ -9523,6 +9835,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-pointer@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "json-pointer@npm:0.6.2"
+  dependencies:
+    foreach: "npm:^2.0.4"
+  checksum: 10c0/47f6103032c0340b3392cb650e0ec817f785eccb553407da13fae85bc535483c9b359d7e756de4ed73130172c28d2b02f8beb53a700a98b12e72c7bf70e734b7
+  languageName: node
+  linkType: hard
+
 "json-schema-ref-resolver@npm:^1.0.1":
   version: 1.0.1
   resolution: "json-schema-ref-resolver@npm:1.0.1"
@@ -9550,6 +9871,13 @@ __metadata:
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
   checksum: 10c0/cb168b61fd4de83e58d09aaa6425ef71001bae30d260e2c57e7d09a5fd82223e2f22a042dedaab8db23b7d9ae46854b08bb1f91675a8be11c5cffebef5fb66a5
+  languageName: node
+  linkType: hard
+
+"json-stringify-safe@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "json-stringify-safe@npm:5.0.1"
+  checksum: 10c0/7dbf35cd0411d1d648dceb6d59ce5857ec939e52e4afc37601aa3da611f0987d5cee5b38d58329ceddf3ed48bd7215229c8d52059ab01f2444a338bf24ed0f37
   languageName: node
   linkType: hard
 
@@ -9709,6 +10037,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash-es@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash-es@npm:4.17.21"
+  checksum: 10c0/fb407355f7e6cd523a9383e76e6b455321f0f153a6c9625e21a8827d10c54c2a2341bd2ae8d034358b60e07325e1330c14c224ff582d04612a46a4f0479ff2f2
+  languageName: node
+  linkType: hard
+
 "lodash.camelcase@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
@@ -9720,6 +10055,20 @@ __metadata:
   version: 4.4.0
   resolution: "lodash.flattendeep@npm:4.4.0"
   checksum: 10c0/83cb80754b921fb4ed2c222b91a82b2524f3bdc60c3ae91e00688bd4bf1bcc28b8a2cc250e11fdc1b6da3a2de09e57008e13f15a209cafdd4f9163d047f97544
+  languageName: node
+  linkType: hard
+
+"lodash.isplainobject@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "lodash.isplainobject@npm:4.0.6"
+  checksum: 10c0/afd70b5c450d1e09f32a737bed06ff85b873ecd3d3d3400458725283e3f2e0bb6bf48e67dbe7a309eb371a822b16a26cca4a63c8c52db3fc7dc9d5f9dd324cbb
+  languageName: node
+  linkType: hard
+
+"lodash.isstring@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "lodash.isstring@npm:4.0.1"
+  checksum: 10c0/09eaf980a283f9eef58ef95b30ec7fee61df4d6bf4aba3b5f096869cc58f24c9da17900febc8ffd67819b4e29de29793190e88dc96983db92d84c95fa85d1c92
   languageName: node
   linkType: hard
 
@@ -9903,6 +10252,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"md5@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "md5@npm:2.3.0"
+  dependencies:
+    charenc: "npm:0.0.2"
+    crypt: "npm:0.0.2"
+    is-buffer: "npm:~1.1.6"
+  checksum: 10c0/14a21d597d92e5b738255fbe7fe379905b8cb97e0a49d44a20b58526a646ec5518c337b817ce0094ca94d3e81a3313879c4c7b510d250c282d53afbbdede9110
+  languageName: node
+  linkType: hard
+
 "mdn-data@npm:2.1.0":
   version: 2.1.0
   resolution: "mdn-data@npm:2.1.0"
@@ -9916,6 +10276,13 @@ __metadata:
   dependencies:
     fs-monkey: "npm:^1.0.4"
   checksum: 10c0/038fc81bce17ea92dde15aaa68fa0fdaf4960c721ce3ffc7c2cb87a259333f5159784ea48b3b72bf9e054254d9d0d0d5209d0fdc3d07d08653a09933b168fbd7
+  languageName: node
+  linkType: hard
+
+"memoize-one@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "memoize-one@npm:6.0.0"
+  checksum: 10c0/45c88e064fd715166619af72e8cf8a7a17224d6edf61f7a8633d740ed8c8c0558a4373876c9b8ffc5518c2b65a960266adf403cc215cb1e90f7e262b58991f54
   languageName: node
   linkType: hard
 
@@ -10771,6 +11138,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-throttle@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "p-throttle@npm:4.1.1"
+  checksum: 10c0/c4bfdcd0318d704b446a7af59dd8e0e32e37ba3d9841dd8dfced1c09742bc2f7a95bc0fcf4072030c62abf4533a9a2ef2954e559462052c5f406ae03d195925a
+  languageName: node
+  linkType: hard
+
+"p-throttle@npm:^6.1.0":
+  version: 6.2.0
+  resolution: "p-throttle@npm:6.2.0"
+  checksum: 10c0/3be65f66eb21137be78b8d18a5240117312b942e3aa788f838ac4be785ab3c40b64ee34b2c393cd948ec7845c0a00241f446395b98ff4754e718fe54fdee0b00
+  languageName: node
+  linkType: hard
+
 "p-try@npm:^2.0.0":
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
@@ -10984,6 +11365,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pify@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "pify@npm:2.3.0"
+  checksum: 10c0/551ff8ab830b1052633f59cb8adc9ae8407a436e06b4a9718bcb27dc5844b83d535c3a8512b388b6062af65a98c49bdc0dd523d8b2617b188f7c8fee457158dc
+  languageName: node
+  linkType: hard
+
 "pino-abstract-transport@npm:^2.0.0":
   version: 2.0.0
   resolution: "pino-abstract-transport@npm:2.0.0"
@@ -11095,6 +11483,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-import@npm:^16.0.1":
+  version: 16.1.0
+  resolution: "postcss-import@npm:16.1.0"
+  dependencies:
+    postcss-value-parser: "npm:^4.0.0"
+    read-cache: "npm:^1.0.0"
+    resolve: "npm:^1.1.7"
+  peerDependencies:
+    postcss: ^8.0.0
+  checksum: 10c0/60e6499354079a3f46242b861412a40c54be7ab99f4ad55096a07ffe5e57fcc01c2c626b5d1fbc7a18cd23adc82b320c205059d0c7ab09e91baba8dc45c88e29
+  languageName: node
+  linkType: hard
+
 "postcss-load-config@npm:^6.0.1":
   version: 6.0.1
   resolution: "postcss-load-config@npm:6.0.1"
@@ -11190,7 +11591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-value-parser@npm:^4.1.0, postcss-value-parser@npm:^4.2.0":
+"postcss-value-parser@npm:^4.0.0, postcss-value-parser@npm:^4.1.0, postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 10c0/f4142a4f56565f77c1831168e04e3effd9ffcc5aebaf0f538eee4b2d465adfd4b85a44257bb48418202a63806a7da7fe9f56c330aebb3cac898e46b4cbf49161
@@ -11472,7 +11873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.12.3, qs@npm:^6.4.0":
+"qs@npm:^6.11.2, qs@npm:^6.12.3, qs@npm:^6.4.0":
   version: 6.13.1
   resolution: "qs@npm:6.13.1"
   dependencies:
@@ -11513,6 +11914,13 @@ __metadata:
   version: 5.1.1
   resolution: "quick-lru@npm:5.1.1"
   checksum: 10c0/a24cba5da8cec30d70d2484be37622580f64765fb6390a928b17f60cd69e8dbd32a954b3ff9176fa1b86d86ff2ba05252fae55dc4d40d0291c60412b0ad096da
+  languageName: node
+  linkType: hard
+
+"raf-schd@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "raf-schd@npm:4.0.3"
+  checksum: 10c0/ecabf0957c05fad059779bddcd992f1a9d3a35dfea439a6f0935c382fcf4f7f7fa60489e467b4c2db357a3665167d2a379782586b59712bb36c766e02824709b
   languageName: node
   linkType: hard
 
@@ -11598,7 +12006,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.3.2":
+"react-is@npm:^16.13.1, react-is@npm:^16.3.2, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
@@ -11626,6 +12034,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-redux@npm:^8.1.3":
+  version: 8.1.3
+  resolution: "react-redux@npm:8.1.3"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.1"
+    "@types/hoist-non-react-statics": "npm:^3.3.1"
+    "@types/use-sync-external-store": "npm:^0.0.3"
+    hoist-non-react-statics: "npm:^3.3.2"
+    react-is: "npm:^18.0.0"
+    use-sync-external-store: "npm:^1.0.0"
+  peerDependencies:
+    "@types/react": ^16.8 || ^17.0 || ^18.0
+    "@types/react-dom": ^16.8 || ^17.0 || ^18.0
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+    react-native: ">=0.59"
+    redux: ^4 || ^5.0.0-beta.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+    redux:
+      optional: true
+  checksum: 10c0/64c8be2765568dc66a3c442a41dd0ed74fe048d5ceb7a4fe72e5bac3d3687996a7115f57b5156af7406521087065a0e60f9194318c8ca99c55e9ce48558980ce
+  languageName: node
+  linkType: hard
+
 "react-transition-group@npm:^4.4.5":
   version: 4.4.5
   resolution: "react-transition-group@npm:4.4.5"
@@ -11647,6 +12087,15 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.1.0"
   checksum: 10c0/283e8c5efcf37802c9d1ce767f302dd569dd97a70d9bb8c7be79a789b9902451e0d16334b05d73299b20f048cbc3c7d288bbbde10b701fa194e2089c237dbea3
+  languageName: node
+  linkType: hard
+
+"read-cache@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "read-cache@npm:1.0.0"
+  dependencies:
+    pify: "npm:^2.3.0"
+  checksum: 10c0/90cb2750213c7dd7c80cb420654344a311fdec12944e81eb912cd82f1bc92aea21885fa6ce442e3336d9fccd663b8a7a19c46d9698e6ca55620848ab932da814
   languageName: node
   linkType: hard
 
@@ -11704,6 +12153,15 @@ __metadata:
     indent-string: "npm:^4.0.0"
     strip-indent: "npm:^3.0.0"
   checksum: 10c0/d64a6b5c0b50eb3ddce3ab770f866658a2b9998c678f797919ceb1b586bab9259b311407280bd80b804e2a7c7539b19238ae6a2a20c843f1a7fcff21d48c2eae
+  languageName: node
+  linkType: hard
+
+"redux@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "redux@npm:4.2.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.9.2"
+  checksum: 10c0/136d98b3d5dbed1cd6279c8c18a6a74c416db98b8a432a46836bdd668475de6279a2d4fd9d1363f63904e00f0678a8a3e7fa532c897163340baf1e71bb42c742
   languageName: node
   linkType: hard
 
@@ -11852,7 +12310,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
+"resolve@npm:^1.1.7, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -11878,7 +12336,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -12894,6 +13352,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"style-inject@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "style-inject@npm:0.3.0"
+  checksum: 10c0/3fa6a8410a4e4dfbd49a5026a4307e85bb30ee9d3691a806246d893d4f0ca9b4e8b1bfdafed3f90801d9b8c32589f5fb0b4ec7fb6ab3e8f14ac992e26d987828
+  languageName: node
+  linkType: hard
+
 "style-loader@npm:^3.3.1":
   version: 3.3.4
   resolution: "style-loader@npm:3.3.4"
@@ -13165,7 +13630,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.3.1, tiny-invariant@npm:^1.3.3":
+"tiny-invariant@npm:^1.0.6, tiny-invariant@npm:^1.3.1, tiny-invariant@npm:^1.3.3":
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
@@ -13469,6 +13934,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^4.0.0":
+  version: 4.30.0
+  resolution: "type-fest@npm:4.30.0"
+  checksum: 10c0/9441fbbc971f92a53d7dfdb0db3f9c71a5a33ac3e021ca605cba8ad0b5c0a1e191cc778b4980c534b098ccb4e3322809100baf763be125510c993c9b8361f60e
+  languageName: node
+  linkType: hard
+
 "typed-array-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "typed-array-buffer@npm:1.0.2"
@@ -13761,6 +14233,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"use-debounce@npm:^10.0.0":
+  version: 10.0.4
+  resolution: "use-debounce@npm:10.0.4"
+  peerDependencies:
+    react: "*"
+  checksum: 10c0/73494fc44b2bd58a7ec799a528fc20077c45fe2e94fedff6dcd88d136f7a39f417d77f584d5613aac615ed32aeb2ea393797ae1f7d5b2645eab57cb497a6d0cb
+  languageName: node
+  linkType: hard
+
+"use-memo-one@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "use-memo-one@npm:1.1.3"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/3d596e65a6b47b2f1818061599738e00daad1f9a9bb4e5ce1f014b20a35b297e50fe4bf1d8c1699ab43ea97f01f84649a736c15ceff96de83bfa696925f6cc6b
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:1.2.2":
+  version: 1.2.2
+  resolution: "use-sync-external-store@npm:1.2.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/23b1597c10adf15b26ade9e8c318d8cc0abc9ec0ab5fc7ca7338da92e89c2536abd150a5891bf076836c352fdfa104fc7231fb48f806fd9960e0cbe03601abaf
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.0.0":
+  version: 1.4.0
+  resolution: "use-sync-external-store@npm:1.4.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/ec011a5055962c0f6b509d6e78c0b143f8cd069890ae370528753053c55e3b360d3648e76cfaa854faa7a59eb08d6c5fb1015e60ffde9046d32f5b2a295acea5
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -13814,6 +14322,15 @@ __metadata:
     "@types/istanbul-lib-coverage": "npm:^2.0.1"
     convert-source-map: "npm:^2.0.0"
   checksum: 10c0/968bcf1c7c88c04df1ffb463c179558a2ec17aa49e49376120504958239d9e9dad5281aa05f2a78542b8557f2be0b0b4c325710262f3b838b40d703d5ed30c23
+  languageName: node
+  linkType: hard
+
+"vite-plugin-css-injected-by-js@npm:^3.1.1":
+  version: 3.5.2
+  resolution: "vite-plugin-css-injected-by-js@npm:3.5.2"
+  peerDependencies:
+    vite: ">2.0.0-0"
+  checksum: 10c0/5c6a2434d4f302640a4bfc7695d56cf83eca03a4f89f05820057fedd8a2e788186105942360d19808042872ba0970ed6b1c04cd02337bbe67d8321993a464c04
   languageName: node
   linkType: hard
 
@@ -14414,9 +14931,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:3.23.8":
+"zod@npm:3.23.8, zod@npm:^3.22.4":
   version: 3.23.8
   resolution: "zod@npm:3.23.8"
   checksum: 10c0/8f14c87d6b1b53c944c25ce7a28616896319d95bc46a9660fe441adc0ed0a81253b02b5abdaeffedbeb23bdd25a0bf1c29d2c12dd919aef6447652dd295e3e69
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^4.4.7":
+  version: 4.5.5
+  resolution: "zustand@npm:4.5.5"
+  dependencies:
+    use-sync-external-store: "npm:1.2.2"
+  peerDependencies:
+    "@types/react": ">=16.8"
+    immer: ">=9.0.6"
+    react: ">=16.8"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    immer:
+      optional: true
+    react:
+      optional: true
+  checksum: 10c0/d04469d76b29c7e4070da269886de4efdadedd3d3824dc2a06ac4ff62e3b5877f925e927afe7382de651829872b99adec48082f1bd69fe486149be666345e626
   languageName: node
   linkType: hard


### PR DESCRIPTION
This PR initalizes Contenful Experiences in the marketing app. The following [guide](https://www.contentful.com/developers/docs/experiences/set-up-experiences-sdk/) was used.

The `Stub` and `StubSection` components are also updated to be registered custom components in Contentful and has been tested on Contentful Studio.

The process of connecting `marketing` to `dsco` revealed a number of integration issues, which this PR resolves:

1. Initially, the `dsco` package would automatically create entrypoint export entries in package.json via `clean-package`. However, this does not work due to `dsco` being linked (it is not being published and pulled down) and therefore dynamic entrypoints are not available.
2. The `dsco` package included a tsup banner for `use client;`, however this is not needed as each design system component should be SSR compatiable.
3. `import-x/no-unresolved` does not appear to work with our monorepo setup at this time, so a separate task was created to investigate and fix this.
