### PR TITLE
Redirect to teacher_dashboard from edit section

### DIFF
--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -20,6 +20,8 @@ class SectionsController < ApplicationController
       return
     end
 
+    puts 'lfm'
+
     @section = existing_section.attributes
 
     @section['course'] = {

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -15,6 +15,11 @@ class SectionsController < ApplicationController
       id: params[:id]
     )
 
+    if Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher_local_nav_v2', false)
+      redirect_to "/teacher_dashboard/sections/#{params[:id]}/settings"
+      return
+    end
+
     @section = existing_section.attributes
 
     @section['course'] = {

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -217,15 +217,21 @@ class SectionsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'redirect to teacher_dashboard from edit if DCDO enabled' do
+  test 'edit has successful response' do
     sign_in @teacher
 
-    section = create(:section, user: @teacher, login_type: 'word')
+    get :edit, params: {id: @word_section.id}
+    assert_response :success
+  end
 
+  test 'redirect to teacher_dashboard from edit if DCDO enabled' do
+    sign_in @teacher
     DCDO.set('teacher_local_nav_v2', true)
 
-    get :edit, params: {id: section.id}
-    assert_redirected_to "/teacher_dashboard/sections/#{section.id}/settings"
+    get :edit, params: {id: @word_section.id}
+    assert_redirected_to "/teacher_dashboard/sections/#{@word_section.id}/settings"
+
+    DCDO.set('teacher_local_nav_v2', nil)
   end
 
   test 'returns forbidden if requested edit section does not belong to teacher' do

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -217,6 +217,17 @@ class SectionsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'redirect to teacher_dashboard from edit if DCDO enabled' do
+    sign_in @teacher
+
+    section = create(:section, user: @teacher, login_type: 'word')
+
+    DCDO.set('teacher_local_nav_v2', true)
+
+    get :edit, params: {id: section.id}
+    assert_redirected_to "/teacher_dashboard/sections/#{section.id}/settings"
+  end
+
   test 'returns forbidden if requested edit section does not belong to teacher' do
     sign_in @teacher
     other_teacher_section = create :section


### PR DESCRIPTION
Redirects from `https://studio.code.org/sections/5658613/edit` to `https://studio.code.org/teacher_dashboard/sections/5658613/settings` using a BE redirect

## Links
https://codedotorg.atlassian.net/browse/TEACH-1443
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Added a unit test
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
