### PR TITLE
Enable ActiveRecord to Query Reporting Database

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -7,15 +7,20 @@
   DATABASE_CONFIGURATION = {
     db_cluster_id: '!Ref AuroraCluster',
     db_endpoint_writer: '!GetAtt AuroraCluster.Endpoint.Address',
+    db_endpoint_writer_port: '!GetAtt AuroraCluster.Endpoint.Port',
     db_endpoint_proxy_writer: '!GetAtt DBProxy.Endpoint',
+    db_endpoint_proxy_writer_port: '3306', # RDS Proxy MySQL Endpoints only use 3306
     db_endpoint_proxy_reader: '!GetAtt ReaderDBProxyEndpoint.Endpoint',
-    db_endpoint_proxy_reporting: '!GetAtt ReportingDBProxyEndpoint.Endpoint'
+    db_endpoint_proxy_reader_port: '3306', # RDS Proxy MySQL Endpoints only use 3306
+    db_endpoint_proxy_reporting: '!GetAtt ReportingDBProxyEndpoint.Endpoint',
+    db_endpoint_proxy_reporting_port: '3306' # RDS Proxy MySQL Endpoints only use 3306
   }.tap do |hash|
     if rack_env?(:production)
       hash[:db_cluster_id] = PRODUCTION_DB_CLUSTER_ID
       # Use a placeholder string for production db cluster endpoint to avoid placing a slightly sensitive value
       # in source code. We set the value of the Secret manually in production.
       hash[:db_endpoint_writer] = 'PLACEHOLDER'
+      hash[:db_endpoint_writer_port] = '3306'
       # We haven't yet provisioned the Writer and Reader Proxy Endpoints in production.
       hash[:db_endpoint_proxy_writer] = 'PLACEHOLDER'
       hash[:db_endpoint_proxy_reader] = 'PLACEHOLDER'
@@ -91,25 +96,48 @@
       Description: 'Publish Database Cluster Writer Endpoint to application configuration setting CDO.db_endpoint_writer'
       Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_writer"
       SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_writer]%>
+  DBWriterEndpointPortConfig:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: 'Publish Database Cluster Writer Endpoint Port to application configuration setting CDO.db_endpoint_writer_port'
+      Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_writer_port"
+      SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_writer_port]%>
   DBProxyWriterEndpointConfig:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: 'Publish RDS Proxy Writer Endpoint to the application configuration setting CDO.db_endpoint_proxy_writer'
       Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_writer"
       SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_writer]%>
+  DBProxyWriterEndpointPortConfig:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: 'Publish RDS Proxy Writer Endpoint Port to the application configuration setting CDO.db_endpoint_proxy_writer_port'
+      Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_writer_port"
+      SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_writer_port]%>
   DBProxyReaderEndpointConfig:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: 'Publish RDS Proxy Reader Endpoint to the application configuration setting CDO.db_endpoint_proxy_reader'
       Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_reader"
       SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_reader]%>
+  DBProxyReaderEndpointPortConfig:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: 'Publish RDS Proxy Reader Endpoint Port to the application configuration setting CDO.db_endpoint_proxy_reader_port'
+      Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_reader_port"
+      SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_reader_port]%>
   DBProxyReportingEndpointConfig:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: 'Publish RDS Proxy Reporting Endpoint to the application configuration setting CDO.db_endpoint_proxy_reporting'
       Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_reporting"
       SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_reporting]%>
-
+  DBProxyReportingEndpointPortConfig:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: 'Publish RDS Proxy Reporting Endpoint Port to the application configuration setting CDO.db_endpoint_proxy_reporting_port'
+      Name: !Sub "CfnStack/${AWS::StackName}/db_endpoint_proxy_reporting_port"
+      SecretString: <%=DATABASE_CONFIGURATION[:db_endpoint_proxy_reporting_port]%>
 <% if database-%>
 # We don't yet provision the production database cluster/instances via CloudFormation, but we're incrementally
 # working towards that. Start with provisioning the DB Instance and Cluster ParameterGroups via this template.

