### PR TITLE
feat(workshops): add format column enum to pd_sessions

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -117,6 +117,7 @@ def main
       US_STATES
       PROJECT_SUBMISSION_STATUS
       EDUCATOR_ROLES
+      PD_SESSION_FORMATS
     ),
     file_type: 'ts'
   )

--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -117,7 +117,6 @@ def main
       US_STATES
       PROJECT_SUBMISSION_STATUS
       EDUCATOR_ROLES
-      PD_SESSION_FORMATS
     ),
     file_type: 'ts'
   )
@@ -179,6 +178,7 @@ def main
         NOT_FUNDED_SUBJECTS
         CSD_CUSTOM_WORKSHOP_MODULES
         PARTICIPANT_GROUP_TYPES
+        PD_SESSION_FORMATS
       ),
       source_module: Pd::SharedWorkshopConstants,
       transform_keys: false

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -10,6 +10,7 @@
 #  updated_at     :datetime
 #  deleted_at     :datetime
 #  code           :string(255)
+#  format         :integer
 #
 # Indexes
 #
@@ -20,6 +21,8 @@
 require 'cdo/code_generation'
 
 class Pd::Session < ApplicationRecord
+  enum format: {in_person: 0, virtual: 1}
+
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
 
   belongs_to :workshop, class_name: 'Pd::Workshop', foreign_key: 'pd_workshop_id', optional: true

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -21,7 +21,8 @@
 require 'cdo/code_generation'
 
 class Pd::Session < ApplicationRecord
-  enum format: SharedWorkshopConstants::PD_SESSION_FORMATS
+  # creates a hash like {in_person: 0, virtual: 1}
+  enum format: Pd::SharedWorkshopConstants::PD_SESSION_FORMATS.to_h {|format| [format[:value], format[:enum_value]]}
 
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
 

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -10,7 +10,7 @@
 #  updated_at     :datetime
 #  deleted_at     :datetime
 #  code           :string(255)
-#  format         :integer
+#  session_format :integer
 #
 # Indexes
 #
@@ -22,7 +22,7 @@ require 'cdo/code_generation'
 
 class Pd::Session < ApplicationRecord
   # creates a hash like {in_person: 0, virtual: 1}
-  enum format: Pd::SharedWorkshopConstants::PD_SESSION_FORMATS.to_h {|format| [format[:value], format[:enum_value]]}
+  enum session_format: Pd::SharedWorkshopConstants::PD_SESSION_FORMATS.to_h {|f| [f[:value], f[:enum_value]]}
 
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
 

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -21,7 +21,7 @@
 require 'cdo/code_generation'
 
 class Pd::Session < ApplicationRecord
-  enum format: {in_person: 0, virtual: 1}
+  enum format: SharedConstants::PD_SESSION_FORMATS
 
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
 

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -21,7 +21,7 @@
 require 'cdo/code_generation'
 
 class Pd::Session < ApplicationRecord
-  enum format: SharedConstants::PD_SESSION_FORMATS
+  enum format: SharedWorkshopConstants::PD_SESSION_FORMATS
 
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
 

--- a/dashboard/db/migrate/20250116214434_add_format_column_to_pd_sessions.rb
+++ b/dashboard/db/migrate/20250116214434_add_format_column_to_pd_sessions.rb
@@ -1,0 +1,5 @@
+class AddFormatColumnToPdSessions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pd_sessions, :format, :integer
+  end
+end

--- a/dashboard/db/migrate/20250116214434_add_format_column_to_pd_sessions.rb
+++ b/dashboard/db/migrate/20250116214434_add_format_column_to_pd_sessions.rb
@@ -1,5 +1,5 @@
 class AddFormatColumnToPdSessions < ActiveRecord::Migration[6.1]
   def change
-    add_column :pd_sessions, :format, :integer
+    add_column :pd_sessions, :session_format, :integer
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_01_13_204313) do
+ActiveRecord::Schema.define(version: 2025_01_16_214434) do
 
   create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1415,6 +1415,7 @@ ActiveRecord::Schema.define(version: 2025_01_13_204313) do
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string "code"
+    t.integer "format"
     t.index ["code"], name: "index_pd_sessions_on_code", unique: true
     t.index ["pd_workshop_id"], name: "index_pd_sessions_on_pd_workshop_id"
   end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1415,7 +1415,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string "code"
-    t.integer "format"
+    t.integer "session_format"
     t.index ["code"], name: "index_pd_sessions_on_code", unique: true
     t.index ["pd_workshop_id"], name: "index_pd_sessions_on_pd_workshop_id"
   end

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -829,4 +829,9 @@ module SharedConstants
     {value: "parent", category: 'other'},
     {value: "other", category: 'other'}
   ].freeze
+
+  PD_SESSION_FORMATS = {
+    in_person: 0,
+    virtual: 1,
+  }.freeze
 end

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -829,9 +829,4 @@ module SharedConstants
     {value: "parent", category: 'other'},
     {value: "other", category: 'other'}
   ].freeze
-
-  PD_SESSION_FORMATS = {
-    in_person: 0,
-    virtual: 1,
-  }.freeze
 end

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -300,9 +300,9 @@ module Pd
       'Train the trainer'
     ].freeze
 
-    PD_SESSION_FORMATS = {
-      in_person: 0,
-      virtual: 1,
-    }.freeze
+    PD_SESSION_FORMATS = [
+      {value: 'in_person', label: 'In-Person', enum_value: 0},
+      {value: 'virtual', label: 'Digital', enum_value: 1}
+    ].freeze
   end
 end

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -299,5 +299,10 @@ module Pd
       'Facilitator',
       'Train the trainer'
     ].freeze
+
+    PD_SESSION_FORMATS = {
+      in_person: 0,
+      virtual: 1,
+    }.freeze
   end
 end


### PR DESCRIPTION
This contains a migration to add an integer column named "session_format" as well as an enum on the Pd::Session model that defines "in_person" and "virtual" as the only formats for now

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
