### PR TITLE
Use DSCO tooltip for tabs when text is too long

### DIFF
--- a/apps/src/componentLibrary/tabs/_Tab.tsx
+++ b/apps/src/componentLibrary/tabs/_Tab.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, {useCallback} from 'react';
+import React, {useCallback, useState} from 'react';
 
 import CloseButton from '@cdo/apps/componentLibrary/closeButton';
 import {ComponentSizeXSToL} from '@cdo/apps/componentLibrary/common/types';
@@ -97,19 +97,26 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
   isClosable = false,
   onClose = () => {},
 }) => {
+  const [longTooltip, setLongTooltip] = useState<TooltipProps>();
   const handleClick = useCallback(() => onClick(value), [onClick, value]);
   const handleClose = useCallback(() => onClose(value), [onClose, value]);
-  const handleNativeTooltip = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleNativeTooltip = (
+    e: React.MouseEvent<HTMLButtonElement> | React.FocusEvent<HTMLButtonElement>
+  ) => {
     const target = e.currentTarget;
     // Locate the element that contains the text (if nested inside spans or other elements).
     const textElement = target.querySelector('span') || target;
 
-    if (textElement.scrollWidth > textElement.clientWidth && !tooltip) {
-      // Set the tooltip text if overflow occurs if the tooltip prop is not passed.
-      target.title = textElement.textContent || '';
+    if (textElement.scrollWidth > textElement.clientWidth) {
+      // Not sure what the ID here should be.
+      setLongTooltip({
+        tooltipId: 'test-id',
+        text: text || '',
+        direction: 'onBottom',
+      });
     } else {
-      // Clear tooltip if no overflow.
-      target.title = '';
+      // is unset necessary / should be somewhere else (onBlur)?
+      setLongTooltip(undefined);
     }
   };
 
@@ -136,6 +143,7 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
       )}
       onClick={handleClick}
       onMouseOver={handleNativeTooltip}
+      onFocus={handleNativeTooltip}
       disabled={disabled}
     >
       {buttonContent}
@@ -149,10 +157,14 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
     </button>
   );
 
