### PR TITLE
TEACH 1507 - progress view links to lesson extras levels do not show student progress

### DIFF
--- a/apps/src/templates/progress/BubbleFactory.jsx
+++ b/apps/src/templates/progress/BubbleFactory.jsx
@@ -222,9 +222,10 @@ export function getBubbleUrl(
   // exist.
   delete current_loc_query_params.version;
 
-  const level_url_query_params = levelUrl.split('?').length > 1 
-    ? queryString.parse(levelUrl.split('?')[1])
-    : {};
+  const level_url_query_params =
+    levelUrl.split('?').length > 1
+      ? queryString.parse(levelUrl.split('?')[1])
+      : {};
   const params = {...current_loc_query_params, ...level_url_query_params};
 
   if (sectionId) {

--- a/apps/src/templates/progress/BubbleFactory.jsx
+++ b/apps/src/templates/progress/BubbleFactory.jsx
@@ -212,7 +212,7 @@ export function getBubbleUrl(
   if (!levelUrl) {
     return null;
   }
-  const params = preserveQueryParams
+  const current_loc_query_params = preserveQueryParams
     ? queryString.parse(currentLocation().search)
     : {};
 
@@ -220,7 +220,12 @@ export function getBubbleUrl(
   // between levels backed by different projects or between a project level and
   // a non-project level puts the user in an error state since the version id doesn't
   // exist.
-  delete params.version;
+  delete current_loc_query_params.version;
+
+  const level_url_query_params = levelUrl.split('?').length > 1 
+    ? queryString.parse(levelUrl.split('?')[1])
+    : {};
+  const params = {...current_loc_query_params, ...level_url_query_params};
 
   if (sectionId) {
     params.section_id = sectionId;
@@ -228,8 +233,9 @@ export function getBubbleUrl(
   if (studentId) {
     params.user_id = studentId;
   }
+
   if (Object.keys(params).length) {
-    return `${levelUrl}?${queryString.stringify(params)}`;
+    return `${levelUrl.split('?')[0]}?${queryString.stringify(params)}`;
   }
   return levelUrl;
 }

--- a/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
+++ b/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
@@ -239,8 +239,14 @@ describe('BubbleFactory', () => {
     });
 
     it('if input url has levelname as a query parameter', () => {
-      const bubbleUrl = getBubbleUrl('//localhost-studio.code.org:3000/s/coursec-2024/lessons/3/extras?level_name=courseC_maze_programming_challenge2_2024', 1, 2);
-      expect(bubbleUrl).to.equal('//localhost-studio.code.org:3000/s/coursec-2024/lessons/3/extras?level_name=courseC_maze_programming_challenge2_2024&section_id=2&user_id=1');
+      const bubbleUrl = getBubbleUrl(
+        '//localhost-studio.code.org:3000/s/coursec-2024/lessons/3/extras?level_name=courseC_maze_programming_challenge2_2024',
+        1,
+        2
+      );
+      expect(bubbleUrl).to.equal(
+        '//localhost-studio.code.org:3000/s/coursec-2024/lessons/3/extras?level_name=courseC_maze_programming_challenge2_2024&section_id=2&user_id=1'
+      );
     });
 
     it('removes version param if it exists even if other params are preserved', () => {

--- a/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
+++ b/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
@@ -238,6 +238,11 @@ describe('BubbleFactory', () => {
       expect(bubbleUrl).to.equal('a-url?section_id=2&user_id=1');
     });
 
+    it('if input url has levelname as a query parameter', () => {
+      const bubbleUrl = getBubbleUrl('//localhost-studio.code.org:3000/s/coursec-2024/lessons/3/extras?level_name=courseC_maze_programming_challenge2_2024', 1, 2);
+      expect(bubbleUrl).to.equal('//localhost-studio.code.org:3000/s/coursec-2024/lessons/3/extras?level_name=courseC_maze_programming_challenge2_2024&section_id=2&user_id=1');
+    });
+
     it('removes version param if it exists even if other params are preserved', () => {
       const levelUrl = 'http://a-level-url.com';
       updateQueryParam('version', '456lmnop');


### PR DESCRIPTION
Issue: The code that generates the href links in progress bubbles assumes that the input level URL does not already contain any query parameters. This is not the case in case of choice levels where the choice level name is passed in as a query parameter. As a result, the href link finally generated was incorrect.

Fix: Also account for query parameters from the input level URL.

## Links

JIRA: https://codedotorg.atlassian.net/browse/TEACH-1507

## Testing story

- New unit tests to assert for this scenario
- Manually validated the changes
- Drone

## Deployment strategy

Regular DTP

## Follow-up work

None

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
