### PR TITLE
Fix a bug where the elementary curriculum tab would not automatically open in settings

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -44,10 +44,6 @@ const CURRICULUM_TYPES_FOR_AUDIENCE = {
   [MARKETING_AUDIENCE.PL]: null,
 };
 
-const selectedSectionFromGroup = (courseGroup, selectedCourseId) => {
-  return _.find(courseGroup, course => selectedCourseId === course.id);
-};
-
 export default function CurriculumQuickAssign({
   isNewSection,
   updateSection,
@@ -151,13 +147,13 @@ export default function CurriculumQuickAssign({
       for (const courseGroup of Object.values(
         filteredCourseOfferings[audience][curriculumType]
       )) {
-        const course = selectedSectionFromGroup(
+        const selectedCourse = _.find(
           courseGroup,
-          sectionCourse?.courseOfferingId
+          course => sectionCourse?.courseOfferingId === course.id
         );
 
-        if (course) {
-          return course;
+        if (selectedCourse) {
+          return selectedCourse;
         }
       }
       return null;
@@ -170,19 +166,19 @@ export default function CurriculumQuickAssign({
       const curriculumTypes = CURRICULUM_TYPES_FOR_AUDIENCE[audience];
 
       if (!curriculumTypes) {
-        const course = selectedSectionFromGroup(
+        const selectedCourse = _.find(
           filteredCourseOfferings[audience],
-          sectionCourse?.courseOfferingId
+          course => sectionCourse?.courseOfferingId === course.id
         );
-        return course ? {course, audience} : null;
+        return selectedCourse ? {selectedCourse, audience} : null;
       }
       for (const curriculumType of curriculumTypes) {
-        const course = selectedSectionFromCurriculumType(
+        const selectedCourse = selectedSectionFromCurriculumType(
           audience,
           curriculumType
         );
-        if (course) {
-          return {course, audience};
+        if (selectedCourse) {
+          return {selectedCourse, audience};
         }
       }
 

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -138,60 +138,45 @@ export default function CurriculumQuickAssign({
     setFilteredCourseOfferings(filterOfferings(courseOfferings));
   }, [courseOfferings, courseFilters?.language]);
 
-  const selectedSectionFromCurriculumType = useCallback(
-    (audience, curriculumType) => {
-      if (!filteredCourseOfferings[audience][curriculumType]) {
-        return null;
-      }
-
-      for (const courseGroup of Object.values(
-        filteredCourseOfferings[audience][curriculumType]
-      )) {
-        const selectedCourse = _.find(
-          courseGroup,
-          course => sectionCourse?.courseOfferingId === course.id
-        );
-
-        if (selectedCourse) {
-          return selectedCourse;
-        }
-      }
-      return null;
-    },
-    [filteredCourseOfferings, sectionCourse]
-  );
-
-  const selectedSectionFromAudience = useCallback(
+  const getCoursesForAudience = useCallback(
     audience => {
       const curriculumTypes = CURRICULUM_TYPES_FOR_AUDIENCE[audience];
 
       if (!curriculumTypes) {
-        const selectedCourse = _.find(
-          filteredCourseOfferings[audience],
-          course => sectionCourse?.courseOfferingId === course.id
-        );
-        return selectedCourse ? {selectedCourse, audience} : null;
-      }
-      for (const curriculumType of curriculumTypes) {
-        const selectedCourse = selectedSectionFromCurriculumType(
-          audience,
-          curriculumType
-        );
-        if (selectedCourse) {
-          return {selectedCourse, audience};
-        }
+        // hoc and pl have no curriculum types and just have a list of curriculum in filteredCourseOfferings
+        return filteredCourseOfferings[audience];
       }
 
-      return null;
+      // return a flattened array of all courses for the given audience
+      return _.flatten(
+        curriculumTypes.flatMap(curriculumType => {
+          if (filteredCourseOfferings[audience][curriculumType]) {
+            return Object.values(
+              filteredCourseOfferings[audience][curriculumType]
+            );
+          }
+          return [];
+        })
+      );
     },
-    [filteredCourseOfferings, sectionCourse, selectedSectionFromCurriculumType]
+    [filteredCourseOfferings]
+  );
+
+  const selectedSectionFromAudience = useCallback(
+    audience => {
+      return _.find(
+        getCoursesForAudience(audience),
+        course => sectionCourse?.courseOfferingId === course.id
+      );
+    },
+    [sectionCourse, getCoursesForAudience]
   );
 
   const getSelectedCourseOffering = useCallback(() => {
     for (const audience of Object.keys(filteredCourseOfferings)) {
-      const result = selectedSectionFromAudience(audience);
-      if (result) {
-        return result;
+      const selectedCourse = selectedSectionFromAudience(audience);
+      if (selectedCourse) {
+        return {course: selectedCourse, audience};
       }
     }
 

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -26,22 +26,26 @@ export const MARKETING_AUDIENCE = {
   PL: 'pl',
 };
 const CURRICULUM_TYPES_FOR_AUDIENCE = {
-  // [MARKETING_AUDIENCE.HIGH]: [
-  //   curriculumTypes.course,
-  //   curriculumTypes.standalone_unit,
-  //   curriculumTypes.module,
-  // ],
-  // [MARKETING_AUDIENCE.MIDDLE]: [
-  //   curriculumTypes.course,
-  //   curriculumTypes.standalone_unit,
-  //   curriculumTypes.module,
-  // ],
+  [MARKETING_AUDIENCE.HIGH]: [
+    curriculumTypes.course,
+    curriculumTypes.standalone_unit,
+    curriculumTypes.module,
+  ],
+  [MARKETING_AUDIENCE.MIDDLE]: [
+    curriculumTypes.course,
+    curriculumTypes.standalone_unit,
+    curriculumTypes.module,
+  ],
   [MARKETING_AUDIENCE.ELEMENTARY]: [
     curriculumTypes.course,
     curriculumTypes.module,
   ],
-  // [MARKETING_AUDIENCE.HOC]: null,
-  // [MARKETING_AUDIENCE.PL]: null,
+  [MARKETING_AUDIENCE.HOC]: null,
+  [MARKETING_AUDIENCE.PL]: null,
+};
+
+const selectedSectionFromGroup = (courseGroup, selectedCourseId) => {
+  return _.find(courseGroup, course => selectedCourseId === course.id);
 };
 
 export default function CurriculumQuickAssign({
@@ -138,15 +142,8 @@ export default function CurriculumQuickAssign({
     setFilteredCourseOfferings(filterOfferings(courseOfferings));
   }, [courseOfferings, courseFilters?.language]);
 
-  const getSelectedCourseOffering = useCallback(() => {
-    const selectedSectionFromGroup = courseGroup => {
-      return _.find(
-        courseGroup,
-        course => sectionCourse?.courseOfferingId === course.id
-      );
-    };
-
-    const selectedSectionFromCurriculumType = (audience, curriculumType) => {
+  const selectedSectionFromCurriculumType = useCallback(
+    (audience, curriculumType) => {
       if (!filteredCourseOfferings[audience][curriculumType]) {
         return null;
       }
@@ -154,23 +151,28 @@ export default function CurriculumQuickAssign({
       for (const courseGroup of Object.values(
         filteredCourseOfferings[audience][curriculumType]
       )) {
-        const course = selectedSectionFromGroup(courseGroup);
+        const course = selectedSectionFromGroup(
+          courseGroup,
+          sectionCourse?.courseOfferingId
+        );
 
-        console.log('lfm 3', course);
         if (course) {
-          console.log('lfm 4', course);
           return course;
         }
       }
       return null;
-    };
+    },
+    [filteredCourseOfferings, sectionCourse]
+  );
 
-    const selectedSectionFromAudience = audience => {
+  const selectedSectionFromAudience = useCallback(
+    audience => {
       const curriculumTypes = CURRICULUM_TYPES_FOR_AUDIENCE[audience];
 
       if (!curriculumTypes) {
         const course = selectedSectionFromGroup(
-          filteredCourseOfferings[audience]
+          filteredCourseOfferings[audience],
+          sectionCourse?.courseOfferingId
         );
         return course ? {course, audience} : null;
       }
@@ -179,16 +181,17 @@ export default function CurriculumQuickAssign({
           audience,
           curriculumType
         );
-        console.log('lfm 2', course);
         if (course) {
-          console.log('lfm 1', course);
           return {course, audience};
         }
       }
 
       return null;
-    };
+    },
+    [filteredCourseOfferings, sectionCourse, selectedSectionFromCurriculumType]
+  );
 
+  const getSelectedCourseOffering = useCallback(() => {
     for (const audience of Object.keys(filteredCourseOfferings)) {
       const result = selectedSectionFromAudience(audience);
       if (result) {
@@ -197,7 +200,7 @@ export default function CurriculumQuickAssign({
     }
 
     return null;
-  }, [filteredCourseOfferings, sectionCourse]);
+  }, [filteredCourseOfferings, selectedSectionFromAudience]);
 
   useEffect(() => {
     if (!filteredCourseOfferings) return;
@@ -205,7 +208,6 @@ export default function CurriculumQuickAssign({
       const determineSelectedCourseOffering = () => {
         const selection = getSelectedCourseOffering(filteredCourseOfferings);
 
-        console.log('lfm 0', selection);
         if (selection) {
           setSelectedCourseOffering(selection.course);
           updateSectionCourseForExistingSections(selection.course);

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {useState, useEffect, useCallback} from 'react';
 
@@ -23,6 +24,24 @@ export const MARKETING_AUDIENCE = {
   HIGH: 'high',
   HOC: 'hoc',
   PL: 'pl',
+};
+const CURRICULUM_TYPES_FOR_AUDIENCE = {
+  // [MARKETING_AUDIENCE.HIGH]: [
+  //   curriculumTypes.course,
+  //   curriculumTypes.standalone_unit,
+  //   curriculumTypes.module,
+  // ],
+  // [MARKETING_AUDIENCE.MIDDLE]: [
+  //   curriculumTypes.course,
+  //   curriculumTypes.standalone_unit,
+  //   curriculumTypes.module,
+  // ],
+  [MARKETING_AUDIENCE.ELEMENTARY]: [
+    curriculumTypes.course,
+    curriculumTypes.module,
+  ],
+  // [MARKETING_AUDIENCE.HOC]: null,
+  // [MARKETING_AUDIENCE.PL]: null,
 };
 
 export default function CurriculumQuickAssign({
@@ -119,67 +138,84 @@ export default function CurriculumQuickAssign({
     setFilteredCourseOfferings(filterOfferings(courseOfferings));
   }, [courseOfferings, courseFilters?.language]);
 
+  const getSelectedCourseOffering = useCallback(() => {
+    const selectedSectionFromGroup = courseGroup => {
+      return _.find(
+        courseGroup,
+        course => sectionCourse?.courseOfferingId === course.id
+      );
+    };
+
+    const selectedSectionFromCurriculumType = (audience, curriculumType) => {
+      if (!filteredCourseOfferings[audience][curriculumType]) {
+        return null;
+      }
+
+      for (const courseGroup of Object.values(
+        filteredCourseOfferings[audience][curriculumType]
+      )) {
+        const course = selectedSectionFromGroup(courseGroup);
+
+        console.log('lfm 3', course);
+        if (course) {
+          console.log('lfm 4', course);
+          return course;
+        }
+      }
+      return null;
+    };
+
+    const selectedSectionFromAudience = audience => {
+      const curriculumTypes = CURRICULUM_TYPES_FOR_AUDIENCE[audience];
+
+      if (!curriculumTypes) {
+        const course = selectedSectionFromGroup(
+          filteredCourseOfferings[audience]
+        );
+        return course ? {course, audience} : null;
+      }
+      for (const curriculumType of curriculumTypes) {
+        const course = selectedSectionFromCurriculumType(
+          audience,
+          curriculumType
+        );
+        console.log('lfm 2', course);
+        if (course) {
+          console.log('lfm 1', course);
+          return {course, audience};
+        }
+      }
+
+      return null;
+    };
+
+    for (const audience of Object.keys(filteredCourseOfferings)) {
+      const result = selectedSectionFromAudience(audience);
+      if (result) {
+        return result;
+      }
+    }
+
+    return null;
+  }, [filteredCourseOfferings, sectionCourse]);
+
   useEffect(() => {
     if (!filteredCourseOfferings) return;
     if (!isNewSection) {
-      //  TO DO: refactor for efficiency.  Consider using a flatten-like function (maybe in a helper file?)
-      const highData = {
-        ...filteredCourseOfferings[MARKETING_AUDIENCE.HIGH][
-          curriculumTypes.course
-        ],
-        ...filteredCourseOfferings[MARKETING_AUDIENCE.HIGH][
-          curriculumTypes.standalone_unit
-        ],
-        ...filteredCourseOfferings[MARKETING_AUDIENCE.HIGH][
-          curriculumTypes.module
-        ],
-      };
-      const middleData = {
-        ...filteredCourseOfferings[MARKETING_AUDIENCE.MIDDLE][
-          curriculumTypes.course
-        ],
-        ...filteredCourseOfferings[MARKETING_AUDIENCE.MIDDLE][
-          curriculumTypes.standalone_unit
-        ],
-        ...filteredCourseOfferings[MARKETING_AUDIENCE.MIDDLE][
-          curriculumTypes.module
-        ],
-      };
-      const elementaryData = {
-        ...filteredCourseOfferings[MARKETING_AUDIENCE.ELEMENTARY][
-          curriculumTypes.course
-        ],
-        ...filteredCourseOfferings[MARKETING_AUDIENCE.ELEMENTARY][
-          curriculumTypes.module
-        ],
-      };
-      const hocData = {...filteredCourseOfferings[MARKETING_AUDIENCE.HOC]};
-      const plData = {...filteredCourseOfferings[MARKETING_AUDIENCE.PL]};
+      const determineSelectedCourseOffering = () => {
+        const selection = getSelectedCourseOffering(filteredCourseOfferings);
 
-      const determineSelectedCourseOffering = (startingData, audience) => {
-        const headers = Object.keys(startingData);
-
-        headers.forEach(header => {
-          const courseDataByHeaderValues = Object.values(startingData[header]);
-          courseDataByHeaderValues.forEach(course => {
-            if (sectionCourse?.courseOfferingId === course.id) {
-              setSelectedCourseOffering(course);
-              updateSectionCourseForExistingSections(course);
-              setMarketingAudience(audience);
-            }
-          });
-        });
+        console.log('lfm 0', selection);
+        if (selection) {
+          setSelectedCourseOffering(selection.course);
+          updateSectionCourseForExistingSections(selection.course);
+          setMarketingAudience(selection.audience);
+          return;
+        }
       };
 
       if (!selectedCourseOffering) {
-        determineSelectedCourseOffering(highData, MARKETING_AUDIENCE.HIGH);
-        determineSelectedCourseOffering(middleData, MARKETING_AUDIENCE.MIDDLE);
-        determineSelectedCourseOffering(
-          elementaryData,
-          MARKETING_AUDIENCE.ELEMENTARY
-        );
-        determineSelectedCourseOffering(hocData, MARKETING_AUDIENCE.HOC);
-        determineSelectedCourseOffering(plData, MARKETING_AUDIENCE.PL);
+        determineSelectedCourseOffering(filteredCourseOfferings);
       }
     }
     // added all these dependencies given the eslint warning
@@ -190,6 +226,7 @@ export default function CurriculumQuickAssign({
     selectedCourseOffering,
     updateSection,
     updateSectionCourseForExistingSections,
+    getSelectedCourseOffering,
   ]);
 
   const updateSectionCourseForExistingSections = useCallback(


### PR DESCRIPTION
This bug was caused by two section under elementary curriculum both having the same name `CS foundations`. The second would overwrite the first and if the selected curriculum was in the first section, it would not be found.

This PR fixes the above bug by preventing overwrites with name conflicts and attempts to speed up the operation to find the selected section by providing an early return.


https://github.com/user-attachments/assets/11f33918-f091-4ce5-ae10-cdfe6cf2cbee

## Links
https://codedotorg.atlassian.net/browse/TEACH-1500
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
