### PR TITLE
Add environment var that turns off statsig local mode

### DIFF
--- a/apps/envConstants.js
+++ b/apps/envConstants.js
@@ -40,4 +40,6 @@ module.exports = {
   HOT: process.env.HOT === '1',
   // Include static assets when serving storybook locally
   STORYBOOK_STATIC_ASSETS: process.env.STORYBOOK_STATIC_ASSETS,
+  // set Statsig local_mode to false to send events to statsig during local development
+  STATSIG_LOCAL_MODE_OFF: process.env.STATSIG_LOCAL_MODE_OFF,
 };

--- a/apps/package.json
+++ b/apps/package.json
@@ -27,6 +27,7 @@
     "start:applab": "yarn grunt dev --app=applab",
     "start:gamelab": "yarn grunt dev --app=gamelab",
     "start:craft": "yarn grunt dev --app=craft",
+    "start:statsig": "STATSIG_LOCAL_MODE_OFF=1 yarn grunt dev",
     "storybook": "./script/start-storybook.sh",
     "storybook:deploy": "./script/deploy-storybook.sh"
   },

--- a/apps/src/metrics/StatsigReporter.js
+++ b/apps/src/metrics/StatsigReporter.js
@@ -50,7 +50,11 @@ class StatsigReporter {
     const managed_test_environment = managed_test_environment_element
       ? managed_test_environment_element.dataset.managedTestServer === 'true'
       : false;
-    this.local_mode = !(isProductionEnvironment() || managed_test_environment);
+    this.local_mode = !(
+      isProductionEnvironment() ||
+      managed_test_environment ||
+      process.env.STATSIG_LOCAL_MODE_OFF
+    );
     // stable_id is set as a cookie in application_controller.rb. However in a
     // the rare case we are running outside of the application layout,
     // set stable_id as a cookie here if it doesn't exist.

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -580,6 +580,9 @@ function createWebpackConfig({
         ),
         PISKEL_DEVELOPMENT_MODE: JSON.stringify(piskelDevMode),
         DEBUG_MINIFIED: envConstants.DEBUG_MINIFIED || 0,
+        'process.env.STATSIG_LOCAL_MODE_OFF': JSON.stringify(
+          envConstants.STATSIG_LOCAL_MODE_OFF ?? ''
+        ),
       }),
       ...(process.env.ANALYZE_BUNDLE
         ? [


### PR DESCRIPTION
There's a small DX improvement in this pr, where instead of modifying the StatsigReporter to manually turn off `local_mode` (which would send events to statsig in development to test the experiment), starting the app with `yarn start:statsig` sets an environment variable that turns off statsig `local_mode` automatically. If this is approved and merged I will update the documentation here: [Statsig AB Testing](https://docs.google.com/document/d/1iFJhJh5BcvaZei0ZFkjfvKFgbrJXurSN-2qx45CoXGA/edit?tab=t.0)
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

the video below shows the statsig events logging to the console at first, indicating `local_mode` is on during normal development (`yarn start`). I then restart the application using `yarn start:statsig`. I cut the chunk of video where the app was re-building. On each refresh, you can see the statsig event log is not shown in the console (except the stable id log, that happens regardless of `local_mode`), and I get put in a random experiment user group where sometimes the Educator Role dropdown is visible, sometimes it's missing, sometimes it's required, sometimes it's not.


https://github.com/user-attachments/assets/30648937-df64-4a85-a7f4-e3dfbec56026




## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
