### PR TITLE
Stop using the user's alternate email for enrollments

### DIFF
--- a/bin/oneoff/unsent_pl_emails_enumerate.rb
+++ b/bin/oneoff/unsent_pl_emails_enumerate.rb
@@ -326,7 +326,11 @@ def get_ids_for_no_workshop_yet
 
     # Let's see if there is an enrollment that hasn't happened...
 
-    Pd::Enrollment.where(email: contact_email).all.each do |enrollment|
+    enrollments = user.alternate_email.present? ?
+      Pd::Enrollment.where(email: contact_email).or(Pd::Enrollment.where(email: user.alternate_email)).all :
+      Pd::Enrollment.where(email: contact_email).all
+
+    enrollments.each do |enrollment|
       enrollment_id = enrollment.pd_workshop_id
 
       puts "  found an enrollment!"

--- a/dashboard/app/controllers/pd/session_attendance_controller.rb
+++ b/dashboard/app/controllers/pd/session_attendance_controller.rb
@@ -18,7 +18,7 @@ class Pd::SessionAttendanceController < ApplicationController
     end
 
     enrollments = @session.workshop.enrollments
-    enrollment = enrollments.find_by(user: current_user) || enrollments.find_by(email: current_user.email_for_enrollments)
+    enrollment = enrollments.find_by(user: current_user) || enrollments.find_by(email: current_user.email)
 
     unless enrollment
       # If signed out, user must sign in then is redirected back. If signed in to an account not associated

--- a/dashboard/app/controllers/pd/session_attendance_controller.rb
+++ b/dashboard/app/controllers/pd/session_attendance_controller.rb
@@ -19,6 +19,10 @@ class Pd::SessionAttendanceController < ApplicationController
 
     enrollments = @session.workshop.enrollments
     enrollment = enrollments.find_by(user: current_user) || enrollments.find_by(email: current_user.email)
+    alternate_email = current_user.alternate_email
+    if enrollment.nil? && alternate_email.present?
+      enrollment = enrollments.find_by(email: alternate_email)
+    end
 
     unless enrollment
       # If signed out, user must sign in then is redirected back. If signed in to an account not associated

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -47,8 +47,8 @@ class Pd::WorkshopEnrollmentController < ApplicationController
     else
       @enrollment = ::Pd::Enrollment.new workshop: @workshop
       @enrollment.full_name = current_user.name
-      @enrollment.email = current_user.email_for_enrollments
-      @enrollment.email_confirmation = current_user.email_for_enrollments
+      @enrollment.email = current_user.email
+      @enrollment.email_confirmation = current_user.email
 
       session_dates = @workshop.sessions.map(&:formatted_date_with_start_and_end_times)
 
@@ -187,11 +187,11 @@ class Pd::WorkshopEnrollmentController < ApplicationController
   # Gets the workshop enrollment associated with the current user id or email used for
   # enrollments if one exists. Otherwise returns a new enrollment for that user.
   private def get_workshop_user_enrollment
