### PR TITLE
HoC 2024 - Update default_hoc_mode to false

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -442,7 +442,7 @@ levelbuilder_mode:
 # make it easier to tell the difference
 use_local_header_color:
 
-default_hoc_mode: actual-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode: false  # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''      # overridden by 'hoc_launch' DCDO param, except in :test
 hoc-2024-nov-launch: true # overridden by 'hoc-2024-nov-launch' DCDO param, except in :test
 


### PR DESCRIPTION
Updates `default_hoc_mode` to `false` on the test environment so we can maintain Eyes test coverage when `hoc_mode`s change on staging and production.

👀 **Note:** this will likely have Eyes diffs

## Links
Jira ticket: [ACQ-2454](https://codedotorg.atlassian.net/browse/ACQ-2454)
Spec: [here](https://docs.google.com/document/d/1npRdcuOhOPGghHXkBZain_7ZvRrqvizAbwT1gwlAaK8/edit?tab=t.93velwtiu6xz#heading=h.qmht17kfjff7)