### PR TITLE
add spinner to curriculum select

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -9,6 +9,7 @@ import {
   CourseOfferingCurriculumTypes as curriculumTypes,
   ParticipantAudience,
 } from '@cdo/apps/generated/curriculum/sharedCourseConstants';
+import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import i18n from '@cdo/locale';
 
 import CurriculumQuickAssignTopRow from './CurriculumQuickAssignTopRow';
@@ -57,6 +58,7 @@ export default function CurriculumQuickAssign({
   const [decideLater, setDecideLater] = useState(false);
   const [marketingAudience, setMarketingAudience] = useState('');
   const [selectedCourseOffering, setSelectedCourseOffering] = useState();
+  const [isLoading, setIsLoading] = useState(true);
 
   const participantType = isNewSection
     ? queryParams('participantType')
@@ -200,7 +202,9 @@ export default function CurriculumQuickAssign({
 
       if (!selectedCourseOffering) {
         determineSelectedCourseOffering(filteredCourseOfferings);
+        setIsLoading(false);
       }
+      isNewSection && setIsLoading(false);
     }
     // added all these dependencies given the eslint warning
   }, [
@@ -278,62 +282,71 @@ export default function CurriculumQuickAssign({
 
   return (
     <div className={moduleStyles.containerWithMarginTop}>
-      <div className={moduleStyles.input}>
-        <label
-          className={classnames(
-            moduleStyles.decideLater,
-            moduleStyles.typographyLabel
+      {isLoading && !isNewSection ? (
+        <>
+          <Heading3>{i18n.assignCurriculum()}</Heading3>
+          <Spinner />
+        </>
+      ) : (
+        <>
+          <div className={moduleStyles.input}>
+            <label
+              className={classnames(
+                moduleStyles.decideLater,
+                moduleStyles.typographyLabel
+              )}
+              htmlFor="decide-later"
+            >
+              {selectedCourseOffering
+                ? i18n.clearAssignedCurriculum()
+                : i18n.decideLater()}
+            </label>
+            <input
+              checked={decideLater}
+              className={classnames(
+                moduleStyles.inputBox,
+                moduleStyles.withBrandAccentColor
+              )}
+              type="checkbox"
+              id="decide-later"
+              onChange={toggleDecideLater}
+            />
+            <Heading3>{i18n.assignCurriculum()}</Heading3>
+            <BodyTwoText>{i18n.useDropdownMessage()}</BodyTwoText>
+          </div>
+          <CurriculumQuickAssignTopRow
+            showPlOfferings={showPlOfferings}
+            marketingAudience={marketingAudience}
+            updateMarketingAudience={setMarketingAudience}
+          />
+          {marketingAudience && filteredCourseOfferings && (
+            <SelectedQuickAssignTable
+              marketingAudience={marketingAudience}
+              courseOfferings={filteredCourseOfferings}
+              setSelectedCourseOffering={offering => {
+                setDecideLater(false);
+                setSelectedCourseOffering(offering);
+              }}
+              updateCourse={value => {
+                updateCourse(value);
+                setIsEditInProgress(true);
+              }}
+              sectionCourse={sectionCourse}
+              isNewSection={isNewSection}
+            />
           )}
-          htmlFor="decide-later"
-        >
-          {selectedCourseOffering
-            ? i18n.clearAssignedCurriculum()
-            : i18n.decideLater()}
-        </label>
-        <input
-          checked={decideLater}
-          className={classnames(
-            moduleStyles.inputBox,
-            moduleStyles.withBrandAccentColor
+          {marketingAudience && (
+            <VersionUnitDropdowns
+              courseOffering={selectedCourseOffering}
+              updateCourse={value => {
+                updateCourse(value);
+                setIsEditInProgress(true);
+              }}
+              sectionCourse={sectionCourse}
+              isNewSection={isNewSection}
+            />
           )}
-          type="checkbox"
-          id="decide-later"
-          onChange={toggleDecideLater}
-        />
-        <Heading3>{i18n.assignCurriculum()}</Heading3>
-        <BodyTwoText>{i18n.useDropdownMessage()}</BodyTwoText>
-      </div>
-      <CurriculumQuickAssignTopRow
-        showPlOfferings={showPlOfferings}
-        marketingAudience={marketingAudience}
-        updateMarketingAudience={setMarketingAudience}
-      />
-      {marketingAudience && filteredCourseOfferings && (
-        <SelectedQuickAssignTable
-          marketingAudience={marketingAudience}
-          courseOfferings={filteredCourseOfferings}
-          setSelectedCourseOffering={offering => {
-            setDecideLater(false);
-            setSelectedCourseOffering(offering);
-          }}
-          updateCourse={value => {
-            updateCourse(value);
-            setIsEditInProgress(true);
-          }}
-          sectionCourse={sectionCourse}
-          isNewSection={isNewSection}
-        />
-      )}
-      {marketingAudience && (
-        <VersionUnitDropdowns
-          courseOffering={selectedCourseOffering}
-          updateCourse={value => {
-            updateCourse(value);
-            setIsEditInProgress(true);
-          }}
-          sectionCourse={sectionCourse}
-          isNewSection={isNewSection}
-        />
+        </>
       )}
     </div>
   );

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -1,15 +1,36 @@
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 
+import Spinner from '@cdo/apps/sharedComponents/Spinner';
 import CurriculumQuickAssign from '@cdo/apps/templates/sectionsRefresh/CurriculumQuickAssign';
 import i18n from '@cdo/locale';
 
 window.fetch = jest.fn().mockResolvedValue({json: jest.fn()});
 
 describe('CurriculumQuickAssign', () => {
+  it('shows spinner when isLoading is true', () => {
+    const wrapper = mount(
+      <CurriculumQuickAssign
+        updateSection={() => {}}
+        sectionCourse={{}}
+        initialParticipantType="student"
+        courseFilters={{}}
+        isNewSection={false}
+      />
+    );
+
+    expect(wrapper.find(Spinner)).toHaveLength(1);
+    expect(wrapper.find('h3').length).toBe(1);
+    expect(wrapper.find('Button')).toHaveLength(0);
+  });
+
   it('renders headers and the top row of buttons', () => {
     const wrapper = mount(
-      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+      <CurriculumQuickAssign
+        updateSection={() => {}}
+        sectionCourse={{}}
+        isNewSection={true}
+      />
     );
 
     expect(wrapper.find('h3').length).toBe(1);
@@ -27,7 +48,11 @@ describe('CurriculumQuickAssign', () => {
 
   it('updates caret direction when clicked', () => {
     const wrapper = mount(
-      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+      <CurriculumQuickAssign
+        updateSection={() => {}}
+        sectionCourse={{}}
+        isNewSection={true}
+      />
     );
 
     expect(wrapper.find('Button').at(0).props().icon).toBe('caret-right');
@@ -40,8 +65,13 @@ describe('CurriculumQuickAssign', () => {
 
   it('opens and closes version dropdowns with table open and collapse', () => {
     const wrapper = mount(
-      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+      <CurriculumQuickAssign
+        updateSection={() => {}}
+        sectionCourse={{}}
+        isNewSection={true}
+      />
     );
+
     expect(wrapper.find('VersionUnitDropdowns')).toHaveLength(0);
     wrapper
       .find('Button')
@@ -57,7 +87,11 @@ describe('CurriculumQuickAssign', () => {
 
   it('leaves dropdowns alone when decide later clicked', () => {
     const wrapper = mount(
-      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+      <CurriculumQuickAssign
+        updateSection={() => {}}
+        sectionCourse={{}}
+        isNewSection={true}
+      />
     );
 
     // No dropdowns active at beginning


### PR DESCRIPTION
Adds spinner to the curriculum selection area.

Note: The new-section-setup feature works the same way as it did before.

The video below shows us looking at the edit section page for a section with curriculum assigned and then looking at a section with NO curriculum assigned.  Either way the user sees the spinner. 


https://github.com/user-attachments/assets/39dc9e75-7efc-4811-a1dc-e26269618c54



## Links

[Ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-1517)

## Testing story

I added one test, and started to change the test to RTL, but it got pretty ugly.  See [this](https://github.com/code-dot-org/code-dot-org/pull/63287/files#r1914914188) comment for reason why we decided to keep it this way.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
