### PR TITLE
Lazy load Music Lab

### DIFF
--- a/apps/src/music/entrypoint.ts
+++ b/apps/src/music/entrypoint.ts
@@ -1,9 +1,15 @@
-import {OptionsToAvoid, Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
-import MusicView from '@cdo/apps/music/views/MusicView'; // avoid hardcoding imports like this in an entrypoint.tsx
+import {lazy} from 'react';
+
+import {Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
 
 export const MusicEntryPoint: Lab2EntryPoint = {
   backgroundMode: false,
   theme: Theme.DARK,
-  view: OptionsToAvoid.UseHardcodedView_WARNING_Bloats_Lab2_Bundle,
-  hardcodedView: MusicView,
+  view: lazy(() =>
+    import(/* webpackChunkName: "music" */ './index.js').then(
+      ({MusicView}) => ({
+        default: MusicView,
+      })
+    )
+  ),
 };

--- a/apps/src/music/index.js
+++ b/apps/src/music/index.js
@@ -1,0 +1,3 @@
+// This file allows us to lazily load the MusicView component.
+// Due to our configuration this needs to be in js so we can use dynamic imports.
+export {default as MusicView} from './views/MusicView';


### PR DESCRIPTION
Lazy load Music Lab. With this, all lab2 labs now use lazy loading.

Before:
<img width="1145" alt="Screenshot 2025-01-13 at 8 57 16 AM" src="https://github.com/user-attachments/assets/f77fda88-24a5-44b6-91bc-eacee63b5947" />

After:
<img width="1148" alt="Screenshot 2025-01-13 at 8 58 21 AM" src="https://github.com/user-attachments/assets/4db1076f-4128-4893-a6f9-e8ad036c1b47" />


## Testing story

Tested locally on Music HOC progression and allthethings Lab2 showcase.