### PR TITLE
Change unit calendar color on focus in addition to hover

### DIFF
--- a/apps/src/code-studio/components/progress/UnitCalendarLessonChunk.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarLessonChunk.jsx
@@ -19,7 +19,7 @@ class UnitCalendarLessonChunk extends Component {
     this.props.handleHover(this.props.lessonChunk.id);
   };
 
-  handleMouseOut = () => {
+  handleMouseLeave = () => {
     this.props.handleHover('');
   };
 
@@ -66,47 +66,30 @@ class UnitCalendarLessonChunk extends Component {
         data-tip
         href={url}
         onMouseEnter={this.handleMouseEnter}
-        onMouseOut={this.handleMouseOut}
+        onMouseLeave={this.handleMouseLeave}
+        onFocus={this.handleMouseEnter}
+        onBlur={this.handleMouseLeave}
       >
         {isMajority && (
-          <div
-            style={styles.boxContent}
-            onMouseEnter={this.handleMouseEnter}
-            onMouseOut={this.handleMouseOut}
-          >
+          <div style={styles.boxContent}>
             {(assessment || unplugged) && (
-              <div
-                key={`lesson-${id}`}
-                style={styles.iconSection}
-                onMouseEnter={this.handleMouseEnter}
-                onMouseOut={this.handleMouseOut}
-              >
+              <div key={`lesson-${id}`} style={styles.iconSection}>
                 <FontAwesome
                   icon="check-circle"
                   style={{
                     color: isHover ? color.white : color.purple,
                     visibility: assessment ? 'visible' : 'hidden',
                   }}
-                  onMouseEnter={this.handleMouseEnter}
-                  onMouseOut={this.handleMouseOut}
                 />
                 <FontAwesome
                   icon="scissors"
                   style={{
                     visibility: unplugged ? 'visible' : 'hidden',
                   }}
-                  onMouseEnter={this.handleMouseEnter}
-                  onMouseOut={this.handleMouseOut}
                 />
               </div>
             )}
-            <div
-              style={styles.titleText}
-              onMouseEnter={this.handleMouseEnter}
-              onMouseOut={this.handleMouseOut}
-            >
-              {displayTitle}
-            </div>
+            <div style={styles.titleText}>{displayTitle}</div>
           </div>
         )}
         {smallChunk && (


### PR DESCRIPTION
Previously, the unit calendar (shown to teachers on the unit overview page to suggest how they could break down the curriculum their classes depending on the length of each classroom period) would change the color of the currently hovered lesson.

This PR updates to also change the color on focus, which is an accessibility best practice.

It also simplifies the mouse leaving/entering logic -- as far as I can tell, changing the state on only the parent produces the desired behavior. I had to update to use the `mouseleave` event rather than `mouseout`. `mouseout` does some unexpected things where it fires every time a child is entered/left, rather than just when leaving the parent element. The w3schools link below does a nice job of demonstrating the difference:

https://www.w3schools.com/jquery/tryit.asp?filename=tryjquery_event_mouseleave_mouseout

<details>
  <summary><b>Video of updated experience</b></summary>
  <video src='https://github.com/user-attachments/assets/2e4d2e89-c50e-449f-9b4f-4870c4754817' />
</details>

## Links

- jira ticket: [A11Y-337](https://codedotorg.atlassian.net/browse/A11Y-337)

## Testing story

Tested manually at http://localhost-studio.code.org:9000/s/csa1-2022.

I also tested that this produced a linter error before this change, and no linter error afterwards.

## Follow-up work

Interestingly, I learned that just the change from `onMouseOut` to `onMouseLeave` resulted in the linter error going away. It looks like by default `onMouseEnter` and `onMouseLeave` are not checked by this linting rule (I'm not sure why?) -- we might want to enable it for these other "do something on hover"-type events.

https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/mouse-events-have-key-events.md