--- a/bin/mysql-client-admin
+++ b/bin/mysql-client-admin
@@ -5,13 +5,11 @@ require 'uri'
 
 raise 'please define CDO.db_credential_admin' unless CDO.db_credential_admin
 credentials = CDO.db_credential_admin
-host = CDO.db_endpoint_writer.split(':')[0]
-port = CDO.db_endpoint_writer.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: host,
-  port: port,
+  host: CDO.db_endpoint_writer,
+  port: CDO.db_endpoint_writer_port,
   path: '/'
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-dashboard-reader
+++ b/bin/mysql-client-dashboard-reader
@@ -5,13 +5,11 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_proxy_reader' unless CDO.db_endpoint_proxy_reader
 credentials = CDO.db_credential_reader
-host = CDO.db_endpoint_proxy_reader.split(':')[0]
-port = CDO.db_endpoint_proxy_reader.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: host,
-  port: port,
+  host: CDO.db_endpoint_proxy_reader,
+  port: CDO.db_endpoint_proxy_reader_port,
   path: '/' + CDO.dashboard_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-dashboard-reporting
+++ b/bin/mysql-client-dashboard-reporting
@@ -5,13 +5,11 @@ require 'uri'
 
 raise 'please set CDO.db_endpoint_proxy_reporting' unless CDO.db_endpoint_proxy_reporting
 credentials = CDO.db_credential_reader
-host = CDO.db_endpoint_proxy_reporting.split(':')[0]
-port = CDO.db_endpoint_proxy_reporting.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: host,
-  port: port,
+  host: CDO.db_endpoint_proxy_reporting,
+  port: CDO.db_endpoint_proxy_reporting_port,
   path: '/' + CDO.dashboard_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-dashboard-writer
+++ b/bin/mysql-client-dashboard-writer
@@ -5,13 +5,11 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_writer' unless CDO.db_endpoint_writer
 credentials = CDO.db_credential_writer
-host = CDO.db_endpoint_proxy_writer.split(':')[0]
-port = CDO.db_endpoint_proxy_writer.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: host,
-  port: port,
+  host: CDO.db_endpoint_writer,
+  port: CDO.db_endpoint_writer_port,
   path: '/' + CDO.dashboard_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-pegasus-reader
+++ b/bin/mysql-client-pegasus-reader
@@ -5,13 +5,11 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_proxy_reader' unless CDO.db_endpoint_proxy_reader
 credentials = CDO.db_credential_reader
-host = CDO.db_endpoint_proxy_reader.split(':')[0]
-port = CDO.db_endpoint_proxy_reader.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: host,
-  port: port,
+  host: CDO.db_endpoint_proxy_reader,
+  port: CDO.db_endpoint_proxy_reader_port,
   path: '/' + CDO.pegasus_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-pegasus-reporting
+++ b/bin/mysql-client-pegasus-reporting
@@ -5,13 +5,11 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_proxy_reporting' unless CDO.db_endpoint_proxy_reporting
 credentials = CDO.db_credential_reader
-host = CDO.db_endpoint_proxy_reporting.split(':')[0]
-port = CDO.db_endpoint_proxy_reporting.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: host,
-  port: port,
+  host: CDO.db_endpoint_proxy_reporting,
+  port: CDO.db_endpoint_proxy_reporting_port,
   path: '/' + CDO.pegasus_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/bin/mysql-client-pegasus-writer
+++ b/bin/mysql-client-pegasus-writer
@@ -5,13 +5,11 @@ require 'uri'
 
 raise 'please define CDO.db_endpoint_writer' unless CDO.db_endpoint_writer
 credentials = CDO.db_credential_writer
