### PR TITLE
Add Minimum Time to `Cdo::Throttle` Expiration

### DIFF
--- a/lib/cdo/throttle.rb
+++ b/lib/cdo/throttle.rb
@@ -4,6 +4,7 @@ require 'dynamic_config/dcdo'
 module Cdo
   module Throttle
     CACHE_PREFIX = "cdo_throttle/".freeze
+    MINIMUM_EXPIRATION = 1.day
 
     # @param [String] id - Unique identifier to throttle on.
     # @param [Integer] limit - Number of requests allowed over period.
@@ -12,7 +13,7 @@ module Cdo
     # Defaults to Cdo::Throttle.throttle_time.
     # @returns [Boolean] Whether or not the request should be throttled.
     def self.throttle(id, limit, period, throttle_for = throttle_time)
-      full_key = CACHE_PREFIX + id.to_s
+      full_key = cache_key(id)
       value = CDO.shared_cache.read(full_key) || empty_value
       now = Time.now.utc
       value[:request_timestamps] << now
@@ -27,11 +28,8 @@ module Cdo
         value[:throttled_until] = now + throttle_for if should_throttle
       end
 
-      # The maximum time (in seconds) for which any information contained in
-      # this entry could possibly be relevant.
-      max_data_relevancy = throttle_for + period
-
-      CDO.shared_cache.write(full_key, value, expires_in: max_data_relevancy)
+      expires_in = expiration_time(period, throttle_for)
+      CDO.shared_cache.write(full_key, value, expires_in: expires_in)
       should_throttle
     end
 
@@ -44,6 +42,23 @@ module Cdo
 
     def self.throttle_time
       DCDO.get('throttle_time_default', 60)
+    end
+
+    def self.cache_key(id)
+      return CACHE_PREFIX + id.to_s
+    end
+
+    def self.expiration_time(period, throttle_for)
+      # The maximum time (in seconds) for which any information contained in
+      # this entry could possibly be relevant.
+      max_data_relevancy = period + throttle_for
+
+      # We saw singificantly increased CPU usage on the cluster after
+      # implementing expiration, and theorize that it may be because we were
+      # expiring entries TOO quickly. Speculatively add a minimum expiration to
+      # see if it smoothes things out.
+      # TODO infra: verify this fix and update either comment or code as necessary
+      return [max_data_relevancy, MINIMUM_EXPIRATION].max
     end
   end
 end

--- a/lib/test/cdo/test_throttle.rb
+++ b/lib/test/cdo/test_throttle.rb
@@ -3,57 +3,78 @@ require 'cdo/throttle'
 require 'timecop'
 
 class ThrottleTest < Minitest::Test
+  def setup
+    Timecop.freeze
+    @start_time = Time.now.utc
+    @throttle_id = 'my_key'
+    @cache_key = Cdo::Throttle.cache_key(@throttle_id)
+  end
+
   def teardown
+    Timecop.return
     CDO.shared_cache.delete_matched(Cdo::Throttle::CACHE_PREFIX)
   end
 
   def test_throttle_with_limit_1
-    Timecop.freeze
-    refute Cdo::Throttle.throttle("my_key", 1, 2) # 1/1 reqs per 2s - not throttled
+    refute Cdo::Throttle.throttle(@throttle_id, 1, 2) # 1/1 reqs per 2s - not throttled
     Timecop.travel(Time.now.utc + 1)
-    assert Cdo::Throttle.throttle("my_key", 1, 2) # 2/1 reqs per 2s - throttled
+    assert Cdo::Throttle.throttle(@throttle_id, 1, 2) # 2/1 reqs per 2s - throttled
     Timecop.travel(Time.now.utc + Cdo::Throttle.throttle_time - 1)
-    assert Cdo::Throttle.throttle("my_key", 1, 2) # still throttled
+    assert Cdo::Throttle.throttle(@throttle_id, 1, 2) # still throttled
     Timecop.travel(Time.now.utc + Cdo::Throttle.throttle_time)
-    refute Cdo::Throttle.throttle("my_key", 1, 2) # 1/1 reqs per 2s after waiting - not throttled anymore
+    refute Cdo::Throttle.throttle(@throttle_id, 1, 2) # 1/1 reqs per 2s after waiting - not throttled anymore
     Timecop.travel(Time.now.utc + 1)
-    assert Cdo::Throttle.throttle("my_key", 1, 2) # 2/1 reqs per 2s - throttled again
+    assert Cdo::Throttle.throttle(@throttle_id, 1, 2) # 2/1 reqs per 2s - throttled again
   end
 
   def test_throttle_with_limit_greater_than_1
-    Timecop.freeze
-    refute Cdo::Throttle.throttle("my_key", 2, 2) # 1/2 reqs per 2s - not throttled
+    refute Cdo::Throttle.throttle(@throttle_id, 2, 2) # 1/2 reqs per 2s - not throttled
     Timecop.travel(Time.now.utc + 1)
