### PR TITLE
Add error handling for nil error on lti landing pg

### DIFF
--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -7,6 +7,14 @@ module Lti
 
       # GET /lti/v1/account_linking/landing
       def landing
+        lti_provider = session.dig(:lms_landing, :lti_provider_name) || params[:lti_provider]
+        new_cta_type = session.dig(:lms_landing, :new_cta_type) || params[:new_cta_type]
+        user_type = session.dig(:lms_landing, :user_type) || current_user&.user_type
+
+        if lti_provider.nil? || new_cta_type.nil? || user_type.nil?
+          flash[:alert] = I18n.t('lti.account_linking.launch_from_lms')
+          redirect_to root_path and return
+        end
       end
 
       # GET /lti/v1/account_linking/finish_link

--- a/dashboard/app/controllers/lti/v1/account_linking_controller.rb
+++ b/dashboard/app/controllers/lti/v1/account_linking_controller.rb
@@ -11,7 +11,7 @@ module Lti
         new_cta_type = session.dig(:lms_landing, :new_cta_type) || params[:new_cta_type]
         user_type = session.dig(:lms_landing, :user_type) || current_user&.user_type
 
-        if lti_provider.nil? || new_cta_type.nil? || user_type.nil?
+        if lti_provider.blank? || new_cta_type.blank? || user_type.blank?
           flash[:alert] = I18n.t('lti.account_linking.launch_from_lms')
           redirect_to root_path and return
         end

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1456,6 +1456,7 @@ en:
       backend_error: "Oops! We encountered an error while trying to link your account. Please try launching Code.org again from your LMS."
       go_back: "Go back"
       invalid_credentials: "Invalid credentials"
+      launch_from_lms: "Please launch from your LMS to link your account."
       linking_page_header: "Link your %{provider} account to your existing Code.org account"
       linking_page_description: "Choose the sign-in method you normally use to access Code.org"
       sign_in_and_connect: "Sign in and connect"


### PR DESCRIPTION
The LTI landing page occasionally throws errors when `lti_provider` is nil. This can be repro'd when you navigate directly to `lti/v1/account_linking/landing`, rather than going through the expected LTI launch sequence.

This PR adds a check and error handling for this in the landing controller action. It redirects the user to the root path with a flash alert.
<img width="1721" alt="Screenshot 2025-01-08 at 2 12 13 PM" src="https://github.com/user-attachments/assets/d21824bd-5111-4fb9-9964-acafe0e6fc2a" />

### Additional Considerations
Due to our multi step sign-up flow, we are forced to stuff data into the session for accessing from a view/page later. The [landing page view](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/views/lti/v1/account_linking/landing.haml), as a result, checks for this data in the session and the params. This view is rendered from the authenticate controller action ([here](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/lti_v1_controller.rb#L205) and [here](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/lti_v1_controller.rb#L226)), so it actually bypasses the [landing controller action](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/lti/v1/account_linking_controller.rb#L9). Typically, the controller action is where you would add the business logic then pass data to the view in variables. As a result, we kind of end up with duplicated code where we are checking for values in the session and params, both from the controller and the view.

Initially, I tried to add the error logic and redirect to the view, however Rails didn't seem to like that and upon doing some research, it seems like it's an anti pattern anyways. I'm open to feedback a better way to do this than what I have.



<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [Jira ticket](https://codedotorg.atlassian.net/browse/P20-1166)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
