### PR TITLE
[Music] New callouts and update to condition description

### DIFF
--- a/apps/src/music/progress/MusicConditions.ts
+++ b/apps/src/music/progress/MusicConditions.ts
@@ -42,7 +42,7 @@ export const MusicConditions: ConditionNames = {
     name: 'played_anything_in_same_function',
     valueType: 'number',
     description:
-      'Checks if something is playing from within a function definition block, at least this many times. Ex. Value: 3',
+      'Tracks how many times a specific block (e.g., sound, drum beat, chord) is played within a function.  Useful for checking how many times a function is called. Ex. Value: 3',
   },
   PLAYED_ANYTHING_IN_SAME_LOOP: {
     name: 'played_anything_in_same_loop',

--- a/apps/src/music/views/Callouts.tsx
+++ b/apps/src/music/views/Callouts.tsx
@@ -86,6 +86,14 @@ const availableCallouts: AvailableCallouts = {
       '.blocklyFlyout:not([style*="display: none;"]) .blocklyDraggable ~ .blocklyDraggable',
     openToolboxCategory: 0,
   },
+  'flyout-third-block': {
+    selector:
+      '.blocklyFlyout:not([style*="display: none;"]) .blocklyDraggable ~ .blocklyDraggable ~ .blocklyDraggable',
+  },
+  'flyout-fourth-block': {
+    selector:
+      '.blocklyFlyout:not([style*="display: none;"]) .blocklyDraggable ~ .blocklyDraggable ~ .blocklyDraggable ~ .blocklyDraggable',
+  },
 };
 
 interface Target {

--- a/apps/src/music/views/Callouts.tsx
+++ b/apps/src/music/views/Callouts.tsx
@@ -73,6 +73,9 @@ const availableCallouts: AvailableCallouts = {
   },
   'run-button': {selector: '#run-button'},
   'trigger-button-1': {selector: `#${Triggers[0].id}`},
+  'trigger-button-2': {selector: `#${Triggers[1].id}`},
+  'trigger-button-3': {selector: `#${Triggers[2].id}`},
+  'trigger-button-4': {selector: `#${Triggers[3].id}`},
   'toolbox-first-row': {selector: '.blocklyTreeRow'},
   'flyout-first-block': {
     selector: '.blocklyFlyout:not([style*="display: none;"]) .blocklyDraggable',


### PR DESCRIPTION
This updates the description for an existing validation condition. See thread for context: https://codedotorg.slack.com/archives/C04TH8400AU/p1734546809986909?thread_ts=1734546004.532139&cid=C04TH8400AU

It also adds two new selectors for flyout callouts. Thread for context: https://codedotorg.slack.com/archives/C04TH8400AU/p1734544921112799

The sibling selector (`~`) is used to reliably target the blocks because the DOM structure contains additional non-block elements that interfere with other CSS pseudo-classes like `:nth-of-type`. We ran into this issue previously here: https://github.com/code-dot-org/code-dot-org/pull/61639/files

At this time, we are not anticipating more similar callout selectors (e.g. fifth/sixth block, etc). When levels have this many blocks, it is possible that they will be out of initial scrolling view, making the callout much less useful. It is hoped that students will be comfortable navigating a toolbox before our levels get this complicated.

Finally, this also adds three new selectors for trigger buttons 2-4. Thread: https://codedotorg.slack.com/archives/C04TH8400AU/p1734556473272699


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
