### PR TITLE
Make #infra-test slack output less overwhelming/confusing

### DIFF
--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -448,9 +448,13 @@ def report_tests_finished(start_time, run_results)
   + (status_page_url ? " <a href=\"#{status_page_url}\">#{test_type} test status page</a>." : '') \
   + (applitools_batch_url ? " <a href=\"#{applitools_batch_url}\">Applitools results</a>." : '')
 
-  unless failures.empty?
-    status_page_link = status_page_url ? "(<a href=\"#{status_page_url}\">STATUS PAGE</a>)" : ''
-    ChatClient.log "*FAILED DASHBOARD #{test_type.upcase} TESTS #{status_page_link}:*", color: 'purple'
+  a_status_page = status_page_url ? "<a href=\"#{status_page_url}\">" : ''
+  end_a = status_page_url ? "</a>" : ''
+
+  if failures.empty?
+    ChatClient.log "*#{a_status_page}SUMMARY, #{suite_success_count} DASHBOARD #{test_type.upcase} TESTS PASSED#{end_a}*", color: 'purple'
+  else
+    ChatClient.log "*#{a_status_page}SUMMARY, #{failures.count} DASHBOARD #{test_type.upcase} TESTS FAILED#{end_a}:*", color: 'purple'
     failures.each do |failure|
       ChatClient.log "\t• #{failure}", color: 'purple'
     end

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -449,13 +449,11 @@ def report_tests_finished(start_time, run_results)
   + (applitools_batch_url ? " <a href=\"#{applitools_batch_url}\">Applitools results</a>." : '')
 
   unless failures.empty?
-    message = "Failed tests:"
-    message += "<ul>"
+    status_page_link = status_page_url ? "(<a href=\"#{status_page_url}\">STATUS PAGE</a>)" : ''
+    ChatClient.log "*FAILED DASHBOARD #{test_type.upcase} TESTS #{status_page_link}:*", color: 'purple'
     failures.each do |failure|
-      message += "\t<li>#{failure}</li>\n"
+      ChatClient.log "\t• #{failure}", color: 'purple'
     end
-    message += "</ul>"
-    ChatClient.log "Failed tests: \n #{failures.map {|s| "\t• #{s}"}.join("\n")}"
   end
 end
 
@@ -858,7 +856,7 @@ def run_feature(browser, feature, options)
     message = "*FAILED: #{test_run_string}* #{log_link}"
     message += "\n(#{RakeUtils.format_duration(test_duration)}#{scenario_info}#{rerun_info}#{eyes_info})"
     message += "\nrerun: `bundle exec ./runner.rb --html#{' --eyes' if eyes?} -c #{browser_name} -f #{feature}`"
-    ChatClient.log message, color: 'purple'
+    ChatClient.log message, color: 'red'
   end
   result_string =
     if scenario_count == 0

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -854,10 +854,10 @@ def run_feature(browser, feature, options)
   else
     ChatClient.log output_synopsis(output_stdout, log_prefix), {wrap_with_tag: 'pre'} if options.output_synopsis
     ChatClient.log prefix_string(output_stderr, log_prefix), {wrap_with_tag: 'pre'}
-    message = "#{log_prefix}<b>dashboard</b> UI tests failed with <b>#{test_run_string}</b> (#{RakeUtils.format_duration(test_duration)}#{scenario_info}#{rerun_info}#{eyes_info})"
-    message += "#{log_link}, first selenium error: <i>#{first_selenium_error(html_log)}</i>" if options.html
-    message += "<br/>rerun:<br/>bundle exec ./runner.rb --html#{' --eyes' if eyes?} -c #{browser_name} -f #{feature}"
-    ChatClient.log message, color: 'red'
+    message = "*FAILED: #{test_run_string}* #{log_link}"
+    message += "\n(#{RakeUtils.format_duration(test_duration)}#{scenario_info}#{rerun_info}#{eyes_info})"
+    message += "\nrerun: `bundle exec ./runner.rb --html#{' --eyes' if eyes?} -c #{browser_name} -f #{feature}`"
+    ChatClient.log message, color: 'purple'
   end
   result_string =
     if scenario_count == 0

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -786,10 +786,11 @@ def run_feature(browser, feature, options)
   # only retry cucumber/selenium errors, not eyes mismatches.
   while !cucumber_succeeded && (reruns < max_reruns)
     reruns += 1
