### PR TITLE
Fix for broken test_GET_chat_request_returns_not_found_if_request_does_not_exist

### DIFF
--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -239,7 +239,7 @@ class AichatControllerTest < ActionController::TestCase
   # chat_request tests
   test 'GET chat_request returns not found if request does not exist' do
     sign_in(@authorized_student1)
-    get :chat_request, params: {id: 1}, as: :json
+    get :chat_request, params: {id: 100}, as: :json
     assert_response :not_found
   end
 


### PR DESCRIPTION
This test is expecting to get a 404 when looking for an aichat_request with the id == 1.  Originally, there were no aichat_requests created as part of the test suite. Now that an aichat_request is created as part of setup, there does exist an aichat_request with id == 1.   Fix by using an id that is larger so that we actually expect it not to be found.

Note: I'm not sure why drone didn't detect this failure on my PR where the break was introduced - #62737

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1734632897858689)


## Testing story

Ran the test file locally with passing result.

