### PR TITLE
Re-Enable Aurora Enhanced MySQL Binary Logging post Hour of Code

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -123,14 +123,14 @@
         # BEGIN: Static configuration settings.
         # WARNING - Changing these settings triggers restart of each database instance in the cluster during Stack Update.
 
-        binlog_format: 'OFF' # Disable binary logging during Hour of Code
+        binlog_format: 'ROW'
         gtid-mode: 'ON'
         enforce_gtid_consistency: 'ON'
 
-        # Disable Enhanced Binary Logging during Hour of Code
-        aurora_enhanced_binlog: 0
-        binlog_backup: 1
-        binlog_replication_globaldb: 1
+        # Enable Enhanced Binary Logging to support Zero-ETL Integration with Redshift
+        aurora_enhanced_binlog: 1
+        binlog_backup: 0
+        binlog_replication_globaldb: 0
         binlog_row_image: full # This is actually a dynamic setting, but let's keep all these settings together.
         binlog_row_metadata: full # Also dynamic.
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#62446

Re-enabling now that Hour of Code is complete. Enabling/disabling binary logging requires a restart of all database instances in a cluster, so we’re merging this now and deploying to production so that when we downscale the database instances (which requires a restart) the change will take effect.