### PR TITLE
[DESIGN2-205-Dropdown] Dropdown Component - DSCO - Update color variables

### DIFF
--- a/apps/src/componentLibrary/dropdown/actionDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/actionDropdown/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2](https://github.com/code-dot-org/code-dot-org/pull/62917)
+
+* updated color variables to use `primitiveColors.css`
+
 ## [0.1.1](https://github.com/code-dot-org/code-dot-org/pull/60025)
 
 * minor menu items width update

--- a/apps/src/componentLibrary/dropdown/checkboxDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/checkboxDropdown/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.1] (https://github.com/code-dot-org/code-dot-org/pull/62917)
+
+- updated color variables to use `primitiveColors.css`
+
 ## [0.6.0] (https://github.com/code-dot-org/code-dot-org/pull/62023)
 
 - added `readOnly` state

--- a/apps/src/componentLibrary/dropdown/customDropdown.module.scss
+++ b/apps/src/componentLibrary/dropdown/customDropdown.module.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 @import '@cdo/apps/componentLibrary/common/styles/variables';
 @import '@cdo/apps/componentLibrary/common/styles/mixins';
 @import '@cdo/apps/componentLibrary/typography/typography.module';
@@ -39,7 +39,7 @@
     background-color: unset;
     border-radius: 0.25rem;
     border: 1px solid;
-    color: $light_black;
+    color: var(--neutral-base-black);
     box-shadow: none;
     gap: 0.5rem;
     margin: 0;
@@ -49,7 +49,7 @@
     appearance: none;
 
     &:focus-visible {
-      outline: 2px solid $light_primary_500;
+      outline: 2px solid var(--brand-teal-50);
       border-radius: 0.25rem;
       outline-offset: 2px;
     }
@@ -118,32 +118,32 @@
           display: flex;
           align-items: center;
           cursor: pointer;
-          color: $light_black;
+          color: var(--neutral-base-black);
 
           &.destructiveDropdownMenuItem {
-            color: $light_negative_500;
+            color: var(--sentiment-error-50);
 
             i {
-              color: $light_negative_500;
+              color: var(--sentiment-error-50);
             }
 
             &:hover {
-              background-color: $light_negative_100;
+              background-color: var(--sentiment-error-10);
             }
 
             &:active {
-              background-color: $light_negative_500;
-              color: $light_white;
+              background-color: var(--sentiment-error-50);
+              color: var(--neutral-base-white);
 
               i::before {
-                background-color: $light_negative_500;
-                color: $light_white;
+                background-color: var(--sentiment-error-50);
+                color: var(--neutral-base-white);
               }
             }
           }
 
           &:focus-visible {
-            outline: 2px solid $light_primary_500;
+            outline: 2px solid var(--brand-teal-50);
             outline-offset: -2px;
           }
 
@@ -159,38 +159,38 @@
         }
 
         &:hover {
-          background-color: $light_gray_100;
+          background-color: var(--neutral-gray-10);
         }
 
         &:active,
         &:has(input[type='checkbox']:checked),
         &:has(.selectedDropdownMenuItem) {
-          background-color: $light_primary_500;
+          background-color: var(--brand-teal-50);
 
           i::before {
-            background-color: $light_white;
-            color: $light_primary_500;
+            background-color: var(--neutral-base-white);
+            color: var(--brand-teal-50);
           }
 
           span {
-            color: $light_white;
+            color: var(--neutral-base-white);
           }
 
           .dropdownMenuItem {
             i::before {
-              background-color: $light_primary_500;
-              color: $light_white;
+              background-color: var(--brand-teal-50);
+              color: var(--neutral-base-white);
             }
 
             span {
-              color: $light_white;
+              color: var(--neutral-base-white);
             }
           }
         }
 
         &:has(input[type='checkbox']:disabled),
         &:has(.disabledDropdownMenuItem) {
-          color: $light_gray_200;
+          color: var(--neutral-gray-20);
           background-color: unset;
           cursor: not-allowed;
 
@@ -199,13 +199,13 @@
 
             i::before {
               background-color: unset;
-              color: $light_gray_200;
+              color: var(--neutral-gray-20);
             }
           }
 
           span,
           .dropdownMenuItem span {
-            color: $light_gray_200;
+            color: var(--neutral-gray-20);
           }
         }
       }
@@ -219,7 +219,7 @@
     padding: 0.25rem;
 
     border-radius: 0 0 0.25rem 0.25rem;
-    border-top: 1px solid $light_gray_300;
+    border-top: 1px solid var(--neutral-gray-30);
   }
 }
 
