### PR TITLE
HoC 2024 - Add new partner to international_partners_table.md

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/international_partners_table.md
+++ b/pegasus/sites.v3/hourofcode.com/views/international_partners_table.md
@@ -40,6 +40,7 @@
 |Indonesia|Prestasi Junior Indonesia|Retna Widiyasrini|retno@prestasijunior.org<br>www.prestasijunior.org|
 |Indonesia|ProVisi Mandiri Pratama|Chatarina Trihastuti|rina@provisimandiripratama.com<br>https://provisimandiripratama.com/|
 |Iraq|ABCode|Batool Hussain|ABcode.global@gmail.com|
+|Ireland|National Learning Network|Pranav Chavan|pranav.chavan@nln.ie<br>https://rehab.ie/national-learning-network/|
 |Israel|Wix|Hour of Code Israel Team|connect@hourofcode.com<br>https://www.hourofcode.co.il|
 |Italy|Programma il Futuro|Enrico Nardelli|didattica@programmailfuturo.it<br>https://programmailfuturo.it|
 |Japan|Code for Everyone / 特定非営利活動法人みんなのコード|Yuta Tonegawa|info@code.or.jp<br>https://code.or.jp/|
@@ -48,6 +49,7 @@
 |Korea of republic|Korea National University of Education|Kwihoon Kim|kimkh@knue.ac.kr<br>https://en.knue.ac.kr/smain.html|
 |Kosovo|SHPIK|Bekim Kasumi|bekim.kasumi@shpik.org<br>www.shpik.org|
 |Latin America|Eidos Global|Marina Puente Pistarini|marina@eidosglobal.org<br>https://www.eidosglobal.org/|
+|Macau|Macau International STEAM Education Association (MISEA)|Man Fai Lai|macaumisea@gmail.com<br>https://www.steam.mo/|
 |Malaysia|Chumbaka|Nigel Sim|nigel@chumbaka.asia<br>www.chumbaka.asia|
 |Malaysia|Fondation Rolf Schnyder|Scott and Andrea Wong|scott.andrea@fondationrolfschnyder.org<br>www.fondationrolfschnyder.org|
 |Malaysia|Malaysia Digital Economy Corporation (MDEC)|Sofia Akmal Abu Bakar|sofia@mdec.com.my<br>https://mdec.my/|
@@ -64,6 +66,7 @@
 |New Zealand|Ara Institute of Canterbury|Amitrajit Sarkar|sarkara@cpit.ac.nz<br>http://www.ara.ac.nz|
 |Nigeria|Odyssey Educational Foundation|Stella UzochukwuDenis|ifywayne@gmail.com<br>www.odysseyedufoundation.org|
 |Nigeria|Skooqs|Oluwadamilola Soyombo|hello@skooqs.com<br>https://skooqs.com|
+|Nigeria and The United States of America|CTRL Code|Mary Adegbesan|ctrl.code1@gmail.com<br>www.ctrlcode.org|
 |Pakistan|DIGIT|Majid Hussain|majid.hussain@digit.com.pk<br>https://digit.com.pk/|
 |Peru|Code en mi Cole|Renzo Sousa|http://codenmicole.com|
 |Peru|Instituto San Agustín - ISAT|Mariano Rojas Erazo|mrojas@isat.edu.pe, comunicaciones@isat.edu.pe<br>https://isat.edu.pe|
@@ -74,7 +77,6 @@
 |Portugal|Gabinete de Modernização das Tecnologias Educativas|Rodolfo Pinto|http://www02.madeira-edu.pt/dre/main.aspx|
 |Romania|ADFABER|Alin Chiriac|alin@adfaber.org<br>https://adfaber.org|
 |Rwanda|Creativity Lab|Ildephonse Mungwarakarama|ildephonse@creativity.rw<br>https://creativity.rw|
-|Singapore|Infocomm Media Development Authority of Singapore||https://www.imda.gov.sg|
 |Slovakia|Accenture|Soňa Dunčková|sona.dunckova@accenture.com|
 |Slovakia|Informatika 2.0||servus@informatika20.sk<br>www.informatika20.sk|
 |South Africa|Code for Change|Sibusiso Khoza|sibusiso@codejika.com<br>https://codeforchange.org.za/|
