### PR TITLE
Accessibility: Use H2 tag in Lab2 PanelContainer

### DIFF
--- a/apps/src/lab2/views/components/PanelContainer.tsx
+++ b/apps/src/lab2/views/components/PanelContainer.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React, {useContext} from 'react';
 
-import {Heading1} from '@cdo/apps/componentLibrary/typography';
+import {Heading2} from '@cdo/apps/componentLibrary/typography';
 
 import {ThemeContext} from '../ThemeWrapper';
 
@@ -65,7 +65,7 @@ const PanelContainer: React.FunctionComponent<PanelContainerProps> = ({
               {leftHeaderContent}
             </div>
           )}
-          <Heading1
+          <Heading2
             className={classNames(
               'panelContainerHeaderItemText',
               moduleStyles.panelContainerHeaderItem,
@@ -75,7 +75,7 @@ const PanelContainer: React.FunctionComponent<PanelContainerProps> = ({
             visualAppearance={'body-three'}
           >
             {headerContent}
-          </Heading1>
+          </Heading2>
           {rightHeaderContent && (
             <div
               className={classNames(

--- a/apps/src/lab2/views/components/PanelContainer.tsx
+++ b/apps/src/lab2/views/components/PanelContainer.tsx
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React, {useContext} from 'react';
 
+import {Heading1} from '@cdo/apps/componentLibrary/typography';
+
 import {ThemeContext} from '../ThemeWrapper';
 
 import moduleStyles from './panelContainer.module.scss';
@@ -63,15 +65,17 @@ const PanelContainer: React.FunctionComponent<PanelContainerProps> = ({
               {leftHeaderContent}
             </div>
           )}
-          <div
+          <Heading1
             className={classNames(
               'panelContainerHeaderItemText',
               moduleStyles.panelContainerHeaderItem,
+              moduleStyles['panelContainerHeaderItem-' + theme],
               moduleStyles.panelContainerHeaderItemText
             )}
+            visualAppearance={'body-three'}
           >
             {headerContent}
-          </div>
+          </Heading1>
           {rightHeaderContent && (
             <div
               className={classNames(

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -31,10 +31,21 @@ $default-spacing: 2px;
   border-bottom: 1px $light_gray_200 solid;
 }
 
+.panelContainerHeaderItem-light {
+  color: $neutral_dark;
+}
+
+.panelContainerHeaderItem-dark {
+  color: $neutral_white;
+}
+
+
 .panelContainerHeaderItem {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
+  margin: 0;
+  font-size: 13px;
 
   &Text {
     width: 100%;

--- a/apps/src/lab2/views/components/panelContainer.module.scss
+++ b/apps/src/lab2/views/components/panelContainer.module.scss
@@ -20,23 +20,23 @@ $default-spacing: 2px;
 .panelContainerHeader-dark {
   @extend %panel-container-header;
   background-color: $light_gray_900;
-  color: $neutral_white;
+  color: $light_white;
   margin-bottom: $default-spacing;
 }
 
 .panelContainerHeader-light {
   @extend %panel-container-header;
   background-color: $neutral_gray10;
-  color: $neutral_dark;
+  color: $light_black;
   border-bottom: 1px $light_gray_200 solid;
 }
 
 .panelContainerHeaderItem-light {
-  color: $neutral_dark;
+  color: $light_black;
 }
 
 .panelContainerHeaderItem-dark {
-  color: $neutral_white;
+  color: $light_white;
 }
 
 


### PR DESCRIPTION
Our VPAT popped up errors in AI Chat, Python Lab and Music Lab because the Lab2 PanelContainer heading text is not surrounded by a heading tag. These all use the same component and therefore could be covered by one PR!

To fix this, I updated the central header text to use an H2 element. I only made the central text an h2 because that is where we always put the main header content (i.e. "Instructions", "Workspace", etc.). However, the component does not enforce this. The left and right content is usually buttons. I figured it made more sense to make the component style the heading once rather than have each usage need to specify and style the heading correctly.

As far as I can tell there is no visual difference here. Only Python Lab has an eyes test, but that test showed no changes with this update.

## Screenshots
These look unchanged to me, and the python lab one passed the eyes test, but here are the 3 labs after the change:

<img width="854" alt="Screenshot 2024-12-17 at 3 16 42 PM" src="https://github.com/user-attachments/assets/bd35355c-3039-4b50-ae34-2eb59b889d72" />
<img width="854" alt="Screenshot 2024-12-17 at 3 16 34 PM" src="https://github.com/user-attachments/assets/47775e21-dfb1-42a8-b780-466e492d369b" />
<img width="1708" alt="Screenshot 2024-12-17 at 3 16 22 PM" src="https://github.com/user-attachments/assets/0ce4549c-e105-419d-b062-7c462c0e6f46" />

## Links
- jira tickets: [A11Y-886 (Music Lab)](https://codedotorg.atlassian.net/browse/A11Y-866), [A11Y-883 (Python Lab)](https://codedotorg.atlassian.net/browse/A11Y-883), [A11Y-1069 (AI Chat)](https://codedotorg.atlassian.net/browse/A11Y-1069)

## Testing story
Tested locally that the headings looked unchanged, and that the Python Lab eyes test still passes.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
