### PR TITLE
[DESIGN2-203-closeButton] closeButton Component - DSCO - Update color variables

### DIFF
--- a/apps/src/componentLibrary/closeButton/CHANGELOG.md
+++ b/apps/src/componentLibrary/closeButton/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1](https://github.com/code-dot-org/code-dot-org/pull/62914)
+- updated color variables to use `primitiveColors.css`
+
 ## [0.4.0](https://github.com/code-dot-org/code-dot-org/pull/62717)
 - rewritten `CloseButtonTest` in typescript
 - refactored/optimized `CloseButtonTest.tsx`

--- a/apps/src/componentLibrary/closeButton/closeButton.module.scss
+++ b/apps/src/componentLibrary/closeButton/closeButton.module.scss
@@ -1,4 +1,4 @@
-@import "color";
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 @import "@cdo/apps/componentLibrary/common/styles/mixins";
 
 // Close Button common styles
@@ -28,7 +28,7 @@
   }
 
   &:focus-visible {
-    outline: 2px solid $light_primary_500;
+    outline: 2px solid var(--brand-teal-50);
     outline-offset: 2px;
     border-radius: 0.25rem;
   }
@@ -41,26 +41,26 @@
 
 // Button Colors
 .closeButton-dark {
-  color: $light_gray_600;
+  color: var(--neutral-gray-60);
 
   &:hover {
-    color: $light_gray_400;
+    color: var(--neutral-gray-40);
   }
 
   &:active {
-    color: $light_gray_600;
+    color: var(--neutral-gray-60);
   }
 }
 
 .closeButton-light {
-  color: $light_gray_400;
+  color: var(--neutral-gray-40);
 
   &:hover {
-    color: $light_gray_600;
+    color: var(--neutral-gray-60);
   }
 
   &:active {
-    color: $light_gray_400;
+    color: var(--neutral-gray-40);
   }
 }
 


### PR DESCRIPTION
Swaps out color variables from `shared/color.scss` with Primitive colors from `primitiveColors.css` on the closeButton component. 

👀 **DOTD note:** there might be Eyes diffs with this.

## Links
Jira ticket: [DESIGN2-203](https://codedotorg.atlassian.net/browse/DESIGN2-203)

## Testing story
Tested locally in Storybook

----

## Before - using `shared/colors.scss`
<img width="994" alt="Before" src="https://github.com/user-attachments/assets/6c8622ca-bced-4eee-82a4-b83c14461c09" />

## After - using `primitiveColors.css`
<img width="994" alt="After" src="https://github.com/user-attachments/assets/69b1abd9-49e7-4d1d-8c97-5158cf6ef6d8" />
