### PR TITLE
Send summer workshop emails to both user's email and alternate email if available

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -77,6 +77,13 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
         Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now
         Pd::WorkshopMailer.organizer_enrollment_receipt(enrollment).deliver_now
 
+        # Also send to the teacher's alternate summer email if they entered it in their application and
+        # it's for a summer workshop.
+        alt_summer_email = user&.alternate_email
+        if alt_summer_email.present? && @workshop.subject == SUBJECT_SUMMER_WORKSHOP
+          Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment, alt_summer_email).deliver_now
+        end
+
         render json: {
           workshop_enrollment_status: RESPONSE_MESSAGES[:SUCCESS],
           account_exists: user.present?,
@@ -112,6 +119,13 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
     enrollment.destroy!
     Pd::WorkshopMailer.teacher_cancel_receipt(enrollment).deliver_now
     Pd::WorkshopMailer.organizer_cancel_receipt(enrollment).deliver_now
+
+    # Also send to the user's alternate summer email if they entered it in their application
+    # and it's for a summer workshop.
+    alt_summer_email = enrollment.user&.alternate_email
+    if alt_summer_email.present? && enrollment.workshop&.subject == SUBJECT_SUMMER_WORKSHOP
+      Pd::WorkshopMailer.teacher_cancel_receipt(enrollment, alt_summer_email).deliver_now
+    end
   end
 
   # POST /api/v1/pd/enrollments/move

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -79,9 +79,11 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
 
         # Also send to the teacher's alternate summer email if they entered it in their application and
         # it's for a summer workshop.
-        alt_summer_email = user&.alternate_email
-        if alt_summer_email.present? && @workshop.subject == SUBJECT_SUMMER_WORKSHOP
-          Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment, alt_summer_email).deliver_now
+        if @workshop.subject == SUBJECT_SUMMER_WORKSHOP
+          alt_summer_email = user&.alternate_email
+          if alt_summer_email.present?
+            Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment, alt_summer_email).deliver_now
+          end
         end
 
         render json: {
@@ -122,9 +124,11 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
 
     # Also send to the user's alternate summer email if they entered it in their application
     # and it's for a summer workshop.
-    alt_summer_email = enrollment.user&.alternate_email
-    if alt_summer_email.present? && enrollment.workshop&.subject == SUBJECT_SUMMER_WORKSHOP
-      Pd::WorkshopMailer.teacher_cancel_receipt(enrollment, alt_summer_email).deliver_now
+    if enrollment.workshop&.subject == SUBJECT_SUMMER_WORKSHOP
+      alt_summer_email = enrollment.user&.alternate_email
+      if alt_summer_email.present?
+        Pd::WorkshopMailer.teacher_cancel_receipt(enrollment, alt_summer_email).deliver_now
+      end
     end
   end
 

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -289,6 +289,14 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
   private def notify
     @workshop.enrollments.each do |enrollment|
       Pd::WorkshopMailer.detail_change_notification(enrollment).deliver_now
+
+      # Also send to the user's alternate summer email if they entered it in their application and it's
+      # for a summer workshop.
+      alt_summer_email = enrollment.user&.alternate_email
+
+      if alt_summer_email.present? && enrollment.workshop&.subject == Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
+        Pd::WorkshopMailer.detail_change_notification(enrollment, to_email: alt_summer_email).deliver_now
+      end
     end
     @workshop.facilitators.each do |facilitator|
       Pd::WorkshopMailer.facilitator_detail_change_notification(facilitator, @workshop).deliver_now

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -292,10 +292,11 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
 
       # Also send to the user's alternate summer email if they entered it in their application and it's
       # for a summer workshop.
-      alt_summer_email = enrollment.user&.alternate_email
-
-      if alt_summer_email.present? && enrollment.workshop&.subject == Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
-        Pd::WorkshopMailer.detail_change_notification(enrollment, to_email: alt_summer_email).deliver_now
+      if enrollment.workshop&.subject == Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
+        alt_summer_email = enrollment.user&.alternate_email
+        if alt_summer_email.present?
+          Pd::WorkshopMailer.detail_change_notification(enrollment, to_email: alt_summer_email).deliver_now
+        end
       end
     end
     @workshop.facilitators.each do |facilitator|

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -35,7 +35,7 @@ class Pd::WorkshopMailer < ApplicationMailer
 
   after_action :save_timestamp
 
-  def teacher_enrollment_receipt(enrollment)
+  def teacher_enrollment_receipt(enrollment, to_email = '')
     @enrollment = enrollment
     @workshop = enrollment.workshop
     @cancel_url = url_for controller: 'pd/workshop_enrollment', action: :cancel, code: enrollment.code
@@ -55,7 +55,7 @@ class Pd::WorkshopMailer < ApplicationMailer
     mail content_type: 'text/html',
       from: from,
       subject: teacher_enrollment_subject(@workshop),
-      to: email_address(@enrollment.full_name, @enrollment.email),
+      to: email_address(@enrollment.full_name, to_email.presence || @enrollment.email),
       reply_to: reply_to
   end
 
@@ -69,14 +69,14 @@ class Pd::WorkshopMailer < ApplicationMailer
       to: email_address(@workshop.organizer.name, @workshop.organizer.email)
   end
 
-  def teacher_cancel_receipt(enrollment)
+  def teacher_cancel_receipt(enrollment, to_email = '')
     @enrollment = enrollment
     @workshop = enrollment.workshop
 
     mail content_type: 'text/html',
       from: from_teacher,
       subject: 'Code.org workshop cancellation',
-      to: email_address(@enrollment.full_name, @enrollment.email),
+      to: email_address(@enrollment.full_name, to_email.presence || @enrollment.email),
       reply_to: email_address(@workshop.organizer.name, @workshop.organizer.email)
   end
 
@@ -100,7 +100,7 @@ class Pd::WorkshopMailer < ApplicationMailer
       to: email_address(@workshop.organizer.name, @workshop.organizer.email)
   end
 
-  def teacher_enrollment_reminder(enrollment, options = nil)
+  def teacher_enrollment_reminder(enrollment, options = nil, to_email = '')
     @enrollment = enrollment
     @workshop = enrollment.workshop
     @organizer = @workshop.organizer
@@ -124,11 +124,11 @@ class Pd::WorkshopMailer < ApplicationMailer
     mail content_type: 'text/html',
       from: from,
       subject: teacher_enrollment_subject(@workshop),
-      to: email_address(@enrollment.full_name, @enrollment.email),
+      to: email_address(@enrollment.full_name, to_email.presence || @enrollment.email),
       reply_to: reply_to
   end
 
-  def teacher_pre_workshop_csa(enrollment)
+  def teacher_pre_workshop_csa(enrollment, to_email = '')
     @enrollment = enrollment
     @workshop = enrollment.workshop
     @cancel_url = url_for controller: 'pd/workshop_enrollment', action: :cancel, code: enrollment.code
@@ -136,7 +136,7 @@ class Pd::WorkshopMailer < ApplicationMailer
     mail content_type: 'text/html',
       from: from_teacher,
       subject: 'Preparing for your Computer Science A summer workshop',
-      to: email_address(@enrollment.full_name, @enrollment.email),
+      to: email_address(@enrollment.full_name, to_email.presence || @enrollment.email),
       reply_to: email_address(@workshop.organizer.name, @workshop.organizer.email)
   end
 
@@ -199,7 +199,7 @@ class Pd::WorkshopMailer < ApplicationMailer
          reply_to: email_address(@workshop.organizer.name, @workshop.organizer.email)
   end
 
-  def detail_change_notification(enrollment)
+  def detail_change_notification(enrollment, to_email = '')
     @enrollment = enrollment
     @workshop = enrollment.workshop
     @cancel_url = url_for controller: 'pd/workshop_enrollment', action: :cancel, code: enrollment.code
@@ -207,7 +207,7 @@ class Pd::WorkshopMailer < ApplicationMailer
     mail content_type: 'text/html',
       from: from_teacher,
       subject: detail_change_notification_subject(@workshop),
-      to: email_address(@enrollment.full_name, @enrollment.email),
+      to: email_address(@enrollment.full_name, to_email.presence || @enrollment.email),
       reply_to: email_address(@workshop.organizer.name, @workshop.organizer.email)
   end
 
@@ -248,7 +248,7 @@ class Pd::WorkshopMailer < ApplicationMailer
 
   # Exit survey email
   # @param enrollment [Pd::Enrollment]
-  def exit_survey(enrollment)
+  def exit_survey(enrollment, to_email = '')
     @workshop = enrollment.workshop
     workshop_title = @workshop.name.presence || @workshop.course
     @teacher = enrollment.user
@@ -264,7 +264,7 @@ class Pd::WorkshopMailer < ApplicationMailer
     mail content_type: content_type,
       from: from_survey,
       subject: "Help us improve Code.org #{workshop_title} workshops!",
-      to: email_address(@enrollment.full_name, @enrollment.email)
+      to: email_address(@enrollment.full_name, to_email.presence || @enrollment.email)
   end
 
   def teacher_follow_up(enrollment)

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -216,9 +216,11 @@ class Pd::Enrollment < ApplicationRecord
 
     # Also send to the user's alternate summer email if they entered it in their application and
     # it's for a summer workshop.
-    alt_summer_email = user&.alternate_email
-    if alt_summer_email.present? && workshop.subject == SUBJECT_SUMMER_WORKSHOP
-      Pd::WorkshopMailer.exit_survey(self, alt_summer_email).deliver_now
+    if workshop.subject == SUBJECT_SUMMER_WORKSHOP
+      alt_summer_email = user&.alternate_email
+      if alt_summer_email.present?
+        Pd::WorkshopMailer.exit_survey(self, alt_summer_email).deliver_now
+      end
     end
 
     update!(survey_sent_at: Time.zone.now)

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -213,6 +213,14 @@ class Pd::Enrollment < ApplicationRecord
     return unless (mailer = Pd::WorkshopMailer.exit_survey(self))
 
     mailer.deliver_now
+
+    # Also send to the user's alternate summer email if they entered it in their application and
+    # it's for a summer workshop.
+    alt_summer_email = user&.alternate_email
+    if alt_summer_email.present? && workshop.subject == SUBJECT_SUMMER_WORKSHOP
+      Pd::WorkshopMailer.exit_survey(self, alt_summer_email).deliver_now
+    end
+
     update!(survey_sent_at: Time.zone.now)
   end
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -469,9 +469,11 @@ class Pd::Workshop < ApplicationRecord
         email.deliver_now
 
         # Also send to the user's alternate summer email if they entered it in their application and it's for a summer workshop.
-        alt_summer_email = enrollment.user&.alternate_email
-        if alt_summer_email.present? && enrollment.workshop&.subject == SUBJECT_SUMMER_WORKSHOP
-          Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, options: {days_before: days}, to_email: alt_summer_email).deliver_now
+        if enrollment.workshop&.subject == SUBJECT_SUMMER_WORKSHOP
+          alt_summer_email = enrollment.user&.alternate_email
+          if alt_summer_email.present?
+            Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, options: {days_before: days}, to_email: alt_summer_email).deliver_now
+          end
         end
       rescue => exception
         errors << "teacher enrollment #{enrollment.id} - #{exception.message}"

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -467,6 +467,12 @@ class Pd::Workshop < ApplicationRecord
       workshop.enrollments.each do |enrollment|
         email = Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, options: {days_before: days})
         email.deliver_now