@@ -246,7 +246,7 @@
 // Dropdown colors
 .dropdownContainer-black {
   .dropdownLabel {
-    color: $light_black;
+    color: var(--neutral-base-black);
   }
 
   .helperSection {
@@ -259,43 +259,43 @@
     }
 
     .dropdownButton {
-      border-color: $light_negative_500;
+      border-color: var(--sentiment-error-50);
     }
   }
 
   .dropdownButton {
-    color: $light_black;
-    border-color: $light_black;
-    background-color: $light_white;
+    color: var(--neutral-base-black);
+    border-color: var(--neutral-base-black);
+    background-color: var(--neutral-base-white);
   }
 
   &:has(.dropdownButton:hover) {
     .dropdownButton:not(:disabled) {
-      color: $light_black;
-      background-color: $light_gray_100;
+      color: var(--neutral-base-black);
+      background-color: var(--neutral-gray-10);
     }
   }
 
   &:has(.dropdownButton:active) {
     .dropdownButton:not(:disabled) {
-      color: $light_black;
-      background-color: $light_white;
+      color: var(--neutral-base-black);
+      background-color: var(--neutral-base-white);
     }
   }
 
   &:has(.dropdownButton:disabled) {
     .dropdownButton {
-      color: $light_gray_200;
-      border-color: $light_gray_200 !important;
+      color: var(--neutral-gray-20);
+      border-color: var(--neutral-gray-20) !important;
       cursor: not-allowed;
 
       .dropdownLabel {
-        color: $light_gray_200;
+        color: var(--neutral-gray-20);
       }
     }
 
     .dropdownLabel {
-      color: $light_gray_200;
+      color: var(--neutral-gray-20);
     }
 
     .helperSection,
@@ -322,7 +322,7 @@
 
 .dropdownContainer-gray {
   .dropdownLabel {
-    color: $light_black;
+    color: var(--neutral-base-black);
   }
 
   .helperSection {
@@ -334,38 +334,38 @@
   }
 
   .dropdownButton {
-    color: $light_black;
-    border-color: $light_gray_400;
-    background-color: $light_white;
+    color: var(--neutral-base-black);
+    border-color: var(--neutral-gray-40);
+    background-color: var(--neutral-base-white);
   }
 
   &:has(.dropdownButton:hover) {
     .dropdownButton:not(:disabled) {
-      color: $light_black;
-      background-color: $light_gray_100;
+      color: var(--neutral-base-black);
+      background-color: var(--neutral-gray-10);
     }
   }
 
   &:has(.dropdownButton:active) {
     .dropdownButton:not(:disabled) {
-      color: $light_black;
-      background-color: $light_white;
+      color: var(--neutral-base-black);
+      background-color: var(--neutral-base-white);
     }
   }
 
   &:has(.dropdownButton:disabled) {
     .dropdownButton {
-      color: $light_gray_200;
-      border-color: $light_gray_200 !important;
+      color: var(--neutral-gray-20);
+      border-color: var(--neutral-gray-20) !important;
       cursor: not-allowed;
 
       .dropdownLabel {
-        color: $light_gray_200;
+        color: var(--neutral-gray-20);
       }
     }
 
     .dropdownLabel {
-      color: $light_gray_200;
+      color: var(--neutral-gray-20);
     }
 
     .helperSection,
@@ -392,7 +392,7 @@
 
 .dropdownContainer-white {
   .dropdownLabel {
-    color: $light_white;
+    color: var(--neutral-base-white);
   }
 
   .helperSection {
@@ -405,41 +405,41 @@
     }
 
     .dropdownButton {
-      border-color: $light_negative_500;
+      border-color: var(--sentiment-error-50);
     }
   }
 
   .dropdownButton {
-    color: $light_white;
-    border-color: $light_white;
-    background-color: $light_black;
+    color: var(--neutral-base-white);
+    border-color: var(--neutral-base-white);
+    background-color: var(--neutral-base-black);
 
     span {
-      color: $light_white;
+      color: var(--neutral-base-white);
     }
   }
 
   &:has(.dropdownButton:hover) {
     .dropdownButton:not(:disabled) {
-      color: $light_white;
-      background-color: $light_gray_900;
+      color: var(--neutral-base-white);
+      background-color: var(--neutral-gray-90);
     }
   }
 
   &:has(.dropdownButton:active) {
     .dropdownButton:not(:disabled) {
-      color: $light_white;
+      color: var(--neutral-base-white);
     }
   }
 
   &:has(.dropdownButton:disabled) {
     .dropdownButton {
-      color: $light_gray_900;
-      border-color: $light_gray_900;
+      color: var(--neutral-gray-90);
+      border-color: var(--neutral-gray-90);
       cursor: not-allowed;
 
       .dropdownLabel {
-        color: $light_gray_900;
+        color: var(--neutral-gray-90);
       }
     }
 

--- a/apps/src/componentLibrary/dropdown/iconDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/iconDropdown/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] (https://github.com/code-dot-org/code-dot-org/pull/62917)
+
+- updated color variables to use `primitiveColors.css`
+
 ## [0.4.0] (https://github.com/code-dot-org/code-dot-org/pull/62023)
 
 - added `readOnly` state

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.1](https://github.com/code-dot-org/code-dot-org/pull/62917)
+
+- updated color variables to use `primitiveColors.css`
+
 ## [0.8.0](https://github.com/code-dot-org/code-dot-org/pull/62806)
 
 - rewritten `SimpleDropdownTest` in typescript

--- a/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
+++ b/apps/src/componentLibrary/dropdown/simpleDropdown/simpleDropdown.module.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 @import '@cdo/apps/componentLibrary/common/styles/variables';
 @import '@cdo/apps/componentLibrary/common/styles/mixins';
 @import '@cdo/apps/componentLibrary/typography/typography.module';
@@ -52,7 +52,7 @@
     appearance: none;
 
     &:focus-visible {
-      outline: 2px solid $light_primary_500;
+      outline: 2px solid var(--brand-teal-50);
       border-radius: 0.25rem;
       outline-offset: 2px;
     }
@@ -85,65 +85,65 @@
 // Dropdown colors
 .dropdownContainer-black {
   .dropdownLabel {
-    color: $light_black;
+    color: var(--neutral-base-black);
   }
 
   select {
-    color: $light_black;
-    border-color: $light_black;
-    background-color: $light_white;
+    color: var(--neutral-base-black);
+    border-color: var(--neutral-base-black);
+    background-color: var(--neutral-base-white);
 
     &.hasError {
-      border-color: $light_negative_500;
+      border-color: var(--sentiment-error-50);
     }
   }
 
   .dropdownArrowDiv:after {
-    color: $light_black;
+    color: var(--neutral-base-black);
   }
 
   .helperSection {
-    color: $light_black;
+    color: var(--neutral-base-black);
   }
 
   .errorSection {
-    color: $light_negative_500;
+    color: var(--sentiment-error-50);
   }
 
   &:has(select:hover) {
     select:not(:disabled) {
-      color: $light_black;
-      background-color: $light_gray_100;
+      color: var(--neutral-base-black);
+      background-color: var(--neutral-gray-10);
     }
 
     .dropdownArrowDiv:after {
-      color: $light_black;
+      color: var(--neutral-base-black);
     }
   }
 
   &:has(select:active) {
     select:not(:disabled) {
-      color: $light_black;
+      color: var(--neutral-base-black);
     }
 
     .dropdownArrowDiv:after {
-      color: $light_black;
+      color: var(--neutral-base-black);
     }
   }
 
   &:has(select:disabled) {
     select {
-      color: $light_gray_200;
-      border-color: $light_gray_200;
+      color: var(--neutral-gray-20);
+      border-color: var(--neutral-gray-20);
     }
 
     .dropdownArrowDiv:after {
-      color: $light_gray_200;
+      color: var(--neutral-gray-20);
     }
 
     .helperSection,
     .errorSection {
-      color: $light_gray_200;
+      color: var(--neutral-gray-20);
     }
   }
 
@@ -165,65 +165,65 @@
 
 .dropdownContainer-gray {
   .dropdownLabel {
-    color: $light_black;
+    color: var(--neutral-base-black);
   }
 
   select {
-    color: $light_black;
-    border-color: $light_gray_400;
-    background-color: $light_white;
+    color: var(--neutral-base-black);
+    border-color: var(--neutral-gray-40);
+    background-color: var(--neutral-base-white);
 
     &.hasError {
-      border-color: $light_negative_500;
+      border-color: var(--sentiment-error-50);
     }
   }
 
   .dropdownArrowDiv:after {
-    color: $light_black;
+    color: var(--neutral-base-black);
   }
 
   .helperSection {
-    color: $light_black;
+    color: var(--neutral-base-black);
   }
 
   .errorSection {
-    color: $light_negative_500;
+    color: var(--sentiment-error-50);
   }
 
   &:has(select:hover) {
     select:not(:disabled) {
-      color: $light_black;
-      background-color: $light_gray_100;
+      color: var(--neutral-base-black);
+      background-color: var(--neutral-gray-10);
     }
 
     .dropdownArrowDiv:after {
-      color: $light_black;
+      color: var(--neutral-base-black);
     }
   }
 
   &:has(select:active) {
     select:not(:disabled) {
-      color: $light_black;
+      color: var(--neutral-base-black);
     }
 
     .dropdownArrowDiv:after {
-      color: $light_black;
+      color: var(--neutral-base-black);
     }
   }
 
   &:has(select:disabled) {
     select {
-      color: $light_gray_200;
-      border-color: $light_gray_200;
+      color: var(--neutral-gray-20);
+      border-color: var(--neutral-gray-20);
     }
 
     .dropdownArrowDiv:after {
-      color: $light_gray_200;
+      color: var(--neutral-gray-20);
     }
 
     .helperSection,
     .errorSection {
-      color: $light_gray_200;
+      color: var(--neutral-gray-20);
     }
   }
 
@@ -245,60 +245,60 @@
 
 .dropdownContainer-white {
   .dropdownLabel {
-    color: $light_white;
+    color: var(--neutral-base-white);
   }
 
   &.dropdownContainer.dropdownContainer-thin select,
   select {
-    color: $light_white;
-    border-color: $light_white;
-    background-color: $light_black;
+    color: var(--neutral-base-white);
+    border-color: var(--neutral-base-white);
+    background-color: var(--neutral-base-black);
   }
 
   .helperSection,
   .errorSection {
-    color: $light_white;
+    color: var(--neutral-base-white);
   }
 
   &:has(select:hover) {
     select:not(:disabled) {
-      color: $light_white;
-      background-color: $light_gray_900;
+      color: var(--neutral-base-white);
+      background-color: var(--neutral-gray-90);
     }
 
     .dropdownArrowDiv:after {
-      color: $light_white;
+      color: var(--neutral-base-white);
     }
   }
 
   &:has(select:active) {
     select:not(:disabled) {
-      color: $light_white;
+      color: var(--neutral-base-white);
     }
 
     .dropdownArrowDiv:after {
-      color: $light_white;
+      color: var(--neutral-base-white);
     }
   }
 
   &:has(select:disabled) {
     select {
-      color: $light_gray_900;
-      border-color: $light_gray_900;
+      color: var(--neutral-gray-90);
+      border-color: var(--neutral-gray-90);
     }
 
     .dropdownArrowDiv:after {
-      color: $light_gray_900;
+      color: var(--neutral-gray-90);
     }
 
     .helperSection,
     .errorSection {
-      color: $light_gray_700;
+      color: var(--neutral-gray-70);
     }
   }
 
   .dropdownArrowDiv:after {
-    color: $light_white;
+    color: var(--neutral-base-white);
   }
 
   &:has(select.readOnly) {
@@ -374,7 +374,7 @@
     gap: 0.375rem;
 
     &.errorSection {
-      color: $light_negative_500;
+      color: var(--sentiment-error-50);
     }
   }
 }
@@ -436,7 +436,7 @@
     gap: 0.375rem;
 
     &.errorSection {
-      color: $light_negative_500;
+      color: var(--sentiment-error-50);
     }
   }
 }
@@ -497,7 +497,7 @@
     gap: 0.25rem;
 
     &.errorSection {
-      color: $light_negative_500;
+      color: var(--sentiment-error-50);
     }
   }
 }
@@ -558,7 +558,7 @@
     gap: 0.25rem;
 
     &.errorSection {
-      color: $light_negative_500;
+      color: var(--sentiment-error-50);
     }
   }
 }


