### PR TITLE
Lab2: teacher panel in cached levels

### DIFF
--- a/apps/src/code-studio/progressReduxSelectors.js
+++ b/apps/src/code-studio/progressReduxSelectors.js
@@ -133,6 +133,32 @@ export const getLevelPropertiesPath = state => {
 };
 
 /**
+ * Returns the dashboard URL path to retrieve the user app options for a script level.
+ * If we don't have a current level, this returns undefined.
+ */
+export const getUserAppOptionsPath = state => {
+  if (state.progress.lessons) {
+    const scriptName = state.progress.scriptName;
+
+    const lessonPosition = state.progress.lessons?.find(
+      lesson => lesson.id === state.progress.currentLessonId
+    ).relative_position;
+
+    const currentLevel = getCurrentLevel(state);
+    const levelPosition = currentLevel.levelNumber;
+
+    const levelId = state.progress.currentLevelId;
+
+    return `/api/user_app_options/${scriptName}/${lessonPosition}/${levelPosition}/${levelId}`;
+
+    //return `/api/user_app_options/${state.progress.scriptName}/1/1/1`;
+    //return '/api/user_app_options/music-jam-2024/1/5/62988';
+  } else {
+    return undefined;
+  }
+};
+
+/**
  * The level object passed down to use via the server (and stored in lesson.lessons.levels)
  * contains more data than we need. This (a) filters to the parts our views care
  * about and (b) determines current status based on the current state of

--- a/apps/src/code-studio/progressReduxSelectors.js
+++ b/apps/src/code-studio/progressReduxSelectors.js
@@ -150,9 +150,6 @@ export const getUserAppOptionsPath = state => {
     const levelId = state.progress.currentLevelId;
 
     return `/api/user_app_options/${scriptName}/${lessonPosition}/${levelPosition}/${levelId}`;
-
-    //return `/api/user_app_options/${state.progress.scriptName}/1/1/1`;
-    //return '/api/user_app_options/music-jam-2024/1/5/62988';
   } else {
     return undefined;
   }

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -52,7 +52,7 @@ import {
   LevelProperties,
   ProjectManagerStorageType,
   ProjectSources,
-  UserAppOptions,
+  PartialUserAppOptions,
   Validation,
 } from './types';
 import {LifecycleEvent} from './utils/LifecycleNotifier';
@@ -571,8 +571,8 @@ async function loadLevelProperties(
 
 async function loadUserAppOptions(
   userAppOptionsPath: string
-): Promise<UserAppOptions> {
-  const response = await HttpClient.fetchJson<UserAppOptions>(
+): Promise<PartialUserAppOptions> {
+  const response = await HttpClient.fetchJson<PartialUserAppOptions>(
     userAppOptionsPath
   );
   return response.value;

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -13,6 +13,7 @@ import {
 } from '@reduxjs/toolkit';
 
 import {
+  getPublicCaching,
   getAppOptionsEditBlocks,
   getAppOptionsEditingExemplar,
   getAppOptionsViewingExemplar,
@@ -145,16 +146,18 @@ export const setUpWithLevel = createAsyncThunk<
 
     Lab2Registry.getInstance().setAppName(levelProperties.appName);
 
-    // If there is a user app options path because we are in a script level, then make
-    // as async call to the server to find out whether the user is an instructor, and
-    // if they are, then update the user role.  This is needed for the teacher panel to
-    // appear in cached levels.
-    if (payload.userAppOptionsPath) {
-      loadUserAppOptions(payload.userAppOptionsPath).then(result => {
-        if (result.isInstructor) {
-          thunkAPI.dispatch(setUserRoleInCourse(CourseRoles.Instructor));
-        }
-      });
+    // If we are cached, and there is a user app options path because we are in a script
+    // level, then make an async call to the server to find out whether the user is an
+    // instructor, and if they are, then update the user role.  This is needed for the
+    // teacher panel to appear in cached levels.
+    if (getPublicCaching()) {
+      if (payload.userAppOptionsPath) {
+        loadUserAppOptions(payload.userAppOptionsPath).then(result => {
+          if (result.isInstructor) {
+            thunkAPI.dispatch(setUserRoleInCourse(CourseRoles.Instructor));
+          }
+        });
+      }
     }
 
     if (!usesProjects) {

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -574,7 +574,6 @@ async function loadUserAppOptions(
 ): Promise<UserAppOptions> {
   const response = await HttpClient.fetchJson<UserAppOptions>(
     userAppOptionsPath
-    //'/api/user_app_options/music-jam-2024/1/5/62988'
   );
   return response.value;
 }

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -110,6 +110,7 @@ export const setUpWithLevel = createAsyncThunk<
     levelId: number;
     scriptId?: number;
     levelPropertiesPath: string;
+    userAppOptionsPath?: string;
     channelId?: string;
     userId?: number;
     scriptLevelId?: string;
@@ -144,11 +145,17 @@ export const setUpWithLevel = createAsyncThunk<
 
     Lab2Registry.getInstance().setAppName(levelProperties.appName);
 
-    loadUserAppOptions().then(result => {
-      if (result.isInstructor) {
-        thunkAPI.dispatch(setUserRoleInCourse(CourseRoles.Instructor));
-      }
-    });
+    // If there is a user app options path because we are in a script level, then make
+    // as async call to the server to find out whether the user is an instructor, and
+    // if they are, then update the user role.  This is needed for the teacher panel to
+    // appear in cached levels.
+    if (payload.userAppOptionsPath) {
+      loadUserAppOptions(payload.userAppOptionsPath).then(result => {
+        if (result.isInstructor) {
+          thunkAPI.dispatch(setUserRoleInCourse(CourseRoles.Instructor));
+        }
+      });
+    }
 
     if (!usesProjects) {
       // If projects are disabled on this level, we can skip loading projects data.
@@ -559,9 +566,12 @@ async function loadLevelProperties(
   return response.value;
 }
 
-async function loadUserAppOptions(): Promise<UserAppOptions> {
+async function loadUserAppOptions(
+  userAppOptionsPath: string
+): Promise<UserAppOptions> {
   const response = await HttpClient.fetchJson<UserAppOptions>(
-    '/api/user_app_options/music-jam-2024/1/5/62988'
+    userAppOptionsPath
+    //'/api/user_app_options/music-jam-2024/1/5/62988'
   );
   return response.value;
 }

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -17,6 +17,10 @@ import {
   getAppOptionsEditingExemplar,
   getAppOptionsViewingExemplar,
 } from '@cdo/apps/lab2/projects/utils';
+import {
+  setUserRoleInCourse,
+  CourseRoles,
+} from '@cdo/apps/templates/currentUserRedux';
 import {LevelStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import {getCurrentLevel} from '../code-studio/progressReduxSelectors';
@@ -47,6 +51,7 @@ import {
   LevelProperties,
   ProjectManagerStorageType,
   ProjectSources,
+  UserAppOptions,
   Validation,
 } from './types';
 import {LifecycleEvent} from './utils/LifecycleNotifier';
@@ -138,6 +143,12 @@ export const setUpWithLevel = createAsyncThunk<
     const {isProjectLevel, usesProjects} = levelProperties;
 
     Lab2Registry.getInstance().setAppName(levelProperties.appName);
+
+    loadUserAppOptions().then(result => {
+      if (result.isInstructor) {
+        thunkAPI.dispatch(setUserRoleInCourse(CourseRoles.Instructor));
+      }
+    });
 
     if (!usesProjects) {
       // If projects are disabled on this level, we can skip loading projects data.
@@ -544,6 +555,13 @@ async function loadLevelProperties(
     levelPropertiesPath,
     {},
     LevelPropertiesValidator
+  );
+  return response.value;
+}
+
+async function loadUserAppOptions(): Promise<UserAppOptions> {
+  const response = await HttpClient.fetchJson<UserAppOptions>(
+    '/api/user_app_options/music-jam-2024/1/5/62988'
   );
   return response.value;
 }

--- a/apps/src/lab2/projects/ProjectContainer.tsx
+++ b/apps/src/lab2/projects/ProjectContainer.tsx
@@ -12,6 +12,7 @@ import {clearHeader} from '@cdo/apps/code-studio/headerRedux';
 import {
   getCurrentScriptLevelId,
   getLevelPropertiesPath,
+  getUserAppOptionsPath,
 } from '@cdo/apps/code-studio/progressReduxSelectors';
 import useLifecycleNotifier from '@cdo/apps/lab2/hooks/useLifecycleNotifier';
 import {
@@ -52,6 +53,7 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
   );
 
   const levelPropertiesPath = useSelector(getLevelPropertiesPath);
+  const userAppOptionsPath = useSelector(getUserAppOptionsPath);
 
   const dispatch = useAppDispatch();
   const isReadOnly = useAppSelector(isReadOnlyWorkspace);
@@ -80,6 +82,7 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
           scriptId,
           scriptLevelId,
           levelPropertiesPath,
+          userAppOptionsPath,
           channelId,
         })
       );
@@ -105,6 +108,7 @@ const ProjectContainer: React.FunctionComponent<ProjectContainerProps> = ({
     scriptId,
     scriptLevelId,
     levelPropertiesPath,
+    userAppOptionsPath,
     dispatch,
     userId,
   ]);

--- a/apps/src/lab2/projects/utils.ts
+++ b/apps/src/lab2/projects/utils.ts
@@ -13,6 +13,7 @@ export interface PartialAppOptions {
   share: boolean;
   isEditingExemplar: boolean;
   isViewingExemplar: boolean;
+  publicCaching: boolean;
 }
 
 /**
@@ -82,6 +83,18 @@ export function getIsShareView(): boolean | undefined {
   if (hasScriptData('script[data-appoptions]')) {
     const appOptions = getScriptData('appoptions') as PartialAppOptions;
     return appOptions.share;
+  }
+}
+
+/**
+ * Fetch whether the page is cached.
+ *
+ * @returns true if the page is cached.
+ */
+export function getPublicCaching(): boolean | undefined {
+  if (hasScriptData('script[data-appoptions]')) {
+    const appOptions = getScriptData('appoptions') as PartialAppOptions;
+    return appOptions.publicCaching;
   }
 }
 

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -19,7 +19,9 @@ export {Theme};
 
 /// ------ USER APP OPTIONS ------ ///
 
