### PR TITLE
Fix links in Copyright Dialog

### DIFF
--- a/apps/src/sharedComponents/footer/CopyrightDialog/index.tsx
+++ b/apps/src/sharedComponents/footer/CopyrightDialog/index.tsx
@@ -42,9 +42,9 @@ const CopyrightDialog: React.FC<CopyrightDialogProps> = ({
         <div className="modalBody">
           <SafeMarkdown
             markdown={i18n.copyright_thanks({
-              donors_link: pegasus('about/donors'),
-              partners_link: pegasus('about/partners'),
-              team_link: pegasus('about/team'),
+              donors_link: pegasus('/about/donors'),
+              partners_link: pegasus('/about/partners'),
+              team_link: pegasus('/about/team'),
             })}
           />
           <BodyThreeText>{i18n.copyright_specialRecognition()}</BodyThreeText>


### PR DESCRIPTION
A user reported a problem with links in the copyright dialog:

> if you press the copyright button that shows “We thank all our donors, partners, our extended team…”, each link is missing a left slash.
> For example, the donation link button brings you to “https://code.orgabout/donors” when I'm assuming it is supposed to get you to “https://code.org/about/donors” which when I added the slash, DOES get you to the supporters' page. This applies to all 3 of the links (donors, partners, and extended team.)
> The image attached (should) show a screenshot of me hovering over the donor button, and the link being incorrect.

![bug](https://github.com/user-attachments/assets/04c7c717-2f8a-4c53-afa6-834583926adb)

The `pegasus` function expects a leading slash: https://github.com/code-dot-org/code-dot-org/blob/52548df577c183122cee857d65f049c94c097229/apps/src/lib/util/urlHelpers.js#L10-L11

Other instances of this function being called throughout the repo confirm this.

Adding the slashes fixes the links.

<img width="527" alt="image" src="https://github.com/user-attachments/assets/d049d41e-1112-4cba-b842-44704ad1d559" />



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
