### PR TITLE
Add neighborhood mini app options to Python Lab levels

### DIFF
--- a/dashboard/app/models/levels/pythonlab.rb
+++ b/dashboard/app/models/levels/pythonlab.rb
@@ -111,6 +111,16 @@ class Pythonlab < Level
     end
   end
 
+  def summarize_for_lab2_properties(script, script_level = nil, current_user = nil)
+    level_properties = super
+    level_properties[:serializedMaze] = get_serialized_maze
+    level_properties
+  end
+
+  def get_serialized_maze
+    serialized_maze || project_template_level&.try(:serialized_maze)
+  end
+
   # Copied from javalab.rb
   def parse_maze
     return if serialized_maze.blank? && project_template_level&.try(:serialized_maze).present?

--- a/dashboard/app/models/levels/pythonlab.rb
+++ b/dashboard/app/models/levels/pythonlab.rb
@@ -35,10 +35,13 @@ class Pythonlab < Level
     predict_settings
     validation_file
     enable_micro_bit
+    mini_app
+    serialized_maze
+    start_direction
   )
 
   validate :has_correct_multiple_choice_answer?
-  before_save :clean_up_predict_settings
+  before_save :clean_up_predict_settings, :parse_maze
 
   def self.create_from_level_builder(params, level_params)
     create!(
@@ -48,6 +51,14 @@ class Pythonlab < Level
         level_num: 'custom',
       )
     )
+  end
+
+  def self.start_directions
+    [['None', nil], ['North', 0], ['East', 1], ['South', 2], ['West', 3]]
+  end
+
+  def self.mini_apps
+    [['None', nil], ['Neighborhood', 'neighborhood']]
   end
 
   def uses_lab2?
@@ -98,5 +109,29 @@ class Pythonlab < Level
     else
       nil
     end
+  end
+
+  # Copied from javalab.rb
+  def parse_maze
+    return if serialized_maze.blank? && project_template_level&.try(:serialized_maze).present?
+    if serialized_maze.nil? && mini_app == 'neighborhood'
+      raise ArgumentError.new('neighborhood must have a serialized_maze')
+    end
+    return if serialized_maze.nil?
+    # convert maze into json object and validate each cell has a tileType
+    maze_json = serialized_maze.is_a?(Array) ? serialized_maze.to_json : serialized_maze
+    maze = JSON.parse(maze_json)
+    maze.each_with_index do |row, x|
+      row.each_with_index do |cell, y|
+        unless cell.is_a?(Hash) && cell.key?('tileType')
+          raise ArgumentError.new("Cell (#{x},#{y}) has no defined tileType")
+        end
+      end
+    end
+    # paint bucket asset id is 303
+    if serialized_maze.include?("303") && (maze.length >= 20)
+      raise ArgumentError.new("Large mazes cannot have paint buckets")
+    end
+    self.serialized_maze = maze
   end
 end

--- a/dashboard/app/models/levels/pythonlab.rb
+++ b/dashboard/app/models/levels/pythonlab.rb
@@ -41,7 +41,7 @@ class Pythonlab < Level
   )
 
   validate :has_correct_multiple_choice_answer?
