### PR TITLE
Add event on visiting student homepage

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -417,6 +417,9 @@ const EVENTS = {
   // Teacher Homepage
   TEACHER_HOMEPAGE_VISITED: 'Teacher Homepage Visited',
 
+  // Student Homepage
+  STUDENT_HOMEPAGE_VISITED: 'Student Homepage Visited',
+
   // Aichat
   UPDATE_CHATBOT: 'Student updates their aichat bot',
   AICHAT_VALIDATION: 'Student passes/fails validation on an aichat level',

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -40,6 +40,12 @@ export default class StudentHomepage extends Component {
   componentDidMount() {
     // The component used here is implemented in legacy HAML/CSS rather than React.
     $('#flashes').appendTo(ReactDOM.findDOMNode(this.refs.flashes)).show();
+
+    analyticsReporter.sendEvent(
+      EVENTS.STUDENT_HOMEPAGE_VISITED,
+      {},
+      PLATFORMS.BOTH
+    );
   }
 
   render() {


### PR DESCRIPTION
Console output:
```
[STATSIG ANALYTICS EVENT]: Student Homepage Visited. Payload: {"payload":{}}
[AMPLITUDE ANALYTICS EVENT]: Student Homepage Visited. Payload: {"payload":{}}
```

Jira ticket: https://codedotorg.atlassian.net/browse/ACQ-2956

