### PR TITLE
Nav - show unit materials dropdown for stand alone courses

### DIFF
--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainer.tsx
@@ -184,7 +184,7 @@ const LessonMaterialsContainer: React.FC<LessonMaterialsContainerProps> = ({
           size="s"
           id="ui-test-lessons-in-assigned-unit-dropdown"
         />
-        {lessonMaterials?.unitNumber && (
+        {lessonMaterials && (
           <UnitResourcesDropdown
             hasNumberedUnits={hasNumberedUnits}
             unitNumber={lessonMaterials.unitNumber}

--- a/apps/src/templates/teacherNavigation/lessonMaterials/UnitResourcesDropdown.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/UnitResourcesDropdown.tsx
@@ -8,7 +8,7 @@ import i18n from '@cdo/locale';
 import {RESOURCE_ICONS} from './ResourceIconType';
 
 type UnitResourcesDropdownProps = {
-  unitNumber?: number;
+  unitNumber?: number | null;
   hasNumberedUnits?: boolean;
   scriptOverviewPdfUrl: string;
   scriptResourcesPdfUrl: string;


### PR DESCRIPTION
Shows the "Unit resource drop down" for standalone units.

<img width="956" alt="image" src="https://github.com/user-attachments/assets/adf31fe3-1c59-40fd-8067-b776a8899975" />



## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65/backlog?selectedIssue=TEACH-1472)
