### PR TITLE
[Music] Disable share and remix on levels using intro2024 library

### DIFF
--- a/dashboard/app/views/levels/editors/_music.html.haml
+++ b/dashboard/app/views/levels/editors/_music.html.haml
@@ -2,6 +2,7 @@
 = render partial: 'levels/editors/fields/music_level_data', locals: {f: f}
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
+%i Warning: Do not enable share/remix unless using the recommended "launch2024" library.
 = render partial: 'levels/editors/fields/browser_tts', locals: {f: f}
 = render partial: 'levels/editors/fields/secondary_finish_button', locals: {f: f}
 = render partial: 'levels/editors/fields/validations', locals: {f: f}

--- a/dashboard/config/levels/custom/music/Music Level 1.level
+++ b/dashboard/config/levels/custom/music/Music Level 1.level
@@ -51,7 +51,7 @@
     },
     "instructions_important": "false",
     "long_instructions": "First, please play one sound.",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "validations": [
       {
         "conditions": [

--- a/dashboard/config/levels/custom/music/Music Level 2.level
+++ b/dashboard/config/levels/custom/music/Music Level 2.level
@@ -57,7 +57,7 @@
     },
     "instructions_important": "false",
     "long_instructions": "Second, please play three sounds at the same time.",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "validations": [
       {
         "conditions": [

--- a/dashboard/config/levels/custom/music/Music Level 3.level
+++ b/dashboard/config/levels/custom/music/Music Level 3.level
@@ -8,7 +8,7 @@
   "properties": {
     "encrypted": "false",
     "background": "music-black",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "level_data": {
       "library": "intro2024",
       "text": "Try everything!",

--- a/dashboard/config/levels/custom/music/Music Sublevel.level
+++ b/dashboard/config/levels/custom/music/Music Sublevel.level
@@ -50,7 +50,7 @@
       }
     },
     "instructions_important": "false",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "validations": [
       {
         "conditions": [

--- a/dashboard/config/levels/custom/music/music-intro-coding-seq-modify-sound.level
+++ b/dashboard/config/levels/custom/music/music-intro-coding-seq-modify-sound.level
@@ -9,7 +9,7 @@
     "encrypted": "false",
     "instructions_important": "false",
     "long_instructions": "####Take a Rest\r\n\r\n1. We want the guitar to play after the rest.\r\n2. Click and drag the blocks into the correct order.\r\n3. Then press [Run](#clickable=run-button).",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "level_data": {
       "library": "intro2024",
       "startSources": {

--- a/dashboard/config/levels/custom/music/music_lab_play_more_sounds.level
+++ b/dashboard/config/levels/custom/music/music_lab_play_more_sounds.level
@@ -56,7 +56,7 @@
     },
     "instructions_important": "false",
     "name_suffix": "_pdx",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "validations": [
       {
         "key": "musiclab_intro_change_sound_elementary_251e3d31-19b7-499e-a47d-362f33f4f2c0",

--- a/dashboard/config/levels/custom/music/musiclab_intro_change_sound_pdx.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_change_sound_pdx.level
@@ -57,7 +57,7 @@
     },
     "instructions_important": "false",
     "name_suffix": "_pdx",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "validations": [
       {
         "key": "musiclab_intro_change_sound_elementary_251e3d31-19b7-499e-a47d-362f33f4f2c0",

--- a/dashboard/config/levels/custom/music/musiclab_intro_change_sound_v2.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_change_sound_v2.level
@@ -57,7 +57,7 @@
     },
     "instructions_important": "false",
     "name_suffix": "_v2",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "validations": [
       {
         "key": "musiclab_intro_change_sound_v2_6054328e-dc95-47fe-8c65-980ce00299f1",

--- a/dashboard/config/levels/custom/music/musiclab_intro_freeplay.level
+++ b/dashboard/config/levels/custom/music/musiclab_intro_freeplay.level
@@ -7,7 +7,7 @@
   "user_id": 574,
   "properties": {
     "encrypted": "false",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "background": "music-black",
     "long_instructions": "####Free Play\n\nYou're ready to create!  Be sure to explore the blocks and the sounds.  There is a lot to explore and use to make an amazing track.",
     "level_data": {

--- a/dashboard/config/levels/custom/music/musiclab_tutorial_change_sound_course-d.level
+++ b/dashboard/config/levels/custom/music/musiclab_tutorial_change_sound_course-d.level
@@ -56,7 +56,7 @@
     },
     "instructions_important": "false",
     "name_suffix": "_course-d",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "validations": [
       {
         "key": "musiclab_intro_change_sound_v2_6054328e-dc95-47fe-8c65-980ce00299f1",

--- a/dashboard/config/levels/custom/music/musiclab_tutorial_change_sound_coursee.level
+++ b/dashboard/config/levels/custom/music/musiclab_tutorial_change_sound_coursee.level
@@ -56,7 +56,7 @@
     },
     "instructions_important": "false",
     "name_suffix": "_coursee",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "validations": [
       {
         "key": "musiclab_intro_change_sound_v2_6054328e-dc95-47fe-8c65-980ce00299f1",

--- a/dashboard/config/levels/custom/music/musiclab_tutorial_change_sound_express.level
+++ b/dashboard/config/levels/custom/music/musiclab_tutorial_change_sound_express.level
@@ -56,7 +56,7 @@
     },
     "instructions_important": "false",
     "name_suffix": "_express",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "validations": [
       {
         "key": "musiclab_intro_change_sound_v2_6054328e-dc95-47fe-8c65-980ce00299f1",

--- a/dashboard/config/levels/custom/music/musiclab_tutorial_d_freeplay.level
+++ b/dashboard/config/levels/custom/music/musiclab_tutorial_d_freeplay.level
@@ -6,7 +6,7 @@
   "user_id": 574,
   "properties": {
     "encrypted": "false",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "background": "music-black",
     "long_instructions": "####Free Play\n\nYou're ready to create!  Be sure to explore the blocks and the sounds.  There is a lot to explore and use to make an amazing track.",
     "level_data": {

--- a/dashboard/config/levels/custom/music/musiclab_tutorial_freeplay.level
+++ b/dashboard/config/levels/custom/music/musiclab_tutorial_freeplay.level
@@ -6,7 +6,7 @@
   "user_id": 574,
   "properties": {
     "encrypted": "false",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "background": "music-black",
     "long_instructions": "####Free Play\n\nYou're ready to create!  Be sure to explore the blocks and the sounds.  There is a lot to explore and use to make an amazing track.",
     "level_data": {

--- a/dashboard/config/levels/custom/music/musiclab_tutorial_freeplay_express.level
+++ b/dashboard/config/levels/custom/music/musiclab_tutorial_freeplay_express.level
@@ -6,7 +6,7 @@
   "user_id": 574,
   "properties": {
     "encrypted": "false",
-    "hide_share_and_remix": "false",
+    "hide_share_and_remix": "true",
     "background": "music-black",
     "long_instructions": "####Free Play\n\nYou're ready to create!  Be sure to explore the blocks and the sounds.  There is a lot to explore and use to make an amazing track.",
     "level_data": {


### PR DESCRIPTION
This removes the share/remix buttons from any levels using the legacy "intro2024" level. It also adds a warning to levelbuilder to discourage re-adding them.
![image](https://github.com/user-attachments/assets/299434d4-4227-4c7f-8c09-54190751df0d)

There are currently 29 levels that use the old libraries. About half of these had share/remix enabled.

Context:
Currently, if you share or remix a project that uses the older library, it is loaded into the project level, which uses the new library. Due to the library mismatch, sound values on `play` blocks end up reset to the default options as the originally chosen sounds are no longer available. 

We discussed allowing the project level to use the project's designated library (https://github.com/code-dot-org/code-dot-org/pull/63176), but decided against it. Because we can't change libraries without a page reload, remixes of intro projects would continue to use the old library even if the user pressed the "start over" button.

Slack thread: https://codedotorg.slack.com/archives/C043WM7TCH3/p1736295733374889?thread_ts=1736293708.533559&cid=C043WM7TCH3

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
