### PR TITLE
Aichat: Fix locale issue on level edit page

### DIFF
--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -7,14 +7,9 @@ import type {
 import {Role} from '../aiComponentLibrary/chatMessage/types';
 import type {ValueOf} from '../types/utils';
 
-import aichatI18n from './locale';
 import {FIELDS_CHECKED_FOR_TOXICITY} from './views/modelCustomization/constants';
 
-export const ChatEventDescriptions = {
-  COPY_CHAT: aichatI18n.chatEventDescriptions_copyChat(),
-  CLEAR_CHAT: aichatI18n.chatEventDescriptions_clearChat(),
-  LOAD_LEVEL: aichatI18n.chatEventDescriptions_loadLevel(),
-} as const;
+export type ChatEventDescriptionKey = 'COPY_CHAT' | 'CLEAR_CHAT' | 'LOAD_LEVEL';
 
 export interface ChatEvent {
   // UTC timestamp in milliseconds
@@ -22,7 +17,8 @@ export interface ChatEvent {
   // This field is optional but when it is defined, it must be set to `true`.
   // This allows the chat event to be visible by default without having to add an extra field.
   hideForParticipants?: true;
-  descriptionKey?: keyof typeof ChatEventDescriptions;
+  /** Optional key used if this event has a localized text description (ex. copy chat, clear chat, load level) */
+  descriptionKey?: ChatEventDescriptionKey;
 }
 
 export interface ChatMessage extends ChatEvent {

--- a/apps/src/aichat/views/ChatEventView.tsx
+++ b/apps/src/aichat/views/ChatEventView.tsx
@@ -11,16 +11,22 @@ import {removeUpdateMessage} from '../redux/aichatRedux';
 import {timestampToLocalTime} from '../redux/utils';
 import {
   ChatEvent,
-  ChatEventDescriptions,
   ModelUpdate,
   isChatMessage,
   isNotification,
   isModelUpdate,
+  ChatEventDescriptionKey,
 } from '../types';
 
 import {AI_CUSTOMIZATIONS_LABELS} from './modelCustomization/constants';
 
 import styles from './chatWorkspace.module.scss';
+
+const ChatEventDescriptions = {
+  COPY_CHAT: aichatI18n.chatEventDescriptions_copyChat(),
+  CLEAR_CHAT: aichatI18n.chatEventDescriptions_clearChat(),
+  LOAD_LEVEL: aichatI18n.chatEventDescriptions_loadLevel(),
+} as const satisfies {[key in ChatEventDescriptionKey]: string};
 
 interface ChatEventViewProps {
   event: ChatEvent;

--- a/dashboard/app/views/levels/editors/fields/_aichat_settings.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_aichat_settings.html.haml
@@ -5,5 +5,6 @@
   #aichat-settings-editor
 
 - content_for :body_scripts do
+  %script{src: webpack_asset_path("js/#{js_locale}/aichat_locale.js")}
   %script{src: webpack_asset_path('js/levels/editors/fields/_aichat_settings.js'),
         data: {aichatsettings: @level.properties["aichat_settings"].to_json}}

--- a/dashboard/app/views/levels/editors/fields/_aichat_settings.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_aichat_settings.html.haml
@@ -5,6 +5,7 @@
   #aichat-settings-editor
 
 - content_for :body_scripts do
+  -# Including the locale bundle since the level editor component references a few localized strings (ex. model card field labels)
   %script{src: webpack_asset_path("js/#{js_locale}/aichat_locale.js")}
   %script{src: webpack_asset_path('js/levels/editors/fields/_aichat_settings.js'),
         data: {aichatsettings: @level.properties["aichat_settings"].to_json}}


### PR DESCRIPTION
We accidentally regressed on the AI Chat level edit page after adding localized strings since a few editor components referenced files with localized strings and we weren't loading the locale bundle on the level edit page. Fix here is to just include locale bundle since it's directly referenced (by way of model card field labels). Also includes a bit of code cleanup to move the mapping of chat event description key localized string into the component where it's actually used, as it's not strictly a type (even though we were kind of using its keys like one).

## Links

https://codedotorg.slack.com/archives/C06FELVTV0Q/p1734710620522009

## Testing story

Tested locally - level edit page, student view, and teacher view (where the descriptions are actually used) seem to work fine.