-    refute Cdo::Throttle.throttle("my_key", 2, 2) # 2/2 reqs per 2s - not throttled
+    refute Cdo::Throttle.throttle(@throttle_id, 2, 2) # 2/2 reqs per 2s - not throttled
     Timecop.travel(Time.now.utc + 0.5)
-    assert Cdo::Throttle.throttle("my_key", 2, 2) # 3/2 reqs per 2s - throttled
+    assert Cdo::Throttle.throttle(@throttle_id, 2, 2) # 3/2 reqs per 2s - throttled
     Timecop.travel(Time.now.utc + Cdo::Throttle.throttle_time)
-    refute Cdo::Throttle.throttle("my_key", 2, 2) # 1/2 reqs per 2s after waiting - not throttled anymore
+    refute Cdo::Throttle.throttle(@throttle_id, 2, 2) # 1/2 reqs per 2s after waiting - not throttled anymore
     Timecop.travel(Time.now.utc + 1)
-    refute Cdo::Throttle.throttle("my_key", 2, 2) # 2/2 reqs per 2s - not throttled
+    refute Cdo::Throttle.throttle(@throttle_id, 2, 2) # 2/2 reqs per 2s - not throttled
     Timecop.travel(Time.now.utc + 0.5)
-    assert Cdo::Throttle.throttle("my_key", 2, 2) # 3/2 reqs per 2s - throttled again
+    assert Cdo::Throttle.throttle(@throttle_id, 2, 2) # 3/2 reqs per 2s - throttled again
   end
 
   def test_throttle_expiration
-    Timecop.freeze
-    start = Time.now.utc
-    throttle_id = 'my_key'
-    period = 2
-    throttle_time = 3
-    cache_id = Cdo::Throttle::CACHE_PREFIX + throttle_id
+    period = 2.days
+    throttle_time = 3.days
 
-    Cdo::Throttle.throttle(throttle_id, 1, period, throttle_time)
-    assert CDO.shared_cache.read(cache_id)
+    Cdo::Throttle.throttle(@throttle_id, 1, period, throttle_time)
+    assert CDO.shared_cache.read(@cache_key)
 
     # Throttle data will be preserved for a little while,
-    Timecop.travel(start + 1)
-    assert CDO.shared_cache.read(cache_id)
-    Timecop.travel(start + period + throttle_time - 1)
-    assert CDO.shared_cache.read(cache_id)
+    Timecop.travel(@start_time + 1)
+    assert CDO.shared_cache.read(@cache_key)
+    Timecop.travel(@start_time + period + throttle_time - 1)
+    assert CDO.shared_cache.read(@cache_key)
 
     # but will expire eventually.
-    Timecop.travel(start + period + throttle_time)
-    refute CDO.shared_cache.read(cache_id)
+    Timecop.travel(@start_time + period + throttle_time)
+    refute CDO.shared_cache.read(@cache_key)
+  end
+
+  def test_throttle_minimum_expiration
+    period = 2.hours
+    throttle_time = 3.hours
+
+    Cdo::Throttle.throttle(@throttle_id, 1, period, throttle_time)
+    assert CDO.shared_cache.read(@cache_key)
+
+    # Throttle data will be preserved for a minimum period of time, even if
+    # it's longer than strictly necessary,
+    Timecop.travel(@start_time + period + throttle_time)
+    assert CDO.shared_cache.read(@cache_key)
+    Timecop.travel(@start_time + period + throttle_time + 1)
+    assert CDO.shared_cache.read(@cache_key)
+
+    # but will still expire eventually.
+    Timecop.travel(@start_time + Cdo::Throttle::MINIMUM_EXPIRATION)
+    refute CDO.shared_cache.read(@cache_key)
   end
 end


### PR DESCRIPTION
After deploying https://github.com/code-dot-org/code-dot-org/pull/63218, we saw unexpected increased CPU usage on the Memcached cluster which backs our Throttle module.

We note that by setting such quick expirations (20-60 seconds), we are now repeatedly expiring and recreating entries which formerly were getting repeatedly updated. We speculate this could be causing the change, although I have not been able to find explicit documentation on the relative performance implications of those two patterns.

This PR represents a speculative fix; by setting a minimum expiration time (arbitrarily set at one day for the sake of this experiment), we hope to reduce wasted work while also avoiding unbounded storage.

Also tried to DRY up both the implementation and the unit test a bit, while I was in the area.

## Links

See https://codedotorg.slack.com/archives/C0T0PNTM3/p1736759210871679 and https://github.com/code-dot-org/code-dot-org/pull/63280 for more

## Testing story

Added a new unit test to validate correctness of the new implementation. I plan to validate whether or not this actually solves the problem we want to solve by monitoring metrics in production :upside_down_face:

## Follow-up work

If this does indeed resolve the CPU usage, we should figure out what minimum we actually want and update the relevant comments accordingly.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
