### PR TITLE
added spinner to curriculum quick assign

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -8,6 +8,7 @@ import {
   CourseOfferingCurriculumTypes as curriculumTypes,
   ParticipantAudience,
 } from '@cdo/apps/generated/curriculum/sharedCourseConstants';
+import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import i18n from '@cdo/locale';
 
 import CurriculumQuickAssignTopRow from './CurriculumQuickAssignTopRow';
@@ -37,6 +38,7 @@ export default function CurriculumQuickAssign({
   const [decideLater, setDecideLater] = useState(false);
   const [marketingAudience, setMarketingAudience] = useState('');
   const [selectedCourseOffering, setSelectedCourseOffering] = useState();
+  const [isLoading, setIsLoading] = useState(true);
 
   const participantType = isNewSection
     ? queryParams('participantType')
@@ -180,7 +182,9 @@ export default function CurriculumQuickAssign({
         );
         determineSelectedCourseOffering(hocData, MARKETING_AUDIENCE.HOC);
         determineSelectedCourseOffering(plData, MARKETING_AUDIENCE.PL);
+        setIsLoading(false);
       }
+      isNewSection && setIsLoading(false);
     }
     // added all these dependencies given the eslint warning
   }, [
@@ -256,56 +260,65 @@ export default function CurriculumQuickAssign({
 
   return (
     <div className={moduleStyles.containerWithMarginTop}>
-      <div className={moduleStyles.input}>
-        <label
-          className={classnames(
-            moduleStyles.decideLater,
-            moduleStyles.typographyLabel
+      {isLoading && !isNewSection ? (
+        <>
+          <Heading3>{i18n.assignCurriculum()}</Heading3>
+          <Spinner />
+        </>
+      ) : (
+        <>
+          <div className={moduleStyles.input}>
+            <label
+              className={classnames(
+                moduleStyles.decideLater,
+                moduleStyles.typographyLabel
+              )}
+              htmlFor="decide-later"
+            >
+              {selectedCourseOffering
+                ? i18n.clearAssignedCurriculum()
+                : i18n.decideLater()}
+            </label>
+            <input
+              checked={decideLater}
+              className={classnames(
+                moduleStyles.inputBox,
+                moduleStyles.withBrandAccentColor
+              )}
+              type="checkbox"
+              id="decide-later"
+              onChange={toggleDecideLater}
+            />
+            <Heading3>{i18n.assignCurriculum()}</Heading3>
+            <BodyTwoText>{i18n.useDropdownMessage()}</BodyTwoText>
+          </div>
+          <CurriculumQuickAssignTopRow
+            showPlOfferings={showPlOfferings}
+            marketingAudience={marketingAudience}
+            updateMarketingAudience={setMarketingAudience}
+          />
+          {marketingAudience && filteredCourseOfferings && (
+            <SelectedQuickAssignTable
+              marketingAudience={marketingAudience}
+              courseOfferings={filteredCourseOfferings}
+              setSelectedCourseOffering={offering => {
+                setDecideLater(false);
+                setSelectedCourseOffering(offering);
+              }}
+              updateCourse={updateCourse}
+              sectionCourse={sectionCourse}
+              isNewSection={isNewSection}
+            />
           )}
-          htmlFor="decide-later"
-        >
-          {selectedCourseOffering
-            ? i18n.clearAssignedCurriculum()
-            : i18n.decideLater()}
-        </label>
-        <input
-          checked={decideLater}
-          className={classnames(
-            moduleStyles.inputBox,
-            moduleStyles.withBrandAccentColor
+          {marketingAudience && (
+            <VersionUnitDropdowns
+              courseOffering={selectedCourseOffering}
+              updateCourse={updateCourse}
+              sectionCourse={sectionCourse}
+              isNewSection={isNewSection}
+            />
           )}
-          type="checkbox"
-          id="decide-later"
-          onChange={toggleDecideLater}
-        />
-        <Heading3>{i18n.assignCurriculum()}</Heading3>
-        <BodyTwoText>{i18n.useDropdownMessage()}</BodyTwoText>
-      </div>
-      <CurriculumQuickAssignTopRow
-        showPlOfferings={showPlOfferings}
-        marketingAudience={marketingAudience}
-        updateMarketingAudience={setMarketingAudience}
-      />
-      {marketingAudience && filteredCourseOfferings && (
-        <SelectedQuickAssignTable
-          marketingAudience={marketingAudience}
-          courseOfferings={filteredCourseOfferings}
-          setSelectedCourseOffering={offering => {
-            setDecideLater(false);
-            setSelectedCourseOffering(offering);
-          }}
-          updateCourse={updateCourse}
-          sectionCourse={sectionCourse}
-          isNewSection={isNewSection}
-        />
-      )}
-      {marketingAudience && (
-        <VersionUnitDropdowns
-          courseOffering={selectedCourseOffering}
-          updateCourse={updateCourse}
-          sectionCourse={sectionCourse}
-          isNewSection={isNewSection}
-        />
+        </>
       )}
     </div>
   );

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -21,7 +21,7 @@ describe('CurriculumQuickAssign', () => {
 
     expect(wrapper.find(Spinner)).toHaveLength(1);
     expect(wrapper.find('h3').length).toBe(1);
-    expect(wrapper.find('Button').length).toBe(0);
+    expect(wrapper.find('Button')).toHaveLength(0);
   });
 
   it('renders headers and the top row of buttons', () => {

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -1,12 +1,75 @@
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
+import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import CurriculumQuickAssign from '@cdo/apps/templates/sectionsRefresh/CurriculumQuickAssign';
 import i18n from '@cdo/locale';
 
 window.fetch = jest.fn().mockResolvedValue({json: jest.fn()});
 
 describe('CurriculumQuickAssign', () => {
+  it('shows spinner when isLoading is true', () => {
+    // Mock `fetch` to avoid actual API calls
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue({}),
+    });
+
+    const wrapper = mount(
+      <CurriculumQuickAssign
+        updateSection={() => {}}
+        sectionCourse={{}}
+        initialParticipantType="teacher"
+        courseFilters={{}}
+        isNewSection={false}
+      />
+    );
+
+    // Wait for the initial state to simulate loading
+    wrapper.update();
+
+    // Verify spinner is rendered
+    expect(wrapper.find(Spinner)).toHaveLength(1);
+
+    // Verify heading text
+    expect(wrapper.find('h3').text()).toBe(i18n.assignCurriculum());
+
+    // Clean up mock
+    global.fetch.mockRestore();
+  });
+  it('shows course options when is new course', () => {
+    // Mock `fetch` to avoid actual API calls
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue({}),
+    });
+
+    const wrapper = mount(
+      <CurriculumQuickAssign
+        updateSection={() => {}}
+        sectionCourse={{}}
+        initialParticipantType="student"
+        courseFilters={{}}
+        isNewSection={true}
+      />
+    );
+
+    wrapper.update();
+
+    // Verify heading text
+    expect(wrapper.find('h3').text()).toBe(i18n.assignCurriculum());
+    expect(wrapper.find('p').length).toBe(1);
+    // We haven't specified participantType = student, so all 5 buttons appear
+    expect(wrapper.find('Button').length).toBe(5);
+    expect(wrapper.find('Button').at(0).props().text).toBe(
+      i18n.courseBlocksGradeBandsElementary()
+    );
+    expect(wrapper.find('Button[id="uitest-high-button"]').props().text).toBe(
+      i18n.courseBlocksGradeBandsHigh()
+    );
+    expect(wrapper.find('input').length).toBe(1);
+
+    // Clean up mock
+    global.fetch.mockRestore();
+  });
   it('renders headers and the top row of buttons', () => {
     const wrapper = mount(
       <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -9,70 +9,28 @@ window.fetch = jest.fn().mockResolvedValue({json: jest.fn()});
 
 describe('CurriculumQuickAssign', () => {
   it('shows spinner when isLoading is true', () => {
-    // Mock `fetch` to avoid actual API calls
-    global.fetch = jest.fn().mockResolvedValue({
-      json: jest.fn().mockResolvedValue({}),
-    });
-
-    const wrapper = mount(
-      <CurriculumQuickAssign
-        updateSection={() => {}}
-        sectionCourse={{}}
-        initialParticipantType="teacher"
-        courseFilters={{}}
-        isNewSection={false}
-      />
-    );
-
-    // Wait for the initial state to simulate loading
-    wrapper.update();
-
-    // Verify spinner is rendered
-    expect(wrapper.find(Spinner)).toHaveLength(1);
-
-    // Verify heading text
-    expect(wrapper.find('h3').text()).toBe(i18n.assignCurriculum());
-
-    // Clean up mock
-    global.fetch.mockRestore();
-  });
-  it('shows course options when is new course', () => {
-    // Mock `fetch` to avoid actual API calls
-    global.fetch = jest.fn().mockResolvedValue({
-      json: jest.fn().mockResolvedValue({}),
-    });
-
     const wrapper = mount(
       <CurriculumQuickAssign
         updateSection={() => {}}
         sectionCourse={{}}
         initialParticipantType="student"
         courseFilters={{}}
-        isNewSection={true}
+        isNewSection={false}
       />
     );
 
-    wrapper.update();
-
-    // Verify heading text
-    expect(wrapper.find('h3').text()).toBe(i18n.assignCurriculum());
-    expect(wrapper.find('p').length).toBe(1);
-    // We haven't specified participantType = student, so all 5 buttons appear
-    expect(wrapper.find('Button').length).toBe(5);
-    expect(wrapper.find('Button').at(0).props().text).toBe(
-      i18n.courseBlocksGradeBandsElementary()
-    );
-    expect(wrapper.find('Button[id="uitest-high-button"]').props().text).toBe(
-      i18n.courseBlocksGradeBandsHigh()
-    );
-    expect(wrapper.find('input').length).toBe(1);
-
-    // Clean up mock
-    global.fetch.mockRestore();
+    expect(wrapper.find(Spinner)).toHaveLength(1);
+    expect(wrapper.find('h3').length).toBe(1);
+    expect(wrapper.find('Button').length).toBe(0);
   });
+
   it('renders headers and the top row of buttons', () => {
     const wrapper = mount(
-      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+      <CurriculumQuickAssign
+        updateSection={() => {}}
+        sectionCourse={{}}
+        isNewSection={true}
+      />
     );
 
     expect(wrapper.find('h3').length).toBe(1);
@@ -90,7 +48,11 @@ describe('CurriculumQuickAssign', () => {
 
   it('updates caret direction when clicked', () => {
     const wrapper = mount(
-      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+      <CurriculumQuickAssign
+        updateSection={() => {}}
+        sectionCourse={{}}
+        isNewSection={true}
+      />
     );
 
     expect(wrapper.find('Button').at(0).props().icon).toBe('caret-right');
@@ -103,7 +65,11 @@ describe('CurriculumQuickAssign', () => {
 
   it('opens and closes version dropdowns with table open and collapse', () => {
     const wrapper = mount(
-      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+      <CurriculumQuickAssign
+        updateSection={() => {}}
+        sectionCourse={{}}
+        isNewSection={true}
+      />
     );
     expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(0);
     wrapper
@@ -120,7 +86,11 @@ describe('CurriculumQuickAssign', () => {
 
   it('leaves dropdowns alone when decide later clicked', () => {
     const wrapper = mount(
-      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+      <CurriculumQuickAssign
+        updateSection={() => {}}
+        sectionCourse={{}}
+        isNewSection={true}
+      />
     );
 
     // No dropdowns active at beginning


### PR DESCRIPTION
Adds spinner to the curriculum selection area.

Note: The new-section-setup feature works the same way as it did before.

The video below shows us looking at the edit section page for a section with curriculum assigned and then looking at a section with NO curriculum assigned.  Either way the user sees the spinner. 


https://github.com/user-attachments/assets/39dc9e75-7efc-4811-a1dc-e26269618c54



## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1517)

## Testing story

I added one test, and started to change the test to RTL, but it got pretty ugly.  See comments in PR.