-host = CDO.db_endpoint_proxy_writer.split(':')[0]
-port = CDO.db_endpoint_proxy_writer.split(':')[1] || 3306
 db_connection_settings = URI::Generic.build(
   scheme: 'mysql',
   userinfo: credentials['username'] + ':' + credentials['password'],
-  host: host,
-  port: port,
+  host: CDO.db_endpoint_writer,
+  port: CDO.db_endpoint_writer_port,
   path: '/' + CDO.pegasus_db_name
 )
 MysqlConsoleHelper.run(db_connection_settings, ARGV.join(' ').strip)

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -578,8 +578,6 @@ dashboard_db_reader:           '<%="#{db_reader}#{dashboard_db_name}"%>'
 dashboard_db_writer:           '<%="#{db_writer}#{dashboard_db_name}"%>'
 pegasus_db_reader:             '<%="#{db_reader}#{pegasus_db_name}"%>'
 pegasus_db_writer:             '<%="#{db_writer}#{pegasus_db_name}"%>'
-dashboard_reporting_db_reader: '<%="#{reporting_db_reader}#{dashboard_db_name}"%>'
-dashboard_reporting_db_writer: '<%="#{reporting_db_writer}#{dashboard_db_name}"%>'
 pegasus_reporting_db_reader:   '<%="#{reporting_db_reader}#{pegasus_db_name}"%>'
 pegasus_reporting_db_writer:   '<%="#{reporting_db_writer}#{pegasus_db_name}"%>'
 

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -546,9 +546,13 @@ devinternal_db_writer: !Secret
 # Until we have a better configuration setting service, use AWS Secrets Manager to store these non-secret values.
 db_cluster_id: !StackSecret
 db_endpoint_writer: !StackSecret
+db_endpoint_writer_port: !StackSecret
 db_endpoint_proxy_writer: !StackSecret
+db_endpoint_proxy_writer_port: !StackSecret
 db_endpoint_proxy_reader: !StackSecret
+db_endpoint_proxy_reader_port: !StackSecret
 db_endpoint_proxy_reporting: !StackSecret
+db_endpoint_proxy_reporting_port: !StackSecret
 
 # Database credentials (username & password) are stored in an AWS Secret in a JSON format required by RDS Proxy:
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-setup.html#rds-proxy-secrets-arns

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -5,9 +5,13 @@ dashboard_enable_pegasus: true
 
 db_cluster_id: localhost
 db_endpoint_writer: localhost
+db_endpoint_writer_port: 3306
 db_endpoint_proxy_writer: localhost
+db_endpoint_proxy_writer_port: 3306
 db_endpoint_proxy_reader: localhost
+db_endpoint_proxy_reader_port: 3306
 db_endpoint_proxy_reporting: localhost
+db_endpoint_proxy_reporting_port: 3306
 
 db_credential_admin: {"username":"root", "password":""}
 db_credential_writer: {"username":"root", "password":""}

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -24,6 +24,20 @@ channels_api_secret: not a real secret
 dashboard_devise_pepper: not a pepper!
 dashboard_secret_key_base: not a secret
 google_maps_api_key: boguskey
+
+db_cluster_id: localhost
+db_endpoint_writer: localhost
+db_endpoint_writer_port: 3306
+db_endpoint_proxy_writer: localhost
+db_endpoint_proxy_writer_port: 3306
+db_endpoint_proxy_reader: localhost
+db_endpoint_proxy_reader_port: 3306
+db_endpoint_proxy_reporting: localhost
+db_endpoint_proxy_reporting_port: 3306
+
+db_credential_admin: {"username":"root", "password":""}
+db_credential_writer: {"username":"root", "password":""}
+db_credential_reader: {"username":"root", "password":""}
 db_writer: 'mysql://root@localhost/'
 
 # Number of workers to start when running `rake build:start_active_job_workers`:

--- a/dashboard/app/models/application_record.rb
+++ b/dashboard/app/models/application_record.rb
@@ -3,6 +3,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   connects_to database: {
     writing: Policies::ActiveRecordRoles.get_writing_role_name,
-    reading: Policies::ActiveRecordRoles.get_reading_role_name
+    reading: Policies::ActiveRecordRoles.get_reading_role_name,
+    reporting: Policies::ActiveRecordRoles.get_reporting_role_name,
   }
 end

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -8,6 +8,7 @@ require 'dynamic_config/dcdo'
 
 writer = URI.parse(CDO.dashboard_db_writer) if CDO.dashboard_db_writer
 reader = URI.parse(CDO.dashboard_db_reader) if CDO.dashboard_db_reader