-  before_save :clean_up_predict_settings, :parse_maze
+  before_save :clean_up_predict_settings, :clean_up_mini_app_settings, :parse_maze
 
   def self.create_from_level_builder(params, level_params)
     create!(
@@ -119,6 +119,13 @@ class Pythonlab < Level
 
   def get_serialized_maze
     serialized_maze || project_template_level&.try(:serialized_maze)
+  end
+
+  def clean_up_mini_app_settings
+    if mini_app != 'neighborhood'
+      properties.delete('serialized_maze')
+      properties.delete('start_direction')
+    end
   end
 
   # Copied from javalab.rb

--- a/dashboard/app/views/levels/editors/fields/_pythonlab_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_pythonlab_fields.html.haml
@@ -1,1 +1,27 @@
-%h1 Python Lab Fields
+%h1.control-legend{data: {toggle: "collapse", target: "#python_lab_fields"}}
+  Python Lab Fields
+
+#python_lab_fields.in.collapse 
+  .field
+    = f.label :mini_app, 'Mini App'
+    = f.select :mini_app, options_for_select(@level.class.mini_apps, @level.mini_app), {}, onchange: 'toggleFields(this.value);'
+
+  #neighborhood{class: ('collapse' if @level.mini_app != 'neighborhood')}
+    .field
+      = f.label :start_direction
+      = f.select :start_direction, options_for_select(@level.class.start_directions, @level.start_direction)
+
+    .field
+      = f.label :serialized_maze
+      - maze_value = @level.serialized_maze ? JSON.pretty_generate(@level.serialized_maze) : ''
+      = f.text_area :serialized_maze, value: maze_value, rows: 20, class: 'input-block-level'
+
+:javascript
+  function toggleFields(val) {
+    const neighborhoodFields = document.getElementById('neighborhood');
+    if (val.toLowerCase() === 'neighborhood') {
+      neighborhoodFields.classList.remove('collapse');
+    } else {
+      neighborhoodFields.classList.add('collapse');
+    }
+  }

--- a/dashboard/app/views/levels/editors/fields/_pythonlab_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_pythonlab_fields.html.haml
@@ -1,7 +1,7 @@
 %h1.control-legend{data: {toggle: "collapse", target: "#python_lab_fields"}}
   Python Lab Fields
 
-#python_lab_fields.in.collapse 
+#python_lab_fields.in.collapse
   .field
     = f.label :mini_app, 'Mini App'
     = f.select :mini_app, options_for_select(@level.class.mini_apps, @level.mini_app), {}, onchange: 'toggleFields(this.value);'

--- a/dashboard/config/levels/custom/pythonlab/pythonlab_neighborhood.level
+++ b/dashboard/config/levels/custom/pythonlab/pythonlab_neighborhood.level
@@ -1,0 +1,360 @@
+<Pythonlab>
+  <config><![CDATA[{
+  "game_id": 72,
+  "created_at": "2024-12-10T21:37:32.000Z",
+  "level_num": "custom",
+  "user_id": 2,
+  "properties": {
+    "encrypted": "false",
+    "long_instructions": "This is a sample Python Lab level that uses the neighborhood",
+    "ai_tutor_available": "false",
+    "hide_share_and_remix": "false",
+    "start_direction": "1",
+    "submittable": "false",
+    "serialized_maze": [
+      [
+        {
+          "tileType": 1,
+          "value": 28,
+          "assetId": 303
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        }
+      ],
+      [
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        }
+      ],
+      [
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 0,
+          "value": 0,
+          "assetId": 46
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 0,
+          "value": 0,
+          "assetId": 46
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 0,
+          "value": 0,
+          "assetId": 46
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 0,
+          "value": 0,
+          "assetId": 46
+        }
+      ],
+      [
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        }
+      ],
+      [
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        }
+      ],
+      [
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 0,
+          "value": 0,
+          "assetId": 46
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 0,
+          "value": 0,
+          "assetId": 46
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 0,
+          "value": 0,
+          "assetId": 46
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 0,
+          "value": 0,
+          "assetId": 46
+        }
+      ],
+      [
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        }
+      ],
+      [
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        },
+        {
+          "tileType": 1,
+          "value": 0,
+          "assetId": 0
+        }
+      ]
+    ],
+    "enable_micro_bit": "false",
+    "mini_app": "neighborhood",
+    "predict_settings": {
+      "isPredictLevel": false
+    }
+  },
+  "published": true
+}]]></config>
+</Pythonlab>

--- a/dashboard/config/levels/custom/pythonlab/pythonlab_neighborhood.level
+++ b/dashboard/config/levels/custom/pythonlab/pythonlab_neighborhood.level
@@ -1,7 +1,8 @@
 <Pythonlab>
   <config><![CDATA[{
+  "published": true,
   "game_id": 72,
-  "created_at": "2024-12-10T21:37:32.000Z",
+  "created_at": "2024-12-11T05:37:32.000Z",
   "level_num": "custom",
   "user_id": 2,
   "properties": {
@@ -9,8 +10,12 @@
     "long_instructions": "This is a sample Python Lab level that uses the neighborhood",
     "ai_tutor_available": "false",
     "hide_share_and_remix": "false",
-    "start_direction": "1",
     "submittable": "false",
+    "enable_micro_bit": "false",
+    "predict_settings": {
+      "isPredictLevel": false
+    },
+    "start_direction": "1",
     "serialized_maze": [
       [
         {
@@ -349,12 +354,8 @@
         }
       ]
     ],
-    "enable_micro_bit": "false",
-    "mini_app": "neighborhood",
-    "predict_settings": {
-      "isPredictLevel": false
-    }
+    "mini_app": "neighborhood"
   },
-  "published": true
+  "audit_log": "[{\"changed_at\":\"2024-12-10 15:42:27 -0800\",\"changed\":[\"serialized_maze\",\"mini_app\",\"predict_settings\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2024-12-10 15:42:56 -0800\",\"changed\":[\"predict_settings\"],\"changed_by_id\":2,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]"
 }]]></config>
 </Pythonlab>