### PR DESCRIPTION
Swaps out color variables from `shared/color.scss` with Primitive colors from `primitiveColors.css` on the Dropdown component.

👀 **DOTD note:** there might be Eyes diffs with this.

## Links
Jira ticket: [DESIGN2-205](https://codedotorg.atlassian.net/browse/DESIGN2-205)

## Testing story
Tested locally in Storybook

----

## Action Dropdown
### Before - using `shared/colors.scss`

https://github.com/user-attachments/assets/414fa263-4c9f-445e-8f73-abd295ec5d95



### After - using `primitiveColors.css`


https://github.com/user-attachments/assets/60285eba-051e-48f2-bb2c-b23a56dbeaa0



----

## Checkbox Dropdown
### Before - using `shared/colors.scss`

https://github.com/user-attachments/assets/3d9fae0f-4578-4431-9274-2ba1709be302



### After - using `primitiveColors.css`

https://github.com/user-attachments/assets/546565a1-aa3a-4ff4-a9b8-fb86d4c5bac1



----

## Icon Dropdown
### Before - using `shared/colors.scss`

https://github.com/user-attachments/assets/8f23c93a-fcac-463d-ba53-6883690e7676



### After - using `primitiveColors.css`


https://github.com/user-attachments/assets/09f9c18c-6783-4a77-b61e-d4edd795c9d0


----

## Simple Dropdown
### Before - using `shared/colors.scss`

https://github.com/user-attachments/assets/d8cb66f7-8828-4003-a9c2-326ea5985a34



### After - using `primitiveColors.css`

https://github.com/user-attachments/assets/fff634d4-a83b-4c00-a5a8-e54451dade47

