### PR TITLE
[DESIGN2-207-Popover] Popover Component - DSCO - Update color variables

### DIFF
--- a/apps/src/componentLibrary/popover/CHANGELOG.md
+++ b/apps/src/componentLibrary/popover/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1](https://github.com/code-dot-org/code-dot-org/pull/62920)
+
+- updated color variables to use `primitiveColors.css`
+
 ## [0.2.0](https://github.com/code-dot-org/code-dot-org/pull/62746)
 
 - rewritten `PopoverTest`, `WithPopoverTest` in typescript

--- a/apps/src/componentLibrary/popover/popover.module.scss
+++ b/apps/src/componentLibrary/popover/popover.module.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import '@cdo/apps/componentLibrary/common/styles/primitiveColors.css';
 @import 'font';
 @import "@cdo/apps/componentLibrary/common/styles/mixins";
 
@@ -70,7 +70,7 @@ $m-tail-length: 12px;
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
-  background-color: $light_white;
+  background-color: var(--neutral-base-white);
   box-shadow: 0 0 16px 0 rgba(0 0 0 / 0.19);
 
   .informationalSection {
@@ -84,7 +84,7 @@ $m-tail-length: 12px;
     }
 
     .iconSection {
-      color: $light_secondary_500;
+      color: var(--brand-purple-50);
       text-align: center;
       font-size: 2rem;
       line-height: 125%;
@@ -171,7 +171,7 @@ $m-tail-length: 12px;
     inset-block-start: 100%;
     inset-inline-start: 50%;
     border-style: solid;
-    border-color: $light_white transparent transparent transparent;
+    border-color: var(--neutral-base-white) transparent transparent transparent;
   }
 }
 
@@ -181,10 +181,10 @@ $m-tail-length: 12px;
     position: absolute;
     inset-inline-end: 100%;
     border-style: solid;
-    border-color: transparent $light_white transparent transparent;
+    border-color: transparent var(--neutral-base-white) transparent transparent;
 
     html[dir='rtl'] & {
-      border-color: transparent transparent transparent $light_white;
+      border-color: transparent transparent transparent var(--neutral-base-white);
     }
   }
 }
@@ -196,7 +196,7 @@ $m-tail-length: 12px;
     inset-block-end: 100%;
     inset-inline-start: 50%;
     border-style: solid;
-    border-color: transparent transparent $light_white transparent;
+    border-color: transparent transparent var(--neutral-base-white) transparent;
   }
 }
 
@@ -206,10 +206,10 @@ $m-tail-length: 12px;
     position: absolute;
     inset-inline-start: 100%;
     border-style: solid;
-    border-color: transparent transparent transparent $light_white;
+    border-color: transparent transparent transparent var(--neutral-base-white);
 
     html[dir='rtl'] & {
-      border-color: transparent $light_white transparent transparent;
+      border-color: transparent var(--neutral-base-white) transparent transparent;
     }
   }
 }


### PR DESCRIPTION
Swaps out color variables from `shared/color.scss` with Primitive colors from `primitiveColors.css` on the Popover component.

👀 **DOTD note:** there might be Eyes diffs with this.

## Links
Jira ticket: [DESIGN2-207](https://codedotorg.atlassian.net/browse/DESIGN2-207)

## Testing story
Tested locally in Storybook

----

## Before - using `shared/colors.scss`
<img width="344" alt="Before" src="https://github.com/user-attachments/assets/774265cf-cfa3-4525-8b41-08fbe7ea8732" />

## After - using `primitiveColors.css`
<img width="344" alt="After" src="https://github.com/user-attachments/assets/ea8405ce-d466-4911-b0f7-10f4fef95510" />
