### PR TITLE
moved multi requirement in create_rollup_tables script

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -54,7 +54,6 @@ def main
   LevelGroup.find_each do |level|
     level.pages.each_with_index do |page, page_index|
       page.levels.each_with_index do |contained_level, position_index|
-        next unless contained_level.type == 'Multi'
         next if contained_levels.
           any? {|existing_contained_level| existing_contained_level[:level_id] == contained_level.id}
 
@@ -68,6 +67,7 @@ def main
           contained_level_text: sanitize_string_for_db(contained_question)
         }
 
+        next unless contained_level.type == 'Multi'
         answers = contained_level.properties['answers']
         answers.each_with_index do |answer, answer_number|
           contained_level_answers << {
@@ -83,8 +83,6 @@ def main
 
   Level.find_each do |level|
     level.contained_levels.each_with_index do |contained_level, index|
-      next unless contained_level.type == 'Multi'
-
       contained_question = get_contained_question(contained_level)
       contained_levels << {
         level_id: level.id,
@@ -95,6 +93,7 @@ def main
         contained_level_text: sanitize_string_for_db(contained_question)
       }
 
+      next unless contained_level.type == 'Multi'
       answers = contained_level.properties['answers']
       answers.each_with_index do |answer, answer_number|
         contained_level_answers << {

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -67,7 +67,7 @@ def main
           contained_level_text: sanitize_string_for_db(contained_question)
         }
 
-        next unless contained_level.type == 'Multi'
+        next unless ['Multi', 'Match', 'EvaluationMulti'].includes? contained_level.type
         answers = contained_level.properties['answers']
         answers.each_with_index do |answer, answer_number|
           contained_level_answers << {
@@ -93,7 +93,7 @@ def main
         contained_level_text: sanitize_string_for_db(contained_question)
       }
 
-      next unless contained_level.type == 'Multi'
+      next unless ['Multi', 'Match', 'EvaluationMulti'].includes? contained_level.type
       answers = contained_level.properties['answers']
       answers.each_with_index do |answer, answer_number|
         contained_level_answers << {


### PR DESCRIPTION
RED team was missing some data from the contained_levels table. The script originally only pulled contained levels if they were of type Multi or if they were part of a BubbleChoice level. This script moves the Multi requirement so that all contained levels should now be imported.

## Links
[Slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1715098215080409)

## Testing story

Will confirm with RED team after implementation that they are getting all of the necessary data.

## Deployment strategy

## Follow-up work
Additional changes may be required depending on the needs of RED team for analysis.
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
