### PR TITLE
[Google Blockly] studio_whenSpriteAndGroupCollide block

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -548,6 +548,8 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     return this;
   };
 
+  // This is intentionally a no-op. Called by PlayLab.
+  // Google Blockly's implementation uses end row inputs instead.
   extendedInput.setInline = function (inline) {
     return this;
   };

--- a/apps/src/blockly/googleBlocklyWrapper.ts
+++ b/apps/src/blockly/googleBlocklyWrapper.ts
@@ -502,6 +502,20 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
     }
   };
 
+  const originalSetInputsInline =
+    blocklyWrapper.Block.prototype.setInputsInline;
+  // Replace the original setInputsInline with a version that forces a
+  // two-row Play Lab block to always use inline inputs..
+  extendedBlockSvg.setInputsInline = function (inline) {
+    originalSetInputsInline.call(this, inline);
+    if (
+      this.type === 'studio_whenSpriteAndGroupCollide' &&
+      !this.getInputsInline()
+    ) {
+      this.setInputsInline(true);
+    }
+  };
+
   const extendedInput = blocklyWrapper.Input.prototype as ExtendedInput;
   const extendedConnection = blocklyWrapper.Connection
     .prototype as ExtendedConnection;
@@ -531,6 +545,10 @@ function initializeBlocklyWrapper(blocklyInstance: GoogleBlocklyInstance) {
       fieldHelper,
       options
     );
+    return this;
+  };
+
+  extendedInput.setInline = function (inline) {
     return this;
   };
 

--- a/apps/src/blockly/types.ts
+++ b/apps/src/blockly/types.ts
@@ -225,6 +225,7 @@ export interface ExtendedInput extends GoogleBlockly.Input {
   // Blockly explicitly uses any for this type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getFieldRow: () => GoogleBlockly.Field<any>[];
+  setInline: (inline: boolean) => ExtendedInput;
 }
 export interface ExtendedConnection extends GoogleBlockly.Connection {
   getFieldHelperOptions: (fieldHelper: string) => FieldHelperOptions;

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -2609,9 +2609,10 @@ exports.install = function (blockly, blockInstallOptions) {
         .appendField(dropdown2, 'SPRITENAME');
       this.appendDummyInput();
       this.appendValueInput('GROUPMEMBER')
+        // setInline is a no-op function in Google Blockly.
         .setInline(true)
         .appendField(msg.set());
-      this.appendEndRowInput().setInline(true).appendField(endLabel);
+      this.appendDummyInput().setInline(true).appendField(endLabel);
 
       this.setPreviousStatement(false);
       this.setNextStatement(true);

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -2604,14 +2604,14 @@ exports.install = function (blockly, blockInstallOptions) {
             msg.toTouchedSpriteName({spriteName: stripQuotes(value)})
           )
       );
-      this.appendDummyInput()
+      this.appendEndRowInput()
         .appendField(dropdown1, 'SPRITE')
         .appendField(dropdown2, 'SPRITENAME');
       this.appendDummyInput();
       this.appendValueInput('GROUPMEMBER')
         .setInline(true)
         .appendField(msg.set());
-      this.appendDummyInput().setInline(true).appendField(endLabel);
+      this.appendEndRowInput().setInline(true).appendField(endLabel);
 
       this.setPreviousStatement(false);
       this.setNextStatement(true);


### PR DESCRIPTION
This adds support for an unusual two-row Play Lab block. 

CDO Blockly:
![image](https://github.com/user-attachments/assets/2e3e3772-106a-4f2c-a7c2-6e5e16ddd7a3)

Google Blockly:
![image](https://github.com/user-attachments/assets/0c0cdf42-4200-4f3f-89a4-fc5a880e48ff)

**Challenges:**
As it is currently defined, this block does not use inline inputs (at the block level), however it does have explicitly set the bottom two inputs to be inline:
1. `'GROUPMEMBER'` ie. the value input that takes the nested variable block and the "set" label
2. the final unnamed input ie. "to touched {sprite}"

If all inputs on the block are set to be inline, Blockly renders everything in one row:

CDO Blockly WITH inline inputs:
![image](https://github.com/user-attachments/assets/86ca2cf2-a31c-4247-875d-4586774a0c51)

Google Blockly does not provide the means to make specific inputs be inline without making the entire block inline. However, it does offer [end row inputs](https://developers.google.com/blockly/reference/js/blockly.inputs_namespace.endrowinput_class) which always moves later inputs to a new row, even if the block should use inline inputs. However, because of the undesired view above, we have always serialized this block to _not_ use inline inputs at all. With Google Blockly, this leads to a different undesired view:

Google Blockly WITHOUT inline inputs:
![image](https://github.com/user-attachments/assets/4bc33247-e5f5-4fe7-82a7-60b1df028bba)

**Solution:**
To solve this problem, I started by converting the last dummy input on the first row to an end row input. (Note: CDO Blockly doesn't support end row inputs, so we just continue to make dummy inputs: https://github.com/code-dot-org/code-dot-org/blob/mike/group-event-block/apps/src/blockly/cdoBlocklyWrapper.js#L240-L241)

While we can't support making an individual input inline, I needed to prevent `Input.setInline(true)` from throwing an error with Google Blockly. I patched it onto our `ExtendedInput`, but it doesn't actually do anything.

Finally, in order to force this particular block to always use inline inputs in Google Blockly, I patched `setInputsInline`. If the xml for this block ever includes `inline="false"` (as it does in at least 28 levels), the block will still be rendered with inline inputs. The end row input will ensure that the block has two rows.

These changes result in the block being rendered as expected. It is fully functional in both version of Blockly and no regressions were seen for CDO Blockly. Furthermore, I was able to confirm that no other blocks are causing errors. To do this, I checked the most open-ended levels in Course 4, the project level, and the toolbox of our toolbox editing mode on levelbuilder.

![2025-01-10 11-44-46 2025-01-10 11_45_37](https://github.com/user-attachments/assets/5d877f31-e7be-42bd-80f0-6cb336f8ab0d)

## Links

https://codedotorg.atlassian.net/browse/CT-907
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
