### PR TITLE
Start/stop animation preview in Game Lab on focus/blur

### DIFF
--- a/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
@@ -51,7 +51,8 @@ export default class AnimationPreview extends React.Component {
 
   componentDidUpdate(prevProps) {
     // Only start/stop animations via focus if there is no playBehavior set.
-    // The playBehavior props sets the animation to always play or never play.
+    // If set, the playBehavior prop sets the animation to 'ALWAYS_PLAY' or 'NEVER_PLAY',
+    // which determines if animation preview should play and should not be overridden by the focus state.
     if (
       !prevProps.isFocused &&
       this.props.isFocused &&

--- a/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
@@ -193,7 +193,7 @@ export default class AnimationPreview extends React.Component {
       /*
         The behavior managed by the onMouseOver and onMouseOut handlers is replicated on focus and blur
         in the componentDidUpdate lifecycle method for accessibility purposes.
-        This div is never actually focused, so using native onFocus and onBlur handlers is . 
+        This div is never actually focused, so using native onFocus and onBlur handlers doesn't work without substantial changes. 
         We include no-op onFocus and onBlur handlers to suppress a11y linter errors.
       */
       <div

--- a/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
@@ -50,16 +50,18 @@ export default class AnimationPreview extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
+    // Only start/stop animations via focus if there is no playBehavior set.
+    // The playBehavior props sets the animation to always play or never play.
     if (
       !prevProps.isFocused &&
       this.props.isFocused &&
-      this.props.playBehavior !== PlayBehavior.NEVER_PLAY
+      !this.props.playBehavior
     ) {
       this.advanceFrame();
     } else if (
       prevProps.isFocused &&
       !this.props.isFocused &&
-      this.props.playBehavior !== PlayBehavior.NEVER_PLAY
+      !this.props.playBehavior
     ) {
       this.stopAndResetAnimation();
     }

--- a/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
@@ -21,6 +21,7 @@ export default class AnimationPreview extends React.Component {
       PlayBehavior.NEVER_PLAY,
     ]),
     onPreviewLoad: PropTypes.func,
+    isFocused: PropTypes.bool,
   };
 
   state = {
@@ -43,6 +44,22 @@ export default class AnimationPreview extends React.Component {
     } else if (
       nextProps.playBehavior !== PlayBehavior.ALWAYS_PLAY &&
       this.timeout_
+    ) {
+      this.stopAndResetAnimation();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      !prevProps.isFocused &&
+      this.props.isFocused &&
+      this.props.playBehavior !== PlayBehavior.NEVER_PLAY
+    ) {
+      this.advanceFrame();
+    } else if (
+      prevProps.isFocused &&
+      !this.props.isFocused &&
+      this.props.playBehavior !== PlayBehavior.NEVER_PLAY
     ) {
       this.stopAndResetAnimation();
     }
@@ -171,6 +188,12 @@ export default class AnimationPreview extends React.Component {
     }
 
     return (
+      /*
+        The behavior managed by the onMouseOver and onMouseOut handlers is replicated on focus and blur
+        in the componentDidUpdate lifecycle method for accessibility purposes.
+        This div is never actually focused, so using native onFocus and onBlur handlers is . 
+        We include no-op onFocus and onBlur handlers to suppress a11y linter errors.
+      */
       <div
         ref="root"
         style={containerStyle}
@@ -184,6 +207,8 @@ export default class AnimationPreview extends React.Component {
             ? this.onMouseOut
             : null
         }
+        onFocus={() => {}}
+        onBlur={() => {}}
       >
         <div style={cropStyle}>
           {

--- a/apps/src/p5lab/AnimationTab/AnimationListItem.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationListItem.jsx
@@ -60,6 +60,7 @@ class AnimationListItem extends React.Component {
       frameDelay: frameDelay,
       name: name,
       isNameValid: true,
+      isFocused: false,
     };
   }
 
@@ -86,6 +87,14 @@ class AnimationListItem extends React.Component {
       );
     }, 200);
   }
+
+  onFocus = () => {
+    this.setState({isFocused: true});
+  };
+
+  onBlur = () => {
+    this.setState({isFocused: false});
+  };
 
   onSelect = () => {
     if (this.props.interfaceMode === P5LabInterfaceMode.BACKGROUND) {
@@ -184,14 +193,17 @@ class AnimationListItem extends React.Component {
   };
 
   render() {
-    const {allAnimationsSingleFrame, isSelected, isSpriteLab, labType, style} =
+    const {allAnimationsSingleFrame, isSpriteLab, labType, style, isSelected} =
       this.props;
+
     const animationProps = Object.assign(
       {},
       this.getAnimationProps(this.props),
       {frameDelay: this.state.frameDelay}
     );
-    const name = this.state.name;
+
+    const {name, isFocused} = this.state;
+
     let animationName;
     if (isSelected) {
       let invalidNameStyle = this.state.isNameValid
@@ -217,12 +229,19 @@ class AnimationListItem extends React.Component {
     const arrowStyle = isSelected ? styles.rightArrow : {};
 
     return (
-      <button style={tileStyle} onClick={this.onSelect} type="button">
+      <button
+        style={tileStyle}
+        onClick={this.onSelect}
+        onFocus={this.onFocus}
+        onBlur={this.onBlur}
+        type="button"
+      >
         <div style={arrowStyle} />
         <ListItemThumbnail
           ref="thumbnail"
           animationProps={animationProps}
           isSelected={isSelected}
+          isFocused={isFocused}
           singleFrameAnimation={allAnimationsSingleFrame}
         />
         {!isSpriteLab && animationName}

--- a/apps/src/p5lab/AnimationTab/ListItemThumbnail.jsx
+++ b/apps/src/p5lab/AnimationTab/ListItemThumbnail.jsx
@@ -51,6 +51,7 @@ export default class ListItemThumbnail extends React.Component {
     singleFrameAnimation: PropTypes.bool.isRequired,
     index: PropTypes.number,
     isSelected: PropTypes.bool,
+    isFocused: PropTypes.bool,
   };
 
   state = {previewSize: 0};
@@ -88,6 +89,7 @@ export default class ListItemThumbnail extends React.Component {
           (this.props.isSelected ? color.purple : color.light_gray),
       },
     });
+
     let playBehavior;
     if (this.props.singleFrameAnimation) {
       playBehavior = PlayBehavior.NEVER_PLAY;
@@ -104,6 +106,7 @@ export default class ListItemThumbnail extends React.Component {
             width={this.state.previewSize}
             height={this.state.previewSize}
             playBehavior={playBehavior}
+            isFocused={this.props.isFocused}
           />
           {this.getIndexBubble()}
         </div>


### PR DESCRIPTION
In the animation picker in Game Lab, the animation previews on hover and stops previewing when your cursor leaves the animation. This is an accessibility no-no, as these previews are then unavailable to folks using tab navigation.

This PR updates the animation picker so that the preview plays if you tab into the animation, and stops playing when you tab out (see video below).

The linter rule is strictly still violated with my implementation, so I added no-op handlers and comments to describe why they're there. I also turned off the linter rule briefly and saw that the violation is no longer given.

<details>
  <summary><b>Video of updated experience</b></summary>
  <video src='https://github.com/user-attachments/assets/8491afc6-45a0-4eae-b462-6216bd98e5c0' />
</details>

## Links

- jira ticket: [A11Y-340](https://codedotorg.atlassian.net/browse/A11Y-340)

## Testing story

Tested manually that animations (eg, the flower animation in the video above) and static images (eg, the "blocks" image above) were appropriately turned on/off and unaffected, respectively, via tab navigation.