### PR TITLE
HoC 2025 - Update CSEdWeek dates

### DIFF
--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -184,7 +184,7 @@ def campaign_date(format)
     id = 'campaign_date_full_year'
   end
 
-  # For hoc2024, we just want campaign dates for the US
+  # For hoc2025, we just want campaign dates for the US
   # and non-US.
   if @country != "us"
     id = "nonus_#{id}"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -11,12 +11,12 @@
   hoc_stat_hours_served: "Over 100M students have tried an Hour of Code"
   hoc_stat_females: "Female students make up 50% of Hour of Code participants"
 
-  campaign_date_start_short: "Dec. 9"
-  campaign_date_start_long: "December 9"
-  campaign_date_short: "Dec. 9-15"
-  campaign_date_full: "December 9-15"
-  campaign_date_year: "2024"
-  campaign_date_full_year: "December 9-15, 2024"
+  campaign_date_start_short: "Dec. 8"
+  campaign_date_start_long: "December 8"
+  campaign_date_short: "Dec. 8-14"
+  campaign_date_full: "December 8-14"
+  campaign_date_year: "2025"
+  campaign_date_full_year: "December 8-14, 2025"
 
   nonus_campaign_date_start_short: "Sept. 5"
   nonus_campaign_date_start_long: "September 5"


### PR DESCRIPTION
Updates the dates for the 2025 Hour of Code. I only updated the US dates now following [last year's PR](https://github.com/code-dot-org/code-dot-org/pull/55814).

## Links
Jira ticket: [ACQ-2905](https://codedotorg.atlassian.net/browse/ACQ-2905)
Spec: [here](https://docs.google.com/document/d/1npRdcuOhOPGghHXkBZain_7ZvRrqvizAbwT1gwlAaK8/edit?tab=t.93velwtiu6xz#heading=h.pg7oeg3dg2e)

----

<img width="1019" alt="Screenshot 2025-01-07 at 10 44 16 AM" src="https://github.com/user-attachments/assets/63c9caf6-649c-4bc4-be39-21c7f6f8bebc" />