### PR TITLE
Fix twitter image meta tag

### DIFF
--- a/dashboard/app/controllers/certificates_controller.rb
+++ b/dashboard/app/controllers/certificates_controller.rb
@@ -20,6 +20,7 @@ class CertificatesController < ApplicationController
     announcement = Announcements.get_announcement_for_page('/certificates')
 
     @image_url = certificate_image_url(data['name'], data['course'], data['donor'])
+    @twitter_image_url = twitter_certificate_image_url(data['name'], data['course'], data['donor'])
     course_name = CurriculumHelper.find_matching_unit_or_unit_group(data['course'])&.localized_title || I18n.t('certificates.one_hour_of_code')
     image_alt = data['name'] ?
       I18n.t('certificates.alt_text_with_name', course_name: course_name, student_name: data['name']) :

--- a/dashboard/app/helpers/certificates_helper.rb
+++ b/dashboard/app/helpers/certificates_helper.rb
@@ -16,6 +16,14 @@ module CertificatesHelper
     "/certificate_images/#{encoded}.jpg"
   end
 
+  def twitter_certificate_image_url(name, course, donor)
+    return CDO.code_org_url('/images/hour_of_code_certificate.jpg', 'https:') if course.blank?
+    is_prefilled = CertificateImage.prefilled_title_course?(course)
+    return CDO.code_org_url("/images/#{CertificateImage.certificate_template_for(course)}", 'https:') if is_prefilled && !name
+    encoded = encode_params(name, course, donor)
+    CDO.code_org_url("/certificate_images/#{encoded}.jpg", 'https:')
+  end
+
   def certificate_print_url(name, course, donor)
     encoded = encode_params(name, course, donor)
     "/print_certificates/#{encoded}"

--- a/dashboard/app/helpers/certificates_helper.rb
+++ b/dashboard/app/helpers/certificates_helper.rb
@@ -21,7 +21,7 @@ module CertificatesHelper
     is_prefilled = CertificateImage.prefilled_title_course?(course)
     return CDO.code_org_url("/images/#{CertificateImage.certificate_template_for(course)}", 'https:') if is_prefilled && !name
     encoded = encode_params(name, course, donor)
-    CDO.code_org_url("/certificate_images/#{encoded}.jpg", 'https:')
+    CDO.studio_url("/certificate_images/#{encoded}.jpg", 'https:')
   end
 
   def certificate_print_url(name, course, donor)

--- a/dashboard/app/views/certificates/show.html.haml
+++ b/dashboard/app/views/certificates/show.html.haml
@@ -4,7 +4,7 @@
   = tag 'meta', property: "og:type", content: 'website'
   = tag 'meta', property: "twitter:title", content: @page_title
   = tag 'meta', property: "twitter:card", content: "summary_large_image"
-  = tag 'meta', property: "twitter:image",  content: @image_url
+  = tag 'meta', property: "twitter:image",  content: @twitter_image_url
 
 %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
 %script{src: webpack_asset_path('js/certificates/show.js'), data: {certificate: @certificate_data.to_json}}

--- a/dashboard/app/views/certificates/show.html.haml
+++ b/dashboard/app/views/certificates/show.html.haml
@@ -1,10 +1,10 @@
 - content_for :og do
   = tag 'meta', property: 'og:image', content: @image_url
   = tag 'meta', property: 'og:title', content: @page_title
-  = tag 'meta', property: "og:type", content: 'website'
-  = tag 'meta', property: "twitter:title", content: @page_title
-  = tag 'meta', property: "twitter:card", content: "summary_large_image"
-  = tag 'meta', property: "twitter:image",  content: @twitter_image_url
+  = tag 'meta', property: 'og:type', content: 'website'
+  = tag 'meta', property: 'twitter:title', content: @page_title
+  = tag 'meta', property: 'twitter:card', content: 'summary_large_image'
+  = tag 'meta', property: 'twitter:image',  content: @twitter_image_url
 
 %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
 %script{src: webpack_asset_path('js/certificates/show.js'), data: {certificate: @certificate_data.to_json}}


### PR DESCRIPTION
We are trying to merge this by EOD. FLUP from https://github.com/code-dot-org/code-dot-org/pull/62849.

Twitter currently shows a broken image:
![image](https://github.com/user-attachments/assets/a2c72ee7-9625-4331-b028-f3996190e057)

This is because the `twitter:image` meta tag does not go to a valid URL:
![image](https://github.com/user-attachments/assets/a766c6c7-ec11-4e40-aff2-e76701fa8bc4)

Fix is to change the URL to include the correct url:
<img width="492" alt="image" src="https://github.com/user-attachments/assets/4b80ab61-21de-4001-9ef5-7e1a931dbc13">

The twitter image tag will now have the following three types of urls (one example of each):
* `https://code.org/images/hour_of_code_certificate.jpg`
* `https://code.org/images/MC_Hour_Of_Code_Certificate_mee_estate.png`
* `https://studio.code.org/#{encoded_params_including_name}.jpg`
  * example: `https://studio.code.org/certificate_images/eyJuYW1lIjoiTGlhbSIsImNvdXJzZSI6ImhvdXJvZmNvZGUiLCJkb25vciI6IkZhY2Vib29rIn0=.jpg`

Tested by copying each of these example urls and making sure an image was available. Note: the encoded certificate needs `studio.code.org` and the unencoded need `code.org`.

## Links

## Testing story
Tested locally to see that all URLs are accurate for `twitter:image` tabs on the links generated from the `/congrats` page twitter share button.

Will test on staging once merged
