### PR TITLE
feat(test-runner): Allowed test-runner to fetch a11y custom config 

### DIFF
--- a/frontend/apps/design-system-storybook/.storybook/test-runner.ts
+++ b/frontend/apps/design-system-storybook/.storybook/test-runner.ts
@@ -15,6 +15,22 @@ const config: TestRunnerConfig = {
     // Get the entire context of a story, including parameters, args, argTypes, etc.
     const storyContext = await getStoryContext(page, context);
 
+    const storyA11yConfigRules = storyContext.parameters?.a11y?.config
+      ?.rules as {id: string; enabled: boolean}[];
+    const customAxeRules = {} as {
+      [key: string]: {
+        enabled: boolean;
+      };
+    };
+
+    // If some custom a11y rules config is passed to the story - it will be automatically fetched by test runner
+    // so that CI and QA will also follow that config.
+    if (storyA11yConfigRules) {
+      storyA11yConfigRules.forEach(
+        rule => (customAxeRules[rule.id] = {enabled: rule.enabled}),
+      );
+    }
+
     // Do not run a11y tests on disabled stories.
     if (storyContext.parameters?.a11y?.disable) {
       return;
@@ -26,6 +42,7 @@ const config: TestRunnerConfig = {
       detailedReportOptions: {
         html: true,
       },
+      axeOptions: {rules: customAxeRules},
     });
   },
 };


### PR DESCRIPTION
### feat(test-runner): Allowed test-runner to fetch a11y custom config  directly from stories and use it for CI and QA

This PR allows test-runner to use custom a11y config from stories for CI and QA

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