--- a/dashboard/test/models/pythonlab_test.rb
+++ b/dashboard/test/models/pythonlab_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class PythonlabTest < ActiveSupport::TestCase
+  test 'can parse serialized_maze' do
+    neighborhood_data = {game_id: 72, level_num: "custom", name: "sample_neighborhood"}
+    serialized_maze = "[[{\"tileType\": 0, \"assetId\": 13, \"value\": 0}],[{\"tileType\":1,\"value\":0}]]"
+    neighborhood_data[:properties] = {
+      serialized_maze: serialized_maze,
+      mini_app: "neighborhood"
+    }
+
+    neighborhood_level = Pythonlab.create(neighborhood_data)
+    refute_empty(neighborhood_level.serialized_maze)
+    assert_equal(2, neighborhood_level.serialized_maze.size)
+  end
+
+  test 'neighborhood level requires serialized_maze' do
+    neighborhood_data = {game_id: 72, level_num: "custom", name: "sample_neighborhood"}
+    neighborhood_data[:properties] = {
+      mini_app: "neighborhood"
+    }
+
+    assert_raises ArgumentError do
+      Pythonlab.create(neighborhood_data)
+    end
+  end
+
+  test 'get_serialized_maze returns template level maze if level doesnt have one' do
+    template_data = {game_id: 72, level_num: "custom", name: "template_neighborhood"}
+    serialized_maze = "[[{\"tileType\": 0, \"assetId\": 13, \"value\": 0}],[{\"tileType\":1,\"value\":0}]]"
+    template_data[:properties] = {
+      serialized_maze: serialized_maze,
+      mini_app: "neighborhood"
+    }
+    template_level = Pythonlab.create(template_data)
+
+    neighborhood_data = {game_id: 72, level_num: "custom", name: "sample_neighborhood"}
+    neighborhood_data[:properties] = {
+      mini_app: "neighborhood",
+      project_template_level_name: template_level.name
+    }
+    neighborhood_level = Pythonlab.create(neighborhood_data)
+    assert_equal template_level.get_serialized_maze, neighborhood_level.get_serialized_maze
+  end
+end

--- a/dashboard/test/models/pythonlab_test.rb
+++ b/dashboard/test/models/pythonlab_test.rb
@@ -42,4 +42,30 @@ class PythonlabTest < ActiveSupport::TestCase
     neighborhood_level = Pythonlab.create(neighborhood_data)
     assert_equal template_level.get_serialized_maze, neighborhood_level.get_serialized_maze
   end
+
+  test 'Remove neighborhood settings for non-neighborhood levels' do
+    level_data = {game_id: 72, level_num: "custom", name: "sample_level"}
+    level_data[:properties] = {
+      serialized_maze: "[[{\"tileType\": 0, \"assetId\": 13, \"value\": 0}],[{\"tileType\":1,\"value\":0}]]",
+      start_direction: 1,
+    }
+    level = Pythonlab.create(level_data)
+    assert_nil(level.serialized_maze)
+    assert_nil(level.start_direction)
+  end
+
+  test 'Keeps neighborhood settings for neighborhood levels' do
+    level_data = {game_id: 72, level_num: "custom", name: "sample_level"}
+    serialized_maze = "[[{\"tileType\": 0, \"assetId\": 13, \"value\": 0}],[{\"tileType\":1,\"value\":0}]]"
+    start_direction = 1
+    level_data[:properties] = {
+      mini_app: "neighborhood",
+      serialized_maze: serialized_maze,
+      start_direction: start_direction,
+    }
+    parsed_maze = JSON.parse(serialized_maze)
+    level = Pythonlab.create(level_data)
+    assert_equal(parsed_maze, level.serialized_maze)
+    assert_equal(start_direction, level.start_direction)
+  end
 end


### PR DESCRIPTION
To start creating a version of neighborhood in Python Lab we need the ability to set some Python Lab levels as neighborhood levels. I followed a very similar setup to Java Lab here, with a few tweaks.

In levelbuilder, we now have Python Lab fields (before it was an empty section of the level edit page). There is a "mini app" dropdown, with the option of either "None" or "Neighborhood". In Java Lab we call this CSA View Mode, and since that name did not make sense for Python Lab I went with "mini app" since that is what we have landed on as a name for this feature generally. When neighborhood is selected, we also show fields for start direction and serialized maze. 

If levelbuilders have the start direction and serialized maze filled in, then switch to a non-neighborhood mini app, on save we will clear out those fields. We don't do this in Java Lab but I added that here because it didn't make sense to clutter the level configuration with confusing, unused information. On save we also validate the serialized maze is valid, same as Java Lab. I added unit tests for the serialized maze validation (mostly copied from Java Lab).

I also updated Python Lab to have an override method for `summarize_for_lab2`, so we can set the serialized maze to the template level's maze if the level does not have a serialized maze. I don't think it's likely other lab2 levels will have a serialized maze, so it made sense to keep this logic unique to python lab.

## Screenshots
### "None" selected
<img width="747" alt="Screenshot 2024-12-10 at 3 56 52 PM" src="https://github.com/user-attachments/assets/db8f8806-732f-48cf-bef6-6388d5cc01f6">

### "Neighborhood" selected
<img width="771" alt="Screenshot 2024-12-10 at 3 56 44 PM" src="https://github.com/user-attachments/assets/f9e873ad-42ce-4e1b-b297-07015ff73bfd">

## Links
- jira ticket: [CT-927](https://codedotorg.atlassian.net/browse/CT-927)


## Testing story
Tested locally

## Follow-up work
Lots of work still to do, see the Intro to Programming release in Codebridge for more tasks!


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
