### PR TITLE
Adding deprecation warning banner to Offline HoC download page

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2407,6 +2407,18 @@ a.download-video {
 
 #hoc_download {
   color: $charcoal;
+  #deprecation-warning-banner {
+    margin: 1em 0;
+    padding: 1em;
+    width: 100%;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    gap: 1em;
+    #warning-icon {
+      font-size: 3em;
+    }
+  }
   .capsule {
     background-color: $lightest_gray;
     border-radius: 10px;

--- a/dashboard/app/views/hoc_download/index.html.haml
+++ b/dashboard/app/views/hoc_download/index.html.haml
@@ -8,6 +8,14 @@
 #hoc_download
   .row
     .span12
+      %div
+        #deprecation-warning-banner{class: 'alert alert-warning', role: 'alert'}
+          %span
+            %i.fa.fa-warning.warning-sign.banner-icon#warning-icon
+          %span
+            = t('hoc_download.deprecation')
+  .row
+    .span12
       %h1
         = t('hoc_download.title')
   .row

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1095,6 +1095,7 @@ en:
     title: 'Hour of Code downloads'
     capsule_title: 'Do you have Internet?'
     capsule_desc: 'Use the online, web-based [%{app_name}](%{url}).'
+    deprecation: 'The following material is no longer supported by Code.org. You may encounter technical issues if you decide to use the material.'
     instructions_headline: 'No Internet?'
     instructions: 'Instructions for teachers: if you have poor Internet service, these Hour of Code tutorials are available to download and install for offline use. Choose your language and platform, download and install it on all the computers in your classroom. You may want to use a USB drive to download once and install on all computers. Note: students will not be able to log into Code Studio, save progress, or print certificates. Teachers may print certificates ahead of time [here](%{url}).'
     minecraft_name: 'Minecraft Hour Of Code'


### PR DESCRIPTION
We no longer support the offline version of our old Hour of Code events. This PR adds a warning banner to inform users we will not provide technical support. This is something we have already been communicating to users for years now in Zendesk tickets.

## Screenshots
**Before**|**After**
---|---
![Screenshot 2025-01-07 at 4 25 50 PM](https://github.com/user-attachments/assets/21de61b4-1935-4bd1-9fd9-d81b977afef8)|![Screenshot 2025-01-07 at 4 30 36 PM](https://github.com/user-attachments/assets/ec811715-b2ac-44fa-9aa9-4b42097a9565)

## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-144)

## Testing story
Manually tested on http://localhost-studio.code.org:3000/download/mc
