### PR TITLE
Make bucket counter visible in Python Lab neighborhood

### DIFF
--- a/apps/src/codebridge/styles/codebridge.scss
+++ b/apps/src/codebridge/styles/codebridge.scss
@@ -14,3 +14,23 @@
   fill: #eee;
 }
 
+// Style the counter used by neighborhood
+.karel-counter-text {
+  text-anchor: end;
+  font-size: 16px;
+  font-family: Verdana, Geneva, sans-serif;
+  font-weight: bold;
+  fill: white;
+  stroke: black;
+  stroke-width: 1;
+  cursor: default;
+
+  html[dir="RTL"] & {
+    text-anchor: start;
+  }
+}
+
+.karel-counter-text.paint {
+  font-size: 33px;
+  stroke-width: 2;
+}

--- a/apps/src/codebridge/styles/codebridge.scss
+++ b/apps/src/codebridge/styles/codebridge.scss
@@ -1,3 +1,4 @@
+// These styles are copied from common.scss, which lab2 does not use.
 // Style the speed slider used by neighborhood
 .sliderTrack {
   stroke: #aaa;


### PR DESCRIPTION
I missed copying over some styles for the python lab neighborhood bucket counter. The styles for Java Lab/other mazes were in `common.scss`, which doesn't seem to be used in lab2. I copied the relevant styling over to `codebridge.scss`.

## Before
![Screenshot 2025-01-09 at 1 36 18 PM](https://github.com/user-attachments/assets/d40f941d-fe61-4b51-90c8-cb6ed1e67d3f)

## After
![Screenshot 2025-01-09 at 1 35 57 PM](https://github.com/user-attachments/assets/961d5362-9095-4b4b-8566-e9eb87bb0e10)

## Links
- jira ticket: [CT-950](https://codedotorg.atlassian.net/browse/CT-950)


## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
