### PR TITLE
Revert "Revert "[Google Blockly] Override For Loop Generator""

### DIFF
--- a/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
+++ b/apps/src/blockly/customBlocks/cdoBlockly/commonBlocks.js
@@ -120,4 +120,6 @@ export const blocks = {
   getColourDropdownField(colours) {
     return new Blockly.FieldColourDropdown(colours, 45, 35);
   },
+  // Custom generator is already provided by CDO Blockly.
+  overrideForLoopGenerator() {},
 };

--- a/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
@@ -10,6 +10,7 @@ import {Order} from 'blockly/javascript';
 import {
   BlocklyWrapperType,
   ExtendedJavascriptGenerator,
+  JavascriptGeneratorType,
 } from '@cdo/apps/blockly/types';
 import i18n from '@cdo/locale';
 
@@ -163,5 +164,120 @@ export const blocks = {
       configOptions,
       isK1
     );
+  },
+
+  overrideForLoopGenerator() {
+    // A custom generator for a "for loop" in labs where variable names should be part of the
+    // of the Globals namespace (e.g. Globals.counter). Used for Play Lab aka Studio
+    Blockly.JavaScript.forBlock.controls_for = function (
+      block: GoogleBlockly.Block,
+      generator: JavascriptGeneratorType
+    ) {
+      // For loop. This code is copied and modified from Core Blockly:
+      // https://github.com/google/blockly/blob/2c29c01b14fd9cec9f7fde82f6c80b6f4f7b7c30/generators/javascript/loops.ts#L85-L178
+
+      // Customization: use translateVarName instead of getVariableName
+      const variable0 = generator.translateVarName(block.getFieldValue('VAR'));
+      // End customation.
+
+      const argument0 =
+        generator.valueToCode(block, 'FROM', Order.ASSIGNMENT) || '0';
+      const argument1 =
+        generator.valueToCode(block, 'TO', Order.ASSIGNMENT) || '0';
+      const increment =
+        generator.valueToCode(block, 'BY', Order.ASSIGNMENT) || '1';
+      let branch = generator.statementToCode(block, 'DO');
+      branch = generator.addLoopTrap(branch, block);
+      let code;
+      if (
+        Blockly.utils.string.isNumber(argument0) &&
+        Blockly.utils.string.isNumber(argument1) &&
+        Blockly.utils.string.isNumber(increment)
+      ) {
+        // All arguments are simple numbers.
+        const up = Number(argument0) <= Number(argument1);
+        code =
+          'for (' +
+          variable0 +
+          ' = ' +
+          argument0 +
+          '; ' +
+          variable0 +
+          (up ? ' <= ' : ' >= ') +
+          argument1 +
+          '; ' +
+          variable0;
+        const step = Math.abs(Number(increment));
+        if (step === 1) {
+          code += up ? '++' : '--';
+        } else {
+          code += (up ? ' += ' : ' -= ') + step;
+        }
+        code += ') {\n' + branch + '}\n';
+      } else {
+        code = '';
+        // Cache non-trivial values to variables to prevent repeated look-ups.
+        let startVar = argument0;
+        if (
+          !argument0.match(/^\w+$/) &&
+          !Blockly.utils.string.isNumber(argument0)
+        ) {
+          startVar = generator.nameDB_!.getDistinctName(
+            variable0 + '_start',
+            Blockly.Names.NameType.VARIABLE
+          );
+          code += 'var ' + startVar + ' = ' + argument0 + ';\n';
+        }
+        let endVar = argument1;
+        if (
+          !argument1.match(/^\w+$/) &&
+          !Blockly.utils.string.isNumber(argument1)
+        ) {
+          endVar = generator.nameDB_!.getDistinctName(
+            variable0 + '_end',
+            Blockly.Names.NameType.VARIABLE
+          );
+          code += 'var ' + endVar + ' = ' + argument1 + ';\n';
+        }
+        // Determine loop direction at start, in case one of the bounds
+        // changes during loop execution.
+        const incVar = generator.nameDB_!.getDistinctName(
+          variable0 + '_inc',
+          Blockly.Names.NameType.VARIABLE
+        );
+        code += 'var ' + incVar + ' = ';
+        if (Blockly.utils.string.isNumber(increment)) {
+          code += Math.abs(Number(increment)) + ';\n';
+        } else {
+          code += 'Math.abs(' + increment + ');\n';
+        }
+        code += 'if (' + startVar + ' > ' + endVar + ') {\n';
+        code += generator.INDENT + incVar + ' = -' + incVar + ';\n';
+        code += '}\n';
+        code +=
+          'for (' +
+          variable0 +
+          ' = ' +
+          startVar +
+          '; ' +
+          incVar +
+          ' >= 0 ? ' +
+          variable0 +
+          ' <= ' +
+          endVar +
+          ' : ' +
+          variable0 +
+          ' >= ' +
+          endVar +
+          '; ' +
+          variable0 +
+          ' += ' +
+          incVar +
+          ') {\n' +
+          branch +
+          '}\n';
+      }
+      return code;
+    };
   },
 };

