### PR TITLE
Header: update vignette color

### DIFF
--- a/apps/src/code-studio/components/header/HeaderVignette.js
+++ b/apps/src/code-studio/components/header/HeaderVignette.js
@@ -5,7 +5,7 @@ export default {
     height: '100%',
     pointerEvents: 'none',
     background:
-      'linear-gradient(to right, rgba(0, 173, 188, 1) 0%, rgba(0, 173, 188, 0) 20px)',
+      'linear-gradient(to right, rgba(0, 147, 164, 1) 0%, rgba(0, 147, 164, 0) 20px)',
   },
   right: {
     position: 'absolute',
@@ -13,6 +13,6 @@ export default {
     height: '100%',
     pointerEvents: 'none',
     background:
-      'linear-gradient(to right, rgba(0, 173, 188, 0) calc(100% - 20px), rgba(0, 173, 188, 1) 100%)',
+      'linear-gradient(to right, rgba(0, 147, 164, 0) calc(100% - 20px), rgba(0, 147, 164, 1) 100%)',
   },
 };


### PR DESCRIPTION
This updates the base color of the vignette to match the background color of the header when items are truncated.  

The vignette was added in https://github.com/code-dot-org/code-dot-org/pull/34551.  The header's background color was updated in https://github.com/code-dot-org/code-dot-org/pull/56282.

### before

<img width="664" alt="Screenshot 2025-01-08 at 9 43 01 AM" src="https://github.com/user-attachments/assets/736addbd-120e-47e3-9402-c85075a34df7" />

### after

<img width="664" alt="Screenshot 2025-01-08 at 9 48 00 AM" src="https://github.com/user-attachments/assets/85c41274-43d6-4c53-9824-3f998967e18e" />
