### PR TITLE
[Google Blockly] Override For Loop Generator

### DIFF
--- a/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
+++ b/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
@@ -120,4 +120,6 @@ export const blocks = {
   getColourDropdownField(colours) {
     return new Blockly.FieldColourDropdown(colours, 45, 35);
   },
+  // Custom generator is already provided by CDO Blockly.
+  overrideForLoopGenerator() {},
 };

--- a/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
@@ -10,6 +10,7 @@ import {Order} from 'blockly/javascript';
 import {
   BlocklyWrapperType,
   ExtendedJavascriptGenerator,
+  JavascriptGeneratorType,
 } from '@cdo/apps/blockly/types';
 import i18n from '@cdo/locale';
 
@@ -163,5 +164,120 @@ export const blocks = {
       configOptions,
       isK1
     );
+  },
+
+  overrideForLoopGenerator() {
+    // A custom generator for a "for loop" in labs where variable names should be part of the
+    // of the Globals namespace (e.g. Globals.counter). Used for Play Lab aka Studio
+    Blockly.JavaScript.forBlock.controls_for = function (
+      block: GoogleBlockly.Block,
+      generator: JavascriptGeneratorType
+    ) {
+      // For loop. This code is copied and modified from Core Blockly:
+      // https://github.com/google/blockly/blob/2c29c01b14fd9cec9f7fde82f6c80b6f4f7b7c30/generators/javascript/loops.ts#L85-L178
+
+      // Customization: use translateVarName instead of getVariableName
+      const variable0 = generator.translateVarName(block.getFieldValue('VAR'));
+      // End customation.
+
+      const argument0 =
+        generator.valueToCode(block, 'FROM', Order.ASSIGNMENT) || '0';
+      const argument1 =
+        generator.valueToCode(block, 'TO', Order.ASSIGNMENT) || '0';
+      const increment =
+        generator.valueToCode(block, 'BY', Order.ASSIGNMENT) || '1';
+      let branch = generator.statementToCode(block, 'DO');
+      branch = generator.addLoopTrap(branch, block);
+      let code;
+      if (
+        Blockly.utils.string.isNumber(argument0) &&
+        Blockly.utils.string.isNumber(argument1) &&
+        Blockly.utils.string.isNumber(increment)
+      ) {
+        // All arguments are simple numbers.
+        const up = Number(argument0) <= Number(argument1);
+        code =
+          'for (' +
+          variable0 +
+          ' = ' +
+          argument0 +
+          '; ' +
+          variable0 +
+          (up ? ' <= ' : ' >= ') +
+          argument1 +
+          '; ' +
+          variable0;
+        const step = Math.abs(Number(increment));
+        if (step === 1) {
+          code += up ? '++' : '--';
+        } else {
+          code += (up ? ' += ' : ' -= ') + step;
+        }
+        code += ') {\n' + branch + '}\n';
+      } else {
+        code = '';
+        // Cache non-trivial values to variables to prevent repeated look-ups.
+        let startVar = argument0;
+        if (
+          !argument0.match(/^\w+$/) &&
+          !Blockly.utils.string.isNumber(argument0)
+        ) {
+          startVar = generator.nameDB_!.getDistinctName(
+            variable0 + '_start',
+            Blockly.Names.NameType.VARIABLE
+          );
+          code += 'var ' + startVar + ' = ' + argument0 + ';\n';
+        }
+        let endVar = argument1;
+        if (
+          !argument1.match(/^\w+$/) &&
+          !Blockly.utils.string.isNumber(argument1)
+        ) {
+          endVar = generator.nameDB_!.getDistinctName(
+            variable0 + '_end',
+            Blockly.Names.NameType.VARIABLE
+          );
+          code += 'var ' + endVar + ' = ' + argument1 + ';\n';
+        }
+        // Determine loop direction at start, in case one of the bounds
+        // changes during loop execution.
+        const incVar = generator.nameDB_!.getDistinctName(
+          variable0 + '_inc',
+          Blockly.Names.NameType.VARIABLE
+        );
+        code += 'var ' + incVar + ' = ';
+        if (Blockly.utils.string.isNumber(increment)) {
+          code += Math.abs(Number(increment)) + ';\n';
+        } else {
+          code += 'Math.abs(' + increment + ');\n';
+        }
+        code += 'if (' + startVar + ' > ' + endVar + ') {\n';
+        code += generator.INDENT + incVar + ' = -' + incVar + ';\n';
+        code += '}\n';
+        code +=
+          'for (' +
+          variable0 +
+          ' = ' +
+          startVar +
+          '; ' +
+          incVar +
+          ' >= 0 ? ' +
+          variable0 +
+          ' <= ' +
+          endVar +
+          ' : ' +
+          variable0 +
+          ' >= ' +
+          endVar +
+          '; ' +
+          variable0 +
+          ' += ' +
+          incVar +
+          ') {\n' +
+          branch +
+          '}\n';
+      }
+      return code;
+    };
   },
 };

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -3516,6 +3516,10 @@ exports.install = function (blockly, blockInstallOptions) {
     return varName + ' = ' + argument0 + ';\n';
   };
 
