### PR TITLE
feat(apps): enable npm linked package support

### DIFF
--- a/apps/tsconfig.build.json
+++ b/apps/tsconfig.build.json
@@ -26,6 +26,7 @@
     "skipLibCheck": true,
     "allowJs": true,
     "baseUrl": "./",
+    "preserveSymlinks": true,
     "paths": {
       "@cdo/apps/*": ["./src/*"],
       "@cdo/storybook/*": ["./.storybook/*"],

--- a/apps/webpack.config.js
+++ b/apps/webpack.config.js
@@ -190,6 +190,10 @@ const APPLICATION_ALIASES = {
   '@cdoide': p('src/weblab2/CDOIDE'),
   '@cdo/generated-scripts': p('generated-scripts'),
   '@codebridge': p('src/codebridge'),
+  // Prevent webpack from including linked npm dependencies' version of React
+  // In other words, only bundle one copy of React (the one specified in this file)
+  // and not the one specified by linked dependencies.
+  react: p('node_modules/react'),
 };
 
 const LOCALE_ALIASES = {


### PR DESCRIPTION
This PR introduces the ability to link npm packages that have their own dependency tree without resulting in multiple react versions and preserving their symlinks. Currently, Code.org uses externally published npm packages which do not result in their dependency tree being included by webpack OR it uses __linked__ packages that do not have dependency on React.

If a __linked__ package consumes react, then Webpack will automatically include that linked package's version of React resulting in duplicate Reacts in the resulting bundle. Instead, configure webpack to resolve react to the `apps` version of React rather than different sub-versions.

This PR enables the subsequent linking of `@code-dot-org/component-library` to `apps`.

References:

1. https://stackoverflow.com/a/31170775

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Drone, regression testing, local testing