### PR TITLE
Add Google Analytics event to successful signup

### DIFF
--- a/apps/src/signUpFlow/FinishStudentAccount.tsx
+++ b/apps/src/signUpFlow/FinishStudentAccount.tsx
@@ -18,6 +18,7 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 import {isEmail} from '@cdo/apps/util/formatValidation';
+import trackEvent from '@cdo/apps/util/trackEvent';
 import {UserTypes} from '@cdo/generated-scripts/sharedConstants';
 
 import {navigateToHref} from '../utils';
@@ -191,6 +192,7 @@ const FinishStudentAccount: React.FunctionComponent<{
   };
 
   const sendFinishEvent = (): void => {
+    // Log to Statsig and Amplitude
     analyticsReporter.sendEvent(
       EVENTS.SIGN_UP_FINISHED_EVENT,
       {
@@ -201,6 +203,11 @@ const FinishStudentAccount: React.FunctionComponent<{
       },
       PLATFORMS.BOTH
     );
+
+    // Log to Google Analytics
+    trackEvent('sign_up', 'sign_up_success', {
+      value: 'student',
+    });
   };
 
   const submitStudentAccount = async () => {

--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -21,6 +21,7 @@ import {schoolInfoInvalid} from '@cdo/apps/schoolInfo/utils/schoolInfoInvalid';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import SchoolDataInputs from '@cdo/apps/templates/SchoolDataInputs';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
+import trackEvent from '@cdo/apps/util/trackEvent';
 import {UserTypes, EducatorRoles} from '@cdo/generated-scripts/sharedConstants';
 
 import {useSchoolInfo} from '../schoolInfo/hooks/useSchoolInfo';
@@ -228,6 +229,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
   };
 
   const sendFinishEvent = (): void => {
+    // Log to Statsig and Amplitude
     const schoolData = buildSchoolData({
       schoolId: schoolInfo.schoolId,
       country: schoolInfo.country,
@@ -248,6 +250,11 @@ const FinishTeacherAccount: React.FunctionComponent<{
       },
       PLATFORMS.BOTH
     );
+
+    // Log to Google Analytics
+    trackEvent('sign_up', 'sign_up_success', {
+      value: 'teacher',
+    });
   };
 
   return (


### PR DESCRIPTION
For the old sign-up flow, we tracked sign-ups on Google Analytics by seeing when a user hit the `/users/finish_sign_up` page. The equivalent to this for the new sign-up flow would be seeing when a user hit either `/new_sign_up/finish_student_account` or `/new_sign_up/finish_teacher_account`, however this is not a very accurate way of knowing the number of sign-ups since a user could run into an error. So, this PR adds a GA event that logs upon a successful submission (just like we currently do for Statsig and Amplitude, so this will align our logging systems).

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2991)

## Testing story
I used the Google Analytics debug view that Brendan used [here](https://github.com/code-dot-org/code-dot-org/pull/60145) to check that both events fired:

Student event:
![success local event student](https://github.com/user-attachments/assets/345212dd-fe60-4df5-8de3-8c2c704bf033)

Teacher event:
![success local event](https://github.com/user-attachments/assets/d5d7464c-d837-4ca1-b48e-8c370fcb1aad)
