### PR TITLE
Add a 'new' tag to the sidebar

### DIFF
--- a/apps/src/componentLibrary/tags/Tags.story.tsx
+++ b/apps/src/componentLibrary/tags/Tags.story.tsx
@@ -67,7 +67,33 @@ DefaultTags.args = {
       tooltipId: 'english-science',
       tooltipContent: 'English, Science',
     },
-    {label: 'No tooltip'},
+  ],
+  size: 'm',
+  className: 'test',
+};
+
+export const NoTooltipTags = SingleTemplate.bind({});
+NoTooltipTags.args = {
+  tagsList: [
+    {label: 'Math'},
+    {
+      label: '+1',
+      icon: {
+        iconName: 'check',
+        iconStyle: 'solid',
+        title: 'check',
+        placement: 'left',
+      },
+    },
+    {
+      label: '+1',
+      icon: {
+        iconName: 'check',
+        iconStyle: 'solid',
+        title: 'check',
+        placement: 'right',
+      },
+    },
   ],
   size: 'm',
   className: 'test',

--- a/apps/src/componentLibrary/tags/Tags.story.tsx
+++ b/apps/src/componentLibrary/tags/Tags.story.tsx
@@ -67,6 +67,7 @@ DefaultTags.args = {
       tooltipId: 'english-science',
       tooltipContent: 'English, Science',
     },
+    {label: 'No tooltip'},
   ],
   size: 'm',
   className: 'test',

