### PR TITLE
LTI new signup

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -421,6 +421,7 @@ const EVENTS = {
   LTI_UNLINK_CLICK: 'lti_unlink_click',
   LTI_UNLINK_CANCEL: 'lti_unlink_cancel',
   LTI_DYNAMIC_REGISTRATION_COMPLETED: 'lti_dynamic_registration_completed',
+  LTI_NEW_ACCOUNT_CLICK: 'lti_new_account_click',
 
   // Teacher Homepage
   TEACHER_HOMEPAGE_VISITED: 'Teacher Homepage Visited',

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -132,11 +132,12 @@ const FinishTeacherAccount: React.FunctionComponent<{
     };
     fetchGdprData();
 
-    const userReturnToHref = sessionStorage.getItem(USER_RETURN_TO_SESSION_KEY) || redirectUrl;
+    const userReturnToHref =
+      sessionStorage.getItem(USER_RETURN_TO_SESSION_KEY) || redirectUrl;
     if (userReturnToHref) {
       setUserReturnTo(userReturnToHref);
     }
-  }, [countryCode, usIp]);
+  }, [countryCode, usIp, redirectUrl]);
 
   // GDPR is valid if
   // 1. The fetch call has completed AND

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -60,7 +60,8 @@ const roleItemGroups = [
 const FinishTeacherAccount: React.FunctionComponent<{
   usIp: boolean;
   countryCode: string;
-}> = ({usIp, countryCode}) => {
+  redirectUrl?: string;
+}> = ({usIp, countryCode, redirectUrl}) => {
   const schoolInfo = useSchoolInfo({usIp});
   const [name, setName] = useState('');
   const [nameErrorMessage, setNameErrorMessage] = useState(null);
@@ -131,7 +132,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
     };
     fetchGdprData();
 
-    const userReturnToHref = sessionStorage.getItem(USER_RETURN_TO_SESSION_KEY);
+    const userReturnToHref = sessionStorage.getItem(USER_RETURN_TO_SESSION_KEY) || redirectUrl;
     if (userReturnToHref) {
       setUserReturnTo(userReturnToHref);
     }

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiContinueAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiContinueAccountCard/index.tsx
@@ -20,7 +20,7 @@ import {LtiProviderContext} from '../../context';
 import styles from '../../../../../link-account.module.scss';
 
 const LtiContinueAccountCard = () => {
-  const {ltiProviderName, continueAccountUrl, userType} =
+  const {ltiProviderName, continueAccountUrl, userType, newAccountUrl} =
     useContext(LtiProviderContext)!;
   const [isSaving, setIsSaving] = useState(false);
 
@@ -40,7 +40,7 @@ const LtiContinueAccountCard = () => {
   const handleSubmit = async () => {
     setIsSaving(true);
 
-    fetch('/lti/v1/account_linking/new_account', {
+    fetch(newAccountUrl.href, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -1,9 +1,8 @@
 import classNames from 'classnames';
-import React, {useContext, useRef, useState} from 'react';
+import React, {useContext, useState} from 'react';
 
 import {Button, buttonColors} from '@cdo/apps/componentLibrary/button';
 import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';
-import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {
@@ -15,8 +14,11 @@ import {
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import {navigateToHref} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
-import {ACCOUNT_TYPE_SESSION_KEY, EMAIL_SESSION_KEY} from '../../../../../../signUpFlow/signUpFlowConstants';
 
+import {
+  ACCOUNT_TYPE_SESSION_KEY,
+  EMAIL_SESSION_KEY,
+} from '../../../../../../signUpFlow/signUpFlowConstants';
 import {LtiProviderContext} from '../../context';
 
 import styles from '../../../../../link-account.module.scss';

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -18,7 +18,7 @@ import i18n from '@cdo/locale';
 import {
   ACCOUNT_TYPE_SESSION_KEY,
   EMAIL_SESSION_KEY,
-} from '../../../../../../signUpFlow/signUpFlowConstants';
+} from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import {LtiProviderContext} from '../../context';
 
 import styles from '../../../../../link-account.module.scss';

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -24,8 +24,13 @@ import {LtiProviderContext} from '../../context';
 import styles from '../../../../../link-account.module.scss';
 
 const LtiNewAccountCard = () => {
-  const {ltiProviderName, newAccountUrl, emailAddress, userType} =
-    useContext(LtiProviderContext)!;
+  const {
+    ltiProviderName,
+    finishSignUpUrl,
+    emailAddress,
+    userType,
+    newAccountUrl,
+  } = useContext(LtiProviderContext)!;
 
   const [isSaving, setIsSaving] = useState(false);
 
@@ -47,14 +52,12 @@ const LtiNewAccountCard = () => {
 
     sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, userType);
     sessionStorage.setItem(EMAIL_SESSION_KEY, emailAddress);
-
-    navigateToHref(newAccountUrl);
+    navigateToHref(finishSignUpUrl);
   };
 
   const handleNewAccountSubmit = async () => {
     setIsSaving(true);
-
-    fetch('/lti/v1/account_linking/new_account', {
+    fetch(newAccountUrl.href, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -13,7 +13,9 @@ import {
   CardHeader,
 } from '@cdo/apps/sharedComponents/card';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
+import {navigateToHref} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
+import {ACCOUNT_TYPE_SESSION_KEY, EMAIL_SESSION_KEY} from '../../../../../../signUpFlow/signUpFlowConstants';
 
 import {LtiProviderContext} from '../../context';
 
@@ -22,7 +24,6 @@ import styles from '../../../../../link-account.module.scss';
 const LtiNewAccountCard = () => {
   const {ltiProviderName, newAccountUrl, emailAddress, userType} =
     useContext(LtiProviderContext)!;
-  const finishSignupFormRef = useRef<HTMLFormElement>(null);
 
   const [isSaving, setIsSaving] = useState(false);
 
@@ -37,12 +38,15 @@ const LtiNewAccountCard = () => {
       PLATFORMS.BOTH
     );
     analyticsReporter.sendEvent(
-      'lti_new_account_click',
+      EVENTS.LTI_NEW_ACCOUNT_CLICK,
       eventPayload,
       PLATFORMS.STATSIG
     );
 
-    finishSignupFormRef.current?.submit();
+    sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, userType);
+    sessionStorage.setItem(EMAIL_SESSION_KEY, emailAddress);
+
+    navigateToHref(newAccountUrl);
   };
 
   const handleNewAccountSubmit = async () => {
@@ -77,18 +81,6 @@ const LtiNewAccountCard = () => {
         {i18n.ltiLinkAccountNewAccountCardContent({
           providerName: ltiProviderName,
         })}
-
-        <form
-          // eslint-disable-next-line react/forbid-dom-props
-          data-testid={'new-account-form'}
-          action={newAccountUrl}
-          ref={finishSignupFormRef}
-          method="post"
-          className={styles.newAccountForm}
-        >
-          <RailsAuthenticityToken />
-          <input type="hidden" value={emailAddress} name={'user[email]'} />
-        </form>
       </CardContent>
       <CardActions>
         <Button

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/cards/LtiNewAccountCard/index.tsx
@@ -11,14 +11,14 @@ import {
   CardContent,
   CardHeader,
 } from '@cdo/apps/sharedComponents/card';
-import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
-import {navigateToHref} from '@cdo/apps/utils';
-import i18n from '@cdo/locale';
-
 import {
   ACCOUNT_TYPE_SESSION_KEY,
   EMAIL_SESSION_KEY,
 } from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
+import {navigateToHref} from '@cdo/apps/utils';
+import i18n from '@cdo/locale';
+
 import {LtiProviderContext} from '../../context';
 
 import styles from '../../../../../link-account.module.scss';

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/context.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/context.tsx
@@ -5,12 +5,13 @@ import {LtiProvider} from './types';
 export interface LtiProviderContextProps {
   ltiProvider: LtiProvider;
   ltiProviderName: string;
-  newAccountUrl: string;
+  newAccountUrl: URL;
   continueAccountUrl: string;
   existingAccountUrl: URL;
   emailAddress: string;
   newCtaType: 'continue' | 'new';
   userType: string;
+  finishSignUpUrl: string;
 }
 
 export const LtiProviderContext = createContext<

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/context.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/context.tsx
@@ -10,7 +10,7 @@ export interface LtiProviderContextProps {
   existingAccountUrl: URL;
   emailAddress: string;
   newCtaType: 'continue' | 'new';
-  userType?: string;
+  userType: string;
 }
 
 export const LtiProviderContext = createContext<

--- a/apps/src/sites/studio/pages/devise/registrations/finish_teacher_account.js
+++ b/apps/src/sites/studio/pages/devise/registrations/finish_teacher_account.js
@@ -10,7 +10,11 @@ $(document).ready(() => {
   const countryCode = getScriptData('countryCode');
   const redirectUrl = getScriptData('redirectUrl');
   ReactDOM.render(
-    <FinishTeacherAccount usIp={usIp} countryCode={countryCode} redirectUrl={redirectUrl} />,
+    <FinishTeacherAccount
+      usIp={usIp}
+      countryCode={countryCode}
+      redirectUrl={redirectUrl}
+    />,
     document.getElementById('finish-teacher-account-root')
   );
 });

--- a/apps/src/sites/studio/pages/devise/registrations/finish_teacher_account.js
+++ b/apps/src/sites/studio/pages/devise/registrations/finish_teacher_account.js
@@ -8,8 +8,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 $(document).ready(() => {
   const usIp = getScriptData('usIp');
   const countryCode = getScriptData('countryCode');
+  const redirectUrl = getScriptData('redirectUrl');
   ReactDOM.render(
-    <FinishTeacherAccount usIp={usIp} countryCode={countryCode} />,
+    <FinishTeacherAccount usIp={usIp} countryCode={countryCode} redirectUrl={redirectUrl} />,
     document.getElementById('finish-teacher-account-root')
   );
 });

--- a/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
+++ b/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
@@ -16,7 +16,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const scriptData = getScriptData('json');
   const ltiProvider = scriptData['lti_provider'];
   const ltiProviderName = scriptData['lti_provider_name'];
-  const finishSignUpUrl = new URL(scriptData['finish_sign_up_url']);
+  const finishSignUpUrl = scriptData['finish_sign_up_url'];
+  const newAccountUrl = new URL(scriptData['new_account_url']);
   const existingAccountUrl = new URL(scriptData['existing_account_url']);
   const emailAddress = scriptData['email'];
   const newCtaType = scriptData['new_cta_type'];
@@ -26,6 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const ltiProviderContext = {
     ltiProvider,
     ltiProviderName,
+    newAccountUrl,
     finishSignUpUrl,
     existingAccountUrl,
     emailAddress,

--- a/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
+++ b/apps/src/sites/studio/pages/lti/v1/account_linking/landing.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const scriptData = getScriptData('json');
   const ltiProvider = scriptData['lti_provider'];
   const ltiProviderName = scriptData['lti_provider_name'];
-  const newAccountUrl = scriptData['new_account_url'];
+  const finishSignUpUrl = new URL(scriptData['finish_sign_up_url']);
   const existingAccountUrl = new URL(scriptData['existing_account_url']);
   const emailAddress = scriptData['email'];
   const newCtaType = scriptData['new_cta_type'];
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const ltiProviderContext = {
     ltiProvider,
     ltiProviderName,
-    newAccountUrl,
+    finishSignUpUrl,
     existingAccountUrl,
     emailAddress,
     newCtaType,

--- a/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -1,4 +1,11 @@
-import {fireEvent, render, screen, within} from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import fetchMock from 'jest-fetch-mock';
 import React from 'react';
 
 import LtiLinkAccountPage from '@cdo/apps/simpleSignUp/lti/link/LtiLinkAccountPage';
@@ -12,8 +19,9 @@ import i18n from '@cdo/locale';
 const DEFAULT_CONTEXT: LtiProviderContextProps = {
   ltiProvider: 'canvas_cloud',
   ltiProviderName: 'Canvas',
-  newAccountUrl: '/new-account',
+  newAccountUrl: new URL('https://example.com/new-account'),
   existingAccountUrl: new URL('https://example.com/existing-account'),
+  finishSignUpUrl: '/finish',
   emailAddress: 'test@code.org',
   newCtaType: 'new',
   continueAccountUrl: '/continue',
@@ -24,6 +32,12 @@ jest.mock('@cdo/apps/utils', () => ({
   ...jest.requireActual('@cdo/apps/utils'),
   navigateToHref: jest.fn(),
 }));
+
+jest.mock('@cdo/apps/util/AuthenticityTokenStore', () => ({
+  getAuthenticityToken: jest.fn(),
+}));
+
+fetchMock.enableMocks();
 
 const navigateToHrefMock = navigateToHref as jest.Mock;
 
@@ -67,7 +81,7 @@ describe('LTI Link Account Page Tests', () => {
   });
 
   describe('LTI Link Account New Account Card Tests', () => {
-    it('should render a new account card', () => {
+    it('should render a new account card', async () => {
       render(
         <LtiProviderContext.Provider value={DEFAULT_CONTEXT}>
           <LtiLinkAccountPage />
@@ -86,15 +100,67 @@ describe('LTI Link Account Page Tests', () => {
       withinNewAccountCard.getByText(
         i18n.ltiLinkAccountNewAccountCardContent({providerName: 'Canvas'})
       );
-      const newAccountForm: HTMLFormElement =
-        // eslint-disable-next-line no-restricted-properties
-        screen.getByTestId('new-account-form');
-
-      const formValues = new FormData(newAccountForm);
-
-      expect(formValues.get('user[email]')).toEqual(
-        DEFAULT_CONTEXT.emailAddress
+      // Should have button to link new account
+      const newAccountButton = withinNewAccountCard.getByText(
+        i18n.ltiLinkAccountNewAccountCardActionLabel()
       );
+
+      fetchMock.mockIf(DEFAULT_CONTEXT.newAccountUrl.href, async () => {
+        return {
+          status: 200,
+        };
+      });
+
+      fireEvent.click(newAccountButton);
+
+      waitFor(() => {
+        expect(navigateToHrefMock).toHaveBeenCalledWith(
+          DEFAULT_CONTEXT.finishSignUpUrl
+        );
+      });
+    });
+  });
+
+  describe('LTI Link Account Continue Card Tests', () => {
+    it('should render a continue card', () => {
+      render(
+        <LtiProviderContext.Provider
+          value={{...DEFAULT_CONTEXT, newCtaType: 'continue'}}
+        >
+          <LtiLinkAccountPage />
+        </LtiProviderContext.Provider>
+      );
+
+      // eslint-disable-next-line no-restricted-properties
+      const continueAccountCard = screen.getByTestId('continue-account-card');
+      const withinContinueAccountCard = within(continueAccountCard);
+
+      // Should render header
+      withinContinueAccountCard.getByText(
+        i18n.ltiLinkAccountNewAccountCardHeaderLabel()
+      );
+      // Should render card content
+      withinContinueAccountCard.getByText(
+        i18n.ltiLinkAccountContinueAccountCardContent({providerName: 'Canvas'})
+      );
+      // Should have button to continue to existing account
+      const continueAccountButton = withinContinueAccountCard.getByText(
+        i18n.ltiIframeCallToAction()
+      );
+
+      fireEvent.click(continueAccountButton);
+
+      fetchMock.mockIf(DEFAULT_CONTEXT.newAccountUrl.href, async () => {
+        return {
+          status: 200,
+        };
+      });
+
+      waitFor(() => {
+        expect(navigateToHrefMock).toHaveBeenCalledWith(
+          DEFAULT_CONTEXT.continueAccountUrl
+        );
+      });
     });
   });
 

--- a/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
+++ b/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/LtiLinkAccountPageTest.tsx
@@ -17,6 +17,7 @@ const DEFAULT_CONTEXT: LtiProviderContextProps = {
   emailAddress: 'test@code.org',
   newCtaType: 'new',
   continueAccountUrl: '/continue',
+  userType: 'teacher',
 };
 
 jest.mock('@cdo/apps/utils', () => ({

--- a/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/WelcomeBanner/WelcomeBannerTest.tsx
+++ b/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/WelcomeBanner/WelcomeBannerTest.tsx
@@ -13,7 +13,8 @@ const getContext = (ltiProvider: LtiProvider): LtiProviderContextProps => {
   return {
     ltiProvider,
     ltiProviderName: 'LMS',
-    newAccountUrl: '/new-account',
+    newAccountUrl: new URL('https://test.com/new-account'),
+    finishSignUpUrl: '/finish',
     existingAccountUrl: new URL('https://test.com/existing-account'),
     emailAddress: 'test@code.org',
     newCtaType: 'new',

--- a/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/WelcomeBanner/WelcomeBannerTest.tsx
+++ b/apps/test/unit/simpleSignUp/lti/link/LtiLinkAccountPage/WelcomeBanner/WelcomeBannerTest.tsx
@@ -18,6 +18,7 @@ const getContext = (ltiProvider: LtiProvider): LtiProviderContextProps => {
     emailAddress: 'test@code.org',
     newCtaType: 'new',
     continueAccountUrl: '/continue',
+    userType: 'teacher',
   };
 };
 

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -111,6 +111,7 @@ class RegistrationsController < Devise::RegistrationsController
     @us_state_options = [{value: '', text: ''}] + User.us_state_dropdown_options.map do |code, name|
       {value: code, text: name}
     end
+    @redirect_url = session[:user_return_to] || home_path
 
     render 'finish_student_account'
   end
@@ -122,6 +123,8 @@ class RegistrationsController < Devise::RegistrationsController
     location = Geocoder.search(request.ip).try(:first)
     @country_code = location&.country_code.to_s.upcase
     @us_ip = ['US', 'RD'].include?(@country_code)
+    @redirect_url = session[:user_return_to] || home_path
+
     render 'finish_teacher_account'
   end
 

--- a/dashboard/app/views/devise/registrations/finish_student_account.haml
+++ b/dashboard/app/views/devise/registrations/finish_student_account.haml
@@ -1,5 +1,5 @@
 = render 'devise/registrations/new_sign_up_locale'
 
-%script{src: webpack_asset_path('js/devise/registrations/finish_student_account.js'), data: {ageOptions: @age_options.to_json, usIp: @us_ip.to_json, countryCode: @country_code.to_json, usStateOptions: @us_state_options.to_json}}
+%script{src: webpack_asset_path('js/devise/registrations/finish_student_account.js'), data: {ageOptions: @age_options.to_json, usIp: @us_ip.to_json, countryCode: @country_code.to_json, usStateOptions: @us_state_options.to_json, redirectUrl: @redirect_url.to_json}}
 
 #finish-student-account-root

--- a/dashboard/app/views/devise/registrations/finish_teacher_account.haml
+++ b/dashboard/app/views/devise/registrations/finish_teacher_account.haml
@@ -1,5 +1,5 @@
 = render 'devise/registrations/new_sign_up_locale'
 
-%script{src: webpack_asset_path('js/devise/registrations/finish_teacher_account.js'), data: {usIp: @us_ip.to_json, countryCode: @country_code.to_json}}
+%script{src: webpack_asset_path('js/devise/registrations/finish_teacher_account.js'), data: {usIp: @us_ip.to_json, countryCode: @country_code.to_json, redirectUrl: @redirect_url.to_json}}
 
 #finish-teacher-account-root

--- a/dashboard/app/views/lti/v1/account_linking/landing.haml
+++ b/dashboard/app/views/lti/v1/account_linking/landing.haml
@@ -14,10 +14,11 @@
     end
 
     email ||= params[:email]
-    new_account_url = user_type == User::TYPE_TEACHER ? users_new_sign_up_finish_teacher_account_path : users_new_sign_up_finish_student_account_path
+    finish_sign_up_url = user_type == User::TYPE_TEACHER ? users_new_sign_up_finish_teacher_account_path : users_new_sign_up_finish_student_account_path
     script_data[:lti_provider] = lti_provider
     script_data[:lti_provider_name] = Policies::Lti::LMS_PLATFORMS[lti_provider.to_sym][:name]
-    script_data[:new_account_url] = new_account_url
+    script_data[:finish_sign_up_url] = finish_sign_up_url
+    script_data[:new_account_url] = CDO.studio_url(lti_v1_account_linking_new_account_path, CDO.default_scheme)
     script_data[:existing_account_url] = CDO.studio_url(lti_v1_account_linking_finish_link_path, CDO.default_scheme)
     script_data[:continue_account_url] = session[:user_return_to] || home_path
     script_data[:email] = email

--- a/dashboard/app/views/lti/v1/account_linking/landing.haml
+++ b/dashboard/app/views/lti/v1/account_linking/landing.haml
@@ -14,7 +14,7 @@
     end
 
     email ||= params[:email]
-    new_account_url = users_finish_sign_up_path
+    new_account_url = user_type == User::TYPE_TEACHER ? users_new_sign_up_finish_teacher_account_path : users_new_sign_up_finish_student_account_path
     script_data[:lti_provider] = lti_provider
     script_data[:lti_provider_name] = Policies::Lti::LMS_PLATFORMS[lti_provider.to_sym][:name]
     script_data[:new_account_url] = new_account_url


### PR DESCRIPTION
Moves LTI signups to the new flow. Since we already know the user type and login type for LTI signups, we can skip those pages of the new flow. Instead of POSTing to the old finish signup page, LTI signups will now redirect to one of the new finish signup pages. Some session variables that are normally set on the first two pages of the new signup flow now also have to be set on the LTI landing page.

This also changes the `newAccountUrl` variable in `LtiNewAccountCard` to actually be the `new_account` route that we have to POST to when setting `lms_landing_opted_out` and caching the partial registration. It used to be that `newAccountUrl` was actually the finish signup page URL. This was confusing, so I added a new separate variable for the `finishSignUpURL`, since we now have separate paths for students and teachers.

Student demo video:

https://github.com/user-attachments/assets/535ea067-6286-4b74-be20-dbc541a314c7

Teacher demo video:

https://github.com/user-attachments/assets/577c5830-1fa4-485b-988f-f7807aa86cd1



## Links

[JIRA](https://codedotorg.atlassian.net/browse/P20-1352)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

To test:

- Launch as a new LTI user. Click the new account option and you should be brought to the new finish signup page.
- The continue and link existing account cards should still work as before. Only the `LtiNewAccountCard` had significant changes here.

Added a test for the LtiContinueAccountCard. This was missing before and we were only testing the LtiNewAccountCard.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
