### PR TITLE
remove user_id from non-dashboard unit overview

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -16,13 +16,19 @@ class ScriptsController < ApplicationController
   use_reader_connection_for_route(:show)
 
   def show
-    if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.unit_group&.default_units&.any? {|u| u.id == @script.id}} && (Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false))
-      if !params[:section_id] && current_user&.last_section_id
-        redirect_to "/teacher_dashboard/sections/#{current_user.last_section_id}/unit/#{@script.name}"
+    if Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false)
+      if request.query_parameters.include? "user_id"
+        redirect_to "#{script_path(@script)}?#{request.query_string.sub("user_id=#{request.query_parameters[:user_id]}", "").sub("&&", "&")}"
         return
-      elsif params[:section_id]
-        redirect_to "/teacher_dashboard/sections/#{params[:section_id]}/unit/#{@script.name}"
-        return
+      end
+      if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.unit_group&.default_units&.any? {|u| u.id == @script.id}}
+        if !params[:section_id] && current_user&.last_section_id
+          redirect_to "/teacher_dashboard/sections/#{current_user.last_section_id}/unit/#{@script.name}"
+          return
+        elsif params[:section_id]
+          redirect_to "/teacher_dashboard/sections/#{params[:section_id]}/unit/#{@script.name}"
+          return
+        end
       end
     end
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -19,8 +19,11 @@ class ScriptsController < ApplicationController
     if Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false)
       if request.query_parameters.include? "user_id"
         redirect_query_string = request.query_string.sub("user_id=#{request.query_parameters[:user_id]}", "").sub("&&", "&")
-        puts redirect_query_string
-        redirect_to "#{script_path(@script)}?#{request.query_string.sub("user_id=#{request.query_parameters[:user_id]}", "").sub("&&", "&")}"
+        if redirect_query_string.empty?
+          redirect_to script_path(@script)
+        else
+          redirect_to "#{script_path(@script)}?#{redirect_query_string}"
+        end
         return
       end
       if current_user&.user_type == "teacher" && current_user.sections_instructed.any? {|s| s.script_id == @script.id || s.unit_group&.default_units&.any? {|u| u.id == @script.id}}

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -18,6 +18,8 @@ class ScriptsController < ApplicationController
   def show
     if Experiment.enabled?(user: current_user, experiment_name: 'teacher-local-nav-v2') || DCDO.get('teacher-local-nav-v2', false)
       if request.query_parameters.include? "user_id"
+        redirect_query_string = request.query_string.sub("user_id=#{request.query_parameters[:user_id]}", "").sub("&&", "&")
+        puts redirect_query_string
         redirect_to "#{script_path(@script)}?#{request.query_string.sub("user_id=#{request.query_parameters[:user_id]}", "").sub("&&", "&")}"
         return
       end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -299,6 +299,16 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_redirected_to "/teacher_dashboard/sections/#{experiment_section.id}/unit/#{experiment_script.name}"
   end
 
+  test "show: should remove user_id url param from non-dashboard unit overview when teacher local nav v2 experiment enabled" do
+    experiment_teacher = create :teacher
+    SingleUserExperiment.find_or_create_by!(min_user_id: experiment_teacher.id, name: 'teacher-local-nav-v2')
+
+    sign_in experiment_teacher
+
+    get :show, params: {id: @coursez_2019.name, user_id: 1}
+    assert_redirected_to "/s/#{@coursez_2019.name}"
+  end
+
   test "should not get edit on production" do
     CDO.stubs(:rack_env).returns(:production)
     Rails.application.config.stubs(:levelbuilder_mode).returns false


### PR DESCRIPTION
This removes the user_id parameter from the query string if the user is not on the teacher dashboard. This is currently enabled only for users in the teacher nav v2 experiment.

## Links

[TEACH-1348](https://codedotorg.atlassian.net/browse/TEACH-1348)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
