### PR TITLE
Return 00000 as invalid zip code client side in zip search

### DIFF
--- a/apps/src/signUpFlow/signUpFlowConstants.tsx
+++ b/apps/src/signUpFlow/signUpFlowConstants.tsx
@@ -35,6 +35,6 @@ export const NEW_SIGN_UP_USER_TYPE = 'new_sign_up_user_type';
 
 // school association
 export const US_COUNTRY_CODE = 'US';
-export const ZIP_REGEX = new RegExp(/(^\d{5}$)/);
+export const ZIP_REGEX = new RegExp(/(^(?!00000)\d{5}$)/);
 export const SELECT_COUNTRY = 'selectCountry';
 export const SCHOOL_ZIP_SEARCH_URL = '/dashboardapi/v1/schoolzipsearch/';

--- a/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
+++ b/apps/test/unit/schoolInfo/hooks/useSchoolInfoTest.jsx
@@ -41,7 +41,7 @@ describe('useSchoolInfo', () => {
     country: US_COUNTRY_CODE,
     schoolId: '1',
     schoolName: 'Cool School',
-    schoolZip: '00000',
+    schoolZip: '99999',
   };
 
   beforeEach(() => {

--- a/apps/test/unit/templates/SchoolZipSearchTest.jsx
+++ b/apps/test/unit/templates/SchoolZipSearchTest.jsx
@@ -49,6 +49,12 @@ describe('SchoolZipSearch', () => {
     expect(screen.getByText(i18n.zipInvalidMessage())).toBeInTheDocument();
   });
 
+  it('should display an error message when the zip code is 00000', () => {
+    renderDefault({schoolZip: '00000'});
+
+    expect(screen.getByText(i18n.zipInvalidMessage())).toBeInTheDocument();
+  });
+
   it('should not display an error message when the zip code is valid', () => {
     renderDefault({schoolZip: '12345'});
 


### PR DESCRIPTION
Updates the zipSearch component to not consider '00000' a valid zip code.

I added the portion of regex that will test for 00000 specifically (thanks @drizco !) and added a test to verify that this new case will display an error message on the front end. I also had to update the zip code in another test file that happened to be 00000.

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2797

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
