### PR TITLE
Music: avoid duplicate sounds

### DIFF
--- a/apps/src/music/player/sequencer/Simple2Sequencer.ts
+++ b/apps/src/music/player/sequencer/Simple2Sequencer.ts
@@ -48,6 +48,10 @@ export default class Simple2Sequencer extends Sequencer {
   private startMeasure: number;
   private inTrigger: boolean;
 
+  // A set of strings (e.g. "electro/beat-4", which is an event ID and when to play) that are used
+  // to ensure the same sound isn't played multiple times at the same time.
+  private uniqueEvents: Set<string>;
+
   private currentEventCount: number;
 
   constructor(
@@ -60,6 +64,7 @@ export default class Simple2Sequencer extends Sequencer {
     this.randomStack = [];
 
     this.functionMap = {};
+    this.uniqueEvents = new Set();
     this.uniqueInvocationIdUpTo = 0;
     this.startMeasure = 1;
     this.inTrigger = false;
@@ -74,6 +79,7 @@ export default class Simple2Sequencer extends Sequencer {
   clear(existingEventCount: number = 0) {
     this.newSequence();
     this.functionMap = {};
+    this.uniqueEvents.clear();
 
     this.currentEventCount = existingEventCount;
   }
@@ -341,8 +347,12 @@ export default class Simple2Sequencer extends Sequencer {
     }
     const currentFunction = this.functionMap[currentFunctionId];
 
-    currentFunction.playbackEvents.push(event);
-    this.updateMeasureForPlayByLength(event.length);
+    const uniqueEventKey = `${event.id}-${event.when}`;
+    if (!this.uniqueEvents.has(uniqueEventKey)) {
+      currentFunction.playbackEvents.push(event);
+      this.updateMeasureForPlayByLength(event.length);
+      this.uniqueEvents.add(uniqueEventKey);
+    }
   }
 
   // Internal helper to get the entry at the top of the stack, or null

--- a/apps/src/music/player/sequencer/Simple2Sequencer.ts
+++ b/apps/src/music/player/sequencer/Simple2Sequencer.ts
@@ -48,8 +48,8 @@ export default class Simple2Sequencer extends Sequencer {
   private startMeasure: number;
   private inTrigger: boolean;
 
-  // A set of strings (e.g. "electro/beat-4", which is an event ID and when to play) that are used
-  // to ensure the same sound isn't played multiple times at the same time.
+  // A set of strings (e.g. "electro/beat-4", which is a hyphen-separated event ID and measure) that are
+  // used to ensure the same sound isn't played more than once at the same time.
   private uniqueEvents: Set<string>;
 
   private currentEventCount: number;
@@ -332,6 +332,11 @@ export default class Simple2Sequencer extends Sequencer {
   }
 
   private addNewEvent<T extends PlaybackEvent>(event: T) {
+    const uniqueEventKey = `${event.id}-${event.when}`;
+    if (this.uniqueEvents.has(uniqueEventKey)) {
+      return;
+    }
+
     this.currentEventCount++;
     if (this.currentEventCount === MAX_NUMBER_EVENTS) {
       console.log(`Reached MAX_NUMBER_EVENTS (${MAX_NUMBER_EVENTS}) events.`);
@@ -347,12 +352,9 @@ export default class Simple2Sequencer extends Sequencer {
     }
     const currentFunction = this.functionMap[currentFunctionId];
 
-    const uniqueEventKey = `${event.id}-${event.when}`;
-    if (!this.uniqueEvents.has(uniqueEventKey)) {
-      currentFunction.playbackEvents.push(event);
-      this.updateMeasureForPlayByLength(event.length);
-      this.uniqueEvents.add(uniqueEventKey);
-    }
+    currentFunction.playbackEvents.push(event);
+    this.updateMeasureForPlayByLength(event.length);
+    this.uniqueEvents.add(uniqueEventKey);
   }
 
   // Internal helper to get the entry at the top of the stack, or null

--- a/apps/test/unit/music/player/sequencer/Simple2SequencerTest.ts
+++ b/apps/test/unit/music/player/sequencer/Simple2SequencerTest.ts
@@ -244,13 +244,13 @@ describe('Simple2Sequencer', () => {
     sequencer.newSequence();
     sequencer.startFunctionContext('when_run');
     sequencer.setEffect('filter', 'low');
-    sequencer.playSound('id', 'blockId');
+    sequencer.playSound('id1', 'blockId1');
 
     const event = sequencer.getPlaybackEvents()[0];
     expect(event.effects?.filter).to.equal('low');
 
     sequencer.startFunctionContext('new function');
-    sequencer.playSound('id', 'blockId');
+    sequencer.playSound('id2', 'blockId2');
 
     const newFunctionEvent =
       sequencer.getOrderedFunctions()[1].playbackEvents[0];
@@ -270,7 +270,7 @@ describe('Simple2Sequencer', () => {
       // Override to play index 1.
       sequencer.startRandom(2, 1);
 
-        sequencer.playSound('id', 'blockId');
+        sequencer.playSound('id1', 'blockId1');
         assert.deepEqual(getLastEvent().skipContext, {
           insideRandom: true,
           skipSound: true,
@@ -278,7 +278,7 @@ describe('Simple2Sequencer', () => {
 
         sequencer.startRandom(2, 1);
 
-          sequencer.playSound('id', 'blockId');
+          sequencer.playSound('id2', 'blockId2');
           assert.deepEqual(getLastEvent().skipContext, {
             insideRandom: true,
             skipSound: true
@@ -286,7 +286,7 @@ describe('Simple2Sequencer', () => {
 
           sequencer.nextRandom();
 
-          sequencer.playSound('id', 'blockId');
+          sequencer.playSound('id3', 'blockId3');
           assert.deepEqual(getLastEvent().skipContext, {
             insideRandom: true,
             skipSound: true
@@ -298,7 +298,7 @@ describe('Simple2Sequencer', () => {
 
         // This context will be played.
 
-        sequencer.playSound('id', 'blockId');
+        sequencer.playSound('id4', 'blockI4d');
         assert.deepEqual(getLastEvent().skipContext, {
           insideRandom: true,
           skipSound: false
@@ -307,7 +307,7 @@ describe('Simple2Sequencer', () => {
         // Override to play index 1.
         sequencer.startRandom(2, 1);
 
-          sequencer.playSound('id', 'blockId');
+          sequencer.playSound('id5', 'blockId5');
           assert.deepEqual(getLastEvent().skipContext, {
             insideRandom: true,
             skipSound: true
@@ -317,7 +317,7 @@ describe('Simple2Sequencer', () => {
 
           // This context will be played.
 
-          sequencer.playSound('id', 'blockId');
+          sequencer.playSound('id6', 'blockId6');
           assert.deepEqual(getLastEvent().skipContext, {
             insideRandom: true,
             skipSound: false

--- a/apps/test/unit/music/player/sequencer/Simple2SequencerTest.ts
+++ b/apps/test/unit/music/player/sequencer/Simple2SequencerTest.ts
@@ -373,4 +373,17 @@ describe('Simple2Sequencer', () => {
       '6',
     ]);
   });
+
+  it('does not play the same sound more than once at the same time', () => {
+    sequencer.newSequence();
+    sequencer.startFunctionContext('when_run');
+    sequencer.playTogether();
+    sequencer.playSound('id1', 'blockId1');
+    sequencer.playSound('id1', 'blockId1');
+    sequencer.endTogether();
+    sequencer.endFunctionContext();
+
+    const playbackEvents = sequencer.getPlaybackEvents();
+    expect(playbackEvents.length).to.equal(1);
+  });
 });


### PR DESCRIPTION
Avoids playing the same sound at the same time more than once.  Duplicate sound events are no longer added to the timeline.

### before

<img width="1062" alt="Screenshot 2025-01-08 at 11 37 41 AM" src="https://github.com/user-attachments/assets/1ed1d7b7-807e-4cb7-82cd-1b909d6394d9" />

### after

<img width="1062" alt="Screenshot 2025-01-08 at 11 37 17 AM" src="https://github.com/user-attachments/assets/a8dbabb0-7633-4744-982e-fe5419693ad5" />

