### PR TITLE
Sort cloudwatch logs by timestamp

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -109,7 +109,14 @@ To run a test file in either directory, `cd` into it before running the tests.
 ```bash
 cd shared
 bundle exec ruby -Itest ./test/path/to/your/test.rb
-``` 
+bundle exec ruby -Itest ./test/test_html_parser.rb
+```
+
+```bash
+cd lib
+bundle exec ruby -Itest ./test/path/to/your/test.rb
+bundle exec ruby -Itest ./test/cdo/aws/test_cloudwatch_logs.rb
+```
 
 ### Pegasus Tests
 `cd pegasus && rake test` will run all of our pegasus Ruby tests. This usually takes ~20 seconds to run.

--- a/lib/cdo/aws/cloudwatch_logs.rb
+++ b/lib/cdo/aws/cloudwatch_logs.rb
@@ -39,6 +39,8 @@ module Cdo
           http_read_timeout: 5,
           http_idle_timeout: 2
         )
+        # CloudWatch requires event batches to be sorted by timestamp
+        events.sort_by! {|event| event[:timestamp]}
         resp = client.put_log_events(
           log_group_name: @log_group_name,
           log_stream_name: @log_stream_name,

--- a/lib/test/cdo/aws/test_cloudwatch_logs.rb
+++ b/lib/test/cdo/aws/test_cloudwatch_logs.rb
@@ -7,20 +7,24 @@ class CdoCloudWatchLogsTest < Minitest::Test
   end
 
   def test_put_log_events
+    # Three log events with distict and ascending timestamps
     events = [
-      {message: 'message1', timestamp: (Time.now.to_f * 1000).to_i},
-      {message: 'message2', timestamp: (Time.now.to_f * 1000).to_i},
-      {message: 'message3', timestamp: (Time.now.to_f * 1000).to_i}
+      {message: 'message1', timestamp: current_timestamp_in_milliseconds(0)},
+      {message: 'message2', timestamp: current_timestamp_in_milliseconds(5)},
+      {message: 'message3', timestamp: current_timestamp_in_milliseconds(10)}
     ]
-    Cdo::CloudWatchLogs.put_log_event('log_group_name', 'log_stream_name', events[0])
-    Cdo::CloudWatchLogs.put_log_events('log_group_name', 'log_stream_name', [events[1], events[2]])
+
+    # Submit events to the buffer, out of order, via separate calls
+    Cdo::CloudWatchLogs.put_log_event('log_group_name', 'log_stream_name', events[1])
+    Cdo::CloudWatchLogs.put_log_events('log_group_name', 'log_stream_name', [events[0], events[2]])
     Cdo::CloudWatchLogs.flush!
+
     refute_empty Cdo::CloudWatchLogs.client.api_requests
     assert_equal(
       {
         log_group_name: 'log_group_name',
         log_stream_name: 'log_stream_name',
-        log_events: events
+        log_events: events # expect events to have been resorted
       }, Cdo::CloudWatchLogs.client.api_requests.first[:params]
     )
   end
@@ -34,5 +38,9 @@ class CdoCloudWatchLogsTest < Minitest::Test
       {message: 'message', timestamp: (Time.now.to_f * 1000).to_i}
     )
     Cdo::CloudWatchLogs.flush!
+  end
+
+  def current_timestamp_in_milliseconds(seconds_offset = 0)
+    ((Time.now.to_f + seconds_offset) * 1000).to_i
   end
 end


### PR DESCRIPTION
Cloudwatch requires `put_log_events` to be sorted by timestamp when submitting. This sorts the buffered batches before sending.

## Links

https://codedotorg.atlassian.net/browse/INF-1556

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
