### PR TITLE
fix: use school_info_school function for census banner

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -202,19 +202,19 @@ class HomeController < ApplicationController
       @homepage_data[:showIncubatorBanner] = show_incubator_banner?
 
       if show_census_banner
-        teachers_school = Queries::SchoolInfo.current_school(current_user)
-        school_stats = SchoolStatsByYear.where(school_id: teachers_school[:school_id]).order(school_year: :desc).first
+        teachers_school = current_user.school_info_school
+        school_stats = SchoolStatsByYear.where(school_id: teachers_school.id).order(school_year: :desc).first
 
         @homepage_data[:censusQuestion] = school_stats.try(:has_high_school_grades?) ? "how_many_20_hours" : "how_many_10_hours"
         @homepage_data[:currentSchoolYear] = current_census_year
         @homepage_data[:existingSchoolInfo] = {
-          id: teachers_school[:school_id],
-          name: teachers_school[:school_name],
+          id: teachers_school.id,
+          name: teachers_school.name,
           country: 'US',
-          zip: teachers_school[:school_zip],
-          type: teachers_school[:school_type],
+          zip: teachers_school.zip,
+          type: teachers_school.school_type,
         }
-        @homepage_data[:ncesSchoolId] = teachers_school[:school_id]
+        @homepage_data[:ncesSchoolId] = teachers_school.id
         @homepage_data[:teacherName] = current_user.name
         @homepage_data[:teacherId] = current_user.id
         @homepage_data[:teacherEmail] = current_user.email

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2429,7 +2429,7 @@ class User < ApplicationRecord
 
   def show_census_teacher_banner?
     # Must have an NCES school to show the banner
-    users_school = try(:school_info).try(:school)
+    users_school = school_info_school
     teacher? && users_school && (next_census_display.nil? || Time.zone.today >= next_census_display.to_date)
   end
 


### PR DESCRIPTION
The user is associated to a school info in two ways
- a 'has one' relation on the user via school_info_id
- a 'has many' relation via the user_school_infos table

this uses the last complete user_school_info to get the user's school rather than school_info_id

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
