### PR TITLE
Return ChatEvent from backend

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -71,8 +71,7 @@ export async function postAichatCompletionMessage(
  * @param eventId
  * @param feedback
  *
- * Sends a POST request to the aichat submit teacher feedback backend controller,
- * then returns the updated chat event if successful.
+ * Sends a POST request to the aichat submit teacher feedback backend controller.
  */
 export async function postSubmitTeacherFeedback(
   eventId: number,
@@ -82,7 +81,7 @@ export async function postSubmitTeacherFeedback(
     eventId,
     feedback,
   };
-  const response = await HttpClient.post(
+  await HttpClient.post(
     `${paths.SUBMIT_TEACHER_FEEDBACK_URL}`,
     JSON.stringify(payload),
     true,
@@ -90,8 +89,6 @@ export async function postSubmitTeacherFeedback(
       'Content-Type': 'application/json; charset=UTF-8',
     }
   );
-
-  return await response.json();
 }
 
 /**

--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -15,7 +15,6 @@ import {
   ChatEvent,
   ChatMessage,
   DetectToxicityResponse,
-  ChatEventApiResponse,
   TeacherFeedback,
 } from './types';
 import {extractFieldsToCheckForToxicity} from './utils';
@@ -71,7 +70,6 @@ export async function postAichatCompletionMessage(
 /**
  * @param eventId
  * @param feedback
- * @returns Promise<ChatEventApiResponse>
  *
  * Sends a POST request to the aichat submit teacher feedback backend controller,
  * then returns the updated chat event if successful.
@@ -79,7 +77,7 @@ export async function postAichatCompletionMessage(
 export async function postSubmitTeacherFeedback(
   eventId: number,
   feedback: TeacherFeedback
-): Promise<ChatEventApiResponse> {
+) {
   const payload = {
     eventId,
     feedback,
@@ -103,7 +101,7 @@ export async function postSubmitTeacherFeedback(
 export async function postLogChatEvent(
   newChatEvent: ChatEvent,
   aichatContext: AichatContext
-): Promise<ChatEventApiResponse> {
+): Promise<ChatEvent> {
   const payload = {
     newChatEvent,
     aichatContext,
@@ -138,15 +136,11 @@ export async function getStudentChatHistory(
   if (scriptLevelId) {
     params.scriptLevelId = scriptLevelId.toString();
   }
-  const response = await HttpClient.fetchJson<ChatEventApiResponse[]>(
+  const response = await HttpClient.fetchJson<ChatEvent[]>(
     paths.STUDENT_CHAT_HISTORY_URL + '?' + new URLSearchParams(params)
   );
 
-  // Write the id from the ChatEventApiResponse into each ChatEvent and return ChatEvent[]
-  return response.value.map<ChatEvent>(chatEventApiResponse => ({
-    ...chatEventApiResponse.chat_event,
-    id: chatEventApiResponse.chat_event_id,
-  }));
+  return response.value;
 }
 
 /**

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -74,11 +74,6 @@ export interface ChatCompletionApiResponse {
   flagged_content?: string;
 }
 
-export interface ChatEventApiResponse {
-  chat_event_id: number;
-  chat_event: ChatMessage;
-}
-
 export type AichatContext = {
   currentLevelId: number | null;
   scriptId: number | null;

--- a/apps/test/unit/aichat/ChatEventLoggerTest.ts
+++ b/apps/test/unit/aichat/ChatEventLoggerTest.ts
@@ -12,6 +12,7 @@ describe('ChatEventLogger', () => {
 
   beforeEach(() => {
     userChatMessage = {
+      id: 1,
       role: Role.USER,
       chatMessageText: 'hello',
       status: AiInteractionStatus.OK,
@@ -32,7 +33,7 @@ describe('ChatEventLogger', () => {
   it('logChatEvent calls on postLogChatEvent', async () => {
     postLogChatEventSpy = jest
       .spyOn(aichatApi, 'postLogChatEvent')
-      .mockResolvedValue({chat_event_id: 1, chat_event: userChatMessage});
+      .mockResolvedValue(userChatMessage);
 
     chatEventLogger.logChatEvent(userChatMessage, aichatContext);
     expect(postLogChatEventSpy).toHaveBeenCalledTimes(1);
@@ -44,7 +45,7 @@ describe('ChatEventLogger', () => {
       .mockImplementation(() => {
         return new Promise(resolve => {
           setTimeout(() => {
-            resolve({chat_event_id: 1, chat_event: userChatMessage});
+            resolve(userChatMessage);
           }, 1000);
         });
       });

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -114,8 +114,8 @@ class AichatController < ApplicationController
     end
 
     response_body = {
-      chat_event_id: logged_event.id,
-      chat_event: logged_event.aichat_event
+      id: logged_event.id,
+      **logged_event.aichat_event
     }
 
     render(status: :ok, json: response_body)
@@ -172,9 +172,10 @@ class AichatController < ApplicationController
     end
 
     aichat_events = AichatEvent.where(user_id: student_user_id, level_id: level_id, script_id: script_id).order(:created_at).map do |event|
+      chat_event = event[:aichat_event].is_a?(String) ? JSON.parse(event[:aichat_event]) : event[:aichat_event]
       {
-        chat_event_id: event.id,
-        chat_event: event[:aichat_event].is_a?(String) ? JSON.parse(event[:aichat_event]) : event[:aichat_event]
+        id: event.id,
+        **chat_event
       }
     end
     render json: aichat_events


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
From https://github.com/code-dot-org/code-dot-org/pull/62797#discussion_r1894439115 - this PR updates the responses returned from `aichat_controller`'s `log_chat_event` and `student_chat_history` to `ChatEvent` (or a `ChatEvent` array). Thus, `ChatEventApiResponse` type is no longer needed.

## Links
Cassi's open PR: https://github.com/code-dot-org/code-dot-org/pull/62797

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
