### PR TITLE
Neighborhood maze generator: correctly set tile type

### DIFF
--- a/apps/src/lab2/levelEditors/neighborhood/NeighborhoodMazeGenerator.tsx
+++ b/apps/src/lab2/levelEditors/neighborhood/NeighborhoodMazeGenerator.tsx
@@ -90,6 +90,7 @@ const NeighborhoodMazeGenerator: React.FunctionComponent<
       const newMaze = maze.map((rowDefinition, rowIndex) =>
         rowDefinition.map((cell, columnIndex) => {
           if (rowIndex === row && columnIndex === column) {
+            // Most assets should be designated as tileType 0 (wall), but a few have different tile types.
             const tileType = customTileTypes[selectedAsset] || 0;
             return {...cell, tileType, assetId: selectedAsset, value};
           }

--- a/apps/src/lab2/levelEditors/neighborhood/NeighborhoodMazeGenerator.tsx
+++ b/apps/src/lab2/levelEditors/neighborhood/NeighborhoodMazeGenerator.tsx
@@ -6,7 +6,7 @@ import FontAwesomeV6Icon from '@cdo/apps/componentLibrary/fontAwesomeV6Icon/Font
 import {MazeCell} from '@cdo/apps/lab2/types';
 import CollapsibleSection from '@cdo/apps/templates/CollapsibleSection';
 
-import {categories, imageTiles} from './constants';
+import {categories, customTileTypes, imageTiles} from './constants';
 
 import moduleStyles from './neighborhood-maze-generator.module.scss';
 
@@ -90,7 +90,8 @@ const NeighborhoodMazeGenerator: React.FunctionComponent<
       const newMaze = maze.map((rowDefinition, rowIndex) =>
         rowDefinition.map((cell, columnIndex) => {
           if (rowIndex === row && columnIndex === column) {
-            return {...cell, assetId: selectedAsset, value};
+            const tileType = customTileTypes[selectedAsset] || 0;
+            return {...cell, tileType, assetId: selectedAsset, value};
           }
           return cell;
         })

--- a/apps/src/lab2/levelEditors/neighborhood/constants.ts
+++ b/apps/src/lab2/levelEditors/neighborhood/constants.ts
@@ -20,7 +20,7 @@ export const categories: Record<string, TileDefinition> = {
   Wall: {min: 62, max: 90},
 };
 
-// Map of asset ids to tile types for all assets that are not obstacles (tile type 0).
+// Map of asset ids to tile types for all assets that are not "walls" (tile type 0).
 export const customTileTypes: Record<number, number> = {
   // Painter is a "start" tile. Painter assets are 287-291.
   287: 2,

--- a/apps/src/lab2/levelEditors/neighborhood/constants.ts
+++ b/apps/src/lab2/levelEditors/neighborhood/constants.ts
@@ -22,11 +22,11 @@ export const categories: Record<string, TileDefinition> = {
 
 // Map of asset ids to tile types for all assets that are not "walls" (tile type 0).
 export const customTileTypes: Record<number, number> = {
-  // Painter is a "start" tile. Painter assets are 287-291.
+  // Painter is a "start" tile. Painter assets are 287-290.
   287: 2,
   288: 2,
+  289: 2,
   290: 2,
-  291: 2,
   // Paint bucket is an open tile.
   303: 1,
   // Street tile is an open tile.

--- a/apps/src/lab2/levelEditors/neighborhood/constants.ts
+++ b/apps/src/lab2/levelEditors/neighborhood/constants.ts
@@ -20,6 +20,19 @@ export const categories: Record<string, TileDefinition> = {
   Wall: {min: 62, max: 90},
 };
 
+// Map of asset ids to tile types for all assets that are not obstacles (tile type 0).
+export const customTileTypes: Record<number, number> = {
+  // Painter is a "start" tile. Painter assets are 287-291.
+  287: 2,
+  288: 2,
+  290: 2,
+  291: 2,
+  // Paint bucket is an open tile.
+  303: 1,
+  // Street tile is an open tile.
+  0: 1,
+};
+
 export const imageTiles = [
   'https://images.code.org/306af44a63cacdc47292475c186372c0-image-1618605886924.png' /*0-street*/,
   'https://images.code.org/8ff6eb2a55a083df97b8f539ca4e0cd1-image-1617321949719.png' /*1-Ntaxi2*/,


### PR DESCRIPTION
Follow up to #63294
I forgot that we needed to update the tile type to indicate if the tile is a wall or not. This PR properly sets the tile type. There's only a few assets that are not walls; the empty street tile, the painter (which is a "start" tile), and the paint bucket. Therefore I made a small object that maps asset id -> tile type for all non-wall tiles, and everything else is designated as a wall (tile type 0). 

## Testing story
Tested that most assets are now considered walls in the generated json.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
