### PR TITLE
fix link on v1 dashboard

### DIFF
--- a/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
+++ b/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
@@ -32,6 +32,7 @@ class ProgressViewHeader extends Component {
       ? getUnitUrl(
           sectionId,
           scriptData.name,
+          null,
           `${scriptData.path}?section_id=${sectionId}`
         )
       : null;


### PR DESCRIPTION
It looks like [this](https://github.com/code-dot-org/code-dot-org/commit/76ae3967f0f1bd75fc01f5de638b0b7fec484629) PR broke this feature.  I just modified the function call to reflect the change from this old PR. 

## Links

[Ticket](https://codedotorg.atlassian.net/browse/TEACH-1566)

Checked that it worked on V1 and V2 dashboard locally. 


