### PR TITLE
Hide remember to save message when fields hidden on setup customization

### DIFF
--- a/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
+++ b/apps/src/aichat/views/modelCustomization/SetupCustomization.tsx
@@ -72,11 +72,11 @@ const SetupCustomization: React.FunctionComponent = () => {
 
   const readOnlyWorkspace: boolean = useSelector(isReadOnlyWorkspace);
 
-  const allFieldsDisabled =
-    (isDisabled(temperature) &&
-      isDisabled(systemPrompt) &&
-      isDisabled(selectedModelId)) ||
-    readOnlyWorkspace;
+  const anyFieldEditable =
+    (isEditable(temperature) ||
+      isEditable(systemPrompt) ||
+      isEditable(selectedModelId)) &&
+    !readOnlyWorkspace;
 
   const renderChooseAndCompareModels = () => {
     return (
@@ -209,9 +209,9 @@ const SetupCustomization: React.FunctionComponent = () => {
         )}
       </div>
       <div className={styles.footerButtonContainer}>
-        <UpdateButton isDisabledDefault={allFieldsDisabled} />
+        <UpdateButton isDisabledDefault={!anyFieldEditable} />
       </div>
-      <SaveChangesAlerts isReadOnly={allFieldsDisabled} />
+      <SaveChangesAlerts isReadOnly={!anyFieldEditable} />
     </div>
   );
 };


### PR DESCRIPTION
In the "Setup" tab of the model customization panel, hide the save message reminder if all of the fields are hidden or read only. Prior to this change, the save message reminder showed up if a level had some fields hidden and others read only.

No change required to other tabs, as the whole tab is hidden if the associated field is hidden (ie, the other tabs have a 1:1 relationship between tab and field).

## Links

- jira ticket: https://codedotorg.atlassian.net/browse/LABS-1174

## Testing story

Tested manually on http://localhost-studio.code.org:9000/s/customizing-llms-2024/lessons/6/levels/4, where this issue was reported.