### PR TITLE
EnrolledWorkshops cleanup - group like code and remove unnecessary wrapper

### DIFF
--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -38,7 +38,7 @@ import {
 } from '../workshop_dashboard/workshopConstants';
 import WorkshopEnrollmentCelebrationDialog from '../workshop_enrollment/WorkshopEnrollmentCelebrationDialog';
 
-import {EnrolledWorkshops, WorkshopsTable} from './EnrolledWorkshops';
+import LandingPageWorkshopsTable from './LandingPageWorkshopsTable';
 import SelfPacedProgressTable from './SelfPacedProgressTable';
 
 import style from './landingPage.module.scss';
@@ -125,8 +125,20 @@ function LandingPage({
     getEnrollSucessWorkshopName()
   );
   const [currentTab, setCurrentTab] = useState(availableTabs[0].value);
+
+  const [workshopsAsParticipant, setWorkshopsAsParticipant] = useState([]);
+  const [loadingWorkshopsAsParticipant, setLoadingWorkshopsAsParticipant] =
+    useState(false);
+  const [loadingWorkshopsAsFacilitator, setLoadingWorkshopsAsFacilitator] =
+    useState(false);
   const [workshopsAsFacilitator, setWorkshopsAsFacilitator] = useState([]);
+  const [loadingWorkshopsAsOrganizer, setLoadingWorkshopsAsOrganizer] =
+    useState(false);
   const [workshopsAsOrganizer, setWorkshopsAsOrganizer] = useState([]);
+  const [
+    loadingWorkshopsAsProgramManager,
+    setLoadingWorkshopsAsProgramManager,
+  ] = useState(false);
   const [workshopsAsProgramManager, setWorkshopsAsProgramManager] = useState(
     []
   );
@@ -144,8 +156,32 @@ function LandingPage({
     dispatch(asyncLoadSectionData());
     dispatch(asyncLoadCoteacherInvite());
 
+    const fetchParticipantData = async () => {
+      setLoadingWorkshopsAsParticipant(true);
+      try {
+        const response = await fetch('/api/v1/pd/workshops_user_enrolled_in', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': await getAuthenticityToken(),
+          },
+        });
+
+        if (response.ok) {
+          const jsonData = await response.json();
+          console.log('jsonData', jsonData);
+          setLoadingWorkshopsAsParticipant(false);
+          setWorkshopsAsParticipant(jsonData);
+        }
+      } catch (error) {
+        console.error('Error fetching participant data:', error);
+      }
+    };
+    fetchParticipantData();
+
     if (userPermissions.includes('facilitator')) {
       const fetchFacilitatorData = async () => {
+        setLoadingWorkshopsAsFacilitator(true);
         try {
           const response = await fetch(
             '/dashboardapi/v1/pd/workshops_as_facilitator_for_pl_page',
@@ -160,6 +196,7 @@ function LandingPage({
 
           if (response.ok) {
             const jsonData = await response.json();
+            setLoadingWorkshopsAsFacilitator(false);
             setWorkshopsAsFacilitator(jsonData.workshops_as_facilitator);
           }
         } catch (error) {
@@ -173,6 +210,7 @@ function LandingPage({
     if (userPermissions.includes('workshop_organizer')) {
       const fetchWorkshopOrganizerData = async () => {
         try {
+          setLoadingWorkshopsAsOrganizer(true);
           const response = await fetch(
             '/dashboardapi/v1/pd/workshops_as_organizer_for_pl_page',
             {
@@ -186,6 +224,7 @@ function LandingPage({
 
           if (response.ok) {
             const jsonData = await response.json();
+            setLoadingWorkshopsAsOrganizer(false);
             setWorkshopsAsOrganizer(jsonData.workshops_as_organizer);
           }
         } catch (error) {
@@ -198,6 +237,7 @@ function LandingPage({
 
     if (userPermissions.includes('program_manager')) {
       const fetchProgramManagerWorkshops = async () => {
+        setLoadingWorkshopsAsProgramManager(true);
         try {
           const response = await fetch(
             '/dashboardapi/v1/pd/workshops_as_program_manager_for_pl_page',
@@ -212,6 +252,7 @@ function LandingPage({
 
           if (response.ok) {
             const jsonData = await response.json();
+            setLoadingWorkshopsAsProgramManager(false);
             setWorkshopsAsProgramManager(jsonData.workshops_as_program_manager);
           }
         } catch (error) {
@@ -470,7 +511,11 @@ function LandingPage({
             isPlSections={true}
           />
         </div>
-        <EnrolledWorkshops />
+        <LandingPageWorkshopsTable
+          workshops={workshopsAsParticipant}
+          isLoading={loadingWorkshopsAsParticipant}
+          tableHeader={i18n.myWorkshops()}
+        />
         <section>
           <Heading2>{i18n.plLandingRecommendedHeading()}</Heading2>
           {RenderStaticRecommendedPL()}
@@ -489,9 +534,9 @@ function LandingPage({
         </section>
         {RenderOwnedPlSections()}
         {workshopsAsFacilitator?.length > 0 && (
-          <WorkshopsTable
+          <LandingPageWorkshopsTable
             workshops={workshopsAsFacilitator}
-            forMyPlPage={true}
+            isLoading={loadingWorkshopsAsFacilitator}
             tableHeader={i18n.inProgressAndUpcomingWorkshops()}
           />
         )}
@@ -512,9 +557,9 @@ function LandingPage({
           {RenderRegionalPartnerResources()}
         </section>
         {workshopsAsProgramManager?.length > 0 && (
-          <WorkshopsTable
+          <LandingPageWorkshopsTable
             workshops={workshopsAsProgramManager}
-            forMyPlPage={true}
+            isLoading={loadingWorkshopsAsProgramManager}
             tableHeader={i18n.inProgressAndUpcomingWorkshops()}
           />
         )}
@@ -538,9 +583,9 @@ function LandingPage({
           />
         </section>
         {workshopsAsOrganizer?.length > 0 && (
-          <WorkshopsTable
+          <LandingPageWorkshopsTable
             workshops={workshopsAsOrganizer}
-            forMyPlPage={true}
+            isLoading={loadingWorkshopsAsOrganizer}
             tableHeader={i18n.inProgressAndUpcomingWorkshops()}
           />
         )}

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -534,13 +534,11 @@ function LandingPage({
           {RenderFacilitatorResources()}
         </section>
         {RenderOwnedPlSections()}
-        {workshopsAsFacilitator?.length > 0 && (
-          <LandingPageWorkshopsTable
-            workshops={workshopsAsFacilitator}
-            isLoading={loadingWorkshopsAsFacilitator}
-            tableHeader={i18n.inProgressAndUpcomingWorkshops()}
-          />
-        )}
+        <LandingPageWorkshopsTable
+          workshops={workshopsAsFacilitator}
+          isLoading={loadingWorkshopsAsFacilitator}
+          tableHeader={i18n.inProgressAndUpcomingWorkshops()}
+        />
       </>
     );
   };
@@ -557,13 +555,11 @@ function LandingPage({
           <Heading2>{i18n.plSectionsRegionalPartnerResources()}</Heading2>
           {RenderRegionalPartnerResources()}
         </section>
-        {workshopsAsProgramManager?.length > 0 && (
-          <LandingPageWorkshopsTable
-            workshops={workshopsAsProgramManager}
-            isLoading={loadingWorkshopsAsProgramManager}
-            tableHeader={i18n.inProgressAndUpcomingWorkshops()}
-          />
-        )}
+        <LandingPageWorkshopsTable
+          workshops={workshopsAsProgramManager}
+          isLoading={loadingWorkshopsAsProgramManager}
+          tableHeader={i18n.inProgressAndUpcomingWorkshops()}
+        />
       </>
     );
   };
@@ -583,13 +579,11 @@ function LandingPage({
             solidBorder={true}
           />
         </section>
-        {workshopsAsOrganizer?.length > 0 && (
-          <LandingPageWorkshopsTable
-            workshops={workshopsAsOrganizer}
-            isLoading={loadingWorkshopsAsOrganizer}
-            tableHeader={i18n.inProgressAndUpcomingWorkshops()}
-          />
-        )}
+        <LandingPageWorkshopsTable
+          workshops={workshopsAsOrganizer}
+          isLoading={loadingWorkshopsAsOrganizer}
+          tableHeader={i18n.inProgressAndUpcomingWorkshops()}
+        />
       </>
     );
   };

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -167,10 +167,9 @@ function LandingPage({
           },
         });
 
+        setLoadingWorkshopsAsParticipant(false);
         if (response.ok) {
           const jsonData = await response.json();
-          console.log('jsonData', jsonData);
-          setLoadingWorkshopsAsParticipant(false);
           setWorkshopsAsParticipant(jsonData);
         }
       } catch (error) {
@@ -194,9 +193,9 @@ function LandingPage({
             }
           );
 
+          setLoadingWorkshopsAsFacilitator(false);
           if (response.ok) {
             const jsonData = await response.json();
-            setLoadingWorkshopsAsFacilitator(false);
             setWorkshopsAsFacilitator(jsonData.workshops_as_facilitator);
           }
         } catch (error) {
@@ -222,9 +221,9 @@ function LandingPage({
             }
           );
 
+          setLoadingWorkshopsAsOrganizer(false);
           if (response.ok) {
             const jsonData = await response.json();
-            setLoadingWorkshopsAsOrganizer(false);
             setWorkshopsAsOrganizer(jsonData.workshops_as_organizer);
           }
         } catch (error) {
@@ -250,9 +249,9 @@ function LandingPage({
             }
           );
 
+          setLoadingWorkshopsAsProgramManager(false);
           if (response.ok) {
             const jsonData = await response.json();
-            setLoadingWorkshopsAsProgramManager(false);
             setWorkshopsAsProgramManager(jsonData.workshops_as_program_manager);
           }
         } catch (error) {
@@ -538,6 +537,7 @@ function LandingPage({
           workshops={workshopsAsFacilitator}
           isLoading={loadingWorkshopsAsFacilitator}
           tableHeader={i18n.inProgressAndUpcomingWorkshops()}
+          participantView={false}
         />
       </>
     );
@@ -559,6 +559,7 @@ function LandingPage({
           workshops={workshopsAsProgramManager}
           isLoading={loadingWorkshopsAsProgramManager}
           tableHeader={i18n.inProgressAndUpcomingWorkshops()}
+          participantView={false}
         />
       </>
     );
@@ -583,6 +584,7 @@ function LandingPage({
           workshops={workshopsAsOrganizer}
           isLoading={loadingWorkshopsAsOrganizer}
           tableHeader={i18n.inProgressAndUpcomingWorkshops()}
+          participantView={false}
         />
       </>
     );

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -515,6 +515,7 @@ function LandingPage({
           workshops={workshopsAsParticipant}
           isLoading={loadingWorkshopsAsParticipant}
           tableHeader={i18n.myWorkshops()}
+          participantView
         />
         <section>
           <Heading2>{i18n.plLandingRecommendedHeading()}</Heading2>

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -173,6 +173,7 @@ function LandingPage({
           setWorkshopsAsParticipant(jsonData);
         }
       } catch (error) {
+        setLoadingWorkshopsAsParticipant(false);
         console.error('Error fetching participant data:', error);
       }
     };
@@ -199,6 +200,7 @@ function LandingPage({
             setWorkshopsAsFacilitator(jsonData.workshops_as_facilitator);
           }
         } catch (error) {
+          setLoadingWorkshopsAsFacilitator(false);
           console.error('Error fetching facilitator data:', error);
         }
       };
@@ -227,6 +229,7 @@ function LandingPage({
             setWorkshopsAsOrganizer(jsonData.workshops_as_organizer);
           }
         } catch (error) {
+          setLoadingWorkshopsAsOrganizer(false);
           console.error('Error fetching workshop organizer data:', error);
         }
       };
@@ -255,6 +258,7 @@ function LandingPage({
             setWorkshopsAsProgramManager(jsonData.workshops_as_program_manager);
           }
         } catch (error) {
+          setLoadingWorkshopsAsProgramManager(false);
           console.error('Error fetching program manager data:', error);
         }
       };

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
@@ -207,6 +207,10 @@ export default class LandingPageWorkshopsTable extends React.Component {
       );
     }
 
+    if (this.props.workshops.length === 0) {
+      return null;
+    }
+
     return (
       <div>
         <Modal

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
@@ -5,34 +5,19 @@ import {Table, Button, Modal} from 'react-bootstrap'; // eslint-disable-line no-
 import ReactTooltip from 'react-tooltip';
 
 import {Heading2} from '@cdo/apps/componentLibrary/typography';
-import i18n from '@cdo/locale';
+import Spinner from '@cdo/apps/sharedComponents/Spinner';
 
 import * as utils from '../../../utils';
-import WorkshopTableLoader from '../workshop_dashboard/components/workshop_table_loader';
 import {workshopShape} from '../workshop_dashboard/types.js';
 import {
   DATE_FORMAT,
   TIME_FORMAT,
 } from '../workshop_dashboard/workshopConstants';
 
-class EnrolledWorkshops extends React.Component {
-  render() {
-    return (
-      <WorkshopTableLoader
-        queryUrl="/api/v1/pd/workshops_user_enrolled_in"
-        hideNoWorkshopsMessage={true}
-        tableHeader={i18n.myWorkshops()}
-      >
-        <WorkshopsTable tableHeader={i18n.myWorkshops()} />
-      </WorkshopTableLoader>
-    );
-  }
-}
-
-class WorkshopsTable extends React.Component {
+export default class LandingPageWorkshopsTable extends React.Component {
   static propTypes = {
     workshops: PropTypes.arrayOf(workshopShape),
-    forMyPlPage: PropTypes.bool,
+    isLoading: PropTypes.bool,
     tableHeader: PropTypes.string,
   };
 
@@ -103,53 +88,16 @@ class WorkshopsTable extends React.Component {
   };
 
   renderWorkshopActionButtons(workshop) {
-    if (this.props.forMyPlPage) {
-      return (
-        <Button
-          onClick={() =>
-            utils.windowOpen(`/pd/workshop_dashboard/workshops/${workshop.id}`)
-          }
-          style={styles.button}
-        >
-          Workshop Details
-        </Button>
-      );
-    } else {
-      return (
-        <div>
-          {workshop.state === 'Not Started' &&
-            workshop.pre_workshop_survey_url &&
-            this.renderPreWorkshopSurveyButton(workshop)}
-          {workshop.state === 'Ended' && (
-            <Button
-              onClick={() => this.openCertificate(workshop)}
-              style={styles.button}
-              disabled={!workshop.attended}
-            >
-              Print certificate
-            </Button>
-          )}
-          <Button
-            onClick={() =>
-              utils.windowOpen(
-                `/pd/workshop_enrollment/${workshop.enrollment_code}`
-              )
-            }
-            style={styles.button}
-          >
-            Workshop details
-          </Button>
-          {workshop.state === 'Not Started' && (
-            <Button
-              onClick={() => this.showCancelModal(workshop.enrollment_code)}
-              style={styles.button}
-            >
-              Cancel enrollment
-            </Button>
-          )}
-        </div>
-      );
-    }
+    return (
+      <Button
+        onClick={() =>
+          utils.windowOpen(`/pd/workshop_dashboard/workshops/${workshop.id}`)
+        }
+        style={styles.button}
+      >
+        Workshop Details
+      </Button>
+    );
   }
 
   renderWorkshopsTable() {
@@ -165,7 +113,7 @@ class WorkshopsTable extends React.Component {
             <th>Date</th>
             <th>Time</th>
             <th>Location</th>
-            {this.props.forMyPlPage && <th>Status</th>}
+            <th>Status</th>
             <th style={{width: '20%'}} />
           </tr>
         </thead>
@@ -205,13 +153,24 @@ class WorkshopsTable extends React.Component {
             <p>{workshop.location_address}</p>
           </div>
         </td>
-        {this.props.forMyPlPage && <td>{workshop.status}</td>}
+        <td>{workshop.status}</td>
         <td>{this.renderWorkshopActionButtons(workshop)}</td>
       </tr>
     );
   }
 
   render() {
+    console.log(this.props);
+
+    if (this.props.isLoading) {
+      return (
+        // While reloading, preserve the height of the previous child component so the refresh is smoother.
+        <div style={{height: this.childHeight}}>
+          <Spinner />
+        </div>
+      );
+    }
+
     return (
       <div>
         <Modal
@@ -249,5 +208,3 @@ const styles = {
     width: '100%',
   },
 };
-
-export {EnrolledWorkshops, WorkshopsTable};

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
@@ -198,8 +198,6 @@ export default class LandingPageWorkshopsTable extends React.Component {
   }
 
   render() {
-    console.log(this.props);
-
     if (this.props.isLoading) {
       return (
         // While reloading, preserve the height of the previous child component so the refresh is smoother.

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
@@ -19,6 +19,7 @@ export default class LandingPageWorkshopsTable extends React.Component {
     workshops: PropTypes.arrayOf(workshopShape),
     isLoading: PropTypes.bool,
     tableHeader: PropTypes.string,
+    participantView: PropTypes.bool,
   };
 
   state = {
@@ -88,16 +89,53 @@ export default class LandingPageWorkshopsTable extends React.Component {
   };
 
   renderWorkshopActionButtons(workshop) {
-    return (
-      <Button
-        onClick={() =>
-          utils.windowOpen(`/pd/workshop_dashboard/workshops/${workshop.id}`)
-        }
-        style={styles.button}
-      >
-        Workshop Details
-      </Button>
-    );
+    if (!!this.props.participantView) {
+      return (
+        <div>
+          {workshop.state === 'Not Started' &&
+            workshop.pre_workshop_survey_url &&
+            this.renderPreWorkshopSurveyButton(workshop)}
+          {workshop.state === 'Ended' && (
+            <Button
+              onClick={() => this.openCertificate(workshop)}
+              style={styles.button}
+              disabled={!workshop.attended}
+            >
+              Print certificate
+            </Button>
+          )}
+          <Button
+            onClick={() =>
+              utils.windowOpen(
+                `/pd/workshop_enrollment/${workshop.enrollment_code}`
+              )
+            }
+            style={styles.button}
+          >
+            Workshop details
+          </Button>
+          {workshop.state === 'Not Started' && (
+            <Button
+              onClick={() => this.showCancelModal(workshop.enrollment_code)}
+              style={styles.button}
+            >
+              Cancel enrollment
+            </Button>
+          )}
+        </div>
+      );
+    } else {
+      return (
+        <Button
+          onClick={() =>
+            utils.windowOpen(`/pd/workshop_dashboard/workshops/${workshop.id}`)
+          }
+          style={styles.button}
+        >
+          Workshop Details
+        </Button>
+      );
+    }
   }
 
   renderWorkshopsTable() {
@@ -113,7 +151,7 @@ export default class LandingPageWorkshopsTable extends React.Component {
             <th>Date</th>
             <th>Time</th>
             <th>Location</th>
-            <th>Status</th>
+            {!this.props.participantView && <th>Status</th>}
             <th style={{width: '20%'}} />
           </tr>
         </thead>
@@ -153,7 +191,7 @@ export default class LandingPageWorkshopsTable extends React.Component {
             <p>{workshop.location_address}</p>
           </div>
         </td>
-        <td>{workshop.status}</td>
+        {!this.props.participantView && <td>{workshop.status}</td>}
         <td>{this.renderWorkshopActionButtons(workshop)}</td>
       </tr>
     );

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
@@ -198,7 +198,6 @@ export default class LandingPageWorkshopsTable extends React.Component {
   }
 
   render() {
-    console.log(this.props);
     if (this.props.isLoading) {
       return (
         // While reloading, preserve the height of the previous child component so the refresh is smoother.

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.jsx
@@ -198,6 +198,7 @@ export default class LandingPageWorkshopsTable extends React.Component {
   }
 
   render() {
+    console.log(this.props);
     if (this.props.isLoading) {
       return (
         // While reloading, preserve the height of the previous child component so the refresh is smoother.

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.story.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.story.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import reactBootstrapStoryDecorator from '../reactBootstrapStoryDecorator';
 
-import {WorkshopsTable} from './EnrolledWorkshops';
+import LandingPageWorkshopsTable from './LandingPageWorkshopsTable';
 
 const workshops = [
   // Have all required and non-required data
@@ -40,12 +40,12 @@ const workshops = [
 ];
 
 export default {
-  component: WorkshopsTable,
+  component: LandingPageWorkshopsTable,
   decorators: [reactBootstrapStoryDecorator],
 };
 
 const Template = args => {
-  return <WorkshopsTable {...args} />;
+  return <LandingPageWorkshopsTable {...args} />;
 };
 
 export const Default = Template.bind({});

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.story.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable.story.jsx
@@ -48,7 +48,14 @@ const Template = args => {
   return <LandingPageWorkshopsTable {...args} />;
 };
 
-export const Default = Template.bind({});
-Default.args = {
+export const ParticipantView = Template.bind({});
+ParticipantView.args = {
   workshops: workshops,
+  participantView: true,
+};
+
+export const OrganizerView = Template.bind({});
+OrganizerView.args = {
+  workshops: workshops,
+  participantView: false,
 };

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTableTest.jsx
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTableTest.jsx
@@ -159,4 +159,12 @@ describe('LandingPageWorkshopsTable', () => {
         .findWhere(n => n.text() === 'Workshop Details').length
     ).to.equal(numButtonsInTable);
   });
+
+  it('doesnt show anything if loading is complete and there are no workshops', function () {
+    const workshopsTable = shallow(
+      <LandingPageWorkshopsTable workshops={[]} isLoading={false} />
+    );
+
+    expect(workshopsTable.find('tbody tr')).to.have.length(0);
+  });
 });

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTableTest.jsx
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTableTest.jsx
@@ -36,7 +36,7 @@ describe('LandingPageWorkshopsTable', () => {
 
   it('Clicking cancel enrollment cancels the enrollment', () => {
     const workshopsTable = shallow(
-      <LandingPageWorkshopsTable workshops={workshops} />
+      <LandingPageWorkshopsTable workshops={workshops} participantView />
     );
 
     // We expect there to be a table with 4 rows in the body, three of which have two buttons
@@ -58,7 +58,7 @@ describe('LandingPageWorkshopsTable', () => {
 
   it('Clicking "Print Certificate" opens the certificate in a new tab if user attended workshop', function () {
     const workshopsTable = shallow(
-      <LandingPageWorkshopsTable workshops={workshops} />
+      <LandingPageWorkshopsTable workshops={workshops} participantView />
     );
 
     // Click the "Print Certificate" button
@@ -79,7 +79,7 @@ describe('LandingPageWorkshopsTable', () => {
 
   it('"Print Certificate" button is disabled if user did not attend workshop', function () {
     const workshopsTable = shallow(
-      <LandingPageWorkshopsTable workshops={workshops} />
+      <LandingPageWorkshopsTable workshops={workshops} participantView />
     );
 
     // Get disabled "Print Certificate" React Button component
@@ -94,7 +94,7 @@ describe('LandingPageWorkshopsTable', () => {
 
   it('Pre-survey link button shown in workshops that have not started', function () {
     const workshopsTable = shallow(
-      <LandingPageWorkshopsTable workshops={workshops} />
+      <LandingPageWorkshopsTable workshops={workshops} participantView />
     );
 
     workshopsTable
@@ -109,7 +109,7 @@ describe('LandingPageWorkshopsTable', () => {
 
   it('Pre-survey link button not shown in ended workshop', function () {
     const workshopsTable = shallow(
-      <LandingPageWorkshopsTable workshops={workshops} />
+      <LandingPageWorkshopsTable workshops={workshops} participantView />
     );
 
     const preWorkshopSurveyButton = workshopsTable
@@ -127,7 +127,7 @@ describe('LandingPageWorkshopsTable', () => {
     );
 
     const workshopsTable = shallow(
-      <LandingPageWorkshopsTable workshops={workshops} />
+      <LandingPageWorkshopsTable workshops={workshops} participantView />
     );
 
     const preWorkshopSurveyButton = workshopsTable
@@ -139,9 +139,12 @@ describe('LandingPageWorkshopsTable', () => {
     expect(preWorkshopSurveyButton.props().disabled).to.be.true;
   });
 
-  it('shows Status column and only has Workshop Details button when forMyPlPage is true', function () {
+  it('shows Status column and only has Workshop Details button when not in a participant view', function () {
     const workshopsTable = shallow(
-      <LandingPageWorkshopsTable workshops={workshops} forMyPlPage={true} />
+      <LandingPageWorkshopsTable
+        workshops={workshops}
+        participantView={false}
+      />
     );
 
     expect(workshopsTable.find('thead tr').text()).to.contain('Status');

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTableTest.jsx
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTableTest.jsx
@@ -4,12 +4,12 @@ import moment from 'moment';
 import React from 'react';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
-import {WorkshopsTable} from '@cdo/apps/code-studio/pd/professional_learning_landing/EnrolledWorkshops';
+import LandingPageWorkshopsTable from '@cdo/apps/code-studio/pd/professional_learning_landing/LandingPageWorkshopsTable';
 import * as utils from '@cdo/apps/utils';
 
 import {serializedWorkshopFactory} from '../../../../factories/professionalLearning';
 
-describe('EnrolledWorkshops', () => {
+describe('LandingPageWorkshopsTable', () => {
   const workshops = [
     serializedWorkshopFactory.build({
       pre_workshop_survey_url: 'code.org/pre_survey_url',
@@ -35,38 +35,34 @@ describe('EnrolledWorkshops', () => {
   });
 
   it('Clicking cancel enrollment cancels the enrollment', () => {
-    const enrolledWorkshopsTable = shallow(
-      <WorkshopsTable workshops={workshops} />
+    const workshopsTable = shallow(
+      <LandingPageWorkshopsTable workshops={workshops} />
     );
 
     // We expect there to be a table with 4 rows in the body, three of which have two buttons
-    expect(enrolledWorkshopsTable.find('tbody tr')).to.have.length(4);
-    expect(enrolledWorkshopsTable.find('tbody tr Button')).to.have.length(8);
-    expect(enrolledWorkshopsTable.state('showCancelModal')).to.be.false;
-    expect(enrolledWorkshopsTable.state('enrollmentCodeToCancel')).to.equal(
-      undefined
-    );
+    expect(workshopsTable.find('tbody tr')).to.have.length(4);
+    expect(workshopsTable.find('tbody tr Button')).to.have.length(8);
+    expect(workshopsTable.state('showCancelModal')).to.be.false;
+    expect(workshopsTable.state('enrollmentCodeToCancel')).to.equal(undefined);
 
     // Pushing the button should bring up the modal
-    enrolledWorkshopsTable
+    workshopsTable
       .find('tbody tr')
       .at(0)
       .find('Button')
       .last()
       .simulate('click');
-    expect(enrolledWorkshopsTable.state('showCancelModal')).to.be.true;
-    expect(enrolledWorkshopsTable.state('enrollmentCodeToCancel')).to.equal(
-      'code1'
-    );
+    expect(workshopsTable.state('showCancelModal')).to.be.true;
+    expect(workshopsTable.state('enrollmentCodeToCancel')).to.equal('code1');
   });
 
   it('Clicking "Print Certificate" opens the certificate in a new tab if user attended workshop', function () {
-    const enrolledWorkshopsTable = shallow(
-      <WorkshopsTable workshops={workshops} />
+    const workshopsTable = shallow(
+      <LandingPageWorkshopsTable workshops={workshops} />
     );
 
     // Click the "Print Certificate" button
-    enrolledWorkshopsTable
+    workshopsTable
       .find('tbody tr')
       .at(2)
       .find('Button')
@@ -82,12 +78,12 @@ describe('EnrolledWorkshops', () => {
   });
 
   it('"Print Certificate" button is disabled if user did not attend workshop', function () {
-    const enrolledWorkshopsTable = shallow(
-      <WorkshopsTable workshops={workshops} />
+    const workshopsTable = shallow(
+      <LandingPageWorkshopsTable workshops={workshops} />
     );
 
     // Get disabled "Print Certificate" React Button component
-    const printCertificateButton = enrolledWorkshopsTable
+    const printCertificateButton = workshopsTable
       .find('tbody tr')
       .at(3)
       .find('Button')
@@ -97,11 +93,11 @@ describe('EnrolledWorkshops', () => {
   });
 
   it('Pre-survey link button shown in workshops that have not started', function () {
-    const enrolledWorkshopsTable = shallow(
-      <WorkshopsTable workshops={workshops} />
+    const workshopsTable = shallow(
+      <LandingPageWorkshopsTable workshops={workshops} />
     );
 
-    enrolledWorkshopsTable
+    workshopsTable
       .find('tbody tr')
       .at(0)
       .find('Button')
@@ -112,11 +108,11 @@ describe('EnrolledWorkshops', () => {
   });
 
   it('Pre-survey link button not shown in ended workshop', function () {
-    const enrolledWorkshopsTable = shallow(
-      <WorkshopsTable workshops={workshops} />
+    const workshopsTable = shallow(
+      <LandingPageWorkshopsTable workshops={workshops} />
     );
 
-    const preWorkshopSurveyButton = enrolledWorkshopsTable
+    const preWorkshopSurveyButton = workshopsTable
       .find('tbody tr')
       .at(3)
       .find('Button')
@@ -130,11 +126,11 @@ describe('EnrolledWorkshops', () => {
       moment(workshops[0].workshop_starting_date).subtract(14, 'days').toDate()
     );
 
-    const enrolledWorkshopsTable = shallow(
-      <WorkshopsTable workshops={workshops} />
+    const workshopsTable = shallow(
+      <LandingPageWorkshopsTable workshops={workshops} />
     );
 
-    const preWorkshopSurveyButton = enrolledWorkshopsTable
+    const preWorkshopSurveyButton = workshopsTable
       .find('tbody tr')
       .at(0)
       .find('Button')
@@ -144,17 +140,17 @@ describe('EnrolledWorkshops', () => {
   });
 
   it('shows Status column and only has Workshop Details button when forMyPlPage is true', function () {
-    const enrolledWorkshopsTable = shallow(
-      <WorkshopsTable workshops={workshops} forMyPlPage={true} />
+    const workshopsTable = shallow(
+      <LandingPageWorkshopsTable workshops={workshops} forMyPlPage={true} />
     );
 
-    expect(enrolledWorkshopsTable.find('thead tr').text()).to.contain('Status');
+    expect(workshopsTable.find('thead tr').text()).to.contain('Status');
 
-    const numButtonsInTable = enrolledWorkshopsTable
+    const numButtonsInTable = workshopsTable
       .find('tbody tr')
       .find('Button').length;
     expect(
-      enrolledWorkshopsTable
+      workshopsTable
         .find('tbody tr')
         .find('Button')
         .findWhere(n => n.text() === 'Workshop Details').length

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
@@ -132,7 +132,7 @@ describe('LandingPage', () => {
     expect(screen.queryByText(i18n.plLandingStartSurvey())).toBeFalsy();
     await waitFor(() => {
       screen.getByText(i18n.myWorkshops());
-      screen.getByText('Address 111');
+      screen.getByText(TEST_WORKSHOP.location_address);
       screen.getByText(i18n.plLandingSelfPacedProgressHeading());
       screen.getByText(i18n.plLandingStaticPLMidHighHeading());
     });
@@ -173,7 +173,7 @@ describe('LandingPage', () => {
 
     await waitFor(() => {
       screen.getByText(i18n.myWorkshops());
-      screen.getByText('Address 111');
+      screen.getByText(TEST_WORKSHOP.location_address);
     });
     fetchStub.mockRestore();
   });

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
@@ -90,8 +90,6 @@ describe('LandingPage', () => {
     });
     screen.getByText(i18n.plLandingGettingStartedHeading());
     expect(screen.queryByText(i18n.plLandingStartSurvey())).toBeFalsy();
-    // eslint-disable-next-line no-restricted-properties
-    screen.getByTestId('enrolled-workshops-loader');
     expect(
       screen.queryByText(i18n.plLandingSelfPacedProgressHeading())
     ).toBeFalsy();
@@ -104,8 +102,6 @@ describe('LandingPage', () => {
       screen.queryByText(i18n.plLandingGettingStartedHeading())
     ).toBeFalsy();
     screen.getByText(i18n.plLandingStartSurvey());
-    // eslint-disable-next-line no-restricted-properties
-    screen.getByTestId('enrolled-workshops-loader');
     screen.getByText(i18n.plLandingSelfPacedProgressHeading());
     screen.getByText(i18n.plLandingStaticPLMidHighHeading());
   });
@@ -116,13 +112,16 @@ describe('LandingPage', () => {
       screen.queryByText(i18n.plLandingGettingStartedHeading())
     ).toBeFalsy();
     screen.getByText(i18n.plLandingStartSurvey());
-    // eslint-disable-next-line no-restricted-properties
-    screen.getByTestId('enrolled-workshops-loader');
     screen.getByText(i18n.plLandingSelfPacedProgressHeading());
     screen.getByText(i18n.plLandingStaticPLMidHighHeading());
   });
 
-  it('page shows upcoming workshops, self-paced courses, and plc enrollments but no survey banner if no pending survey exists', () => {
+  it('page shows upcoming workshops, self-paced courses, and plc enrollments but no survey banner if no pending survey exists', async () => {
+    const fetchStub = jest.spyOn(window, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([TEST_WORKSHOP]),
+    });
+
     renderDefault({
       lastWorkshopSurveyUrl: null,
       lastWorkshopSurveyCourse: null,
@@ -131,10 +130,14 @@ describe('LandingPage', () => {
       screen.queryByText(i18n.plLandingGettingStartedHeading())
     ).toBeFalsy();
     expect(screen.queryByText(i18n.plLandingStartSurvey())).toBeFalsy();
-    // eslint-disable-next-line no-restricted-properties
-    screen.getByTestId('enrolled-workshops-loader');
-    screen.getByText(i18n.plLandingSelfPacedProgressHeading());
-    screen.getByText(i18n.plLandingStaticPLMidHighHeading());
+    await waitFor(() => {
+      screen.getByText(i18n.myWorkshops());
+      screen.getByText('Address 111');
+      screen.getByText(i18n.plLandingSelfPacedProgressHeading());
+      screen.getByText(i18n.plLandingStaticPLMidHighHeading());
+    });
+
+    fetchStub.mockRestore();
   });
 
   it('page shows self-paced progress table if enrolled in self-paced courses', () => {
@@ -157,11 +160,22 @@ describe('LandingPage', () => {
     screen.getByText(i18n.joinedProfessionalLearningSectionsHomepageTitle());
   });
 
-  it('page shows enrolled workshops table', () => {
+  it('page shows enrolled workshops table', async () => {
+    const fetchStub = jest
+      .spyOn(window, 'fetch')
+      .mockClear()
+      .mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([TEST_WORKSHOP]),
+      });
+
     renderDefault();
 
-    // eslint-disable-next-line no-restricted-properties
-    screen.getByTestId('enrolled-workshops-loader');
+    await waitFor(() => {
+      screen.getByText(i18n.myWorkshops());
+      screen.getByText('Address 111');
+    });
+    fetchStub.mockRestore();
   });
 
   it('page shows no tabs for teacher with no relevant permissions', () => {
@@ -263,10 +277,17 @@ describe('LandingPage', () => {
     const fetchStub = jest
       .spyOn(window, 'fetch')
       .mockClear()
-      .mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({workshops_as_facilitator: [TEST_WORKSHOP]}),
+      .mockImplementation(args => {
+        if (args.includes('workshops_user_enrolled_in')) {
+          return Promise.resolve({ok: true, json: () => []});
+        } else if (args.includes('workshops_as_facilitator_for_pl_page')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => {
+              return {workshops_as_facilitator: [TEST_WORKSHOP]};
+            },
+          });
+        }
       });
 
     await waitFor(() => {
@@ -329,10 +350,17 @@ describe('LandingPage', () => {
     const fetchStub = jest
       .spyOn(window, 'fetch')
       .mockClear()
-      .mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({workshops_as_program_manager: [TEST_WORKSHOP]}),
+      .mockImplementation(args => {
+        if (args.includes('workshops_user_enrolled_in')) {
+          return Promise.resolve({ok: true, json: () => []});
+        } else if (args.includes('workshops_as_program_manager_for_pl_page')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => {
+              return {workshops_as_program_manager: [TEST_WORKSHOP]};
+            },
+          });
+        }
       });
 
     await waitFor(() => {
@@ -357,25 +385,35 @@ describe('LandingPage', () => {
     const fetchStub = jest
       .spyOn(window, 'fetch')
       .mockClear()
-      .mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({workshops_as_organizer: [TEST_WORKSHOP]}),
+      .mockImplementation(args => {
+        if (args.includes('workshops_user_enrolled_in')) {
+          return Promise.resolve({ok: true, json: () => []});
+        } else if (args.includes('workshops_as_organizer_for_pl_page')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => {
+              return {workshops_as_organizer: [TEST_WORKSHOP]};
+            },
+          });
+        }
       });
-
+    renderDefault({
+      userPermissions: ['workshop_organizer'],
+    });
     await waitFor(() => {
-      renderDefault({
-        userPermissions: ['workshop_organizer'],
-      });
+      screen.getByText(i18n.plLandingTabWorkshopOrganizerCenter());
     });
     fireEvent.click(
-      screen.getAllByText(i18n.plLandingTabWorkshopOrganizerCenter())[0]
+      screen.getByText(i18n.plLandingTabWorkshopOrganizerCenter())
     );
 
     // Workshop Organizer Resources
     screen.getByText(i18n.plSectionsWorkshopResources());
 
-    // Workshop Organizer workshop table
-    screen.getByText(i18n.inProgressAndUpcomingWorkshops());
+    await waitFor(() => {
+      // Workshop Organizer workshop table
+      screen.getByText(i18n.inProgressAndUpcomingWorkshops());
+    });
 
     fetchStub.mockRestore();
   });


### PR DESCRIPTION
Part of a series of cleanups on our multiple components that display tables of workshops. I'm starting with the component on the PL Landing Page, which is conveniently well-covered by both unit and UI tests.

What I did:
- moved fetching *participant* workshops alongside other sets of workshops (ie facilitated, managed, etc)
- renamed `EnrolledWorkshops` to `LandingPageWorkshopsTable` to better reflect its purpose 
- removed the use of `WorkshopTableLoader` because I'd like to remove that all together
  - for context, it's only used in a couple of places (`ServerSortWorkshopTable` is the other place) and is highly customized. The amount of shared code is not worth just pulling out basic fetch calls into their own components in my opinion 
- Removed the `forMyPlPage` prop from `LandingPageWorkshopsTable` and replaced it with `participantView` as that better described what the prop controlled. Note that these props are inverses of each other. 
  - I also added a Storybook entry for this 
- Added a Spinner in `LandingPageWorkshopsTable` so it's a bit less jarring when the table finally loads

What I chose to not do:
- refactor `LandingPageWorkshopsTable` into a functional component. A class component is fine here as there isn't any lifecycle handlers (ie `componentDidMount`). This is definitely something that could be tackled as a future clean up and, if I was creating the component today, I would make it a functional component. Just trying to keep the diff clean and keep this PR moving.
- Removing Bootstrap out of `LandingPageWorkshopsTable` and/or updating it to use design system components. I'm going for a mostly no-op refactor here.
- Refactoring either component to Typescript. I am not particularly familiar with Typescript and don't want this PR to linger over the break. Again, a possible future improvement.
- Refactored `LandingPageWorkshopsTableTest` to use jest/RTL. Honestly, this one was a bit of an oversight, but again I'd like to get this PR out.

Next steps:
- Pretty much everything in the "What I chose not to do" section above
- Refactoring `ServerSortWorkshopTable` and remove `WorkshopTableLoader`

## Screenshots

"My Workshops"

<img width="1421" alt="Screenshot 2024-12-17 at 10 40 06 AM" src="https://github.com/user-attachments/assets/13750faf-6507-432c-9720-c05d44594c4f" />


Spinner for organized workshops


https://github.com/user-attachments/assets/e4d5440b-bf66-425a-91fc-69eabb3c9eef

