### PR TITLE
Fix: workshop enrollment for non nces schools

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -157,7 +157,7 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
     {
       school_type: params[:school_info][:school_type],
       school_state: params[:school_info][:school_state],
-      school_zip: params[:school_info][:school_zip],
+      school_zip: params[:school_info][:zip],
       school_district_name: params[:school_info][:school_district_name]&.strip_utf8mb4,
       school_district_other: params[:school_info][:school_district_other]&.strip_utf8mb4,
       school_id: params[:school_info][:school_id],

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -538,7 +538,7 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
     {
       country: 'US',
       school_name: 'A Seattle school',
-      school_zip: '98102'
+      zip: '98102'
     }
   end
 end


### PR DESCRIPTION
Fixes a bug in the workshop enrollment request params. A non-nces school sends a `zip` param but the controller was expecting `school_zip` causing a validation error when creating the `school_info`

![Screenshot 2025-01-06 at 3 34 47 PM](https://github.com/user-attachments/assets/f25d7f68-368a-49dd-a9d5-be0b2ef26ae8)


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
