### PR TITLE
Lazy load AI Chat lab

### DIFF
--- a/apps/src/aichat/entrypoint.ts
+++ b/apps/src/aichat/entrypoint.ts
@@ -1,9 +1,15 @@
-import AichatView from '@cdo/apps/aichat/views/AichatView'; // avoid hardcoding imports like this in an entrypoint.tsx
-import {Lab2EntryPoint, OptionsToAvoid, Theme} from '@cdo/apps/lab2/types';
+import {lazy} from 'react';
+
+import {Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
 
 export const AIChatEntryPoint: Lab2EntryPoint = {
   backgroundMode: false,
   theme: Theme.LIGHT,
-  view: OptionsToAvoid.UseHardcodedView_WARNING_Bloats_Lab2_Bundle,
-  hardcodedView: AichatView,
+  view: lazy(() =>
+    import(/* webpackChunkName: "aichat" */ './index.js').then(
+      ({AichatView}) => ({
+        default: AichatView,
+      })
+    )
+  ),
 };

--- a/apps/src/aichat/index.js
+++ b/apps/src/aichat/index.js
@@ -1,0 +1,3 @@
+// This file allows us to lazily load the MusicView component.
+// Due to our configuration this needs to be in js so we can use dynamic imports.
+export {default as AichatView} from './views/AichatView';


### PR DESCRIPTION
Similar to https://github.com/code-dot-org/code-dot-org/pull/62882. Lazy loads the AI Chat lab as part of converting all Lab2 labs to use lazy loading

Before:
<img width="1622" alt="Screenshot 2024-12-11 at 1 04 20 PM" src="https://github.com/user-attachments/assets/4445f658-c07e-4f6b-8f26-86b2829ad71c" />

After:
<img width="1619" alt="Screenshot 2024-12-11 at 1 02 14 PM" src="https://github.com/user-attachments/assets/0a4cd81b-769f-48ea-9d64-5d2d9933412a" />

## Testing story

Tested by comparing JS bundle sizes and adding log statement in AichatView.

## Follow-up work

Will do Panels and StandaloneVideo next. Will hold off on Music for post HOC just in case we need to hotfix anything.
