### PR TITLE
Speed up the `dashboardapi/section_courses/:section_id` endpoint

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -292,7 +292,7 @@ class ApiController < ApplicationController
 
   def show_courses_with_progress
     section = load_section
-    render json: CourseVersion.courses_for_unit_selector(section.participant_unit_ids, section.participant_units)
+    render json: CourseVersion.courses_for_unit_selector(section.participant_unit_ids)
   end
 
   use_reader_connection_for_route(:section_level_progress)

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -292,7 +292,7 @@ class ApiController < ApplicationController
 
   def show_courses_with_progress
     section = load_section
-    render json: CourseVersion.courses_for_unit_selector(section.participant_unit_ids)
+    render json: CourseVersion.courses_for_unit_selector(section.participant_unit_ids, section.participant_units)
   end
 
   use_reader_connection_for_route(:section_level_progress)

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -219,10 +219,6 @@ class CourseOffering < ApplicationRecord
     end
   end
 
-  def self.single_unit_course_offerings_containing_units_info(unit_ids)
-    single_unit_course_offerings_containing_units(unit_ids).map {|co| co.summarize_for_unit_selector(unit_ids)}
-  end
-
   def summarize_for_unit_selector(unit_ids)
     {
       display_name: any_versions_launched? ? localized_display_name : localized_display_name + ' *',
@@ -423,11 +419,6 @@ class CourseOffering < ApplicationRecord
 
   def any_version_is_unit?
     course_versions.any? {|cv| cv.content_root_type == 'Unit'}
-  end
-
-  def self.single_unit_course_offerings_containing_units(unit_ids)
-    # Checks if course offering is a UNIT and that unit has id in unit_ids
-    CourseOffering.all.select {|co| co.units_included_in_any_version?(unit_ids) && co.any_version_is_unit?}
   end
 
   def csd?

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -43,9 +43,9 @@ class CourseOffering < ApplicationRecord
 
   KEY_CHAR_RE = /[a-z0-9\-]/
   KEY_RE = /\A#{KEY_CHAR_RE}+\Z/
-  validates_format_of :key,
-    with: KEY_RE,
-    message: "must contain only lowercase alphabetic characters, numbers, and dashes; got \"%{value}\"."
+  validates :key,
+    format: {with: KEY_RE,
+    message: "must contain only lowercase alphabetic characters, numbers, and dashes; got \"%{value}\"."}
 
   ELEMENTARY_SCHOOL_GRADES = %w[K 1 2 3 4 5].freeze
   MIDDLE_SCHOOL_GRADES = %w[6 7 8].freeze
@@ -426,6 +426,7 @@ class CourseOffering < ApplicationRecord
   end
 
   def self.single_unit_course_offerings_containing_units(unit_ids)
+    # Checks if course offering is a UNIT and that unit has id in unit_ids
     CourseOffering.all.select {|co| co.units_included_in_any_version?(unit_ids) && co.any_version_is_unit?}
   end
 

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -43,9 +43,9 @@ class CourseOffering < ApplicationRecord
 
   KEY_CHAR_RE = /[a-z0-9\-]/
   KEY_RE = /\A#{KEY_CHAR_RE}+\Z/
-  validates :key,
-    format: {with: KEY_RE,
-    message: "must contain only lowercase alphabetic characters, numbers, and dashes; got \"%{value}\"."}
+  validates_format_of :key,
+    with: KEY_RE,
+    message: "must contain only lowercase alphabetic characters, numbers, and dashes; got \"%{value}\"."
 
   ELEMENTARY_SCHOOL_GRADES = %w[K 1 2 3 4 5].freeze
   MIDDLE_SCHOOL_GRADES = %w[6 7 8].freeze

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -33,9 +33,9 @@ class CourseVersion < ApplicationRecord
 
   KEY_CHAR_RE = /[a-z0-9\-]/
   KEY_RE = /\A#{KEY_CHAR_RE}+\Z/
-  validates_format_of :key,
-    with: KEY_RE,
-    message: "must contain only digits, letters, or dashes; got \"%{value}\"."
+  validates :key,
+    format: {with: KEY_RE,
+    message: "must contain only digits, letters, or dashes; got \"%{value}\"."}
 
   # Placeholder key for curriculum that will not be updated but want the
   # features that come with a course version (resources, vocab, etc)
@@ -179,8 +179,15 @@ class CourseVersion < ApplicationRecord
   # CSD has multiple headers in the list with the units for that year under it.
   # See fakeCoursesWithProgress in teacherDashboardTestHelpers.js for an example of what
   # the resulting data looks like
-  def self.courses_for_unit_selector(unit_ids)
+  def self.courses_for_unit_selector(unit_ids, units)
+    # offerings = units.joins {course_offering}.where {course_offering.course_versions.content_root_id.in(unit_ids)}.map {|co| co.summarize_for_unit_selector(unit_ids)}.uniq
+    offerings = Unit.joins(:course_version).where(id: unit_ids).map {|u| u.course_version.course_offering&.summarize_for_unit_selector(unit_ids)}.uniq
+    offerings_old = CourseOffering.single_unit_course_offerings_containing_units_info(unit_ids)
+    versions = []
+    versions_old = CourseVersion.unit_group_course_versions_with_units_info(unit_ids)
+    puts 'lfm', offerings.length, offerings_old.length
     CourseOffering.single_unit_course_offerings_containing_units_info(unit_ids).concat(CourseVersion.unit_group_course_versions_with_units_info(unit_ids)).sort_by {|c| c[:display_name]}
+    {offerings: offerings, offerings1: offerings_old, versions: versions, versions_old: versions_old}
   end
 
   def summarize_for_assignment_dropdown(user, locale_code)
@@ -204,6 +211,7 @@ class CourseVersion < ApplicationRecord
   end
 
   def self.unit_group_course_versions_with_units(unit_ids)
+    # Checks if unit groups contain any of the units
     CourseVersion.where(content_root_type: 'UnitGroup').all.select {|cv| cv.included_in_units?(unit_ids)}
   end
 

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -180,16 +180,11 @@ class CourseVersion < ApplicationRecord
   # See fakeCoursesWithProgress in teacherDashboardTestHelpers.js for an example of what
   # the resulting data looks like
   def self.courses_for_unit_selector(unit_ids)
-    # offerings = units.joins {course_offering}.where {course_offering.course_versions.content_root_id.in(unit_ids)}.map {|co| co.summarize_for_unit_selector(unit_ids)}.uniq
+    standalone_units = Unit.joins(:course_version).where(id: unit_ids).map {|u| u.course_version.course_offering&.summarize_for_unit_selector(unit_ids)}.uniq
 
-    # TODO(lfm): we could also get the units in this and decrease the number of queries? maybe not if its a select on units
-    offerings = Unit.joins(:course_version).where(id: unit_ids).map {|u| u.course_version.course_offering&.summarize_for_unit_selector(unit_ids)}.uniq
-    offerings_old = CourseOffering.single_unit_course_offerings_containing_units_info(unit_ids)
-    versions =  Unit.joins(unit_groups: :course_version).where(id: unit_ids).where(course_version: {content_root_type: 'UnitGroup'}).flat_map {|u| u.unit_groups.map(&:course_version)}.map(&:summarize_for_unit_selector).uniq
-    versions_old = CourseVersion.unit_group_course_versions_with_units_info(unit_ids)
-    puts 'lfm', offerings.length, offerings_old.length, unit_ids
-    # CourseOffering.single_unit_course_offerings_containing_units_info(unit_ids).concat(CourseVersion.unit_group_course_versions_with_units_info(unit_ids)).sort_by {|c| c[:display_name]}
-    {offerings: offerings, offerings1: offerings_old, versions: versions, versions_old: versions_old}
+    unit_groups =  Unit.joins(unit_groups: :course_version).where(id: unit_ids).where(course_version: {content_root_type: 'UnitGroup'}).flat_map {|u| u.unit_groups.map(&:course_version)}.map(&:summarize_for_unit_selector).uniq
+
+    standalone_units.concat(unit_groups).sort_by {|c| c[:display_name]}
   end
 
   def summarize_for_assignment_dropdown(user, locale_code)

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -181,12 +181,14 @@ class CourseVersion < ApplicationRecord
   # the resulting data looks like
   def self.courses_for_unit_selector(unit_ids)
     # offerings = units.joins {course_offering}.where {course_offering.course_versions.content_root_id.in(unit_ids)}.map {|co| co.summarize_for_unit_selector(unit_ids)}.uniq
+
+    # TODO(lfm): we could also get the units in this and decrease the number of queries? maybe not if its a select on units
     offerings = Unit.joins(:course_version).where(id: unit_ids).map {|u| u.course_version.course_offering&.summarize_for_unit_selector(unit_ids)}.uniq
     offerings_old = CourseOffering.single_unit_course_offerings_containing_units_info(unit_ids)
-    versions = []
+    versions =  Unit.joins(unit_groups: :course_version).where(id: unit_ids).where(course_version: {content_root_type: 'UnitGroup'}).flat_map {|u| u.unit_groups.map(&:course_version)}.map(&:summarize_for_unit_selector).uniq
     versions_old = CourseVersion.unit_group_course_versions_with_units_info(unit_ids)
     puts 'lfm', offerings.length, offerings_old.length, unit_ids
-    CourseOffering.single_unit_course_offerings_containing_units_info(unit_ids).concat(CourseVersion.unit_group_course_versions_with_units_info(unit_ids)).sort_by {|c| c[:display_name]}
+    # CourseOffering.single_unit_course_offerings_containing_units_info(unit_ids).concat(CourseVersion.unit_group_course_versions_with_units_info(unit_ids)).sort_by {|c| c[:display_name]}
     {offerings: offerings, offerings1: offerings_old, versions: versions, versions_old: versions_old}
   end
 

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -207,15 +207,6 @@ class CourseVersion < ApplicationRecord
     ]
   end
 
