### PR TITLE
A11y - Updating GDPR dialog to use new DSCO buttons

### DIFF
--- a/apps/src/templates/GDPRDialog.jsx
+++ b/apps/src/templates/GDPRDialog.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
+import Button, {buttonColors} from '@cdo/apps/componentLibrary/button/Button';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import i18n from '@cdo/locale';
 
@@ -61,18 +61,18 @@ export default class GDPRDialog extends Component {
         </div>
         <DialogFooter>
           <Button
-            __useDeprecatedTag
-            text={i18n.gdprDialogLogout()}
-            href={logOutUrl}
-            color={Button.ButtonColor.gray}
             className="ui-test-gdpr-dialog-logout"
+            text={i18n.gdprDialogLogout()}
+            useAsLink={true}
+            href={logOutUrl}
+            color={buttonColors.gray}
+            type="secondary"
+            size="m"
           />
           <Button
-            __useDeprecatedTag
+            className="ui-test-gdpr-dialog-accept"
             text={i18n.gdprDialogYes()}
             onClick={this.handleYesClick}
-            color={Button.ButtonColor.brandSecondaryDefault}
-            className="ui-test-gdpr-dialog-accept"
           />
         </DialogFooter>
       </BaseDialog>


### PR DESCRIPTION
This PR updates the buttons in the GDPR dialog to use the new DSCO components instead of the old buttons with the __useDeprecatedTag! I checked by using the ?force_in_eu=1 param in the url.


Before:
<img width="661" alt="Screenshot 2024-12-20 at 9 15 08 AM" src="https://github.com/user-attachments/assets/ab4452f5-e7ad-4b87-ab7c-5e3e7705a1ea" />

After:
<img width="668" alt="Screenshot 2024-12-20 at 9 26 13 AM" src="https://github.com/user-attachments/assets/cb00b3cd-bdf4-44f5-9444-8f1b9839f9a4" />

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-124

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
