### PR TITLE
Stop setting primary_contact_info during multi-auth migration

### DIFF
--- a/dashboard/lib/services/user/multi_auth_migrator.rb
+++ b/dashboard/lib/services/user/multi_auth_migrator.rb
@@ -1,0 +1,67 @@
+module Services
+  module User
+    class MultiAuthMigrator < Services::Base
+      attr_reader :user, :provider
+
+      def initialize(user:)
+        @user = user
+        @provider = user.provider
+      end
+
+      def call
+        raise "Migration not implemented for provider #{provider}" unless provider_supported?
+
+        return true if user.migrated?
+
+        # Add the user's new auth option, but do not set it as primary contact info.
+        # Primary contact info will be set automatically in an after_create hook.
+        user.authentication_options = [migrated_auth_option] unless user.sponsored?
+
+        user.provider = 'migrated'
+        user.uid = nil
+        user.oauth_token = nil
+        user.oauth_token_expiration = nil
+        user.oauth_refresh_token = nil
+        user
+      end
+
+      private def oauth_provider?
+        AuthenticationOption::OAUTH_CREDENTIAL_TYPES.include?(provider)
+      end
+
+      private def provider_supported?
+        provider.nil? ||
+          %w(manual migrated sponsored).include?(provider) ||
+          oauth_provider?
+      end
+
+      private def oauth_token_json
+        token_fields = [:oauth_token, :oauth_token_expiration, :oauth_refresh_token]
+        if token_fields.any? {|f| user.send(f).present?}
+          return {
+            oauth_token: user.oauth_token,
+            oauth_token_expiration: user.oauth_token_expiration,
+            oauth_refresh_token: user.oauth_refresh_token
+          }.to_json
+        end
+      end
+
+      private def migrated_auth_option
+        ao = AuthenticationOption.new(
+          email: user.email,
+          hashed_email: user.hashed_email || '',
+        )
+        if oauth_provider?
+          ao.credential_type = provider
+          ao.authentication_id = user.uid
+          ao.data = oauth_token_json
+        elsif user.email.present? || user.hashed_email.present?
+          ao.credential_type = AuthenticationOption::EMAIL
+        else
+          return nil
+        end
+        ao
+      end
+    end
+  end
+end

--- a/dashboard/lib/user_multi_auth_helper.rb
+++ b/dashboard/lib/user_multi_auth_helper.rb
@@ -52,6 +52,11 @@ module UserMultiAuthHelper
   end
 
   def migrate_to_multi_auth
+    if DCDO.get('migration_service_enabled', false)
+      Services::User::MultiAuthMigrator.call(user: self)
+      return save!
+    end
+
     raise "Migration not implemented for provider #{provider}" unless
       provider.nil? ||
         %w(manual migrated sponsored).include?(provider) ||

--- a/dashboard/test/controllers/report_abuse_controller_test.rb
+++ b/dashboard/test/controllers/report_abuse_controller_test.rb
@@ -34,6 +34,7 @@ class ReportAbuseControllerTest < ActionController::TestCase
   test "signed in user can update abuse score when reporting not restricted to verified teachers" do
     @controller.stubs(:restrict_reporting_to_verified_teachers).returns(false)
     DCDO.stubs(:get).with('restrict_reporting_to_verified_teachers', false).returns(false)
+    DCDO.stubs(:get).with('migration_service_enabled', false).returns(false)
 
     user = create(:student)
     sign_in user

--- a/dashboard/test/integration/account_purger_test.rb
+++ b/dashboard/test/integration/account_purger_test.rb
@@ -33,6 +33,7 @@ class AccountPurgerIntegrationTest < ActionDispatch::IntegrationTest
   # We can purge a student in a section when they have a family name.
   test 'can purge a student account with a family name that is in a section' do
     DCDO.stubs(:get).with('family-name-features', false).returns(true)
+    DCDO.stubs(:get).with('migration_service_enabled', false).returns(false)
     user = create :young_student_with_teacher
 
     # Delete the user

--- a/dashboard/test/lib/services/user/multi_auth_migrator_test.rb
+++ b/dashboard/test/lib/services/user/multi_auth_migrator_test.rb
@@ -17,22 +17,62 @@ class Services::User::MultiAuthMigratorTest < ActiveSupport::TestCase
     context 'when already migrated' do
       let(:provider) {'migrated'}
 
-      it 'returns true' do
+      it 'is still migrated' do
         _(migrate).must_equal true
+        _(user.migrated?).must_equal true
       end
     end
 
     context 'when sponsored' do
       let(:provider) {'sponsored'}
 
-      it 'is still sponsored' do
+      it 'is migrated and still sponsored' do
         migrate
+        _(user.migrated?).must_equal true
         _(user.sponsored?).must_equal true
       end
 
       it 'does not add an auth option' do
         migrate
         _(user.authentication_options).must_be_empty
+      end
+    end
+
+    context 'when Google' do
+      let(:user) {build(:user, :google_sso_provider)}
+
+      it 'migrates the user' do
+        migrate
+        _(user.migrated?).must_equal true
+      end
+
+      it 'creates the correct auth option' do
+        migrate
+        _(user.authentication_options.first.credential_type).must_equal AuthenticationOption::GOOGLE
+        _(user.authentication_options.first.data).wont_be_nil
+      end
+
+      it 'sets legacy auth fields to nil' do
+        migrate
+        _(user.uid).must_be_nil
+        _(user.oauth_token).must_be_nil
+        _(user.oauth_token_expiration).must_be_nil
+        _(user.oauth_refresh_token).must_be_nil
+      end
+    end
+
+    context 'when Clever' do
+      let(:user) {build(:user, :clever_sso_provider)}
+
+      it 'migrates the user' do
+        migrate
+        _(user.migrated?).must_equal true
+      end
+
+      it 'creates the correct auth option' do
+        migrate
+        _(user.authentication_options.first.credential_type).must_equal AuthenticationOption::CLEVER
+        _(user.authentication_options.first.data).wont_be_nil
       end
     end
 

