### PR TITLE
Add ui test for section settings

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2.feature
@@ -37,3 +37,4 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
 
     Then element "#unit-selector-v2" contains text "Interactive Animations and Games ('24-'25)"
     Then element "#uitest-sidebar-section-dropdown" contains text "Sally's Super Section"
+    Then element "#uitest-sidebar-section-dropdown" does not contain text "Untitled Section"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2.feature
@@ -25,12 +25,10 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
     And I click selector "button:contains(Middle School)" once I see it
     And I click selector "input[name='Interactive Animations and Games']" once I see it
 
-    And I click selector "#uitest-section-name-setup"
-    And I type "Sally's Super Section" into "#uitest-section-name-setup"
-    And I press enter key
+    And I press backspace to clear element "#uitest-section-name-setup"
+    And I press keys "Sally's Super Section" for element "#uitest-section-name-setup"
 
     And I press "button:contains(Save)" using jQuery
-#    And I click selector "#uitest-save-section-changes" to load a new page
 
     And I wait until element "h6:contains(Icon Key)" is visible
     And I wait until element "#ui-test-progress-table-v2" is visible

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2.feature
@@ -1,0 +1,41 @@
+@no_mobile
+Feature: Using the V2 teacher dashboard local navigation - Eyes
+  Background:
+    Given I am on "http://studio.code.org/home"
+    Given I use a cookie to mock the DCDO key "teacher-local-nav-v2" as "true"
+    Given I use a cookie to mock the DCDO key "progress-table-v2-enabled" as "true"
+
+  Scenario: Modifying settings on the teacher dashboard
+    Given I create an authorized teacher-associated student named "Sally"
+    Given I am assigned to unit "allthethings"
+
+    When I sign in as "Teacher_Sally" and go home
+    And I get levelbuilder access
+
+    When I click selector "a:contains(Untitled Section)" once I see it to load a new page
+
+    Then I wait until element "#ui-test-teacher-sidebar" is visible
+
+    Given I click selector "#ui-test-teacher-sidebar a:contains('Settings')" once I see it
+    And I wait until element "#uitest-spinner" is not visible
+    And I wait until element "h1:contains('Edit Section Details')" is visible
+
+    And I press the first "input[name='grades[]']" element
+
+    And I click selector "button:contains(Middle School)" once I see it
+    And I click selector "input[name='Interactive Animations and Games']" once I see it
+
+    And I click selector "#uitest-section-name-setup"
+    And I type "Sally's Super Section" into "#uitest-section-name-setup"
+    And I press enter key
+
+    And I press "button:contains(Save)" using jQuery
+#    And I click selector "#uitest-save-section-changes" to load a new page
+
+    And I wait until element "h6:contains(Icon Key)" is visible
+    And I wait until element "#ui-test-progress-table-v2" is visible
+
+    And I wait until element "#ui-test-skeleton-progress-column" is not visible
+
+    Then element "#unit-selector-v2" contains text "Interactive Animations and Games ('24-'25)"
+    Then element "#uitest-sidebar-section-dropdown" contains text "Sally's Super Section"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2.feature
@@ -1,5 +1,5 @@
 @no_mobile
-Feature: Using the V2 teacher dashboard local navigation - Eyes
+Feature: Using the V2 teacher dashboard local navigation
   Background:
     Given I am on "http://studio.code.org/home"
     Given I use a cookie to mock the DCDO key "teacher-local-nav-v2" as "true"

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard_local_nav_v2_eyes.feature
@@ -27,7 +27,6 @@ Feature: Using the V2 teacher dashboard local navigation - Eyes
     And I join the section
 
     When I sign in as "Teacher_Sally" and go home
-    And I get levelbuilder access
 
     When I click selector "a:contains(Untitled Section)" once I see it to load a new page
 


### PR DESCRIPTION
Adds a UI test that tests whether section settings are modified and modifications are seen in other teacher dashboard pages.

The test:
* Changes the section name and section assignment
* Navigates to the progress page
* Tests that the name and section assignment are changed in the sidebar and progress page

## Links
https://codedotorg.atlassian.net/browse/TEACH-1429
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Passes locally
<img width="655" alt="image" src="https://github.com/user-attachments/assets/f9a25531-74c0-4f49-b13c-0253993d639e" />