+
+        # Also send to the user's alternate summer email if they entered it in their application and it's for a summer workshop.
+        alt_summer_email = enrollment.user&.alternate_email
+        if alt_summer_email.present? && enrollment.workshop&.subject == SUBJECT_SUMMER_WORKSHOP
+          Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, options: {days_before: days}, to_email: alt_summer_email).deliver_now
+        end
       rescue => exception
         errors << "teacher enrollment #{enrollment.id} - #{exception.message}"
       end
@@ -544,6 +550,12 @@ class Pd::Workshop < ApplicationRecord
     scheduled_start_in_days(20).select {|ws| ws.course == COURSE_CSA && ws.subject == Pd::Workshop::SUBJECT_CSA_SUMMER_WORKSHOP}.each do |workshop|
       workshop.enrollments.each do |enrollment|
         Pd::WorkshopMailer.teacher_pre_workshop_csa(enrollment).deliver_now
+
+        # Also send to the user's alternate summer email if they entered it in their application.
+        alt_summer_email = enrollment.user&.alternate_email
+        if alt_summer_email.present?
+          Pd::WorkshopMailer.teacher_pre_workshop_csa(enrollment, to_email: alt_summer_email).deliver_now
+        end
       rescue => exception
         errors << "teacher enrollment #{enrollment.id} - #{exception.message}"
       end

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -237,6 +237,21 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
     end
   end
 
