### PR TITLE
fix(storybook): update swc to use auto jsx transform

### DIFF
--- a/frontend/apps/design-system-storybook/.storybook/main.ts
+++ b/frontend/apps/design-system-storybook/.storybook/main.ts
@@ -55,6 +55,17 @@ const config: StorybookConfig = {
     name: getAbsolutePath('@storybook/react-webpack5'),
     options: {},
   },
+  swc: () => ({
+    // Removes the need to import React by specifying we are targeting React 17+ using the React jsx transform
+    // See: https://storybook.js.org/docs/8.5/configure/integration/compilers#the-swc-compiler-doesnt-work-with-react
+    jsc: {
+      transform: {
+        react: {
+          runtime: 'automatic',
+        },
+      },
+    },
+  }),
   webpackFinal: async config => {
     if (config.resolve) {
       config.resolve.alias = {


### PR DESCRIPTION
This PR updates the swc loader to use the auto jsx transform. This is necessary to support the new JSX transform in React 17.

For more information, see:

- [Storybook Documentation](https://storybook.js.org/docs/8.5/configure/integration/compilers#the-swc-compiler-doesnt-work-with-react)