### PR TITLE
Add more display name validation in sign up

### DIFF
--- a/apps/i18n/signup/en_us.json
+++ b/apps/i18n/signup/en_us.json
@@ -62,6 +62,7 @@
   "female": "Female",
   "parentEmailPlaceholder": "parentemail@email.com",
   "display_name_error_message": "Please enter your display name",
+  "display_name_too_long_error_message": "Display name is too long. Max is {maxLength} characters.",
   "email_error_message": "Please enter a valid email",
   "age_error_message": "Please select an age",
   "state_error_message": "Please select a state",

--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -405,7 +405,7 @@ const FinishStudentAccount: React.FunctionComponent<{
               title: 'arrow-right',
             }}
             disabled={
-              name.trim() === '' ||
+              name?.trim() === '' ||
               name?.length > MAX_DISPLAY_NAME_LENGTH ||
               age === '' ||
               (usIp && state === '') ||

--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -154,10 +154,10 @@ const FinishStudentAccount: React.FunctionComponent<{
   };
 
   const onNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const newName = e.target.value.trim();
+    const newName = e.target.value;
     setName(newName);
 
-    if (newName === '') {
+    if (newName.trim() === '') {
       setNameErrorMessage(locale.display_name_error_message());
     } else if (newName.length > MAX_DISPLAY_NAME_LENGTH) {
       setNameErrorMessage(
@@ -407,7 +407,8 @@ const FinishStudentAccount: React.FunctionComponent<{
               title: 'arrow-right',
             }}
             disabled={
-              name === '' ||
+              name.trim() === '' ||
+              name?.length > MAX_DISPLAY_NAME_LENGTH ||
               age === '' ||
               (usIp && state === '') ||
               (isParent && (parentEmail === '' || showParentEmailError)) ||

--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -51,8 +51,6 @@ const FinishStudentAccount: React.FunctionComponent<{
   const [gender, setGender] = useState('');
 
   // Field errors
-  //const [showNameError, setShowNameError] = useState(false);
-  //const [showNameTooLongError, setShowNameTooLongError] = useState(false);
   const [nameErrorMessage, setNameErrorMessage] = useState<string | null>(null);
   const [showParentEmailError, setShowParentEmailError] = useState(false);
   const [showAgeError, setShowAgeError] = useState(false);

--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -30,6 +30,7 @@ import {
   USER_RETURN_TO_SESSION_KEY,
   clearSignUpSessionStorage,
   NEW_SIGN_UP_USER_TYPE,
+  MAX_DISPLAY_NAME_LENGTH,
 } from './signUpFlowConstants';
 
 import style from './signUpFlowStyles.module.scss';
@@ -50,7 +51,9 @@ const FinishStudentAccount: React.FunctionComponent<{
   const [gender, setGender] = useState('');
 
   // Field errors
-  const [showNameError, setShowNameError] = useState(false);
+  //const [showNameError, setShowNameError] = useState(false);
+  //const [showNameTooLongError, setShowNameTooLongError] = useState(false);
+  const [nameErrorMessage, setNameErrorMessage] = useState<string | null>(null);
   const [showParentEmailError, setShowParentEmailError] = useState(false);
   const [showAgeError, setShowAgeError] = useState(false);
   const [showStateError, setShowStateError] = useState(false);
@@ -151,13 +154,19 @@ const FinishStudentAccount: React.FunctionComponent<{
   };
 
   const onNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const newName = e.target.value;
+    const newName = e.target.value.trim();
     setName(newName);
 
     if (newName === '') {
-      setShowNameError(true);
+      setNameErrorMessage(locale.display_name_error_message());
+    } else if (newName.length > MAX_DISPLAY_NAME_LENGTH) {
+      setNameErrorMessage(
+        locale.display_name_too_long_error_message({
+          maxLength: MAX_DISPLAY_NAME_LENGTH,
+        })
+      );
     } else {
-      setShowNameError(false);
+      setNameErrorMessage(null);
     }
   };
 
@@ -190,7 +199,7 @@ const FinishStudentAccount: React.FunctionComponent<{
         'user type': 'student',
         'has school': false,
         'has marketing value selected': true,
-        'has display name': !showNameError,
+        'has display name': !nameErrorMessage,
       },
       PLATFORMS.BOTH
     );
@@ -310,9 +319,9 @@ const FinishStudentAccount: React.FunctionComponent<{
               placeholder={locale.coder()}
               onChange={onNameChange}
             />
-            {showNameError && (
+            {nameErrorMessage && (
               <BodyThreeText className={style.errorMessage}>
-                {locale.display_name_error_message()}
+                {nameErrorMessage}
               </BodyThreeText>
             )}
           </div>

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -33,6 +33,7 @@ import {
   USER_RETURN_TO_SESSION_KEY,
   clearSignUpSessionStorage,
   NEW_SIGN_UP_USER_TYPE,
+  MAX_DISPLAY_NAME_LENGTH,
 } from './signUpFlowConstants';
 
 import style from './signUpFlowStyles.module.scss';
@@ -43,7 +44,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
 }> = ({usIp, countryCode}) => {
   const schoolInfo = useSchoolInfo({usIp});
   const [name, setName] = useState('');
-  const [showNameError, setShowNameError] = useState(false);
+  const [nameErrorMessage, setNameErrorMessage] = useState(null);
   const [emailOptInChecked, setEmailOptInChecked] = useState(false);
   const [gdprChecked, setGdprChecked] = useState(false);
   const [showGDPR, setShowGDPR] = useState(false);
@@ -113,13 +114,19 @@ const FinishTeacherAccount: React.FunctionComponent<{
   }, [showGDPR, gdprChecked, isGdprLoaded]);
 
   const onNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const newName = e.target.value;
+    const newName = e.target.value.trim();
     setName(newName);
 
     if (newName === '') {
-      setShowNameError(true);
+      setNameErrorMessage(locale.display_name_error_message());
+    } else if (newName.length > MAX_DISPLAY_NAME_LENGTH) {
+      setNameErrorMessage(
+        locale.display_name_too_long_error_message({
+          maxLength: MAX_DISPLAY_NAME_LENGTH,
+        })
+      );
     } else {
-      setShowNameError(false);
+      setNameErrorMessage(null);
     }
   };
 
@@ -176,7 +183,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
         'user type': 'teacher',
         'has school': hasSchool,
         'has marketing value selected': true,
-        'has display name': !showNameError,
+        'has display name': !nameErrorMessage,
         country: countryCode,
       },
       PLATFORMS.BOTH
@@ -221,9 +228,9 @@ const FinishTeacherAccount: React.FunctionComponent<{
             <BodyThreeText className={style.displayNameSubtext}>
               {locale.this_is_what_your_students_will_see()}
             </BodyThreeText>
-            {showNameError && (
+            {nameErrorMessage && (
               <BodyThreeText className={style.errorMessage}>
-                {locale.display_name_error_message()}
+                {nameErrorMessage}
               </BodyThreeText>
             )}
           </div>

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -114,10 +114,10 @@ const FinishTeacherAccount: React.FunctionComponent<{
   }, [showGDPR, gdprChecked, isGdprLoaded]);
 
   const onNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const newName = e.target.value.trim();
+    const newName = e.target.value;
     setName(newName);
 
-    if (newName === '') {
+    if (newName.trim() === '') {
       setNameErrorMessage(locale.display_name_error_message());
     } else if (newName.length > MAX_DISPLAY_NAME_LENGTH) {
       setNameErrorMessage(
@@ -295,7 +295,8 @@ const FinishTeacherAccount: React.FunctionComponent<{
               title: 'arrow-right',
             }}
             disabled={
-              name === '' ||
+              name.trim() === '' ||
+              name?.length > MAX_DISPLAY_NAME_LENGTH ||
               !gdprValid ||
               (isInSchoolRequiredExperiment && schoolInfoInvalid(schoolInfo))
             }

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -295,7 +295,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
               title: 'arrow-right',
             }}
             disabled={
-              name.trim() === '' ||
+              name?.trim() === '' ||
               name?.length > MAX_DISPLAY_NAME_LENGTH ||
               !gdprValid ||
               (isInSchoolRequiredExperiment && schoolInfoInvalid(schoolInfo))

--- a/apps/src/signUpFlow/signUpFlowConstants.tsx
+++ b/apps/src/signUpFlow/signUpFlowConstants.tsx
@@ -38,3 +38,5 @@ export const US_COUNTRY_CODE = 'US';
 export const ZIP_REGEX = new RegExp(/(^(?!00000)\d{5}$)/);
 export const SELECT_COUNTRY = 'selectCountry';
 export const SCHOOL_ZIP_SEARCH_URL = '/dashboardapi/v1/schoolzipsearch/';
+
+export const MAX_DISPLAY_NAME_LENGTH = 70;

--- a/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
@@ -8,6 +8,7 @@ import locale from '@cdo/apps/signUpFlow/locale';
 import {
   ACCOUNT_TYPE_SESSION_KEY,
   EMAIL_SESSION_KEY,
+  MAX_DISPLAY_NAME_LENGTH,
   USER_RETURN_TO_SESSION_KEY,
 } from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
@@ -190,6 +191,40 @@ describe('FinishStudentAccount', () => {
     // Error shows and button is disabled with empty display name
     screen.getByText(locale.display_name_error_message());
     expect(finishSignUpButton).toBeDisabled();
+  });
+
+  it('only whitespace in the displayName field shows error message', () => {
+    renderDefault();
+    const displayNameInput = screen.getAllByDisplayValue('')[1];
+
+    // Error message doesn't show and button is disabled by default
+    expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
+
+    // Enter display name
+    fireEvent.change(displayNameInput, {target: {value: ' '}});
+
+    // Error shows with whitespace display name
+    screen.getByText(locale.display_name_error_message());
+  });
+
+  it('adding a long display name shows error message', () => {
+    renderDefault();
+    const displayNameInput = screen.getAllByDisplayValue('')[1];
+
+    // Error message doesn't show and button is disabled by default
+    expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
+
+    // Enter display name
+    fireEvent.change(displayNameInput, {
+      target: {value: 'a'.repeat(MAX_DISPLAY_NAME_LENGTH + 1)},
+    });
+
+    // Error shows with long display name
+    screen.getByText(
+      locale.display_name_too_long_error_message({
+        maxLength: MAX_DISPLAY_NAME_LENGTH,
+      })
+    );
   });
 
   it('leaving the age field empty shows error message and disabled submit button until age is entered', async () => {

--- a/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishStudentAccountTest.tsx
@@ -205,6 +205,11 @@ describe('FinishStudentAccount', () => {
 
     // Error shows with whitespace display name
     screen.getByText(locale.display_name_error_message());
+
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
+    expect(finishSignUpButton).toBeDisabled();
   });
 
   it('adding a long display name shows error message', () => {
@@ -225,6 +230,11 @@ describe('FinishStudentAccount', () => {
         maxLength: MAX_DISPLAY_NAME_LENGTH,
       })
     );
+
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
+    expect(finishSignUpButton).toBeDisabled();
   });
 
   it('leaving the age field empty shows error message and disabled submit button until age is entered', async () => {

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -8,6 +8,7 @@ import locale from '@cdo/apps/signUpFlow/locale';
 import {
   ACCOUNT_TYPE_SESSION_KEY,
   EMAIL_SESSION_KEY,
+  MAX_DISPLAY_NAME_LENGTH,
   SCHOOL_ID_SESSION_KEY,
   SCHOOL_NAME_SESSION_KEY,
   SCHOOL_ZIP_SESSION_KEY,
@@ -167,6 +168,40 @@ describe('FinishTeacherAccount', () => {
 
     // Error shows with empty display name
     screen.getByText(locale.display_name_error_message());
+  });
+
+  it('only whitespace in the displayName field shows error message', () => {
+    renderDefault();
+    const displayNameInput = screen.getAllByDisplayValue('')[0];
+
+    // Error message doesn't show and button is disabled by default
+    expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
+
+    // Enter display name
+    fireEvent.change(displayNameInput, {target: {value: ' '}});
+
+    // Error shows with whitespace display name
+    screen.getByText(locale.display_name_error_message());
+  });
+
+  it('adding a long display name shows error message', () => {
+    renderDefault();
+    const displayNameInput = screen.getAllByDisplayValue('')[0];
+
+    // Error message doesn't show and button is disabled by default
+    expect(screen.queryByText(locale.display_name_error_message())).toBe(null);
+
+    // Enter display name
+    fireEvent.change(displayNameInput, {
+      target: {value: 'a'.repeat(MAX_DISPLAY_NAME_LENGTH + 1)},
+    });
+
+    // Error shows with long display name
+    screen.getByText(
+      locale.display_name_too_long_error_message({
+        maxLength: MAX_DISPLAY_NAME_LENGTH,
+      })
+    );
   });
 
   it('GDPR has expected behavior if api call returns true', async () => {

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -182,6 +182,11 @@ describe('FinishTeacherAccount', () => {
 
     // Error shows with whitespace display name
     screen.getByText(locale.display_name_error_message());
+
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
+    expect(finishSignUpButton).toBeDisabled();
   });
 
   it('adding a long display name shows error message', () => {
@@ -202,6 +207,11 @@ describe('FinishTeacherAccount', () => {
         maxLength: MAX_DISPLAY_NAME_LENGTH,
       })
     );
+
+    const finishSignUpButton = screen.getByRole('button', {
+      name: locale.go_to_my_account(),
+    });
+    expect(finishSignUpButton).toBeDisabled();
   });
 
   it('GDPR has expected behavior if api call returns true', async () => {


### PR DESCRIPTION
Adds client-side checks for:
- a display name of only whitespace
- a display name that's too long (current limit is [70 characters](https://github.com/code-dot-org/code-dot-org/blob/f562f0fa03c9d8ea68211b2ada821dd5002f5839/dashboard/app/models/user.rb#L562))


https://github.com/user-attachments/assets/7ececb40-865d-4c70-9bda-c8a2cd507d3d

![Screenshot 2025-01-08 at 4 42 03 PM](https://github.com/user-attachments/assets/c3b56c0f-81b8-4b6c-89ae-267e7bb84ccd)


Jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2935

I'll let Jorge know when this PR is merged to get a start on translation, but we decided that it is better to have any error message, even if it's only in English for now.