### PR TITLE
Remove start_direction from pythonlab level properties

### DIFF
--- a/dashboard/app/models/levels/pythonlab.rb
+++ b/dashboard/app/models/levels/pythonlab.rb
@@ -37,7 +37,6 @@ class Pythonlab < Level
     enable_micro_bit
     mini_app
     serialized_maze
-    start_direction
   )
 
   validate :has_correct_multiple_choice_answer?
@@ -51,10 +50,6 @@ class Pythonlab < Level
         level_num: 'custom',
       )
     )
-  end
-
-  def self.start_directions
-    [['None', nil], ['North', 0], ['East', 1], ['South', 2], ['West', 3]]
   end
 
   def self.mini_apps
@@ -124,7 +119,6 @@ class Pythonlab < Level
   def clean_up_mini_app_settings
     if mini_app != 'neighborhood'
       properties.delete('serialized_maze')
-      properties.delete('start_direction')
     end
   end
 

--- a/dashboard/app/views/levels/editors/fields/_pythonlab_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_pythonlab_fields.html.haml
@@ -8,10 +8,6 @@
 
   #neighborhood{class: ('collapse' if @level.mini_app != 'neighborhood')}
     .field
-      = f.label :start_direction
-      = f.select :start_direction, options_for_select(@level.class.start_directions, @level.start_direction)
-
-    .field
       = f.label :serialized_maze
       - maze_value = @level.serialized_maze ? JSON.pretty_generate(@level.serialized_maze) : ''
       = f.text_area :serialized_maze, value: maze_value, rows: 20, class: 'input-block-level'

--- a/dashboard/config/levels/custom/pythonlab/pythonlab_neighborhood.level
+++ b/dashboard/config/levels/custom/pythonlab/pythonlab_neighborhood.level
@@ -14,7 +14,6 @@
     "predict_settings": {
       "isPredictLevel": false
     },
-    "start_direction": "1",
     "serialized_maze": [
       [
         {

--- a/dashboard/test/models/pythonlab_test.rb
+++ b/dashboard/test/models/pythonlab_test.rb
@@ -47,25 +47,20 @@ class PythonlabTest < ActiveSupport::TestCase
     level_data = {game_id: 72, level_num: "custom", name: "sample_level"}
     level_data[:properties] = {
       serialized_maze: "[[{\"tileType\": 0, \"assetId\": 13, \"value\": 0}],[{\"tileType\":1,\"value\":0}]]",
-      start_direction: 1,
     }
     level = Pythonlab.create(level_data)
     assert_nil(level.serialized_maze)
-    assert_nil(level.start_direction)
   end
 
   test 'Keeps neighborhood settings for neighborhood levels' do
     level_data = {game_id: 72, level_num: "custom", name: "sample_level"}
     serialized_maze = "[[{\"tileType\": 0, \"assetId\": 13, \"value\": 0}],[{\"tileType\":1,\"value\":0}]]"
-    start_direction = 1
     level_data[:properties] = {
       mini_app: "neighborhood",
       serialized_maze: serialized_maze,
-      start_direction: start_direction,
     }
     parsed_maze = JSON.parse(serialized_maze)
     level = Pythonlab.create(level_data)
     assert_equal(parsed_maze, level.serialized_maze)
-    assert_equal(start_direction, level.start_direction)
   end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR removes `start_direction` (which was added as part of the mini-app neighborhood configuration) from `pythonlab` level properties. Curriculum doesn't use start direction because it's confusing for the user.

## After update

https://github.com/user-attachments/assets/fb0a9317-8979-4124-9905-9f7b71c8cbb9



## Links
[jira](https://codedotorg.atlassian.net/browse/CT-949)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Locally, I went to the pythonlab level edit page and saw that the start direction field was no longer displayed. I also updated  `pythonlab_test`.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
