### PR TITLE
Music: turn off lab2 background mode

### DIFF
--- a/apps/src/lab2/utils/LifecycleNotifier.tsx
+++ b/apps/src/lab2/utils/LifecycleNotifier.tsx
@@ -50,6 +50,7 @@ class LifecycleNotifier {
         this.listeners[event].splice(index, 1);
       }
     }
+    return this;
   }
 
   notify<T extends LifecycleEvent>(event: T, ...args: CallbackArgs[T]) {

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -107,8 +107,14 @@ export default class AnalyticsReporter {
   }
 
   private session: Session | undefined;
+  private startInProgress: boolean = false;
 
   async startSession() {
+    // If a session is already in the process of starting, do not start another.
+    if (this.startInProgress) {
+      return;
+    }
+    this.startInProgress = true;
     // Capture start time before making init call
     const startTime = Date.now();
 
@@ -143,6 +149,7 @@ export default class AnalyticsReporter {
     }
 
     trackEvent('music', 'music_session_start');
+    this.startInProgress = false;
   }
 
   isSessionInProgress() {

--- a/apps/src/music/entrypoint.ts
+++ b/apps/src/music/entrypoint.ts
@@ -2,7 +2,7 @@ import {OptionsToAvoid, Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
 import MusicView from '@cdo/apps/music/views/MusicView'; // avoid hardcoding imports like this in an entrypoint.tsx
 
 export const MusicEntryPoint: Lab2EntryPoint = {
-  backgroundMode: true,
+  backgroundMode: false,
   theme: Theme.DARK,
   view: OptionsToAvoid.UseHardcodedView_WARNING_Bloats_Lab2_Bundle,
   hardcodedView: MusicView,


### PR DESCRIPTION
This turns off backgroundMode for Music Lab, which is a Lab2 feature that keeps the lab view rendered in the background. Music Lab was the only lab using this, and it was originally because we wanted to ensure we only set up Blockly once per page load. Now however, Blockly setup and other one-time only setup like creating the sound cache has been moved into singleton/static code, so Music Lab no longer needs to remain rendered in the background. This did require a few minor changes to accommodate unmounting (e.g. deregistering lifecycle listeners). 

Since Music Lab was the only lab using background mode, I'd like to go ahead and get rid of the background mode feature in Lab2 after this. I think this will help with some of the lifecycle issues we've been facing, and is a prerequisite for any lifecycle related refactoring we may choose to do later (see: https://github.com/code-dot-org/code-dot-org/pull/62523)

## Testing story

Tested locally on HOC progression. Confirmed that Music Lab works correctly after being unmounted (ex. while transitioning to Panels level). Blockly only gets initialized once, and sounds remain cached. Lifecycle hooks only fire once and analytics sessions start/end correctly.