### PR TITLE
Add Level Sign In Callout Shown event 

### DIFF
--- a/apps/src/code-studio/components/header/SignInCallout.jsx
+++ b/apps/src/code-studio/components/header/SignInCallout.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import i18n from '@cdo/locale';
 
 const CALLOUT_COLOR = '#454545';
@@ -10,8 +12,8 @@ const CALLOUT_Z_INDEX = 1040;
 const CALLOUT_TOP = 30;
 
 /*
- * This is a callout attached to the sign-in button that's used on CSF level
- * pages to remind the user to sign-in.  Note that the sign-in button is
+ * This is a callout attached to the sign-in button that's used on CSF and CSC
+ * levels pages to remind the user to sign-in.  Note that the sign-in button is
  * defined in shared/haml/user_header.haml and is not a React component.
  * This component is injected into the page by src/code-studio/header.js.
  */
@@ -24,6 +26,10 @@ export default class SignInCallout extends React.Component {
     super(props);
 
     this.renderContent = this.renderContent.bind(this);
+  }
+
+  componentDidMount() {
+    analyticsReporter.sendEvent(EVENTS.LEVEL_SIGN_IN_CALLOUT_SHOWN);
   }
 
   renderContent() {

--- a/apps/src/code-studio/components/header/SignInCalloutWrapper.jsx
+++ b/apps/src/code-studio/components/header/SignInCalloutWrapper.jsx
@@ -43,6 +43,7 @@ export default class SignInCalloutWrapper extends React.Component {
     this.setState({hideCallout: true});
     cookies.set(HideSignInCallout, 'true', {expires: 1, path: '/'});
     sessionStorage.setItem(HideSignInCallout, 'true');
+    // Needed to prevent sending the user to the sign up page when dismissing the callout
     event.preventDefault();
     // Needed to prevent triggering the Create Account Button Clicked analytics event firing
     event.stopPropagation();

--- a/apps/src/code-studio/components/header/SignInCalloutWrapper.jsx
+++ b/apps/src/code-studio/components/header/SignInCalloutWrapper.jsx
@@ -44,6 +44,8 @@ export default class SignInCalloutWrapper extends React.Component {
     cookies.set(HideSignInCallout, 'true', {expires: 1, path: '/'});
     sessionStorage.setItem(HideSignInCallout, 'true');
     event.preventDefault();
+    // Needed to prevent triggering the Create Account Button Clicked analytics event firing
+    event.stopPropagation();
     this.signInElement &&
       this.signInElement.classList.remove('z_index_above_modal');
   }

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -511,6 +511,9 @@ const EVENTS = {
     'Global Edition Region Switch Confirm Accepted',
   GLOBAL_EDITION_REGION_SWITCH_CONFIRM_REJECTED:
     'Global Edition Region Switch Confirm Rejected',
+
+  // Sign in callout on CSF and CSC levels
+  LEVEL_SIGN_IN_CALLOUT_SHOWN: 'Level Sign In Callout Shown',
 };
 
 const EVENT_GROUP_NAMES = {


### PR DESCRIPTION
Also prevent the "Create Account Button Clicked" event from firing when dismissing the callout.

Console output:
```
[STATSIG ANALYTICS EVENT]: Level Sign In Callout Shown. Payload: {}
[AMPLITUDE ANALYTICS EVENT]: Level Sign In Callout Shown. Payload: {}
```

I checked the following cases:
- The "Create Account Button Clicked" event still happens if the Create Account button is clicked, but not if the callout is dismissed
- The callout is not shown again if it's dismissed and the event, correspondingly, also does not fire after the callout is dismissed

