### PR TITLE
Reduce ActiveJob workers on staging from 10 to 4

### DIFF
--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -21,3 +21,7 @@ cdo_amplitude_api_key: !Secret
 mailjet_api_key: !Secret
 mailjet_secret_key: !Secret
 mailgun_api_key: !Secret
+
+# Number of workers to start when running `rake build:start_active_job_workers`:
+active_job_backend_n_workers_to_start: 4
+active_job_backend_rolling_restart_in_n_batches: 2


### PR DESCRIPTION
[PR](https://github.com/code-dot-org/code-dot-org/pull/63360) earlier in the day increased staging's delayed_job worker count from 2 to 8.

This put us over the 80% memory usage alarm threshold on the staging server, because while quiescent RAM usage on staging leaves LOTS of headroom, we see huge RAM spikes in one part of the build (I suspect webpacking production JS):
![image (1)](https://github.com/user-attachments/assets/b39d5a66-7220-4f8a-b6e1-d2b5aa3725e6)

This PR drops us down to 4 workers, so only a 2 worker RAM increase over yesterday's levels.