+reporting_reader = URI.parse(CDO.dashboard_reporting_db_reader) if CDO.dashboard_reporting_db_reader
 %>
 
 mysql_defaults: &mysql_defaults
@@ -65,6 +66,16 @@ environment_defaults: &environment_defaults
     password: <%= reader.password %>
     port: <%= reader.port || 3306 %>
     username: <%= reader.user %>
+  <% end %>
+  <% if reporting_reader %>
+  primary_reporting:
+    replica: true
+    <<: *mysql_defaults
+    database: <%= reporting_reader.path.sub(%r{^/},"") %>
+    host: <%= reporting_reader.host %>
+    password: <%= reporting_reader.password %>
+    port: <%= reporting_reader.port || 3306 %>
+    username: <%= reporting_reader.user %>
   <% end %>
 
 development:

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -8,7 +8,6 @@ require 'dynamic_config/dcdo'
 
 writer = URI.parse(CDO.dashboard_db_writer) if CDO.dashboard_db_writer
 reader = URI.parse(CDO.dashboard_db_reader) if CDO.dashboard_db_reader
-reporting_reader = URI.parse(CDO.dashboard_reporting_db_reader) if CDO.dashboard_reporting_db_reader
 %>
 
 mysql_defaults: &mysql_defaults
@@ -67,16 +66,18 @@ environment_defaults: &environment_defaults
     port: <%= reader.port || 3306 %>
     username: <%= reader.user %>
   <% end %>
-  <% if reporting_reader %>
+  # Always provision a reporting replica database connection pool, even in environments that do not have an Aurora
+  # cluster with a "reporting" RDS Proxy, such as local development environments and continuous integration
+  # builds. In those non-AWS environments, CDO.db_endpoint_proxy_reporting is set to the same servername as the writer
+  # (typically 'localhost').
   primary_reporting:
     replica: true
     <<: *mysql_defaults
-    database: <%= reporting_reader.path.sub(%r{^/},"") %>
-    host: <%= reporting_reader.host %>
-    password: <%= reporting_reader.password %>
-    port: <%= reporting_reader.port || 3306 %>
-    username: <%= reporting_reader.user %>
-  <% end %>
+    host: <%= CDO.db_endpoint_proxy_reporting %>
+    port: <%= CDO.db_endpoint_proxy_reporting_port %>
+    username: <%= CDO.db_credential_reader['username'] %>
+    password: <%= CDO.db_credential_reader['password'] %>
+    database: <%= CDO.dashboard_db_name %>
 
 development:
   <<: *environment_defaults

--- a/dashboard/lib/policies/active_record_roles.rb
+++ b/dashboard/lib/policies/active_record_roles.rb
@@ -16,4 +16,12 @@ module Policies::ActiveRecordRoles
     configurations = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, include_replicas: true)
     configurations.find(&:replica?)&.spec_name&.to_sym || get_writing_role_name
   end
+
+  # Get the name of the ActiveRecord "role" used for connecting to the reporting
+  # database which is a clone of our primary database meant for large / long
+  # queries usually used for data analysis. This role should not be used when
+  # handling web requests.
+  def self.get_reporting_role_name
+    :primary_reporting
+  end
 end

--- a/dashboard/test/lib/policies/active_record_roles_test.rb
+++ b/dashboard/test/lib/policies/active_record_roles_test.rb
@@ -44,4 +44,8 @@ class Policies::ActiveRecordRolesTest < ActiveSupport::TestCase
     ActiveRecord::Base.stubs(:configurations).returns(test_config)
     assert_equal Policies::ActiveRecordRoles.get_reading_role_name, :secondary
   end
