### PR TITLE
Add Twitter <meta> tags to certificate page

### DIFF
--- a/dashboard/app/views/certificates/show.html.haml
+++ b/dashboard/app/views/certificates/show.html.haml
@@ -1,6 +1,10 @@
 - content_for :og do
   = tag 'meta', property: 'og:image', content: @image_url
   = tag 'meta', property: 'og:title', content: @page_title
+  = tag 'meta', property: "og:type", content: 'website'
+  = tag 'meta', property: "twitter:title", content: @page_title
+  = tag 'meta', property: "twitter:card", content: "summary_large_image"
+  = tag 'meta', property: "twitter:image",  content: @image_url
 
 %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
 %script{src: webpack_asset_path('js/certificates/show.js'), data: {certificate: @certificate_data.to_json}}


### PR DESCRIPTION
In order for twitter to show a card with the image of a certificate, we need to set certain meta tags.

Current tweet:
<img width="579" alt="image" src="https://github.com/user-attachments/assets/bc809131-3bb0-403b-a669-24cc6538bcd1">

Example of a twitter card tweet (what we want it to look like): 
<img width="592" alt="image" src="https://github.com/user-attachments/assets/d0437da0-0335-4d78-9159-b542b281d2b8">
(Unrelated, but Coursera's twitter share button is also broken and I had to manually edit the URL. I thought that was fun)

### Tags we are adding:
Tags from [This documentation](https://developer.x.com/en/docs/x-for-websites/cards/overview/summary):
* `twitter:title`
* `twitter:card`
* `twitter:image`

Tag recommended by [this SO question](https://stackoverflow.com/questions/44355062/twitter-cards-no-card-found-card-error)
* `og:type`

`og:type` may not be required, but there doesn't seem to be a reason not to add it to be safe. See docs [here](https://ogp.me/#types)

We are trying to merge this before HoC

## Links
https://codedotorg.atlassian.net/browse/TEACH-1501
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Because the card is generated using a website scrawler, we cannot fully test that the twitter link will work locally. We can test on production or staging (updated from Kelby's comment)

We should test that the image is shown in a draft tweet and that everything looks fine in the deprecated [Card validator](https://cards-dev.x.com/validator)

Tested manually by checking that all meta tags were appropriately showing up on the certificates page:
<img width="637" alt="image" src="https://github.com/user-attachments/assets/df1bd117-9632-425f-9be5-c76effc90b8d">

Note all 4 new tags show up in dev console and no existing tags were removed.

