### PR TITLE
Remove Percona Monitoring Server

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -343,7 +343,7 @@ roles = {
     RoleName: 'ProductManager_FullAccess',
     GoogleIdsSSMParameter: 'ProductGoogleIDs',
     ManagedPolicyArns: [
-      'arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess'
+      'arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess',
       '!Ref BedrockKnowledgeBaseInvocationPolicy',
       '!Ref CloudwatchDashboardViewerPolicy',
     ]
@@ -769,45 +769,6 @@ roles.each do |name, config| %>
             - !Sub "arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/analysis-events"
       ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-  # Percona Monitoring and Management RDS access role.
-  # See: https://www.percona.com/doc/percona-monitoring-and-management/amazon-rds.html#creating-a-policy
-  # TODO: Move to Data stack
-  PMMRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: [ec2.amazonaws.com, ecs-tasks.amazonaws.com]
-            Action: ['sts:AssumeRole']
-      Policies:
-        - PolicyName: PMMRolePolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Sid: Stmt1508404837000
-                Effect: Allow
-                Action:
-                  - 'rds:DescribeDBInstances'
-                  - 'cloudwatch:GetMetricStatistics'
-                  - 'cloudwatch:ListMetrics'
-                Resource: '*'
-              - Sid: Stmt1508410723001
-                Effect: Allow
-                Action:
-                  - 'logs:DescribeLogStreams'
-                  - 'logs:GetLogEvents'
-                  - 'logs:FilterLogEvents'
-                Resource:
-                  - "arn:aws:logs:*:*:log-group:RDSOSMetrics:*"
-  # TODO: Move to Data stack
-  PMMInstanceProfile:
-    Type: AWS::IAM::InstanceProfile
-    Properties:
-      InstanceProfileName: Percona-Monitoring-Management
-      Path: '/'
-      Roles: [!Ref PMMRole]
   # Global managed-policy named role used by ECS.
   # Ref: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
   EcsTaskExecutionRole:
@@ -883,10 +844,6 @@ Outputs:
     Description: Firehose Lambda Role ARN
     Value: !GetAtt FirehoseLambdaRole.Arn
     Export: {Name: !Sub "${AWS::StackName}-FirehoseLambdaRoleARN"}
-  PerconaMonitoringRoleARN:
-    Description: Percona Monitoring Role ARN
-    Value: !GetAtt PMMRole.Arn
-    Export: {Name: !Sub "${AWS::StackName}-PerconaMonitoringRoleARN"}
   SessionPermissions:
     Description: Session Permissions
     Value: !Ref SessionPermissions


### PR DESCRIPTION
We used to utilize the open source [Percona Monitoring and Management software](https://www.percona.com/software/database-tools/percona-monitoring-and-management) to carry out low level performance analytics of our production MySQL database, but AWS database Performance Insights provides most of the functionality we need, and the costs to maintain/configure the Percona system are not worth it. Delete the AWS Resources that were provisioned for this system.

## Testing story

Note the change to the ProductManager Role is to fix an unrelated syntax error

``` bash
code-dot-org $ export AWS_PROFILE=codeorg-admin
code-dot-org $ bin/aws_access

code-dot-org $ bundle exec rake stack:iam:validate RAILS_ENV=production ADMIN=true
Finished stack:iam:environment (less than a minute)
Pending update for stack `IAM`:
Remove PMMInstanceProfile [AWS::IAM::InstanceProfile]
Remove PMMRole [AWS::IAM::Role]
Modify ProductManagerFullAccessRole [AWS::IAM::Role] Properties (ManagedPolicyArns)
Finished stack:iam:validate (less than a minute)
```

## Deployment strategy

Manually delete the following Resources:

- [x] Terminate EC2 Instance running Percona Monitoring software
- [x] Delete Load Balancer used to terminate SSL
- [x] Delete DNS record 
- [x] Delete SSL Certificate for Percona web interface
- [x] Delete `PMM` and `Percona` SQL users from production database
- [x] Execute this stack change: `bundle exec rake stack:iam:start RAILS_ENV=production ADMIN=true`


## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
