### PR TITLE
Removing Zip Code placeholder in new School Association

### DIFF
--- a/apps/src/templates/SchoolZipSearch.jsx
+++ b/apps/src/templates/SchoolZipSearch.jsx
@@ -27,7 +27,6 @@ export default function SchoolZipSearch({fieldNames, schoolZip, setSchoolZip}) {
           label={i18n.enterYourSchoolZip()}
           onChange={e => handleZipChange(e.target.value)}
           value={schoolZip}
-          placeholder="00000"
         />
         {schoolZip && !schoolZipIsValid && (
           <BodyThreeText className={style.errorMessage}>


### PR DESCRIPTION
We found that many users were copying the placeholder 00000 and getting errors. We considered changing the placeholder to 12345 (which is a valid zip code) but then worried users would associate with schools in that zip code who don't actually work there. 

Eventually we decided the safest bet was to remove the placeholder altogether.

Before:
<img width="706" alt="Screenshot 2024-12-12 at 12 51 50 PM" src="https://github.com/user-attachments/assets/1f3d070d-4070-419c-8f71-39d2642da689" />

After:
<img width="704" alt="Screenshot 2024-12-12 at 1 09 42 PM" src="https://github.com/user-attachments/assets/bceec9df-3e05-46fa-a513-e3ad51b658e0" />


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2915

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
