### PR TITLE
Temporarily set Gemfile ruby version to a range until chef converges

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-ruby '3.3.4'
+ruby '>= 3.0', '< 3.5'
+# after pushing this fuzzy match thru chef, commit to make this be:
+# ruby '3.3.4'
 
 # Ruby 2.7 no longer includes some libraries by default; install
 # the ones we need here

--- a/cookbooks/Gemfile
+++ b/cookbooks/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-ruby '3.3.4'
+ruby '>= 3.0', '< 3.5'
+# after pushing this fuzzy match thru chef, commit to make this be:
+# ruby '3.3.4'
 
 gem 'berkshelf'
 gem 'chef', '17.6.18'


### PR DESCRIPTION
Part of the Ruby 3.3.4 upgrade: [main PR](https://github.com/code-dot-org/code-dot-org/pull/60329)

If we pin ruby to an exact version, while our existing chef managed systems run an old version, they can't upgrade, they'll error out with:
```
git fetch
git pull --ff-only origin staging
https://github.com/code-dot-org/code-dot-org/commit/327f10e9f0ef36ddfe384e907784e8137fb25500
GetSecretValue: staging/cdo/slack_endpoint
sudo bundle config set --local without development production adhoc test levelbuilder integration
sudo bundle install --quiet --jobs 16

Error: 'sudo bundle install --quiet --jobs 16' returned 18
Don't run Bundler as root. Bundler can ask for sudo if it is needed, and
installing your bundle as root will break this application for all non-root
users on this machine.
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Your Ruby version is 3.0.5, but your Gemfile specified 3.3.4

websites failed in 0:13 minutes
```

The solution is to temporarily set Gemfile to allow a fuzzy range of ruby versions, then chef will be able to converge when its run by ci_build, install the new ruby version, and then we'll be ready for the strict exact match Gemfile version to come through the pipeline.