@@ -88,14 +90,13 @@
 |Sri Lanka|Shilpa Sayura Foundation|Niranjan Meegammana|niranjan.meegammana@gmail.com<br>http://shilpasayura.org|
 |Sri Lanka|Spectrum Institute of Science & Technology|Dinu Ravindra|dinu@spectrumcampus.edu.lk<br>https://www.spectrumcampus.edu.lk/|
 |Sri Lanka|STEMUP Educational Foundation|Prabhath Mannapperuma|prabhath@stemup.foundation<br>http://stemup.lk|
-|Taiwan|Junyi Academy|Ray Lu|support@junyiacademy.org<br>https://www.junyiacademy.org|
 |Tanzania|Jenga Hub||info@jengahub.com<br>http://jengahub.com|
 |Thailand|Aksorn Education PLC|Sasithorn Eve|sasithornr@aksorn.com<br>www.aksorn.com|
 |Thailand|Digital Economy Promotion Agency (DEPA)||https://www.depa.or.th/|
-|Thailand|Spark Education|Apinya Hiranyawech|apinya@spark-education.co<br>www.spark-education.co|
+|Thailand|Spark Education|Apinya Hiranyawech|apinya@spark-education.co<br>https://spark-education.co/|
 |Turkey|RobinCode|Gözde Erbaz|gozde@robincode.org<br>http://www.robincode.org|
 |UK|Computing At School (CAS)|Abi Edwards|compatsch@bcs.uk<br>http://www.computingatschool.org.uk|
-|United Kingdom|Apps for Good|Ross Dempster Johnson|education@appsforgood.org<br>www.appsforgood.org|
+|United Kingdom|Apps for Good|Ross Dempster Johnson|education@appsforgood.org<br>https://www.appsforgood.org/|
 |United States|Code.X||contact@codedotx.org<br>https://www.codedotx.org/|
 |Uruguay|Elemental|Magela Fuzatti|info@elemental.edu.uy<br>https://www.elemental.edu.uy/|
 |Uruguay|UNESCO|Zelmira May|z.may@unesco.org<br>https://es.unesco.org/fieldoffice/montevideo|

--- a/pegasus/sites.v3/hourofcode.com/views/international_partners_table.md
+++ b/pegasus/sites.v3/hourofcode.com/views/international_partners_table.md
@@ -2,6 +2,7 @@
 |---|---|---|---|
 |Americas|The Trust for the Americas|Pierina Nepote Rangel|pnepote@trust-oea.org<br>https://www.thetrustfortheamericas.org/|
 |Antigua and Barbuda|iLabGlobal & Caribbean Tech Genius Foundation|Makŏ Williams|mako@iLabGlobal.com<br>https://ilabglobal.com/<br>http://techgenius.edu.ag/|
+|Argentina|Municipalidad de Córdoba|Alicia La Terza|seceduc.lic.laterza@gmail.com<br>https://cordoba.gob.ar/areas-de-gobierno/secretaria-de-educacion/|
 |Australia|Grok Academy|Lisette Tennant|https://groklearning.com|
 |Botswana|CSEdBotswana|Dr. Ethel Tshukudu|ethel.tshukudu01@gmail.com<br>https://www.csedbotswana.org/|
 |Brasil|Universidade Federal Do Amapá|Simone De Almeida Delphim Leal|leal@unifap.br<br>www.unifap.br|


### PR DESCRIPTION
Adds a new partner to https://hourofcode.com/international-partners. Updates to this data table used to be done in Dropbox, but we removed that particular sync [here](https://github.com/code-dot-org/code-dot-org/pull/62067), so we will update this list manually for the Global team until we move to the CMS. 

## Links
Jira ticket: [ACQ-2866](https://codedotorg.atlassian.net/browse/ACQ-2866)
Slak convo: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1733334880629389)

----

<img width="1300" alt="Screenshot 2024-12-05 at 1 10 05 PM" src="https://github.com/user-attachments/assets/b59f6296-39b6-42b1-a453-f7b9e2d932b0">
