### PR TITLE
P20-1177: Update `omniauth-google-oauth2` gem from v0.6.0 to v.1.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -161,7 +161,7 @@ gem 'devise_invitable', '~> 2.0.2'
 
 gem 'omniauth-clever', '~> 2.0.1', github: 'code-dot-org/omniauth-clever', tag: 'v2.0.1'
 gem 'omniauth-facebook', '~> 4.0.0'
-gem 'omniauth-google-oauth2', '~> 0.6.0'
+gem 'omniauth-google-oauth2', '~> 1.1.3'
 gem 'omniauth-microsoft_v2_auth', github: 'dooly-ai/omniauth-microsoft_v2_auth'
 
 # Resolve CVE 2015 9284

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -609,13 +609,14 @@ GEM
       rack-protection
     omniauth-facebook (4.0.0)
       omniauth-oauth2 (~> 1.2)
-    omniauth-google-oauth2 (0.6.0)
+    omniauth-google-oauth2 (1.1.3)
       jwt (>= 2.0)
-      omniauth (>= 1.1.1)
-      omniauth-oauth2 (>= 1.5)
-    omniauth-oauth2 (1.7.3)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
-      omniauth (>= 1.9, < 3)
+      omniauth (~> 2.0)
     omniauth-rails_csrf_protection (1.0.2)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
@@ -1043,7 +1044,7 @@ DEPENDENCIES
   oj (~> 3.10)
   omniauth-clever (~> 2.0.1)!
   omniauth-facebook (~> 4.0.0)
-  omniauth-google-oauth2 (~> 0.6.0)
+  omniauth-google-oauth2 (~> 1.1.3)
   omniauth-microsoft_v2_auth!
   omniauth-rails_csrf_protection (~> 1.0.2)
   open_uri_redirections


