### PR TITLE
Block lab2 projects UI

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -3012,6 +3012,7 @@
   "topRight": "top right",
   "tos": "Terms of Service",
   "tosLong": "This project has been reported for violating Code.org's [Terms of Service]({url}) and cannot be shared with others.",
+  "tosWithoutLink": "This project has been reported for violating Code.org's Terms of Service and cannot be shared with others.",
   "tryAgain": "Try again",
   "tryBlocksBelowFeedback": "Try using one of the blocks below:",
   "tryHOC": "Try the Hour of Code",

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -83,6 +83,8 @@ export interface LabState {
   levelProperties: LevelProperties | undefined;
   // If this lab should presented in a "share" or "play-only" view, which may hide certain UI elements.
   isShareView: boolean | undefined;
+  // If this lab is blocked due to inappropriate content, e.g., abuse score >= 15.
+  isBlocked: boolean | undefined;
   overrideValidations: Validation[] | undefined;
 }
 
@@ -95,6 +97,7 @@ const initialState: LabState = {
   validationState: getInitialValidationState(),
   levelProperties: undefined,
   isShareView: undefined,
+  isBlocked: undefined,
   overrideValidations: undefined,
 };
 
@@ -240,12 +243,12 @@ export const setUpWithLevel = createAsyncThunk<
 
     Lab2Registry.getInstance().setProjectManager(projectManager);
     // Load channel and source.
