### PR TITLE
P20-1180: Restrict GE Region Switch Confirmation Modal ui test to Chrome

### DIFF
--- a/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
+++ b/dashboard/test/ui/features/platform/global_edition/region_switch_confirm.feature
@@ -1,4 +1,5 @@
 @no_mobile
+@chrome
 Feature: Global Edition - Region Switch Confirm Modal
 
   Background:


### PR DESCRIPTION
```
And I wait until I am on "http://code.org/global/fa"
features/step_definitions/steps.rb:361
WARNING: 'I wait until I am on' is not reliable in Safari. Consider 'to load a new page' steps instead.
And element "#global-edition-region-switch-confirm" is not visible
features/step_definitions/steps.rb:892
A JavaScript exception occured: Can't find variable: $ (Selenium::WebDriver::Error::JavascriptError)
./utils/selenium_browser.rb:38:in `create_response'
./features/step_definitions/steps.rb:881:in `element_visible?'
./features/step_definitions/steps.rb:893:in `/^element "([^"]*)" is (not )?visible$/'
./features/support/hooks.rb:28:in `block in '
features/platform/global_edition/region_switch_confirm.feature:42:in `And element "#global-edition-region-switch-confirm" is not visible'
36    # Replaces 'unexpected response' message with the actual parsed error from the JSON response, if provided.
37    def create_response(code, body, content_type)
38      super
39    rescue Selenium::WebDriver::Error::WebDriverError => exception
40      if (msg = exception.message.match(/unexpected response, code=(?\d+).*\n(?.*)/))
41# gem install syntax to get syntax highlighting
```
## Links
- JIRA task: [P20-1180](https://codedotorg.atlassian.net/browse/P20-1180)
- Original PR: https://github.com/code-dot-org/code-dot-org/pull/61631