### PR TITLE
feat(Divider): add thumbnail and tooltip to component definition

### DIFF
--- a/frontend/apps/marketing/src/components/divider/dividerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/divider/dividerContentfulDefinition.ts
@@ -7,7 +7,7 @@ export const DividerContentfulComponentDefinition: ComponentDefinition = {
   category: 'Custom Components',
   builtInStyles: 'cfMargin',
   thumbnailUrl:
-    'https://images.ctfassets.net/90t6bu6vlf76/2szIrFB6A7UrWF4wQLW2zV/0531f1a17546c6a92ccbc07a87231f85/component_divider_thumbnail.png',
+    'https://images.ctfassets.net/90t6bu6vlf76/6UpajalIAQ0bHw17sZky2Y/6c93c9859576d981676325338e844075/component_divider_thumbnail.png',
   tooltip: {
     description:
       'Use a divider to visually separate content sections. It spans the full width and helps improve readability and layout structure.',

--- a/frontend/apps/marketing/src/components/divider/dividerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/divider/dividerContentfulDefinition.ts
@@ -6,6 +6,11 @@ export const DividerContentfulComponentDefinition: ComponentDefinition = {
   name: 'Divider',
   category: 'Custom Components',
   builtInStyles: 'cfMargin',
+  // thumbnailUrl: 'https://code.org/images/logo.svg',
+  tooltip: {
+    description: 'A horizontal line to separate content',
+    // imageUrl: 'https://code.org/images/logo.svg',
+  },
   variables: {
     color: {
       displayName: 'Color',

--- a/frontend/apps/marketing/src/components/divider/dividerContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/divider/dividerContentfulDefinition.ts
@@ -6,10 +6,13 @@ export const DividerContentfulComponentDefinition: ComponentDefinition = {
   name: 'Divider',
   category: 'Custom Components',
   builtInStyles: 'cfMargin',
-  // thumbnailUrl: 'https://code.org/images/logo.svg',
+  thumbnailUrl:
+    'https://images.ctfassets.net/90t6bu6vlf76/2szIrFB6A7UrWF4wQLW2zV/0531f1a17546c6a92ccbc07a87231f85/component_divider_thumbnail.png',
   tooltip: {
-    description: 'A horizontal line to separate content',
-    // imageUrl: 'https://code.org/images/logo.svg',
+    description:
+      'Use a divider to visually separate content sections. It spans the full width and helps improve readability and layout structure.',
+    imageUrl:
+      'https://images.ctfassets.net/90t6bu6vlf76/3gRz7bA5miAVaFwJqM6w18/075ca1479e4c79c3969e3cb4a87a9992/component_divider_tooltip.png',
   },
   variables: {
     color: {


### PR DESCRIPTION
Adds thumbnail and tooltip for the Divider component on Contentful in the Experiences sidebar. Images are hosted on Contentful (in the Media section) and use the tags `Component thumbnail` and `Component tooltip`.

## Links
Jira ticket: [ACQ-3023](https://codedotorg.atlassian.net/browse/ACQ-3023)

## Testing story
Tested locally in Contentful

----

https://github.com/user-attachments/assets/14940fdc-4d0a-4227-a813-64b8815eb3c0

<img width="441" alt="Screenshot 2025-01-23 at 12 13 14 PM" src="https://github.com/user-attachments/assets/2a963d6f-479c-4acf-9e9b-fac6cd4bf2e6" />