### PR TITLE
A11y-318: Fix form label in Java Lab prompter (plus more)

### DIFF
--- a/apps/src/javalab/components/PhotoSelectionView.jsx
+++ b/apps/src/javalab/components/PhotoSelectionView.jsx
@@ -1,8 +1,10 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
-import color from '@cdo/apps/util/color';
+
+import moduleStyles from './photo-selection-view.module.scss';
 
 const photoInputId = 'photoInput';
 
@@ -20,18 +22,24 @@ export default function PhotoSelectionView({
   };
 
   return (
-    <label htmlFor={photoInputId} style={{...styles.container, ...style}}>
+    <label
+      htmlFor={photoInputId}
+      className={moduleStyles.container}
+      style={style}
+    >
       <input
         id={photoInputId}
-        className="uitest-hidden-uploader"
+        className={classNames(
+          'uitest-hidden-uploader',
+          moduleStyles.hiddenInput
+        )}
         type="file"
         accept="image/*"
         capture="camera"
-        hidden={true}
         onChange={onInputChange}
       />
-      <FontAwesomeV6Icon iconName="camera" style={styles.camera} />
-      <div style={styles.prompt}>{promptText}</div>
+      <FontAwesomeV6Icon iconName="camera" className={moduleStyles.camera} />
+      <div className={moduleStyles.prompt}>{promptText}</div>
     </label>
   );
 }
@@ -47,22 +55,4 @@ PhotoSelectionView.propTypes = {
   promptText: PropTypes.string,
   /** Optional. Additional styles to apply to the component */
   style: PropTypes.object,
-};
-
-const styles = {
-  container: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 20,
-    backgroundColor: color.black,
-  },
-  camera: {
-    fontSize: 48,
-  },
-  prompt: {
-    textColor: color.white,
-    textAlign: 'center',
-  },
 };

--- a/apps/src/javalab/components/PhotoSelectionView.jsx
+++ b/apps/src/javalab/components/PhotoSelectionView.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import color from '@cdo/apps/util/color';
 
 const photoInputId = 'photoInput';
@@ -19,24 +20,19 @@ export default function PhotoSelectionView({
   };
 
   return (
-    <div style={{...styles.container, ...style}}>
-      <label
-        htmlFor={photoInputId}
-        className="fa fa-camera"
-        style={styles.label}
-      >
-        <input
-          id={photoInputId}
-          className="uitest-hidden-uploader"
-          type="file"
-          accept="image/*"
-          capture="camera"
-          hidden={true}
-          onChange={onInputChange}
-        />
-      </label>
+    <label htmlFor={photoInputId} style={{...styles.container, ...style}}>
+      <input
+        id={photoInputId}
+        className="uitest-hidden-uploader"
+        type="file"
+        accept="image/*"
+        capture="camera"
+        hidden={true}
+        onChange={onInputChange}
+      />
+      <FontAwesomeV6Icon iconName="camera" style={styles.camera} />
       <div style={styles.prompt}>{promptText}</div>
-    </div>
+    </label>
   );
 }
 
@@ -62,10 +58,11 @@ const styles = {
     padding: 20,
     backgroundColor: color.black,
   },
-  label: {
+  camera: {
     fontSize: 48,
   },
   prompt: {
     textColor: color.white,
+    textAlign: 'center',
   },
 };

--- a/apps/src/javalab/components/PhotoSelectionView.jsx
+++ b/apps/src/javalab/components/PhotoSelectionView.jsx
@@ -29,10 +29,7 @@ export default function PhotoSelectionView({
     >
       <input
         id={photoInputId}
-        className={classNames(
-          'uitest-hidden-uploader',
-          moduleStyles.hiddenInput
-        )}
+        className={classNames('uitest-hidden-uploader')}
         type="file"
         accept="image/*"
         capture="camera"

--- a/apps/src/javalab/components/photo-selection-view.module.scss
+++ b/apps/src/javalab/components/photo-selection-view.module.scss
@@ -6,6 +6,14 @@
   align-items: center;
   padding: 20px;
   background-color: $black;
+
+  // We hide the input element because we use the label to trigger the file picker
+  // We use opacity 0 and height 0 rather than hidden so the input is still tabbable.
+  input[type="file"] {
+    opacity: 0;
+    height: 0;
+    line-height: 0;
+  }
 }
 
 .camera {
@@ -19,6 +27,3 @@
   margin-top: 4px;
 }
 
-.hiddenInput {
-  opacity: 0;
-}

--- a/apps/src/javalab/components/photo-selection-view.module.scss
+++ b/apps/src/javalab/components/photo-selection-view.module.scss
@@ -1,0 +1,24 @@
+@import 'color';
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  background-color: $black;
+}
+
+.camera {
+  font-size: 48px;
+}
+
+.prompt {
+  color: $white;
+  text-align: center;
+  font-size: 13px;
+  margin-top: 4px;
+}
+
+.hiddenInput {
+  opacity: 0;
+}

--- a/apps/test/unit/javalab/components/PhotoSelectionViewTest.js
+++ b/apps/test/unit/javalab/components/PhotoSelectionViewTest.js
@@ -20,7 +20,7 @@ describe('PhotoSelectionView', () => {
       />
     );
 
-    expect(wrapper.text()).toBe(promptText);
+    expect(wrapper.text()).toContain(promptText);
   });
 
   it('invokes onPhotoSelected callback after photo is selected', () => {


### PR DESCRIPTION
This covers the ticket [A11Y-318](https://codedotorg.atlassian.net/browse/A11Y-318), which was that the Java Lab prompter has a label without an associated control. While working on this I also fixed another accessibility issue with the prompter, and moved the styles to a css file since I was already updating the styles.

In case you haven't seen the prompter, when a program uses the prompter, we temporarily show this over the console:
![Screenshot 2024-12-17 at 10 34 59 AM](https://github.com/user-attachments/assets/65b90e3c-bed8-43bf-b9a6-4feab3c0ddf6)

Previously, the prompter had a hidden file input, and the label itself was a font awesome icon of a camera. Below the label was the text "Upload an image!" Only the camera icon was clickable to pull up the file uploader, and the camera icon was not tabbable.

The accessibility error was occuring because there was no text label inside the label tag, only the hidden input. To fix this, I moved the "Upload an image!" text to be inside the `<label>` tag rather than outside of it.

However, neither the text nor the icon were tabbable at this point. To fix this, I changed the input element from hidden to have 0 opacity and 0 height, so it still exists on the page.

A side benefit of these changes is now you can click anywhere on the console while the prompter is up to open the file browser, rather than having to click on the camera icon only. It's also tabbable! 

There is a tiny eyes diff with this change with the scroll bar changing height slightly. This didn't seem worth trying to make match perfectly, we can accept the new eyes change when it comes in.

![Screenshot 2024-12-17 at 10 32 33 AM](https://github.com/user-attachments/assets/91d968d8-2eea-4739-8ce0-7ecc9d729135)

## Links

- jira ticket: [A11Y-318](https://codedotorg.atlassian.net/browse/A11Y-318)


## Testing story
Tested locally and via the prompter eyes test.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
