### PR TITLE
show assign button for every unit

### DIFF
--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -146,8 +146,7 @@ class CourseScript extends Component {
             {confirmationMessageOpen && (
               <span style={styles.confirmText}>{i18n.assignSuccess()}</span>
             )}
-            {!isAssigned &&
-              viewAs === ViewType.Instructor &&
+            {viewAs === ViewType.Instructor &&
               showAssignButton &&
               selectedSection && (
                 <div className={styles.assignButton}>


### PR DESCRIPTION
Adds assign button to every unit in a course when a teacher is viewing the unit landing page. 

Previously, the button would not be present for the unit assigned to the section.

![image](https://github.com/user-attachments/assets/542d0091-f39d-43fc-8f52-f6b8f0d3284a)



## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1518)

## Testing story

Verified it worked on my local enviroment.