### PR TITLE
Panels: fade in over previous option

### DIFF
--- a/apps/src/lab2/levelEditors/panels/EditPanels.tsx
+++ b/apps/src/lab2/levelEditors/panels/EditPanels.tsx
@@ -254,6 +254,20 @@ const EditPanel: React.FunctionComponent<EditPanelProps> = ({
           }
         />
       </div>
+      <div className={moduleStyles.fieldRow}>
+        <Checkbox
+          checked={!!panel.fadeInOverPrevious}
+          name="fadeInOverPrevious"
+          label="Fade in over previous"
+          size="s"
+          onChange={event =>
+            updatePanel({
+              ...panel,
+              fadeInOverPrevious: event.target.checked,
+            })
+          }
+        />
+      </div>
       {last && (
         <div className={moduleStyles.fieldRow}>
           <label htmlFor={panel.nextUrl}>


### PR DESCRIPTION
The "fade in over previous" effect for a panels image added in https://github.com/code-dot-org/code-dot-org/pull/61820 can now be set with a new checkbox in levelbuilder.

<img width="844" alt="Screenshot 2024-12-10 at 9 26 15 PM" src="https://github.com/user-attachments/assets/5f225f94-9012-42ee-845e-11010798239e">

