### PR TITLE
Add eyes test for section switching on new dashboard

### DIFF
--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -191,6 +191,7 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
           selectedValue={String(selectedSection?.id)}
           className={styles.sectionDropdown}
           name="section-dropdown"
+          id="uitest-sidebar-section-dropdown"
           color="gray"
           disabled={isLoadingSectionData || !selectedSection}
         />

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -20,8 +20,6 @@ class SectionsController < ApplicationController
       return
     end
 
-    puts 'lfm'
-
     @section = existing_section.attributes
 
     @section['course'] = {

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -75,8 +75,8 @@ class TestController < ApplicationController
     return unless (user = current_user)
     script = Unit.find_by_name(params.require(:script_name))
 
-    Section.create!(name: "New Section", user: user, script: script, participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student)
-    head :ok
+    section = Section.create!(name: "New Section", user: user, script: script, participant_type: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.student)
+    render json: {section_code: section.code}
   end
 
   def create_student_section_with_name

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -56,12 +56,16 @@ Given(/^I am a teacher with student sections named Section 1 and Section 2/) do
   )
 end
 
-Given(/^I create a new student section assigned to "([^"]*)"$/) do |script_name|
-  browser_request(
-    url: '/api/test/create_student_section_assigned_to_script',
-    method: 'POST',
-    body: {script_name: script_name}
+Given(/^I create a new student section assigned to "([^"]*)"( and save the section)?$/) do |script_name, save|
+  response = JSON.parse(browser_request(
+                          url: '/api/test/create_student_section_assigned_to_script',
+                          method: 'POST',
+                          body: {script_name: script_name}
+    )
   )
+  if save
+    @section_url = "http://studio.code.org/join/#{response['section_code']}"
+  end
 end
 
 And /^I create a new "([^"]*)" student section with course "([^"]*)", version "([^"]*)"(?: and unit "([^"]*)")?$/ do |marketing_audience, assignment_family, version_year, secondary|

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
@@ -22,6 +22,13 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
     When I sign in as "Teacher_Sally" and go home
     And I get levelbuilder access
 
+    And I create a new student section assigned to "interactive-games-animations-2024" and save the section
+    Given I create a student named "Talia"
+    And I join the section
+
+    When I sign in as "Teacher_Sally" and go home
+    And I get levelbuilder access
+
     When I click selector "a:contains(Untitled Section)" once I see it to load a new page
 
     Then I wait until element "#ui-test-teacher-sidebar" is visible
@@ -32,7 +39,18 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
     And I wait until element "#ui-test-skeleton-progress-column" is not visible
     And I scroll to "#ui-test-lesson-header-10"
 
-    And I see no difference for "progress v2"
+    Then I see no difference for "progress v2 - first section"
+
+    Then I select the "New Section" option in dropdown "uitest-sidebar-section-dropdown"
+
+    Then I wait until element "#ui-test-teacher-sidebar" is visible
+
+    And I wait until element "h6:contains(Icon Key)" is visible
+    And I wait until element "#ui-test-progress-table-v2" is visible
+
+    And I wait until element "#ui-test-skeleton-progress-column" is not visible
+
+    Then I see no difference for "progress v2 - second section"
 
     And I close my eyes
 


### PR DESCRIPTION
Adds an eyes test that switches the section using the sidebar section dropdown on the progress page.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1429