+  test 'sends cancel enrollment email to both the users email and alternate summer email if available and for a summer workshop' do
+    Pd::WorkshopMailer.expects(:teacher_cancel_receipt).returns(stub(:deliver_now)).times(2)
+    Pd::WorkshopMailer.expects(:organizer_cancel_receipt).returns(stub(:deliver_now))
+
+    @teacher = create :teacher
+    workshop = create :summer_workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD
+    application = create :pd_teacher_application, course: 'csd', application_year: workshop.school_year, user: @teacher, status: 'accepted'
+    enrollment = create :pd_enrollment, application_id: application.id, user: @teacher, workshop: workshop
+
+    assert_destroys Pd::Enrollment do
+      delete :cancel, params: {enrollment_code: enrollment.code}
+      assert_response :success
+    end
+  end
+
   test 'enrollments can be created' do
     @teacher = create :teacher
     assert_creates(Pd::Enrollment) do
@@ -283,6 +298,38 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
     assert_response :success
     assert_equal RESPONSE_MESSAGES[:SUCCESS], JSON.parse(@response.body)["workshop_enrollment_status"]
     refute_nil Pd::Enrollment.find_by(pd_workshop_id: workshop.id)
+  end
+
+  test 'sends enrollment receipt email to both the users email and alternate summer email if available and for a summer workshop' do
+    Pd::WorkshopMailer.expects(:teacher_enrollment_receipt).returns(stub(:deliver_now)).times(2)
+
+    @teacher = create :teacher
+    sign_in @teacher
+    workshop = create :summer_workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD
+    create :pd_teacher_application, course: 'csd', application_year: workshop.school_year, user: @teacher, status: 'accepted'
+
+    post :create, params: {
+      user_id: @teacher.id,
+      workshop_id: workshop.id,
+      first_name: "Janine",
+      last_name: "Teagues",
+      email: "janine@test.xx",
+      school_info: {school_id: School.first.id},
+      role: "Counselor",
+      grades_teaching: ["Kindergarten", "Grade 1", "Grade 2"],
+      attended_csf_intro_workshop: "No",
+      csf_course_experience: {'Course A': "none", 'Course B': "a few lessons", 'Course E': "most lessons"},
+      csf_courses_planned: ["Course E", "Course F"],
+      csf_intro_intent: "No",
+      years_teaching: "30",
+      years_teaching_cs: "10",
+      previous_courses: "I don’t have experience teaching any of these courses",
+      csf_intro_other_factors: "I want to learn computer science concepts.",
+      taught_ap_before: "Yes, AP CS Principles or AP CS A",
+      planning_to_teach_ap: "Yes"
+    }
+
+    assert_response :success
   end
 
   test 'creating a duplicate enrollment sends \'duplicate\' workshop enrollment status' do

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -238,13 +238,14 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
   end
 
   test 'sends cancel enrollment email to both the users email and alternate summer email if available and for a summer workshop' do