-export interface UserAppOptions {
+// Partial definition of the UserAppOptions structure, only defining the
+// pieces we need at the moment.
+export interface PartialUserAppOptions {
   isInstructor: boolean;
 }
 

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -17,6 +17,12 @@ import {lab2EntryPoints} from '../../lab2EntryPoints';
 
 export {Theme};
 
+/// ------ USER APP OPTIONS ------ ///
+
+export interface UserAppOptions {
+  isInstructor: boolean;
+}
+
 /// ------ PROJECTS ------ ///
 
 /** Identifies a project. Corresponds to the "value" JSON column for the entry in the projects table. */

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -736,6 +736,7 @@ module LevelsHelper
       app_options[:is_viewing_exemplar] = level_options[:is_viewing_exemplar] || false
     end
     app_options[:share] = level_options[:share] if level_options[:share]
+    app_options[:public_caching] = @public_caching
     app_options.camelize_keys
   end
 


### PR DESCRIPTION
The teacher panel wasn't showing for Lab2 scripts marked as cached, such as `/s/music-jam-2024`.  Now it shows.

The reason was that when cached levels are rendered, `current_user` is `nil`, and as a result the rendered page's `is_instructor` value is `false` even though that's not necessarily correct.

The correct solution is to asynchronously call `/api/user_app_options` and find out whether `isInstructor` is `true`.  If so, we dispatch a `setUserRoleInCourse` with `Instructor`, and the teacher panel will appear.

Non-Lab2 apps already do the retrieval [here](https://github.com/code-dot-org/code-dot-org/blob/606b1e7b8587a5ec0784eb9e44515170eac30a99/apps/src/code-studio/initApp/loadApp.js#L359-L372) and dispatch [here](https://github.com/code-dot-org/code-dot-org/blob/606b1e7b8587a5ec0784eb9e44515170eac30a99/apps/src/StudioApp.js#L3563-L3565).  

Note that in this solution, we only set the role to `Instructor`, and don't un-set it again.  This assumes that if the user is an instructor for one level, they will be an instructor for any level in the same lesson, and this enables us to keep the teacher panel showing even as we switch levels in the same lesson without page loads, which is a nice user experience.  Examining the server-side code [here](https://github.com/code-dot-org/code-dot-org/blob/606b1e7b8587a5ec0784eb9e44515170eac30a99/dashboard/app/controllers/api_controller.rb#L532), it indeed appears that if a user is an instructor on one level, then they'll be instructor on any level in the same script. 

For further context, support for the teacher panel on cached pages was first added in https://github.com/code-dot-org/code-dot-org/pull/43522, and was fixed in https://github.com/code-dot-org/code-dot-org/pull/47278.  Interestingly, the alternative option described in the latter would have preemptively solved this issue, though at the expense of multiple calls to `/api/user_app_options` in non-Lab2 levels.  

This change is effectively a follow-up to https://github.com/code-dot-org/code-dot-org/pull/58269.  