-    @workshop.enrollments.where(user_id: current_user.id).or(@workshop.enrollments.where(email: current_user.email_for_enrollments)).first || Pd::Enrollment.new(
+    @workshop.enrollments.where(user_id: current_user.id).first || Pd::Enrollment.new(
       pd_workshop_id: @workshop.id,
       user_id: current_user.id,
       full_name: current_user.name,
-      email: current_user.email_for_enrollments
+      email: current_user.email
     )
   end
 

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -187,7 +187,16 @@ class Pd::WorkshopEnrollmentController < ApplicationController
   # Gets the workshop enrollment associated with the current user id or email used for
   # enrollments if one exists. Otherwise returns a new enrollment for that user.
   private def get_workshop_user_enrollment
-    @workshop.enrollments.where(user_id: current_user.id).first || Pd::Enrollment.new(
+    enrollment_by_user_id = @workshop.enrollments.where(user_id: current_user.id).first
+    return enrollment_by_user_id if enrollment_by_user_id.present?
+
+    enrollment_by_email = @workshop.enrollments.where(email: current_user.email).first
+    return enrollment_by_email if enrollment_by_email.present?
+
+    enrollment_by_alternate_email = @workshop.enrollments.where(email: current_user.alternate_email).first
+    return enrollment_by_alternate_email if enrollment_by_alternate_email.present?
+
+    Pd::Enrollment.new(
       pd_workshop_id: @workshop.id,
       user_id: current_user.id,
       full_name: current_user.name,

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -120,7 +120,7 @@ module Pd::Application
     end
 
     def formatted_applicant_email
-      applicant_email = user.email.presence || sanitized_form_data_hash[:alternate_email]
+      applicant_email = user.email
       if applicant_email.blank?
         raise "invalid email address for application #{id}"
       end
@@ -288,7 +288,7 @@ module Pd::Application
     end
 
     def email
-      user.try(:email) || sanitized_form_data_hash[:alternate_email]
+      user.try(:email)
     end
 
     def regional_partner_name

--- a/dashboard/app/models/pd/attendance.rb
+++ b/dashboard/app/models/pd/attendance.rb
@@ -53,7 +53,7 @@ class Pd::Attendance < ApplicationRecord
   def resolve_enrollment
     Pd::Enrollment.with_deleted.find_by(id: pd_enrollment_id) ||
       workshop.enrollments.find_by(user_id: teacher_id) ||
-      workshop.enrollments.find_by(email: User.with_deleted.find_by(id: teacher_id).try(&:email_for_enrollments))
+      workshop.enrollments.find_by(email: User.with_deleted.find_by(id: teacher_id).try(&:email))
   end
 
   def self.for_teacher(teacher)

--- a/dashboard/app/models/pd/attendance.rb
+++ b/dashboard/app/models/pd/attendance.rb
@@ -53,7 +53,8 @@ class Pd::Attendance < ApplicationRecord
   def resolve_enrollment
     Pd::Enrollment.with_deleted.find_by(id: pd_enrollment_id) ||
       workshop.enrollments.find_by(user_id: teacher_id) ||
-      workshop.enrollments.find_by(email: User.with_deleted.find_by(id: teacher_id).try(&:email))
+      workshop.enrollments.find_by(email: User.with_deleted.find_by(id: teacher_id).try(&:email)) ||
+      workshop.enrollments.find_by(email: User.with_deleted.find_by(id: teacher_id).try(&:alternate_email))
   end
 
   def self.for_teacher(teacher)

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -91,7 +91,7 @@ class Pd::Enrollment < ApplicationRecord
   end
 
   def self.for_user(user)
-    where('email = ? OR user_id = ?', user.email_for_enrollments, user.id)
+    where('email = ? OR user_id = ?', user.email, user.id)
   end
 
   # Name split (https://github.com/code-dot-org/code-dot-org/pull/11679) was deployed on 2016-11-09

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -91,7 +91,10 @@ class Pd::Enrollment < ApplicationRecord
   end
 
   def self.for_user(user)
-    where('email = ? OR user_id = ?', user.email, user.id)
+    alternate_email = user.alternate_email
+    alternate_email.present? ?
+      where('email = ? OR email = ? OR user_id = ?', user.email, alternate_email, user.id) :
+      where('email = ? OR user_id = ?', user.email, user.id)
   end
 
   # Name split (https://github.com/code-dot-org/code-dot-org/pull/11679) was deployed on 2016-11-09

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -152,7 +152,7 @@ class Pd::Workshop < ApplicationRecord
   def self.enrolled_in_by(teacher)
     base_query = joins(:enrollments)
     user_id_where_clause = base_query.where(pd_enrollments: {user_id: teacher.id})
-    email_where_clause = base_query.where(pd_enrollments: {email: teacher.email_for_enrollments})
+    email_where_clause = base_query.where(pd_enrollments: {email: teacher.email})
 
     user_id_where_clause.or(email_where_clause).distinct
   end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -154,7 +154,13 @@ class Pd::Workshop < ApplicationRecord
     user_id_where_clause = base_query.where(pd_enrollments: {user_id: teacher.id})
     email_where_clause = base_query.where(pd_enrollments: {email: teacher.email})
 
-    user_id_where_clause.or(email_where_clause).distinct
+    alternate_email = teacher.alternate_email
+    if alternate_email.present?
+      alternate_email_where_clause = base_query.where(pd_enrollments: {email: alternate_email})
+      user_id_where_clause.or(email_where_clause).or(alternate_email_where_clause).distinct
+    else
+      user_id_where_clause.or(email_where_clause).distinct
+    end
   end
 
   def self.exclude_summer

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -444,18 +444,6 @@ class User < ApplicationRecord
     primary_contact_info.try(:hashed_email) || ''
   end
 
-  # Email used for the user's enrollments:
-  # Returns the 'alternateEmail' field from the user's latest accepted teacher application if it exists to
-  # help ensure the enrollment emails are delivered. Otherwise, returns the user's email.
-  def email_for_enrollments
-    latest_accepted_app = Pd::Application::TeacherApplication.where(
-      user: self,
-      status: 'accepted'
-    ).order(application_year: :desc).first&.form_data_hash
-    alternate_email = latest_accepted_app ? latest_accepted_app['alternateEmail'] : ''
-    alternate_email.presence || email
-  end
-
   # assign a course to a facilitator that is qualified to teach it
   def course_as_facilitator=(course)
     courses_as_facilitator << courses_as_facilitator.find_or_create_by(facilitator_id: id, course: course)

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -285,35 +285,6 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
     refute_nil Pd::Enrollment.find_by(pd_workshop_id: workshop.id)
   end
 
-  test 'creating an enrollment can find user and submit if enrollment email is alternate email' do
-    teacher = create :teacher
-    sign_in teacher
-
-    application = create :pd_teacher_application, user: teacher, status: 'accepted'
-    app_alt_email = application.form_data_hash['alternateEmail']
-
-    refute_equal teacher.email, app_alt_email
-    assert_equal teacher.email_for_enrollments, app_alt_email
-
-    params = enrollment_test_params.merge(
-      {
-        user_id: teacher.id,
-        email: app_alt_email,
-        email_confirmation: app_alt_email,
-        workshop_id: @workshop.id,
-        school_info: school_info_params
-      }
-    )
-    post :create, params: params
-
-    assert_response :success
-
-    response_body = JSON.parse(@response.body)
-    assert_equal RESPONSE_MESSAGES[:SUCCESS], response_body["workshop_enrollment_status"]
-    assert response_body["account_exists"]
-    refute_nil Pd::Enrollment.find_by(pd_workshop_id: @workshop.id)
-  end
-
   test 'creating a duplicate enrollment sends \'duplicate\' workshop enrollment status' do
     @teacher = create :teacher
     params = enrollment_test_params.merge(

--- a/dashboard/test/controllers/pd/session_attendance_controller_test.rb
+++ b/dashboard/test/controllers/pd/session_attendance_controller_test.rb
@@ -81,7 +81,7 @@ class Pd::SessionAttendanceControllerTest < ActionController::TestCase
   end
 
   test 'attend with a matching enrollment by email updates the enrollment.user' do
-    enrollment = create :pd_enrollment, workshop: @workshop, user: nil, email: @teacher.email_for_enrollments
+    enrollment = create :pd_enrollment, workshop: @workshop, user: nil, email: @teacher.email
     sign_in @teacher
 
     assert_creates Pd::Attendance do

--- a/dashboard/test/controllers/pd/session_attendance_controller_test.rb
+++ b/dashboard/test/controllers/pd/session_attendance_controller_test.rb
@@ -91,6 +91,18 @@ class Pd::SessionAttendanceControllerTest < ActionController::TestCase
     assert_equal @teacher, enrollment.reload.user
   end
 
+  test 'attend with a matching enrollment by alternate email updates the enrollment.user' do
+    create :pd_teacher_application, user: @teacher, status: 'accepted'
+    enrollment = create :pd_enrollment, workshop: @workshop, user: nil, email: @teacher.alternate_email
+    sign_in @teacher
+
+    assert_creates Pd::Attendance do
+      get :attend, params: {session_code: @session.code}
+    end
+
+    assert_equal @teacher, enrollment.reload.user
+  end
+
   test_redirect_to_sign_in_for :select_enrollment, method: :post, params: -> {{session_code: @session.code}}
 
   test 'select_enrollment updates enrollment and creates attendance for selection' do

--- a/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
@@ -141,48 +141,6 @@ class Pd::WorkshopEnrollmentControllerTest < ActionController::TestCase
     assert_template :new
   end
 
-  test 'teacher enrollment email defaults to user email if no alternate email in application' do
-    teacher = create :teacher
-    sign_in teacher
-
-    workshop = create :workshop, organizer: @organizer, num_sessions: 1
-
-    application = create :pd_teacher_application, user: teacher, status: 'accepted'
-    new_form_data_hash = application.form_data_hash
-    new_form_data_hash['alternateEmail'] = ''
-    application.update(form_data_hash: new_form_data_hash)
-    app_alt_email = application.form_data_hash['alternateEmail']
-
-    assert app_alt_email.empty?
-
-    get :new, params: {workshop_id: workshop.id}
-    assert_response :success
-    assert_template :new
-
-    enrollment_email = JSON.parse(assigns(:script_data)[:props])["enrollment"]["email"]
-
-    refute_equal enrollment_email, app_alt_email
-    assert_equal enrollment_email, teacher.email
-  end
-
-  test 'teacher enrollment email uses application alternate email if available' do
-    teacher = create :teacher
-    sign_in teacher
-
-    workshop = create :workshop, organizer: @organizer, num_sessions: 1
-    application = create :pd_teacher_application, user: teacher, status: 'accepted'
-    app_alt_email = application.form_data_hash['alternateEmail']
-
-    get :new, params: {workshop_id: workshop.id}
-    assert_response :success
-    assert_template :new
-
-    enrollment_email = JSON.parse(assigns(:script_data)[:props])["enrollment"]["email"]
-
-    refute_equal enrollment_email, teacher.email
-    assert_equal enrollment_email, app_alt_email
-  end
-
   # TODO: remove this test when workshop_organizer is deprecated
   test 'workshop organizers can see enrollment form' do
     # Note - organizers can see the form, but cannot enroll in their own workshops.

--- a/dashboard/test/lib/services/complete_application_reminder_test.rb
+++ b/dashboard/test/lib/services/complete_application_reminder_test.rb
@@ -118,7 +118,7 @@ class Services::CompleteApplicationReminderTest < ActiveSupport::TestCase
       teacher_without_email = create :teacher, :with_school_info, :demigrated
       teacher_without_email.update_attribute(:email, '')
       teacher_without_email.update_attribute(:hashed_email, '')
-      application_hash_without_email = build :pd_teacher_application_hash, alternate_email: ''
+      application_hash_without_email = build :pd_teacher_application_hash
       application_without_email = create :pd_teacher_application,
                                          status: 'incomplete',
                                          user: teacher_without_email,

--- a/dashboard/test/models/pd/application/application_base_test.rb
+++ b/dashboard/test/models/pd/application/application_base_test.rb
@@ -365,28 +365,14 @@ module Pd::Application
       assert_includes application.formatted_applicant_email, application.applicant_full_name
     end
 
-    test 'formatted_applicant_email uses alternate email if no user account email' do
+    test 'formatted_applicant_email raises error if no user email' do
       teacher_without_email = create :teacher, :with_school_info, :demigrated
       teacher_without_email.update_attribute(:email, '')
       teacher_without_email.update_attribute(:hashed_email, '')
-
-      application = create :pd_teacher_application, user: teacher_without_email
-
-      assert teacher_without_email.email.blank?
-
-      assert_includes application.formatted_applicant_email, application.applicant_full_name
-      assert_includes application.formatted_applicant_email, application.sanitized_form_data_hash[:alternate_email]
-    end
-
-    test 'formatted_applicant_email raises error if no user email or alternate email' do
-      teacher_without_email = create :teacher, :with_school_info, :demigrated
-      teacher_without_email.update_attribute(:email, '')
-      teacher_without_email.update_attribute(:hashed_email, '')
-      application_hash_without_email = build :pd_teacher_application_hash, alternate_email: ''
+      application_hash_without_email = build :pd_teacher_application_hash
       application_without_email = create :pd_teacher_application, user: teacher_without_email, form_data: application_hash_without_email.to_json
 
       assert teacher_without_email.email.blank?
-      assert application_without_email.sanitized_form_data_hash[:alternate_email].blank?
       assert_raises_matching("invalid email address for application #{application_without_email.id}") do
         application_without_email.formatted_applicant_email
       end

--- a/dashboard/test/models/pd/attendance_test.rb
+++ b/dashboard/test/models/pd/attendance_test.rb
@@ -100,7 +100,7 @@ class Pd::AttendanceTest < ActiveSupport::TestCase
 
   test 'resolve_enrollment' do
     teacher = create :teacher
-    enrollment = create :pd_enrollment, workshop: @workshop, user_id: teacher.id, email: teacher.email_for_enrollments
+    enrollment = create :pd_enrollment, workshop: @workshop, user_id: teacher.id, email: teacher.email
     attendance = create :pd_attendance, teacher: teacher, workshop: @workshop, session: @workshop.sessions.first
 
     # by user id

--- a/dashboard/test/models/pd/attendance_test.rb
+++ b/dashboard/test/models/pd/attendance_test.rb
@@ -100,6 +100,8 @@ class Pd::AttendanceTest < ActiveSupport::TestCase
 
   test 'resolve_enrollment' do
     teacher = create :teacher
+    create :pd_teacher_application, user: teacher, status: 'accepted'
+    alternate_email = teacher.alternate_email
     enrollment = create :pd_enrollment, workshop: @workshop, user_id: teacher.id, email: teacher.email
     attendance = create :pd_attendance, teacher: teacher, workshop: @workshop, session: @workshop.sessions.first
 
@@ -112,6 +114,10 @@ class Pd::AttendanceTest < ActiveSupport::TestCase
 
     # by email with deleted user
     teacher.destroy!
+    assert_equal enrollment, attendance.reload.resolve_enrollment
+
+    # by alternate email with deleted user
+    enrollment.update!(email: alternate_email)
     assert_equal enrollment, attendance.reload.resolve_enrollment
 
     # soft-deleted enrollments are still matched

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -12,27 +12,10 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     refute_equal enrollment1.code, enrollment2.code
   end
 
-  test 'enrollment.for_user using application alternate email' do
+  test 'enrollment.for_user using user email' do
     user = create :teacher
 
-    workshop = create :workshop, course: COURSE_CSD
-
-    application = create :pd_teacher_application, user: user, pd_workshop_id: workshop.id, course: 'csd', status: 'accepted'
-    assert_equal user.email_for_enrollments, application.form_data_hash['alternateEmail']
-
-    enrollment1 = create :pd_enrollment, user_id: nil, email: user.email_for_enrollments, workshop: workshop, application_id: application.id
-    enrollment2 = create :pd_enrollment, user_id: user.id, email: 'someoneelse@example.com', workshop: (create :workshop, course: COURSE_CSF)
-
-    enrollments = Pd::Enrollment.for_user(user).to_a
-    assert_equal Set.new([enrollment1, enrollment2]), Set.new(enrollments)
-  end
-
-  test 'enrollment.for_user using user email instead of application alternate email' do
-    user = create :teacher
-
-    assert_equal user.email_for_enrollments, user.email
-
-    enrollment1 = create :pd_enrollment, user_id: nil, email: user.email_for_enrollments, workshop: (create :workshop, course: COURSE_CSD)
+    enrollment1 = create :pd_enrollment, user_id: nil, email: user.email, workshop: (create :workshop, course: COURSE_CSD)
     enrollment2 = create :pd_enrollment, user_id: user.id, email: 'someoneelse@example.com', workshop: (create :workshop, course: COURSE_CSF)
 
     enrollments = Pd::Enrollment.for_user(user).to_a
@@ -63,22 +46,11 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
 
   test 'resolve_user returns user using user email' do
     teacher = create :teacher
-    enrollment_with_email = build :pd_enrollment, email: teacher.email_for_enrollments
+    enrollment_with_email = build :pd_enrollment, email: teacher.email
 
     assert_equal enrollment_with_email.email, teacher.email
     assert_nil enrollment_with_email.user
     assert_equal teacher, enrollment_with_email.resolve_user
-  end
-
-  test 'resolve_user returns user using application alternate email' do
-    teacher = create :teacher
-    workshop = create :workshop, course: COURSE_CSD
-    application = create :pd_teacher_application, user: teacher, pd_workshop_id: workshop.id, course: 'csd', status: 'accepted'
-    enrollment_with_alt_email = build :pd_enrollment, email: teacher.email_for_enrollments, application_id: application.id
-
-    assert_equal enrollment_with_alt_email.email, application.form_data_hash['alternateEmail']
-    assert_nil enrollment_with_alt_email.user
-    assert_equal teacher, enrollment_with_alt_email.resolve_user
   end
 
   test 'autoupdate_user_field called on validation' do

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -22,6 +22,16 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     assert_equal Set.new([enrollment1, enrollment2]), Set.new(enrollments)
   end
 
+  test 'enrollment.for_user using user alternate email' do
+    user = create :teacher
+    create :pd_teacher_application, user: user, status: 'accepted'
+
+    enrollment = create :pd_enrollment, user_id: nil, email: user.alternate_email, workshop: (create :workshop, course: COURSE_CSD)
+
+    enrollments_for_user = Pd::Enrollment.for_user(user).to_a
+    assert_equal enrollments_for_user.first, enrollment
+  end
+
   test 'find by code' do
     enrollment = create :pd_enrollment
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -74,7 +74,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_empty Pd::Workshop.enrolled_in_by(teacher)
 
     # Email match only
-    enrollment.update!(email: teacher.email_mismatch)
+    enrollment.update!(email: teacher.email)
     assert_equal [@workshop], Pd::Workshop.enrolled_in_by(teacher)
 
     # UserId only

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -57,7 +57,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   test 'query by enrolled teacher' do
     # Teachers enroll in a workshop as a whole
     teacher = create :teacher
-    create :pd_enrollment, workshop: @workshop, full_name: teacher.name, email: teacher.email_for_enrollments
+    create :pd_enrollment, workshop: @workshop, full_name: teacher.name, email: teacher.email
 
     # create a workshop with a different teacher enrollment, which should not be returned below
     other_workshop = create(:workshop)
@@ -74,7 +74,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_empty Pd::Workshop.enrolled_in_by(teacher)
 
     # Email match only
-    enrollment.update!(email: teacher.email_for_enrollments)
+    enrollment.update!(email: teacher.email_mismatch)
     assert_equal [@workshop], Pd::Workshop.enrolled_in_by(teacher)
 
     # UserId only
@@ -82,7 +82,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_equal [@workshop], Pd::Workshop.enrolled_in_by(teacher)
 
     # Both email and user id. Should still find workshop exactly once
-    enrollment.update!(email: teacher.email_for_enrollments, user: teacher)
+    enrollment.update!(email: teacher.email, user: teacher)
     assert_equal [@workshop], Pd::Workshop.enrolled_in_by(teacher)
   end
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -84,6 +84,11 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     # Both email and user id. Should still find workshop exactly once
     enrollment.update!(email: teacher.email, user: teacher)
     assert_equal [@workshop], Pd::Workshop.enrolled_in_by(teacher)
+
+    # Alternate email match only
+    create :pd_teacher_application, user: teacher, status: 'accepted'
+    enrollment.update!(email: teacher.alternate_email, user: nil)
+    assert_equal [@workshop], Pd::Workshop.enrolled_in_by(teacher)
   end
 
   test 'exclude_summer scope' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -330,6 +330,30 @@ class UserTest < ActiveSupport::TestCase
     assert_equal hashed_email, teacher.read_attribute(:hashed_email)
   end
 
+  test 'alternate_email returns nil if user has no latest accepted application' do
+    user = create :teacher
+    assert user.alternate_email.blank?
+  end
+
+  test 'alternate_email returns nil if users latest accepted application has no alternate email' do
+    user = create :teacher
+    application = create :pd_teacher_application, user: user, status: 'accepted'
+    application_form_data = application.form_data_hash
+    application_form_data['alternateEmail'] = ''
+    application.update!(form_data_hash: application_form_data)
+
+    assert application.form_data_hash['alternateEmail'].blank?
+    assert user.alternate_email.blank?
+  end
+
+  test 'alternate_email returns app alternate email if users latest accepted application has alternate email' do
+    user = create :teacher
+    application = create :pd_teacher_application, user: user, status: 'accepted'
+    app_alternate_email = application.form_data_hash['alternateEmail']
+
+    assert_equal user.alternate_email, app_alternate_email
+  end
+
   test "log in with password with pepper" do
     assert Devise.pepper
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -330,30 +330,6 @@ class UserTest < ActiveSupport::TestCase
     assert_equal hashed_email, teacher.read_attribute(:hashed_email)
   end
 
-  test 'email_for_enrollments returns user.email if user has no latest accepted application' do
-    user = create :teacher
-    assert_equal user.email_for_enrollments, user.email
-  end
-
-  test 'email_for_enrollments returns user.email if users latest accepted application has no alternate email' do
-    user = create :teacher
-    application = create :pd_teacher_application, user: user
-    application_form_data = application.form_data_hash
-    application_form_data['alternateEmail'] = nil
-    application.update!(form_data_hash: application_form_data)
-
-    assert application.form_data_hash['alternateEmail'].blank?
-    assert_equal user.email_for_enrollments, user.email
-  end
-
-  test 'email_for_enrollments returns app alternate email if users latest accepted application has alternate email' do
-    user = create :teacher
-    application = create :pd_teacher_application, user: user, status: 'accepted'
-    app_alternate_email = application.form_data_hash['alternateEmail']
-
-    assert_equal user.email_for_enrollments, app_alternate_email
-  end
-
   test "log in with password with pepper" do
     assert Devise.pepper
 


### PR DESCRIPTION
We have received a lot of Zendesk tickets about users having trouble with the alternate email they could set in their application to receive emails over the summer for professional development content. The original implementation of the alternate email was that it would be set as the enrollment email, which would then be the only email that would receive PD-related emails for that enrollment. This led to a lot of confusion and also some odd edge cases that exposed bugs.

To make this less complicated, the new approach will be always using the user's main email as their enrollment email, using it for all associations connecting them to their PD content, and always sending mail to that email. If a user sets an alternate email in their application, that email will also receive any summer workshop mail. So this will hopefully prevent any odd edge case bugs since applications, enrollments, etc. will all use the same user email.

I'm doing this work in two parts so that no one PR is too big (though this one is already getting kinda big):
1) This PR: remove places where we reference the alternate email and just rely on the user's email
2) [Followup PR](https://github.com/code-dot-org/code-dot-org/pull/63338): send emails to both the user's email and alternate email for summer workshops

One note about the changes is that we'll still need to search for both the user's email and alternate email (if it exists) when searching for enrollments by email in the case that the enrollment already exists prior to this PR merging and has the email set as the user's alternate email.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2941)
Followup PR to send PD content to both emails: [here](https://github.com/code-dot-org/code-dot-org/pull/63338)

## Testing story
Updating unit tests.
