### PR TITLE
fix question text not showing up in contained_levels for FreeResponse levels

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -28,12 +28,13 @@ end
 def get_contained_question(contained_level)
   contained_question_markdown = contained_level.properties['markdown']
 
-  contained_question_text = nil
-  if contained_level.properties['questions']
-    contained_question_text = contained_level.
-      properties['questions'].
-      first['text']
-  end
+  contained_question_text = if contained_level.properties['questions']
+                              contained_level.properties['questions'].first['text']
+                            elsif contained_level.properties['long_instructions']
+                              contained_level.properties['long_instructions']
+                            else
+                              nil
+                            end
 
   if contained_question_markdown.nil?
     return contained_question_text || ""


### PR DESCRIPTION
This fixes a bug that caused FreeResponse level question text to not be copied into the contained_levels table correctly.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
