### PR TITLE
Fix empty states not lined up

### DIFF
--- a/apps/src/templates/teacherDashboard/teacher-dashboard.module.scss
+++ b/apps/src/templates/teacherDashboard/teacher-dashboard.module.scss
@@ -74,6 +74,13 @@
   text-align: center;
 }
 
+.emptyClassroomImage {
+  height: 200px;
+  align-items: end;
+  display: flex;
+  justify-content: center;
+}
+
 .header {
   display: flex;
   justify-content: space-between;

--- a/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
+++ b/apps/src/templates/teacherNavigation/ElementOrEmptyPage.tsx
@@ -96,12 +96,12 @@ const ElementOrEmptyPage: React.FC<ElementOrEmptyPageProps> = ({
   } else {
     return (
       <div className={dashboardStyles.emptyClassroomDiv}>
-        <div className={dashboardStyles.emptyClassroomDiv}>
+        <div className={dashboardStyles.emptyClassroomImage}>
           {displayedImage()}
-          <Heading3 className={styles.topPadding}>{heading}</Heading3>
-          <BodyTwoText>{textDescription()}</BodyTwoText>
-          {link()}
         </div>
+        <Heading3 className={styles.topPadding}>{heading}</Heading3>
+        <BodyTwoText>{textDescription()}</BodyTwoText>
+        {link()}
       </div>
     );
   }

--- a/apps/src/templates/teacherNavigation/EmptyState.tsx
+++ b/apps/src/templates/teacherNavigation/EmptyState.tsx
@@ -19,12 +19,12 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
 }) => {
   return (
     <div className={dashboardStyles.emptyClassroomDiv}>
-      <div className={dashboardStyles.emptyClassroomDiv}>
+      <div className={dashboardStyles.emptyClassroomImage}>
         {imageComponent}
-        <Heading3 className={styles.topPadding}>{headline}</Heading3>
-        <BodyTwoText>{descriptionText}</BodyTwoText>
-        {button}
       </div>
+      <Heading3 className={styles.topPadding}>{headline}</Heading3>
+      <BodyTwoText>{descriptionText}</BodyTwoText>
+      {button}
     </div>
   );
 };

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -127,32 +127,34 @@ const UnitCalendar: React.FC = () => {
   }
 
   return (
-    <div className={styles.calendarContentContainer}>
+    <div>
       {!isLoading && <CalendarEmptyState />}
-      {!isLoading && hasCalendar && (
-        <div>
-          <div className={styles.minutesPerWeekWrapper}>
-            <div className={styles.minutesPerWeekDescription}>
-              {i18n.instructionalMinutesPerWeek()}
+      <div className={styles.calendarContentContainer}>
+        {!isLoading && hasCalendar && (
+          <div>
+            <div className={styles.minutesPerWeekWrapper}>
+              <div className={styles.minutesPerWeekDescription}>
+                {i18n.instructionalMinutesPerWeek()}
+              </div>
+              <SimpleDropdown
+                name="minutesPerWeek"
+                onChange={event => handleDropdownChange(event.target.value)}
+                items={weeklyMinutesOptions}
+                selectedValue={weeklyInstructionalMinutes}
+                size="s"
+                dropdownTextThickness="thin"
+                labelText="minutes per week dropdown"
+                isLabelVisible={false}
+              />
             </div>
-            <SimpleDropdown
-              name="minutesPerWeek"
-              onChange={event => handleDropdownChange(event.target.value)}
-              items={weeklyMinutesOptions}
-              selectedValue={weeklyInstructionalMinutes}
-              size="s"
-              dropdownTextThickness="thin"
-              labelText="minutes per week dropdown"
-              isLabelVisible={false}
+            <UnitCalendarGrid
+              lessons={calendarLessons}
+              weeklyInstructionalMinutes={parseInt(weeklyInstructionalMinutes)}
+              weekWidth={WEEK_WIDTH}
             />
           </div>
-          <UnitCalendarGrid
-            lessons={calendarLessons}
-            weeklyInstructionalMinutes={parseInt(weeklyInstructionalMinutes)}
-            weekWidth={WEEK_WIDTH}
-          />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION

Before: The images in empty states between no students and no curriculum did not line up correctly and would jump around.
![image](https://github.com/user-attachments/assets/7144ae37-f978-40cc-a1fe-c93ec0b75efe)

After:
Uploading Screen Recording 2025-01-14 at 8.14.08 AM.mov…



## Links
https://codedotorg.atlassian.net/browse/TEACH-1496
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested manually.
