### PR TITLE
Expire `Cdo::Throttle` Cache Entries

### DIFF
--- a/lib/cdo/throttle.rb
+++ b/lib/cdo/throttle.rb
@@ -27,7 +27,11 @@ module Cdo
         value[:throttled_until] = now + throttle_for if should_throttle
       end
 
-      CDO.shared_cache.write(full_key, value)
+      # The maximum time (in seconds) for which any information contained in
+      # this entry could possibly be relevant.
+      max_data_relevancy = throttle_for + period
+
+      CDO.shared_cache.write(full_key, value, expires_in: max_data_relevancy)
       should_throttle
     end
 

--- a/lib/test/cdo/test_throttle.rb
+++ b/lib/test/cdo/test_throttle.rb
@@ -34,4 +34,26 @@ class ThrottleTest < Minitest::Test
     Timecop.travel(Time.now.utc + 0.5)
     assert Cdo::Throttle.throttle("my_key", 2, 2) # 3/2 reqs per 2s - throttled again
   end
+
+  def test_throttle_expiration
+    Timecop.freeze
+    start = Time.now.utc
+    throttle_id = 'my_key'
+    period = 2
+    throttle_time = 3
+    cache_id = Cdo::Throttle::CACHE_PREFIX + throttle_id
+
+    Cdo::Throttle.throttle(throttle_id, 1, period, throttle_time)
+    assert CDO.shared_cache.read(cache_id)
+
+    # Throttle data will be preserved for a little while,
+    Timecop.travel(start + 1)
+    assert CDO.shared_cache.read(cache_id)
+    Timecop.travel(start + period + throttle_time - 1)
+    assert CDO.shared_cache.read(cache_id)
+
+    # but will expire eventually.
+    Timecop.travel(start + period + throttle_time)
+    refute CDO.shared_cache.read(cache_id)
+  end
 end


### PR DESCRIPTION
Our `Cdo::Throttle` module uses the shared cache to store the data it needs to determine whether a given resource should be throttled, but currently entries are stored indefinitely despite throttling being by definition a temporary state.

This only became an issue recently when [we started throttling datablock storage](https://github.com/code-dot-org/code-dot-org/pull/61132); with the significantly increased usage, we are [now seeing unbounded growth on the underlying memcached cluster](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2?graph=~(metrics~(~(~'AWS*2fElastiCache~'CurrItems~'CacheClusterId~'autoscale-prod~'CacheNodeId~'0001)~(~'...~'0002))~region~'us-east-1~title~'Current*20Items~stat~'Average~view~'timeSeries~start~'2024-08-01T11*3a20*3a00.405Z~end~'2024-12-06T13*3a02*3a00.756Z~period~86400)):

![image](https://github.com/user-attachments/assets/a2d69569-024a-4e0d-a208-75e0f321a83b)

Fortunately, the fix is relatively straightforward! The throttle module allows us to specify a defined period of time in which to consider throttling, and a defined duration to throttle for; if it has been at least `throttle_for + period` seconds since the last interaction, there's no longer any need to retain the relevant entry so we can allow it to expire.

## Testing story

Added a unit test to check the new functionality. Also verified manually that datablock throttling in applab continues to work as expected.

## Follow-up work

I'm not certain what we should do about the existing entries. Many of them will be updated with expiration values as users continue to interact with datablock-backed projects, but any projects that are no longer getting traffic may have their throttle entries persisted indefinitely.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