### PR DESCRIPTION
## Sign-up
![google-auth-sign-up](https://github.com/user-attachments/assets/82967f24-9dea-44ea-83a8-8bfb748b5cb1)

## Sign-in
![gogle-auth-sign-in](https://github.com/user-attachments/assets/ecad59a7-ef1f-4e32-81fe-dca80e0123fa)

## Commits
<ul>
<li><a href="https://github.com/zquestz/omniauth-google-oauth2/commit/827978dba46af03ca1ea1586bf475228f21b1336"><code>827978d</code></a> Bump to version 1.1.3</li>
<li><a href="https://github.com/zquestz/omniauth-google-oauth2/commit/bb30853e07c56773da6fd6d590e01b8db4b7ce7f"><code>bb30853</code></a> (fix:typo) mocdels -&gt; models (<a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/issues/460">#460</a>)</li>
<li><a href="https://github.com/zquestz/omniauth-google-oauth2/commit/42889149638bac446f964abf5d4e96669d50e39f"><code>4288914</code></a> POST to <a href="https://www.googleapis.com/oauth2/v3/tokeninfo">https://www.googleapis.com/oauth2/v3/tokeninfo</a> intead of GET (<a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/issues/457">#457</a>)</li>
<li><a href="https://github.com/zquestz/omniauth-google-oauth2/commit/0af26d4bbe495e453d046370aa1606da22134537"><code>0af26d4</code></a> improve README (<a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/issues/459">#459</a>)</li>
<li><a href="https://github.com/zquestz/omniauth-google-oauth2/commit/294bb61b34ade2f80b20ba1ea1d8ceeb752f88d1"><code>294bb61</code></a> Fix rubocop warnings</li>
<li><a href="https://github.com/zquestz/omniauth-google-oauth2/commit/f89203122953cb4f1aed80d9dacb64ccf3e3d9d5"><code>f892031</code></a> Bump version to 1.1.2</li>
<li><a href="https://github.com/zquestz/omniauth-google-oauth2/commit/422c3acd36a917c013e1e9b4bbe7f3ce5f49a235"><code>422c3ac</code></a> Add support for enable_granular_consent option (<a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/issues/455">#455</a>)</li>
<li><a href="https://github.com/zquestz/omniauth-google-oauth2/commit/492b20b21dee2ff9b4c12873eb9c7670dc11d061"><code>492b20b</code></a> Update README.md (<a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/issues/453">#453</a>)</li>
<li><a href="https://github.com/zquestz/omniauth-google-oauth2/commit/2f8cefd7ef9701e92b7ee227073fb5f85c847817"><code>2f8cefd</code></a> Add Ruby 3.2 to GitHub CI file (<a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/issues/445">#445</a>)</li>
<li><a href="https://github.com/zquestz/omniauth-google-oauth2/commit/1ff05061b3394ef965b6ed11c02cb01cc94f314a"><code>1ff0506</code></a> Loosen dependency version requirements (<a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/issues/440">#440</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/zquestz/omniauth-google-oauth2/compare/v0.6.0...v1.1.3">compare view</a></li>
</ul>

<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/zquestz/omniauth-google-oauth2/releases">omniauth-google-oauth2's releases</a>.</em></p>
<blockquote>
<h2>v1.1.3</h2>
<h3>Added</h3>
<ul>
<li>Updated to use POST instead of GET for tokeninfo endpoint. (<a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/pull/457">zquestz/omniauth-google-oauth2#457</a>)</li>
</ul>
<h3>Deprecated</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Removed</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Fixed</h3>
<ul>
<li>Documentation typos.</li>
<li>Rubocop configuration updates.</li>
</ul>
<h2>v1.1.2</h2>
<h3>Added</h3>
<ul>
<li>Add support for enable_granular_consent option (<a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/issues/455">#455</a>)</li>
</ul>
<h3>Deprecated</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Removed</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Fixed</h3>
<ul>
<li>Nothing.</li>
</ul>
<h2>v1.1.1</h2>
<h3>Added</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Deprecated</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Removed</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Fixed</h3>
<ul>
<li>Fixed JWT decoding issue. (Invalid segment encoding) <a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/pull/431">#431</a></li>
</ul>
<h2>v1.1.0</h2>
<h3>Added</h3>
<ul>
<li><code>overridable_authorize_options</code> has been added to restrict overriding authorize_options by request params. <a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/pull/423">#423</a></li>
<li>Support for oauth2 2.0.x. <a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/pull/429">#429</a></li>
</ul>
<h3>Deprecated</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Removed</h3>
<ul>
<li>Nothing.</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/zquestz/omniauth-google-oauth2/blob/master/CHANGELOG.md">omniauth-google-oauth2's changelog</a>.</em></p>
<blockquote>
<h2>1.1.3 - 2024-08-29</h2>
<h3>Added</h3>
<ul>
<li>Updated to use POST instead of GET for tokeninfo endpoint.</li>
</ul>
<h3>Deprecated</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Removed</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Fixed</h3>
<ul>
<li>Documentation typos.</li>
<li>Rubocop configuration updates.</li>
</ul>
<h2>1.1.2 - 2024-03-28</h2>
<h3>Added</h3>
<ul>
<li>Add support for enable_granular_consent option (<a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/issues/455">#455</a>)</li>
</ul>
<h3>Deprecated</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Removed</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Fixed</h3>
<ul>
<li>Nothing.</li>
</ul>
<h2>1.1.1 - 2022-09-05</h2>
<h3>Added</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Deprecated</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Removed</h3>
<ul>
<li>Nothing.</li>
</ul>
<h3>Fixed</h3>
<ul>
<li>Fixed JWT decoding issue. (Invalid segment encoding) <a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/pull/431">#431</a></li>
</ul>
<h2>1.1.0 - 2022-09-03</h2>
<h3>Added</h3>
<ul>
<li><code>overridable_authorize_options</code> has been added to restrict overriding authorize_options by request params. <a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/pull/423">#423</a></li>
<li>Support for oauth2 2.0.x. <a href="https://redirect.github.com/zquestz/omniauth-google-oauth2/pull/429">#429</a></li>
</ul>
<h3>Deprecated</h3>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>

## Links
- JIRA task: [P20-1177](https://codedotorg.atlassian.net/browse/P20-1177)
- Related PR: https://github.com/code-dot-org/code-dot-org/pull/61180