### PR TITLE
Give project validators ability to block projects

### DIFF
--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -115,7 +115,7 @@ class ReportAbuseController < ApplicationController
     # and signed in users to report.
     restrict_reporting_to_verified_users = DCDO.get('restrict-abuse-reporting-to-verified', true)
     amount =
-      if current_user&.verified_teacher?
+      if current_user&.verified_teacher? || current_user&.project_validator?
         20
       elsif current_user && !restrict_reporting_to_verified_users
         10

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -123,7 +123,7 @@ class ReportAbuseController < ApplicationController
         0
       end
     begin
-      value = Projects.new(get_storage_id).increment_abuse(channel_id, amount)
+      value = Projects.new(get_storage_id).increment_abuse(channel_id, amount, current_user&.project_validator?)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       raise ActionController::BadRequest.new, "Bad channel_id"
     end

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -123,6 +123,7 @@ class ReportAbuseController < ApplicationController
         0
       end
     begin
+      # Project validators can update the abuse score on frozen projects while other users cannot.
       value = Projects.new(get_storage_id).increment_abuse(channel_id, amount, current_user&.project_validator?)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       raise ActionController::BadRequest.new, "Bad channel_id"

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -1036,8 +1036,8 @@ class FilesApi < Sinatra::Base
 
         case rating
         when :adult, :racy
-          # Incrementing abuse score by 15 to differentiate from manually reported projects
-          new_score = project.increment_abuse(encrypted_channel_id, 15, true)
+          # Incrementing abuse score by 15 to differentiate from manually reported projects.
+          new_score = project.increment_abuse(encrypted_channel_id, 15, true) # Automatic moderation can be applied to frozen projects.
           FileBucket.new.replace_abuse_score(encrypted_channel_id, s3_prefix, new_score)
           response.headers['x-cdo-content-rating'] = rating.to_s
           cache_for 1.hour

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -1037,7 +1037,7 @@ class FilesApi < Sinatra::Base
         case rating
         when :adult, :racy
           # Incrementing abuse score by 15 to differentiate from manually reported projects
-          new_score = project.increment_abuse(encrypted_channel_id, 15)
+          new_score = project.increment_abuse(encrypted_channel_id, 15, true)
           FileBucket.new.replace_abuse_score(encrypted_channel_id, s3_prefix, new_score)
           response.headers['x-cdo-content-rating'] = rating.to_s
           cache_for 1.hour

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -290,13 +290,13 @@ class Projects
     0
   end
 
-  def buffer_abuse_score(channel_id, current_user)
+  def buffer_abuse_score(channel_id)
     buffered_abuse_score = -50
     # Reset to 0 first so projects that are featured,
     # unfeatured, then re-featured don't have super low
     # abuse scores.
     reset_abuse(channel_id)
-    increment_abuse(channel_id, buffered_abuse_score, current_user&.project_validator?)
+    increment_abuse(channel_id, buffered_abuse_score)
   end
 
   def content_moderation_disabled?(channel_id)

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -254,15 +254,17 @@ class Projects
     return true
   end
 
-  def increment_abuse(channel_id, amount = 10)
+  def increment_abuse(channel_id, amount, override_frozen = false)
     _owner, project_id = storage_decrypt_channel_id(channel_id)
 
     row = @table.where(id: project_id).exclude(state: 'deleted').first
     raise NotFound, "channel `#{channel_id}` not found" unless row
     # If the project is frozen then it is an active featured project or a curriculum exemplar.
-    # Do not update the abuse score of a frozen project unless the current_user is a project validator.
+    # Do not update the abuse score of a frozen project unless override_frozen is true.
+    # This flag is set to true if the current_user is a project validator or if the project's
+    # thumbnail image was flagged by image moderation.
     increment_amount =
-      if JSON.parse(row[:value])['frozen'] && !current_user&.project_validator
+      if JSON.parse(row[:value])['frozen'] && !override_frozen
         0
       else
         amount
@@ -288,13 +290,13 @@ class Projects
     0
   end
 
-  def buffer_abuse_score(channel_id)
+  def buffer_abuse_score(channel_id, current_user)
     buffered_abuse_score = -50
     # Reset to 0 first so projects that are featured,
     # unfeatured, then re-featured don't have super low
     # abuse scores.
     reset_abuse(channel_id)
