### PR TITLE
Music: fix sound panel column

### DIFF
--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -139,6 +139,11 @@
 
     &Middle {
       font-size: 11px;
+      min-width: 240px;
+      text-align: center;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     &Right {


### PR DESCRIPTION
This fixes the layout of the middle column in the sound panel, which is just used to show the pack for a sound in the "Sounds" toggle.

### before

<img width="647" alt="Screenshot 2025-01-08 at 2 07 10 PM" src="https://github.com/user-attachments/assets/28c39220-9a25-4060-8008-44fb14ea65fa" />

### after

<img width="647" alt="Screenshot 2025-01-08 at 2 04 56 PM" src="https://github.com/user-attachments/assets/e4c04b4b-32c1-4cf6-9a27-3bf818c80d2f" />

