### PR TITLE
[Music] Next connection mutator and context menu option for levelbuilder

### DIFF
--- a/apps/src/blockly/addons/contextMenu.ts
+++ b/apps/src/blockly/addons/contextMenu.ts
@@ -18,6 +18,7 @@ import {
   NAVIGATION_CURSOR_TYPES,
   DARK_THEME_SUFFIX,
 } from '../constants';
+import {ExtendedBlockSvg} from '../types';
 import {getBaseName} from '../utils';
 
 // Some options are only available to levelbuilders via start mode.
@@ -77,6 +78,42 @@ const registerMovable = function (weight: number) {
   GoogleBlockly.ContextMenuRegistry.registry.register(movableOption);
 };
 
+const registerNextConnection = function (weight: number) {
+  const nextConnectionOption = {
+    displayText: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      const block = scope.block;
+      if (!block) {
+        return '';
+      }
+      const displayText = `${
+        block.nextConnection ? 'Disable' : 'Enable'
+      } Next Connection`;
+      return displayText;
+    },
+    preconditionFn: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      const block = scope.block as ExtendedBlockSvg;
+
+      // This option requires a custom mutator in order to serialize the disabled connection.
+      if (Blockly.isStartMode && block?.canSerializeNextConnection) {
+        return MenuOptionStates.ENABLED;
+      }
+      return MenuOptionStates.HIDDEN;
+    },
+    callback: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
+      const block = scope.block;
+      if (!block) {
+        return;
+      }
+      block.nextConnection?.disconnect();
+      block.setNextStatement(!block.nextConnection);
+    },
+    scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.BLOCK,
+    id: 'nextConnection',
+    weight,
+  };
+  GoogleBlockly.ContextMenuRegistry.registry.register(nextConnectionOption);
+};
+
 const registerEditable = function (weight: number) {
   const editableOption = {
     displayText: function (scope: GoogleBlockly.ContextMenuRegistry.Scope) {
@@ -124,6 +161,7 @@ const registerShadow = function (weight: number) {
   };
   GoogleBlockly.ContextMenuRegistry.registry.register(shadowOption);
 };
+
 const registerUnshadow = function (weight: number) {
   const unshadowOption = {
     // If there's 1 child, text should be 'Make Child Block Non-Shadow'
@@ -526,6 +564,7 @@ function registerCustomBlockOptions() {
   registerHelp(nextWeight++);
   registerDeletable(nextWeight++);
   registerMovable(nextWeight++);
+  registerNextConnection(nextWeight++);
   registerEditable(nextWeight++);
   registerShadow(nextWeight++);
   registerUnshadow(nextWeight++);

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/commonProcedureCallerMutator.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/commonProcedureCallerMutator.ts
@@ -26,6 +26,9 @@ export const commonFunctions = {
     if (model.getParameters().length) {
       state['params'] = model.getParameters().map(p => p.getName());
     }
+    if (!this.nextConnection) {
+      state['disableNextConnection'] = true;
+    }
     return state;
   },
 
@@ -39,6 +42,9 @@ export const commonFunctions = {
   loadExtraState: function (this: ProcedureBlock, state: Record<string, any>) {
     this.behaviorId = state['behaviorId'];
     this.deserialize_(state['name'], state['params'] || []);
+    if (state['disableNextConnection']) {
+      this.setNextStatement(false);
+    }
   },
 
   /**
@@ -61,4 +67,6 @@ export const commonFunctions = {
     }
     this.paramsFromSerializedState_ = params;
   },
+
+  canSerializeNextConnection: true,
 };

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -190,6 +190,7 @@ export type GoogleBlocklyInstance = typeof GoogleBlockly;
 // types and can cast to them when needed.
 
 export interface ExtendedBlockSvg extends GoogleBlockly.BlockSvg {
+  canSerializeNextConnection?: boolean;
   isVisible: () => boolean;
   isUserVisible: () => boolean;
   shouldBeGrayedOut: () => boolean;

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -19,6 +19,7 @@ import {
   FIELD_EFFECT_NAME_OPTIONS,
   FIELD_SOUNDS_VALIDATOR,
   FIELD_PATTERNS_VALIDATOR,
+  NEXT_CONNECTION_MUTATOR,
 } from '../constants';
 import {
   fieldSoundsDefinition,
@@ -110,6 +111,7 @@ export const playSoundAtCurrentLocationSimple2 = {
     tooltip: musicI18n.blockly_blockPlaySoundTooltip(),
     helpUrl: DOCS_BASE_URL + 'play_sample',
     extensions: [FIELD_SOUNDS_VALIDATOR],
+    mutator: NEXT_CONNECTION_MUTATOR,
   },
   generator: block =>
     `Sequencer.playSound("${block.getFieldValue(FIELD_SOUNDS_NAME)}", "${
@@ -129,6 +131,7 @@ export const playPatternAtCurrentLocationSimple2 = {
     tooltip: musicI18n.blockly_blockPlayPatternTooltip(),
     helpUrl: DOCS_BASE_URL + 'play_pattern',
     extensions: [FIELD_PATTERNS_VALIDATOR],
+    mutator: NEXT_CONNECTION_MUTATOR,
   },
   generator: block =>
     `Sequencer.playPattern(${JSON.stringify(
@@ -157,6 +160,7 @@ export const playPatternAiAtCurrentLocationSimple2 = {
     tooltip: musicI18n.blockly_blockPlayPatternAiTooltip(),
     helpUrl: DOCS_BASE_URL + 'play_pattern_ai',
     extensions: [FIELD_PATTERNS_VALIDATOR],
+    mutator: NEXT_CONNECTION_MUTATOR,
   },
   generator: block =>
     `Sequencer.playPattern(${JSON.stringify(
@@ -175,6 +179,7 @@ export const playChordAtCurrentLocationSimple2 = {
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockPlayChordTooltip(),
     helpUrl: DOCS_BASE_URL + 'play_keys',
+    mutator: NEXT_CONNECTION_MUTATOR,
   },
   generator: block =>
     `Sequencer.playChord(${JSON.stringify(
@@ -193,6 +198,7 @@ export const playTuneAtCurrentLocationSimple2 = {
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockPlayTuneTooltip(),
     helpUrl: DOCS_BASE_URL + 'play_tune',
+    mutator: NEXT_CONNECTION_MUTATOR,
   },
   generator: block =>
     `Sequencer.playTune(${JSON.stringify(
@@ -265,6 +271,7 @@ export const playSoundsTogether = {
     style: 'logic_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundsTogether(),
     helpUrl: DOCS_BASE_URL + 'play_together',
+    mutator: NEXT_CONNECTION_MUTATOR,
   },
   generator: block =>
     ` Sequencer.playTogether();
@@ -300,6 +307,7 @@ export const playSoundsSequential = {
     style: 'logic_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundsSequentialTooltip(),
     helpUrl: DOCS_BASE_URL + 'play_sequential',
+    mutator: NEXT_CONNECTION_MUTATOR,
   },
   generator: block =>
     ` Sequencer.playSequential();
@@ -326,6 +334,7 @@ export const playSoundsRandom = {
     style: 'logic_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundsRandomTooltip(),
     helpUrl: DOCS_BASE_URL + 'play_random',
+    mutator: NEXT_CONNECTION_MUTATOR,
   },
   generator: block => {
     const resultArray = [];
@@ -380,6 +389,7 @@ export const repeatSimple2 = {
     style: 'loop_blocks',
     tooltip: Blockly.Msg['CONTROLS_REPEAT_TOOLTIP'],
     helpUrl: DOCS_BASE_URL + 'repeat',
+    mutator: NEXT_CONNECTION_MUTATOR,
   },
   generator: block => {
     const repeats = block.getFieldValue('times');

--- a/apps/src/music/blockly/constants.js
+++ b/apps/src/music/blockly/constants.js
@@ -7,6 +7,7 @@ export const FIELD_EFFECTS_EXTENSION = 'field_effects_extension';
 export const FIELD_PATTERNS_VALIDATOR = 'field_patterns_extensions';
 export const FIELD_SOUNDS_VALIDATOR = 'field_sounds_validator';
 export const PLAY_MULTI_MUTATOR = 'play_multi_mutator';
+export const NEXT_CONNECTION_MUTATOR = 'next_connection_mutator';
 
 // Field / Input Names
 

--- a/apps/src/music/blockly/extensions.js
+++ b/apps/src/music/blockly/extensions.js
@@ -123,6 +123,23 @@ export const playMultiMutator = {
 };
 
 /*
+ * Mutator for blocks that support disabling the next connection.
+ */
+export const nextConnectionMutator = {
+  saveExtraState: function () {
+    return {
+      disableNextConnection: !this.nextConnection,
+    };
+  },
+  loadExtraState: function (state) {
+    if (state.disableNextConnection) {
+      this.setNextStatement(false);
+    }
+  },
+  canSerializeNextConnection: true,
+};
+
+/*
  * Extension for the effects field, which replaces the input_dummy in the block
  * with a dynamic field_dropdown and updates the effect value dropdown
  * based on the selected effect name.

--- a/apps/src/music/blockly/setup.ts
+++ b/apps/src/music/blockly/setup.ts
@@ -12,6 +12,7 @@ import {
   FIELD_EFFECTS_EXTENSION,
   FIELD_SOUNDS_VALIDATOR,
   FIELD_PATTERNS_VALIDATOR,
+  NEXT_CONNECTION_MUTATOR,
 } from './constants';
 import {
   getDefaultTrackNameExtension,
@@ -19,6 +20,7 @@ import {
   effectsFieldExtension,
   fieldSoundsValidator,
   fieldPatternsValidator,
+  nextConnectionMutator,
 } from './extensions';
 import FieldChord from './FieldChord';
 import FieldPattern from './FieldPattern';
@@ -44,6 +46,10 @@ export function setUpBlocklyForMusicLab() {
   Blockly.Extensions.register(FIELD_SOUNDS_VALIDATOR, fieldSoundsValidator);
   Blockly.Extensions.register(FIELD_PATTERNS_VALIDATOR, fieldPatternsValidator);
   Blockly.Extensions.registerMutator(PLAY_MULTI_MUTATOR, playMultiMutator);
+  Blockly.Extensions.registerMutator(
+    NEXT_CONNECTION_MUTATOR,
+    nextConnectionMutator
+  );
 
   // Needed for TypeScript to recognize the type of the MUSIC_BLOCKS. Remove
   // after converting musicBlocks to TypeScript.


### PR DESCRIPTION
In October, we defined a variant of the `play together` block which does not have a [next connection](https://developers.google.com/blockly/guides/create-custom-blocks/define-blocks#next_connection): https://github.com/code-dot-org/code-dot-org/pull/61578

The purpose of this block was to prevent students from adding code below the intended last block of the starter program in the new HoC lesson.

Later, we considered a similar solution for `play sound` variant block, with hopes that it could help prevent students from writing recursive programs in the new HoC lesson. This was not merged, in part due to the restricted deploy window and in part due an interest from engineers in finding a more general solution.
https://github.com/code-dot-org/code-dot-org/pull/62836

Most recently, the K5 curriculum team requested a variant to the simple `repeat` loop block that works the same way.

Drawbacks to variant blocks:
* Eng needs to maintain two separate definitions for nearly identical blocks (due to projects and levels using both types)
* Curric needs to understand the difference between the normal and variant blocks
* The variant blocks can only be added to a level's start sources JSON (no options in Start Mode)

CDO Blockly supports dynamically removing the next connection of a block by using a levelbuilder-only [context menu option](https://github.com/code-dot-org/blockly/blob/v4.1.0/core/ui/block.js#L1053-L1064):
<img width="471" alt="image" src="https://github.com/user-attachments/assets/fb8e97df-6948-4a11-ac91-a67d92882f9d" />
The custom block method [`setNextConnectionDisabled`](https://github.com/code-dot-org/blockly/blob/v4.1.0/core/ui/block.js#L1962-L1973) works by setting `block.nextConnectionDisabled_`. This is then read by `block.isNextConnectionDisabled()` as part of the serialization of every block via `blockToDom`. If the block XML includes a `'next_connection_disabled'` attribute, the next connection is toggled as needed during deserialization via `domToBlock`.

Migrating this feature in full would require patching several functions that we don't have easy access to, and that would just be for XML. While we have successfully monkey-patched `BlockSvg` and wrapped `domToBlock` (and the JSON equivalent) for other purposes, it's something we should avoid where possible.

This branch adds a context menu option that has some of the same features. It will immediately toggle the presence of the next connection for a block by calling `block.setNextStatement` directly. In order for serialization to work correctly, I defined a new mutator extension (including JSON hooks `loadExtraState` and `saveExtraState` which are Blockly-supported methods). Because we are not patching the main block serialization system, these hooks need to be added to the definition of each block type that should support this feature. For more complex blocks that already have these hooks (e.g. function call blocks), we can achieve the same thing by adding the necessary logic to the existing mutator.

The mutator also provides these blocks with a `canSerializeNextConnection: true` flag. This flag is read by the context menu option to determine whether it should be displayed or hidden. 

With these changes, a levelbuilder will be able to enter start-mode and toggle the next connection of certain blocks off or on:
<img width="45%" alt="image" src="https://github.com/user-attachments/assets/77592a12-10b0-4299-a880-27a3c991e18e" /><img width="45%" alt="image" src="https://github.com/user-attachments/assets/bce4c6d0-542a-44e9-b807-e0d69bccdfa7" />

This setting persists to the student experience, although the menu option is not available there.

The following Simple2 blocks are supported:
|![image (253)](https://github.com/user-attachments/assets/757d9b66-6952-4429-895e-dc058874a381)|![image (254)](https://github.com/user-attachments/assets/94fe09fd-42e7-4fbd-babe-690cfff35127)|![image (255)](https://github.com/user-attachments/assets/90aa7ad9-c8fc-42a0-8c5d-3070b50e6d71)|
|-|-|-|

This intentional excludes the blocks `rest`, `triggered` (event), and `set effect` as its thought that disabling the next connection doesn't really make sense for those cases.

## Links

Slack thread: https://codedotorg.slack.com/archives/C04TH8400AU/p1733943688385099
Jira: https://codedotorg.atlassian.net/browse/LABS-1303

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## Follow-up work

If other blocks need to support this feature, we can enable this by adding the new custom mutator to their definition, or in cases where there is already a custom mutator, modifying it to handle that state.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