+    retry_again_msg = reruns < max_reruns ? " once, will retry" : ", not going to retry"
 
     ChatClient.log output_synopsis(output_stdout, log_prefix), {wrap_with_tag: 'pre'} if options.output_synopsis
     # Since output_stderr is empty, we do not log it to ChatClient.
-    message = "#{test_run_string} failed once, retrying (#{reruns}/#{max_reruns}, flakiness: #{to_percent(flakiness_for_test(test_run_string), 3) || '?'})"
+    message = "#{test_run_string} failed#{retry_again_msg} (retry #{reruns} of #{max_reruns}, flakiness: #{to_percent(flakiness_for_test(test_run_string), 3) || '?'})"
     message += "#{log_link}, first selenium error: <i>#{first_selenium_error(html_log)}</i>" if options.html
     ChatClient.log message
     $lock.synchronize do

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -775,10 +775,11 @@ def run_feature(browser, feature, options)
   while !cucumber_succeeded && (reruns < max_reruns)
     reruns += 1
 
-    ChatClient.log "#{test_run_string} first selenium error: #{first_selenium_error(html_log)}" if options.html
     ChatClient.log output_synopsis(output_stdout, log_prefix), {wrap_with_tag: 'pre'} if options.output_synopsis
     # Since output_stderr is empty, we do not log it to ChatClient.
-    ChatClient.log "<b>dashboard</b> UI tests failed with <b>#{test_run_string}</b> (#{RakeUtils.format_duration(test_duration)})#{log_link}, retrying (#{reruns}/#{max_reruns}, flakiness: #{flakiness_for_test(test_run_string) || '?'})..."
+    message = "#{test_run_string} failed once, retrying (#{reruns}/#{max_reruns}, flakiness: #{flakiness_for_test(test_run_string) || '?'})"
+    message += "<br/>first selenium error: #{first_selenium_error(html_log)}" if options.html
+    ChatClient.log message
     $lock.synchronize do
       log_error prefix_string(Time.now, log_prefix)
       log_error prefix_string(browser.to_yaml, log_prefix)
@@ -839,10 +840,10 @@ def run_feature(browser, feature, options)
     # Don't log individual successes because we hit ChatClient rate limits
     # ChatClient.log "<b>dashboard</b> UI tests passed with <b>#{test_run_string}</b> (#{RakeUtils.format_duration(test_duration)}#{scenario_info})"
   else
-    ChatClient.log "#{test_run_string} first selenium error: #{first_selenium_error(html_log)}" if options.html
     ChatClient.log output_synopsis(output_stdout, log_prefix), {wrap_with_tag: 'pre'} if options.output_synopsis
     ChatClient.log prefix_string(output_stderr, log_prefix), {wrap_with_tag: 'pre'}
     message = "#{log_prefix}<b>dashboard</b> UI tests failed with <b>#{test_run_string}</b> (#{RakeUtils.format_duration(test_duration)}#{scenario_info}#{rerun_info}#{eyes_info})#{log_link}"
+    message += "<br/>first selenium error: #{first_selenium_error(html_log)}" if options.html
     message += "<br/>rerun:<br/>bundle exec ./runner.rb --html#{' --eyes' if eyes?} -c #{browser_name} -f #{feature}"
     ChatClient.log message, color: 'red'
   end

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -449,7 +449,13 @@ def report_tests_finished(start_time, run_results)
   + (applitools_batch_url ? " <a href=\"#{applitools_batch_url}\">Applitools results</a>." : '')
 
   unless failures.empty?
-    ChatClient.log "Failed tests: \n #{failures.join("\n")}"
+    message = "Failed tests:"
+    message += "<ul>"
+    failures.each do |failure|
+      message += "\t<li>#{failure}</li>\n"
+    end
+    message += "</ul>"
+    ChatClient.log "Failed tests: \n #{failures.map {|s| "\t• #{s}"}.join("\n")}"
   end
 end
 
@@ -711,6 +717,12 @@ def cucumber_arguments_for_feature(options, test_run_string, max_reruns)
   arguments
 end
 