--- a/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/commonBlocks.ts
@@ -9,6 +9,7 @@ import {Order} from 'blockly/javascript';
 
 import {
   BlocklyWrapperType,
+  ExtendedCodeGenerator,
   ExtendedJavascriptGenerator,
   JavascriptGeneratorType,
 } from '@cdo/apps/blockly/types';
@@ -177,7 +178,9 @@ export const blocks = {
       // https://github.com/google/blockly/blob/2c29c01b14fd9cec9f7fde82f6c80b6f4f7b7c30/generators/javascript/loops.ts#L85-L178
 
       // Customization: use translateVarName instead of getVariableName
-      const variable0 = generator.translateVarName(block.getFieldValue('VAR'));
+      const variable0 = (
+        generator as unknown as ExtendedCodeGenerator
+      ).translateVarName(block.getFieldValue('VAR'));
       // End customation.
 
       const argument0 =

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -3516,6 +3516,10 @@ exports.install = function (blockly, blockInstallOptions) {
     return varName + ' = ' + argument0 + ';\n';
   };
 
+  // Overrides the standard generator from Core Blockly.
+  // Variable labels in Playlab include the Globals namespace.
+  Blockly.customBlocks.overrideForLoopGenerator();
+
   blockGeneratorFunctionDictionary.studio_ask = function () {
     var blockId = `block_id_${this.id}`;
     var question = this.getFieldValue('TEXT');


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#63211 which reverts https://github.com/code-dot-org/code-dot-org/pull/63143

This first attempt was causing a build failure due to a conflict with the v11 bump (https://github.com/code-dot-org/code-dot-org/pull/62722) that was merged at the same time.

https://codedotorg.slack.com/archives/C0T0PNTM3/p1736450198482559?thread_ts=1736447426.409099&cid=C0T0PNTM3

The test build was failing with this error:
```
Running "webpack:uglify" (webpack) task
ERROR in ./src/blockly/customBlocks/googleBlockly/commonBlocks.ts:180:35
TS2339: Property 'translateVarName' does not exist on type 'JavascriptGenerator'.
    178 |
    179 |       // Customization: use translateVarName instead of getVariableName
  > 180 |       const variable0 = generator.translateVarName(block.getFieldValue('VAR'));
        |                                   ^^^^^^^^^^^^^^^^
    181 |       // End customation.
    182 |
    183 |       const argument0 =

webpack compiled with 1 error
```

We saw and fixed similar issues when preparing for the v11 bump (https://github.com/code-dot-org/code-dot-org/pull/62320) but as this work was done in parallel against v10, it was missed.

The only new change here is to cast the `generator` to our extended type for it. https://github.com/code-dot-org/code-dot-org/pull/63212/commits/1c33a263285d35b520e4f5a2d68b6ccb3980602a