--- a/dashboard/test/lib/services/user/multi_auth_migrator_test.rb
+++ b/dashboard/test/lib/services/user/multi_auth_migrator_test.rb
@@ -76,6 +76,36 @@ class Services::User::MultiAuthMigratorTest < ActiveSupport::TestCase
       end
     end
 
+    context 'when Microsoft' do
+      let(:user) {build(:user, :microsoft_v2_sso_provider)}
+
+      it 'migrates the user' do
+        migrate
+        _(user.migrated?).must_equal true
+      end
+
+      it 'creates the correct auth option' do
+        migrate
+        _(user.authentication_options.first.credential_type).must_equal AuthenticationOption::MICROSOFT
+        _(user.authentication_options.first.data).wont_be_nil
+      end
+    end
+
+    context 'when Facebook' do
+      let(:user) {build(:user, :facebook_sso_provider)}
+
+      it 'migrates the user' do
+        migrate
+        _(user.migrated?).must_equal true
+      end
+
+      it 'creates the correct auth option' do
+        migrate
+        _(user.authentication_options.first.credential_type).must_equal AuthenticationOption::FACEBOOK
+        _(user.authentication_options.first.data).wont_be_nil
+      end
+    end
+
     context 'when provider is not supported' do
       let(:provider) {'foo_provider'}
 

--- a/dashboard/test/lib/services/user/multi_auth_migrator_test.rb
+++ b/dashboard/test/lib/services/user/multi_auth_migrator_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class Services::User::MultiAuthMigratorTest < ActiveSupport::TestCase
+  let(:described_instance) {described_class.new(user: user)}
+  let!(:user) {build(:user, provider: provider, encrypted_password: nil)}
+  let(:provider) {'manual'}
+
+  describe '#call' do
+    subject(:migrate) {described_instance.call}
+
+    it 'migrates user to multi auth' do
+      migrate
+      _(user.migrated?).must_equal true
+      _(user.authentication_options.first).wont_be_nil
+    end
+
+    context 'when already migrated' do
+      let(:provider) {'migrated'}
+
+      it 'returns true' do
+        _(migrate).must_equal true
+      end
+    end
+
+    context 'when sponsored' do
+      let(:provider) {'sponsored'}
+
+      it 'is still sponsored' do
+        migrate
+        _(user.sponsored?).must_equal true
+      end
+
+      it 'does not add an auth option' do
+        migrate
+        _(user.authentication_options).must_be_empty
+      end
+    end
+
+    context 'when provider is not supported' do
+      let(:provider) {'foo_provider'}
+
+      it 'raises an exception' do
+        error = _ {migrate}.must_raise RuntimeError
+        _(error.message).must_equal "Migration not implemented for provider #{provider}"
+      end
+    end
+  end
+end

--- a/dashboard/test/models/sections/clever_section_test.rb
+++ b/dashboard/test/models/sections/clever_section_test.rb
@@ -30,6 +30,7 @@ class CleverSectionTest < ActiveSupport::TestCase
   test 'from clever service with family name import' do
     DCDO.stubs(:get).with('clever_family_name', false).returns(true)
     DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
+    DCDO.stubs(:get).with('migration_service_enabled', false).returns(false)
 
     owner = create :teacher
     student_list = [

--- a/dashboard/test/models/sections/google_classroom_section_test.rb
+++ b/dashboard/test/models/sections/google_classroom_section_test.rb
@@ -4,6 +4,7 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
   test 'from google classroom service without family name import' do
     DCDO.stubs(:get).with('google_classroom_family_name', false).returns(false)
     DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
+    DCDO.stubs(:get).with('migration_service_enabled', false).returns(false)
 
     owner = create :teacher
     student_list = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(
@@ -46,6 +47,7 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
   test 'from google classroom service with family name import' do
     DCDO.stubs(:get).with('google_classroom_family_name', false).returns(true)
     DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(false)
+    DCDO.stubs(:get).with('migration_service_enabled', false).returns(false)
 
     owner = create :teacher
     student_list = Google::Apis::ClassroomV1::ListStudentsResponse.from_json(


### PR DESCRIPTION
Dupe oauth-based auth options and users have been popping up for a long time. The first error in HB is from 2020, but the duplicate auth options/users go back 6 years in the db. This PR aims to solve one area of the code that is causing these dupe users.

The [code that migrates users to multi-auth,](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/user_multi_auth_helper.rb#L63) which runs in a hook after users are created, explicitly sets the user's `primary_contact_info` to a new authentication option before saving the user. As we discovered with LTI, manually setting `primary_contact_info` around the same time as a user and authentication option are created can lead to duplicate records because of a circular dependency. Also, `primary_contact_info` is set automatically in a callback when a new `AuthenticationOption` is created, so it never needs to be set manually when new users are created.

This PR refactors the multi-auth migration code into its own service object and does not set the user's `primary_contact_info`. Instead, it relies on the `after_create` hook in the `AuthenticationOption` model to set it instead. This avoids the circular dependency.

The new service object is only called if a DCDO flag is set. Otherwise, the old code will run instead. Hoping this will reduce some of the risk since this change will affect all newly created users.

## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1167)

## Testing story

Had to stub the DCDO flag in some other tests that create users and also stub DCDO flags.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
