### PR TITLE
Fix projects tab not loading new data for each section

### DIFF
--- a/apps/src/templates/projects/SectionProjectsListWithData.jsx
+++ b/apps/src/templates/projects/SectionProjectsListWithData.jsx
@@ -1,58 +1,55 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {useState} from 'react';
 import {connect} from 'react-redux';
 
 import Spinner from '@cdo/apps/sharedComponents/Spinner';
 
 import SectionProjectsList from './SectionProjectsList';
 
-class SectionProjectsListWithData extends Component {
-  static propTypes = {
-    studioUrlPrefix: PropTypes.string,
+const SectionProjectsListWithData = ({
+  sectionId,
+  localeCode,
+  studioUrlPrefix,
+}) => {
+  const [projectsData, setProjectsData] = useState({});
+  const [isLoading, setIsLoading] = useState(true);
 
-    // Props provided by redux.
-    localeCode: PropTypes.string,
-    sectionId: PropTypes.number,
-  };
+  React.useEffect(() => {
+    setIsLoading(true);
+    const projectsDataUrl = `/dashboardapi/v1/projects/section/${sectionId}`;
 
-  state = {
-    projectsData: {},
-    isLoading: true,
-  };
-
-  componentDidMount() {
-    const projectsDataUrl = `/dashboardapi/v1/projects/section/${this.props.sectionId}`;
     $.ajax({
       url: projectsDataUrl,
       method: 'GET',
       dataType: 'json',
     }).done(projectsData => {
-      this.setState({
-        projectsData: projectsData,
-        isLoading: false,
-      });
+      setProjectsData(projectsData);
+      setIsLoading(false);
     });
-  }
+  }, [sectionId, setProjectsData, setIsLoading]);
 
-  render() {
-    const {studioUrlPrefix} = this.props;
-    const {projectsData} = this.state;
+  return (
+    <div>
+      {isLoading && <Spinner />}
+      {!isLoading && (
+        <SectionProjectsList
+          localeCode={localeCode}
+          projectsData={projectsData}
+          studioUrlPrefix={studioUrlPrefix}
+          showProjectThumbnails={true}
+        />
+      )}
+    </div>
+  );
+};
 
-    return (
-      <div>
-        {this.state.isLoading && <Spinner />}
-        {!this.state.isLoading && (
-          <SectionProjectsList
-            localeCode={this.props.localeCode}
-            projectsData={projectsData}
-            studioUrlPrefix={studioUrlPrefix}
-            showProjectThumbnails={true}
-          />
-        )}
-      </div>
-    );
-  }
-}
+SectionProjectsListWithData.propTypes = {
+  studioUrlPrefix: PropTypes.string,
+
+  // Props provided by redux.
+  localeCode: PropTypes.string,
+  sectionId: PropTypes.number,
+};
 
 export const UnconnectedSectionProjectsListWithData =
   SectionProjectsListWithData;


### PR DESCRIPTION
When switching sections on the projects tab, nothing would reload and the existing section data would still be displayed.

This PR loads data for the new selected section by changing from a `componentDidMount` which only runs once to `useEffect` that runs whenever the sectionId changes. This PR also changes SectionProjectsListWithData from a component to a function to better fit current standards.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1521
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally

https://github.com/user-attachments/assets/5dc44c4f-e6af-408d-9a71-555fd812ce20
