### PR TITLE
[Music] Fix start over for advanced projects

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -455,7 +455,12 @@ class UnconnectedMusicView extends React.Component {
   };
 
   getStartSources = () => {
-    if (!this.props.levelProperties?.levelData?.startSources) {
+    const startSources = this.props.levelProperties?.levelData?.startSources;
+    const currentBlockMode = this.props.blockMode;
+    const levelBlockMode = this.props.levelProperties?.levelData?.blockMode;
+    if (!startSources || currentBlockMode !== levelBlockMode) {
+      // Use the default start sources if the level doesn't have any,
+      // or if the block mode doesn't match.
       const startSourcesFilename = 'startSources' + this.props.blockMode;
       return require(`@cdo/static/music/${startSourcesFilename}.json`);
     } else {


### PR DESCRIPTION
@amy-b reported an issue with remixed advanced mode projects:
> I'm trying to make a project using the Advanced Model. I tried to [remix an existing level,](https://levelbuilder-studio.code.org/projects/music/MtAblLPl4-FH90fHicvbUA) but it seems the timeline isn't populating.

https://codedotorg.slack.com/archives/C04TH8400AU/p1736364444720219

This was initially hard to diagnose as remixing from an advanced mode level into the singular project level _is_ supported and working. However, we realized things would break once you tried to use the start over button.

The problem is straight-forward enough. When starting over, we would clear the workspace and reload

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
