### PR TITLE
Remove references to a staging-next deployed environment

### DIFF
--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -261,7 +261,7 @@ module Cdo
     end
 
     # Identify whether we are executing on the managed test system (test.code.org / test-studio.code.org)
-    # to ensure that other systems (such as staging-next or Continuous Integration builds) that are operating
+    # to ensure that other systems (such as Continuous Integration builds) that are operating
     # with RACK_ENV=test do not carry out actions on behalf of the managed test system.
     def test_system?
       rack_env?(:test) && pegasus_hostname == 'test.code.org'

--- a/lib/cdo/developers_topic.rb
+++ b/lib/cdo/developers_topic.rb
@@ -4,13 +4,11 @@ require 'cdo/slack'
 module DevelopersTopic
   BRANCH_PREFIXES = {
     staging: 'DTS: ',
-    'staging-next': 'DTSN: ',
     test: 'DTT: ',
     production: 'DTP: ',
     levelbuilder: 'DTL: '
   }.freeze
   STAGING = 'staging'.freeze
-  STAGING_NEXT = 'staging-next'.freeze
   TEST = 'test'.freeze
   PRODUCTION = 'production'.freeze
   LEVELBUILDER = 'levelbuilder'.freeze
@@ -29,11 +27,6 @@ module DevelopersTopic
   # @return [Boolean] Whether DTS is yes.
   def self.dts?
     branch_open_for_merge? STAGING
-  end
-
-  # @return [Boolean] Whether DTSN is yes.
-  def self.dtsn?
-    branch_open_for_merge? STAGING_NEXT
   end
 
   # @return [Boolean] Whether DTT is yes.
@@ -55,12 +48,6 @@ module DevelopersTopic
   # @raise [RuntimeError] If the existing DTS topic does not specify a message.
   def self.dts
     branch_message STAGING
-  end
-
-  # @return [String] The DTSN portion of the room topic.
-  # @raise [RuntimeError] If the existing DTS topic does not specify a message.
-  def self.dtsn
-    branch_message STAGING_NEXT
   end
 
   # @return [String] The DTT portion of the room topic.
@@ -87,12 +74,6 @@ module DevelopersTopic
     set_branch_message STAGING, message
   end
 
-  # @param new_subtopic [String] The string to which DTSN should be set.
-  # @raise [RuntimeError] If the existing DTSN topic does not specify a message.
-  def self.set_dtsn(message)
-    set_branch_message STAGING_NEXT, message
-  end
-
   # @param message [String] The string to which DTT should be set.
   # @raise [RuntimeError] If the existing DTT topic does not specify a message.
   def self.set_dtt(message)
@@ -113,7 +94,7 @@ module DevelopersTopic
 
   private_class_method def self.get_room_for_branch(branch)
     case branch
-    when STAGING, STAGING_NEXT
+    when STAGING
       DEVELOPERS_ROOM
     when TEST, PRODUCTION, LEVELBUILDER
       DEPLOY_STATUS_ROOM

--- a/lib/cdo/github.rb
+++ b/lib/cdo/github.rb
@@ -11,11 +11,9 @@ module GitHub
   DASHBOARD_DB_DIR = 'dashboard/db/'.freeze
   PEGASUS_DB_DIR = 'pegasus/migrations/'.freeze
   STAGING_BRANCH = 'staging'.freeze
-  STAGING_NEXT_BRANCH = 'staging-next'.freeze
   STATUS_SUCCESS = 'success'.freeze
   STATUS_FAILURE = 'failure'.freeze
   STATUS_CONTEXT = 'DTS'.freeze
-  STATUS_CONTEXT_DTSN = 'DTSN'.freeze
 
   # Configures Octokit with our GitHub access token.
   # @raise [RuntimeError] If CDO.github_access_token is not defined.
@@ -335,42 +333,6 @@ module GitHub
     Octokit.pulls(REPO, base: STAGING_BRANCH)
     paged_for_each(Octokit.last_response) do |pull|
       set_dts_check_fail(pull)
-    end
-  end
-
-  def self.set_dtsn_check_pass(pull)
-    Octokit.create_status(
-      pull['base']['repo']['full_name'],
-      pull['head']['sha'],
-      STATUS_SUCCESS,
-      context: STATUS_CONTEXT_DTSN,
-      description: 'The staging-next branch is open.'
-    )
-  end
-
-  def self.set_all_dtsn_check_pass
-    configure_octokit
-    Octokit.pulls(REPO, base: STAGING_NEXT_BRANCH)
-    paged_for_each(Octokit.last_response) do |pull|
-      set_dtsn_check_pass(pull)
-    end
-  end
-
-  def self.set_dtsn_check_fail(pull)
-    Octokit.create_status(
-      pull['base']['repo']['full_name'],
-      pull['head']['sha'],
-      STATUS_FAILURE,
-      context: STATUS_CONTEXT_DTSN,
-      description: 'The staging-next branch is closed. Check #developers.'
-    )
-  end
-
-  def self.set_all_dtsn_check_fail
-    configure_octokit
-    Octokit.pulls(REPO, base: STAGING_NEXT_BRANCH)
-    paged_for_each(Octokit.last_response) do |pull|
-      set_dtsn_check_fail(pull)
     end
   end
 

--- a/pegasus/routes/dev/dev_routes.rb
+++ b/pegasus/routes/dev/dev_routes.rb
@@ -63,22 +63,3 @@ post '/api/dev/check-dts' do
   end
   'success'
 end
-
-post '/api/dev/check-dtsn' do
-  forbidden! unless rack_env == :test || rack_env == :development
-  forbidden! unless verify_signature(CDO.github_webhook_secret)
-  data = JSON.parse(params[:payload])
-  unless CHECK_DTS_ACTIONS.include?(data['action']) &&
-      request.env['HTTP_X_GITHUB_EVENT'] == 'pull_request' &&
-      data['pull_request']['base']['ref'] == 'staging-next'
-    status 202
-    next 'I only check the DTSN status for PRs against staging-next'
-  end
-  GitHub.configure_octokit
-  if DevelopersTopic.dtsn?
-    GitHub.set_dtsn_check_pass(data['pull_request'])
-  else
-    GitHub.set_dtsn_check_fail(data['pull_request'])
-  end
-  'success'
-end


### PR DESCRIPTION
For the past three years, we have only used the `staging-next` branch as a placeholder for changes during the Hour of Code freeze, and have not deployed a full environment. We still want to run any Drone checks or GitHub actions against the branch, so those references to the branch remain. This PR removes the Deploy To Staging Next (DTSN) references, and other references related to a full environment.

Continues #62767

## Testing story

It would be helpful to have another person checkout this branch and search the repo for references to confirm I didn't miss anything.

* "staging-next"
* "staging_next"
* "dtsn"

## Privacy

N/A

## Security

N/A

## PR Checklist:

- [ ] ~Tests provide adequate coverage~
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