-  def self.unit_group_course_versions_with_units(unit_ids)
-    # Checks if unit groups contain any of the units
-    CourseVersion.where(content_root_type: 'UnitGroup').all.select {|cv| cv.included_in_units?(unit_ids)}
-  end
-
-  def self.unit_group_course_versions_with_units_info(unit_ids)
-    unit_group_course_versions_with_units(unit_ids).map(&:summarize_for_unit_selector)
-  end
-
   def summarize_for_unit_selector
     {
       id: id,

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -179,13 +179,13 @@ class CourseVersion < ApplicationRecord
   # CSD has multiple headers in the list with the units for that year under it.
   # See fakeCoursesWithProgress in teacherDashboardTestHelpers.js for an example of what
   # the resulting data looks like
-  def self.courses_for_unit_selector(unit_ids, units)
+  def self.courses_for_unit_selector(unit_ids)
     # offerings = units.joins {course_offering}.where {course_offering.course_versions.content_root_id.in(unit_ids)}.map {|co| co.summarize_for_unit_selector(unit_ids)}.uniq
     offerings = Unit.joins(:course_version).where(id: unit_ids).map {|u| u.course_version.course_offering&.summarize_for_unit_selector(unit_ids)}.uniq
     offerings_old = CourseOffering.single_unit_course_offerings_containing_units_info(unit_ids)
     versions = []
     versions_old = CourseVersion.unit_group_course_versions_with_units_info(unit_ids)
-    puts 'lfm', offerings.length, offerings_old.length
+    puts 'lfm', offerings.length, offerings_old.length, unit_ids
     CourseOffering.single_unit_course_offerings_containing_units_info(unit_ids).concat(CourseVersion.unit_group_course_versions_with_units_info(unit_ids)).sort_by {|c| c[:display_name]}
     {offerings: offerings, offerings1: offerings_old, versions: versions, versions_old: versions_old}
   end

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -180,7 +180,7 @@ class CourseVersion < ApplicationRecord
   # See fakeCoursesWithProgress in teacherDashboardTestHelpers.js for an example of what
   # the resulting data looks like
   def self.courses_for_unit_selector(unit_ids)
-    standalone_units = Unit.joins(:course_version).where(id: unit_ids).map {|u| u.course_version.course_offering&.summarize_for_unit_selector(unit_ids)}.uniq
+    standalone_units = Unit.joins(:course_version).where(id: unit_ids).map {|u| u.course_version.course_offering&.summarize_for_unit_selector(unit_ids)}.compact.uniq
 
     unit_groups =  Unit.joins(unit_groups: :course_version).where(id: unit_ids).where(course_version: {content_root_type: 'UnitGroup'}).flat_map {|u| u.unit_groups.map(&:course_version)}.map(&:summarize_for_unit_selector).uniq
 

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -33,9 +33,9 @@ class CourseVersion < ApplicationRecord
 
   KEY_CHAR_RE = /[a-z0-9\-]/
   KEY_RE = /\A#{KEY_CHAR_RE}+\Z/
-  validates :key,
-    format: {with: KEY_RE,
-    message: "must contain only digits, letters, or dashes; got \"%{value}\"."}
+  validates_format_of :key,
+    with: KEY_RE,
+    message: "must contain only digits, letters, or dashes; got \"%{value}\"."
 
   # Placeholder key for curriculum that will not be updated but want the
   # features that come with a course version (resources, vocab, etc)

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -70,8 +70,6 @@ class Section < ApplicationRecord
   has_many :instructors, through: :active_section_instructors, class_name: 'User'
   has_one :lti_section
   has_one :lti_course, through: :lti_section
-  before_validation :strip_emoji_from_name
-  before_create :assign_code
   after_destroy :soft_delete_lti_section
 
   has_many :followers, dependent: :destroy
@@ -105,6 +103,8 @@ class Section < ApplicationRecord
   validate :pl_sections_must_use_email_logins
   validate :pl_sections_must_use_pl_grade
   validate :participant_type_not_changed
+
+  before_validation :strip_emoji_from_name
 
   scope :visible, -> {where(hidden: false)}
 
@@ -173,7 +173,7 @@ class Section < ApplicationRecord
   TYPES = [
     # Insert non-workshop section types here.
   ].concat(Pd::Workshop::SECTION_TYPES).freeze
-  validates :section_type, inclusion: {in: TYPES, allow_nil: true}
+  validates_inclusion_of :section_type, in: TYPES, allow_nil: true
 
   VALID_GRADES = [
     SharedConstants::STUDENT_GRADE_LEVELS,
@@ -231,12 +231,13 @@ class Section < ApplicationRecord
     [LOGIN_TYPE_EMAIL, LOGIN_TYPE_PICTURE, LOGIN_TYPE_WORD].exclude? login_type
   end
 
-  validates :user, presence: {unless: -> {deleted?}}
+  validates_presence_of :user, unless: -> {deleted?}
   def user_must_be_teacher
     errors.add(:user_id, 'must be a teacher') unless user.try(:teacher?)
   end
   validate :user_must_be_teacher, unless: -> {deleted?}
 
+  before_create :assign_code
   def assign_code
     self.code = unused_random_code unless code
   end

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -70,6 +70,8 @@ class Section < ApplicationRecord
   has_many :instructors, through: :active_section_instructors, class_name: 'User'
   has_one :lti_section
   has_one :lti_course, through: :lti_section
+  before_validation :strip_emoji_from_name
+  before_create :assign_code
   after_destroy :soft_delete_lti_section
 
   has_many :followers, dependent: :destroy
@@ -103,8 +105,6 @@ class Section < ApplicationRecord
   validate :pl_sections_must_use_email_logins
   validate :pl_sections_must_use_pl_grade
   validate :participant_type_not_changed
-
-  before_validation :strip_emoji_from_name
 
   scope :visible, -> {where(hidden: false)}
 
@@ -173,7 +173,7 @@ class Section < ApplicationRecord
   TYPES = [
     # Insert non-workshop section types here.
   ].concat(Pd::Workshop::SECTION_TYPES).freeze
-  validates_inclusion_of :section_type, in: TYPES, allow_nil: true
+  validates :section_type, inclusion: {in: TYPES, allow_nil: true}
 
   VALID_GRADES = [
     SharedConstants::STUDENT_GRADE_LEVELS,
@@ -231,13 +231,12 @@ class Section < ApplicationRecord
     [LOGIN_TYPE_EMAIL, LOGIN_TYPE_PICTURE, LOGIN_TYPE_WORD].exclude? login_type
   end
 
-  validates_presence_of :user, unless: -> {deleted?}
+  validates :user, presence: {unless: -> {deleted?}}
   def user_must_be_teacher
     errors.add(:user_id, 'must be a teacher') unless user.try(:teacher?)
   end
   validate :user_must_be_teacher, unless: -> {deleted?}
 
-  before_create :assign_code
   def assign_code
     self.code = unused_random_code unless code
   end
@@ -604,13 +603,17 @@ class Section < ApplicationRecord
     end
   end
 
+  def participant_units
+    Unit.joins(:user_scripts).where(user_scripts: {user_id: students.pluck(:id)}).distinct.select {|s| s.course_assignable?(user)}
+  end
+
   # Returns the ids of all units which any participant in this section has ever
   # been assigned to or made progress on if the instructor of the section can
   # be an instructor for that unit
   def participant_unit_ids
     # This performs two queries, but could be optimized to perform only one by
     # doing additional joins.
-    Unit.joins(:user_scripts).where(user_scripts: {user_id: students.pluck(:id)}).distinct.select {|s| s.course_assignable?(user)}.pluck(:id)
+    participant_units.pluck(:id)
   end
 
   def code_review_enabled?

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -603,17 +603,13 @@ class Section < ApplicationRecord
     end
   end
 
-  def participant_units
-    Unit.joins(:user_scripts).where(user_scripts: {user_id: students.pluck(:id)}).distinct.select {|s| s.course_assignable?(user)}
-  end
-
   # Returns the ids of all units which any participant in this section has ever
   # been assigned to or made progress on if the instructor of the section can
   # be an instructor for that unit
   def participant_unit_ids
     # This performs two queries, but could be optimized to perform only one by
     # doing additional joins.
-    participant_units.pluck(:id)
+    Unit.joins(:user_scripts).where(user_scripts: {user_id: students.pluck(:id)}).distinct.select {|s| s.course_assignable?(user)}.pluck(:id)
   end
 
   def code_review_enabled?

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -165,7 +165,7 @@ class Unit < ApplicationRecord
       message: 'cannot start with a tilde or dot or contain slashes'
     }
 
-  validates_presence_of :link
+  validates :link, presence: true
   validates :published_state, acceptance: {accept: Curriculum::SharedCourseConstants::PUBLISHED_STATE.to_h.values.push(nil), message: 'must be nil, in_development, pilot, beta, preview or stable'}
   validate :deeper_learning_courses_cannot_be_launched
 

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -165,7 +165,7 @@ class Unit < ApplicationRecord
       message: 'cannot start with a tilde or dot or contain slashes'
     }
 
-  validates :link, presence: true
+  validates_presence_of :link
   validates :published_state, acceptance: {accept: Curriculum::SharedCourseConstants::PUBLISHED_STATE.to_h.values.push(nil), message: 'must be nil, in_development, pilot, beta, preview or stable'}
   validate :deeper_learning_courses_cannot_be_launched
 


### PR DESCRIPTION
Speeds up the `dashboardapi/section_courses/:section_id` endpoint by de-duplicating database queries and simplifying the code structure.

the section_courses endpoint previously did this:
Retrieve the list of unit_ids that students have made progress in
For ALL CourseOfferings: check if any of the CourseOfferings's CourseVersions are a unit and if that unit is in the list of unit_ids
For ALL CourseVersions: if that CourseVersion is a UnitGroup (not a Unit), check if any Units in that UnitGroup are in the list of unit_ids
Return the concatenation of those two lists

Now:
Retrieve the list of unit_ids that students have made progress in
For each unit in unit_ids, find all corresponding CourseOfferings that are Units through associations
for each unit in unit_ids, find all corresponding CourseVersions that are UnitGroups through associations
return the concatenation

This significantly decreases the number of database queries

Old queries:
1278 queries, example completed in `1589ms (Views: 7.4ms | ActiveRecord: 549.7ms | Allocations: 1450020)`
Another example with just units: 1333 queries
Another example with just unit groups: 300 queries

New queries:
168 queries, example completed in `174ms (Views: 3.5ms | ActiveRecord: 44.8ms | Allocations: 79084)`
Another example with just units: 15 queries
Another example with just unit groups: 71 queries

## Links
https://codedotorg.atlassian.net/browse/TEACH-1515
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