+
+  test 'get_reporting_role_name' do
+    assert_equal Policies::ActiveRecordRoles.get_reporting_role_name, :primary_reporting
+  end
 end

--- a/lib/cdo/db.rb
+++ b/lib/cdo/db.rb
@@ -1,3 +1,4 @@
+require 'uri'
 require 'cdo/sequel'
 require 'sequel'
 require 'cdo/cache'
@@ -12,4 +13,13 @@ PEGASUS_DB.singleton_class.prepend StaticModels
 # rubocop:enable CustomCops/PegasusDbUsage
 
 DASHBOARD_DB = Cdo::Sequel.database_connection_pool CDO.dashboard_db_writer, CDO.dashboard_db_reader
-DASHBOARD_REPORTING_DB_READER = Cdo::Sequel.database_connection_pool CDO.dashboard_reporting_db_reader, CDO.dashboard_reporting_db_reader
+
+credentials = CDO.db_credential_reader
+dashboard_reporting_connection_settings = URI::Generic.build(
+  scheme: 'mysql',
+  userinfo: credentials['username'] + ':' + credentials['password'],
+  host: CDO.db_endpoint_proxy_reporting,
+  port: CDO.db_endpoint_proxy_reporting_port,
+  path: '/' + CDO.dashboard_db_name
+)
+DASHBOARD_REPORTING_DB_READER = Cdo::Sequel.database_connection_pool dashboard_reporting_connection_settings, dashboard_reporting_connection_settings

--- a/lib/cdo/db.rb
+++ b/lib/cdo/db.rb
@@ -13,13 +13,3 @@ PEGASUS_DB.singleton_class.prepend StaticModels
 # rubocop:enable CustomCops/PegasusDbUsage
 
 DASHBOARD_DB = Cdo::Sequel.database_connection_pool CDO.dashboard_db_writer, CDO.dashboard_db_reader
-
-credentials = CDO.db_credential_reader
-dashboard_reporting_connection_settings = URI::Generic.build(
-  scheme: 'mysql',
-  userinfo: credentials['username'] + ':' + credentials['password'],
-  host: CDO.db_endpoint_proxy_reporting,
-  port: CDO.db_endpoint_proxy_reporting_port,
-  path: '/' + CDO.dashboard_db_name
-)
-DASHBOARD_REPORTING_DB_READER = Cdo::Sequel.database_connection_pool dashboard_reporting_connection_settings, dashboard_reporting_connection_settings


### PR DESCRIPTION
Add the `:reporting` role so our ActiveRecord queries can optionally target our reporting database for long queries.

## Links
Inspired by these PR's:
* https://github.com/code-dot-org/code-dot-org/blob/e92e57b18607fe060c6d052c4ed5bd1506443abf/dashboard/config/database.yml#L63-L74
* https://github.com/code-dot-org/code-dot-org/blob/e92e57b18607fe060c6d052c4ed5bd1506443abf/dashboard/app/models/application_record.rb#L4-L7

## Testing story
* Unit tests
* Provision an adhoc to exercise the CloudFormation changes (`bundle exec rake adhoc:start RAILS_ENV=adhoc DATABASE=yes STACK_NAME=adhoc-configure-db-port`) and set Gatekeeper setting `dashboard_read_replica` to true


bin/mysql-client-dashboard-reporting
```sql

mysql> SELECT @@max_execution_time;
+----------------------+
| @@max_execution_time |
+----------------------+
|                    0 |
+----------------------+
1 row in set (0.01 sec)

mysql> SELECT @@aurora_read_replica_read_committed;
+--------------------------------------+
| @@aurora_read_replica_read_committed |
+--------------------------------------+
|                                    1 |
+--------------------------------------+
1 row in set (0.01 sec)

mysql> SELECT @@transaction_isolation;
+-------------------------+
| @@transaction_isolation |
+-------------------------+
| READ-COMMITTED          |
+-------------------------+
1 row in set (0.00 sec)
````
