### PR TITLE
Python Neighborhood: Add GridFactory and World

### DIFF
--- a/apps/lib/pyodide/neighborhood-0.1.0-py3-none-any.whl
+++ b/apps/lib/pyodide/neighborhood-0.1.0-py3-none-any.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7789a722a5fd361573d87965348f75cc4f7cd64abff075c31c68297bde98be36
-size 7143

--- a/apps/lib/pyodide/neighborhood-0.2.0-py3-none-any.whl
+++ b/apps/lib/pyodide/neighborhood-0.2.0-py3-none-any.whl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d80ff59b6baed372763190398c09c6846cdf3e86f9e39236dd5bd1fd7e8c9256
-size 8568
+oid sha256:79d3d192bb62969ef2cdbd1c12d35d1d93c5c5fac85aabb0b7f1db6c76909147
+size 9154

--- a/apps/lib/pyodide/neighborhood-0.2.0-py3-none-any.whl
+++ b/apps/lib/pyodide/neighborhood-0.2.0-py3-none-any.whl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:79d3d192bb62969ef2cdbd1c12d35d1d93c5c5fac85aabb0b7f1db6c76909147
-size 9154
+oid sha256:a17c18d5902bb7af5d4d1ebe60663732e8f13f3821399efb989482676f4dafde
+size 9305

--- a/apps/lib/pyodide/neighborhood-0.2.0-py3-none-any.whl
+++ b/apps/lib/pyodide/neighborhood-0.2.0-py3-none-any.whl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a17c18d5902bb7af5d4d1ebe60663732e8f13f3821399efb989482676f4dafde
-size 9305
+oid sha256:19bf66975b7d8c8de5976935d346fb2487c64733345cf02cb8d5c9e8ebc58b9f
+size 9246

--- a/apps/lib/pyodide/neighborhood-0.2.0-py3-none-any.whl
+++ b/apps/lib/pyodide/neighborhood-0.2.0-py3-none-any.whl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d80ff59b6baed372763190398c09c6846cdf3e86f9e39236dd5bd1fd7e8c9256
+size 8568

--- a/apps/src/pythonlab/pyodideWebWorker.ts
+++ b/apps/src/pythonlab/pyodideWebWorker.ts
@@ -39,7 +39,7 @@ async function loadPyodideAndPackages() {
     // https://github.com/code-dot-org/pythonlab-packages
     `/blockly/js/pyodide/${version}/unittest_runner-0.1.0-py3-none-any.whl`,
     `/blockly/js/pyodide/${version}/pythonlab_setup-0.1.0-py3-none-any.whl`,
-    `/blockly/js/pyodide/${version}/neighborhood-0.1.0-py3-none-any.whl`,
+    `/blockly/js/pyodide/${version}/neighborhood-0.2.0-py3-none-any.whl`,
   ]);
   // Warm up the pyodide environment by running setup code.
   await runInternalCode(SETUP_CODE, -1);

--- a/python/pythonlab/neighborhood/neighborhood/__init__.py
+++ b/python/pythonlab/neighborhood/neighborhood/__init__.py
@@ -1,2 +1,1 @@
 from .painter import Painter as Painter
-from .support.grid_factory import GridFactory as GridFactory

--- a/python/pythonlab/neighborhood/neighborhood/__init__.py
+++ b/python/pythonlab/neighborhood/neighborhood/__init__.py
@@ -1,1 +1,2 @@
 from .painter import Painter as Painter
+from .support.grid_factory import GridFactory as GridFactory

--- a/python/pythonlab/neighborhood/neighborhood/painter.py
+++ b/python/pythonlab/neighborhood/neighborhood/painter.py
@@ -18,6 +18,10 @@ class Painter:
     self.y = y
     self.direction = direction
     self.remaining_paint = paint
+    self.world = World()
+    # If we haven't set up the grid yet, do so now from the default file.
+    if (self.world.grid is None):
+      self.world.set_grid_from_file()
 
   def turn_left(self):
     """

--- a/python/pythonlab/neighborhood/neighborhood/painter.py
+++ b/python/pythonlab/neighborhood/neighborhood/painter.py
@@ -1,7 +1,6 @@
 from .support.neighborhood_signal_key import NeighborhoodSignalKey
 from .support.signal_message_type import SignalMessageType
 from .support.neighborhood_signal_message import NeighborhoodSignalMessage
-from .support.world import World
 
 class Painter:
   def __init__(self, x=0, y=0, direction="East", paint=0):
@@ -18,10 +17,6 @@ class Painter:
     self.y = y
     self.direction = direction
     self.remaining_paint = paint
-    self.world = World()
-    # If we haven't set up the grid yet, do so now from the default file.
-    if (self.world.grid is None):
-      self.world.set_grid_from_file()
 
   def turn_left(self):
     """

--- a/python/pythonlab/neighborhood/neighborhood/painter.py
+++ b/python/pythonlab/neighborhood/neighborhood/painter.py
@@ -1,6 +1,7 @@
 from .support.neighborhood_signal_key import NeighborhoodSignalKey
 from .support.signal_message_type import SignalMessageType
 from .support.neighborhood_signal_message import NeighborhoodSignalMessage
+from .support.world import World
 
 class Painter:
   def __init__(self, x=0, y=0, direction="East", paint=0):

--- a/python/pythonlab/neighborhood/neighborhood/support/grid.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid.py
@@ -1,12 +1,16 @@
 from .neighborhood_runtime_exception import NeighborhoodRuntimeException
 from .exception_key import ExceptionKey
 from .grid_square import GridSquare
