### PR TITLE
Lazy load Panels and Standalone Video

### DIFF
--- a/apps/src/aichat/index.js
+++ b/apps/src/aichat/index.js
@@ -1,3 +1,3 @@
-// This file allows us to lazily load the MusicView component.
+// This file allows us to lazily load the AichatView component.
 // Due to our configuration this needs to be in js so we can use dynamic imports.
 export {default as AichatView} from './views/AichatView';

--- a/apps/src/panels/entrypoint.ts
+++ b/apps/src/panels/entrypoint.ts
@@ -1,8 +1,14 @@
-import {OptionsToAvoid, Lab2EntryPoint} from '@cdo/apps/lab2/types';
-import PanelsLabView from '@cdo/apps/panels/PanelsLabView'; // avoid hardcoding imports like this in an entrypoint.tsx
+import {lazy} from 'react';
+
+import {Lab2EntryPoint} from '@cdo/apps/lab2/types';
 
 export const PanelsEntryPoint: Lab2EntryPoint = {
   backgroundMode: false,
-  view: OptionsToAvoid.UseHardcodedView_WARNING_Bloats_Lab2_Bundle,
-  hardcodedView: PanelsLabView,
+  view: lazy(() =>
+    import(/* webpackChunkName: "panels" */ './index.js').then(
+      ({PanelsLabView}) => ({
+        default: PanelsLabView,
+      })
+    )
+  ),
 };

--- a/apps/src/panels/index.js
+++ b/apps/src/panels/index.js
@@ -1,0 +1,3 @@
+// This file allows us to lazily load the PanelsLabView component.
+// Due to our configuration this needs to be in js so we can use dynamic imports.
+export {default as PanelsLabView} from './PanelsLabView';

--- a/apps/src/standaloneVideo/entrypoint.ts
+++ b/apps/src/standaloneVideo/entrypoint.ts
@@ -1,8 +1,14 @@
-import {OptionsToAvoid, Lab2EntryPoint} from '@cdo/apps/lab2/types';
-import StandaloneVideo from '@cdo/apps/standaloneVideo/StandaloneVideo'; // avoid hardcoding imports like this in an entrypoint.tsx
+import {lazy} from 'react';
+
+import {Lab2EntryPoint} from '@cdo/apps/lab2/types';
 
 export const StandaloneVideoEntryPoint: Lab2EntryPoint = {
   backgroundMode: false,
-  view: OptionsToAvoid.UseHardcodedView_WARNING_Bloats_Lab2_Bundle,
-  hardcodedView: StandaloneVideo,
+  view: lazy(() =>
+    import(/* webpackChunkName: "standaloneVideo" */ './index.js').then(
+      ({StandaloneVideo}) => ({
+        default: StandaloneVideo,
+      })
+    )
+  ),
 };

--- a/apps/src/standaloneVideo/index.js
+++ b/apps/src/standaloneVideo/index.js
@@ -1,0 +1,3 @@
+// This file allows us to lazily load the StandaloneVideo component.
+// Due to our configuration this needs to be in js so we can use dynamic imports.
+export {default as StandaloneVideo} from './StandaloneVideo';


### PR DESCRIPTION
Continuing from https://github.com/code-dot-org/code-dot-org/pull/62915. Lazy loads Panels and Standalone Video labs as part of converting all Lab2 labs to use lazy loading.

Before:
<img width="1512" alt="Screenshot 2024-12-16 at 3 32 11 PM" src="https://github.com/user-attachments/assets/2861fea1-715d-448c-96cf-0375005ea7ee" />

After:
<img width="1512" alt="Screenshot 2024-12-16 at 3 30 43 PM" src="https://github.com/user-attachments/assets/040858d1-6255-4ab0-92ca-ecc85d313b5c" />

## Testing story

Compared bundle sizes and checked which files were loaded.