### PR TITLE
test(workshops): add ui tests around enrolling in workshop with school info

### DIFF
--- a/apps/src/templates/SchoolNameInput.jsx
+++ b/apps/src/templates/SchoolNameInput.jsx
@@ -15,6 +15,7 @@ export default function SchoolNameInput({
 
   return (
     <TextField
+      id="uitest-school-name"
       name={fieldNames.schoolName}
       label={i18n.schoolOrganizationQuestion()}
       onChange={e => handleSchoolNameChange(e.target.value)}

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -180,7 +180,7 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
       school_district_other: params[:school_info][:school_district_other]&.strip_utf8mb4,
       school_id: params[:school_info][:school_id],
       school_name: params[:school_info][:school_name]&.strip_utf8mb4,
-      country: "US" # we currently only support enrollment in pd for US schools
+      country: params[:school_info][:country]
     }
   end
 

--- a/dashboard/test/ui/features/acquisition_products/pd/workshop_enrollment.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/workshop_enrollment.feature
@@ -1,0 +1,69 @@
+@dashboard_db_access
+Feature: Workshop Enrollment
+
+Scenario: Enrolling in a new workshop with school info US nces school
+  Given I am a teacher enrolling in "CS Principles"
+  And I wait until element "#uitest-country-dropdown" is visible
+  And I select the "United States" option in dropdown "uitest-country-dropdown"
+  And I wait until element "#uitest-school-zip" is visible
+  And I press keys "31513" for element "#uitest-school-zip"
+  And I wait until element "#uitest-school-dropdown" is visible
+  And I select the "Appling County High School" option in dropdown "uitest-school-dropdown"
+  And I click "button#submit"
+  And I wait until current URL contains "my-professional-learning"
+
+  # test clean up
+  And I delete the workshop
+
+Scenario: Enrolling in a new workshop with school info unknown school
+  Given I am a teacher enrolling in "CS Principles"
+  And I wait until element "#uitest-country-dropdown" is visible
+  And I select the "United States" option in dropdown "uitest-country-dropdown"
+  And I wait until element "#uitest-school-zip" is visible
+  And I press keys "31513" for element "#uitest-school-zip"
+  And I wait until element "#uitest-school-dropdown" is visible
+  And I select the "Not listed here - add my school" option in dropdown "uitest-school-dropdown"
+  And I wait until element "#uitest-school-name" is visible
+  And I press keys "New School" for element "#uitest-school-name"
+  And I click "button#submit"
+  And I wait until current URL contains "my-professional-learning"
+
+  # test clean up
+  And I delete the workshop
+
+Scenario: Enrolling in a new workshop with school info no school setting
+  Given I am a teacher enrolling in "CS Principles"
+  And I wait until element "#uitest-country-dropdown" is visible
+  And I select the "United States" option in dropdown "uitest-country-dropdown"
+  And I wait until element "#uitest-school-zip" is visible
+  And I press keys "31513" for element "#uitest-school-zip"
+  And I wait until element "#uitest-school-dropdown" is visible
+  And I select the "I don't teach CS in a school setting" option in dropdown "uitest-school-dropdown"
+  And I click "button#submit"
+  And I wait until current URL contains "my-professional-learning"
+
+  # test clean up
+  And I delete the workshop
+
+Scenario: Enrolling in a new workshop with school info non-US school
+  Given I am a teacher enrolling in "CS Principles"
+  And I wait until element "#uitest-country-dropdown" is visible
+  And I select the "Canada" option in dropdown "uitest-country-dropdown"
+  And I wait until element "#uitest-school-name" is visible
+  And I press keys "New School" for element "#uitest-school-name"
+  And I click "button#submit"
+  And I wait until current URL contains "my-professional-learning"
+
+  # test clean up
+  And I delete the workshop
+
+Scenario: Enrolling in a new workshop with invalid school info
+  Given I am a teacher enrolling in "CS Principles"
+  And I wait until element "#uitest-country-dropdown" is visible
+  And I click "button#submit"
+  And I wait until element "span:contains('School information is required')" is visible
+
+  # test clean up
+  And I delete the workshop
+
+

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -268,6 +268,16 @@ And(/^I am viewing a workshop with fake survey results$/) do
   steps "And I am on \"http://studio.code.org/pd/workshop_dashboard/daily_survey_results/#{workshop.id}\""
 end
 
+Given(/^I am a teacher enrolling in "([^"]*)"$/) do |course|
+  workshop = FactoryBot.create(:workshop, course: course)
+  @workshop_id = workshop.id
+  random_teacher_name = "Test Teacher" + SecureRandom.hex[0..9]
+  steps <<~GHERKIN
+    And I create a teacher named "#{random_teacher_name}"
+    And I am on "http://studio.code.org/pd/workshops/#{@workshop_id}/enroll"
+  GHERKIN
+end
+
 def create_fake_survey_questions(workshop)
   Pd::SurveyQuestion.find_or_create_by!(form_id: CDO.jotform_forms['local_summer']['day_0'],
     questions: [


### PR DESCRIPTION
The workshop enrollment form collects the teacher's school info, assigns it to the enrollment, and assigns the new school info to the user if it changed. after a bug was found in which the POST /workshops/1/enroll failed because the `zip` on the request did not match the expected `school_zip` in the controller, we decided to shore up this request with a ui test. These new tests revealed another bug, where users attempting to change their school info to another country receive a failed request saying their school info is invalid. This is because the controller is ignoring the `country` sent in the request and overriding it with `"US"` because workshops are only offered to US based teachers. I think this should be validated further up in the controller, rather than causing the school info validation to fail.

follow up ticket [[ACQ-3033] Validate workshop enrollment submitted by teachers outside US - Code.org Jira](https://codedotorg.atlassian.net/browse/ACQ-3033)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[[ACQ-2938] Add ui test for workshop enrollment school info - Code.org Jira](https://codedotorg.atlassian.net/browse/ACQ-2938)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