+def to_percent(number, n_sig_digits)
+  percent = number * 100.0
+  return 0 if percent.zero?
+  "#{percent.round(-(Math.log10(percent).ceil - n_sig_digits))}%"
+end
+
 def run_feature(browser, feature, options)
   browser_name = browser_name_or_unknown(browser)
   test_run_string = test_run_identifier(browser, feature)
@@ -777,8 +789,8 @@ def run_feature(browser, feature, options)
 
     ChatClient.log output_synopsis(output_stdout, log_prefix), {wrap_with_tag: 'pre'} if options.output_synopsis
     # Since output_stderr is empty, we do not log it to ChatClient.
-    message = "#{test_run_string} failed once, retrying (#{reruns}/#{max_reruns}, flakiness: #{flakiness_for_test(test_run_string) || '?'})"
-    message += "<br/>first selenium error: #{first_selenium_error(html_log)}" if options.html
+    message = "#{test_run_string} failed once, retrying (#{reruns}/#{max_reruns}, flakiness: #{to_percent(flakiness_for_test(test_run_string), 3) || '?'})"
+    message += "#{log_link}, first selenium error: <i>#{first_selenium_error(html_log)}</i>" if options.html
     ChatClient.log message
     $lock.synchronize do
       log_error prefix_string(Time.now, log_prefix)
@@ -842,8 +854,8 @@ def run_feature(browser, feature, options)
   else
     ChatClient.log output_synopsis(output_stdout, log_prefix), {wrap_with_tag: 'pre'} if options.output_synopsis
     ChatClient.log prefix_string(output_stderr, log_prefix), {wrap_with_tag: 'pre'}
-    message = "#{log_prefix}<b>dashboard</b> UI tests failed with <b>#{test_run_string}</b> (#{RakeUtils.format_duration(test_duration)}#{scenario_info}#{rerun_info}#{eyes_info})#{log_link}"
-    message += "<br/>first selenium error: #{first_selenium_error(html_log)}" if options.html
+    message = "#{log_prefix}<b>dashboard</b> UI tests failed with <b>#{test_run_string}</b> (#{RakeUtils.format_duration(test_duration)}#{scenario_info}#{rerun_info}#{eyes_info})"
+    message += "#{log_link}, first selenium error: <i>#{first_selenium_error(html_log)}</i>" if options.html
     message += "<br/>rerun:<br/>bundle exec ./runner.rb --html#{' --eyes' if eyes?} -c #{browser_name} -f #{feature}"
     ChatClient.log message, color: 'red'
   end

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -859,7 +859,6 @@ def run_feature(browser, feature, options)
     ChatClient.log prefix_string(output_stderr, log_prefix), {wrap_with_tag: 'pre'}
     message = "*FAILED: #{test_run_string}* #{log_link}"
     message += "\n(#{RakeUtils.format_duration(test_duration)}#{scenario_info}#{rerun_info}#{eyes_info})"
-    message += "\nrerun: `bundle exec ./runner.rb --html#{' --eyes' if eyes?} -c #{browser_name} -f #{feature}`"
     ChatClient.log message, color: 'red'
   end
   result_string =


### PR DESCRIPTION
Minor redesign of the #infra-test slack output to more clearly indicate important information to the DOTD, reduce repeated info, clarify language (e.g. if a test will be retried or not), easier to copy-paste retry commands, visually groups related information reduce overuse of bold on things that shouldn't be visually prominent. Result should reduce errors over the long term, be easier for new engineers, and be easier for those of us who still get lost in the existing page trying to find what's an error and what isn't.

IMO the before and after shots don't do it justice, because what's really missing is a ZILLION now much visually quieter "will retry not a suite failure" test "failures".

# After:

<img width="725" alt="image" src="https://github.com/user-attachments/assets/c158de59-b1ea-46e6-936f-1155b1c1be06" />

# Before:

![before](https://github.com/user-attachments/assets/ef35ac03-cded-4382-97d3-6ca9e104275c)

# Some of the new "Features":

![image](https://github.com/user-attachments/assets/735837d5-cec6-40da-acfb-ef9b7503bcd2)

Also
- more compact
- less repetitive
- collapse "first selenium error" into same slack message so its not confusingly "first", and groups results together better
- wayyyyy less bold, bold used to call eye of DOTD to most common used elements
- encourage use of links vs getting lost in the slack