### PR TITLE
Remove IE-specific event logging from Google Classroom Share button

### DIFF
--- a/apps/src/templates/progress/GoogleClassroomShareButton.jsx
+++ b/apps/src/templates/progress/GoogleClassroomShareButton.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import firehoseClient from '@cdo/apps/metrics/firehose';
-import {isIE11} from '@cdo/apps/util/browser-detector';
 import i18n from '@cdo/locale';
 
 // used to give each instance a unique id to use for callback names
@@ -33,16 +32,10 @@ export default class GoogleClassroomShareButton extends React.PureComponent {
     this.onShareStart = this.onShareStart.bind(this);
     this.onShareComplete = this.onShareComplete.bind(this);
     this.logEvent = this.logEvent.bind(this);
-
-    // For metrics in IE.
-    this.blur = this.blur.bind(this);
-    this.mouseOver = this.mouseOver.bind(this);
-    this.mouseOut = this.mouseOut.bind(this);
   }
 
   instanceId = componentCount++;
   buttonRef = null;
-  iframeMouseOver = false;
   state = {
     buttonMounted: false,
   };
@@ -54,13 +47,6 @@ export default class GoogleClassroomShareButton extends React.PureComponent {
     // Use unique callback names since we're adding to the global namespace
     window[this.onShareStartName()] = this.onShareStart;
     window[this.onShareCompleteName()] = this.onShareComplete;
-
-    // The button callbacks are not supported in IE, so in IE we use click
-    // events to record analytics. The button is rendered in an iframe though,
-    // so to detect the click events we need to use the 'blur' event.
-    if (isIE11) {
-      window.addEventListener('blur', this.blur);
-    }
   }
 
   componentDidUpdate(prevProps) {
@@ -83,21 +69,6 @@ export default class GoogleClassroomShareButton extends React.PureComponent {
 
   onShareComplete() {
     this.logEvent('share_completed');
-  }
-
-  blur() {
-    if (this.iframeMouseOver) {
-      // This is the only event we will capture in IE.
-      this.logEvent('button_clicked');
-    }
-  }
-
-  mouseOver() {
-    this.iframeMouseOver = true;
-  }
-
-  mouseOut() {
-    this.iframeMouseOver = false;
   }
 
   logEvent(event) {
@@ -129,11 +100,7 @@ export default class GoogleClassroomShareButton extends React.PureComponent {
   render() {
     return (
       <span style={styles.container}>
-        <span
-          ref={elem => (this.buttonRef = elem)}
-          onMouseOver={this.mouseOver}
-          onMouseOut={this.mouseOut}
-        />
+        <span ref={elem => (this.buttonRef = elem)} />
         {this.state.buttonMounted && (
           <span style={styles.label}>{i18n.shareToGoogleClassroom()}</span>
         )}


### PR DESCRIPTION
Removes some old (5 years ago) IE-specific event logging code that was causing a11y-related linter errors.

~~Interestingly, I am seeing a pretty large number of these events being logged (see below), even though they are supposedly IE-specific? I did a bit of digging and don't see any obvious other source for these events, and their intention (ie, to log IE-specific behavior) seems pretty clear, so I'm still inclined to remove them. Open to other interpretations, however.~~

[See comment below](https://github.com/code-dot-org/code-dot-org/pull/63151#discussion_r1907938794) -- I think this event was being logged across all browsers even though it was intended for IE11. The fact no one noticed gives me more confidence it's safe to delete :).

![image](https://github.com/user-attachments/assets/d244f520-7ab2-4b27-9a75-267b9e5aafd1)

## Links

- https://codedotorg.atlassian.net/browse/A11Y-343
- https://codedotorg.atlassian.net/browse/A11Y-344
- PR that added this functionality: https://github.com/code-dot-org/code-dot-org/pull/36512

## Testing story

I haven't tested this yet (requires some google classroom / oauth setup) -- going to ask someone in teacher tools/platform to check it out.