### PR TITLE
only add multi levels to level_source table

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -114,17 +114,19 @@ def main
     next
   end
 
-  contained_levels.map {|row| row[:contained_level_id]}.each do |contained_level_id|
-    LevelSource.
-      where(level_id: contained_level_id).
+  contained_levels.each do |contained_level|
+    if contained_level[:contained_level_type] == 'Multi'
+      LevelSource.
+      where(level_id: contained_level[:contained_level_id]).
       find_each do |level_source|
-      level_sources_multi_types << {
-        level_source_id: level_source.id,
-        level_id: level_source.level_id,
-        data: level_source.data,
-        md5: level_source.md5,
-        hidden: level_source.hidden
-      }
+        level_sources_multi_types << {
+          level_source_id: level_source.id,
+          level_id: level_source.level_id,
+          data: level_source.data,
+          md5: level_source.md5,
+          hidden: level_source.hidden
+        }
+      end
     end
   end
 


### PR DESCRIPTION
This updates the create_rollup_tables script to only add multi type levels to the level_sources_multi_type table

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
