### PR TITLE
Add name field to pd_workshops table (take 2)

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -24,6 +24,7 @@
 #  funding_type        :string(255)
 #  properties          :text(65535)
 #  module              :string(255)
+#  name                :string(255)
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20241210181552_add_name_field_to_pd_workshops.rb
+++ b/dashboard/db/migrate/20241210181552_add_name_field_to_pd_workshops.rb
@@ -1,0 +1,5 @@
+class AddNameFieldToPdWorkshops < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pd_workshops, :name, :string
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_03_163649) do
+ActiveRecord::Schema.define(version: 2024_12_10_181552) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1536,6 +1536,7 @@ ActiveRecord::Schema.define(version: 2024_12_03_163649) do
     t.string "funding_type"
     t.text "properties"
     t.string "module"
+    t.string "name"
     t.index ["organizer_id"], name: "index_pd_workshops_on_organizer_id"
     t.index ["regional_partner_id"], name: "index_pd_workshops_on_regional_partner_id"
   end


### PR DESCRIPTION
Adds `name` field to the `pd_workshops` table. This is a second take of [this PR](https://github.com/code-dot-org/code-dot-org/pull/62821) since it got into a weird state with the switch to `staging-next` and some styling updates.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2835)
Tech plan: [here](https://docs.google.com/document/d/1R0X9LhfxA2b1BpSGryXaPekyhm2lkf3WeuT9WkWE8nw/edit?tab=t.0)

## Testing story
Successfully ran migration.
