### PR TITLE
allow PII detection via AWS comprehend

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -202,6 +202,11 @@ Resources:
             Action:
               - 'comprehend:DetectToxicContent'
             Resource: '*'
+          # PII detection for stanford data share
+          - Effect: Allow
+            Action:
+              - 'comprehend:DetectPiiEntities'
+            Resource: '*'
           # TODO: Move to dedicated policy for AI TA
           # AI TA Bedrock access
           - Effect: Allow


### PR DESCRIPTION
for background, see:
* https://codedotorg.slack.com/archives/C03DBDN67B7/p1736893721869759
* https://github.com/code-dot-org/code-dot-org/pull/60986

## Testing story

not tested. this api will be used by a script that will run directly on production-daemon via manual runs. my plan is to test the comprehend commands manually on that machine after this change reaches production.