+  const preferredTooltip = tooltip || longTooltip;
+
   return (
     <li role="presentation">
-      {tooltip ? (
-        <WithTooltip tooltipProps={tooltip}>{buttonElement}</WithTooltip>
+      {preferredTooltip ? (
+        <WithTooltip tooltipProps={preferredTooltip}>
+          {buttonElement}
+        </WithTooltip>
       ) : (
         buttonElement
       )}

--- a/apps/src/componentLibrary/tabs/_Tab.tsx
+++ b/apps/src/componentLibrary/tabs/_Tab.tsx
@@ -150,10 +150,14 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
   useEffect(() => {
     if (tabTextRef.current) {
       const textElement = tabTextRef.current;
-      if (textElement.scrollWidth > textElement.clientWidth && !tooltip) {
+      if (
+        textElement.scrollWidth > textElement.clientWidth &&
+        !tooltip &&
+        text
+      ) {
         setLongTooltip({
           tooltipId: 'test123',
-          text: text || '',
+          text: text,
           direction: 'onBottom',
         });
       } else {

--- a/apps/src/componentLibrary/tabs/_Tab.tsx
+++ b/apps/src/componentLibrary/tabs/_Tab.tsx
@@ -156,7 +156,7 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
         text
       ) {
         setOverflowTooltip({
-          tooltipId: 'test123',
+          tooltipId: `${tabButtonId}-overflow-tooltip`,
           text: text,
           direction: 'onBottom',
         });
@@ -164,7 +164,7 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
         setOverflowTooltip(undefined);
       }
     }
-  }, [text, tooltip]);
+  }, [text, tooltip, tabButtonId]);
 
   return (
     <li role="presentation">

--- a/apps/src/componentLibrary/tabs/_Tab.tsx
+++ b/apps/src/componentLibrary/tabs/_Tab.tsx
@@ -104,7 +104,7 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
   isClosable = false,
   onClose = () => {},
 }) => {
-  const [longTooltip, setLongTooltip] = useState<TooltipProps>();
+  const [overflowTooltip, setOverflowTooltip] = useState<TooltipProps>();
   const tabTextRef = useRef<HTMLSpanElement | null>(null);
   const handleClick = useCallback(() => onClick(value), [onClick, value]);
   const handleClose = useCallback(() => onClose(value), [onClose, value]);
@@ -145,7 +145,7 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
     </button>
   );
 
-  const preferredTooltip = tooltip || longTooltip;
+  const preferredTooltip = tooltip || overflowTooltip;
 
   useEffect(() => {
     if (tabTextRef.current) {
@@ -155,13 +155,13 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
         !tooltip &&
         text
       ) {
-        setLongTooltip({
+        setOverflowTooltip({
           tooltipId: 'test123',
           text: text,
           direction: 'onBottom',
         });
       } else {
-        setLongTooltip(undefined);
+        setOverflowTooltip(undefined);
       }
     }
   }, [text, tooltip]);

--- a/apps/src/componentLibrary/tabs/_Tab.tsx
+++ b/apps/src/componentLibrary/tabs/_Tab.tsx
@@ -1,5 +1,11 @@
 import classNames from 'classnames';
-import React, {useCallback, useState} from 'react';
+import React, {
+  useCallback,
+  useState,
+  useRef,
+  useEffect,
+  MutableRefObject,
+} from 'react';
 
 import CloseButton from '@cdo/apps/componentLibrary/closeButton';
 import {ComponentSizeXSToL} from '@cdo/apps/componentLibrary/common/types';
@@ -67,7 +73,8 @@ const renderTabButtonContent = (
   icon?: FontAwesomeV6IconProps,
   text?: string,
   iconLeft?: FontAwesomeV6IconProps,
-  iconRight?: FontAwesomeV6IconProps
+  iconRight?: FontAwesomeV6IconProps,
+  tabTextRef?: MutableRefObject<HTMLSpanElement | null>
 ) => {
   if (isIconOnly && icon) {
     return <FontAwesomeV6Icon {...icon} />;
@@ -75,7 +82,7 @@ const renderTabButtonContent = (
   return (
     <>
       {iconLeft && <FontAwesomeV6Icon {...iconLeft} />}
-      {text && <span>{text}</span>}
+      {text && <span ref={tabTextRef}>{text}</span>}
       {iconRight && <FontAwesomeV6Icon {...iconRight} />}
     </>
   );
@@ -98,27 +105,9 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
   onClose = () => {},
 }) => {
   const [longTooltip, setLongTooltip] = useState<TooltipProps>();
+  const tabTextRef = useRef<HTMLSpanElement | null>(null);
   const handleClick = useCallback(() => onClick(value), [onClick, value]);
   const handleClose = useCallback(() => onClose(value), [onClose, value]);
-  const handleNativeTooltip = (
-    e: React.MouseEvent<HTMLButtonElement> | React.FocusEvent<HTMLButtonElement>
-  ) => {
-    const target = e.currentTarget;
-    // Locate the element that contains the text (if nested inside spans or other elements).
-    const textElement = target.querySelector('span') || target;
-
-    if (textElement.scrollWidth > textElement.clientWidth) {
-      // Not sure what the ID here should be.
-      setLongTooltip({
-        tooltipId: 'test-id',
-        text: text || '',
-        direction: 'onBottom',
-      });
-    } else {
-      // is unset necessary / should be somewhere else (onBlur)?
-      setLongTooltip(undefined);
-    }
-  };
 
   checkTabForErrors(isIconOnly, icon, text);
 
@@ -127,7 +116,8 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
     icon,
     text,
     iconLeft,
-    iconRight
+    iconRight,
+    tabTextRef
   );
 
   const buttonElement = (
@@ -142,8 +132,6 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
         isIconOnly && moduleStyles.iconOnlyTab
       )}
       onClick={handleClick}
-      onMouseOver={handleNativeTooltip}
-      onFocus={handleNativeTooltip}
       disabled={disabled}
     >
       {buttonContent}
@@ -158,6 +146,21 @@ const _Tab: React.FunctionComponent<TabsProps> = ({
   );
 
   const preferredTooltip = tooltip || longTooltip;
+
+  useEffect(() => {
+    if (tabTextRef.current) {
+      const textElement = tabTextRef.current;
+      if (textElement.scrollWidth > textElement.clientWidth && !tooltip) {
+        setLongTooltip({
+          tooltipId: 'test123',
+          text: text || '',
+          direction: 'onBottom',
+        });
+      } else {
+        setLongTooltip(undefined);
+      }
+    }
+  }, [text, tooltip]);
 
   return (
     <li role="presentation">


### PR DESCRIPTION
Currently, we use an element's `title` attribute to show the full text of a tab that is overflowing on hover, but not when focused. This violates this [accessibility linting rule](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/mouse-events-have-key-events.md).

Turns out that some browsers do not show the `title` attribute on focus at all, which means we needed a different approach to meet the linter's standard (see Slack thread linked below for more detail).

This PR updates our DSCO `Tabs` component to use a DSCO tooltip to show the full text of an overflowing tab. DSCO tooltips by default are made visible when focused (or hovered), which gives us the accessibility best practice this PR was intended to resolve in the first place "for free".

<details>
  <summary><b>Video of updated experience</b></summary>
  <video src='https://github.com/user-attachments/assets/b2e3165a-ad54-40f0-ada2-18200c256603' />
</details>

## Links

- Jira: https://codedotorg.atlassian.net/browse/A11Y-338
- Slack thread: https://codedotorg.slack.com/archives/C9MB4CL07/p1734569974217859

## Testing story

I tested manually in Storybook that this looks good. There's currently no unit test for this behavior as far as I can tell, and seems a bit tricky to test, so I haven't added a unit test.

## Follow-up work

I am curious about the interaction between consumers that provide a tooltip and tabs that are overflowing. It seems to me like maybe we should prioritize being able to see the full text of a tab over whatever tooltip was provided by the consumer? Or at least resize the selected tab to show the full text of the tab? Currently, if the consumer provides a tooltip, and the tab text is overflowing, it's not possible for the user to see the full text of the tab (as I understand it).