### PR TITLE
fix(dsco): fix sass relative imports

### DIFF
--- a/frontend/packages/dsco/tsup.config.ts
+++ b/frontend/packages/dsco/tsup.config.ts
@@ -26,7 +26,12 @@ export default defineConfig({
       }),
       importMapper: path => {
         // Convert any references to @ to the ./src directory
-        return resolve(__dirname, path.replace(/^@\//, './src/'));
+        // Note: sass will detect relative paths if the file exists
+        // resulting in a situation where if the file is found relatively
+        // it results in a nested import statement when esbuild tries to resolve it.
+        // To avoid this, remove any strings prior to `@` and replace it with `./src/`
+        // See: https://github.com/glromeo/esbuild-sass-plugin/issues/136#issuecomment-1542828117
+        return resolve(__dirname, path.replace(/^(.*?)@\//, './src/'));
       },
     }),
   ],


### PR DESCRIPTION
sass will detect relative paths if the file exists resulting in a situation where if the file is found relatively it results in a nested import statement when esbuild tries to resolve it.

To avoid this, remove any strings prior to `@` and replace it with `./src/`