### PR TITLE
Remove __useDeprecatedTag from SchoolInfoInterstitial

### DIFF
--- a/apps/src/schoolInfo/SchoolInfoInterstitial.jsx
+++ b/apps/src/schoolInfo/SchoolInfoInterstitial.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React, {useEffect, useMemo, useState} from 'react';
 
+import Button from '@cdo/apps/componentLibrary/button';
 import fontConstants from '@cdo/apps/fontConstants';
-import Button from '@cdo/apps/legacySharedComponents/Button';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
@@ -138,21 +138,23 @@ export default function SchoolInfoInterstitial({
         </div>
         <div style={styles.bottom}>
           <Button
-            onClick={dismissSchoolInfoForm}
-            style={styles.button}
-            color="gray"
-            size="large"
             text={i18n.dismiss()}
+            onClick={dismissSchoolInfoForm}
+            size="m"
+            type="secondary"
             id="dismiss-button"
+            color="gray"
+            style={styles.button}
           />
           <Button
-            onClick={handleSchoolInfoSubmit}
-            style={styles.button}
-            size="large"
             text={i18n.save()}
-            color={Button.ButtonColor.brandSecondaryDefault}
+            onClick={handleSchoolInfoSubmit}
+            size="m"
+            type="primary"
             id="save-button"
+            color="purple"
             disabled={saveDisabled}
+            style={styles.button}
           />
         </div>
       </div>
@@ -207,6 +209,7 @@ const styles = {
     color: color.red,
   },
   button: {
+    width: '6.25em',
     marginLeft: 7,
     marginRight: 7,
     marginTop: 15,


### PR DESCRIPTION
The SchoolInfoInterstitial uses the legacy Button component. 
When specified with `__useDeprecatedTag` and an onClick function, the Button component creates a `<div onClick>`, or a ‘clickable div’. Clickable divs are an accessibility anti-pattern because they may be styled to look like buttons, but do not communicate their functionality in a way that screenreaders or assistive technology can identify.
We could get rid of the `__useDeprecatedTag` by applying the same changes as in PR #49339 however, we have a new DSCO Button component that is fully accessible.

This PR:
- Uses the `componentLibrary/button` instead of the `legacySharedComponents/Button`.

## Links

- jira ticket: [A11Y-133](https://codedotorg.atlassian.net/browse/A11Y-133)


## Testing story
|Before|After|
|-------|-----|
|<img width="711" alt="Screenshot 2025-01-22 at 12 56 33" src="https://github.com/user-attachments/assets/09134d28-69f5-4a7a-89b8-b939fc27291b" />|<img width="711" alt="Screenshot 2025-01-22 at 12 56 04" src="https://github.com/user-attachments/assets/5c25a754-f980-42fd-ba35-3e7a662d1686" />|
|<img width="711" alt="Screenshot 2025-01-22 at 15 10 17" src="https://github.com/user-attachments/assets/d4dc4390-6347-4f8f-b523-3ebd7bd18bc2" />|<img width="711" alt="Screenshot 2025-01-22 at 15 09 12" src="https://github.com/user-attachments/assets/61921569-d2ce-4a2a-8f3d-e33bd9dbdc95" />|

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
