### PR TITLE
make evidence column support 4 byte emoji

### DIFF
--- a/dashboard/app/controllers/test_ai_proxy_controller.rb
+++ b/dashboard/app/controllers/test_ai_proxy_controller.rb
@@ -19,6 +19,7 @@ class TestAiProxyController < ApplicationController
         'Key Concept' => key_concept,
         'Label' => 'Convincing Evidence',
         'Observations' => 'This is a fake assessment for testing purposes 👍',
+        'Evidence' => 'Fake evidence for testing purposes 👍',
       }
     end
     render json: {data: response_data}

--- a/dashboard/db/migrate/20250113204313_evidence_to_utf8mb4_in_learning_goal_ai_evaluations.rb
+++ b/dashboard/db/migrate/20250113204313_evidence_to_utf8mb4_in_learning_goal_ai_evaluations.rb
@@ -1,0 +1,13 @@
+class EvidenceToUtf8mb4InLearningGoalAiEvaluations < ActiveRecord::Migration[6.1]
+  def up
+    # in order to increase from 3 to 4 bytes per character without increasing
+    # the column size, we need to ensure there are no rows with observations
+    # longer than 48K characters. Spot-checking reveals the longest existing
+    # entry is only 27K.
+    execute 'alter table learning_goal_ai_evaluations modify evidence text charset utf8mb4 collate utf8mb4_unicode_ci'
+  end
+
+  def down
+    execute 'alter table learning_goal_ai_evaluations modify evidence text charset utf8 collate utf8_unicode_ci'
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_16_152219) do
+ActiveRecord::Schema.define(version: 2025_01_13_204313) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -765,7 +765,7 @@ ActiveRecord::Schema.define(version: 2024_12_16_152219) do
     t.datetime "updated_at", precision: 6, null: false
     t.text "observations", collation: "utf8mb4_unicode_ci"
     t.integer "ai_confidence_exact_match"
-    t.text "evidence"
+    t.text "evidence", collation: "utf8mb4_unicode_ci"
     t.index ["learning_goal_id"], name: "index_learning_goal_ai_evaluations_on_learning_goal_id"
     t.index ["rubric_ai_evaluation_id"], name: "index_learning_goal_ai_evaluations_on_rubric_ai_evaluation_id"
   end


### PR DESCRIPTION
Finishes [AITT-895: Fix TA errors due to 4-byte emoji in evidence column](https://codedotorg.atlassian.net/browse/AITT-895)

* Similar solution to https://github.com/code-dot-org/code-dot-org/pull/62557, but for a different column.

## Testing story

UI test coverage is added in this PR
