### PR TITLE
Log events when students and signed out users visit Unit and Course Overview Pages

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -89,6 +89,22 @@ class UnitOverview extends React.Component {
         },
         PLATFORMS.BOTH
       );
+    } else if (props.userType === 'student') {
+      analyticsReporter.sendEvent(
+        EVENTS.UNIT_OVERVIEW_PAGE_VISITED_BY_STUDENT_EVENT,
+        {
+          'unit name': props.scriptName,
+        },
+        PLATFORMS.BOTH
+      );
+    } else {
+      analyticsReporter.sendEvent(
+        EVENTS.UNIT_OVERVIEW_PAGE_VISITED_BY_SIGNED_OUT_USER_EVENT,
+        {
+          'unit name': props.scriptName,
+        },
+        PLATFORMS.BOTH
+      );
     }
   }
 

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -87,8 +87,16 @@ const EVENTS = {
   // Course/Unit info
   COURSE_OVERVIEW_PAGE_VISITED_BY_TEACHER_EVENT:
     'Course Overview Page Visited By Teacher',
+  COURSE_OVERVIEW_PAGE_VISITED_BY_STUDENT_EVENT:
+    'Course Overview Page Visited By Student',
+  COURSE_OVERVIEW_PAGE_VISITED_BY_SIGNED_OUT_USER_EVENT:
+    'Course Overview Page Visited By Signed Out User',
   UNIT_OVERVIEW_PAGE_VISITED_BY_TEACHER_EVENT:
     'Unit Overview Page Visited By Teacher',
+  UNIT_OVERVIEW_PAGE_VISITED_BY_STUDENT_EVENT:
+    'Unit Overview Page Visited By Student',
+  UNIT_OVERVIEW_PAGE_VISITED_BY_SIGNED_OUT_USER_EVENT:
+    'Unit Overview Page Visited By Signed Out User',
   TRY_NOW_BUTTON_CLICK_EVENT: 'Try Now Button Clicked',
 
   // Lesson info

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -88,6 +88,22 @@ class CourseOverview extends Component {
         },
         PLATFORMS.BOTH
       );
+    } else if (props.userType === 'student') {
+      analyticsReporter.sendEvent(
+        EVENTS.COURSE_OVERVIEW_PAGE_VISITED_BY_STUDENT_EVENT,
+        {
+          'unit group name': props.name,
+        },
+        PLATFORMS.BOTH
+      );
+    } else {
+      analyticsReporter.sendEvent(
+        EVENTS.COURSE_OVERVIEW_PAGE_VISITED_BY_SIGNED_OUT_USER_EVENT,
+        {
+          'unit group name': props.name,
+        },
+        PLATFORMS.BOTH
+      );
     }
   }
 


### PR DESCRIPTION
Logs events for viewing the unit and course overview pages for non-teachers. Because the current event is specific to teachers, I added new events for students and signed out users. We'll combine them on the Statsig/Amplitude side.

Unit Overview:

<img width="1413" alt="Screenshot 2025-01-21 at 2 52 24 PM" src="https://github.com/user-attachments/assets/d4943c05-88b0-43f8-b97d-d26d7d023af3" />

<img width="1418" alt="Screenshot 2025-01-21 at 2 55 29 PM" src="https://github.com/user-attachments/assets/ab831168-4fe8-4713-a0d6-99559b1c8ebe" />

Course Overview

<img width="1416" alt="Screenshot 2025-01-21 at 3 08 27 PM" src="https://github.com/user-attachments/assets/4055151e-2011-43f8-8b71-5338167461f3" />

<img width="1412" alt="Screenshot 2025-01-21 at 3 07 24 PM" src="https://github.com/user-attachments/assets/bea2b435-e7f8-4448-8776-235aa2ba3468" />


