### PR TITLE
fix(marketing): disable contentful client when no secrets are present

### DIFF
--- a/frontend/apps/marketing/src/contentful/client.ts
+++ b/frontend/apps/marketing/src/contentful/client.ts
@@ -1,12 +1,27 @@
 import {createClient} from 'contentful';
 
-export default createClient({
-  // your space id
+/**
+ * For values and documentation, please refer to .env.example
+ */
+const clientProps = {
   space: process.env.CONTENTFUL_SPACE_ID!,
-  // your environment id
   environment: process.env.CONTENTFUL_ENV_ID,
-  // Supported values: 'preview.contentful.com' or 'cdn.contentful.com',
   host: process.env.CONTENTFUL_API_HOST,
-  // needs to be access token if host = 'cdn.contentful.com' and preview token if 'preview.contentful.com'
   accessToken: process.env.CONTENTFUL_TOKEN!,
-});
+};
+
+/**
+ * Check if all the required environment variables are available.
+ * If not, the client will not be created.
+ */
+const isEnvironmentAvailable = Object.values(clientProps).every(
+  value => !!value,
+);
+
+if (!isEnvironmentAvailable) {
+  console.warn(
+    'Contentful client is not available, no content will be fetched from Contentful.',
+  );
+}
+
+export default isEnvironmentAvailable ? createClient(clientProps) : undefined;

--- a/frontend/apps/marketing/src/contentful/get-experience.ts
+++ b/frontend/apps/marketing/src/contentful/get-experience.ts
@@ -13,6 +13,13 @@ export const getExperience = async (
   localeCode: string,
   isEditorMode = false,
 ) => {
+  if (!client) {
+    // The client will not be available if the environment variables for secrets are not set.
+    // Rather than crashing the app, we log a warning and return undefined to allow Next.js to static
+    // render the foundations of the page.
+    return {experience: undefined, error: undefined};
+  }
+
   // While in editor mode, the experience is passed to the ExperienceRoot
   // component by the editor, so we don't fetch it here
   if (isEditorMode) {


### PR DESCRIPTION
The contentful client throws an error if the required secrets are not present.

Unfortunately, this results in Next.js crashing with the following error during a build:

```
   Collecting page data  ..Error: Failed to collect configuration for /[locale]/[slug]
    at <unknown> (/workspaces/code-dot-org/frontend/node_modules/next/dist/build/utils.js:1131:23)
    at async Span.traceAsyncFn (/workspaces/code-dot-org/frontend/node_modules/next/dist/trace/trace.js:153:20) {
  [cause]: TypeError: Expected parameter accessToken
      at <unknown> (/workspaces/code-dot-org/frontend/apps/marketing/.next/server/app/[locale]/[slug]/page.js:7:4934)
      at 66569 (/workspaces/code-dot-org/frontend/apps/marketing/.next/server/app/[locale]/[slug]/page.js:7:9138)
      at Function.t (/workspaces/code-dot-org/frontend/apps/marketing/.next/server/webpack-runtime.js:1:128)
      at async getLayoutOrPageModule (/workspaces/code-dot-org/frontend/node_modules/next/dist/server/lib/app-dir-module.js:37:15)
      at async collectAppPageSegments (/workspaces/code-dot-org/frontend/node_modules/next/dist/build/segment-config/app/app-segments.js:50:45)
      at async (/workspaces/code-dot-org/frontend/node_modules/next/dist/build/utils.js:1129:28)
      at async Span.traceAsyncFn (/workspaces/code-dot-org/frontend/node_modules/next/dist/trace/trace.js:153:20)
}

> Build error occurred
Error: Failed to collect page data for /[locale]/[slug]
    at <unknown> (/workspaces/code-dot-org/frontend/node_modules/next/dist/build/utils.js:1234:15) {
  type: 'Error'
```

Rather than crashing the build, the client should be `undefined` when the required secrets are not present. If the client is `undefined`, the page will not render any content from Contentful, allowing Next.js to produce foundational static pages that it can pre-render.