-    increment_abuse(channel_id, buffered_abuse_score)
+    increment_abuse(channel_id, buffered_abuse_score, current_user&.project_validator?)
   end
 
   def content_moderation_disabled?(channel_id)

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -260,7 +260,14 @@ class Projects
     row = @table.where(id: project_id).exclude(state: 'deleted').first
     raise NotFound, "channel `#{channel_id}` not found" unless row
 
-    new_score = row[:abuse_score] + (JSON.parse(row[:value])['frozen'] ? 0 : amount)
+    increment_amount =
+      if JSON.parse(row[:value])['frozen'] && !current_user&.project_validator
+        amount
+      else
+        0
+      end
+
+    new_score = row[:abuse_score] + increment_amount
 
     update_count = @table.where(id: project_id).exclude(state: 'deleted').update({abuse_score: new_score})
     raise NotFound, "channel `#{channel_id}` not found" if update_count == 0

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -262,9 +262,9 @@ class Projects
 
     increment_amount =
       if JSON.parse(row[:value])['frozen'] && !current_user&.project_validator
-        amount
-      else
         0
+      else
+        amount
       end
 
     new_score = row[:abuse_score] + increment_amount

--- a/dashboard/legacy/middleware/helpers/projects.rb
+++ b/dashboard/legacy/middleware/helpers/projects.rb
@@ -259,7 +259,8 @@ class Projects
 
     row = @table.where(id: project_id).exclude(state: 'deleted').first
     raise NotFound, "channel `#{channel_id}` not found" unless row
-
+    # If the project is frozen then it is an active featured project or a curriculum exemplar.
+    # Do not update the abuse score of a frozen project unless the current_user is a project validator.
     increment_amount =
       if JSON.parse(row[:value])['frozen'] && !current_user&.project_validator
         0


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Currently, when a verified/authorized teacher reports abuse on a project, the abuse score of the project is increased by `20` so that the project [is blocked](https://github.com/code-dot-org/code-dot-org/blob/672509f2f7373c5c87e78bd92e2170f8b2560f3b/lib/cdo/shared_constants.rb#L83-L86). A project with abuse score `>= 15` is blocked.
https://github.com/code-dot-org/code-dot-org/blob/672509f2f7373c5c87e78bd92e2170f8b2560f3b/apps/src/code-studio/initApp/project.js#L462-L464

However, if the project is frozen, then the project's abuse score cannot be updated because of this line:
https://github.com/code-dot-org/code-dot-org/blob/32f3aac928c84fc22f372ac0eb7f2b88d7024a8a/dashboard/legacy/middleware/helpers/projects.rb#L263

Recently, there was an abuse report via Zendesk on a project that had been an [active featured project so that it was frozen](https://github.com/code-dot-org/code-dot-org/blob/32f3aac928c84fc22f372ac0eb7f2b88d7024a8a/dashboard/app/controllers/featured_projects_controller.rb#L15-L24). Its offending content was not in the App Lab program, but in the data table contents so that the program had to be run a handful of times before seeing offensive text. Customer service has a verified teacher account and so reported abuse from this account. But because it was frozen, the project was unable to be blocked.

Thus, I had to manually unfreeze the project so that I could access and then delete the table. Then I blocked the project. 

In order to make things easier in the future for customer service, this PR allows project validators to report abuse and block projects (by incrementing a project's abuse score by 20) even if the project is frozen. The verified teacher account that customer service uses has both `authorized_teacher` and `project_validator` permissions.

I added a boolean flag parameter to `increment_abuse` in `projects.rb` because this function is called on in `files_api.rb`. If a project's thumbnail image is flagged by image moderation, the abuse score of the project is automatically incremented by 15. Thus, I set the `override_frozen` param to `true` for this call.


https://github.com/code-dot-org/code-dot-org/blob/f39e8b9abba57da9c1ec80d397630fe22a0821ce/dashboard/legacy/middleware/files_api.rb#L1038-L1041

## Links
[Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/516358)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally using an account with project validator permission and NOT authorized teacher permission and was able to report abuse on projects, even if the project was frozen. A teacher account with only authorized teacher permission still cannot report abuse on frozen projects.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
