### PR TITLE
HoC 2024 - Remove hoc_mode Slack warning

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -161,9 +161,9 @@ def main
         # Schedule a reminder for the dotd to check Zendesk in 2 hours
         Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 7200, 'Reminder: check <https://codeorg.zendesk.com/agent/filters/44863373|Zendesk>')
 
-        # Check hoc_mode and hoc_launch only on successful DTPs, so that we get about 1 reminder per
-        # day to bring staging, test and production to the same hoc_mode and hoc_launch after a
-        # hoc_mode or hoc_launch change. Note that this will only warn us if test and production
+        # Check hoc_launch only on successful DTPs, so that we get about 1 reminder per
+        # day to bring staging, test and production to the same hoc_launch after a
+        # hoc_launch change. Note that this will only warn us if test and production
         # (but not staging) are out of sync.
         check_hoc_launch
       end

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -165,7 +165,6 @@ def main
         # day to bring staging, test and production to the same hoc_mode and hoc_launch after a
         # hoc_mode or hoc_launch change. Note that this will only warn us if test and production
         # (but not staging) are out of sync.
-        check_hoc_mode
         check_hoc_launch
       end
     else
@@ -204,19 +203,6 @@ def main
   # Return the same output and status code that BUILD returned.
   puts log
   status
-end
-
-def check_hoc_mode
-  hoc_mode = DCDO.get('hoc_mode', false)
-  if hoc_mode != CDO.default_hoc_mode
-    # The test machine cannot remember DCDO params, so its hoc_mode is controlled by
-    # CDO.default_hoc_mode.
-    msg = "<!here> #{rack_env} hoc_mode (#{hoc_mode.inspect}) and default_hoc_mode " \
-      "(#{CDO.default_hoc_mode.inspect}) are out of sync. Please update CDO.default_hoc_mode in " \
-      "github, DCDO hoc_mode in staging, and DCDO hoc_mode in production to the same values, so " \
-      "that our staging, test and production environments all show the same version of our site."
-    ChatClient.log msg
-  end
 end
 
 def check_hoc_launch


### PR DESCRIPTION
Removes the [warning message in Slack](https://codedotorg.slack.com/archives/C03CK8FGX/p1733525672706399) that checks to see if the test and production servers have matching `hoc_mode`s.

## Links
Slack convo: [here](https://codedotorg.slack.com/archives/C5V9YCXTR/p1733857669023579?thread_ts=1733857027.170499&cid=C5V9YCXTR)

## Testing story
Not sure how to test this, so if anyone reviewing this knows how please comment