### PR TITLE
A11Y - Update redirect dialog to use DSCO button

### DIFF
--- a/apps/src/code-studio/components/RedirectDialog.jsx
+++ b/apps/src/code-studio/components/RedirectDialog.jsx
@@ -35,12 +35,14 @@ const RedirectDialog = ({
           onClick={handleClose}
           type="secondary"
           color="gray"
+          size="s"
         />
         <Button
           text={redirectButtonText}
           onClick={redirect}
           type="primary"
           color="purple"
+          size="s"
         />
       </DialogFooter>
     </BaseDialog>

--- a/apps/src/code-studio/components/RedirectDialog.jsx
+++ b/apps/src/code-studio/components/RedirectDialog.jsx
@@ -1,57 +1,59 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Button from '@cdo/apps/legacySharedComponents/Button';
+import Button from '@cdo/apps/componentLibrary/button';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import {navigateToHref} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 
-export default class RedirectDialog extends React.Component {
-  static propTypes = {
-    isOpen: PropTypes.bool.isRequired,
-    details: PropTypes.string.isRequired,
-    handleClose: PropTypes.func.isRequired,
-    redirectUrl: PropTypes.string.isRequired,
-    redirectButtonText: PropTypes.string.isRequired,
+const RedirectDialog = ({
+  isOpen,
+  details,
+  handleClose,
+  redirectUrl,
+  redirectButtonText,
+}) => {
+  const redirect = () => {
+    navigateToHref(redirectUrl);
   };
 
-  redirect = () => {
-    navigateToHref(this.props.redirectUrl);
-  };
+  return (
+    <BaseDialog
+      useUpdatedStyles
+      isOpen={isOpen}
+      style={styles.dialog}
+      handleClose={handleClose}
+    >
+      <div>
+        <h2 style={styles.dialogHeader}>{i18n.notInRightPlace()}</h2>
+        {details}
+      </div>
+      <DialogFooter>
+        <Button
+          text={i18n.stayHere()}
+          onClick={handleClose}
+          type="secondary"
+          color="gray"
+        />
+        <Button
+          text={redirectButtonText}
+          onClick={redirect}
+          type="primary"
+          color="purple"
+        />
+      </DialogFooter>
+    </BaseDialog>
+  );
+};
 
-  render() {
-    const {isOpen, details, handleClose, redirectButtonText} = this.props;
-
-    return (
-      <BaseDialog
-        useUpdatedStyles
-        isOpen={isOpen}
-        style={styles.dialog}
-        handleClose={handleClose}
-      >
-        <div>
-          <h2 style={styles.dialogHeader}>{i18n.notInRightPlace()}</h2>
-          {details}
-        </div>
-        <DialogFooter>
-          <Button
-            __useDeprecatedTag
-            text={i18n.stayHere()}
-            onClick={handleClose}
-            color={Button.ButtonColor.gray}
-          />
-          <Button
-            __useDeprecatedTag
-            text={redirectButtonText}
-            onClick={this.redirect}
-            color={Button.ButtonColor.brandSecondaryDefault}
-          />
-        </DialogFooter>
-      </BaseDialog>
-    );
-  }
-}
+RedirectDialog.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  details: PropTypes.string.isRequired,
+  handleClose: PropTypes.func.isRequired,
+  redirectUrl: PropTypes.string.isRequired,
+  redirectButtonText: PropTypes.string.isRequired,
+};
 
 const styles = {
   dialog: {
@@ -61,3 +63,5 @@ const styles = {
     marginTop: 0,
   },
 };
+
+export default RedirectDialog;

--- a/apps/src/code-studio/components/RedirectDialog.story.jsx
+++ b/apps/src/code-studio/components/RedirectDialog.story.jsx
@@ -12,7 +12,7 @@ export default {
   },
 };
 
-const Template = args => {
+const TemplateWrapper = args => {
   const [isOpen, setIsOpen] = useState(true);
 
   const handleClose = () => {
@@ -22,6 +22,8 @@ const Template = args => {
 
   return <RedirectDialog {...args} isOpen={isOpen} handleClose={handleClose} />;
 };
+
+const Template = args => <TemplateWrapper {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/apps/src/code-studio/components/RedirectDialog.story.jsx
+++ b/apps/src/code-studio/components/RedirectDialog.story.jsx
@@ -1,0 +1,47 @@
+import {action} from '@storybook/addon-actions';
+import React, {useState} from 'react';
+
+import RedirectDialog from './RedirectDialog';
+
+export default {
+  component: RedirectDialog,
+  argTypes: {
+    handleClose: {action: 'closed'},
+    redirectUrl: {control: 'text'},
+    redirectButtonText: {control: 'text'},
+  },
+};
+
+const Template = args => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => {
+    setIsOpen(false);
+    action('closed')();
+  };
+
+  return (
+    <span>
+      <button type="button" onClick={handleOpen}>
+        Open Redirect Dialog
+      </button>
+      <RedirectDialog {...args} isOpen={isOpen} handleClose={handleClose} />
+    </span>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  details:
+    'You are trying to access a restricted area. Please use the button below to navigate to the correct page.',
+  redirectUrl: 'https://example.com',
+  redirectButtonText: 'Redirect',
+};
+
+export const CustomDetails = Template.bind({});
+CustomDetails.args = {
+  details: 'This is a custom details message.',
+  redirectUrl: 'https://example.com',
+  redirectButtonText: 'Go to Custom URL',
+};

--- a/apps/src/code-studio/components/RedirectDialog.story.jsx
+++ b/apps/src/code-studio/components/RedirectDialog.story.jsx
@@ -13,22 +13,14 @@ export default {
 };
 
 const Template = args => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
 
-  const handleOpen = () => setIsOpen(true);
   const handleClose = () => {
     setIsOpen(false);
     action('closed')();
   };
 
-  return (
-    <span>
-      <button type="button" onClick={handleOpen}>
-        Open Redirect Dialog
-      </button>
-      <RedirectDialog {...args} isOpen={isOpen} handleClose={handleClose} />
-    </span>
-  );
+  return <RedirectDialog {...args} isOpen={isOpen} handleClose={handleClose} />;
 };
 
 export const Default = Template.bind({});


### PR DESCRIPTION
The RedirectDialog uses the legacy Button component. 
When specified with `__useDeprecatedTag` and an onClick function, the Button component creates a `<div onClick>`, or a ‘clickable div’. Clickable divs are an accessibility anti-pattern because they may be styled to look like buttons, but do not communicate their functionality in a way that screenreaders or assistive technology can identify.
We could get rid of the `__useDeprecatedTag` by applying the same changes as in PR #49339 however, we have a new DSCO Button component that is fully accessible.

This PR:
- Makes the  RedirectDialog Class Component into a Functional Component.
- Uses the `componentLibrary/button` instead of the `legacySharedComponents/Button`.
- Adds a storybook test for the RedirectDialog.

## Links

- jira ticket: [A11Y-144](https://codedotorg.atlassian.net/browse/A11Y-144)

## Testing story

Added storybook.
| Before | After |
|-|-|
|<img width="836" alt="Screenshot 2025-01-08 at 21 21 16" src="https://github.com/user-attachments/assets/53ad2948-330c-4777-b781-667f640ac2b4" />|<img width="836" alt="Screenshot 2025-01-08 at 21 29 31" src="https://github.com/user-attachments/assets/144e5655-f8c9-4ba9-b923-7e1c34efb2dd" />|


## Deployment strategy

Accept new eyes-test that may fail with different button styles.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
