### PR TITLE
NAV/make page reload when section data is edited

### DIFF
--- a/apps/src/code-studio/calendarRedux.ts
+++ b/apps/src/code-studio/calendarRedux.ts
@@ -11,18 +11,21 @@ interface CalendarLesson {
 }
 
 export interface CalendarState {
+  unitName: string | null;
   showCalendar: boolean;
   calendarLessons: CalendarLesson[] | null;
   versionYear: number | null;
 }
 
 interface CalendarDataPayload {
+  unitName: string | null;
   showCalendar: boolean;
   calendarLessons: CalendarLesson[] | null;
   versionYear: number | null;
 }
 
 const initialState: CalendarState = {
+  unitName: null,
   showCalendar: false,
   calendarLessons: null,
   versionYear: null,
@@ -33,6 +36,7 @@ const calendarReduxSlice = createSlice({
   initialState,
   reducers: {
     setCalendarData(state, action: PayloadAction<CalendarDataPayload>) {
+      state.unitName = action.payload.unitName;
       state.showCalendar = action.payload.showCalendar;
       state.calendarLessons = action.payload.calendarLessons;
       state.versionYear = action.payload.versionYear;

--- a/apps/src/code-studio/components/progress/UnitSummaryUtils.tsx
+++ b/apps/src/code-studio/components/progress/UnitSummaryUtils.tsx
@@ -212,6 +212,7 @@ export const setUnitSummaryReduxData = (
 
   dispatch(
     setCalendarData({
+      unitName: unitData.name,
       showCalendar: !!unitData.showCalendar,
       calendarLessons: unitData.calendarLessons,
       versionYear: unitData.version_year

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -15,6 +15,7 @@ import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shap
 import {
   assignToSection,
   unassignSection,
+  updateNeedsReloadFunction,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import i18n from '@cdo/locale';
 
@@ -38,6 +39,7 @@ const MultipleSectionsAssigner = ({
   unassignSection,
   assignToSection,
   updateHiddenScript,
+  updateNeedsReloadFunction,
 }) => {
   const [currentSectionsAssigned, setCurrentSectionsAssigned] = useState([]);
 
@@ -112,6 +114,9 @@ const MultipleSectionsAssigner = ({
         } else {
           unhideAndAssignUnit(currentSectionsAssigned[i]);
         }
+        // set state to reflect that the page needs to be refreshed
+        // when a user changes tabs (for the calendar, etc)
+        updateNeedsReloadFunction();
       }
     }
 
@@ -277,6 +282,7 @@ MultipleSectionsAssigner.propTypes = {
   unassignSection: PropTypes.func.isRequired,
   assignToSection: PropTypes.func.isRequired,
   updateHiddenScript: PropTypes.func.isRequired,
+  updateNeedsReloadFunction: PropTypes.func.isRequired,
 };
 
 export const UnconnectedMultipleSectionsAssigner = MultipleSectionsAssigner;
@@ -285,4 +291,5 @@ export default connect(state => ({}), {
   assignToSection,
   updateHiddenScript,
   unassignSection,
+  updateNeedsReloadFunction,
 })(MultipleSectionsAssigner);

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -15,7 +15,7 @@ import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shap
 import {
   assignToSection,
   unassignSection,
-  updateNeedsReloadFunction,
+  setNeedsReload,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import i18n from '@cdo/locale';
 
@@ -39,7 +39,7 @@ const MultipleSectionsAssigner = ({
   unassignSection,
   assignToSection,
   updateHiddenScript,
-  updateNeedsReloadFunction,
+  setNeedsReload,
 }) => {
   const [currentSectionsAssigned, setCurrentSectionsAssigned] = useState([]);
 
@@ -114,9 +114,7 @@ const MultipleSectionsAssigner = ({
         } else {
           unhideAndAssignUnit(currentSectionsAssigned[i]);
         }
-        // set state to reflect that the page needs to be refreshed
-        // when a user changes tabs (for the calendar, etc)
-        updateNeedsReloadFunction();
+        setNeedsReload();
       }
     }
 
@@ -282,7 +280,7 @@ MultipleSectionsAssigner.propTypes = {
   unassignSection: PropTypes.func.isRequired,
   assignToSection: PropTypes.func.isRequired,
   updateHiddenScript: PropTypes.func.isRequired,
-  updateNeedsReloadFunction: PropTypes.func.isRequired,
+  setNeedsReload: PropTypes.func.isRequired,
 };
 
 export const UnconnectedMultipleSectionsAssigner = MultipleSectionsAssigner;
@@ -291,5 +289,5 @@ export default connect(state => ({}), {
   assignToSection,
   updateHiddenScript,
   unassignSection,
-  updateNeedsReloadFunction,
+  setNeedsReload,
 })(MultipleSectionsAssigner);

--- a/apps/src/templates/MultipleSectionsAssigner.jsx
+++ b/apps/src/templates/MultipleSectionsAssigner.jsx
@@ -15,7 +15,7 @@ import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shap
 import {
   assignToSection,
   unassignSection,
-  setNeedsReload,
+  sectionHasNewData,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import i18n from '@cdo/locale';
 
@@ -39,7 +39,7 @@ const MultipleSectionsAssigner = ({
   unassignSection,
   assignToSection,
   updateHiddenScript,
-  setNeedsReload,
+  sectionHasNewData,
 }) => {
   const [currentSectionsAssigned, setCurrentSectionsAssigned] = useState([]);
 
@@ -114,7 +114,7 @@ const MultipleSectionsAssigner = ({
         } else {
           unhideAndAssignUnit(currentSectionsAssigned[i]);
         }
-        setNeedsReload();
+        sectionHasNewData();
       }
     }
 
@@ -280,7 +280,7 @@ MultipleSectionsAssigner.propTypes = {
   unassignSection: PropTypes.func.isRequired,
   assignToSection: PropTypes.func.isRequired,
   updateHiddenScript: PropTypes.func.isRequired,
-  setNeedsReload: PropTypes.func.isRequired,
+  sectionHasNewData: PropTypes.func.isRequired,
 };
 
 export const UnconnectedMultipleSectionsAssigner = MultipleSectionsAssigner;
@@ -289,5 +289,5 @@ export default connect(state => ({}), {
   assignToSection,
   updateHiddenScript,
   unassignSection,
-  setNeedsReload,
+  sectionHasNewData,
 })(MultipleSectionsAssigner);

--- a/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
@@ -107,7 +107,6 @@ class ManageStudentsActionsCell extends Component {
 
   onRequestDelete = () => {
     this.setState({deleting: true});
-    this.props.updateNeedsReloadFunction();
   };
 
   onCancelDelete = () => {
@@ -158,7 +157,6 @@ class ManageStudentsActionsCell extends Component {
       this.onAdd();
     } else {
       this.props.saveStudent(id);
-      this.props.updateNeedsReloadFunction();
       firehoseClient.putRecord(
         {
           study: 'teacher-dashboard',
@@ -181,8 +179,6 @@ class ManageStudentsActionsCell extends Component {
   onAdd = () => {
     const {id, sectionId} = this.props;
     this.props.addStudent(id);
-    console.log('onAdd inside');
-    this.props.updateNeedsReloadFunction();
     firehoseClient.putRecord(
       {
         study: 'teacher-dashboard',

--- a/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
@@ -8,10 +8,7 @@ import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import firehoseClient from '@cdo/apps/metrics/firehose';
 import PopUpMenu, {MenuBreak} from '@cdo/apps/sharedComponents/PopUpMenu';
-import {
-  asyncLoadSectionData,
-  updateNeedsReloadFunction,
-} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {asyncLoadSectionData} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import {navigateToHref} from '@cdo/apps/utils';
 import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
@@ -53,7 +50,6 @@ class ManageStudentsActionsCell extends Component {
     saveStudent: PropTypes.func,
     addStudent: PropTypes.func,
     loadSectionData: PropTypes.func,
-    updateNeedsReloadFunction: PropTypes.func,
   };
 
   state = {
@@ -346,6 +342,5 @@ export default connect(
     loadSectionData(sectionId) {
       dispatch(asyncLoadSectionData(sectionId));
     },
-    updateNeedsReloadFunction: () => dispatch(updateNeedsReloadFunction()),
   })
 )(ManageStudentsActionsCell);

--- a/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
@@ -8,7 +8,10 @@ import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import firehoseClient from '@cdo/apps/metrics/firehose';
 import PopUpMenu, {MenuBreak} from '@cdo/apps/sharedComponents/PopUpMenu';
-import {asyncLoadSectionData} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {
+  asyncLoadSectionData,
+  updateNeedsReloadFunction,
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import {navigateToHref} from '@cdo/apps/utils';
 import {SectionLoginType} from '@cdo/generated-scripts/sharedConstants';
@@ -50,6 +53,7 @@ class ManageStudentsActionsCell extends Component {
     saveStudent: PropTypes.func,
     addStudent: PropTypes.func,
     loadSectionData: PropTypes.func,
+    updateNeedsReloadFunction: PropTypes.func,
   };
 
   state = {
@@ -103,6 +107,7 @@ class ManageStudentsActionsCell extends Component {
 
   onRequestDelete = () => {
     this.setState({deleting: true});
+    this.props.updateNeedsReloadFunction();
   };
 
   onCancelDelete = () => {
@@ -153,6 +158,7 @@ class ManageStudentsActionsCell extends Component {
       this.onAdd();
     } else {
       this.props.saveStudent(id);
+      this.props.updateNeedsReloadFunction();
       firehoseClient.putRecord(
         {
           study: 'teacher-dashboard',
@@ -175,6 +181,8 @@ class ManageStudentsActionsCell extends Component {
   onAdd = () => {
     const {id, sectionId} = this.props;
     this.props.addStudent(id);
+    console.log('onAdd inside');
+    this.props.updateNeedsReloadFunction();
     firehoseClient.putRecord(
       {
         study: 'teacher-dashboard',
@@ -342,5 +350,6 @@ export default connect(
     loadSectionData(sectionId) {
       dispatch(asyncLoadSectionData(sectionId));
     },
+    updateNeedsReloadFunction: () => dispatch(updateNeedsReloadFunction()),
   })
 )(ManageStudentsActionsCell);

--- a/apps/src/templates/manageStudents/Table/index.jsx
+++ b/apps/src/templates/manageStudents/Table/index.jsx
@@ -54,7 +54,6 @@ import {
   sortableOptions,
 } from '@cdo/apps/templates/tables/tableConstants';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
-import {updateNeedsReloadFunction} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {
   selectedSectionSelector,
   syncEnabled,
@@ -144,7 +143,6 @@ class ManageStudentsTable extends Component {
     transferStatus: PropTypes.object,
     setSortByFamilyName: PropTypes.func,
     syncEnabled: PropTypes.bool,
-    updateNeedsReloadFunction: PropTypes.func,
   };
 
   constructor(props) {
@@ -1174,6 +1172,5 @@ export default connect(
         setSortByFamilyName(isSortedByFamilyName, sectionId, unitName, source)
       );
     },
-    updateNeedsReloadFunction: () => dispatch(updateNeedsReloadFunction()),
   })
 )(ManageStudentsTable);

--- a/apps/src/templates/manageStudents/Table/index.jsx
+++ b/apps/src/templates/manageStudents/Table/index.jsx
@@ -402,7 +402,6 @@ class ManageStudentsTable extends Component {
 
   handleSaveAllClick() {
     this.props.saveAllStudents();
-    this.props.updateNeedsReloadFunction();
 
     analyticsReporter.sendEvent(
       EVENTS.SECTION_STUDENTS_TABLE_SAVE_ALL_CLICKED,

--- a/apps/src/templates/manageStudents/Table/index.jsx
+++ b/apps/src/templates/manageStudents/Table/index.jsx
@@ -54,6 +54,7 @@ import {
   sortableOptions,
 } from '@cdo/apps/templates/tables/tableConstants';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
+import {updateNeedsReloadFunction} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {
   selectedSectionSelector,
   syncEnabled,
@@ -143,6 +144,7 @@ class ManageStudentsTable extends Component {
     transferStatus: PropTypes.object,
     setSortByFamilyName: PropTypes.func,
     syncEnabled: PropTypes.bool,
+    updateNeedsReloadFunction: PropTypes.func,
   };
 
   constructor(props) {
@@ -400,6 +402,7 @@ class ManageStudentsTable extends Component {
 
   handleSaveAllClick() {
     this.props.saveAllStudents();
+    this.props.updateNeedsReloadFunction();
 
     analyticsReporter.sendEvent(
       EVENTS.SECTION_STUDENTS_TABLE_SAVE_ALL_CLICKED,
@@ -1172,5 +1175,6 @@ export default connect(
         setSortByFamilyName(isSortedByFamilyName, sectionId, unitName, source)
       );
     },
+    updateNeedsReloadFunction: () => dispatch(updateNeedsReloadFunction()),
   })
 )(ManageStudentsTable);

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
@@ -180,12 +180,6 @@ const sectionSlice = createSlice({
   name: 'teacherSections',
   initialState,
   reducers: {
-    setNeedsReload(state) {
-      state.needsReload = true;
-    },
-    setClearReload(state) {
-      state.needsReload = false;
-    },
     setAuthProviders(state, action: PayloadAction<string[]>) {
       state.providers = action.payload.map(mapProviderToSectionType);
     },
@@ -1143,8 +1137,6 @@ export const {
   updateSelectedSection,
   sectionHasNewData,
   sectionDoesNotHaveNewData,
-  setNeedsReload,
-  setClearReload,
 } = sectionSlice.actions;
 
 export default sectionSlice.reducer;

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
@@ -183,6 +183,9 @@ const sectionSlice = createSlice({
     setNeedsReload(state) {
       state.needsReload = true;
     },
+    setClearReload(state) {
+      state.needsReload = false;
+    },
     setAuthProviders(state, action: PayloadAction<string[]>) {
       state.providers = action.payload.map(mapProviderToSectionType);
     },
@@ -1150,6 +1153,8 @@ export const {
   sectionHasNewData,
   sectionDoesNotHaveNewData,
   updateNeedsReload,
+  setNeedsReload,
+  setClearReload,
 } = sectionSlice.actions;
 
 export default sectionSlice.reducer;

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
@@ -218,9 +218,6 @@ const sectionSlice = createSlice({
         state.selectedSectionName = '';
       }
     },
-    updateNeedsReload(state) {
-      state.needsReload = true;
-    },
     updateSelectedSection(state, action: PayloadAction<ServerSection>) {
       const sectionId = action.payload.id;
       if (sectionId) {
@@ -303,7 +300,6 @@ const sectionSlice = createSlice({
       },
     },
     sectionHasNewData(state) {
-      console.log('inside sectionHaseNewData');
       state.needsReload = true;
     },
     sectionDoesNotHaveNewData(state) {
@@ -777,11 +773,6 @@ export const finishEditingSection =
     });
   };
 
-export const updateNeedsReloadFunction = (): SectionThunkAction => dispatch => {
-  console.log('updateNeedsReloadFunction CALLED');
-  dispatch(updateNeedsReload());
-};
-
 /**
  * Removes a section or throws an error if the section does not exist.
  */
@@ -1152,7 +1143,6 @@ export const {
   updateSelectedSection,
   sectionHasNewData,
   sectionDoesNotHaveNewData,
-  updateNeedsReload,
   setNeedsReload,
   setClearReload,
 } = sectionSlice.actions;

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.ts
@@ -108,6 +108,7 @@ export interface TeacherSectionState {
   initialLoginType?: keyof typeof SectionLoginType;
   coteacherInvite?: SectionInstructor;
   coteacherInviteForPl?: SectionInstructor;
+  needsReload?: boolean;
 }
 
 /** @const {null} null used to indicate no section selected */
@@ -157,6 +158,8 @@ const initialState: TeacherSectionState = {
   ltiSyncResult: null,
   isLoadingSectionData: false,
   initialUnitName: null,
+  // used to track if data about the section has changed
+  needsReload: false,
 };
 
 // Maps authentication provider to OAuthSectionTypes for ease of comparison
@@ -177,6 +180,9 @@ const sectionSlice = createSlice({
   name: 'teacherSections',
   initialState,
   reducers: {
+    setNeedsReload(state) {
+      state.needsReload = true;
+    },
     setAuthProviders(state, action: PayloadAction<string[]>) {
       state.providers = action.payload.map(mapProviderToSectionType);
     },
@@ -208,6 +214,9 @@ const sectionSlice = createSlice({
         state.selectedSectionId = NO_SECTION;
         state.selectedSectionName = '';
       }
+    },
+    updateNeedsReload(state) {
+      state.needsReload = true;
     },
     updateSelectedSection(state, action: PayloadAction<ServerSection>) {
       const sectionId = action.payload.id;
@@ -289,6 +298,13 @@ const sectionSlice = createSlice({
           },
         };
       },
+    },
+    sectionHasNewData(state) {
+      console.log('inside sectionHaseNewData');
+      state.needsReload = true;
+    },
+    sectionDoesNotHaveNewData(state) {
+      state.needsReload = false;
     },
     startLoadingSectionData(state) {
       state.isLoadingSectionData = true;
@@ -758,6 +774,11 @@ export const finishEditingSection =
     });
   };
 
+export const updateNeedsReloadFunction = (): SectionThunkAction => dispatch => {
+  console.log('updateNeedsReloadFunction CALLED');
+  dispatch(updateNeedsReload());
+};
+
 /**
  * Removes a section or throws an error if the section does not exist.
  */
@@ -1126,6 +1147,9 @@ export const {
   startLoadingSectionData,
   updateSectionAiTutorEnabled,
   updateSelectedSection,
+  sectionHasNewData,
+  sectionDoesNotHaveNewData,
+  updateNeedsReload,
 } = sectionSlice.actions;
 
 export default sectionSlice.reducer;

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import {
   Route,
   Outlet,
@@ -6,6 +6,7 @@ import {
   createBrowserRouter,
   RouterProvider,
   Navigate,
+  useLocation,
   generatePath,
 } from 'react-router-dom';
 
@@ -44,6 +45,20 @@ import UnitCalendar from './UnitCalendar';
 
 import styles from './teacher-navigation.module.scss';
 
+const PathChangeHandler: React.FC<{needsReload: boolean}> = ({needsReload}) => {
+  const location = useLocation();
+  const previousLocation = useRef(location.pathname);
+
+  useEffect(() => {
+    if (needsReload && previousLocation.current !== location.pathname) {
+      window.location.reload();
+    }
+    previousLocation.current = location.pathname;
+  }, [needsReload, location.pathname]);
+
+  return null; // This component doesn't render anything.
+};
+
 interface TeacherNavigationRouterProps {
   studioUrlPrefix: string;
   showAITutorTab: boolean;
@@ -67,6 +82,10 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
     [selectedSection]
   );
 
+  const needsReload = useAppSelector(
+    state => state.teacherSections.needsReload
+  );
+
   const studentCount = useAppSelector(
     state => state.teacherSections.selectedStudents.length
   );
@@ -79,10 +98,15 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
       <Route
         path={TEACHER_NAVIGATION_SECTIONS_URL}
         element={
-          <div className={styles.pageAndSidebar}>
-            <TeacherNavigationBar />
-            <Outlet />
-          </div>
+          <>
+            <PathChangeHandler
+              needsReload={needsReload ? needsReload : false}
+            />
+            <div className={styles.pageAndSidebar}>
+              <TeacherNavigationBar />
+              <Outlet />
+            </div>
+          </>
         }
       >
         <Route path={SPECIFIC_SECTION_BASE_URL} element={<PageLayout />}>
@@ -266,13 +290,14 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
       </Route>
     ),
     [
-      sectionId,
-      studentCount,
-      providerName,
-      anyStudentHasProgress,
-      showAITutorTab,
-      selectedSection,
+      needsReload,
       studioUrlPrefix,
+      providerName,
+      studentCount,
+      anyStudentHasProgress,
+      selectedSection,
+      sectionId,
+      showAITutorTab,
     ]
   );
 

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -302,13 +302,13 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
     ),
     [
       needsReload,
-      studioUrlPrefix,
-      providerName,
-      studentCount,
-      anyStudentHasProgress,
-      selectedSection,
       sectionId,
+      studentCount,
+      providerName,
+      anyStudentHasProgress,
       showAITutorTab,
+      selectedSection,
+      studioUrlPrefix,
     ]
   );
 

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useRef} from 'react';
+import {useDispatch} from 'react-redux';
 import {
   Route,
   Outlet,
@@ -8,11 +9,13 @@ import {
   Navigate,
   useLocation,
   generatePath,
+  useParams,
 } from 'react-router-dom';
 
 import TutorTab from '@cdo/apps/aiTutor/views/teacherDashboard/TutorTab';
 import TeacherUnitOverview from '@cdo/apps/code-studio/components/progress/TeacherUnitOverview';
 import GlobalEditionWrapper from '@cdo/apps/templates/GlobalEditionWrapper';
+import {setClearReload} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import TeacherCourseOverview from '../courseOverview/TeacherCourseOverview';
@@ -33,6 +36,7 @@ import TextResponses from '../textResponses/TextResponses';
 import ElementOrEmptyPage from './ElementOrEmptyPage';
 import LessonMaterialsContainer from './lessonMaterials/LessonMaterialsContainer';
 import PageLayout from './PageLayout';
+import {asyncLoadSelectedSection} from './selectedSectionLoader';
 import TeacherNavigationBar from './TeacherNavigationBar';
 import {
   LABELED_TEACHER_NAVIGATION_PATHS,
@@ -45,18 +49,24 @@ import UnitCalendar from './UnitCalendar';
 
 import styles from './teacher-navigation.module.scss';
 
+// This component doesn't render anything but rather tracks
+// if new data needs to be reloaded.
 const PathChangeHandler: React.FC<{needsReload: boolean}> = ({needsReload}) => {
+  const dispatch = useDispatch();
+  const urlSectionId = useParams().sectionId;
+
   const location = useLocation();
   const previousLocation = useRef(location.pathname);
 
   useEffect(() => {
     if (needsReload && previousLocation.current !== location.pathname) {
-      window.location.reload();
+      asyncLoadSelectedSection(urlSectionId ? urlSectionId : '0', true);
+      dispatch(setClearReload());
     }
     previousLocation.current = location.pathname;
-  }, [needsReload, location.pathname]);
+  }, [needsReload, location.pathname, urlSectionId, dispatch]);
 
-  return null; // This component doesn't render anything.
+  return null;
 };
 
 interface TeacherNavigationRouterProps {
@@ -77,18 +87,24 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
   );
   const selectedSection = useAppSelector(selectedSectionSelector);
 
+  const studentCount = useAppSelector(
+    state => state.teacherSections.selectedStudents.length
+  );
+
+  // need to update anyStudentHasProgress when new students are added
   const anyStudentHasProgress = React.useMemo(
     () => (selectedSection ? selectedSection.anyStudentHasProgress : true),
-    [selectedSection]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedSection, studentCount]
   );
 
   const needsReload = useAppSelector(
     state => state.teacherSections.needsReload
   );
 
-  const studentCount = useAppSelector(
-    state => state.teacherSections.selectedStudents.length
-  );
+  // const studentCount = useAppSelector(
+  //   state => state.teacherSections.selectedStudents.length
+  // );
   const providerName = useAppSelector(state =>
     sectionProviderName(state, state.teacherSections.selectedSectionId)
   );

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -87,24 +87,19 @@ const TeacherNavigationRouter: React.FC<TeacherNavigationRouterProps> = ({
   );
   const selectedSection = useAppSelector(selectedSectionSelector);
 
-  const studentCount = useAppSelector(
-    state => state.teacherSections.selectedStudents.length
-  );
-
-  // need to update anyStudentHasProgress when new students are added
   const anyStudentHasProgress = React.useMemo(
     () => (selectedSection ? selectedSection.anyStudentHasProgress : true),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedSection, studentCount]
+    [selectedSection]
+  );
+
+  const studentCount = useAppSelector(
+    state => state.teacherSections.selectedStudents.length
   );
 
   const needsReload = useAppSelector(
     state => state.teacherSections.needsReload
   );
 
-  // const studentCount = useAppSelector(
-  //   state => state.teacherSections.selectedStudents.length
-  // );
   const providerName = useAppSelector(state =>
     sectionProviderName(state, state.teacherSections.selectedSectionId)
   );

--- a/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationRouter.tsx
@@ -15,7 +15,7 @@ import {
 import TutorTab from '@cdo/apps/aiTutor/views/teacherDashboard/TutorTab';
 import TeacherUnitOverview from '@cdo/apps/code-studio/components/progress/TeacherUnitOverview';
 import GlobalEditionWrapper from '@cdo/apps/templates/GlobalEditionWrapper';
-import {setClearReload} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {sectionDoesNotHaveNewData} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 
 import TeacherCourseOverview from '../courseOverview/TeacherCourseOverview';
@@ -61,7 +61,7 @@ const PathChangeHandler: React.FC<{needsReload: boolean}> = ({needsReload}) => {
   useEffect(() => {
     if (needsReload && previousLocation.current !== location.pathname) {
       asyncLoadSelectedSection(urlSectionId ? urlSectionId : '0', true);
-      dispatch(setClearReload());
+      dispatch(sectionDoesNotHaveNewData());
     }
     previousLocation.current = location.pathname;
   }, [needsReload, location.pathname, urlSectionId, dispatch]);

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -1,5 +1,4 @@
 import React, {useState, useEffect} from 'react';
-import {useSelector} from 'react-redux';
 
 import UnitCalendarGrid from '@cdo/apps//code-studio/components/progress/UnitCalendarGrid';
 import {setCalendarData} from '@cdo/apps/code-studio/calendarRedux';
@@ -32,19 +31,16 @@ const UnitCalendar: React.FC = () => {
     useState<string>(WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS[4].toString());
 
   const selectedSection = useAppSelector(selectedSectionSelector);
-  const unitName = useSelector(
-    (state: {unitSelection: {unitName: string}}) => state.unitSelection.unitName
-  );
 
-  const unitNameFromProgress = useAppSelector(
-    state => state.progress?.scriptName
-  );
+  const unitName = selectedSection.unitName;
 
   const hasCalendar = useAppSelector(state => state.calendar?.showCalendar);
 
   const calendarLessons = useAppSelector(
     state => state.calendar?.calendarLessons
   );
+
+  const calendarUnitName = useAppSelector(state => state.calendar?.unitName);
 
   const {userId, userType} = useAppSelector(state => state.currentUser);
 
@@ -54,6 +50,7 @@ const UnitCalendar: React.FC = () => {
     if (!selectedSection.courseOfferingId || !unitName) {
       dispatch(
         setCalendarData({
+          unitName: null,
           showCalendar: false,
           calendarLessons: null,
           versionYear: null,
@@ -62,12 +59,13 @@ const UnitCalendar: React.FC = () => {
       return;
     }
     if (
-      (!isLoading &&
-        unitName &&
-        userType &&
-        userId &&
-        (hasCalendar === undefined || calendarLessons === null)) ||
-      unitNameFromProgress !== unitName
+      !isLoading &&
+      unitName &&
+      userType &&
+      userId &&
+      (hasCalendar === undefined ||
+        calendarLessons === null ||
+        unitName !== calendarUnitName)
     ) {
       setIsLoading(true);
       HttpClient.fetchJson<UnitSummaryResponse>(
@@ -98,10 +96,10 @@ const UnitCalendar: React.FC = () => {
     userType,
     hasCalendar,
     calendarLessons,
-    unitNameFromProgress,
     dispatch,
     isLoading,
     selectedSection.courseOfferingId,
+    calendarUnitName,
   ]);
 
   const weeklyMinutesOptions = WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS.map(
@@ -120,9 +118,16 @@ const UnitCalendar: React.FC = () => {
     });
   };
 
+  const needsReload = useAppSelector(
+    state => state.teacherSections.needsReload
+  );
+
+  if (isLoading || needsReload) {
+    return <Spinner size={'large'} />;
+  }
+
   return (
     <div className={styles.calendarContentContainer}>
-      {isLoading && <Spinner />}
       {!isLoading && <CalendarEmptyState />}
       {!isLoading && hasCalendar && (
         <div>

--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -80,6 +80,10 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
 
   const selectedSection = useAppSelector(selectedSectionSelector);
 
+  const needsReload = useAppSelector(
+    state => state.teacherSections.needsReload
+  );
+
   React.useEffect(() => {
     const fetchLessonMaterials = async () => {
       const state = getStore().getState().teacherSections;
@@ -140,12 +144,6 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
       setSelectedLesson(lessons[0]);
     }
   }, [lessons]);
-
-  React.useEffect(() => {
-    analyticsReporter.sendEvent(EVENTS.VIEW_LESSON_MATERIALS, {
-      unitName: lessonMaterials?.unitName,
-    });
-  }, [lessonMaterials?.unitName]);
 
   const onDropdownChange = (value: string) => {
     setSelectedLesson(getLessonFromId(Number(value)));
@@ -231,7 +229,7 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
     );
   };
 
-  if (isLoading) {
+  if (isLoading || needsReload) {
     return <Spinner size={'large'} />;
   }
 

--- a/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
+++ b/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
@@ -18,12 +18,16 @@ import {
   updateSelectedSection,
 } from '../teacherDashboard/teacherSectionsRedux';
 
-export const asyncLoadSelectedSection = async (sectionId: string) => {
+export const asyncLoadSelectedSection = async (
+  sectionId: string,
+  forceReload?: boolean
+) => {
   const state = getStore().getState().teacherSections;
 
   if (
-    state.selectedSectionId === parseInt(sectionId) ||
-    state.isLoadingSectionData
+    (state.selectedSectionId === parseInt(sectionId) ||
+      state.isLoadingSectionData) &&
+    !forceReload
   ) {
     return;
   }

--- a/apps/test/unit/templates/MultipleSectionsAssignerTest.js
+++ b/apps/test/unit/templates/MultipleSectionsAssignerTest.js
@@ -8,6 +8,7 @@ import {fakeTeacherSectionsForDropdown} from '@cdo/apps/templates/teacherDashboa
 import {
   assignToSection,
   unassignSection,
+  sectionHasNewData,
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 import {expect} from '../../util/reconfiguredChai'; // eslint-disable-line no-restricted-imports
@@ -27,6 +28,7 @@ describe('MultipleSectionsAssigner', () => {
     updateHiddenScript: updateHiddenScript,
     participantAudience: 'student',
     isAssigningCourse: true,
+    sectionHasNewData: sectionHasNewData,
   };
   const setUp = (overrideProps = {}) => {
     const props = {...defaultProps, ...overrideProps};


### PR DESCRIPTION
Old issue: When a section was assigned a multi-unit course (think "all of CSA") but no unit, and then later was assigned a unit from the course landing page (think "unit 1"), the "Lesson Materials" and "Calendar" pages would still show now incorrect graphic.  (see below)

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/301006bf-b11d-44e6-b966-44f794fc0c77" />

Now, when the user assigns a unit, the correct information will show on those pages. 


## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1465)

Note: in this ticket, it says that there was an issue with the roster.  I didn't find that to be the case as I was testing... I haven't looked if a different PR fixed that or if this ticket was incorrect to start.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

