### PR TITLE
[DESIGN2-201-Checkbox] Checkbox Component - DSCO - Update color variables

### DIFF
--- a/apps/src/componentLibrary/checkbox/CHANGELOG.md
+++ b/apps/src/componentLibrary/checkbox/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1](https://github.com/code-dot-org/code-dot-org/pull/62908)
+
+- updated color variables to use `primitiveColors.css`
+
 ## [0.5.0](https://github.com/code-dot-org/code-dot-org/pull/62716)
 
 - rewritten `CheckboxTest` in typescript

--- a/apps/src/componentLibrary/checkbox/checkbox.module.scss
+++ b/apps/src/componentLibrary/checkbox/checkbox.module.scss
@@ -1,4 +1,4 @@
-@import "color";
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 
 // Checkbox common styles
 .label {
@@ -13,7 +13,7 @@
       display: inline-block;
       content: ' ';
       text-align: center;
-      border: 2px solid $neutral_dark;
+      border: 2px solid var(--neutral-base-black);
       border-radius: 4px;
     }
   }
@@ -28,31 +28,31 @@
 
     &:checked + i::before {
       content: "\f00c";
-      color: $neutral_white;
-      background: $light_primary_500;
-      border: 2px solid $light_primary_500;
+      color: var(--neutral-base-white);
+      background: var(--brand-teal-50);
+      border: 2px solid var(--brand-teal-50);
       border-radius: 4px;
     }
 
     &:indeterminate + i::before {
       content: "\e404";
-      color: $neutral_white;
-      background: $light_primary_500;
-      border: 2px solid $light_primary_500;
+      color: var(--neutral-base-white);
+      background: var(--brand-teal-50);
+      border: 2px solid var(--brand-teal-50);
       border-radius: 4px;
     }
 
     // Focus styles
     &:focus-visible {
       + i::before {
-        outline: 2px solid $light_primary_500;
+        outline: 2px solid var(--brand-teal-50);
         outline-offset: 2px;
         border-radius: 4px;
       }
       &:indeterminate + i::before {
-        color: $neutral_white;
-        background: $light_primary_500;
-        border: 2px solid $light_primary_500;
+        color: var(--neutral-base-white);
+        background: var(--brand-teal-50);
+        border: 2px solid var(--brand-teal-50);
       }
     }
   }
@@ -63,16 +63,16 @@
 
     i {
       &::before {
-        background-color: $brand_primary_light;
+        background-color: var(--brand-teal-5);
       }
     }
 
     input[type="checkbox"] {
       &:checked + i::before,
       &:indeterminate + i::before {
-        color: $neutral_white;
-        background: $light_primary_700;
-        border-color: $light_primary_700;
+        color: var(--neutral-base-white);
+        background: var(--brand-teal-70);
+        border-color: var(--brand-teal-70);
       }
     }
   }
@@ -81,17 +81,17 @@
   &:active {
     i {
       &::before {
-        background-color: $brand_primary_light;
-        border-color: $light_primary_500;
+        background-color: var(--brand-teal-5);
+        border-color: var(--brand-teal-50);
       }
     }
 
     input[type="checkbox"] {
       &:checked + i::before,
       &:indeterminate + i::before {
-        color: $neutral_white;
-        background: $light_primary_700;
-        border-color: $light_primary_500;
+        color: var(--neutral-base-white);
+        background: var(--brand-teal-70);
+        border-color: var(--brand-teal-50);
       }
     }
   }
@@ -99,31 +99,31 @@
   // Disabled styles
   &:has(input[type="checkbox"]:disabled) {
     span {
-      color: $neutral_dark20;
+      color: var(--neutral-gray-20);
     }
 
     i::before {
-      border-color: $neutral_dark20;
+      border-color: var(--neutral-gray-20);
     }
 
     input[type="checkbox"] {
       &:checked + i::before,
       &:indeterminate + i::before {
-        background: $neutral_dark20;
-        color: $neutral_white;
+        background: var(--neutral-gray-20);
+        color: var(--neutral-base-white);
       }
     }
 
     &:hover {
       cursor: not-allowed;
       i::before {
-        background: $neutral_white;
+        background: var(--neutral-base-white);
       }
 
       input[type="checkbox"]:checked + i::before,
       input[type="checkbox"]:indeterminate + i::before {
-        background: $neutral_dark20;
-        border-color: $neutral_dark20;
+        background: var(--neutral-gray-20);
+        border-color: var(--neutral-gray-20);
       }
     }
   }


### PR DESCRIPTION
Swaps out color variables from `shared/color.scss` with Primitive colors from `primitiveColors.css` on the Checkbox component. 

👀 **DOTD note:** there might be Eyes diffs with this.

## Links
Jira ticket: [DESIGN2-201](https://codedotorg.atlassian.net/browse/DESIGN2-201)

## Testing story
Tested locally in Storybook

----

## Before - using `shared/colors.scss`
<img width="992" alt="Before" src="https://github.com/user-attachments/assets/9ee90845-c678-4804-90cf-afb689a7dde0" />

## After - using `primitiveColors.css`
<img width="992" alt="After" src="https://github.com/user-attachments/assets/34be70ba-0306-4772-a4c3-f2ceb7b49588" />
