### PR TITLE
Reduce Scope of `@i18n` Codeowners Entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,13 +6,6 @@
 # i18n #
 ########
 
-# Files containing internationalization strings
-/i18n/                     @code-dot-org/i18n
-/apps/i18n/                @code-dot-org/i18n
-/dashboard/config/locales/ @code-dot-org/i18n
-/pegasus/cache/i18n/       @code-dot-org/i18n
-/pegasus/sites.v3/*/i18n/  @code-dot-org/i18n
-
 # Scripts controlling the internationalization sync
 /bin/i18n/                  @code-dot-org/i18n
 


### PR DESCRIPTION
As discussed in the first Code Standards Working Group meeting, with guidance from @mgc1194 

In the interest of improving the I18n team's noise::signal ratio for automatically-tagged pull requests, remove entries from the codeowners file which will notify the team any time any developer adjusts any source string, leaving only those entries related to specific i18n functionality.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
