### PR TITLE
Update honeybadger_test.rb to skip test

### DIFF
--- a/dashboard/test/integration/honeybadger_test.rb
+++ b/dashboard/test/integration/honeybadger_test.rb
@@ -34,6 +34,7 @@ class HoneybadgerTest < ActionDispatch::IntegrationTest
   FILTERED = "[FILTERED]"
 
   test "does NOT log encrypted data" do
+    skip 'races the reconfiguration and errors if it contacts real honeybadger server'
     student = create :student
     sign_in student
 


### PR DESCRIPTION
Skips flaky honeybadger test.

It races the re-configuration to point to the dummy backend because honeybadger workers do not immediately shutdown... and as a result, it sometimes calls the real honeybadger which rate-limits and errors out and furthermore posts the notification in a different queue than the one the test expects.

Discussion: https://codedotorg.slack.com/archives/C0T0PNTM3/p1736268224800839
Decision: https://codedotorg.slack.com/archives/C0T0PNTM3/p1736459306065309

This skips pending a fix in https://codedotorg.atlassian.net/browse/P20-1354

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
