### PR TITLE
Lab2: simplify renderer, entrypoints, and AppName type

### DIFF
--- a/apps/lab2EntryPoints.ts
+++ b/apps/lab2EntryPoints.ts
@@ -16,7 +16,7 @@ import {PythonlabEntryPoint} from '@cdo/apps/pythonlab/entrypoint';
 import {StandaloneVideoEntryPoint} from '@cdo/apps/standaloneVideo/entrypoint';
 import {Weblab2EntryPoint} from '@cdo/apps/weblab2/entrypoint';
 
-export const lab2EntryPoints: Record<string, Lab2EntryPoint> = {
+export const lab2EntryPoints = {
   aichat: AIChatEntryPoint,
   dance: DanceEntryPoint,
   music: MusicEntryPoint,
@@ -24,4 +24,4 @@ export const lab2EntryPoints: Record<string, Lab2EntryPoint> = {
   pythonlab: PythonlabEntryPoint,
   standalone_video: StandaloneVideoEntryPoint,
   weblab2: Weblab2EntryPoint,
-};
+} as const satisfies Record<string, Lab2EntryPoint>;

--- a/apps/src/aichat/entrypoint.ts
+++ b/apps/src/aichat/entrypoint.ts
@@ -3,7 +3,6 @@ import {lazy} from 'react';
 import {Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
 
 export const AIChatEntryPoint: Lab2EntryPoint = {
-  backgroundMode: false,
   theme: Theme.LIGHT,
   view: lazy(() =>
     import(/* webpackChunkName: "aichat" */ './index.js').then(

--- a/apps/src/dance/lab2/entrypoint.ts
+++ b/apps/src/dance/lab2/entrypoint.ts
@@ -3,7 +3,6 @@ import {lazy} from 'react';
 import {Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
 
 export const DanceEntryPoint: Lab2EntryPoint = {
-  backgroundMode: false,
   theme: Theme.LIGHT,
   view: lazy(() =>
     import(/* webpackChunkName: "danceLab2" */ './index.js').then(

--- a/apps/src/lab2/constants.ts
+++ b/apps/src/lab2/constants.ts
@@ -2,18 +2,7 @@ import {AppName} from './types';
 
 export const SOURCE_FILE = 'main.json';
 
-export const BLOCKLY_LABS: AppName[] = [
-  'dance',
-  'flappy',
-  'music',
-  'thebadguys',
-  'turtle',
-  'craft',
-  'studio',
-  'bounce',
-  'poetry',
-  'spritelab',
-];
+export const BLOCKLY_LABS: AppName[] = ['dance', 'music'];
 
 export const LABS_WITH_JSON_SOURCES: AppName[] = ['aichat'];
 

--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -241,45 +241,14 @@ export interface MazeCell {
   assetId: number;
 }
 
-export enum OptionsToAvoid {
-  /**
-   * @deprecated: using this option will result in hardcoding this lab into the
-   * downloaded bundle for ALL other lab2 labs, slowing down their loading and
-   * consuming excessive school internet bandwidth.
-   *
-   * See `pythonlab/entrypoint.tsx` for an example that doesn't use this option.
-   *
-   * Please only use this option if there's a good reason you can't lazy load
-   * your lab. With this option set, you must also specify `hardcodedEntryPoint`.
-   */
-  UseHardcodedView_WARNING_Bloats_Lab2_Bundle,
-}
-
 // Configuration for how a Lab should be rendered
 export interface Lab2EntryPoint {
-  /**
-   * Whether this lab should remain rendered in the background once mounted.
-   * If true, the lab will always be present in the tree, but will be hidden
-   * via visibility: hidden when not active. If false, the lab will only
-   * be rendered in the tree when active.
-   */
-  backgroundMode: boolean;
   /**
    * A lazy loaded view for the lab. This should be a lazy-loaded react
    * component using a dynamic import. See `pythonlab/entrypoint.tsx` for an
    * example.
    */
-  view: LazyExoticComponent<ComponentType> | OptionsToAvoid;
-  /**
-   * Using this option will result in hardcoding this lab into the downloaded
-   * bundle for ALL other lab2 labs, slowing down their loading and consuming
-   * excessive school internet bandwidth. Please use `view` instead,
-   * which lazy loads you lab on demand, unless you have a really good reason
-   * you can't lazy load.
-   *
-   * See `pythonlab/entrypoint.tsx` for an example that doesn't use this option.
-   */
-  hardcodedView?: ComponentType;
+  view: LazyExoticComponent<ComponentType>;
   /**
    * Display theme for this lab. This will likely be configured by user
    * preferences eventually, but for now this is fixed for each lab. Defaults

--- a/apps/src/lab2/views/LabViewsRenderer.tsx
+++ b/apps/src/lab2/views/LabViewsRenderer.tsx
@@ -4,8 +4,7 @@
  * helps facilitate level-switching between labs without page reloads.
  */
 
-import classNames from 'classnames';
-import React, {Suspense, useContext, useEffect, useState} from 'react';
+import React, {Suspense, useContext, useEffect} from 'react';
 
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -14,7 +13,6 @@ import {lab2EntryPoints} from '../../../lab2EntryPoints';
 import {PERMISSIONS} from '../constants';
 import ProgressContainer from '../progress/ProgressContainer';
 import {getAppOptionsViewingExemplar} from '../projects/utils';
-import {AppName, Lab2EntryPoint, OptionsToAvoid} from '../types';
 
 import NoExemplarPage from './components/NoExemplarPage';
 import ExtraLinks from './ExtraLinks';
@@ -40,15 +38,6 @@ const LabViewsRenderer: React.FunctionComponent = () => {
 
   const isViewingExemplar = getAppOptionsViewingExemplar();
 
-  const [appsToRender, setAppsToRender] = useState<AppName[]>([]);
-
-  // When navigating to a new app type, add it to the list of apps to render.
-  useEffect(() => {
-    if (currentAppName && !appsToRender.includes(currentAppName)) {
-      setAppsToRender([...appsToRender, currentAppName]);
-    }
-  }, [currentAppName, appsToRender]);
-
   // Set the theme for the current app.
   const {setTheme} = useContext(ThemeContext);
   useEffect(() => {
@@ -58,84 +47,33 @@ const LabViewsRenderer: React.FunctionComponent = () => {
     }
   }, [currentAppName, setTheme]);
 
-  const renderApp = (lab2EntryPoint: Lab2EntryPoint): React.ReactNode => {
-    return lab2EntryPoint.view ===
-      OptionsToAvoid.UseHardcodedView_WARNING_Bloats_Lab2_Bundle ? (
-      React.createElement(lab2EntryPoint.hardcodedView!)
-    ) : (
-      <Suspense fallback={<Loading isLoading={true} />}>
-        <lab2EntryPoint.view />
-      </Suspense>
-    );
-  };
-
   // Do not render lab view if project is blocked and user is not a project validator.
-  if (isBlocked && !isProjectValidator) {
+  if (!currentAppName || (isBlocked && !isProjectValidator)) {
     return null;
   }
-  // Iterate through appsToRender and render Lab views for each. If
-  // backgroundMode is true, the Lab view will always be rendered, but
-  // visibility will be toggled based on whether the app is active. If
-  // backgroundMode is false, the Lab view will only be rendered when the
-  // app is active.
+
+  // Show a fallback no exemplar page if we are trying to view
+  // exemplar but there is not exemplar for this level.
+  if (isViewingExemplar && !exemplarSources) {
+    return <NoExemplarPage />;
+  }
+
+  const properties = lab2EntryPoints[currentAppName];
+  if (!properties) {
+    console.warn("Don't know how to render app: " + currentAppName);
+    return null;
+  }
+
+  const LabView = properties.view;
   return (
-    <>
-      {appsToRender.map(appName => {
-        const properties = lab2EntryPoints[appName];
-        if (!properties) {
-          console.warn("Don't know how to render app: " + appName);
-          return null;
-        }
-        // Show a fallback no exemplar page if we are  trying to view
-        // exemplar but there is not exemplar for this level.
-        if (isViewingExemplar && !exemplarSources) {
-          return <NoExemplarPage />;
-        }
-
-        return (
-          <ProgressContainer key={appName} appType={appName}>
-            {properties.backgroundMode && (
-              <VisibilityContainer
-                appName={appName}
-                visible={currentAppName === appName}
-              >
-                {renderApp(properties)}
-                {!hideExtraLinks && levelId && <ExtraLinks levelId={levelId} />}
-              </VisibilityContainer>
-            )}
-
-            {!properties.backgroundMode && currentAppName === appName && (
-              <VisibilityContainer appName={appName} visible={true}>
-                {renderApp(properties)}
-                {!hideExtraLinks && levelId && <ExtraLinks levelId={levelId} />}
-              </VisibilityContainer>
-            )}
-          </ProgressContainer>
-        );
-      })}
-    </>
-  );
-};
-
-interface VisibilityContainerProps {
-  appName: AppName;
-  visible: boolean;
-  children: React.ReactNode;
-}
-
-const VisibilityContainer: React.FunctionComponent<
-  VisibilityContainerProps
-> = ({appName, visible, children}) => {
-  return (
-    <div
-      id={`lab2-${appName}`}
-      className={classNames(
-        moduleStyles.visibilityContainer,
-        visible && moduleStyles.visible
-      )}
-    >
-      {children}
-    </div>
+    <ProgressContainer key={currentAppName} appType={currentAppName}>
+      <div id={`lab2-${currentAppName}`} className={moduleStyles.labContainer}>
+        <Suspense fallback={<Loading isLoading={true} />}>
+          <LabView />
+        </Suspense>
+        {!hideExtraLinks && levelId && <ExtraLinks levelId={levelId} />}
+      </div>
+    </ProgressContainer>
   );
 };
 

--- a/apps/src/lab2/views/lab-views-renderer.module.scss
+++ b/apps/src/lab2/views/lab-views-renderer.module.scss
@@ -1,10 +1,5 @@
-.visibilityContainer {
+.labContainer {
   width: 100%;
   height: 100%;
   position: absolute;
-  visibility: hidden;
-
-  &.visible {
-    visibility: visible;
-  }
 }

--- a/apps/src/music/entrypoint.ts
+++ b/apps/src/music/entrypoint.ts
@@ -3,7 +3,6 @@ import {lazy} from 'react';
 import {Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
 
 export const MusicEntryPoint: Lab2EntryPoint = {
-  backgroundMode: false,
   theme: Theme.DARK,
   view: lazy(() =>
     import(/* webpackChunkName: "music" */ './index.js').then(

--- a/apps/src/panels/entrypoint.ts
+++ b/apps/src/panels/entrypoint.ts
@@ -3,7 +3,6 @@ import {lazy} from 'react';
 import {Lab2EntryPoint} from '@cdo/apps/lab2/types';
 
 export const PanelsEntryPoint: Lab2EntryPoint = {
-  backgroundMode: false,
   view: lazy(() =>
     import(/* webpackChunkName: "panels" */ './index.js').then(
       ({PanelsLabView}) => ({

--- a/apps/src/pythonlab/entrypoint.ts
+++ b/apps/src/pythonlab/entrypoint.ts
@@ -3,7 +3,6 @@ import {lazy} from 'react';
 import {Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
 
 export const PythonlabEntryPoint: Lab2EntryPoint = {
-  backgroundMode: false,
   view: lazy(() =>
     import(/* webpackChunkName: "pythonlab" */ './index.js').then(
       ({PythonlabView}) => ({

--- a/apps/src/standaloneVideo/entrypoint.ts
+++ b/apps/src/standaloneVideo/entrypoint.ts
@@ -3,7 +3,6 @@ import {lazy} from 'react';
 import {Lab2EntryPoint} from '@cdo/apps/lab2/types';
 
 export const StandaloneVideoEntryPoint: Lab2EntryPoint = {
-  backgroundMode: false,
   view: lazy(() =>
     import(/* webpackChunkName: "standaloneVideo" */ './index.js').then(
       ({StandaloneVideo}) => ({

--- a/apps/src/weblab2/entrypoint.ts
+++ b/apps/src/weblab2/entrypoint.ts
@@ -3,7 +3,6 @@ import {lazy} from 'react';
 import {Lab2EntryPoint, Theme} from '@cdo/apps/lab2/types';
 
 export const Weblab2EntryPoint: Lab2EntryPoint = {
-  backgroundMode: false,
   theme: Theme.DARK,
   view: lazy(() =>
     import(/* webpackChunkName: "weblab2" */ './index.js').then(


### PR DESCRIPTION
Now that all Lab2 labs use lazy loading and no longer use background mode, we can simplify our renderer logic quite a bit. This removes background more support and uses the lazy loading component for all labs. This also removes the `background` property from all entrypoints accordingly.

Also included a semi-related change to fix the type for the lab2Entrypoints object (see comment for more details).

## Testing story

Tested locally on a variety of lesson progressions and standalone projects including
- Music Lab HOC 2024 & standalone
- Customizing LLMs (AI Chat)
- Data Science with Python
- allthethings lab2 showcase