### PR TITLE
Codebridge: Fix instructions text highlighting

### DIFF
--- a/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
+++ b/apps/src/codebridge/InfoPanel/styles/validated-instructions.module.scss
@@ -106,6 +106,7 @@
 
 .markdownText {
   line-height: 0;
+  user-select: text;
 
   h1,
   h2,


### PR DESCRIPTION
Some text was not able to be highlighted in the codebridge instructions, specifically headers and bullet points. This allows highlighting all the text in the instructions.

### Before
https://github.com/user-attachments/assets/ba8aeb36-8ea8-4ea2-8f90-1b2ff9c87069

### After
https://github.com/user-attachments/assets/d78dfcbf-67ae-4e1b-ac6b-056a94014e4c


## Links

- [slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1737576958418829)

## Testing story
Tested locally that highlighting now works.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