+from .grid_helpers import is_square_2d_array
 
 class Grid:
     def __init__(self, squares: list[list[GridSquare]]):
         self.grid = squares
+        # The grid should not be empty.
+        if len(squares) == 0:
+            raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is empty")
         # The grid should always be a square.
-        if not self.is_square_grid(squares):
+        if not is_square_2d_array(squares):
             raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is not a square")
         self.size = len(squares)
         
@@ -29,9 +33,3 @@ class Grid:
     def get_size(self) -> int:
         return self.size
 
-    def is_square_grid(self, squares: list[list[GridSquare]]) -> bool:
-        height = len(squares)
-        for y in range(height):
-            if len(squares[y]) != height:
-                return False
-        return True

--- a/python/pythonlab/neighborhood/neighborhood/support/grid.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid.py
@@ -5,7 +5,7 @@ from .grid_helpers import GridHelpers
 
 class Grid:
     def __init__(self, squares: list[list[GridSquare]]):
-        self.grid = squares
+        self.grid_squares = squares
         # The grid should not be empty.
         if len(squares) == 0:
             raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is empty")
@@ -17,16 +17,16 @@ class Grid:
 
     def print_grid(self):
         for y in range(self.size):
-            squares = [self.grid[x][y].get_printable_description() for x in range(self.size)]
+            squares = [self.grid_squares[x][y].get_printable_description() for x in range(self.size)]
             print(",".join(squares))
 
     def valid_location(self, x: int, y: int) -> bool:
         # A coordinate cannot be moved into if it is out of range or if the tile is not passable
-        return 0 <= x < self.size and 0 <= y < self.size and self.grid[x][y].is_passable()
+        return 0 <= x < self.size and 0 <= y < self.size and self.grid_squares[x][y].is_passable()
 
     def get_square(self, x: int, y: int) -> GridSquare:
         if self.valid_location(x, y):
-            return self.grid[x][y]
+            return self.grid_squares[x][y]
         else:
             raise NeighborhoodRuntimeException(ExceptionKey.GET_SQUARE_FAILED)
 

--- a/python/pythonlab/neighborhood/neighborhood/support/grid.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid.py
@@ -1,7 +1,7 @@
 from .neighborhood_runtime_exception import NeighborhoodRuntimeException
 from .exception_key import ExceptionKey
 from .grid_square import GridSquare
-from .grid_helpers import is_square_2d_array
+from .grid_helpers import GridHelpers
 
 class Grid:
     def __init__(self, squares: list[list[GridSquare]]):
@@ -10,7 +10,7 @@ class Grid:
         if len(squares) == 0:
             raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is empty")
         # The grid should always be a square.
-        if not is_square_2d_array(squares):
+        if not GridHelpers.is_square_2d_array(squares):
             raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is not a square")
         self.size = len(squares)
         

--- a/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
@@ -18,43 +18,39 @@ class GridFactory:
   def create_grid_from_string(self, description: str) -> Grid:
       try:
           grid_squares = json.loads(description)
-          height = len(grid_squares)
-          if height == 0:
+          size = len(grid_squares)
+          if size == 0:
               raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is empty")
           
-          if not is_square_2d_array(grid_squares)
+          if not is_square_2d_array(grid_squares):
               raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is not a square")
           
-          # # Initialize the grid array (list of lists in Python)
-          # grid = [[None] * height for _ in range(width)]
+          grid = [[None for i in range(size)] for j in range(size)]
           
-          # # Iterate over each line and column to populate the grid
-          # for current_y in range(height):
-          #     line = grid_squares[current_y]
-          #     if len(line) != width:
-          #         raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
+          # Populate the grid with the parsed values
+          for current_y in range(size):
+              row = grid_squares[current_y]
               
-          #     for current_x in range(len(line)):
-          #         descriptor = line[current_x]
-          #         try:
-          #             # Parse the tile type and asset ID
-          #             tile_type = int(descriptor[self.GRID_SQUARE_TYPE_FIELD])
-          #             asset_id = 0
-          #             if self.GRID_SQUARE_ASSET_ID_FIELD in descriptor:
-          #                 asset_id = int(descriptor[self.GRID_SQUARE_ASSET_ID_FIELD])
-                      
-          #             # Parse the value if it exists
-          #             if self.GRID_SQUARE_VALUE_FIELD in descriptor:
-          #                 value = int(descriptor[self.GRID_SQUARE_VALUE_FIELD])
-          #                 grid[current_x][current_y] = GridSquare(tile_type, asset_id, value)
-          #             else:
-          #                 grid[current_x][current_y] = GridSquare(tile_type, asset_id)
+              for current_x in range(len(row)):
+                  square_descriptor = row[current_x]
+                  try:
+                      # Parse the tile type and asset ID
+                      tile_type = int(square_descriptor[self.GRID_SQUARE_TYPE_FIELD])
+                      asset_id = 0
+                      if self.GRID_SQUARE_ASSET_ID_FIELD in square_descriptor:
+                          asset_id = int(square_descriptor[self.GRID_SQUARE_ASSET_ID_FIELD])
+
+                      value = None
+                      # Parse the value if it exists
+                      if self.GRID_SQUARE_VALUE_FIELD in square_descriptor:
+                          value = int(square_descriptor[self.GRID_SQUARE_VALUE_FIELD])
+
+                      grid[current_x][current_y] = GridSquare(tile_type, asset_id, value)
                   
-          #         except (ValueError, KeyError) as e:
-          #             raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID) from e
+                  except (ValueError, KeyError):
+                      raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
           
