### PR TITLE
[Design2-254] Update DSCO Variables values

### DIFF
--- a/apps/src/componentLibrary/common/styles/primitiveColors.css
+++ b/apps/src/componentLibrary/common/styles/primitiveColors.css
@@ -106,7 +106,7 @@
     --sentiment-error-20: #ffbfb6;
     --sentiment-error-30: #ff8677;
     --sentiment-error-40: #f95d4a;
-    --sentiment-error-50: #e5311a;
+    --sentiment-error-50: #e02d16;
     --sentiment-error-60: #c12814;
     --sentiment-error-70: #aa2513;
     --sentiment-error-80: #842418;

--- a/frontend/packages/dsco/src/common/styles/primitiveColors.css
+++ b/frontend/packages/dsco/src/common/styles/primitiveColors.css
@@ -67,7 +67,7 @@
   --brand-teal-80: #00636e;
   --brand-teal-90: #004b54;
   --neutral-base-black: #292f36;
-  --neutral-base-white: #fff;
+  --neutral-base-white: #ffffff;
   --neutral-black-alpha-10: #292f361a;
   --neutral-black-alpha-20: #292f3633;
   --neutral-black-alpha-30: #292f364d;
@@ -91,14 +91,14 @@
   --neutral-gray-90: #4c5661;
   --neutral-gray-95: #394450;
   --neutral-white-alpha-10: #ffffff1a;
-  --neutral-white-alpha-20: #fff3;
+  --neutral-white-alpha-20: #ffffff33;
   --neutral-white-alpha-30: #ffffff4d;
-  --neutral-white-alpha-40: #fff6;
+  --neutral-white-alpha-40: #ffffff66;
   --neutral-white-alpha-5: #ffffff0d;
   --neutral-white-alpha-50: #ffffff80;
-  --neutral-white-alpha-60: #fff9;
+  --neutral-white-alpha-60: #ffffff99;
   --neutral-white-alpha-70: #ffffffb2;
-  --neutral-white-alpha-80: #fffc;
+  --neutral-white-alpha-80: #ffffffcc;
   --neutral-white-alpha-90: #ffffffe5;
   --neutral-white-alpha-95: #fffffff2;
   --sentiment-error-10: #ffe1dd;
@@ -106,7 +106,7 @@
   --sentiment-error-20: #ffbfb6;
   --sentiment-error-30: #ff8677;
   --sentiment-error-40: #f95d4a;
-  --sentiment-error-50: #e5311a;
+  --sentiment-error-50: #e02d16;
   --sentiment-error-60: #c12814;
   --sentiment-error-70: #aa2513;
   --sentiment-error-80: #842418;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [Design2-254] Update DSCO Variables values

This update will fix contrast ratio acessibility issue for destructive buttons, error messages, etc.

Updates both instances of primitiveColors.css since we're in the middle of moving from apps/src/componentsLibrary to packages/dsco right now.

Lint rules in frontend directory allow us to use figma generating color values without need of replacing `#ffffff;` with `#fff;`, which makes process of updating colors faster and easier. (that's why in packages/dsco primitiveColors.css have more changes then apps/src/componentLibrary instance of primitiveColors.css)

## Links
- jira ticket: [DESIGN2-254](https://codedotorg.atlassian.net/browse/DESIGN2-254)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
