### PR TITLE
[Google Blockly] get block properties directly

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
@@ -107,9 +107,9 @@ export const procedureDefMutator = {
     const state = Object.create(null);
     state['description'] = getBlockDescription(this);
     state['procedureId'] = this.getProcedureModel().getId();
-    state['initialDeleteConfig'] = this.isDeletable();
-    state['initialEditConfig'] = this.isEditable();
-    state['initialMoveConfig'] = this.isMovable();
+    state['initialDeleteConfig'] = this.isOwnDeletable();
+    state['initialEditConfig'] = this.isOwnEditable();
+    state['initialMoveConfig'] = this.isOwnMovable();
     state['userCreated'] = this.userCreated;
     state['invisible'] = this.invisible;
 


### PR DESCRIPTION
After the first attempt at the Blockly v11 upgrade, a user reported an issue where function definition blocks were not movable as expected when dragged from the toolbox:
https://app.screencastify.com/v3/watch/TRh8yCNHviiOix2DupY8

In order to support our modal function editor, we perform some additional state management on function definition blocks (whether the modal editor is enabled or not). Specifically, we store each block's initial editable/movable/deletable state because the modal editor overrides these values. This makes it possible for the same project to be loaded in different levels which is especially important for remixing. 

The bug was occurring on v11 due a new override of `isMovable` being introduced for the `BlockSvg` (an extension of `Block`).  See https://github.com/google/blockly/pull/7971
[Block.isMovable](https://github.com/google/blockly/blob/0c20129a26ec111fc36a711e2a54553f4b726804/core/block.ts#L823-L830):
```
  isMovable(): boolean {
    return (
      this.movable_ &&
      !this.isShadow_ &&
      !this.isDeadOrDying() &&
      !this.workspace.options.readOnly
    );
  }
```
[BlockSvg.isMovable](https://github.com/google/blockly/blob/0c20129a26ec111fc36a711e2a54553f4b726804/core/block_svg.ts#L1690-L1692):
```
  override isMovable(): boolean {
    return this.dragStrategy.isMovable();
  }
```
With this change, blocks in a flyout are no longer consider "movable" even though they might have `movable: true` state. This is because when a flyout block is dragged, a movable copy is actually created. 
https://github.com/google/blockly/pull/7991/files#diff-a0d82110fb1a9c53ea94842f102f20e07cd6ce1c721a88cd64e6b5911087522d

We have been calling this method (as well as `isEditable` and `isDeletable` to get block's actual properties, which are private) to set the initial block state. What we actually care about is the block's movable property, which can still be accessed directly with `block.isOwnMovable()`. While doing this, it makes sense to use the similar methods for the block's editable and deletable state, even though the way we had it was still working as of v11. In fact, this is consistent with how core Blockly handles adding attributes to the state object based on the state of the block. https://github.com/google/blockly/pull/6847/files#diff-0fef52db90a84f97a5abda37b99d143e3486b6af9495561e47a50ab6aeb7e852

This change works with both v10 and v11 so it is safe to merge ahead of re-attempting the upgrade.

![2025-01-13 09-41-51 2025-01-13 09_43_04](https://github.com/user-attachments/assets/3e3e237e-4892-40db-a6ac-54b5c100eedf)


## Links

https://codeorg.zendesk.com/agent/tickets/522839


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
