### PR TITLE
[DESIGN2-204-mixins.css] Mixins.css - DSCO - Update color variables

### DIFF
--- a/apps/src/componentLibrary/common/CHANGELOG.md
+++ b/apps/src/componentLibrary/common/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2](https://github.com/code-dot-org/code-dot-org/pull/62862)
+
+- updated color variables to use `primitiveColors.css`
+
 ## [0.5.1](https://github.com/code-dot-org/code-dot-org/pull/62743)
 
 - updated comments for `colors.css` and `primitiveColors.css` DSCO Variables colors

--- a/apps/src/componentLibrary/common/styles/mixins.scss
+++ b/apps/src/componentLibrary/common/styles/mixins.scss
@@ -1,4 +1,5 @@
-@import 'color', 'font';
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
+@import 'font';
 
 // Typography - Label styles
 @mixin label-common {
@@ -116,37 +117,37 @@
 }
 
 @mixin field-helper-section-black {
-  color: $light_black;
+  color: var(--neutral-base-black);
 }
 
 @mixin field-helper-section-black-disabled {
-  color: $light_gray_200;
+  color: var(--neutral-gray-20);
 }
 
 @mixin field-helper-section-white {
-  color: $light_white;
+  color: var(--neutral-base-white);
 }
 
 @mixin field-helper-section-white-disabled {
-  color: $light_gray_700;
+  color: var(--neutral-gray-70);
 }
 
 @mixin field-error-section-black {
-  color: $light_negative_500;
+  color: var(--sentiment-error-50);
 }
 
 @mixin field-error-section-white {
-  color: $light_white;
+  color: var(--neutral-base-white);
 }
 
 @mixin field-read-only-black-colors {
-  color: $light_black;
-  border-color: $light_gray_200;
-  background-color: $light_gray_50;
+  color: var(--neutral-base-black);
+  border-color: var(--neutral-gray-20);
+  background-color: var(--neutral-gray-5);
 }
 
 @mixin field-read-only-white-colors {
-  color: $light_white;
-  border-color: $light_gray_700;
-  background-color: $light_gray_900;
+  color: var(--neutral-base-white);
+  border-color: var(--neutral-gray-70);
+  background-color: var(--neutral-gray-90);
 }


### PR DESCRIPTION
Swaps out color variables from `shared/color.scss` with Primitive colors from `primitiveColors.css` on the `mixins.css` stylesheet component. 

👀 **DOTD note:** there might be Eyes diffs with this.

## Links
Jira ticket: [DESIGN2-204](https://codedotorg.atlassian.net/browse/DESIGN2-204)

## Testing story
Tested locally in Storybook