### PR TITLE
Do not send reminder emails to applications for deleted workshops

### DIFF
--- a/dashboard/lib/services/registration_reminder.rb
+++ b/dashboard/lib/services/registration_reminder.rb
@@ -64,9 +64,13 @@ class Services::RegistrationReminder
         on pd_applications.user_id = pd_enrollments.user_id
         and pd_enrollments.created_at >= accepted.sent_at
       SQL
+      joins(<<~SQL.squish).
+        left outer join pd_workshops
+        on pd_workshops.id = CAST(JSON_EXTRACT(pd_applications.form_data, '$.pd_workshop_id') AS UNSIGNED)
+      SQL
       where(pd_applications: {application_year: Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR}).
       where(pd_enrollments: {id: nil}).
-      where.not(pd_workshops: {deleted_at: nil}).
+      where(pd_workshops: {deleted_at: nil}).
       distinct
   end
 end

--- a/dashboard/lib/services/registration_reminder.rb
+++ b/dashboard/lib/services/registration_reminder.rb
@@ -66,6 +66,7 @@ class Services::RegistrationReminder
       SQL
       where(pd_applications: {application_year: Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR}).
       where(pd_enrollments: {id: nil}).
+      where.not(pd_workshops: {deleted_at: nil}).
       distinct
   end
 end

--- a/dashboard/test/lib/services/registration_reminder_test.rb
+++ b/dashboard/test/lib/services/registration_reminder_test.rb
@@ -167,6 +167,22 @@ class Services::RegistrationReminderTest < ActiveSupport::TestCase
     assert_equal 0, Services::RegistrationReminder.applications_needing_second_reminder.count
   end
 
+  test 'applications_needing_first_reminder omits applications to deleted workshops' do
+    workshop = create :pd_workshop, deleted_at: 1.day.ago
+    application = create :pd_teacher_application, pd_workshop_id: workshop.id
+    create :pd_application_email, application: application, email_type: 'accepted', sent_at: 2.weeks.ago
+    create :pd_application_email, application: application, email_type: 'registration_reminder', sent_at: 1.week.ago
+    assert_equal 0, Services::RegistrationReminder.applications_needing_second_reminder.count
+  end
+
+  test 'applications_needing_second_reminder omits applications to deleted workshops' do
+    workshop = create :pd_workshop, deleted_at: 1.day.ago
+    application = create :pd_teacher_application, pd_workshop_id: workshop.id
+    create :pd_application_email, application: application, email_type: 'accepted', sent_at: 2.weeks.ago
+    create :pd_application_email, application: application, email_type: 'registration_reminder', sent_at: 1.week.ago
+    assert_equal 0, Services::RegistrationReminder.applications_needing_second_reminder.count
+  end
+
   test 'applications_needing_second_reminder includes eligible applications' do
     # This application meets all the requirements: A registration email, a reminder email at least
     # a week old, and no second reminder or enrollment.

--- a/dashboard/test/lib/services/registration_reminder_test.rb
+++ b/dashboard/test/lib/services/registration_reminder_test.rb
@@ -169,7 +169,9 @@ class Services::RegistrationReminderTest < ActiveSupport::TestCase
 
   test 'applications_needing_first_reminder omits applications to deleted workshops' do
     workshop = create :pd_workshop, deleted_at: 1.day.ago
-    application = create :pd_teacher_application, pd_workshop_id: workshop.id
+    application_hash = build :pd_teacher_application_hash, regional_partner_id: create(:regional_partner).id
+    application_hash[:pd_workshop_id] = workshop.id
+    application = create :pd_teacher_application, form_data: application_hash.to_json
     create :pd_application_email, application: application, email_type: 'accepted', sent_at: 2.weeks.ago
     create :pd_application_email, application: application, email_type: 'registration_reminder', sent_at: 1.week.ago
     assert_equal 0, Services::RegistrationReminder.applications_needing_second_reminder.count
@@ -177,7 +179,9 @@ class Services::RegistrationReminderTest < ActiveSupport::TestCase
 
   test 'applications_needing_second_reminder omits applications to deleted workshops' do
     workshop = create :pd_workshop, deleted_at: 1.day.ago
-    application = create :pd_teacher_application, pd_workshop_id: workshop.id
+    application_hash = build :pd_teacher_application_hash, regional_partner_id: create(:regional_partner).id
+    application_hash[:pd_workshop_id] = workshop.id
+    application = create :pd_teacher_application, form_data: application_hash.to_json
     create :pd_application_email, application: application, email_type: 'accepted', sent_at: 2.weeks.ago
     create :pd_application_email, application: application, email_type: 'registration_reminder', sent_at: 1.week.ago
     assert_equal 0, Services::RegistrationReminder.applications_needing_second_reminder.count


### PR DESCRIPTION
This PR joins the workshop table to the application reminder SQL query to ensure we are filtering out applications associated with workshops that have a deleted_at date. 

I added two tests for this- one for the first reminder and one for the second.

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2847

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
