### PR TITLE
Simplify docker/developers/README.md for "default use case"

### DIFF
--- a/docker/developers/README.md
+++ b/docker/developers/README.md
@@ -1,111 +1,42 @@
 # Development with Docker
 
-## Features
+The basic setup runs dashboard (our service) and its dependencies (e.g. mysql, redis)
+inside containers. For an alternative setup, where only dependencies like mysql run
+inside containers, see the [alternative setup](#alternative-setup-run-dependent-services-in-docker).
 
-* Run development server requirements such as MySQL and Redis in containers.
+## Basic Setup
 
-## Running a Native Dashboard Server
-
-If you want to run the server code natively, but leverage Docker to run the dependent
-services, you can follow these instructions.
-
-First, install docker using [the instructions below](#installing-docker). Then follow the
-normal [SETUP.md](../../SETUP.md) instructions for your platform.  You can skip over many
-steps that are related to running MySQL and Redis.
-
-> **Note**
->
-> If you are already running MySQL and/or Redis natively, you may depending on your
-> operating system need to stop those services or the `docker compose run` command below
-> will fail due to in-use ports.
->
-> On Linux, that will likely be:
->
-> ```shell
-> sudo systemctl stop mysql
-> sudo systemctl stop redis
-> ```
->
-> On MacOS, that will likely be:
->
-> ```shell
-> brew services stop mysql@8.0
-> brew services stop redis
-> ```
-
-Once you have a working Ruby and Node environment, you can then use this command to spin
-up the database and Redis servers:
-
-```shell
-docker compose run dashboard-services
-```
-
-This will tell you which items you will need to place in your `locals.yml` file for the
-server to connect to the contained database.
-
-Just copy those lines into your `locals.yml` and start your Dashboard server as normal via:
-
-```shell
-./bin/dashboard-server
-```
+1. Install docker for: [macOS](#macos), [Ubuntu](#ubuntu), [Windows](#windows)
+1. To start dashboard and its dependencies, run in this directory:
+   ```shell
+   docker-compose up
+   ```
 
 ## Installing Docker
+
+See platform-specific installation instructions: [macOS](#macos), [Ubuntu](#ubuntu), [Windows](#windows)
 
 Our Docker development environment requires at least [Docker
 Compose](https://docs.docker.com/compose/) version 2.23 or higher, as well as a compatible
 installation of [Docker Engine](https://docs.docker.com/engine/). If you'd like a GUI
 interface and a one-click installation process, consider [Docker
-Desktop](https://docs.docker.com/desktop/) as an optional alternative to manual
-installation.
-
-### Official Installation Instructions
-
-The official documentation for each service will be the most up-to-date and
-officially-supported way to install each service, but may not cover every edge case for
-your local development environment:
-
-- [Docker Engine](https://docs.docker.com/engine/install/)
-- [Docker Compose](https://docs.docker.com/compose/install/)
-- Docker Desktop ([Mac](https://docs.docker.com/desktop/setup/install/mac-install/),
-  [Windows](https://docs.docker.com/desktop/setup/install/windows-install/),
-  [Linux](https://docs.docker.com/desktop/setup/install/linux/))
-
-Alternatively, consider consulting your package management for your OS.
-
-### Code.org Installation Instructions
-
-Below are installation steps which have worked for other code.org engineers to install the
-specific requirements needed for our setup. See the appropriate section below:
-[macOS](#macos), [Ubuntu](#ubuntu), [Windows](#windows)
+Desktop](https://docs.docker.com/desktop/).
 
 ### macOS
 
-> **Note**
->
-> Mac support is currently limited; in part because of the performance issues when trying
-> to run our stack within the hypervisor that MacOS runs docker inside of, in part because
-> of the architectural differences between different Apple chips, and in part because of
-> the lack of test devices among developers who have worked on this so far.
+Installing Docker Desktop for macOS ([download](https://docs.docker.com/desktop/setup/install/mac-install/)) provides all required dependencies.
 
-1. Install Docker itself:
+### Advanced Option: if you prefer a fully open source toolchain without a GUI
+
+The [colima](https://github.com/abiosoft/colima) project provides a fully open source
+docker-compatible engine for macOS.
+
+1. Install dependencies from homebrew:
    ```shell
-   brew install docker
+   brew install docker docker-compose colima
    ```
 
-1. Install Docker Compose:
-   ```shell
-   export DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
-   mkdir -p $DOCKER_CONFIG/cli-plugins
-   curl -SL https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-darwin-$(uname -m) -o $DOCKER_CONFIG/cli-plugins/docker-compose
-   chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
-   ```
-
-1. Install Colima as a container runtime:
-   ```shell
-   brew install colima
-   ```
-
-1. Start the Colima service (and have it start on login)
+1. Start the Colima service (and have it start on login):
    ```shell
    brew services start colima
    ```
@@ -147,9 +78,7 @@ When you install that, you will need to follow the instructions in that app to e
 Docker, which may require updating some system settings. There are other instructions
 found [here](https://docs.docker.com/desktop/install/windows-install/) that may help.
 
-1. Install Docker Desktop from [here](https://www.docker.com/products/docker-desktop/).
-   Using instructions found
-   [here](https://docs.docker.com/desktop/install/windows-install/).
+1. Install Docker Desktop from [here](https://docs.docker.com/desktop/install/windows-install/).
 
 1. Start Docker Desktop. It will say "Engine running" in the lower-left corner of the
    Docker Desktop window.
@@ -169,3 +98,47 @@ Once Docker with Docker Compose has been installed:
    ```shell
    docker compose version
    ```
+
+## Alternative Setup: run dependent services in docker
+
+If you want to run the server code natively, but leverage Docker to run the dependent
+services, you can follow these instructions.
+
+First [install docker](#installing-docker). Then follow the normal [SETUP.md](../../SETUP.md) instructions for your platform.  You can skip over many steps that are related to running
+MySQL and Redis.
+
+> **Note**
+>
+> If you are already running MySQL and/or Redis natively, you may depending on your
+> operating system need to stop those services or the `docker compose run` command below
+> will fail due to in-use ports.
+>
+> On Linux, that will likely be:
+>
+> ```shell
+> sudo systemctl stop mysql
+> sudo systemctl stop redis
+> ```
+>
+> On MacOS, that will likely be:
+>
+> ```shell
+> brew services stop mysql@8.0
+> brew services stop redis
+> ```
+
+Once you have a working Ruby and Node environment, you can then use this command to spin
+up the database and Redis servers:
+
+```shell
+docker compose run dashboard-services
+```
+
+This will tell you which items you will need to place in your `locals.yml` file for the
+server to connect to the contained database.
+
+Just copy those lines into your `locals.yml` and start your Dashboard server as normal via:
+
+```shell
+./bin/dashboard-server
+```

--- a/docker/developers/README.md
+++ b/docker/developers/README.md
@@ -1,8 +1,8 @@
 # Development with Docker
 
-The basic setup runs dashboard (our service) and its dependencies (e.g. mysql, redis)
-inside containers. For an alternative setup, where only dependencies like mysql run
-inside containers, see the [alternative setup](#alternative-setup-run-dependent-services-in-docker).
+The basic setup runs dashboard (our service) and its dependent services (e.g. mysql, redis)
+inside containers. For an alternative setup, where only dependent services run inside containers,
+see the [alternative setup](#alternative-setup-run-dependent-services-in-docker).
 
 ## Basic Setup
 


### PR DESCRIPTION
**UPDATE:** this PR may be too early, I wasn't aware that we're not at the `docker compose up` stage yet

Our core use case as I understand it is: make it as easy as possible for potential open source contributors to get code.org locally.

For most people that's just:
1. Install docker desktop
2. `docker compose up` from this directory

The rest of the content in the existing docker/developers/README.md is great, but the nuance didn't need to have top billing. Simple first, then give options. The goal here is to make the simplest possible setup for vanilla flavored macOS users really obvious, while not obscuring the possibility for more advanced/flexible configurations.

This was originally a set of review comments on: https://github.com/code-dot-org/code-dot-org/pull/62579, but I failed to notice that I never submitted the review. This will merge conflict with https://github.com/code-dot-org/code-dot-org/pull/63019 (adds S3 support with minio), but I'm happy to do the work to resolve the merges whether merging this or that PR first.