### PR TITLE
Fix student name links not appearing

### DIFF
--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -44,7 +44,9 @@ const getSelectedUnit = state => {
 };
 
 export const getSelectedScriptName = state => {
-  return getSelectedUnit(state) ? getSelectedUnit(state).key : null;
+  return getSelectedUnit(state)
+    ? getSelectedUnit(state).key
+    : null || state.unitSelection.unitName;
 };
 
 /* Get the user friendly name of a script(the unit or course name) */

--- a/apps/test/unit/redux/unitSelectionReduxTest.js
+++ b/apps/test/unit/redux/unitSelectionReduxTest.js
@@ -26,6 +26,17 @@ describe('unitSelectionRedux', () => {
       expect(getSelectedScriptName(state)).toEqual('csd1-2018');
     });
 
+    it('returns unitName if script selected but no coursesWithProgress', () => {
+      const state = {
+        unitSelection: {
+          scriptId: 5,
+          unitName: 'csp1-2024',
+          coursesWithProgress: [],
+        },
+      };
+      expect(getSelectedScriptName(state)).toEqual('csp1-2024');
+    });
+
     it('returns null if no script is selected', () => {
       const state = {
         unitSelection: {
@@ -33,7 +44,7 @@ describe('unitSelectionRedux', () => {
           coursesWithProgress: fakeCoursesWithProgress,
         },
       };
-      expect(getSelectedScriptName(state)).toEqual(null);
+      expect(getSelectedScriptName(state)).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Fixes student name links on Roster page and Stats page not showing up

Before:
![image](https://github.com/user-attachments/assets/55a5b06c-6be5-4138-914d-979535f8b059)

After:
![image](https://github.com/user-attachments/assets/ee06652f-0609-4b71-9d3f-870a4ea2036c)


## Links
https://codedotorg.atlassian.net/browse/TEACH-1520

