### PR TITLE
Update color variables on apps/src/accounts stylesheets

### DIFF
--- a/apps/src/accounts/AccountInformation/style.module.scss
+++ b/apps/src/accounts/AccountInformation/style.module.scss
@@ -1,6 +1,6 @@
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 @import '@cdo/apps/componentLibrary/common/styles/mixins';
 @import '@cdo/apps/componentLibrary/typography/typography.module';
-@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 
 .accountForm {
   label {

--- a/apps/src/accounts/AccountInformation/style.module.scss
+++ b/apps/src/accounts/AccountInformation/style.module.scss
@@ -1,7 +1,5 @@
 @import '@cdo/apps/componentLibrary/common/styles/mixins';
 @import '@cdo/apps/componentLibrary/typography/typography.module';
-// TODO - Remove this import once the typography.module is updated to include
-// primitive colors in https://github.com/code-dot-org/code-dot-org/pull/62863
 @import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 
 .accountForm {

--- a/apps/src/accounts/AccountInformation/style.module.scss
+++ b/apps/src/accounts/AccountInformation/style.module.scss
@@ -1,5 +1,8 @@
 @import '@cdo/apps/componentLibrary/common/styles/mixins';
 @import '@cdo/apps/componentLibrary/typography/typography.module';
+// TODO - Remove this import once the typography.module is updated to include
+// primitive colors in https://github.com/code-dot-org/code-dot-org/pull/62863
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 
 .accountForm {
   label {
@@ -9,7 +12,7 @@
 
     &.verifiedTeacher {
       font-weight: bold;
-      color: $light_affirmative_500;
+      color: var(--sentiment-success-50);
       margin: 0;
     }
   }

--- a/apps/src/accounts/common/common.styles.module.scss
+++ b/apps/src/accounts/common/common.styles.module.scss
@@ -1,6 +1,6 @@
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 @import '@cdo/apps/componentLibrary/common/styles/mixins';
 @import '@cdo/apps/componentLibrary/typography/typography.module';
-@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 
 .inputContainer {
   display: flex;

--- a/apps/src/accounts/common/common.styles.module.scss
+++ b/apps/src/accounts/common/common.styles.module.scss
@@ -1,7 +1,5 @@
 @import '@cdo/apps/componentLibrary/common/styles/mixins';
 @import '@cdo/apps/componentLibrary/typography/typography.module';
-// TODO - Remove this import once the typography.module is updated to include
-// primitive colors in https://github.com/code-dot-org/code-dot-org/pull/62863
 @import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 
 .inputContainer {

--- a/apps/src/accounts/common/common.styles.module.scss
+++ b/apps/src/accounts/common/common.styles.module.scss
@@ -1,5 +1,8 @@
 @import '@cdo/apps/componentLibrary/common/styles/mixins';
 @import '@cdo/apps/componentLibrary/typography/typography.module';
+// TODO - Remove this import once the typography.module is updated to include
+// primitive colors in https://github.com/code-dot-org/code-dot-org/pull/62863
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 
 .inputContainer {
   display: flex;
@@ -31,6 +34,6 @@ button.submit {
 }
 
 h2.sectionHeader {
-  color: $light_primary_500;
+  color: var(--brand-teal-50);
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
These two stylesheets need to be updated to use `primitiveColors.css` explicitly to not rely on the bundling of other imported stylesheets. This is causing drone failures on this PR: https://github.com/code-dot-org/code-dot-org/pull/62863. 

## Links
Jira ticket: [DESIGN2-206](https://codedotorg.atlassian.net/browse/DESIGN2-206)
Slack convo: [here](https://codedotorg.slack.com/archives/C07UW4ED66Q/p1733767517339399?thread_ts=1733521215.903719&cid=C07UW4ED66Q)

## Testing story
Tested locally