-          # Return the grid as a Grid object
-          # return Grid(grid)
+          return Grid(grid)
       
       except json.JSONDecodeError:
           raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)

--- a/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
@@ -7,14 +7,15 @@ from .grid_square import GridSquare
 from .neighborhood_runtime_exception import NeighborhoodRuntimeException
 
 class GridFactory:
-  GRID_FILE_NAME = 'serialized_maze.txt'
+  DEFAULT_GRID_FILE_NAME = 'serialized_maze.txt'
   GRID_SQUARE_TYPE_FIELD = 'tileType'
   GRID_SQUARE_ASSET_ID_FIELD = 'assetId'
   GRID_SQUARE_VALUE_FIELD = 'value'
 
-  def create_grid_from_file(self) -> Grid:
+  def create_grid_from_file(self, filename: str | None) -> Grid:
     try:
-        with open(self.GRID_FILE_NAME, 'r') as file:
+        file_to_open = filename if filename else self.DEFAULT_GRID_FILE_NAME
+        with open(file_to_open, 'r') as file:
           return self.create_grid_from_string(file.read())
     except FileNotFoundError:
         raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
@@ -62,6 +63,6 @@ class GridFactory:
       except json.JSONDecodeError:
           raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
       
-  def createEmptyGrid(self, size: int) -> Grid:
+  def create_empty_grid(self, size: int) -> Grid:
     grid = [[GridSquare(1, 0) for i in range(size)] for j in range(size)]
     return Grid(grid)

--- a/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
@@ -6,63 +6,68 @@ from .grid_helpers import is_square_2d_array
 from .grid_square import GridSquare
 from .neighborhood_runtime_exception import NeighborhoodRuntimeException
 
+DEFAULT_GRID_FILE_NAME = 'serialized_maze.txt'
+GRID_SQUARE_TYPE_FIELD = 'tileType'
+GRID_SQUARE_ASSET_ID_FIELD = 'assetId'
+GRID_SQUARE_VALUE_FIELD = 'value'
+
 class GridFactory:
-  DEFAULT_GRID_FILE_NAME = 'serialized_maze.txt'
-  GRID_SQUARE_TYPE_FIELD = 'tileType'
-  GRID_SQUARE_ASSET_ID_FIELD = 'assetId'
-  GRID_SQUARE_VALUE_FIELD = 'value'
+    @staticmethod
+    def create_grid_from_file(filename: str | None = None) -> Grid:
+        try:
+            file_to_open = filename if filename else DEFAULT_GRID_FILE_NAME
+            with open(file_to_open, 'r') as file:
+                return GridFactory.create_grid_from_string(file.read())
+        except FileNotFoundError:
+            raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
 
-  def create_grid_from_file(self, filename: str | None) -> Grid:
-    try:
-        file_to_open = filename if filename else self.DEFAULT_GRID_FILE_NAME
-        with open(file_to_open, 'r') as file:
-          return self.create_grid_from_string(file.read())
-    except FileNotFoundError:
-        raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
+    # Creates a grid from a string, assuming that the string is a 2d array of JSON objects,
+    # with each JSON object containing an integer tileType and optionally an integer value
+    # corresponding with the paintCount for that tile.
+    @staticmethod
+    def create_grid_from_string(description: str) -> Grid:
+        try:
+            grid_squares = json.loads(description)
+            size = len(grid_squares)
+            if size == 0:
+                raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is empty")
+            
+            if not is_square_2d_array(grid_squares):
+                raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is not a square")
+            
+            grid = [[None for i in range(size)] for j in range(size)]
+            
+            # Populate the grid with the parsed values
+            for current_y in range(size):
+                row = grid_squares[current_y]
+                
+                for current_x in range(len(row)):
+                    square_descriptor = row[current_x]
+                    try:
+                        # Parse the tile type and asset ID
+                        tile_type = int(square_descriptor[GRID_SQUARE_TYPE_FIELD])
+                        asset_id = 0
+                        if GRID_SQUARE_ASSET_ID_FIELD in square_descriptor:
+                            asset_id = int(square_descriptor[GRID_SQUARE_ASSET_ID_FIELD])
 
-  # Creates a grid from a string, assuming that the string is a 2d array of JSON objects,
-  # with each JSON object containing an integer tileType and optionally an integer value
-  # corresponding with the paintCount for that tile.
-  def create_grid_from_string(self, description: str) -> Grid:
-      try:
-          grid_squares = json.loads(description)
-          size = len(grid_squares)
-          if size == 0:
-              raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is empty")
-          
-          if not is_square_2d_array(grid_squares):
-              raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is not a square")
-          
-          grid = [[None for i in range(size)] for j in range(size)]
-          
-          # Populate the grid with the parsed values
-          for current_y in range(size):
-              row = grid_squares[current_y]
-              
-              for current_x in range(len(row)):
-                  square_descriptor = row[current_x]
-                  try:
-                      # Parse the tile type and asset ID
-                      tile_type = int(square_descriptor[self.GRID_SQUARE_TYPE_FIELD])
-                      asset_id = 0
-                      if self.GRID_SQUARE_ASSET_ID_FIELD in square_descriptor:
-                          asset_id = int(square_descriptor[self.GRID_SQUARE_ASSET_ID_FIELD])
+                        value = None
+                        # Parse the value if it exists
+                        if GRID_SQUARE_VALUE_FIELD in square_descriptor:
+                            value = int(square_descriptor[GRID_SQUARE_VALUE_FIELD])
 
