### PR TITLE
Fix Violations of and Reenable `Lint/RedundantRequireStatement`

### DIFF
--- a/.config/rubocop/todo.yml
+++ b/.config/rubocop/todo.yml
@@ -115,11 +115,6 @@ Lint/RedundantCopDisableDirective:
 Lint/RedundantDirGlobSort:
   Enabled: false
 
-# Offense count: 13
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/RedundantRequireStatement:
-  Enabled: false
-
 # Offense count: 9
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowedMethods.

--- a/bin/curriculum/import_data_docs.rb
+++ b/bin/curriculum/import_data_docs.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'set'
 require 'json'
 require 'optparse'
 require 'uri'

--- a/bin/curriculum/import_reference_guides.rb
+++ b/bin/curriculum/import_reference_guides.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'set'
 require 'json'
 require 'optparse'
 require 'uri'

--- a/bin/oneoff/export_pardot_contacts.rb
+++ b/bin/oneoff/export_pardot_contacts.rb
@@ -13,7 +13,6 @@
 require_relative '../../deployment'
 require 'cdo/pegasus'
 require 'cdo/pardot'
-require 'set'
 require 'cdo/sequel'
 
 PEGASUS_DB_READER = Cdo::Sequel.database_connection_pool(

--- a/dashboard/app/controllers/curriculum_proxy_controller.rb
+++ b/dashboard/app/controllers/curriculum_proxy_controller.rb
@@ -1,5 +1,4 @@
 require 'net/http'
-require 'set'
 
 # This proxy controller allows us to serve curriculum builder docs that live on
 # [docs|curriculum].code.org as if they live on studio.code.org. This is done so that we can

--- a/dashboard/app/controllers/media_proxy_controller.rb
+++ b/dashboard/app/controllers/media_proxy_controller.rb
@@ -9,8 +9,6 @@
 # abuse and potentially add other abuse prevention measures (e.g. a signature
 # based on a secret.)
 
-require 'set'
-
 class MediaProxyController < ApplicationController
   include ProxyHelper
 

--- a/dashboard/app/controllers/redirect_proxy_controller.rb
+++ b/dashboard/app/controllers/redirect_proxy_controller.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 class RedirectProxyController < ApplicationController
   include ProxyHelper
 

--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -9,7 +9,6 @@
 # list of JSON response types. We will need to monitor usage to detect
 # abuse and potentially add other abuse prevention measures.
 
-require 'set'
 require 'cdo/shared_constants'
 
 class XhrProxyController < ApplicationController

--- a/dashboard/legacy/middleware/helpers/table.rb
+++ b/dashboard/legacy/middleware/helpers/table.rb
@@ -1,5 +1,4 @@
 require 'csv'
-require 'set'
 
 class TableMetadata
   def self.generate_column_list(records)

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 class LevelLoader
   # Top-level entry point, called by rake seed:custom_levels
   def self.load_custom_levels(level_name, root_dir)

--- a/dashboard/lib/services/lti.rb
+++ b/dashboard/lib/services/lti.rb
@@ -3,7 +3,6 @@ require 'queries/lti'
 require 'user'
 require 'authentication_option'
 require 'sections/section'
-require 'set'
 require 'metrics/events'
 
 module Services

--- a/dashboard/scripts/archive/buy_twilio_numbers
+++ b/dashboard/scripts/archive/buy_twilio_numbers
@@ -2,7 +2,6 @@
 # This script uses the Twilio API to bulk-purchase numbers for load-balancing SMS via the Messaging Service.
 require_relative '../../config/environment'
 require 'twilio-ruby'
-require 'set'
 
 # credentials
 ACCOUNT_SID = CDO.twilio_sid

--- a/lib/cdo/ci_utils.rb
+++ b/lib/cdo/ci_utils.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 module CI
   module Utils
     # Checks the HEAD commit for the current CI build for the specified tag,

--- a/lib/cdo/rack/upgrade_insecure_requests.rb
+++ b/lib/cdo/rack/upgrade_insecure_requests.rb
@@ -4,7 +4,6 @@
 
 require 'cdo/rack/process_html'
 require 'dynamic_config/dcdo'
-require 'set'
 
 module Rack
   class UpgradeInsecureRequests < ProcessHtml


### PR DESCRIPTION
This one is pretty simple:

> Checks for unnecessary `require` statement.

Looks like the only unnecessary `require` statement we have is `require 'set'`, which was made reduntant in Ruby 3.2

Despite still being on Ruby 3.0, we are preparing for an eventual upgrade to Ruby 3.3, and so have configured Rubocop to target that version instead of the one we're actually on.

Speculatively opening this PR anyway, just to check what breaks.

- https://docs.rubocop.org/rubocop/cops_lint.html#lintredundantrequirestatement
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantRequireStatement

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