-    Pd::WorkshopMailer.expects(:teacher_cancel_receipt).returns(stub(:deliver_now)).times(2)
-    Pd::WorkshopMailer.expects(:organizer_cancel_receipt).returns(stub(:deliver_now))
-
     @teacher = create :teacher
     workshop = create :summer_workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD
     application = create :pd_teacher_application, course: 'csd', application_year: workshop.school_year, user: @teacher, status: 'accepted'
     enrollment = create :pd_enrollment, application_id: application.id, user: @teacher, workshop: workshop
+
+    Pd::WorkshopMailer.expects(:teacher_cancel_receipt).with(enrollment).returns(stub(:deliver_now))
+    Pd::WorkshopMailer.expects(:teacher_cancel_receipt).with(enrollment, @teacher.alternate_email).returns(stub(:deliver_now))
+    Pd::WorkshopMailer.expects(:organizer_cancel_receipt).returns(stub(:deliver_now))
 
     assert_destroys Pd::Enrollment do
       delete :cancel, params: {enrollment_code: enrollment.code}

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -798,9 +798,10 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
     teacher = create :teacher
     workshop = create :csa_academic_year_workshop, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP, virtual: 'true', funding_type: nil
     application = create :pd_teacher_application, course: 'csa', application_year: workshop.school_year, user: teacher, status: 'accepted'
