### PR TITLE
Add abuse score info/button to lab2 Extra Links modal

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -337,6 +337,8 @@ export interface ExtraLinksProjectData {
     is_featured_project: boolean;
     featured_status: string;
     remix_ancestry: string[];
+    is_published_project: 'yes' | 'no';
+    abuse_score: number;
   };
   meesage?: string;
 }

--- a/apps/src/lab2/views/ExtraLinks.tsx
+++ b/apps/src/lab2/views/ExtraLinks.tsx
@@ -82,7 +82,6 @@ const ExtraLinks: React.FunctionComponent<ExtraLinksProps> = ({
   useEffect(() => {
     setIsLoading(true);
     fetchExtraLinksData(levelId, channelId).then(data => {
-      console.log('data', data);
       setExtraLinksData(data);
       setIsLoading(false);
     });

--- a/apps/src/lab2/views/ExtraLinks.tsx
+++ b/apps/src/lab2/views/ExtraLinks.tsx
@@ -82,6 +82,7 @@ const ExtraLinks: React.FunctionComponent<ExtraLinksProps> = ({
   useEffect(() => {
     setIsLoading(true);
     fetchExtraLinksData(levelId, channelId).then(data => {
+      console.log('data', data);
       setExtraLinksData(data);
       setIsLoading(false);
     });

--- a/apps/src/lab2/views/ExtraLinksModal.tsx
+++ b/apps/src/lab2/views/ExtraLinksModal.tsx
@@ -5,6 +5,7 @@ import {Heading3, StrongText} from '@cdo/apps/componentLibrary/typography';
 import AccessibleDialog from '@cdo/apps/sharedComponents/AccessibleDialog';
 import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
+import * as utils from '@cdo/apps/utils';
 import {FeaturedProjectStatus} from '@cdo/generated-scripts/sharedConstants';
 
 import {ExtraLinksLevelData, ExtraLinksProjectData} from '../types';
@@ -144,6 +145,14 @@ const ExtraLinksModal: React.FunctionComponent<ExtraLinksModalProps> = ({
     }
   };
 
+  const onReportAbuse = async () => {
+    try {
+      utils.navigateToHref('/report_abuse');
+    } catch (e) {
+      console.log('Error reporting abuse on project.');
+    }
+  };
+
   return isOpen ? (
     <AccessibleDialog onClose={onClose}>
       <Heading3>Extra links</Heading3>
@@ -196,6 +205,7 @@ const ExtraLinksModal: React.FunctionComponent<ExtraLinksModalProps> = ({
         featuredProjectStatus={featuredProjectStatus}
         onBookmark={onBookmark}
         onResetAbuseScore={onResetAbuseScore}
+        onReportAbuse={onReportAbuse}
         abuseScore={abuseScore}
       />
     </AccessibleDialog>
@@ -330,7 +340,8 @@ const RemixAncestry: React.FunctionComponent<{
 const AbuseScoreInfo: React.FunctionComponent<{
   abuseScore: number | undefined;
   onResetAbuseScore: () => void;
-}> = ({abuseScore, onResetAbuseScore}) => {
+  onReportAbuse: () => void;
+}> = ({abuseScore, onResetAbuseScore, onReportAbuse}) => {
   if (abuseScore === undefined) {
     return null;
   }
@@ -352,6 +363,14 @@ const AbuseScoreInfo: React.FunctionComponent<{
           onClick={onResetAbuseScore}
         />
       </div>
+      <div>
+        <Button
+          size="xs"
+          text={'Report abuse'}
+          onClick={onReportAbuse}
+          className={moduleStyles.bottomButton}
+        />
+      </div>
     </>
   );
 };
@@ -362,6 +381,7 @@ interface ProjectLinkDataProps {
   featuredProjectStatus?: string;
   onBookmark: () => void;
   onResetAbuseScore: () => void;
+  onReportAbuse: () => void;
   abuseScore?: number;
 }
 
@@ -371,6 +391,7 @@ const ProjectLinkData: React.FunctionComponent<ProjectLinkDataProps> = ({
   featuredProjectStatus,
   onBookmark,
   onResetAbuseScore,
+  onReportAbuse,
   abuseScore,
 }) => {
   if (!projectLinkData) {
@@ -410,6 +431,7 @@ const ProjectLinkData: React.FunctionComponent<ProjectLinkDataProps> = ({
               <AbuseScoreInfo
                 abuseScore={abuseScore}
                 onResetAbuseScore={onResetAbuseScore}
+                onReportAbuse={onReportAbuse}
               />
             </li>
           </>

--- a/apps/src/lab2/views/ExtraLinksModal.tsx
+++ b/apps/src/lab2/views/ExtraLinksModal.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 
+import Button, {buttonColors} from '@cdo/apps/componentLibrary/button';
 import {Heading3, StrongText} from '@cdo/apps/componentLibrary/typography';
-import Button from '@cdo/apps/legacySharedComponents/Button';
 import AccessibleDialog from '@cdo/apps/sharedComponents/AccessibleDialog';
 import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -36,7 +36,10 @@ const ExtraLinksModal: React.FunctionComponent<ExtraLinksModalProps> = ({
   const [deleteError, setDeleteError] = useState('');
   const [featuredProjectStatus, setFeaturedProjectStatus] = useState<
     string | undefined
-  >('');
+  >(projectLinkData?.project_info?.featured_status);
+  const [abuseScore, setAbuseScore] = useState<number | undefined>(
+    projectLinkData?.project_info?.abuse_score
+  );
 
   const channelId: string | undefined = useAppSelector(
     state => state.lab.channel && state.lab.channel.id
@@ -53,6 +56,12 @@ const ExtraLinksModal: React.FunctionComponent<ExtraLinksModalProps> = ({
   useEffect(() => {
     if (projectLinkData?.project_info) {
       setFeaturedProjectStatus(projectLinkData?.project_info.featured_status);
+    }
+  }, [projectLinkData]);
+
+  useEffect(() => {
+    if (projectLinkData?.project_info?.abuse_score) {
+      setAbuseScore(projectLinkData.project_info.abuse_score);
     }
   }, [projectLinkData]);
 
@@ -121,6 +130,20 @@ const ExtraLinksModal: React.FunctionComponent<ExtraLinksModalProps> = ({
     }
   };
 
+  const onResetAbuseScore = async () => {
+    try {
+      await HttpClient.post(
+        `/v3/channels/${channelId}/abuse/delete`,
+        '',
+        true,
+        {contentType: 'application/json;charset=UTF-8'}
+      );
+      setAbuseScore(0);
+    } catch (e) {
+      console.log('Error resetting abuse score to 0.');
+    }
+  };
+
   return isOpen ? (
     <AccessibleDialog onClose={onClose}>
       <Heading3>Extra links</Heading3>
@@ -172,6 +195,8 @@ const ExtraLinksModal: React.FunctionComponent<ExtraLinksModalProps> = ({
         projectLinkData={projectLinkData}
         featuredProjectStatus={featuredProjectStatus}
         onBookmark={onBookmark}
+        onResetAbuseScore={onResetAbuseScore}
+        abuseScore={abuseScore}
       />
     </AccessibleDialog>
   ) : null;
@@ -204,8 +229,7 @@ const CloneLevelButton: React.FunctionComponent<CloneLevelButtonProps> = ({
   return (
     <div>
       <Button
-        size={Button.ButtonSize.small}
-        color={Button.ButtonColor.purple}
+        size="xs"
         onClick={() => setShowCloneField(!showCloneField)}
         text={showCloneField ? 'Cancel Clone' : 'Clone'}
       />
@@ -217,11 +241,7 @@ const CloneLevelButton: React.FunctionComponent<CloneLevelButtonProps> = ({
             value={clonedLevelName}
             onChange={event => setClonedLevelName(event.target.value)}
           />
-          <Button
-            onClick={handleClone}
-            text={'Clone'}
-            size={Button.ButtonSize.small}
-          />
+          <Button onClick={handleClone} text={'Clone'} size="xs" />
           {cloneError && (
             <p className={moduleStyles.errorMessage}>{cloneError}</p>
           )}
@@ -253,19 +273,16 @@ const DeleteLevelButton: React.FunctionComponent<DeleteLevelButtonProps> = ({
   return (
     <div>
       <Button
-        size={Button.ButtonSize.small}
+        size="xs"
         text={showDeleteConfirm ? 'Cancel Delete' : 'Delete'}
-        color={Button.ButtonColor.red}
+        color={buttonColors.destructive}
         onClick={() => setShowDeleteConfirm(!showDeleteConfirm)}
+        className={moduleStyles.bottomButton}
       />
       {showDeleteConfirm && (
         <div>
           {'Are you sure you want to delete this level? '}
-          <Button
-            onClick={handleDelete}
-            text={'Confirm Delete'}
-            size={Button.ButtonSize.small}
-          />
+          <Button onClick={handleDelete} text={'Confirm Delete'} size="xs" />
           {deleteError && (
             <p className={moduleStyles.errorMessage}>{deleteError}</p>
           )}
@@ -286,12 +303,7 @@ const FeaturedProjectInfo: React.FunctionComponent<
     return (
       <>
         <div>Not a featured project</div>
-        <Button
-          size={Button.ButtonSize.small}
-          color={Button.ButtonColor.purple}
-          onClick={onBookmark}
-          text={'Bookmark as featured'}
-        />
+        <Button size="xs" onClick={onBookmark} text={'Bookmark as featured'} />
       </>
     );
   }
@@ -315,11 +327,42 @@ const RemixAncestry: React.FunctionComponent<{
   );
 };
 
+const AbuseScoreInfo: React.FunctionComponent<{
+  abuseScore: number | undefined;
+  onResetAbuseScore: () => void;
+}> = ({abuseScore, onResetAbuseScore}) => {
+  if (abuseScore === undefined) {
+    return null;
+  }
+  const msg =
+    abuseScore <= 15
+      ? 'Safe to share project.'
+      : 'This project is blocked from sharing';
+
+  return (
+    <>
+      Abuse score: {abuseScore}
+      <ul>
+        <li>{msg}</li>
+      </ul>
+      <div>
+        <Button
+          size="xs"
+          text={'Reset abuse score to 0'}
+          onClick={onResetAbuseScore}
+        />
+      </div>
+    </>
+  );
+};
+
 interface ProjectLinkDataProps {
   projectLinkData?: ExtraLinksProjectData;
   isStandaloneProject: boolean;
   featuredProjectStatus?: string;
   onBookmark: () => void;
+  onResetAbuseScore: () => void;
+  abuseScore?: number;
 }
 
 const ProjectLinkData: React.FunctionComponent<ProjectLinkDataProps> = ({
@@ -327,6 +370,8 @@ const ProjectLinkData: React.FunctionComponent<ProjectLinkDataProps> = ({
   isStandaloneProject,
   featuredProjectStatus,
   onBookmark,
+  onResetAbuseScore,
+  abuseScore,
 }) => {
   if (!projectLinkData) {
     return null;
@@ -336,8 +381,6 @@ const ProjectLinkData: React.FunctionComponent<ProjectLinkDataProps> = ({
   if (!ownerInfo || !projectInfo) {
     return null;
   }
-  const remixList = projectInfo.remix_ancestry;
-
   return (
     <>
       <StrongText>Project Info</StrongText>
@@ -353,13 +396,20 @@ const ProjectLinkData: React.FunctionComponent<ProjectLinkDataProps> = ({
             <li>
               Remix ancestry:
               <ul>
-                <RemixAncestry remixList={remixList} />
+                <RemixAncestry remixList={projectInfo.remix_ancestry} />
               </ul>
             </li>
+            <li>Project submitted: {projectInfo.is_published_project}</li>
             <li>
               <FeaturedProjectInfo
                 featuredProjectStatus={featuredProjectStatus}
                 onBookmark={onBookmark}
+              />
+            </li>
+            <li>
+              <AbuseScoreInfo
+                abuseScore={abuseScore}
+                onResetAbuseScore={onResetAbuseScore}
               />
             </li>
           </>

--- a/apps/src/lab2/views/ExtraLinksModal.tsx
+++ b/apps/src/lab2/views/ExtraLinksModal.tsx
@@ -141,15 +141,8 @@ const ExtraLinksModal: React.FunctionComponent<ExtraLinksModalProps> = ({
       );
       setAbuseScore(0);
     } catch (e) {
-      console.log('Error resetting abuse score to 0.');
-    }
-  };
-
-  const onReportAbuse = async () => {
-    try {
-      utils.navigateToHref('/report_abuse');
-    } catch (e) {
-      console.log('Error reporting abuse on project.');
+      // Set abuse score to number < 0 so that error message will be displayed to the admin user.
+      setAbuseScore(-1);
     }
   };
 
@@ -205,7 +198,6 @@ const ExtraLinksModal: React.FunctionComponent<ExtraLinksModalProps> = ({
         featuredProjectStatus={featuredProjectStatus}
         onBookmark={onBookmark}
         onResetAbuseScore={onResetAbuseScore}
-        onReportAbuse={onReportAbuse}
         abuseScore={abuseScore}
       />
     </AccessibleDialog>
@@ -338,21 +330,24 @@ const RemixAncestry: React.FunctionComponent<{
 };
 
 const AbuseScoreInfo: React.FunctionComponent<{
-  abuseScore: number | undefined;
+  abuseScore: number;
   onResetAbuseScore: () => void;
-  onReportAbuse: () => void;
-}> = ({abuseScore, onResetAbuseScore, onReportAbuse}) => {
-  if (abuseScore === undefined) {
-    return null;
+}> = ({abuseScore, onResetAbuseScore}) => {
+  let msg = '';
+  if (abuseScore < 0) {
+    msg = 'There was an error resetting abuse score to 0. Please try again.';
+  } else if (abuseScore < 15) {
+    msg = 'Safe to share project.';
+  } else {
+    msg = 'This project is blocked from sharing';
   }
-  const msg =
-    abuseScore <= 15
-      ? 'Safe to share project.'
-      : 'This project is blocked from sharing';
+  const onReportAbuse = async () => {
+    utils.navigateToHref('/report_abuse');
+  };
 
   return (
     <>
-      Abuse score: {abuseScore}
+      Abuse score: {abuseScore >= 0 ? abuseScore : ''}
       <ul>
         <li>{msg}</li>
       </ul>
@@ -381,7 +376,6 @@ interface ProjectLinkDataProps {
   featuredProjectStatus?: string;
   onBookmark: () => void;
   onResetAbuseScore: () => void;
-  onReportAbuse: () => void;
   abuseScore?: number;
 }
 
@@ -391,7 +385,6 @@ const ProjectLinkData: React.FunctionComponent<ProjectLinkDataProps> = ({
   featuredProjectStatus,
   onBookmark,
   onResetAbuseScore,
-  onReportAbuse,
   abuseScore,
 }) => {
   if (!projectLinkData) {
@@ -427,13 +420,14 @@ const ProjectLinkData: React.FunctionComponent<ProjectLinkDataProps> = ({
                 onBookmark={onBookmark}
               />
             </li>
-            <li>
-              <AbuseScoreInfo
-                abuseScore={abuseScore}
-                onResetAbuseScore={onResetAbuseScore}
-                onReportAbuse={onReportAbuse}
-              />
-            </li>
+            {abuseScore !== undefined && (
+              <li>
+                <AbuseScoreInfo
+                  abuseScore={abuseScore}
+                  onResetAbuseScore={onResetAbuseScore}
+                />
+              </li>
+            )}
           </>
         )}
       </ul>

--- a/apps/src/lab2/views/extra-links.module.scss
+++ b/apps/src/lab2/views/extra-links.module.scss
@@ -11,3 +11,9 @@
 .errorMessage {
   color: $red;
 }
+
+.bottomButton {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -645,20 +645,23 @@ class ProjectsController < ApplicationController
     owner_info['name'] = User.find_channel_owner(src_channel_id).try(:username)
     project_info['is_featured_project'] = FeaturedProject.exists?(storage_app_id: project_info['id'])
 
+    project = Project.find_by_channel_id(src_channel_id)
     remix_ancestry = Projects.remix_ancestry(src_channel_id, depth: 5)
     project_info['remix_ancestry'] = []
-    project_type = Project.find_by_channel_id(src_channel_id)['project_type']
+    project_type = project.project_type
     if remix_ancestry.present?
       remix_ancestry.each do |channel_id|
         project_info['remix_ancestry'] << "/projects/#{project_type}/#{channel_id}/view"
       end
     end
     if project_info['is_featured_project']
-      project = FeaturedProject.find_by project_id: project_info['id']
-      project_info['featured_status'] = project.status
+      featured_project = FeaturedProject.find_by project_id: project_info['id']
+      project_info['featured_status'] = featured_project.status
     else
       project_info['featured_status'] = 'n/a'
     end
+    project_info['abuse_score'] = project['abuse_score']
+    project_info['is_published_project'] = project['published_at'] ? 'yes' : 'no'
     return render json: {owner_info: owner_info, project_info: project_info}
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds the following to the Extra Links modal for lab2 labs:
- whether project was submitted (published) or not
- abuse score
- button to reset abuse score to 0
- button to report abuse on project (set abuse score to 20)

If there's an error in resetting a project's abuse score to 0, an error message is displayed to user. https://github.com/code-dot-org/code-dot-org/pull/62929#pullrequestreview-2500450328 Note that buffering a project's abuse score (setting to -50) has not been working and we deprecated the route to buffer abuse scores https://github.com/code-dot-org/code-dot-org/pull/62853. However, if a project's score is by chance `< 0`, the project validator will see a message to try to reset the abuse score to 0 and once they do, the abuse score (0) will be displayed.

The buttons in the Extra Links modal are also updated and now use DSCO buttons.

Note that a project has to be submitted/published for a project to be included in the featured project gallery.

Follow-up includes the blocking of a project when the abuse score is >= 15. Automated image moderation increments a project's abuse score by 15.

## After update

Screenshot of Extra Links modal for music standalone project:
![Screenshot 2024-12-12 at 10 51 08 AM](https://github.com/user-attachments/assets/6438107b-9ddc-4554-9e9b-586618916d1f)

Screenshot of Extra Links modal for pythonlab standalone project:
![Screenshot 2024-12-12 at 10 52 59 AM](https://github.com/user-attachments/assets/69899b6b-26ce-40f6-bf8f-b310e02c2583)


Screenshot of Extra Links modal for aichat level (no standalone project so project info including abuse score is not displayed):
![Screenshot 2024-12-12 at 10 51 38 AM](https://github.com/user-attachments/assets/ec071edd-d138-45f5-8439-d22d937fd4f5)


Screencast video of project validator account - opening music lab project which is actively featured (and frozen). Via Extra Links, project validator can report abuse on project so abuse score is changed to 20; and then reset abuse score to 0.

https://github.com/user-attachments/assets/0eb18cf6-81a9-400f-bc06-fbc6781cfbb4



## Links
[jira](https://codedotorg.atlassian.net/browse/CT-937)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Locally, I created a music lab project from a student account. Then using a project validator account, I set it as an active featured project. I was able to report abuse on the project, and then reset the abuse score to 0, both via Extra Links modal buttons. Screencast video above.


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Follow-up includes the blocking of a project when the abuse score is >= 15. Automated image moderation increments a project's abuse score by 15.

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