-                      value = None
-                      # Parse the value if it exists
-                      if self.GRID_SQUARE_VALUE_FIELD in square_descriptor:
-                          value = int(square_descriptor[self.GRID_SQUARE_VALUE_FIELD])
-
-                      grid[current_x][current_y] = GridSquare(tile_type, asset_id, value)
-                  
-                  except (ValueError, KeyError):
-                      raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
-          
-          return Grid(grid)
-      
-      except json.JSONDecodeError:
-          raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
-      
-  def create_empty_grid(self, size: int) -> Grid:
-    grid = [[GridSquare(1, 0) for i in range(size)] for j in range(size)]
-    return Grid(grid)
+                        grid[current_x][current_y] = GridSquare(tile_type, asset_id, value)
+                    
+                    except (ValueError, KeyError):
+                        raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
+            
+            return Grid(grid)
+        
+        except json.JSONDecodeError:
+            raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
+        
+    # Create a grid of a given size with empty grid squares.
+    # Used for testing.
+    @staticmethod
+    def create_empty_grid(size: int) -> Grid:
+        grid = [[GridSquare(1, 0) for i in range(size)] for j in range(size)]
+        return Grid(grid)

--- a/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
@@ -2,7 +2,7 @@ import json
 
 from .exception_key import ExceptionKey
 from .grid import Grid
-from .grid_helpers import is_square_2d_array
+from .grid_helpers import GridHelpers
 from .grid_square import GridSquare
 from .neighborhood_runtime_exception import NeighborhoodRuntimeException
 
@@ -14,6 +14,9 @@ GRID_SQUARE_VALUE_FIELD = 'value'
 class GridFactory:
     @staticmethod
     def create_grid_from_file(filename: str | None = None) -> Grid:
+        """
+        Creates a grid from a file. If a filename is not provided, the default file will be used.
+        """
         try:
             file_to_open = filename if filename else DEFAULT_GRID_FILE_NAME
             with open(file_to_open, 'r') as file:
@@ -21,18 +24,20 @@ class GridFactory:
         except FileNotFoundError:
             raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
 
-    # Creates a grid from a string, assuming that the string is a 2d array of JSON objects,
-    # with each JSON object containing an integer tileType and optionally an integer value
-    # corresponding with the paintCount for that tile.
     @staticmethod
     def create_grid_from_string(description: str) -> Grid:
+        """
+        Creates a grid from a string, assuming that the string is a 2d array of JSON objects,
+        with each JSON object containing an integer tileType and optionally an integer value
+        corresponding with the paintCount for that tile.
+        """
         try:
             grid_squares = json.loads(description)
             size = len(grid_squares)
             if size == 0:
                 raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is empty")
             
-            if not is_square_2d_array(grid_squares):
+            if not GridHelpers.is_square_2d_array(grid_squares):
                 raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is not a square")
             
             grid = [[None for i in range(size)] for j in range(size)]
@@ -64,10 +69,3 @@ class GridFactory:
         
         except json.JSONDecodeError:
             raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
-        
-    # Create a grid of a given size with empty grid squares.
-    # Used for testing.
-    @staticmethod
-    def create_empty_grid(size: int) -> Grid:
-        grid = [[GridSquare(1, 0) for i in range(size)] for j in range(size)]
-        return Grid(grid)

--- a/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
@@ -12,6 +12,13 @@ class GridFactory:
   GRID_SQUARE_ASSET_ID_FIELD = 'assetId'
   GRID_SQUARE_VALUE_FIELD = 'value'
 
+  def create_grid_from_file(self) -> Grid:
+    try:
+        with open(self.GRID_FILE_NAME, 'r') as file:
+          return self.create_grid_from_string(file.read())
+    except FileNotFoundError:
+        raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
+
   # Creates a grid from a string, assuming that the string is a 2d array of JSON objects,
   # with each JSON object containing an integer tileType and optionally an integer value
   # corresponding with the paintCount for that tile.
@@ -54,3 +61,7 @@ class GridFactory:
       
       except json.JSONDecodeError:
           raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
+      
+  def createEmptyGrid(self, size: int) -> Grid:
+    grid = [[GridSquare(1, 0) for i in range(size)] for j in range(size)]
+    return Grid(grid)

