### PR TITLE
Reduce ActiveJob worker count on staging to 2 workers

### DIFF
--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -23,5 +23,5 @@ mailjet_secret_key: !Secret
 mailgun_api_key: !Secret
 
 # Number of workers to start when running `rake build:start_active_job_workers`:
-active_job_backend_n_workers_to_start: 4
-active_job_backend_rolling_restart_in_n_batches: 2
+active_job_backend_n_workers_to_start: 2
+active_job_backend_rolling_restart_in_n_batches: 1


### PR DESCRIPTION
In case yesterday's reduction to 4 workers isn't enough and staging still gives a low memory page, here's a PR you can merge to revert worker count on staging back to the values before I started monkeying with them.