### PR TITLE
[Blockly] Relax required block equivalence check

### DIFF
--- a/apps/src/required_block_utils.js
+++ b/apps/src/required_block_utils.js
@@ -226,6 +226,7 @@ var ignoredAttributes = [
   'uservisible',
   'usercreated',
   'id',
+  'inline',
 ];
 
 /**
@@ -270,7 +271,11 @@ function childrenEquivalent(expected, given, ignoreChildBlocks) {
   var filterFn = function (node) {
     // CDO Blockly returns tag names in all caps
     var tagName = node.tagName && node.tagName.toLowerCase();
-    return ignoreChildBlocks && tagName !== 'next' && tagName !== 'statement';
+    return (
+      // Google Blockly sometimes adds a mutation where CDO Blockly would not.
+      tagName === 'mutation' ||
+      (ignoreChildBlocks && tagName !== 'next' && tagName !== 'statement')
+    );
   };
   var children1 = Array.prototype.filter.call(expected.childNodes, filterFn);
   var children2 = Array.prototype.filter.call(given.childNodes, filterFn);

--- a/apps/src/required_block_utils.js
+++ b/apps/src/required_block_utils.js
@@ -268,17 +268,18 @@ function attributesEquivalent(expected, given) {
  * Checks whether the children of two different elements are equivalent
  */
 function childrenEquivalent(expected, given, ignoreChildBlocks) {
-  var filterFn = function (node) {
+  const filterFn = function (node) {
     // CDO Blockly returns tag names in all caps
-    var tagName = node.tagName && node.tagName.toLowerCase();
-    return (
-      // Google Blockly sometimes adds a mutation where CDO Blockly would not.
-      tagName === 'mutation' ||
-      (ignoreChildBlocks && tagName !== 'next' && tagName !== 'statement')
-    );
+    const tagName = node.tagName && node.tagName.toLowerCase();
+    // Google Blockly sometimes adds a mutation where CDO Blockly would not.
+    const isMutation = tagName === 'mutation';
+    const isIgnorableChild =
+      ignoreChildBlocks && (tagName === 'next' || tagName === 'statement');
+
+    return !isMutation && !isIgnorableChild;
   };
-  var children1 = Array.prototype.filter.call(expected.childNodes, filterFn);
-  var children2 = Array.prototype.filter.call(given.childNodes, filterFn);
+  const children1 = Array.prototype.filter.call(expected.childNodes, filterFn);
+  const children2 = Array.prototype.filter.call(given.childNodes, filterFn);
 
   if (expected.getAttribute('inputcount') === '???') {
     // If required block ignores inputcount, allow arbitrary children


### PR DESCRIPTION
I happened across an issue in an Artist level where we would provide incorrect feedback about required blocks.
At `s/course4/lessons/10/levels/6`, you can see that using a perfect solution still provides a hint about stronger code:

<img width="630" alt="image" src="https://github.com/user-attachments/assets/e9206434-3bf6-4abf-af22-683ccaddb4ea" />

<img width="678" alt="image" src="https://github.com/user-attachments/assets/cc3c7da6-6cb6-466c-95f0-d61114ff6c83" />

This utility works by comparing the xml of all of the student's blocks against a set of required blocks. The comparison that _shouldn't_ prove problematic relates to this expected and given block:

<table><tr><td>Expected</td><td>Given</td></tr>
<tr><td>

```
<block type="controls_for_counter" inline="true">
	<value name="FROM">
		<block type="math_number">
			<title name="NUM">15</title>
		</block>
	</value>
	<value name="TO">
		<block type="math_number">
			<title name="NUM">300</title>
		</block>
	</value>
	<value name="BY">
		<block type="math_number">
			<title name="NUM">15</title>
		</block>
	</value>
</block>
```

</td>
<td>

```
<block type="controls_for_counter" id="3.e5wHy[[,#N@HBHexJk">
	<mutation counter="counter"></mutation>
	<value name="FROM">
		<block type="math_number" id="_;djn`}u,[u#@l^Q@_qo">
			<field name="NUM">15</field>
		</block>
	</value>
	<value name="TO">
		<block type="math_number" id=")1d_v)b7zl(nkhB|w/y,">
			<field name="NUM">300</field>
		</block>
	</value>
	<value name="BY">
		<block type="math_number" id="WE9CR/}qN:7?9sq.Jsin">
			<field name="NUM">15</field>
		</block>
	</value>
	<statement name="DO">
		...ignored child block code...
	</statement>
</block>
```

</td></tr></table>

There are obviously several differences between this snippets. Some of which were already accounted for and some were not.

1. Google Blockly has extra serialized block ids. This is already handled by the list of `ignoredAttributes` (which includes `'id'`).
2. `<title/>` vs `<field/>` for fields. This is already handled: https://github.com/code-dot-org/code-dot-org/blob/89cce6834575dfa71afde3591ec0d296c73d7ce5/apps/src/required_block_utils.js#L192-L195
3. Additional blocks connected to the statement input of the given block. This is already handled. If `ignoreChildBlocks` is true, we ignore the `<statement/>` child entirely.
4. The expected block includes `inline="true"`. This is not handled, but can be using the same technique for ids described in 1.
5. The given block includes an extra `<mutation/>` that is only present with Google Blockly. This is not handled, but can be using the same helper that filters child blocks, described in 3.

Ignoring the inline attribute should be safe because this can never be toggled by the user. If the blocks are otherwise equivalent, this attribute does not indicate a problem. In this case, the loop block does have inline inputs, but that's omitted from the serialization because it's the default.

For the mutation, I opted to always filter them out even if `ignoreChildBlocks` is false. This is because the mutation isn't related to child blocks and would be there either way.  For readability, I introduced a couple of constants which required flipping some of the logic around.

By relaxing the required block check, the solution for this puzzle now passes as expected:

<img width="677" alt="image" src="https://github.com/user-attachments/assets/9519e7c4-af69-415e-9394-f6da8dc6a495" />


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
