### PR TITLE
Fix error causing student links to not show student info on teacher dashboard

### DIFF
--- a/apps/src/templates/teacherDashboard/urlHelpers.js
+++ b/apps/src/templates/teacherDashboard/urlHelpers.js
@@ -14,9 +14,18 @@ export const teacherDashboardUrl = (sectionId, path = '') => {
   return dashboardPrefix + sectionId + path;
 };
 
-export const getUnitUrl = (sectionId, unitName, unassignedUnitUrl) => {
+export const getUnitUrl = (
+  sectionId,
+  unitName,
+  studentId = null,
+  unassignedUnitUrl
+) => {
   if (showV2TeacherDashboard() && sectionId && unitName) {
-    return `/teacher_dashboard/sections/${sectionId}/unit/${unitName}`;
+    if (studentId) {
+      return `/teacher_dashboard/sections/${sectionId}/unit/${unitName}?user_id=${studentId}`;
+    } else {
+      return `/teacher_dashboard/sections/${sectionId}/unit/${unitName}`;
+    }
   }
 
   return unassignedUnitUrl;
@@ -30,6 +39,7 @@ export const unitUrlForStudent = (sectionId, unitName, studentId) => {
   return getUnitUrl(
     sectionId,
     unitName,
+    studentId,
     `/s/${unitName}?section_id=${sectionId}&user_id=${studentId}&viewAs=Instructor`
   );
 };


### PR DESCRIPTION
This fixes an error that caused links to student details from the Progress, Stats, Text Responses, and Roster pages in the new teacher dashboard to not link to the correct student unit overview page.

## Links

[TEACH-1514](https://codedotorg.atlassian.net/browse/TEACH-1514)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
