### PR TITLE
Add signedIn state to Level Activity event

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2169,7 +2169,11 @@ StudioApp.prototype.configureDom = function (config) {
       eventName = EVENTS.LEVEL_ACTIVITY;
     }
     if (!runButtonWasClicked) {
-      analyticsReporter.sendEvent(eventName, {}, PLATFORMS.BOTH);
+      analyticsReporter.sendEvent(
+        eventName,
+        {signedIn: config.isSignedIn},
+        PLATFORMS.BOTH
+      );
       runButtonWasClicked = true;
     }
   };


### PR DESCRIPTION
Adds signed in state as a property of the `Level Activity` event. The reason to do this is to access the usefulness of the sign in callout that appears on certain levels. We want to know if people see that callout then make **signed in** progress on a level.

Signed out:
![Screenshot 2025-01-22 at 11 14 39 AM](https://github.com/user-attachments/assets/f88efcca-4566-4873-a0cc-de87101ebd83)

Signed in:
![Screenshot 2025-01-22 at 11 16 23 AM](https://github.com/user-attachments/assets/cd878c24-890b-4968-bd29-417160939063)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
