### PR TITLE
Lazy load Dance Lab2

### DIFF
--- a/apps/src/dance/lab2/entrypoint.ts
+++ b/apps/src/dance/lab2/entrypoint.ts
@@ -1,10 +1,15 @@
-import {OptionsToAvoid, Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
+import {lazy} from 'react';
 
-import DanceView from './views/DanceView';
+import {Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
 
 export const DanceEntryPoint: Lab2EntryPoint = {
   backgroundMode: false,
   theme: Theme.LIGHT,
-  view: OptionsToAvoid.UseHardcodedView_WARNING_Bloats_Lab2_Bundle,
-  hardcodedView: DanceView,
+  view: lazy(() =>
+    import(/* webpackChunkName: "danceLab2" */ './index.js').then(
+      ({DanceView}) => ({
+        default: DanceView,
+      })
+    )
+  ),
 };

--- a/apps/src/dance/lab2/index.js
+++ b/apps/src/dance/lab2/index.js
@@ -1,0 +1,3 @@
+// This file allows us to lazily load the DanceView component.
+// Due to our configuration this needs to be in js so we can use dynamic imports.
+export {default as DanceView} from './views/DanceView';


### PR DESCRIPTION
Lazy load Dance Lab2, as part of migrating all Lab2 labs to use lazy loading. Verified that the bundle size is changed and Dance-specific files are not loaded until the level is loaded.

Before:
<img width="1514" alt="Screenshot 2024-12-09 at 2 26 47 PM" src="https://github.com/user-attachments/assets/633a3e18-757a-44c7-bdd4-7d22a08b01a9">

After:
<img width="1520" alt="Screenshot 2024-12-09 at 2 27 45 PM" src="https://github.com/user-attachments/assets/87309165-8ce0-44f8-8ba7-8976fb6f5150">

## Testing story

Tested by manually adding console log in a Dance file and comparing bundle downloads.

## Follow-up Work

Will follow-up with AI Chat lab, and potentially Panels and Standalone Video as well. Will probably hold off on Music until post HOC just in case we need to hotfix at any point during HOC.