### PR TITLE
[Google Blockly] Prepare for EventType enum

### DIFF
--- a/apps/src/blockly/addons/workspaceSvgFrame.ts
+++ b/apps/src/blockly/addons/workspaceSvgFrame.ts
@@ -188,15 +188,13 @@ export default class WorkspaceSvgFrame extends SvgFrame {
  * @param {Blockly.Events.Abstract} event - The Blockly event object.
  */
 function onWorkspaceChange(event: GoogleBlockly.Events.Abstract) {
-  if (
-    [
-      Blockly.Events.DELETE,
-      Blockly.Events.MOVE,
-      Blockly.Events.THEME_CHANGE,
-      Blockly.Events.VIEWPORT_CHANGE,
-    ].includes(event.type) &&
-    event.workspaceId
-  ) {
+  const expectedEventTypes: string[] = [
+    Blockly.Events.BLOCK_DELETE,
+    Blockly.Events.BLOCK_MOVE,
+    Blockly.Events.THEME_CHANGE,
+    Blockly.Events.VIEWPORT_CHANGE,
+  ];
+  if (expectedEventTypes.includes(event.type) && event.workspaceId) {
     const workspace = Blockly.common.getWorkspaceById(event.workspaceId);
     const svgFrame = (workspace as EditorWorkspaceSvg).svgFrame_;
     svgFrame.render();

--- a/apps/src/blockly/eventHandlers.ts
+++ b/apps/src/blockly/eventHandlers.ts
@@ -120,12 +120,11 @@ export function storeWorkspaceWidth(e: GoogleBlockly.Events.Abstract) {
 // Jigsaw only. Sets a fill pattern defines a path in order to show pictures
 // over the blocks.
 export function setPathFill(e: GoogleBlockly.Events.Abstract) {
-  if (
-    [Blockly.Events.FINISHED_LOADING, Blockly.Events.BLOCK_MOVE].includes(
-      e.type
-    ) &&
-    e.workspaceId
-  ) {
+  const expectedEventTypes: string[] = [
+    Blockly.Events.FINISHED_LOADING,
+    Blockly.Events.BLOCK_MOVE,
+  ];
+  if (expectedEventTypes.includes(e.type) && e.workspaceId) {
     if (!Blockly.isJigsaw) {
       return;
     }
@@ -182,15 +181,14 @@ export function bumpRTLBlocks() {
 
 // When blocks on the main workspace are changed, update the block limits indicators.
 export function updateBlockLimits(event: GoogleBlockly.Events.Abstract) {
-  if (
-    ![
-      Blockly.Events.BLOCK_CHANGE,
-      Blockly.Events.BLOCK_MOVE,
-      Blockly.Events.BLOCK_CREATE,
-      // High Contrast theme has a different font size, so we update the indicators.
-      Blockly.Events.THEME_CHANGE,
-    ].includes(event.type)
-  ) {
+  const expectedEventTypes: string[] = [
+    Blockly.Events.BLOCK_CHANGE,
+    Blockly.Events.BLOCK_MOVE,
+    Blockly.Events.BLOCK_CREATE,
+    // High Contrast theme has a different font size, so we update the indicators.
+    Blockly.Events.THEME_CHANGE,
+  ];
+  if (!expectedEventTypes.includes(event.type)) {
     return;
   }
 


### PR DESCRIPTION
Blockly 11.2.0 introduces a new enum for Blockly-owned event types:
- https://github.com/google/blockly/pull/8530

The `EventType` enum allows Blockly to be certain that their own event subclasses have distinct `.type` values. In a few places where we check event types, this means that TypeScript will determine that we are comparing against an `EventType[]` rather than a `string[]`. This introduces a couple of challenges. 

The base `Abstract` event class doesn't use the new type, because that would prohibit developers from defining their own event types. This means we can't be certain that a given event's class will be on of the `EventType` enum. Also, the `EventType` type is not exported with the Blockly package, which means we can't import it and do something like cast our event types to it.

To get around this problem, we can define a string array of our expected event types and use that for comparison. We know that every `EventType` is a string and that that is also the type of the base `Abtract` event type.
This change will allow us to bump from Blockly 11.1.1 to 11.2.0.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
