### PR TITLE
Prevent reloading course dropdown if previously loaded

### DIFF
--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -74,10 +74,6 @@ export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
   const selectedSection =
     state.teacherSections.sections[state.teacherSections.selectedSectionId];
 
-  console.log('lfm', {
-    selectedSection,
-    loadedSectionId: state.unitSelection.loadedSectionId,
-  });
   if (
     state.unitSelection.isLoadingCoursesWithProgress ||
     !selectedSection ||
@@ -113,10 +109,6 @@ export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
       dispatch(setCoursesWithProgress(reorderedCourses));
       dispatch(finishedLoadingCoursesWithProgress());
       dispatch(setLoadedSectionId(selectedSection.id));
-      console.log('lfm1', {
-        selectedSection,
-        loadedSectionId: state.loadedSectionId,
-      });
     })
     .catch(err => {
       console.error(err.message);
@@ -177,7 +169,6 @@ export default function unitSelection(state = initialState, action) {
   }
 
   if (action.type === SET_LOADED_SECTION_ID) {
-    console.log('lfm2', action);
     return {
       ...state,
       loadedSectionId: action.loadedSectionId,

--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -11,12 +11,18 @@ export const START_LOADING_COURSES = 'unitSelection/START_LOADING_COURSES';
 export const FINISHED_LOADING_COURSES =
   'unitSelection/FINISHED_LOADING_COURSES';
 
+const SET_LOADED_SECTION_ID = 'unitSelection/SET_LOADED_SECTION_ID';
+
 // Action creators
 export const setScriptId = scriptId => ({type: SET_SCRIPT, scriptId});
 export const setUnitName = unitName => ({type: SET_UNIT_NAME, unitName});
 export const setCoursesWithProgress = coursesWithProgress => ({
   type: SET_COURSES,
   coursesWithProgress,
+});
+export const setLoadedSectionId = loadedSectionId => ({
+  type: SET_LOADED_SECTION_ID,
+  loadedSectionId,
 });
 
 export const startLoadingCoursesWithProgress = () => ({
@@ -68,10 +74,17 @@ export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
   const selectedSection =
     state.teacherSections.sections[state.teacherSections.selectedSectionId];
 
-  if (state.unitSelection.isLoadingCoursesWithProgress || !selectedSection) {
+  console.log('lfm', {
+    selectedSection,
+    loadedSectionId: state.unitSelection.loadedSectionId,
+  });
+  if (
+    state.unitSelection.isLoadingCoursesWithProgress ||
+    !selectedSection ||
+    state.unitSelection.loadedSectionId === selectedSection.id
+  ) {
     return;
   }
-
   dispatch(startLoadingCoursesWithProgress());
 
   fetch(`/dashboardapi/section_courses/${selectedSection.id}`, {
@@ -99,6 +112,11 @@ export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
       ].reverse();
       dispatch(setCoursesWithProgress(reorderedCourses));
       dispatch(finishedLoadingCoursesWithProgress());
+      dispatch(setLoadedSectionId(selectedSection.id));
+      console.log('lfm1', {
+        selectedSection,
+        loadedSectionId: state.loadedSectionId,
+      });
     })
     .catch(err => {
       console.error(err.message);
@@ -112,6 +130,7 @@ const initialState = {
   unitName: null,
   coursesWithProgress: [],
   isLoadingCoursesWithProgress: false,
+  loadedSectionId: null,
 };
 
 export default function unitSelection(state = initialState, action) {
@@ -154,6 +173,14 @@ export default function unitSelection(state = initialState, action) {
     return {
       ...state,
       isLoadingCoursesWithProgress: false,
+    };
+  }
+
+  if (action.type === SET_LOADED_SECTION_ID) {
+    console.log('lfm2', action);
+    return {
+      ...state,
+      loadedSectionId: action.loadedSectionId,
     };
   }
 


### PR DESCRIPTION
The course dropdown is loaded by a useEffect on the `UnitSelector` and `UnitSelectorV2`. This component is reused on multiple dashboard pages and whenever a new page is loaded it will try to reload the data.

This PR prevents reloading the course dropdown information when it has already been loaded previously.


https://github.com/user-attachments/assets/cd68c138-4806-46d7-9e64-a8fc12246abf



## Links
https://codedotorg.atlassian.net/browse/TEACH-1515
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