-    create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
+    enrollment = create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
 
-    Pd::WorkshopMailer.expects(:detail_change_notification).returns(mock_mail).times(2)
+    Pd::WorkshopMailer.expects(:detail_change_notification).with(enrollment).returns(mock_mail)
+    Pd::WorkshopMailer.expects(:detail_change_notification).with(enrollment, to_email: teacher.alternate_email).returns(mock_mail)
 
     params = workshop_params.merge(course: Pd::Workshop::COURSE_CSA, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP, virtual: true, funding_type: nil)
 

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -222,6 +222,19 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     assert_nil enrollment.reload.survey_sent_at
   end
 
+  test 'send_exit_survey sends email to both the users email and alternate email if available and for a summer workshop' do
+    mock_mail = stub(deliver_now: nil)
+    Pd::WorkshopMailer.expects(:exit_survey).returns(mock_mail).times(2)
+
+    teacher = create :teacher
+    workshop = create :summer_workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD
+    application = create :pd_teacher_application, course: 'csd', application_year: workshop.school_year, user: teacher, status: 'accepted'
+    enrollment = create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
+
+    enrollment.send_exit_survey
+    refute_nil enrollment.reload.survey_sent_at
+  end
+
   test 'name is deprecated and calls through to full_name' do
     enrollment = create :pd_enrollment
     enrollment.expects(:full_name)

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -224,12 +224,14 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
 
   test 'send_exit_survey sends email to both the users email and alternate email if available and for a summer workshop' do
     mock_mail = stub(deliver_now: nil)
-    Pd::WorkshopMailer.expects(:exit_survey).returns(mock_mail).times(2)
 
     teacher = create :teacher
     workshop = create :summer_workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD
     application = create :pd_teacher_application, course: 'csd', application_year: workshop.school_year, user: teacher, status: 'accepted'
     enrollment = create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
+
+    Pd::WorkshopMailer.expects(:exit_survey).with(enrollment).returns(mock_mail)
+    Pd::WorkshopMailer.expects(:exit_survey).with(enrollment, teacher.alternate_email).returns(mock_mail)
 
     enrollment.send_exit_survey
     refute_nil enrollment.reload.survey_sent_at

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -794,6 +794,20 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_includes(e.message, 'bad email')
   end
 
