### PR TITLE
Default to sorting Not Started workshops by ascending date

### DIFF
--- a/apps/src/code-studio/pd/constants.js
+++ b/apps/src/code-studio/pd/constants.js
@@ -21,3 +21,6 @@ export const PrivacyDialogMode = utils.makeEnum(
   'TEACHER_APPLICATION',
   'PRINCIPAL_APPROVAL'
 );
+
+export const DATE_ORDER_ASC = 'date asc';
+export const DATE_ORDER_DESC = 'date desc';

--- a/apps/src/code-studio/pd/workshop_dashboard/components/server_sort_workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/server_sort_workshop_table.jsx
@@ -22,11 +22,12 @@ export default class ServerSortWorkshopTable extends React.Component {
     showOrganizer: PropTypes.bool,
     generateCaptionFromWorkshops: PropTypes.func,
     moreUrl: PropTypes.string,
+    initialOrderBy: PropTypes.oneOf(['date desc', 'date asc']),
   };
 
   constructor(props) {
     super(props);
-    this.state = {orderBy: 'date desc'};
+    this.state = {orderBy: props.initialOrderBy || 'date desc'};
   }
 
   handleWorkshopsReceived = workshops => {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/server_sort_workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/server_sort_workshop_table.jsx
@@ -8,6 +8,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {
+  DATE_ORDER_ASC,
+  DATE_ORDER_DESC,
+} from '@cdo/apps/code-studio/pd/constants';
+
 import WorkshopTable from './workshop_table';
 import WorkshopTableLoader from './workshop_table_loader';
 
@@ -22,12 +27,12 @@ export default class ServerSortWorkshopTable extends React.Component {
     showOrganizer: PropTypes.bool,
     generateCaptionFromWorkshops: PropTypes.func,
     moreUrl: PropTypes.string,
-    initialOrderBy: PropTypes.oneOf(['date desc', 'date asc']),
+    initialOrderBy: PropTypes.oneOf([DATE_ORDER_ASC, DATE_ORDER_DESC]),
   };
 
   constructor(props) {
     super(props);
-    this.state = {orderBy: props.initialOrderBy || 'date desc'};
+    this.state = {orderBy: props.initialOrderBy || DATE_ORDER_DESC};
   }
 
   handleWorkshopsReceived = workshops => {

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
@@ -296,6 +296,11 @@ export class WorkshopFilter extends React.Component {
     )}`;
   }
 
+  getDefaultOrderBy() {
+    const workshopState = this.getFiltersFromUrlParams().state;
+    return workshopState === 'Not Started' ? 'date asc' : 'date desc';
+  }
+
   // Updates the URL with the new query params so it can be shared.
   // This will trigger React-Router to pass new props and re-render with the new filters.
   updateLocationAndSetFilters(newFilters) {
@@ -531,6 +536,7 @@ export class WorkshopFilter extends React.Component {
             showStatus
             showOrganizer={this.props.permission.has(WorkshopAdmin)}
             generateCaptionFromWorkshops={this.generateCaptionFromWorkshops}
+            initialOrderBy={this.getDefaultOrderBy()}
           />
         </Row>
       </Grid>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
@@ -36,7 +36,7 @@ import {
 import RegionalPartnerDropdown, {
   RegionalPartnerPropType,
 } from '../components/regional_partner_dropdown';
-import {SelectStyleProps} from '../constants';
+import {SelectStyleProps, DATE_ORDER_ASC, DATE_ORDER_DESC} from '../constants';
 
 import DatePicker from './components/date_picker';
 import ServerSortWorkshopTable from './components/server_sort_workshop_table';
@@ -298,7 +298,7 @@ export class WorkshopFilter extends React.Component {
 
   getDefaultOrderBy() {
     const workshopState = this.getFiltersFromUrlParams().state;
-    return workshopState === 'Not Started' ? 'date asc' : 'date desc';
+    return workshopState === 'Not Started' ? DATE_ORDER_ASC : DATE_ORDER_DESC;
   }
 
   // Updates the URL with the new query params so it can be shared.

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
@@ -550,3 +550,5 @@ export default connect(state => ({
   showRegionalPartnerDropdown:
     state.regionalPartners.regionalPartners.length > 1,
 }))(WorkshopFilter);
+
+export {WorkshopFilter as UnconnectedWorkshopFilter};

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
@@ -8,6 +8,11 @@ import React from 'react';
 import {Button, ButtonToolbar} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {connect} from 'react-redux';
 
+import {
+  DATE_ORDER_ASC,
+  DATE_ORDER_DESC,
+} from '@cdo/apps/code-studio/pd/constants';
+
 import ServerSortWorkshopTable from './components/server_sort_workshop_table';
 import {
   PermissionPropType,
@@ -138,6 +143,7 @@ export class WorkshopIndex extends React.Component {
           tableId="inProgressWorkshopsTable"
           showOrganizer={showOrganizer}
           moreUrl={this.generateFilterUrl('In Progress')}
+          initialOrderBy={DATE_ORDER_DESC}
         />
         <h2>Not Started</h2>
         <ServerSortWorkshopTable
@@ -148,7 +154,7 @@ export class WorkshopIndex extends React.Component {
           showSignupUrl
           showOrganizer={showOrganizer}
           moreUrl={this.generateFilterUrl('Not Started')}
-          initialOrderBy="date asc"
+          initialOrderBy={DATE_ORDER_ASC}
         />
         <h2>Past</h2>
         <ServerSortWorkshopTable
@@ -157,6 +163,7 @@ export class WorkshopIndex extends React.Component {
           tableId="endedWorkshopsTable"
           showOrganizer={showOrganizer}
           moreUrl={this.generateFilterUrl('Ended')}
+          initialOrderBy={DATE_ORDER_DESC}
         />
       </div>
     );

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
@@ -21,7 +21,6 @@ import SubmissionsDownloadForm from './reports/foorm/submissions_download_form';
 
 const FILTER_API_URL = '/api/v1/pd/workshops/filter';
 const defaultFilters = {
-  date_order: 'desc',
   limit: 5,
 };
 const filterParams = {
@@ -149,6 +148,7 @@ export class WorkshopIndex extends React.Component {
           showSignupUrl
           showOrganizer={showOrganizer}
           moreUrl={this.generateFilterUrl('Not Started')}
+          initialOrderBy="date asc"
         />
         <h2>Past</h2>
         <ServerSortWorkshopTable

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshop_filterTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshop_filterTest.js
@@ -1,4 +1,10 @@
-import WorkshopFilter from '@cdo/apps/code-studio/pd/workshop_dashboard/workshop_filter';
+import {shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import React from 'react';
+
+import Permission, {
+  WorkshopAdmin,
+} from '@cdo/apps/code-studio/pd/workshop_dashboard/permission';
+import {UnconnectedWorkshopFilter as WorkshopFilter} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshop_filter';
 
 describe('WorkshopFilter component', () => {
   it('can create and combine subject options', () => {
@@ -58,5 +64,80 @@ describe('WorkshopFilter component', () => {
         WorkshopFilter.combineSubjectOptions(testCase.current, testCase.legacy)
       ).toEqual(testCase.expected);
     });
+  });
+
+  it('uses date ascending ordering for Not Started workshops', () => {
+    const ajaxStub = jest.spyOn($, 'ajax').mockReturnValue({
+      done: successCallback => {
+        successCallback();
+
+        return {fail: () => {}};
+      },
+    });
+    const permission = new Permission([WorkshopAdmin]);
+
+    const workshopFilter = shallow(
+      <WorkshopFilter
+        permission={permission}
+        location={{query: {state: 'Not Started'}}}
+        regionalPartnerFilter={{value: 'all', label: 'All'}}
+      />
+    );
+
+    expect(
+      workshopFilter.find('ServerSortWorkshopTable').props().initialOrderBy
+    ).toEqual('date asc');
+
+    ajaxStub.mockRestore();
+  });
+
+  it('uses date descending ordering for In Progress workshops', () => {
+    const ajaxStub = jest.spyOn($, 'ajax').mockReturnValue({
+      done: successCallback => {
+        successCallback();
+
+        return {fail: () => {}};
+      },
+    });
+    const permission = new Permission([WorkshopAdmin]);
+
+    const workshopFilter = shallow(
+      <WorkshopFilter
+        permission={permission}
+        location={{query: {state: 'In Progress'}}}
+        regionalPartnerFilter={{value: 'all', label: 'All'}}
+      />
+    );
+
+    expect(
+      workshopFilter.find('ServerSortWorkshopTable').props().initialOrderBy
+    ).toEqual('date desc');
+
+    ajaxStub.mockRestore();
+  });
+
+  it('uses date descending ordering for Past workshops', () => {
+    const ajaxStub = jest.spyOn($, 'ajax').mockReturnValue({
+      done: successCallback => {
+        successCallback();
+
+        return {fail: () => {}};
+      },
+    });
+    const permission = new Permission([WorkshopAdmin]);
+
+    const workshopFilter = shallow(
+      <WorkshopFilter
+        permission={permission}
+        location={{query: {state: 'Ended'}}}
+        regionalPartnerFilter={{value: 'all', label: 'All'}}
+      />
+    );
+
+    expect(
+      workshopFilter.find('ServerSortWorkshopTable').props().initialOrderBy
+    ).toEqual('date desc');
+
+    ajaxStub.mockRestore();
   });
 });

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshop_indexTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshop_indexTest.js
@@ -65,4 +65,33 @@ describe('WorkshopIndex', () => {
       });
     });
   });
+
+  it('defaults to ordering by date descending for In Progress and Past workshops', () => {
+    const permission = new Permission([WorkshopAdmin]);
+    const workshopIndex = shallow(<WorkshopIndex permission={permission} />, {
+      context,
+    });
+
+    expect(workshopIndex.find('h2').at(0).text()).to.equal('In Progress');
+    expect(
+      workshopIndex.find('ServerSortWorkshopTable').at(0).props().initialOrderBy
+    ).to.equal('date desc');
+
+    expect(workshopIndex.find('h2').at(2).text()).to.equal('Past');
+    expect(
+      workshopIndex.find('ServerSortWorkshopTable').at(2).props().initialOrderBy
+    ).to.equal('date desc');
+  });
+
+  it('defaults to ordering by date ascending for Not Started workshops', () => {
+    const permission = new Permission([WorkshopAdmin]);
+    const workshopIndex = shallow(<WorkshopIndex permission={permission} />, {
+      context,
+    });
+
+    expect(workshopIndex.find('h2').at(1).text()).to.equal('Not Started');
+    expect(
+      workshopIndex.find('ServerSortWorkshopTable').at(1).props().initialOrderBy
+    ).to.equal('date asc');
+  });
 });


### PR DESCRIPTION
When a table is filtered to only show Not Started workshops, order them by ascending date instead of descending date. See [jira ticket](https://codedotorg.atlassian.net/browse/ACQ-2767).

Index view:
<img width="1406" alt="Screenshot 2024-12-18 at 3 02 37 PM" src="https://github.com/user-attachments/assets/fd31ff3a-d1b8-4e0d-b5a3-473c2d6ff991" />


Filter view filtered only to not started (note I had to refresh to see this change but that may be because there's only a couple workshops):

<img width="1416" alt="Screenshot 2024-12-18 at 3 03 17 PM" src="https://github.com/user-attachments/assets/f1999c57-0c44-483e-8331-57d242f46c04" />


Filter view with no filter on status:

<img width="1416" alt="Screenshot 2024-12-18 at 3 02 50 PM" src="https://github.com/user-attachments/assets/2effca49-c8e2-4f85-8050-7761954ac4b8" />


## Testing story

tested locally

I also added unit tests. Unfortunately, these were very difficult to write using React Testing Library, so I stuck with Enzyme  for now. Created https://codedotorg.atlassian.net/browse/ACQ-2926 as a placeholder task to tackle this in more depth in the new year.

