### PR TITLE
Updating parent email checkbox and adding test

### DIFF
--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -129,6 +129,11 @@ const FinishStudentAccount: React.FunctionComponent<{
       PLATFORMS.BOTH
     );
     const newIsParentCheckedChoice = !isParent;
+    // If the user unchecks the parent checkbox, clear the parent email field
+    if (!newIsParentCheckedChoice) {
+      setParentEmail('');
+      setShowParentEmailError(false);
+    }
     setIsParent(newIsParentCheckedChoice);
   };
 

--- a/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
@@ -362,6 +362,42 @@ describe('FinishStudentAccount', () => {
     expect(finishSignUpButton).toBeDisabled();
   });
 
+  it('clears parent email if parent checkbox is unchecked, and can submit successfully', async () => {
+    renderDefault();
+    await waitFor(() => {
+      expect(fetchStub.calledOnce).toBe(true);
+    });
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
+
+    // Set other required fields
+    const displayNameInput = screen.getAllByDisplayValue('')[1];
+    const stateInput = screen.getAllByRole('combobox')[1];
+    const ageInput = screen.getAllByRole('combobox')[0];
+    fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
+    fireEvent.change(stateInput, {target: {value: 'WA'}});
+    fireEvent.change(ageInput, {target: {value: '6'}});
+    // Check parent checkbox
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+
+    // Enter parent email
+    const parentEmailInput = screen.getAllByDisplayValue('')[1];
+    fireEvent.change(parentEmailInput, {
+      target: {value: '@invalidparentemail'},
+    });
+
+    // Uncheck parent checkbox
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    // Click finish sign up button
+    fireEvent.click(finishSignUpButton);
+
+    await waitFor(() => {
+      // Verify the user is redirected to the finish sign up page
+      expect(navigateToHrefMock).toHaveBeenCalledWith('/home');
+    });
+  });
+
   it('GDPR has expected behavior if api call returns true', async () => {
     act(() => {
       fetchStub.callsFake(() => {


### PR DESCRIPTION
Before, if a student checked the parent email and filled in an invalid email, if they unchecked the box and hit finish, their account creation would fail. This PR updates the parent email to an empty string if the box is unchecked. 

I added a test to verify that the submit button will work in this scenario.

In the video, you can see after I uncheck the box (when I recheck it) that the email field is blank again (and then the account is created successfully)

https://github.com/user-attachments/assets/e2b3b0dc-a1fa-4ba1-81e6-c932ce321660


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2782

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