+  // Overrides the standard generator from Core Blockly.
+  // Variable labels in Playlab include the Globals namespace.
+  Blockly.customBlocks.overrideForLoopGenerator();
+
   blockGeneratorFunctionDictionary.studio_ask = function () {
     var blockId = `block_id_${this.id}`;
     var question = this.getFieldValue('TEXT');


### PR DESCRIPTION
This adds support for Play Lab's for loop blocks. Similar to other blocks using variables (https://github.com/code-dot-org/code-dot-org/pull/63057), we expect for loops to use values like `Globals.counter` instead of just `counter`. This is handled by a custom `translateVarName` generator function.

To handle this problem, I compared the block generator functions for the `countrols_for` block in each version of Blockly.
Google Blockly:
https://github.com/google/blockly/blob/2c29c01b14fd9cec9f7fde82f6c80b6f4f7b7c30/generators/javascript/loops.ts#L85-L178

CDO Blockly:
https://github.com/code-dot-org/blockly/blob/v4.1.0/generators/javascript/loops.js#L129-L254


The important difference in each is how we get the initial variable name from the block. Google Blockly just gets the name from the variable field:
```
const variable0 = generator.getVariableName(block.getFieldValue('VAR'));
```

However, in CDO Blockly, we use the custom `translateVarName` function:
```
  var variable0 = Blockly.JavaScript.translateVarName(
    this.getTitleValue('VAR')
  );
```

We have already added the functionality to add `Globals.` to the variable name here:
https://github.com/code-dot-org/code-dot-org/pull/63057/files#diff-188d1ce24ff6fffe4a2cef0045a8dc561b70367b85180965682c8c6fab563835

To fix this, I needed to override the block generator function for `controls_for` blocks, but only in Google Blockly. I utilized our `customBlocks` files to add a helper for this. It is intentionally no-opped in CDO Blockly. The new function is based on the current Google Blockly implementation but is customized to use `translateVarName` instead of `getVariableName`.

_Note:_ In the variables PR (https://github.com/code-dot-org/code-dot-org/pull/63057), I defined the generators for `variables_get` and `variables_set` directly in the Play Lab files (`studio/blocks.js`). This worked fine because the new generator function was already identical to CDO Blockly's. The function for `controls_for` on the other hand is more complex and has some other differences due to changes in the Blockly API.

This change makes all levels in "Play Lab: For Loops" fully playable (starting with `/s/course4/lessons/11/levels/1`).

<img width="1223" alt="image" src="https://github.com/user-attachments/assets/795d3080-72bf-4b96-b19d-a26b9c39f71d" />

## Links

https://codedotorg.atlassian.net/browse/CT-907
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