--- a/apps/src/componentLibrary/tags/_Tag.tsx
+++ b/apps/src/componentLibrary/tags/_Tag.tsx
@@ -32,7 +32,6 @@ export interface TagProps {
    *  Icon object consists of icon(icon name/style, title for screenReader,
    *  and the placement of the icon (left or right))*/
   icon?: TagIconProps;
-  // color?: TagColor;
 }
 
 const Tag: React.FunctionComponent<TagProps> = ({

--- a/apps/src/componentLibrary/tags/_Tag.tsx
+++ b/apps/src/componentLibrary/tags/_Tag.tsx
@@ -20,10 +20,11 @@ export interface TagProps {
   /** Tag label */
   label: string;
   /** Tag tooltip content. Can be a simple string or ReactNode (some jsx/html markup/view).
-   *  For example - check Tags.story.tsx*/
-  tooltipContent: string | React.ReactNode;
+   *  For example - check Tags.story.tsx
+   *  Can be null to disable the tooltip */
+  tooltipContent?: string | React.ReactNode;
   /** Tag tooltip id (required for better accessibility, see ) */
-  tooltipId: string;
+  tooltipId?: string;
   /** aria-label for the tag.
    *  Used to allow screen reader to read tag as ariaLabel content instead of the label content */
   ariaLabel?: string;
@@ -31,6 +32,7 @@ export interface TagProps {
    *  Icon object consists of icon(icon name/style, title for screenReader,
    *  and the placement of the icon (left or right))*/
   icon?: TagIconProps;
+  // color?: TagColor;
 }
 
 const Tag: React.FunctionComponent<TagProps> = ({
@@ -39,7 +41,7 @@ const Tag: React.FunctionComponent<TagProps> = ({
   tooltipId,
   icon,
 }) => {
-  return (
+  return tooltipContent && tooltipId ? (
     <WithTooltip
       tooltipProps={{
         direction: 'onTop',
@@ -57,6 +59,12 @@ const Tag: React.FunctionComponent<TagProps> = ({
         {icon && icon.placement === 'right' && <TagIcon {...icon} />}
       </div>
     </WithTooltip>
+  ) : (
+    <div className={moduleStyles.tag}>
+      {icon && icon.placement === 'left' && <TagIcon {...icon} />}
+      <span>{label}</span>
+      {icon && icon.placement === 'right' && <TagIcon {...icon} />}
+    </div>
   );
 };
 

--- a/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
+++ b/apps/src/templates/teacherNavigation/TeacherNavigationBar.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-router-dom';
 
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
+import Tags from '@cdo/apps/componentLibrary/tags/Tags';
 import Typography from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
@@ -80,9 +81,23 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
     ['roster', 'settings'];
 
   const teacherNavigationBarContent = [
-    {title: coursecontentSectionTitle, keys: courseContentKeys},
-    {title: performanceSectionTitle, keys: performanceContentKeys},
-    {title: classroomContentSectionTitle, keys: classroomContentKeys},
+    {
+      title: coursecontentSectionTitle,
+      keys: courseContentKeys,
+      sectionTag: (
+        <Tags tagsList={[{label: 'New'}]} className={styles.sidebarNewTags} />
+      ),
+    },
+    {
+      title: performanceSectionTitle,
+      keys: performanceContentKeys,
+      sectionTag: null,
+    },
+    {
+      title: classroomContentSectionTitle,
+      keys: classroomContentKeys,
+      sectionTag: null,
+    },
   ];
 
   const navigate = useNavigate();
@@ -159,12 +174,15 @@ const TeacherNavigationBar: React.FunctionComponent = () => {
   };
 
   const navbarComponents = teacherNavigationBarContent.map(
-    ({title, keys}, index) => {
+    ({title, keys, sectionTag}, index) => {
       const sidebarOptions = getSidebarOptionsForSection(keys);
 
       return (
         <div key={`section-${index}`}>
-          {title}
+          <div className={styles.sidebarSectionHeader}>
+            {title}
+            {sectionTag}
+          </div>
           {sidebarOptions}
         </div>
       );

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -38,6 +38,25 @@
   padding-bottom: 16px;
 }
 
+.sidebarSectionHeader {
+  display: flex;
+  flex-direction: row;
+  align-items: end;
+  margin-bottom: 2px;
+}
+
+.sidebarNewTags{
+  margin-inline-start: 10px;
+
+  div {
+    background-color: $light_primary_500 !important;
+
+    span {
+      color: $white !important;
+    }
+  }
+}
+
 .sectionDropdown {
   padding-left: 16px;
   width: 210px;
@@ -90,7 +109,7 @@
 
 .sectionHeader {
   margin-top: 0;
-  margin-bottom: 2px;
+  margin-bottom: 0;
   padding-left: 16px;
   padding-top: 20px;
   color: var(--text-neutral-quaternary);

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -48,13 +48,15 @@
 .sidebarNewTags{
   margin-inline-start: 10px;
 
-  div {
-    background-color: $light_primary_500 !important;
+}
 
-    span {
-      color: $white !important;
-    }
-  }
+.sidebarSectionHeader .sidebarNewTags div {
+  background-color: $light_primary_500;
+
+}
+
+.sidebarSectionHeader .sidebarNewTags div span {
+  color: $white
 }
 
 .sectionDropdown {

--- a/frontend/packages/component-library/src/tags/_Tag.tsx
+++ b/frontend/packages/component-library/src/tags/_Tag.tsx
@@ -20,10 +20,11 @@ export interface TagProps {
   /** Tag label */
   label: string;
   /** Tag tooltip content. Can be a simple string or ReactNode (some jsx/html markup/view).
-   *  For example - check Tags.story.tsx*/
-  tooltipContent: string | React.ReactNode;
+   *  For example - check Tags.story.tsx
+   *  Can be null to disable the tooltip */
+  tooltipContent?: string | React.ReactNode;
   /** Tag tooltip id (required for better accessibility, see ) */
-  tooltipId: string;
+  tooltipId?: string;
   /** aria-label for the tag.
    *  Used to allow screen reader to read tag as ariaLabel content instead of the label content */
   ariaLabel?: string;
@@ -39,7 +40,7 @@ const Tag: React.FunctionComponent<TagProps> = ({
   tooltipId,
   icon,
 }) => {
-  return (
+  return tooltipContent && tooltipId ? (
     <WithTooltip
       tooltipProps={{
         direction: 'onTop',
@@ -57,6 +58,12 @@ const Tag: React.FunctionComponent<TagProps> = ({
         {icon && icon.placement === 'right' && <TagIcon {...icon} />}
       </div>
     </WithTooltip>
+  ) : (
+    <div className={moduleStyles.tag}>
+      {icon && icon.placement === 'left' && <TagIcon {...icon} />}
+      <span>{label}</span>
+      {icon && icon.placement === 'right' && <TagIcon {...icon} />}
+    </div>
   );
 };
 

--- a/frontend/packages/component-library/src/tags/stories/Tags.story.tsx
+++ b/frontend/packages/component-library/src/tags/stories/Tags.story.tsx
@@ -71,6 +71,33 @@ DefaultTags.args = {
   className: 'test',
 };
 
+export const NoTooltipTags = SingleTemplate.bind({});
+NoTooltipTags.args = {
+  tagsList: [
+    {label: 'Math'},
+    {
+      label: '+1',
+      icon: {
+        iconName: 'check',
+        iconStyle: 'solid',
+        title: 'check',
+        placement: 'left',
+      },
+    },
+    {
+      label: '+1',
+      icon: {
+        iconName: 'check',
+        iconStyle: 'solid',
+        title: 'check',
+        placement: 'right',
+      },
+    },
+  ],
+  size: 'm',
+  className: 'test',
+};
+
 export const TagsWithHTMLTooltipContent = SingleTemplate.bind({});
 TagsWithHTMLTooltipContent.args = {
   tagsList: [


### PR DESCRIPTION
Adds a `new` tag to the sidebar
![image](https://github.com/user-attachments/assets/66bb2a4f-c4d3-4f9f-a34e-f75f1a750d8b)

Uses the DSCO `Tags` component and adds necessary functionality.

## Links
https://codedotorg.atlassian.net/browse/TEACH-1601
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
