### PR TITLE
check status of person viewing page

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverviewActionRow.tsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewActionRow.tsx
@@ -147,6 +147,11 @@ const UnitOverviewActionRow: React.FC<UnitOverviewActionRowProps> = ({
   const viewAs = useSelector(
     (state: {viewAs: keyof typeof ViewType}) => state.viewAs
   ) as string;
+
+  const isTeacher = useSelector(
+    (state: {currentUser: {isTeacher: boolean}}) => state.currentUser.isTeacher
+  );
+
   const selectedSectionId = useAppSelector(
     state => state.teacherSections.selectedSectionId
   );
@@ -273,7 +278,7 @@ const UnitOverviewActionRow: React.FC<UnitOverviewActionRowProps> = ({
           )}
         </div>
 
-        {showV2TeacherDashboard() && (
+        {showV2TeacherDashboard() && isTeacher && (
           <div className={styles.viewAs}>
             {<label className={styles.viewAsLabel}>{i18n.viewPageAs()}</label>}
             <SegmentedButtons


### PR DESCRIPTION
Modifies header to only show `student/teacher` toggle if the person logged in is a `Teacher`.

[Addresses ZenDesk ticket](https://codedotorg.slack.com/archives/C045UAX4WKH/p1737492362930999?thread_ts=1737057284.131479&cid=C045UAX4WKH)


## Testing story

Made sure all unit tests passed before starting drone build.  I imagine this might trigger some eyes diffs...

Also tested locally as a student and a teacher both with the teacherDashboard experiment flag toggled on and off. 