-    const {sources, channel} = await setUpAndLoadProject(
+    const {sources, channel, abuseScore} = await setUpAndLoadProject(
       projectManager,
       thunkAPI.dispatch
     );
     setProjectAndLevelData(
-      {initialSources: sources, channel, levelProperties},
+      {initialSources: sources, channel, levelProperties, abuseScore},
       thunkAPI.signal.aborted,
       thunkAPI.dispatch,
       thunkAPI.getState
@@ -393,11 +396,15 @@ const labSlice = createSlice({
         channel?: Channel;
         levelProperties: LevelProperties;
         initialSources?: ProjectSources;
+        abuseScore?: number;
       }>
     ) {
       state.channel = action.payload.channel;
       state.levelProperties = action.payload.levelProperties;
       state.initialSources = action.payload.initialSources;
+      if (typeof action.payload.abuseScore === 'number') {
+        state.isBlocked = action.payload.abuseScore >= 15 ? true : false;
+      }
     },
     setIsShareView(state, action: PayloadAction<boolean>) {
       state.isShareView = action.payload;
@@ -535,6 +542,7 @@ function setProjectAndLevelData(
     levelProperties: LevelProperties;
     channel?: Channel;
     initialSources?: ProjectSources;
+    abuseScore?: number;
   },
   aborted: boolean,
   dispatch: ThunkDispatch<unknown, unknown, AnyAction>,
@@ -547,6 +555,7 @@ function setProjectAndLevelData(
   // Dispatch level change last so labs can react to the new level data
   // and new initial sources at once.
   dispatch(onLevelChange(data));
+
   Lab2Registry.getInstance()
     .getLifecycleNotifier()
     .notify(
@@ -554,6 +563,7 @@ function setProjectAndLevelData(
       data.levelProperties,
       data.channel,
       data.initialSources,
+      data.abuseScore,
       isReadOnlyWorkspace(getState())
     );
 }

--- a/apps/src/lab2/lab2Redux.ts
+++ b/apps/src/lab2/lab2Redux.ts
@@ -83,7 +83,7 @@ export interface LabState {
   levelProperties: LevelProperties | undefined;
   // If this lab should presented in a "share" or "play-only" view, which may hide certain UI elements.
   isShareView: boolean | undefined;
-  // If this lab is blocked due to inappropriate content, e.g., abuse score >= 15.
+  // If this lab is blocked because abuse score >= 15.
   isBlocked: boolean | undefined;
   overrideValidations: Validation[] | undefined;
 }
@@ -555,7 +555,6 @@ function setProjectAndLevelData(
   // Dispatch level change last so labs can react to the new level data
   // and new initial sources at once.
   dispatch(onLevelChange(data));
-
   Lab2Registry.getInstance()
     .getLifecycleNotifier()
     .notify(

--- a/apps/src/lab2/projects/ChannelsStore.ts
+++ b/apps/src/lab2/projects/ChannelsStore.ts
@@ -27,6 +27,8 @@ export interface ChannelsStore {
   publish: (channel: Channel) => Promise<Response>;
 
   unpublish: (channel: Channel) => Promise<Response>;
+
+  getAbuseScore: (channel: Channel) => Promise<number>;
 }
 
 // Note: We don't need to actually save a channel for local storage.
@@ -67,6 +69,11 @@ export class LocalChannelsStore implements ChannelsStore {
   unpublish() {
     // Unpublishing is not supported for local storage.
     return Promise.resolve(new Response(''));
+  }
+
+  getAbuseScore() {
+    // Abuse score is not supported for local storage.
+    return Promise.resolve(0);
   }
 }
 
@@ -110,5 +117,9 @@ export class RemoteChannelsStore implements ChannelsStore {
 
   unpublish(channel: Channel) {
     return channelsApi.unpublish(channel);
+  }
+
+  getAbuseScore(channel: Channel) {
+    return channelsApi.fetchAbuseScore(channel.id);
   }
 }

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -10,7 +10,7 @@
  *
  * If a project manager is destroyed, the enqueued save will be cancelled, if it exists.
  */
-import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
+import {NetworkError} from '@cdo/apps/util/HttpClient';
 import {currentLocation} from '@cdo/apps/utils';
 
 import LabMetricsReporter from '../Lab2MetricsReporter';
@@ -91,10 +91,7 @@ export default class ProjectManager {
     }
 
     this.lastChannel = channel;
-    const response = await HttpClient.fetchJson<{abuse_score: number}>(
-      `/v3/channels/${this.channelId}/abuse`
-    );
-    const abuseScore = response.value.abuse_score;
+    const abuseScore = await this.channelsStore.getAbuseScore(channel);
     return {sources, channel, abuseScore};
   }
 

--- a/apps/src/lab2/projects/ProjectManager.ts
+++ b/apps/src/lab2/projects/ProjectManager.ts
@@ -10,7 +10,7 @@
  *
  * If a project manager is destroyed, the enqueued save will be cancelled, if it exists.
  */
-import {NetworkError} from '@cdo/apps/util/HttpClient';
+import HttpClient, {NetworkError} from '@cdo/apps/util/HttpClient';
 import {currentLocation} from '@cdo/apps/utils';
 
 import LabMetricsReporter from '../Lab2MetricsReporter';
@@ -91,7 +91,11 @@ export default class ProjectManager {
     }
 
     this.lastChannel = channel;
-    return {sources, channel};
+    const response = await HttpClient.fetchJson<{abuse_score: number}>(
+      `/v3/channels/${this.channelId}/abuse`
+    );
+    const abuseScore = response.value.abuse_score;
+    return {sources, channel, abuseScore};
   }
 
   // Restore the given version of the project. This will call restore on the sources store

--- a/apps/src/lab2/projects/channelsApi.ts
+++ b/apps/src/lab2/projects/channelsApi.ts
@@ -38,3 +38,10 @@ export async function publish(channel: Channel): Promise<Response> {
 export async function unpublish(channel: Channel): Promise<Response> {
   return HttpClient.post(`${rootUrl}/${channel.id}/unpublish`, '', false);
 }
+
+export async function fetchAbuseScore(channelId: string): Promise<number> {
+  const {value} = await HttpClient.fetchJson<{abuse_score: number}>(
+    `/v3/channels/${channelId}/abuse`
+  );
+  return value.abuse_score;
+}

--- a/apps/src/lab2/projects/channelsApi.ts
+++ b/apps/src/lab2/projects/channelsApi.ts
@@ -41,7 +41,7 @@ export async function unpublish(channel: Channel): Promise<Response> {
 
 export async function fetchAbuseScore(channelId: string): Promise<number> {
   const {value} = await HttpClient.fetchJson<{abuse_score: number}>(
-    `/v3/channels/${channelId}/abuse`
+    `${rootUrl}/${channelId}/abuse`
   );
   return value.abuse_score;
 }

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -52,6 +52,7 @@ export interface ProjectAndSources {
   // When projects are loaded for the first time, sources may not be present
   sources?: ProjectSources;
   channel: Channel;
+  abuseScore?: number;
 }
 
 /// ------ SOURCES ------ ///

--- a/apps/src/lab2/utils/LifecycleNotifier.tsx
+++ b/apps/src/lab2/utils/LifecycleNotifier.tsx
@@ -16,6 +16,7 @@ type CallbackArgs = {
     levelProperties: LevelProperties,
     channel: Channel | undefined,
     initialSources: ProjectSources | undefined,
+    abuseScore: number | undefined,
     isReadOnly: boolean | undefined
   ];
 };

--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -41,10 +41,8 @@
     }
   }
 
-  .blockedProjectPageContainer {
-    animation: fadein 2s;
+  .blockedProjectUIContainer {
     background-color: $white;
-    color: $neutral_dark;
     position: absolute;
     width: 100%;
     height: 100%;
@@ -53,7 +51,7 @@
     z-index: 80;
   }
 
-  .blockedProjectPageContainerPV {
+  .blockedProjectUIContainerProjectValidator {
     position: absolute;
     display: flex;
     justify-content: center;

--- a/apps/src/lab2/views/Lab2Wrapper.module.scss
+++ b/apps/src/lab2/views/Lab2Wrapper.module.scss
@@ -40,4 +40,25 @@
       }
     }
   }
+
+  .blockedProjectPageContainer {
+    animation: fadein 2s;
+    background-color: $white;
+    color: $neutral_dark;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    z-index: 80;
+  }
+
+  .blockedProjectPageContainerPV {
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    z-index: 80;
+  }
+
 }

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -7,13 +7,15 @@
 // while to load; and a sad bee when things go wrong.
 
 import classNames from 'classnames';
-import React, {useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 
 import {setCurrentLevelId} from '@cdo/apps/code-studio/progressRedux';
 import {useBrowserTextToSpeech} from '@cdo/apps/sharedComponents/BrowserTextToSpeechWrapper';
+import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 
+import {PERMISSIONS} from '../constants';
 import ErrorBoundary from '../ErrorBoundary';
 import useLifecycleNotifier from '../hooks/useLifecycleNotifier';
 import {
@@ -28,6 +30,7 @@ import {LifecycleEvent} from '../utils';
 
 import {ErrorFallbackPage, ErrorUI} from './ErrorFallbackPage';
 import Loading from './Loading';
+import {ProjectBlockedPage} from './ProjectBlockedPage';
 
 import moduleStyles from './Lab2Wrapper.module.scss';
 
@@ -35,9 +38,27 @@ export interface Lab2WrapperProps {
   children: React.ReactNode;
 }
 
+async function fetchIsProjectValidator(): Promise<boolean> {
+  const permissionsResponse = await HttpClient.fetchJson<{
+    permissions: string[];
+  }>('/api/v1/users/current/permissions');
+  const {permissions} = permissionsResponse.value;
+
+  return permissions.includes(PERMISSIONS.PROJECT_VALIDATOR) ? true : false;
+}
+
 const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
   const isLoading: boolean = useSelector(isLabLoading);
   const isPageError: boolean = useSelector(hasPageError);
+  const isBlocked: boolean | undefined = useSelector(
+    (state: {lab: LabState}) => state.lab.isBlocked
+  );
+  const [isProjectValidator, setIsProjectValidator] = useState(false);
+  useEffect(() => {
+    fetchIsProjectValidator().then(data => {
+      setIsProjectValidator(data);
+    });
+  }, []);
   const errorMessage: string | undefined = useSelector(
     (state: {lab: LabState}) =>
       state.lab.pageError?.errorMessage || state.lab.pageError?.error?.message
@@ -93,6 +114,9 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
         <Loading isLoading={isLoading} />
 
         {isPageError && <ErrorUI message={errorMessage} />}
+        {isBlocked && (
+          <ProjectBlockedPage isProjectValidator={isProjectValidator} />
+        )}
       </div>
     </ErrorBoundary>
   );

--- a/apps/src/lab2/views/Lab2Wrapper.tsx
+++ b/apps/src/lab2/views/Lab2Wrapper.tsx
@@ -30,7 +30,7 @@ import {LifecycleEvent} from '../utils';
 
 import {ErrorFallbackPage, ErrorUI} from './ErrorFallbackPage';
 import Loading from './Loading';
-import {ProjectBlockedPage} from './ProjectBlockedPage';
+import {ProjectBlockedUI} from './ProjectBlockedUI';
 
 import moduleStyles from './Lab2Wrapper.module.scss';
 
@@ -50,9 +50,7 @@ async function fetchIsProjectValidator(): Promise<boolean> {
 const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
   const isLoading: boolean = useSelector(isLabLoading);
   const isPageError: boolean = useSelector(hasPageError);
-  const isBlocked: boolean | undefined = useSelector(
-    (state: {lab: LabState}) => state.lab.isBlocked
-  );
+  const isBlocked = useAppSelector(state => state.lab.isBlocked);
   const [isProjectValidator, setIsProjectValidator] = useState(false);
   useEffect(() => {
     fetchIsProjectValidator().then(data => {
@@ -115,7 +113,7 @@ const Lab2Wrapper: React.FunctionComponent<Lab2WrapperProps> = ({children}) => {
 
         {isPageError && <ErrorUI message={errorMessage} />}
         {isBlocked && (
-          <ProjectBlockedPage isProjectValidator={isProjectValidator} />
+          <ProjectBlockedUI isProjectValidator={isProjectValidator} />
         )}
       </div>
     </ErrorBoundary>

--- a/apps/src/lab2/views/ProjectBlockedPage.tsx
+++ b/apps/src/lab2/views/ProjectBlockedPage.tsx
@@ -1,0 +1,57 @@
+import React, {useState} from 'react';
+
+import AbuseExclamation from '@cdo/apps/code-studio/components/AbuseExclamation';
+import Alert, {alertTypes} from '@cdo/apps/componentLibrary/alert/Alert';
+import i18n from '@cdo/locale';
+
+import Lab2Registry from '../Lab2Registry';
+
+import moduleStyles from './Lab2Wrapper.module.scss';
+
+export const ProjectBlockedPage: React.FunctionComponent<{
+  isProjectValidator: boolean;
+}> = ({isProjectValidator}) => {
+  const [showAlert, setShowAlert] = useState(true);
+  const projectManager = Lab2Registry.getInstance().getProjectManager();
+  const shareUrl = projectManager ? projectManager.getShareUrl() : null;
+
+  if (isProjectValidator) {
+    return (
+      <div
+        id="blocked-project-page-container-pv"
+        className={moduleStyles.blockedProjectPageContainerPV}
+      >
+        {showAlert && (
+          <Alert
+            text={i18n.tosLong({url: 'http://code.org/tos'})}
+            type={alertTypes.danger}
+            onClose={() => {
+              setShowAlert(false);
+            }}
+          />
+        )}
+      </div>
+    );
+  } else {
+    return (
+      <div
+        id="blocked-project-page-container"
+        className={moduleStyles.blockedProjectPageContainer}
+      >
+        <AbuseExclamation
+          i18n={{
+            tos: i18n.tosLong({url: 'http://code.org/tos'}),
+            contact_us: i18n.contactUs({
+              url: `https://support.code.org/hc/en-us/requests/new?&description=${encodeURIComponent(
+                `Abuse error for project at url: ${shareUrl}`
+              )}`,
+            }),
+            edit_project: i18n.editProject(),
+            go_to_code_studio: i18n.goToCodeStudio(),
+          }}
+          isOwner={false}
+        />
+      </div>
+    );
+  }
+};

--- a/apps/src/lab2/views/ProjectBlockedUI.tsx
+++ b/apps/src/lab2/views/ProjectBlockedUI.tsx
@@ -25,7 +25,7 @@ export const ProjectBlockedUI: React.FunctionComponent<{
       >
         {showAlert && (
           <Alert
-            text={i18n.tosLong({url: 'http://code.org/tos'})}
+            text={i18n.tosWithoutLink()}
             type={alertTypes.danger}
             onClose={() => {
               setShowAlert(false);

--- a/apps/src/lab2/views/ProjectBlockedUI.tsx
+++ b/apps/src/lab2/views/ProjectBlockedUI.tsx
@@ -2,24 +2,26 @@ import React, {useState} from 'react';
 
 import AbuseExclamation from '@cdo/apps/code-studio/components/AbuseExclamation';
 import Alert, {alertTypes} from '@cdo/apps/componentLibrary/alert/Alert';
+import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
 import Lab2Registry from '../Lab2Registry';
 
 import moduleStyles from './Lab2Wrapper.module.scss';
 
-export const ProjectBlockedPage: React.FunctionComponent<{
+export const ProjectBlockedUI: React.FunctionComponent<{
   isProjectValidator: boolean;
 }> = ({isProjectValidator}) => {
   const [showAlert, setShowAlert] = useState(true);
   const projectManager = Lab2Registry.getInstance().getProjectManager();
   const shareUrl = projectManager ? projectManager.getShareUrl() : null;
+  const isOwner = useAppSelector(state => state.lab.channel?.isOwner || false);
 
   if (isProjectValidator) {
     return (
       <div
-        id="blocked-project-page-container-pv"
-        className={moduleStyles.blockedProjectPageContainerPV}
+        id="blocked-project-ui-container-project-validator"
+        className={moduleStyles.blockedProjectUIContainerProjectValidator}
       >
         {showAlert && (
           <Alert
@@ -35,8 +37,8 @@ export const ProjectBlockedPage: React.FunctionComponent<{
   } else {
     return (
       <div
-        id="blocked-project-page-container"
-        className={moduleStyles.blockedProjectPageContainer}
+        id="blocked-project-ui-container"
+        className={moduleStyles.blockedProjectUIContainer}
       >
         <AbuseExclamation
           i18n={{
@@ -49,7 +51,7 @@ export const ProjectBlockedPage: React.FunctionComponent<{
             edit_project: i18n.editProject(),
             go_to_code_studio: i18n.goToCodeStudio(),
           }}
-          isOwner={false}
+          isOwner={isOwner}
         />
       </div>
     );


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR adds the UI when a lab2 project is blocked if it's abuse score is >= threshold of 15. It follows up https://github.com/code-dot-org/code-dot-org/pull/62929 which added ability to update abuse score for lab2 projects via extra links box.

In `lab2Redux`, we fetch the abuse score on level load. The reason is that if a user is on a project-backed level, they may be able to share the project with the share URL (this is not yet possible for lab2 projects, but may be possible in the future. This is possible for legacy project-backed levels). `isBlocked` is added as a state value and then accessed to determine if the blocked UI should be displayed or not. 

In `lab2Wrapper`, permissions are fetched because the blocked project UI is different for project validators vs non-project validators. For non-project validators, the entire lab panel is blocked and the `AbuseExclamation` component is displayed.

### After update - screenshot of blocked project on a student account

<img width="1364" alt="Screenshot 2025-01-06 at 4 47 40 PM" src="https://github.com/user-attachments/assets/cc54849c-7a64-4c9b-ab75-d6f0df55cc9a" />




For project validators, an alert is displayed and can be closed  so that project validators can still view the project content to confirm if the content is inappropriate or not.

### After update - screenshot of blocked project on a teacher account with project validator permission

![Screenshot 2025-01-07 at 3 46 59 PM](https://github.com/user-attachments/assets/9621465a-df42-4553-90df-a89c44bcf92f)


Initially, I fetched permissions in the new `ProjectBlockedUI` component, but there was a delay in fetching data so that the non-project validator version of the UI would appear for less than a second and then the project validator version would be displayed. So I decided to fetch permissions in `Lab2Wrapper` instead.

## After update

Screencast video of non-blocked project being blocked, and then unblocked on a project validator account.


https://github.com/user-attachments/assets/6f0216e0-33a3-4559-a579-9db977f5a1b6





## Links
[jira](https://codedotorg.atlassian.net/browse/CT-944)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally:
- On a student account I created a pythonlab project.
- On a teacher account with project validator permission, I reported abuse on the student project and saw that the UI is displayed. The UI depends on whether the account has project validator permission or not.
- With project validator permission, I then reset the abuse score via Extra Links and saw that the blocked project UI is no longer displayed.


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
