### PR TITLE
Lab2 prototype: auto-typed level properties

### DIFF
--- a/apps/lab2EntryPoints.ts
+++ b/apps/lab2EntryPoints.ts
@@ -16,7 +16,7 @@ import {PythonlabEntryPoint} from '@cdo/apps/pythonlab/entrypoint';
 import {StandaloneVideoEntryPoint} from '@cdo/apps/standaloneVideo/entrypoint';
 import {Weblab2EntryPoint} from '@cdo/apps/weblab2/entrypoint';
 
-export const lab2EntryPoints: Record<string, Lab2EntryPoint> = {
+export const lab2EntryPoints = {
   aichat: AIChatEntryPoint,
   dance: DanceEntryPoint,
   music: MusicEntryPoint,
@@ -24,4 +24,6 @@ export const lab2EntryPoints: Record<string, Lab2EntryPoint> = {
   pythonlab: PythonlabEntryPoint,
   standalone_video: StandaloneVideoEntryPoint,
   weblab2: Weblab2EntryPoint,
-};
+} as const satisfies {[key: string]: Lab2EntryPoint};
+// ^ as const makes it so we can use typeof keyof lab2EntryPoints to get the union of all keys,
+// while the satisfies ensures that all values are of type Lab2EntryPoint

--- a/apps/src/lab2/views/Lab2TypeExperiment.tsx
+++ b/apps/src/lab2/views/Lab2TypeExperiment.tsx
@@ -1,0 +1,115 @@
+import {lab2EntryPoints} from 'lab2EntryPoints';
+import React, {useEffect, useState} from 'react';
+
+import {ProjectSources} from '../types';
+
+// List of all apps that we support, as keys of entrypoints
+type App = keyof typeof lab2EntryPoints;
+
+// Common level properties interface for all labs
+interface BaseLevelProperties<T extends App> {
+  appName: T;
+  isProjectLevel?: boolean;
+  hideAndShareRemix?: boolean;
+  // ... other common stuff
+}
+
+// Some examples of lab-specific properties...
+
+interface MusicLevelProperties extends BaseLevelProperties<'music'> {
+  library: object;
+}
+
+interface PythonLevelProps extends BaseLevelProperties<'pythonlab'> {
+  validationCode: string;
+}
+
+// Here we map each app to its specific level properties type
+type LevelPropertiesMap = {
+  music: MusicLevelProperties;
+  pythonlab: PythonLevelProps;
+
+  // Connect other lab-specific types here.
+  // Currently just filling out the rest with base level props to make TS happy.
+  aichat: BaseLevelProperties<'aichat'>;
+  dance: BaseLevelProperties<'dance'>;
+  panels: BaseLevelProperties<'panels'>;
+  standalone_video: BaseLevelProperties<'standalone_video'>;
+  weblab2: BaseLevelProperties<'weblab2'>;
+};
+
+// Assume we have some selector to get the app for the current level before we load level props...
+function getAppType(levelId: number): App {
+  // Fake implementation
+  return levelId % 2 === 0 ? 'music' : 'pythonlab';
+}
+
+// Assume this does all the work to load level properties and sources for a given level (like we do in lab2Redux currently)
+async function loadData<T extends App>(
+  levelId: number
+): Promise<LevelPropertiesMap[T]> {
+  const app = getAppType(levelId);
+  if (app === 'music') {
+    // ✅ TS ensures that this is a MusicLevelProperties
+    return {appName: app, library: {}} as LevelPropertiesMap[T];
+  }
+  if (app === 'pythonlab') {
+    // ✅ TS ensures that this is a PythonLevelProperties
+    return {appName: app, validationCode: 'code'} as LevelPropertiesMap[T];
+  }
+
+  throw new Error('Unknown app type');
+}
+
+// Props type for Lab view components
+interface LabProps<T extends App> {
+  levelProps: LevelPropertiesMap[T];
+  initialSources: ProjectSources;
+}
+
+// Sample lab-specific views that use lab-specific props that are automatically typed
+const MusicLab: React.FC<LabProps<'music'>> = ({
+  levelProps,
+  initialSources,
+}) => {
+  return (
+    <div>{`Music Lab using lab-specific props! Library: ${levelProps.library}`}</div>
+  );
+};
+
+const PythonLab: React.FC<LabProps<'pythonlab'>> = ({
+  levelProps,
+  initialSources,
+}) => {
+  return (
+    <div>{`Python Lab using lab-specific props! Validation code: ${levelProps.validationCode}`}</div>
+  );
+};
+
+// Here we map each lab type to its view component (we could roll this into lab2EntryPoints)
+const AppTypeMap: {[K in App]?: React.FC<LabProps<K>>} = {
+  music: MusicLab,
+  pythonlab: PythonLab,
+};
+
+// Simple Lab Container view that loads level properties and renders the appropriate lab view
+const LabContainer: React.FC<{levelId: number}> = ({levelId}) => {
+  const [levelProps, setLevelProps] = useState<LevelPropertiesMap[App]>();
+
+  useEffect(() => {
+    // Reload data whenever level changes
+    loadData(levelId).then(setLevelProps);
+  }, [levelId]);
+
+  if (!levelProps) {
+    return null;
+  }
+
+  // Use the loaded level props to render the appropriate lab view
+  const appName = levelProps.appName;
+  const AppView = AppTypeMap[appName] as React.FC<LabProps<typeof appName>>;
+
+  return <AppView levelProps={levelProps} initialSources={{source: ''}} />;
+};
+
+export default LabContainer;


### PR DESCRIPTION
Some sample prototype code for how we might support auto-typing level properties for labs in Lab2. Uses some of the same ideas from https://github.com/code-dot-org/code-dot-org/pull/62523 in terms of loading level properties as part of the wrapper component's state instead of in redux, and passing level properties and initial sources as props instead of via redux. Inspired by discussion here: https://github.com/code-dot-org/code-dot-org/pull/62932#discussion_r1884142849

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