--- a/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid_factory.py
@@ -1,0 +1,60 @@
+import json
+
+from .exception_key import ExceptionKey
+from .grid import Grid
+from .grid_helpers import is_square_2d_array
+from .grid_square import GridSquare
+from .neighborhood_runtime_exception import NeighborhoodRuntimeException
+
+class GridFactory:
+  GRID_FILE_NAME = 'serialized_maze.txt'
+  GRID_SQUARE_TYPE_FIELD = 'tileType'
+  GRID_SQUARE_ASSET_ID_FIELD = 'assetId'
+  GRID_SQUARE_VALUE_FIELD = 'value'
+
+  # Creates a grid from a string, assuming that the string is a 2d array of JSON objects,
+  # with each JSON object containing an integer tileType and optionally an integer value
+  # corresponding with the paintCount for that tile.
+  def create_grid_from_string(self, description: str) -> Grid:
+      try:
+          grid_squares = json.loads(description)
+          height = len(grid_squares)
+          if height == 0:
+              raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is empty")
+          
+          if not is_square_2d_array(grid_squares)
+              raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID, "Grid is not a square")
+          
+          # # Initialize the grid array (list of lists in Python)
+          # grid = [[None] * height for _ in range(width)]
+          
+          # # Iterate over each line and column to populate the grid
+          # for current_y in range(height):
+          #     line = grid_squares[current_y]
+          #     if len(line) != width:
+          #         raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)
+              
+          #     for current_x in range(len(line)):
+          #         descriptor = line[current_x]
+          #         try:
+          #             # Parse the tile type and asset ID
+          #             tile_type = int(descriptor[self.GRID_SQUARE_TYPE_FIELD])
+          #             asset_id = 0
+          #             if self.GRID_SQUARE_ASSET_ID_FIELD in descriptor:
+          #                 asset_id = int(descriptor[self.GRID_SQUARE_ASSET_ID_FIELD])
+                      
+          #             # Parse the value if it exists
+          #             if self.GRID_SQUARE_VALUE_FIELD in descriptor:
+          #                 value = int(descriptor[self.GRID_SQUARE_VALUE_FIELD])
+          #                 grid[current_x][current_y] = GridSquare(tile_type, asset_id, value)
+          #             else:
+          #                 grid[current_x][current_y] = GridSquare(tile_type, asset_id)
+                  
+          #         except (ValueError, KeyError) as e:
+          #             raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID) from e
+          
+          # Return the grid as a Grid object
+          # return Grid(grid)
+      
+      except json.JSONDecodeError:
+          raise NeighborhoodRuntimeException(ExceptionKey.INVALID_GRID)

--- a/python/pythonlab/neighborhood/neighborhood/support/grid_helpers.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid_helpers.py
@@ -1,4 +1,9 @@
-def is_square_2d_array(squares: list[list[any]]) -> bool:
+class GridHelpers:
+    @staticmethod
+    def is_square_2d_array(squares: list[list[any]]) -> bool:
+        """
+        Validate the the given 2d array is a square.
+        """
         height = len(squares)
         for y in range(height):
             if len(squares[y]) != height:

--- a/python/pythonlab/neighborhood/neighborhood/support/grid_helpers.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid_helpers.py
@@ -1,0 +1,6 @@
+def is_square_2d_array(squares: list[list[any]]) -> bool:
+        height = len(squares)
+        for y in range(height):
+            if len(squares[y]) != height:
+                return False
+        return True

--- a/python/pythonlab/neighborhood/neighborhood/support/grid_square.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/grid_square.py
@@ -5,7 +5,7 @@ from .square_type import SquareType
 
 class GridSquare:
 
-    def __init__(self, tile_type: int, asset_id: int, value: int | None =0):
+    def __init__(self, tile_type: int, asset_id: int, value: int | None = 0):
         self.set_tile_type(tile_type)
         self.asset_id = asset_id
         self.paint_count = value

--- a/python/pythonlab/neighborhood/neighborhood/support/world.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/world.py
@@ -1,9 +1,13 @@
 from .grid_factory import GridFactory
 
-# A singleton class that represents the world of the neighborhood.
-# The first time it is created it will load the neighborhood grid from a file,
-# and all subsequent references will return the same instance.
 class World(object):
+  """
+  A singleton class that represents the world of the neighborhood.
+  The first time it is created it will set the grid to None. Users of the world
+  should check if the grid is None, and set it appropriately if it is.
+  All subsequent references will reuse the same grid, so multiple painters can operate
+  on the same grid.
+  """
   _instance = None
 
   def __new__(cls):

--- a/python/pythonlab/neighborhood/neighborhood/support/world.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/world.py
@@ -1,0 +1,19 @@
+from .grid_factory import GridFactory
+
+# A singleton class that represents the world of the neighborhood.
+# The first time it is created it will load the neighborhood grid from a file,
+# and all subsequent references will return the same instance.
+class World(object):
+  _instance = None
+
+  def __new__(cls):
+    if cls._instance is None:
+      cls._instance = super(World, cls).__new__(cls)
+      cls._instance.grid = None
+    return cls._instance
+  
+  def set_grid_from_file(self, filename: str | None = None):
+    self.grid = GridFactory.create_grid_from_file(filename)
+
+  def set_grid_from_string(self, description: str):
+    self.grid = GridFactory.create_grid_from_string(description)

--- a/python/pythonlab/neighborhood/neighborhood/support/world.py
+++ b/python/pythonlab/neighborhood/neighborhood/support/world.py
@@ -7,6 +7,7 @@ class World(object):
   should check if the grid is None, and set it appropriately if it is.
   All subsequent references will reuse the same grid, so multiple painters can operate
   on the same grid.
