### PR TITLE
P20-1180: Fix Safari ui test for Global Edition Region Switch Confirm modal 

### DIFF
--- a/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
+++ b/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
@@ -34,7 +34,7 @@ Feature: Global Edition - Region Switch Confirm Modal
 
     # User accepts the switch to the regional version and gets redirected to it
     Given I clear local storage
-    And I reload the page
+    And I am on "http://code.org"
     And I wait until element "#global-edition-region-switch-confirm.fade.in[role='dialog']" is visible
     When I press "global-edition-region-switch-confirm-accept"
     Then I get redirected away from "http://code.org"


### PR DESCRIPTION
```
And I wait until I am on "http://code.org/global/fa"
features/step_definitions/steps.rb:361
WARNING: 'I wait until I am on' is not reliable in Safari. Consider 'to load a new page' steps instead.
Timeout: I am not on https://test.code.org/global/fa like I want.
         I am on https://test.code.org/global/fa# instead.
timed out after 120 seconds (Selenium::WebDriver::Error::TimeoutError)
./features/step_definitions/steps.rb:8:in `wait_until'
./features/step_definitions/steps.rb:367:in `/^I wait until I am on "([^"]*)"$/'
./features/support/hooks.rb:28:in `block in '
features/platform/global_edition/region_switch_confirm.feature:41:in `And I wait until I am on "http://code.org/global/fa"'
6
7def wait_until(timeout = DEFAULT_WAIT_TIMEOUT)
8  Selenium::WebDriver::Wait.new(timeout: timeout).until do
9    yield
10  rescue Selenium::WebDriver::Error::UnknownError => exception
11# gem install syntax to get syntax highlighting
```

## Links
- JIRA task: [P20-1180](https://codedotorg.atlassian.net/browse/P20-1180)
- Original PR: https://github.com/code-dot-org/code-dot-org/pull/61631
- S3 Log: https://cucumber-logs.s3.amazonaws.com/test/test/Safari_platform_global_edition_region_switch_confirm_output.html?versionId=vobdCbiF_haZvcJvDuUJ_0JTxP06g9dQ