### PR TITLE
Delaying CAP Delaware lockout until 2025/01/06

### DIFF
--- a/dashboard/lib/policies/child_account/state_policies.rb
+++ b/dashboard/lib/policies/child_account/state_policies.rb
@@ -19,8 +19,8 @@ module Policies::ChildAccount::StatePolicies
         name: 'DPDPA',
         max_age: 12,
         grace_period_duration: 14.days.seconds,
-        lockout_date: DateTime.parse('2025-01-01T00:00:00-05:00'),
-        start_date: DateTime.parse('2025-01-01T00:00:00-05:00'),
+        lockout_date: DateTime.parse('2025-01-06T00:00:00-05:00'),
+        start_date: DateTime.parse('2025-01-06T00:00:00-05:00'),
       },
     }
 

--- a/dashboard/test/lib/policies/child_account/state_policies_test.rb
+++ b/dashboard/test/lib/policies/child_account/state_policies_test.rb
@@ -36,8 +36,8 @@ class Policies::ChildAccount::StatePoliciesTest < ActiveSupport::TestCase
 
     describe 'for Delaware' do
       let(:co_state_policy) {state_policies['DE']}
-      let(:default_start_date) {DateTime.parse('2025-01-01T00:00:00-05:00')}
-      let(:default_lockout_date) {DateTime.parse('2025-01-01T00:00:00-05:00')}
+      let(:default_start_date) {DateTime.parse('2025-01-06T00:00:00-05:00')}
+      let(:default_lockout_date) {DateTime.parse('2025-01-06T00:00:00-05:00')}
 
       it 'contains expected max age' do
         _(co_state_policy[:max_age]).must_equal 12


### PR DESCRIPTION
Change CAP Delaware lockout start date to January 6th to avoid deploying a big configuration change while everyone is out of office/on holiday.

The # of impacted users should be low:
- There are few users in Delaware
- [Most schools](https://education.delaware.gov/wp-content/uploads/2024/05/2024-25-School-District-Composite_Final.pdf) do not start before 1/6
- The change helps the teachers (gives them more time)

## Links
[Jira](https://codedotorg.atlassian.net/browse/P20-1342)

## Testing story
* Unit tests

