### PR TITLE
Show updated evidence level on focus in AI TA

### DIFF
--- a/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
+++ b/apps/src/templates/rubrics/EvidenceLevelsForTeachersV2.jsx
@@ -125,8 +125,10 @@ export default function EvidenceLevelsForTeachersV2({
               type="button"
               key={evidenceLevel.id}
               onClick={() => radioButtonCallback(evidenceLevel.understanding)}
+              onFocus={() => handleMouseOver(evidenceLevel.understanding)}
+              onBlur={handleMouseOut}
               onMouseOver={() => handleMouseOver(evidenceLevel.understanding)}
-              onMouseOut={() => handleMouseOut()}
+              onMouseOut={handleMouseOut}
               className={classnames(
                 style.evidenceLevel,
                 [


### PR DESCRIPTION
Shows updated evidence level as a user tabs through the difference evidence levels in AI TA. Brings tab navigation experience to parity with users using a mouse.

### After update (note changing description as we tab)
https://github.com/user-attachments/assets/36610d7d-cfe3-477b-aaa2-3cb3dc0e1c33

## Links

- https://codedotorg.atlassian.net/browse/A11Y-345
- https://codedotorg.atlassian.net/browse/A11Y-346

## Testing story

Tested manually (see video above).