+  test 'sends teacher_enrollment_reminder email to both the users email and alternate email if available and for a summer workshop' do
+    mock_mail = stub
+    mock_mail.stubs(:deliver_now)
+    Pd::WorkshopMailer.expects(:teacher_enrollment_reminder).returns(mock_mail).times(2)
+
+    teacher = create :teacher
+    workshop = create :summer_workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD
+    application = create :pd_teacher_application, course: 'csd', application_year: workshop.school_year, user: teacher, status: 'accepted'
+    create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
+    Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
+
+    Pd::Workshop.send_reminder_for_upcoming_in_days(1)
+  end
+
   test 'errors in organizer reminders in send_reminder_for_upcoming_in_days do not stop batch' do
     mock_mail = stub
     mock_mail.stubs(:deliver_now).returns(nil).then.returns(nil).then.returns(nil).then.returns(nil).then.returns(nil).then.raises(RuntimeError, 'bad email')
@@ -907,6 +921,20 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
 
     Pd::WorkshopMailer.expects(:teacher_pre_workshop_csa).returns(mock_mail).never
+    Pd::Workshop.send_teacher_pre_work_csa
+  end
+
+  test 'CSA teacher pre-work email sends to both the users email and alternate summer email if available' do
+    mock_mail = stub
+    mock_mail.stubs(:deliver_now).returns(nil)
+
+    teacher = create :teacher
+    workshop = create :csa_academic_year_workshop, num_facilitators: 2, subject: Pd::Workshop::SUBJECT_CSA_SUMMER_WORKSHOP
+    application = create :pd_teacher_application, course: 'csa', application_year: workshop.school_year, user: teacher, status: 'accepted'
+    create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
+
+    Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
+    Pd::WorkshopMailer.expects(:teacher_pre_workshop_csa).returns(mock_mail).times(2)
     Pd::Workshop.send_teacher_pre_work_csa
   end
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -797,13 +797,15 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   test 'sends teacher_enrollment_reminder email to both the users email and alternate email if available and for a summer workshop' do
     mock_mail = stub
     mock_mail.stubs(:deliver_now)
-    Pd::WorkshopMailer.expects(:teacher_enrollment_reminder).returns(mock_mail).times(2)
 
     teacher = create :teacher
     workshop = create :summer_workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD
     application = create :pd_teacher_application, course: 'csd', application_year: workshop.school_year, user: teacher, status: 'accepted'
-    create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
+    enrollment = create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
+
     Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
+    Pd::WorkshopMailer.expects(:teacher_enrollment_reminder).with(enrollment, options: {:days_before => 1}).returns(mock_mail)
+    Pd::WorkshopMailer.expects(:teacher_enrollment_reminder).with(enrollment, options: {:days_before => 1}, to_email: teacher.alternate_email).returns(mock_mail)
 
     Pd::Workshop.send_reminder_for_upcoming_in_days(1)
   end
@@ -931,10 +933,11 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     teacher = create :teacher
     workshop = create :csa_academic_year_workshop, num_facilitators: 2, subject: Pd::Workshop::SUBJECT_CSA_SUMMER_WORKSHOP
     application = create :pd_teacher_application, course: 'csa', application_year: workshop.school_year, user: teacher, status: 'accepted'
-    create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
+    enrollment = create :pd_enrollment, application_id: application.id, user: teacher, workshop: workshop
 
     Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
-    Pd::WorkshopMailer.expects(:teacher_pre_workshop_csa).returns(mock_mail).times(2)
+    Pd::WorkshopMailer.expects(:teacher_pre_workshop_csa).with(enrollment).returns(mock_mail)
+    Pd::WorkshopMailer.expects(:teacher_pre_workshop_csa).with(enrollment, to_email: teacher.alternate_email).returns(mock_mail)
     Pd::Workshop.send_teacher_pre_work_csa
   end
 


### PR DESCRIPTION
Following [this PR](https://github.com/code-dot-org/code-dot-org/pull/63213) that stopped associating enrollments with a user's alternate email (set in their teacher application), this PR finishes this work by ensuring workshop emails are sent to both the user's email and their alternate email if it is set and is for a summer workshop.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2941)
Previous PR that removed other uses of the alternate email: [here](https://github.com/code-dot-org/code-dot-org/pull/63213)

## Testing story
Adding unit tests.

