### PR TITLE
Add educator role to sign up

### DIFF
--- a/apps/i18n/signup/en_us.json
+++ b/apps/i18n/signup/en_us.json
@@ -43,6 +43,8 @@
   "finish_creating_teacher_account": "Finish creating your teacher account",
   "tailor_experience": "Tailor your Code.org experience with a few details.",
   "what_do_you_want_to_be_called": "What do you want to be called on Code.org?*",
+  "what_is_your_role": "What is your primary role?",
+  "select_a_role": "Please select a role",
   "this_is_what_your_students_will_see": "This is what your students will see.",
   "keep_me_updated": "Keep me updated:",
   "get_informational_emails": "Get informational emails about Code.org updates and opportunities (1-2/month)",

--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -115,6 +115,7 @@ def main
       NON_SCHOOL_OPTIONS
       US_STATES
       PROJECT_SUBMISSION_STATUS
+      EDUCATOR_ROLES
     ),
     file_type: 'ts'
   )

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -150,7 +150,6 @@ const FinishTeacherAccount: React.FunctionComponent<{
       !gdprValid ||
       (isInSchoolRequiredExperiment && schoolInfoInvalid(schoolInfo)) ||
       (requireEducatorRole && !educatorRole),
-
     [
       gdprValid,
       isInSchoolRequiredExperiment,
@@ -283,21 +282,19 @@ const FinishTeacherAccount: React.FunctionComponent<{
             )}
           </div>
           {showEducatorRole && (
-            <div>
-              <SimpleDropdown
-                className={classNames(style.dropdownContainer, {
-                  [style.requiredLabel]: requireEducatorRole,
-                })}
-                labelText={locale.what_is_your_role()}
-                name="educator_role"
-                selectedValue={educatorRole}
-                onChange={e => {
-                  setEducatorRole(e.target.value);
-                }}
-                itemGroups={roleItemGroups}
-                dropdownTextThickness="thin"
-              />
-            </div>
+            <SimpleDropdown
+              className={classNames(style.dropdownContainer, {
+                [style.requiredLabel]: requireEducatorRole,
+              })}
+              labelText={locale.what_is_your_role()}
+              name="educator_role"
+              selectedValue={educatorRole}
+              onChange={e => {
+                setEducatorRole(e.target.value);
+              }}
+              itemGroups={roleItemGroups}
+              dropdownTextThickness="thin"
+            />
           )}
           <SchoolDataInputs
             {...schoolInfo}

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -285,10 +285,10 @@ const FinishTeacherAccount: React.FunctionComponent<{
           {showEducatorRole && (
             <div>
               <SimpleDropdown
-                className={style.dropdownContainer}
-                labelText={`${locale.what_is_your_role()}${
-                  requireEducatorRole ? '*' : ''
-                }`}
+                className={classNames(style.dropdownContainer, {
+                  [style.requiredLabel]: requireEducatorRole,
+                })}
+                labelText={locale.what_is_your_role()}
                 name="educator_role"
                 selectedValue={educatorRole}
                 onChange={e => {

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -5,6 +5,7 @@ import React, {useState, useEffect, useMemo} from 'react';
 import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import Checkbox from '@cdo/apps/componentLibrary/checkbox/Checkbox';
 import CloseButton from '@cdo/apps/componentLibrary/closeButton/CloseButton';
+import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/FontAwesomeV6Icon';
 import TextField from '@cdo/apps/componentLibrary/textField/TextField';
 import {
@@ -20,7 +21,7 @@ import {schoolInfoInvalid} from '@cdo/apps/schoolInfo/utils/schoolInfoInvalid';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import SchoolDataInputs from '@cdo/apps/templates/SchoolDataInputs';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
-import {UserTypes} from '@cdo/generated-scripts/sharedConstants';
+import {UserTypes, EducatorRoles} from '@cdo/generated-scripts/sharedConstants';
 
 import {useSchoolInfo} from '../schoolInfo/hooks/useSchoolInfo';
 import {navigateToHref} from '../utils';
@@ -38,6 +39,22 @@ import {
 
 import style from './signUpFlowStyles.module.scss';
 
+const roleItemGroups = [
+  {
+    label: '',
+    groupItems: [{value: '', text: locale.select_a_role()}],
+  },
+  ...Object.entries(
+    EducatorRoles.reduce((groups, {category, value, label}) => {
+      if (!groups[category]) {
+        groups[category] = [];
+      }
+      groups[category].push({value, text: label});
+      return groups;
+    }, {} as Record<string, {value: string; text: string}[]>)
+  ).map(([label, groupItems]) => ({label, groupItems})),
+];
+
 const FinishTeacherAccount: React.FunctionComponent<{
   usIp: boolean;
   countryCode: string;
@@ -45,6 +62,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
   const schoolInfo = useSchoolInfo({usIp});
   const [name, setName] = useState('');
   const [nameErrorMessage, setNameErrorMessage] = useState(null);
+  const [educatorRole, setEducatorRole] = useState('');
   const [emailOptInChecked, setEmailOptInChecked] = useState(false);
   const [gdprChecked, setGdprChecked] = useState(false);
   const [showGDPR, setShowGDPR] = useState(false);
@@ -147,6 +165,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
         email_preference_opt_in: emailOptInChecked,
         school_info_attributes: {...schoolInfo},
         country_code: countryCode,
+        educator_role: educatorRole || null,
       },
     };
     const authToken = await getAuthenticityToken();
@@ -220,7 +239,6 @@ const FinishTeacherAccount: React.FunctionComponent<{
               name="displayName"
               id="uitest-display-name"
               label={locale.what_do_you_want_to_be_called()}
-              className={style.nameInput}
               value={name}
               placeholder={locale.msCoder()}
               onChange={onNameChange}
@@ -233,6 +251,19 @@ const FinishTeacherAccount: React.FunctionComponent<{
                 {nameErrorMessage}
               </BodyThreeText>
             )}
+          </div>
+          <div>
+            <SimpleDropdown
+              className={style.dropdownContainer}
+              labelText={locale.what_is_your_role()}
+              name="educator_role"
+              selectedValue={educatorRole}
+              onChange={e => {
+                setEducatorRole(e.target.value);
+              }}
+              itemGroups={roleItemGroups}
+              dropdownTextThickness="thin"
+            />
           </div>
           <SchoolDataInputs
             {...schoolInfo}

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -46,9 +46,7 @@ const roleItemGroups = [
   },
   ...Object.entries(
     EducatorRoles.reduce((groups, {category, value, label}) => {
-      if (!groups[category]) {
-        groups[category] = [];
-      }
+      groups[category] = groups[category] ?? [];
       groups[category].push({value, text: label});
       return groups;
     }, {} as Record<string, {value: string; text: string}[]>)

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -252,9 +252,10 @@ const FinishTeacherAccount: React.FunctionComponent<{
                 iconName={'circle-xmark'}
                 className={style.xIcon}
               />
-              <BodyThreeText className={style.errorMessageText}>
-                <SafeMarkdown markdown={locale.error_signing_up_message()} />
-              </BodyThreeText>
+              <SafeMarkdown
+                markdown={locale.error_signing_up_message()}
+                className={style.errorMessageText}
+              />
             </div>
             <CloseButton
               onClick={() => showErrorCreatingAccountMessage(false)}

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -78,6 +78,18 @@ const FinishTeacherAccount: React.FunctionComponent<{
     false
   );
 
+  const showEducatorRole = statsigReporter.getIsInExperiment(
+    'educator_role',
+    'showEducatorRole',
+    false
+  );
+
+  const requireEducatorRole = statsigReporter.getIsInExperiment(
+    'educator_role',
+    'requireEducatorRole',
+    false
+  );
+
   // Remove oauth user_type cookie if it exists
   cookies.remove(NEW_SIGN_UP_USER_TYPE);
 
@@ -130,6 +142,24 @@ const FinishTeacherAccount: React.FunctionComponent<{
   const gdprValid = useMemo(() => {
     return isGdprLoaded && ((showGDPR && gdprChecked) || !showGDPR);
   }, [showGDPR, gdprChecked, isGdprLoaded]);
+
+  const formDisabled = useMemo(
+    () =>
+      name?.trim() === '' ||
+      name?.length > MAX_DISPLAY_NAME_LENGTH ||
+      !gdprValid ||
+      (isInSchoolRequiredExperiment && schoolInfoInvalid(schoolInfo)) ||
+      (requireEducatorRole && !educatorRole),
+
+    [
+      gdprValid,
+      isInSchoolRequiredExperiment,
+      name,
+      schoolInfo,
+      requireEducatorRole,
+      educatorRole,
+    ]
+  );
 
   const onNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const newName = e.target.value;
@@ -252,19 +282,23 @@ const FinishTeacherAccount: React.FunctionComponent<{
               </BodyThreeText>
             )}
           </div>
-          <div>
-            <SimpleDropdown
-              className={style.dropdownContainer}
-              labelText={locale.what_is_your_role()}
-              name="educator_role"
-              selectedValue={educatorRole}
-              onChange={e => {
-                setEducatorRole(e.target.value);
-              }}
-              itemGroups={roleItemGroups}
-              dropdownTextThickness="thin"
-            />
-          </div>
+          {showEducatorRole && (
+            <div>
+              <SimpleDropdown
+                className={style.dropdownContainer}
+                labelText={`${locale.what_is_your_role()}${
+                  requireEducatorRole ? '*' : ''
+                }`}
+                name="educator_role"
+                selectedValue={educatorRole}
+                onChange={e => {
+                  setEducatorRole(e.target.value);
+                }}
+                itemGroups={roleItemGroups}
+                dropdownTextThickness="thin"
+              />
+            </div>
+          )}
           <SchoolDataInputs
             {...schoolInfo}
             includeHeaders={false}
@@ -325,12 +359,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
               iconStyle: 'solid',
               title: 'arrow-right',
             }}
-            disabled={
-              name?.trim() === '' ||
-              name?.length > MAX_DISPLAY_NAME_LENGTH ||
-              !gdprValid ||
-              (isInSchoolRequiredExperiment && schoolInfoInvalid(schoolInfo))
-            }
+            disabled={formDisabled}
             isPending={isSubmitting}
           />
         </div>

--- a/apps/src/signUpFlow/signUpFlowStyles.module.scss
+++ b/apps/src/signUpFlow/signUpFlowStyles.module.scss
@@ -475,6 +475,12 @@ span {
     }
   }
 
+  .requiredLabel {
+    span::after {
+      content: '*';
+    }
+  }
+
   .dropdownContainer div {
     width: 100%;
   }

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -74,8 +74,8 @@ describe('FinishTeacherAccount', () => {
     );
   });
 
-  it('renders finish teacher account page with school zip when usIp is true', () => {
-    renderDefault(true);
+  it('renders finish teacher account page with school zip when usIp is true', async () => {
+    await waitFor(renderDefault);
 
     // Renders page title
     screen.getByText(locale.finish_creating_teacher_account());
@@ -98,8 +98,10 @@ describe('FinishTeacherAccount', () => {
     screen.getByText(locale.go_to_my_account());
   });
 
-  it('renders finish teacher account page with school name when usIp is false', () => {
-    renderDefault(false);
+  it('renders finish teacher account page with school name when usIp is false', async () => {
+    await waitFor(() => {
+      renderDefault(false);
+    });
 
     // Renders page title
     screen.getByText(locale.finish_creating_teacher_account());
@@ -118,8 +120,9 @@ describe('FinishTeacherAccount', () => {
     screen.getByText(locale.go_to_my_account());
   });
 
-  it('school info is tracked in sessionStorage', () => {
-    renderDefault();
+  it('school info is tracked in sessionStorage', async () => {
+    await waitFor(renderDefault);
+
     const zipCode = '98122';
     const schoolName = 'Seattle Academy';
 
@@ -141,8 +144,8 @@ describe('FinishTeacherAccount', () => {
     expect(sessionStorage.getItem(SCHOOL_NAME_SESSION_KEY)).toBe(schoolName);
   });
 
-  it('finish teacher signup button starts disabled', () => {
-    renderDefault();
+  it('finish teacher signup button starts disabled', async () => {
+    await waitFor(renderDefault);
 
     const finishSignUpButton = screen.getByRole('button', {
       name: locale.go_to_my_account(),
@@ -150,8 +153,8 @@ describe('FinishTeacherAccount', () => {
     expect(finishSignUpButton).toBeDisabled();
   });
 
-  it('leaving the displayName field empty shows error message', () => {
-    renderDefault();
+  it('leaving the displayName field empty shows error message', async () => {
+    await waitFor(renderDefault);
     const displayNameInput = screen.getAllByDisplayValue('')[0];
 
     // Error message doesn't show and button is disabled by default
@@ -170,8 +173,8 @@ describe('FinishTeacherAccount', () => {
     screen.getByText(locale.display_name_error_message());
   });
 
-  it('only whitespace in the displayName field shows error message', () => {
-    renderDefault();
+  it('only whitespace in the displayName field shows error message', async () => {
+    await waitFor(renderDefault);
     const displayNameInput = screen.getAllByDisplayValue('')[0];
 
     // Error message doesn't show and button is disabled by default
@@ -189,8 +192,8 @@ describe('FinishTeacherAccount', () => {
     expect(finishSignUpButton).toBeDisabled();
   });
 
-  it('adding a long display name shows error message', () => {
-    renderDefault();
+  it('adding a long display name shows error message', async () => {
+    await waitFor(renderDefault);
     const displayNameInput = screen.getAllByDisplayValue('')[0];
 
     // Error message doesn't show and button is disabled by default
@@ -221,7 +224,7 @@ describe('FinishTeacherAccount', () => {
       json: () => Promise.resolve({gdpr: true, force_in_eu: false}),
     } as Response);
 
-    renderDefault();
+    await waitFor(renderDefault);
 
     // Check that GDPR message is displayed
     await screen.findByText(locale.data_transfer_notice());
@@ -359,9 +362,7 @@ describe('FinishTeacherAccount', () => {
     };
     sessionStorage.setItem('email', email);
 
-    await waitFor(() => {
-      renderDefault();
-    });
+    await waitFor(renderDefault);
 
     // Set up finish sign up button onClick jest function
     const finishSignUpButton = screen.getByRole('button', {

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -36,8 +36,22 @@ const navigateToHrefMock = navigateToHref as jest.Mock;
 const getAuthenticityTokenMock = getAuthenticityToken as jest.Mock;
 
 describe('FinishTeacherAccount', () => {
-  afterEach(() => {
+  let fetchStub: sinon.SinonStub;
+
+  beforeEach(() => {
     sessionStorage.clear();
+
+    // Stub fetch to return a default mock response
+    fetchStub = sinon.stub(window, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({gdpr: false, force_in_eu: false}),
+    } as Response);
+  });
+
+  afterEach(() => {
+    // Restore the original fetch
+    fetchStub.restore();
   });
 
   function renderDefault(
@@ -218,7 +232,7 @@ describe('FinishTeacherAccount', () => {
   });
 
   it('GDPR has expected behavior if api call returns true', async () => {
-    const fetchStub = sinon.stub(window, 'fetch').resolves({
+    fetchStub.resolves({
       ok: true,
       status: 200,
       json: () => Promise.resolve({gdpr: true, force_in_eu: false}),
@@ -238,13 +252,9 @@ describe('FinishTeacherAccount', () => {
     expect(finishSignUpButton).toBeDisabled();
     fireEvent.click(screen.getAllByRole('checkbox')[0]);
     expect(finishSignUpButton).not.toBeDisabled();
-
-    // Restore the original fetch implementation
-    fetchStub.restore();
   });
 
   it('clicking finish sign up button triggers fetch call and shows error if backend error', async () => {
-    const fetchStub = sinon.stub(window, 'fetch');
     fetchStub.callsFake(() =>
       Promise.resolve({
         ok: false,
@@ -317,12 +327,9 @@ describe('FinishTeacherAccount', () => {
       // SafeMarkdown tag, so the email itself is checked to know if the message shows.
       screen.getByText('support@code.org');
     });
-
-    fetchStub.restore();
   });
 
   it('clicking finish sign up button triggers fetch call and redirects user to home page', async () => {
-    const fetchStub = sinon.stub(window, 'fetch');
     fetchStub.callsFake(url => {
       if (typeof url === 'string' && url.includes('/users/gdpr_check')) {
         return Promise.resolve({
@@ -398,12 +405,9 @@ describe('FinishTeacherAccount', () => {
       // Verify the user is redirected to the finish sign up page
       expect(navigateToHrefMock).toHaveBeenCalledWith('/home');
     });
-
-    fetchStub.restore();
   });
 
   it('setting redirect url in sessionStorage then clicking finish sign up button triggers fetch call and redirects user to redirect page', async () => {
-    const fetchStub = sinon.stub(window, 'fetch');
     fetchStub.callsFake(url => {
       if (typeof url === 'string' && url.includes('/users/gdpr_check')) {
         return Promise.resolve({
@@ -483,7 +487,8 @@ describe('FinishTeacherAccount', () => {
       // Verify the user is redirected to the finish sign up page
       expect(navigateToHrefMock).toHaveBeenCalledWith(userReturnToUrl);
     });
+  });
 
-    fetchStub.restore();
+  // TODO: when experiment ends, move relevant tests above and remove this describe block
   });
 });

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import React from 'react';
 import sinon from 'sinon'; // eslint-disable-line no-restricted-imports
 
+import StatsigReporter from '@cdo/apps/metrics/StatsigReporter';
 import FinishTeacherAccount from '@cdo/apps/signUpFlow/FinishTeacherAccount';
 import locale from '@cdo/apps/signUpFlow/locale';
 import {
@@ -282,6 +283,7 @@ describe('FinishTeacherAccount', () => {
           usIp: true,
         },
         country_code: 'US',
+        educator_role: null,
       },
     };
     sessionStorage.setItem('email', email);
@@ -365,6 +367,7 @@ describe('FinishTeacherAccount', () => {
           usIp: true,
         },
         country_code: 'US',
+        educator_role: null,
       },
     };
     sessionStorage.setItem('email', email);
@@ -444,6 +447,7 @@ describe('FinishTeacherAccount', () => {
           usIp: true,
         },
         country_code: 'US',
+        educator_role: null,
       },
     };
     sessionStorage.setItem('email', email);
@@ -490,5 +494,97 @@ describe('FinishTeacherAccount', () => {
   });
 
   // TODO: when experiment ends, move relevant tests above and remove this describe block
+  describe('Educator role experiment', () => {
+    let getIsInExperimentSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      getIsInExperimentSpy = jest
+        .spyOn(StatsigReporter, 'getIsInExperiment')
+        .mockReturnValue(false);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('hides educator_role dropdown if not in experiment', async () => {
+      await waitFor(renderDefault);
+
+      const roleDropdown = screen.queryByLabelText(locale.what_is_your_role());
+      expect(roleDropdown).not.toBeInTheDocument();
+    });
+
+    it('renders educator_role dropdown if in experiment', async () => {
+      getIsInExperimentSpy.mockImplementation((experiment, param) => {
+        if (experiment === 'educator_role' && param === 'showEducatorRole') {
+          return true;
+        }
+        return false;
+      });
+      await waitFor(renderDefault);
+
+      const roleDropdown = screen.queryByLabelText(locale.what_is_your_role());
+      expect(roleDropdown).toBeInTheDocument();
+    });
+
+    it('does not require educator_role if not in experiment', async () => {
+      getIsInExperimentSpy.mockImplementation((experiment, param) => {
+        if (experiment === 'educator_role') {
+          if (param === 'showEducatorRole') {
+            return true;
+          }
+          if (param === 'requireEducatorRole') {
+            return false;
+          }
+        }
+        return false;
+      });
+      await waitFor(renderDefault);
+
+      const roleDropdown = screen.queryByLabelText(locale.what_is_your_role());
+      expect(roleDropdown).toBeInTheDocument();
+
+      const displayNameInput = screen.getAllByRole('textbox')[0];
+      fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
+
+      const finishSignUpButton = screen.getByRole('button', {
+        name: locale.go_to_my_account(),
+      });
+      expect(finishSignUpButton).toBeEnabled();
+    });
+
+    it('requires educator_role if in experiment', async () => {
+      getIsInExperimentSpy.mockImplementation((experiment, param) => {
+        if (experiment === 'educator_role') {
+          if (param === 'showEducatorRole') {
+            return true;
+          }
+          if (param === 'requireEducatorRole') {
+            return true;
+          }
+        }
+        return false;
+      });
+      await waitFor(renderDefault);
+
+      const roleDropdown = screen.getByLabelText(locale.what_is_your_role());
+      expect(roleDropdown).toBeInTheDocument();
+
+      const displayNameInput = screen.getAllByRole('textbox')[0];
+      fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
+
+      let finishSignUpButton = screen.getByRole('button', {
+        name: locale.go_to_my_account(),
+      });
+      expect(finishSignUpButton).toBeDisabled();
+
+      fireEvent.change(roleDropdown, {target: {value: 'classroom_teacher'}});
+
+      finishSignUpButton = screen.getByRole('button', {
+        name: locale.go_to_my_account(),
+      });
+
+      expect(finishSignUpButton).toBeEnabled();
+    });
   });
 });

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -516,7 +516,10 @@ describe('FinishTeacherAccount', () => {
 
     it('renders educator_role dropdown if in experiment', async () => {
       getIsInExperimentSpy.mockImplementation((experiment, param) => {
-        if (experiment === 'educator_role' && param === 'showEducatorRole') {
+        if (experiment !== 'educator_role') {
+          return false;
+        }
+        if (param === 'showEducatorRole') {
           return true;
         }
         return false;
@@ -529,13 +532,14 @@ describe('FinishTeacherAccount', () => {
 
     it('does not require educator_role if not in experiment', async () => {
       getIsInExperimentSpy.mockImplementation((experiment, param) => {
-        if (experiment === 'educator_role') {
-          if (param === 'showEducatorRole') {
-            return true;
-          }
-          if (param === 'requireEducatorRole') {
-            return false;
-          }
+        if (experiment !== 'educator_role') {
+          return false;
+        }
+        if (param === 'showEducatorRole') {
+          return true;
+        }
+        if (param === 'requireEducatorRole') {
+          return false;
         }
         return false;
       });
@@ -555,13 +559,14 @@ describe('FinishTeacherAccount', () => {
 
     it('requires educator_role if in experiment', async () => {
       getIsInExperimentSpy.mockImplementation((experiment, param) => {
-        if (experiment === 'educator_role') {
-          if (param === 'showEducatorRole') {
-            return true;
-          }
-          if (param === 'requireEducatorRole') {
-            return true;
-          }
+        if (experiment !== 'educator_role') {
+          return false;
+        }
+        if (param === 'showEducatorRole') {
+          return true;
+        }
+        if (param === 'requireEducatorRole') {
+          return true;
         }
         return false;
       });

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -168,6 +168,7 @@ class User < ApplicationRecord
     has_seen_ai_assessments_announcement
     seen_ta_scores_map
     roster_synced
+    educator_type
   )
 
   attr_accessor(

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -168,7 +168,7 @@ class User < ApplicationRecord
     has_seen_ai_assessments_announcement
     seen_ta_scores_map
     roster_synced
-    educator_type
+    educator_role
   )
 
   attr_accessor(

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -117,6 +117,7 @@ class User < ApplicationRecord
   #     brute-force password attempts
   #   roster_synced: Indicates if the user was created during a roster sync operation from an LMS. Implies that the user
   #     is a school-managed account.
+  #   educator_role: Indicates the role of the educator, e.g. 'teacher', 'school_admin', 'district_admin', etc.
   serialized_attrs %w(
     ops_first_name
     ops_last_name

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -220,6 +220,8 @@ class User < ApplicationRecord
   validates_presence_of :user_type
   validates_inclusion_of :user_type, in: USER_TYPE_OPTIONS, if: :user_type?
 
+  validates_inclusion_of :educator_role, in: Policies::User::ALLOWED_EDUCATOR_ROLES, if: :educator_role?
+
   belongs_to :studio_person, optional: true
   has_many :hint_view_requests
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -222,7 +222,7 @@ class User < ApplicationRecord
 
   validates_inclusion_of :educator_role, in: Policies::User::ALLOWED_EDUCATOR_ROLES, if: :educator_role?
 
-  validate :educator_role_allowed_for_teacher
+  validate :educator_role_allowed_for_teacher, on: :create
 
   belongs_to :studio_person, optional: true
   has_many :hint_view_requests

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -222,6 +222,8 @@ class User < ApplicationRecord
 
   validates_inclusion_of :educator_role, in: Policies::User::ALLOWED_EDUCATOR_ROLES, if: :educator_role?
 
+  validate :educator_role_allowed_for_teacher
+
   belongs_to :studio_person, optional: true
   has_many :hint_view_requests
 
@@ -2770,6 +2772,14 @@ class User < ApplicationRecord
         errors.add(:us_state,  I18n.t('activerecord.errors.models.user.attributes.lockout_flow'))
       end
       errors.add(:age,  I18n.t('activerecord.errors.models.user.attributes.lockout_flow')) if birthday_changed?
+    end
+  end
+
+  private def educator_role_allowed_for_teacher
+    return if educator_role.blank?
+
+    unless teacher?
+      errors.add(:educator_role, "can only be assigned to teachers")
     end
   end
 

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -1,4 +1,11 @@
 class Policies::User
+  ALLOWED_EDUCATOR_TYPES = Set[
+    "teacher".freeze,
+    "school_admin".freeze,
+    "district_admin".freeze,
+    "librarian".freeze,
+  ].freeze
+
   # Returns the user.attributes along with the attributes of select
   # associations.
   def self.user_attributes(user)

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -1,5 +1,5 @@
 class Policies::User
-  ALLOWED_EDUCATOR_TYPES = Set[
+  ALLOWED_EDUCATOR_ROLES = Set[
     "teacher".freeze,
     "school_admin".freeze,
     "district_admin".freeze,

--- a/dashboard/lib/policies/user.rb
+++ b/dashboard/lib/policies/user.rb
@@ -1,10 +1,5 @@
 class Policies::User
-  ALLOWED_EDUCATOR_ROLES = Set[
-    "teacher".freeze,
-    "school_admin".freeze,
-    "district_admin".freeze,
-    "librarian".freeze,
-  ].freeze
+  ALLOWED_EDUCATOR_ROLES = SharedConstants::EDUCATOR_ROLES.pluck(:value)
 
   # Returns the user.attributes along with the attributes of select
   # associations.

--- a/dashboard/lib/services/partial_registration/user_builder.rb
+++ b/dashboard/lib/services/partial_registration/user_builder.rb
@@ -62,6 +62,7 @@ module Services
           :email,
           :hashed_email,
           :name,
+          :educator_role,
           :email_preference_opt_in_required,
           :email_preference_opt_in,
           :email_preference_request_ip,

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -126,6 +126,9 @@ FactoryBot.define do
         password {nil}
         after(:create) {|user| user.update(admin: true)}
       end
+      trait :with_educator_role do
+        educator_role {SharedConstants::EDUCATOR_ROLES.first[:value]}
+      end
       trait :with_school_info do
         school_info
       end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -816,6 +816,25 @@ class UserTest < ActiveSupport::TestCase
     refute_nil user.errors[:email]
   end
 
+  test "can create teacher user with a valid educator_role" do
+    user = create :teacher, :with_educator_role
+    assert user.valid?
+    assert_empty user.errors[:educator_role]
+  end
+
+  test "cannot create teacher user with an invalid educator_role" do
+    user = build(:teacher, educator_role: "fake_role")
+    refute user.save
+    assert_includes user.errors[:educator_role], "is not included in the list"
+  end
+
+  test "cannot create student user with an educator_role" do
+    user = assert_does_not_create(User) do
+      User.create(@good_data.merge({educator_role: SharedConstants::EDUCATOR_ROLES.first[:value]}))
+    end
+    refute_nil user.errors[:educator_role]
+  end
+
   test "LTI users with school_info_id should have a user_school_info entry" do
     lti_integration = create :lti_integration
     auth_id = "#{lti_integration[:issuer]}|#{lti_integration[:client_id]}|#{SecureRandom.alphanumeric}"

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -835,6 +835,12 @@ class UserTest < ActiveSupport::TestCase
     refute_nil user.errors[:educator_role]
   end
 
+  test "teachers with a valid educator_role can change user_type to student" do
+    user = create :teacher, :with_educator_role
+    user.set_user_type(User::TYPE_STUDENT)
+    assert user.valid?
+  end
+
   test "LTI users with school_info_id should have a user_school_info entry" do
     lti_integration = create :lti_integration
     auth_id = "#{lti_integration[:issuer]}|#{lti_integration[:client_id]}|#{SecureRandom.alphanumeric}"

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -808,4 +808,16 @@ module SharedConstants
     OWNER_TOO_NEW: 'owner_too_new',
     PROJECT_TOO_NEW: 'project_too_new',
   }
+
+  EDUCATOR_ROLES = [
+    {value: "classroom_teacher", label: "Classroom Teacher", category: 'Educator'},
+    {value: "stem_tech_teacher", label: "STEM/Technology Teacher", category: 'Educator'},
+    {value: "subject_area_teacher", label: "Subject Area Teacher", category: 'Educator'},
+    {value: "librarian_media_specialist", label: "Librarian/School Media Specialist", category: 'Educator'},
+    {value: "homeschool_teacher", label: "Homeschool Teacher", category: 'Educator'},
+    {value: "school_admin", label: "School Administrator", category: "Administrator"},
+    {value: "district_admin", label: "District Administrator", category: "Administrator"},
+    {value: "parent", label: "Parent", category: 'Other'},
+    {value: "other", label: "Other", category: 'Other'}
+  ].freeze
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This pr adds `educator_role` to the user model as a serialized attribute and validates that only teacher users can add it on creation of the user (`user_type` updates won't cause an error), and that it must be a valid `educator_role` defined in SharedConstants.

On the front end, a statsig a/b/c experiment is set up to run where 1/3 of users will not see an `educator_role` dropdown on signup, 1/3 will see it but it won't be required, and 1/3 will be required to select a role.

There were some console warnings when running the existing FinishTeacherAccount component tests, most of which just needed `waitFor` wrapping the render method. There was another error about nesting a div within a p, which is also fixed in this pr.

## Links

[jira](https://codedotorg.atlassian.net/browse/ACQ-2879)
[figma](https://www.figma.com/design/88sbry7xnl1wcyrOgbgFtn/Sign-Up-Flow?node-id=4783-8030&m=dev)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
