### PR TITLE
10 ActiveJob workers on staging+levelbuilder, 140 in prod

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -649,8 +649,8 @@ active_job_queues:
 active_job_queue_adapter: :delayed_job
 
 # Number of workers to start when running `rake build:start_active_job_workers`:
-active_job_backend_n_workers_to_start: 2
-active_job_backend_rolling_restart_in_n_batches: 1
+active_job_backend_n_workers_to_start: 10
+active_job_backend_rolling_restart_in_n_batches: 2
 
 # aiproxy credentials
 aiproxy_api_key: !Secret

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -78,3 +78,7 @@ use_geolocation_override: true
 # ActiveJob Queue Adapter, default to async which doesn't require manually
 # starting the worker processes. See locals.yml.default for more discussion.
 active_job_queue_adapter: :async
+
+# Number of workers to start when running `rake build:start_active_job_workers`:
+active_job_backend_n_workers_to_start: 2
+active_job_backend_rolling_restart_in_n_batches: 1

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -55,5 +55,5 @@ mailjet_secret_key: !Secret
 mailgun_api_key: !Secret
 
 # Number of workers to start when running `rake build:start_active_job_workers`:
-active_job_backend_n_workers_to_start: 150
+active_job_backend_n_workers_to_start: 140
 active_job_backend_rolling_restart_in_n_batches: 5

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -25,6 +25,10 @@ dashboard_devise_pepper: not a pepper!
 dashboard_secret_key_base: not a secret
 google_maps_api_key: boguskey
 db_writer: 'mysql://root@localhost/'
+
+# Number of workers to start when running `rake build:start_active_job_workers`:
+active_job_backend_n_workers_to_start: 2
+active_job_backend_rolling_restart_in_n_batches: 1
 <% end -%>
 
 netsim_enable_metrics: true
@@ -68,9 +72,3 @@ use_cookie_dcdo: true
 
 # Allows Geolocation to be altered via cookies.
 use_geolocation_override: true
-
-# Number of workers to start when running `rake build:start_active_job_workers`:
-<% if test_system? && chef_managed %>
-active_job_backend_n_workers_to_start: 10
-active_job_backend_rolling_restart_in_n_batches: 2
-<% end -%>


### PR DESCRIPTION
Issues addressed:
- We were running into performance issues on the levelbuilder server. Currently its using only 2 activejob (delayed_job) workers, matching local dev.
- Memory leakage caused 150 workers in prod to eventually grow into the warning zone (>80% RAM used on production-daemon).
- Staging is used for bug bashes, any ones using ActiveJob would run into problems by being limited to 2 workers

This PR changes:
- the default number of workers to "10 workers restarted in 2 batches". This will change the current number of workers available on staging and levelbuilder, both of which have *plenty* of free RAM (40GB and 100GB free, respectively). Also restarts workers in a rolling deploy (2 batches), which will avoid erroneous errors during deploy.
- drops n_workers in prod to 140
- Keeps 2 workers in drone (ram limited)