+  The grid can be removed by calling remove_grid.
   """
   _instance = None
 
@@ -21,3 +22,6 @@ class World(object):
 
   def set_grid_from_string(self, description: str):
     self.grid = GridFactory.create_grid_from_string(description)
+
+  def remove_grid(self):
+    self.grid = None

--- a/python/pythonlab/neighborhood/pyproject.toml
+++ b/python/pythonlab/neighborhood/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neighborhood"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = '>=3.12'
 dependencies = []
 

--- a/python/pythonlab/neighborhood/tests/support/constants.py
+++ b/python/pythonlab/neighborhood/tests/support/constants.py
@@ -1,0 +1,2 @@
+# 2x2 grid
+SAMPLE_MAZE = '[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":0,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]'

--- a/python/pythonlab/neighborhood/tests/support/serialized_maze.txt
+++ b/python/pythonlab/neighborhood/tests/support/serialized_maze.txt
@@ -1,0 +1,1 @@
+[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":0,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]

--- a/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
+++ b/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
@@ -7,30 +7,28 @@ from neighborhood.support.square_type import SquareType
 sample_maze = '[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":0,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]'
 
 def test_cannot_create_invalid_grid_from_string():
-  grid_factory = GridFactory()
   # non-square grid
   try:
-    grid_factory.create_grid_from_string('[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}], [{"tileType":1,"value":0,"assetId":0}]]')
+    GridFactory.create_grid_from_string('[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}], [{"tileType":1,"value":0,"assetId":0}]]')
     assert False
   except NeighborhoodRuntimeException as e:
     assert str(e) == "NeighborhoodRuntimeException: INVALID_GRID: Grid is not a square"
   # empty grid
   try:
-    grid_factory.create_grid_from_string('[]')
+    GridFactory.create_grid_from_string('[]')
     assert False
   except NeighborhoodRuntimeException as e: 
     assert str(e) == "NeighborhoodRuntimeException: INVALID_GRID: Grid is empty"
   # invalid configuration, missing a tile type
   invalid_grid = '[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}],[{"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]'
   try:
-    grid_factory.create_grid_from_string(invalid_grid)
+    GridFactory.create_grid_from_string(invalid_grid)
     assert False
   except NeighborhoodRuntimeException as e:
     assert str(e) == "NeighborhoodRuntimeException: INVALID_GRID"
 
 def test_can_create_valid_grid_from_string():
-  grid_factory = GridFactory()
-  grid = grid_factory.create_grid_from_string(sample_maze)
+  grid = GridFactory.create_grid_from_string(sample_maze)
   assert grid.get_size() == 2
   assert grid.valid_location(0, 0)
   assert grid.grid[0][0].asset_id == 0
@@ -41,9 +39,8 @@ def test_can_create_valid_grid_from_string():
   assert grid.grid[0][0].is_passable()
 
 def test_can_create_grid_from_json():
-  grid_factory = GridFactory()
   test_file_path = os.path.join(os.path.dirname(__file__), 'serialized_maze.txt')
-  grid = grid_factory.create_grid_from_file(test_file_path)
+  grid = GridFactory.create_grid_from_file(test_file_path)
   assert grid.get_size() == 2
   assert grid.valid_location(0, 0)
   assert grid.grid[0][0].asset_id == 0
@@ -54,8 +51,7 @@ def test_can_create_grid_from_json():
   assert grid.grid[0][0].is_passable()
 
 def test_can_create_empty_grid():
-  grid_factory = GridFactory()
-  grid = grid_factory.create_empty_grid(4)
+  grid = GridFactory.create_empty_grid(4)
   assert grid.get_size() == 4
   assert grid.valid_location(0, 0)
   assert grid.valid_location(3, 3)

--- a/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
+++ b/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
@@ -1,24 +1,41 @@
 from neighborhood.support.grid_factory import GridFactory
+from neighborhood.support.neighborhood_runtime_exception import NeighborhoodRuntimeException
+from neighborhood.support.square_type import SquareType
 
-sample_maze = '[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
-  {"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}],\
-  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":53},{"tileType":1,"value":0,"assetId":54},{"tileType":1,"value":0,"assetId":0},\
-  {"tileType":1,"value":0,"assetId":0},{"tileType":2,"value":0,"assetId":287},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}],\
-  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
-  {"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}],\
-  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":3,"assetId":303},\
-  {"tileType":1,"value":0,"assetId":0},{"tileType":0,"value":0,"assetId":47},{"tileType":0,"value":0,"assetId":1},{"tileType":1,"value":0,"assetId":0}],\
-  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
-  {"tileType":1,"value":0,"assetId":0},{"tileType":0,"value":0,"assetId":2},{"tileType":0,"value":0,"assetId":3},{"tileType":1,"value":0,"assetId":0}],\
-  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
-  {"tileType":1,"value":0,"assetId":0},{"tileType":0,"value":0,"assetId":4},{"tileType":0,"value":0,"assetId":5},{"tileType":1,"value":0,"assetId":0}],\
-  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
-  {"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}],\
-  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
-  {"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]'
+# 2x2 grid
+sample_maze = '[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":0,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]'
 
-def test_can_create_grid_from_string():
+def test_cannot_create_invalid_grid_from_string():
   grid_factory = GridFactory()
   # non-square grid
-  # try:
-  #   grid = grid_factory.create_grid_from_string('[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}], [{"tileType":1,"value":0,"assetId":0}]]')
+  try:
+    grid_factory.create_grid_from_string('[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}], [{"tileType":1,"value":0,"assetId":0}]]')
+    assert False
+  except NeighborhoodRuntimeException as e:
+    assert str(e) == "NeighborhoodRuntimeException: INVALID_GRID: Grid is not a square"
+  # empty grid
+  try:
+    grid_factory.create_grid_from_string('[]')
+    assert False
+  except NeighborhoodRuntimeException as e: 
+    assert str(e) == "NeighborhoodRuntimeException: INVALID_GRID: Grid is empty"
+  # invalid configuration, missing a tile type
+  invalid_grid = '[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}],[{"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]'
+  try:
+    grid_factory.create_grid_from_string(invalid_grid)
+    assert False
+  except NeighborhoodRuntimeException as e:
+    assert str(e) == "NeighborhoodRuntimeException: INVALID_GRID"
+
+def test_can_create_valid_grid_from_string():
+  grid_factory = GridFactory()
+  grid = grid_factory.create_grid_from_string(sample_maze)
+  assert grid.get_size() == 2
+  assert grid.valid_location(0, 0)
+  assert grid.grid[0][0].asset_id == 0
+  assert grid.grid[1][0].paint_count == 1
+  assert grid.grid[0][0].paint_count == 0
+  assert grid.grid[0][0].square_type == SquareType.OPEN
+  assert not grid.grid[0][1].is_passable()
+  assert grid.grid[0][0].is_passable()
+

--- a/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
+++ b/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
@@ -1,0 +1,24 @@
+from neighborhood.support.grid_factory import GridFactory
+
+sample_maze = '[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
+  {"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}],\
+  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":53},{"tileType":1,"value":0,"assetId":54},{"tileType":1,"value":0,"assetId":0},\
+  {"tileType":1,"value":0,"assetId":0},{"tileType":2,"value":0,"assetId":287},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}],\
+  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
+  {"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}],\
+  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":3,"assetId":303},\
+  {"tileType":1,"value":0,"assetId":0},{"tileType":0,"value":0,"assetId":47},{"tileType":0,"value":0,"assetId":1},{"tileType":1,"value":0,"assetId":0}],\
+  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
+  {"tileType":1,"value":0,"assetId":0},{"tileType":0,"value":0,"assetId":2},{"tileType":0,"value":0,"assetId":3},{"tileType":1,"value":0,"assetId":0}],\
+  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
+  {"tileType":1,"value":0,"assetId":0},{"tileType":0,"value":0,"assetId":4},{"tileType":0,"value":0,"assetId":5},{"tileType":1,"value":0,"assetId":0}],\
+  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
+  {"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}],\
+  [{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},\
+  {"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]'
+
+def test_can_create_grid_from_string():
+  grid_factory = GridFactory()
+  # non-square grid
+  # try:
+  #   grid = grid_factory.create_grid_from_string('[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}], [{"tileType":1,"value":0,"assetId":0}]]')

--- a/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
+++ b/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
@@ -29,21 +29,21 @@ def test_can_create_valid_grid_from_string():
   grid = GridFactory.create_grid_from_string(SAMPLE_MAZE)
   assert grid.get_size() == 2
   assert grid.valid_location(0, 0)
-  assert grid.grid[0][0].asset_id == 0
-  assert grid.grid[1][0].paint_count == 1
-  assert grid.grid[0][0].paint_count == 0
-  assert grid.grid[0][0].square_type == SquareType.OPEN
-  assert not grid.grid[0][1].is_passable()
-  assert grid.grid[0][0].is_passable()
+  assert grid.grid_squares[0][0].asset_id == 0
+  assert grid.grid_squares[1][0].paint_count == 1
+  assert grid.grid_squares[0][0].paint_count == 0
+  assert grid.grid_squares[0][0].square_type == SquareType.OPEN
+  assert not grid.grid_squares[0][1].is_passable()
+  assert grid.grid_squares[0][0].is_passable()
 
 def test_can_create_grid_from_json():
   test_file_path = os.path.join(os.path.dirname(__file__), 'serialized_maze.txt')
   grid = GridFactory.create_grid_from_file(test_file_path)
   assert grid.get_size() == 2
   assert grid.valid_location(0, 0)
-  assert grid.grid[0][0].asset_id == 0
-  assert grid.grid[1][0].paint_count == 1
-  assert grid.grid[0][0].paint_count == 0
-  assert grid.grid[0][0].square_type == SquareType.OPEN
-  assert not grid.grid[0][1].is_passable()
-  assert grid.grid[0][0].is_passable()
+  assert grid.grid_squares[0][0].asset_id == 0
+  assert grid.grid_squares[1][0].paint_count == 1
+  assert grid.grid_squares[0][0].paint_count == 0
+  assert grid.grid_squares[0][0].square_type == SquareType.OPEN
+  assert not grid.grid_squares[0][1].is_passable()
+  assert grid.grid_squares[0][0].is_passable()

--- a/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
+++ b/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
@@ -1,3 +1,4 @@
+import os
 from neighborhood.support.grid_factory import GridFactory
 from neighborhood.support.neighborhood_runtime_exception import NeighborhoodRuntimeException
 from neighborhood.support.square_type import SquareType
@@ -41,7 +42,8 @@ def test_can_create_valid_grid_from_string():
 
 def test_can_create_grid_from_json():
   grid_factory = GridFactory()
-  grid = grid_factory.create_grid_from_file()
+  test_file_path = os.path.join(os.path.dirname(__file__), 'serialized_maze.txt')
+  grid = grid_factory.create_grid_from_file(test_file_path)
   assert grid.get_size() == 2
   assert grid.valid_location(0, 0)
   assert grid.grid[0][0].asset_id == 0
@@ -50,3 +52,11 @@ def test_can_create_grid_from_json():
   assert grid.grid[0][0].square_type == SquareType.OPEN
   assert not grid.grid[0][1].is_passable()
   assert grid.grid[0][0].is_passable()
+
+def test_can_create_empty_grid():
+  grid_factory = GridFactory()
+  grid = grid_factory.create_empty_grid(4)
+  assert grid.get_size() == 4
+  assert grid.valid_location(0, 0)
+  assert grid.valid_location(3, 3)
+  assert not grid.valid_location(4, 4)

--- a/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
+++ b/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
@@ -39,3 +39,14 @@ def test_can_create_valid_grid_from_string():
   assert not grid.grid[0][1].is_passable()
   assert grid.grid[0][0].is_passable()
 
+def test_can_create_grid_from_json():
+  grid_factory = GridFactory()
+  grid = grid_factory.create_grid_from_file()
+  assert grid.get_size() == 2
+  assert grid.valid_location(0, 0)
+  assert grid.grid[0][0].asset_id == 0
+  assert grid.grid[1][0].paint_count == 1
+  assert grid.grid[0][0].paint_count == 0
+  assert grid.grid[0][0].square_type == SquareType.OPEN
+  assert not grid.grid[0][1].is_passable()
+  assert grid.grid[0][0].is_passable()

--- a/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
+++ b/python/pythonlab/neighborhood/tests/support/test_grid_factory.py
@@ -2,9 +2,7 @@ import os
 from neighborhood.support.grid_factory import GridFactory
 from neighborhood.support.neighborhood_runtime_exception import NeighborhoodRuntimeException
 from neighborhood.support.square_type import SquareType
-
-# 2x2 grid
-sample_maze = '[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":0,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]'
+from constants import SAMPLE_MAZE
 
 def test_cannot_create_invalid_grid_from_string():
   # non-square grid
@@ -28,7 +26,7 @@ def test_cannot_create_invalid_grid_from_string():
     assert str(e) == "NeighborhoodRuntimeException: INVALID_GRID"
 
 def test_can_create_valid_grid_from_string():
-  grid = GridFactory.create_grid_from_string(sample_maze)
+  grid = GridFactory.create_grid_from_string(SAMPLE_MAZE)
   assert grid.get_size() == 2
   assert grid.valid_location(0, 0)
   assert grid.grid[0][0].asset_id == 0
@@ -49,10 +47,3 @@ def test_can_create_grid_from_json():
   assert grid.grid[0][0].square_type == SquareType.OPEN
   assert not grid.grid[0][1].is_passable()
   assert grid.grid[0][0].is_passable()
-
-def test_can_create_empty_grid():
-  grid = GridFactory.create_empty_grid(4)
-  assert grid.get_size() == 4
-  assert grid.valid_location(0, 0)
-  assert grid.valid_location(3, 3)
-  assert not grid.valid_location(4, 4)

--- a/python/pythonlab/neighborhood/tests/support/test_world.py
+++ b/python/pythonlab/neighborhood/tests/support/test_world.py
@@ -1,8 +1,9 @@
 from neighborhood.support.world import World
+from constants import SAMPLE_MAZE
 
 def test_world_always_returns_same_grid():
   world_1 = World()
-  world_1.set_grid_from_string('[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":0,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]')
+  world_1.set_grid_from_string(SAMPLE_MAZE)
   world_2 = World()
   assert world_1 is world_2
   assert world_1.grid is world_2.grid

--- a/python/pythonlab/neighborhood/tests/support/test_world.py
+++ b/python/pythonlab/neighborhood/tests/support/test_world.py
@@ -1,0 +1,8 @@
+from neighborhood.support.world import World
+
+def test_world_always_returns_same_grid():
+  world_1 = World()
+  world_1.set_grid_from_string('[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":0,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]')
+  world_2 = World()
+  assert world_1 is world_2
+  assert world_1.grid is world_2.grid

--- a/python/pythonlab/neighborhood/tests/test_painter.py
+++ b/python/pythonlab/neighborhood/tests/test_painter.py
@@ -1,10 +1,4 @@
 from neighborhood.painter import Painter
-from neighborhood.support.world import World
-
-# Set up the world to be from a string rather than trying to load a file.
-def setUp():
-  world = World()
-  world.set_grid_from_string('[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":0,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]')
 
 def test_initialize_painter():
   painter = Painter()

--- a/python/pythonlab/neighborhood/tests/test_painter.py
+++ b/python/pythonlab/neighborhood/tests/test_painter.py
@@ -1,4 +1,10 @@
 from neighborhood.painter import Painter
+from neighborhood.support.world import World
+
+# Set up the world to be from a string rather than trying to load a file.
+def setUp():
+  world = World()
+  world.set_grid_from_string('[[{"tileType":1,"value":0,"assetId":0},{"tileType":1,"value":1,"assetId":0}],[{"tileType":0,"value":0,"assetId":0},{"tileType":1,"value":0,"assetId":0}]]')
 
 def test_initialize_painter():
   painter = Painter()

--- a/uv.lock
+++ b/uv.lock
@@ -526,7 +526,7 @@ wheels = [
 
 [[package]]
 name = "neighborhood"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "python/pythonlab/neighborhood" }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This PR implements more support code for the python neighborhood. It implements:
- `GridFactory`: class with static methods that generate a grid either from a file or from a string (from string will only be used for testing)
- `World`: singleton class that tracks the Grid for a run of the neighborhood. We need a single Grid so that multiple painters can operate on the same grid and see the same state (for example, if a cell has paint or not).

I also did some refactoring/renaming of previous work. It was confusing that the `Grid` object had a `grid` field; I renamed it to `grid_squares. I also moved the check for if a 2d array is a square to a helper class.

In addition, I bumped the version of the neighborhood module from 0.1.0 to 0.2.0 since we've made a lot of changes. This will ensure that in non-development environments you get the most recent package (when we keep the same version it's possible you will see a cached, old version).

## Links
- jira ticket: [CT-958](https://codedotorg.atlassian.net/browse/CT-958)

## Testing story
Mostly tested via unit tests. I also temporarily exported `World` while testing to check that we can load the grid from the file in the user's project and print it, which we can do!

## Follow-up work
Next up I'll set up the painter to reference `World`. There's a bit of complexity here because we want painters in a single session to share the same world, but if you run the program again we reset the world. I think I'll add some setup/cleanup code in `pythonlab_setup` to handle resetting the world (that's why I added a `remove_grid` method in `World).


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
