### PR TITLE
AI Chat: move child content to footer prop

### DIFF
--- a/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
+++ b/apps/src/aiComponentLibrary/chatMessage/ChatMessage.tsx
@@ -17,7 +17,7 @@ interface ChatMessageProps {
   status: string;
   showProfaneUserMessage?: boolean;
   customStyles?: {[label: string]: string};
-  children?: React.ReactNode;
+  footer?: React.ReactNode;
   isTA?: boolean;
 }
 
@@ -27,7 +27,7 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
   status,
   showProfaneUserMessage,
   customStyles,
-  children,
+  footer,
   isTA,
 }) => {
   const hasDangerStyle =
@@ -47,50 +47,54 @@ const ChatMessage: React.FunctionComponent<ChatMessageProps> = ({
   }, [chatMessageText, role, status, showProfaneUserMessage]);
 
   return (
-    <>
-      <div className={moduleStyles[`message-container-${role}`]}>
-        <div className={moduleStyles.messageWithChildren}>
-          <div className={moduleStyles[`container-${role}`]}>
-            {role === Role.ASSISTANT && (
-              <div
-                className={classNames(
-                  isTA && moduleStyles.botIconContainerWithOverlay
-                )}
-              >
-                <div className={classNames(moduleStyles.botIconContainer)}>
-                  <img
-                    src={aiBotOutlineIcon}
-                    alt={commonI18n.aiChatBotIconAlt()}
-                    className={moduleStyles.botIcon}
-                  />
-                </div>
-                {isTA && (
-                  <div className={moduleStyles.botOverlay}>
-                    <span>{'TA'}</span>
-                  </div>
-                )}
-              </div>
-            )}
+    <div className={moduleStyles[`message-container-${role}`]}>
+      <div className={moduleStyles.messageWithChildren}>
+        <div className={moduleStyles[`container-${role}`]}>
+          {role === Role.ASSISTANT && (
             <div
               className={classNames(
-                moduleStyles[`message-${role}`],
-                customStyles && customStyles[`message-${role}`],
-                hasDangerStyle && moduleStyles.danger,
-                hasWarningStyle && moduleStyles.warning
+                isTA && moduleStyles.botIconContainerWithOverlay
               )}
-              aria-label={
-                role === Role.ASSISTANT
-                  ? commonI18n.aiChatMessageBot()
-                  : commonI18n.aiChatMessageUser()
-              }
             >
-              <SafeMarkdown markdown={getDisplayText} />
+              <div className={classNames(moduleStyles.botIconContainer)}>
+                <img
+                  src={aiBotOutlineIcon}
+                  alt={commonI18n.aiChatBotIconAlt()}
+                  className={moduleStyles.botIcon}
+                />
+              </div>
+              {isTA && (
+                <div className={moduleStyles.botOverlay}>
+                  <span>{'TA'}</span>
+                </div>
+              )}
             </div>
+          )}
+          <div
+            className={classNames(
+              moduleStyles[`message-${role}`],
+              customStyles && customStyles[`message-${role}`],
+              hasDangerStyle && moduleStyles.danger,
+              hasWarningStyle && moduleStyles.warning
+            )}
+            aria-label={
+              role === Role.ASSISTANT
+                ? commonI18n.aiChatMessageBot()
+                : commonI18n.aiChatMessageUser()
+            }
+          >
+            <SafeMarkdown markdown={getDisplayText} />
           </div>
-          <div className={moduleStyles.childContainer}>{children}</div>
+        </div>
+        <div
+          className={
+            isTA ? moduleStyles.footerWithOverlay : moduleStyles.footer
+          }
+        >
+          {footer}
         </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
+++ b/apps/src/aiComponentLibrary/chatMessage/chat-message.module.scss
@@ -5,6 +5,9 @@
 $message-border-radius: 8px;
 $user-color: $light_gray_100;
 $assistant-color: $brand_primary_light;
+$bot-container-size: 32px;
+$icon-message-gap: 8px;
+$icon-overlay-padding-right: 8px;
 
 %message {
   @extend %markdown-styles;
@@ -88,7 +91,7 @@ $assistant-color: $brand_primary_light;
 %container {
   display: flex;
   flex-direction: row;
-  gap: 8px;
+  gap: $icon-message-gap;
 }
 
 .container-assistant {
@@ -102,14 +105,10 @@ $assistant-color: $brand_primary_light;
   justify-content: flex-end;
 }
 
-.userProfaneMessageButton {
-  width: 120px;
-}
-
 .botIconContainer {
-  flex: 0 0 32px;
-  height: 32px;
-  width: 32px;
+  flex: 0 0 $bot-container-size;
+  height: $bot-container-size;
+  width: $bot-container-size;
   background: $light-black;
   border-radius: 20px;
   display: flex;
@@ -121,12 +120,16 @@ $assistant-color: $brand_primary_light;
 .botIconContainerWithOverlay {
   position: relative;
   display: flex;
-  padding-right: 8px;
+  padding-right: $icon-overlay-padding-right;
   padding-top: 3px;
 }
 
-.childContainer {
-  margin-left: 48px;
+.footer {
+  margin-left: $bot-container-size + $icon-message-gap;
+}
+
+.footerWithOverlay {
+  margin-left: $bot-container-size + $icon-message-gap + $icon-overlay-padding-right;
 }
 
 .botIcon {

--- a/apps/src/aiDifferentiation/AiDiffContainer.tsx
+++ b/apps/src/aiDifferentiation/AiDiffContainer.tsx
@@ -250,11 +250,12 @@ const AiDiffContainer: React.FC<AiDiffContainerProps> = ({
                   customStyles={style}
                   key={id}
                   isTA={true}
-                >
-                  {item.role === Role.ASSISTANT && (
-                    <AiDiffBotMessageFooter message={item} />
-                  )}
-                </ChatMessage>
+                  footer={
+                    item.role === Role.ASSISTANT && (
+                      <AiDiffBotMessageFooter message={item} />
+                    )
+                  }
+                />
               )
             )}
             <img

--- a/apps/src/aichat/views/ChatMessageView.tsx
+++ b/apps/src/aichat/views/ChatMessageView.tsx
@@ -11,7 +11,7 @@ import {ChatMessage as ChatMessageType} from '../types';
 
 import TeacherFeedbackFooter from './TeacherFeedbackFooter';
 
-import moduleStyles from '@cdo/apps/aiComponentLibrary/chatMessage/chat-message.module.scss';
+import moduleStyles from './chat-message-view.module.scss';
 
 interface ChatMessageViewProps {
   chatMessage: ChatMessageType;
@@ -33,48 +33,64 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
     );
   }, [chatMessage, showProfaneUserMessage]);
 
+  const ShowHideMessageButton = () => (
+    <Button
+      onClick={() => {
+        setShowProfaneUserMessage(!showProfaneUserMessage);
+      }}
+      text={
+        showProfaneUserMessage
+          ? aichatI18n.chatMessage_hideMessage()
+          : aichatI18n.chatMessage_showMessage()
+      }
+      size="xs"
+      type="tertiary"
+      className={moduleStyles.userProfaneMessageButton}
+    />
+  );
+
+  // TODO: Clean up this logic; ideally these should just be inverses of each other.
+
+  const noProfanityViolation =
+    displayText === chatMessage.chatMessageText &&
+    chatMessage.status !== Status.PROFANITY_VIOLATION;
+  const hasProfanityViolation =
+    chatMessage.role === Role.USER &&
+    chatMessage.status === Status.PROFANITY_VIOLATION;
+
+  const NoProfanityFooter = () => (
+    <TeacherFeedbackFooter
+      isProfanityViolation={false}
+      chatMessage={chatMessage}
+    />
+  );
+
+  const ProfanityFooter = () => (
+    <>
+      {showProfaneUserMessage && (
+        <TeacherFeedbackFooter
+          isProfanityViolation={true}
+          chatMessage={chatMessage}
+        />
+      )}
+      <div className={moduleStyles.showHideMessageButtonContainer}>
+        <ShowHideMessageButton />
+      </div>
+    </>
+  );
+
+  const footer = noProfanityViolation ? (
+    <NoProfanityFooter />
+  ) : hasProfanityViolation ? (
+    <ProfanityFooter />
+  ) : null;
+
   return (
     <ChatMessage
       {...chatMessage}
       showProfaneUserMessage={showProfaneUserMessage}
-    >
-      {isChatHistoryView &&
-        displayText === chatMessage.chatMessageText &&
-        chatMessage.status !== Status.PROFANITY_VIOLATION && (
-          <TeacherFeedbackFooter
-            isProfanityViolation={false}
-            chatMessage={chatMessage}
-          />
-        )}
-
-      {isChatHistoryView &&
-        chatMessage.role === Role.USER &&
-        chatMessage.status === Status.PROFANITY_VIOLATION && (
-          <>
-            {showProfaneUserMessage && (
-              <TeacherFeedbackFooter
-                isProfanityViolation={true}
-                chatMessage={chatMessage}
-              />
-            )}
-            <div className={moduleStyles[`container-user`]}>
-              <Button
-                onClick={() => {
-                  setShowProfaneUserMessage(!showProfaneUserMessage);
-                }}
-                text={
-                  showProfaneUserMessage
-                    ? aichatI18n.chatMessage_hideMessage()
-                    : aichatI18n.chatMessage_showMessage()
-                }
-                size="xs"
-                type="tertiary"
-                className={moduleStyles.userProfaneMessageButton}
-              />
-            </div>
-          </>
-        )}
-    </ChatMessage>
+      footer={isChatHistoryView && footer}
+    />
   );
 };
 

--- a/apps/src/aichat/views/chat-message-view.module.scss
+++ b/apps/src/aichat/views/chat-message-view.module.scss
@@ -1,0 +1,8 @@
+.showHideMessageButtonContainer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.userProfaneMessageButton {
+  width: 120px;
+}


### PR DESCRIPTION
One of the follow-ups to https://github.com/code-dot-org/code-dot-org/pull/62797. Both GenAI Curriculum chat and AI Diff use footer for chat messages, which are currently passed as children to the common ChatMessage component. In making some UI changes to the GenAI chat footer, I felt like it made more sense to pass this as a dedicated prop, rather than as children so its purposes was more clear. Open to discussion if anyone has strong feelings otherwise though!

This also fixes a padding issue with the current GenAI footer layout (which was the original motivation for this change).

AI Diff Chat after (no change):
<img width="515" alt="Screenshot 2025-01-17 at 4 39 45 PM" src="https://github.com/user-attachments/assets/c2d4751c-e367-4c02-b13c-52cde97dd39f" />

GenAI chat after (flag button is now aligned with message):
<img width="970" alt="Screenshot 2025-01-17 at 4 40 23 PM" src="https://github.com/user-attachments/assets/c1257c5d-f8ec-42dc-839b-5276d0030887" />
