### PR TITLE
Neighborhood: switch to using common translation

### DIFF
--- a/apps/src/miniApps/neighborhood/Neighborhood.ts
+++ b/apps/src/miniApps/neighborhood/Neighborhood.ts
@@ -1,9 +1,9 @@
 import {tiles, MazeController} from '@code-dot-org/maze';
 
-import javalabMsg from '@cdo/apps/javalab/locale';
 import {LevelProperties} from '@cdo/apps/lab2/types';
 import * as timeoutList from '@cdo/apps/lib/util/timeoutList';
 import Slider from '@cdo/apps/slider';
+import commonI18n from '@cdo/locale';
 
 import {NeighborhoodSignalType} from './constants';
 import {NeighborhoodSignal} from './types';
@@ -111,9 +111,7 @@ export default class Neighborhood {
     if (!this.seenFirstSignal) {
       this.seenFirstSignal = true;
       this.onOutputMessage(
-        // TODO: Replace javalabMsg.startingPainter() with loc string from common locale
-        // (once translation is available) since javalab locale is not loaded for pythonlab.
-        `${this.statusMessagePrefix} ${javalabMsg.startingPainter()}`
+        `${this.statusMessagePrefix} ${commonI18n.startingPainter()}`
       );
       this.onNewlineMessage();
     }


### PR DESCRIPTION
We were using the java lab translation for "starting painter", but this throws an error in python lab because the java lab translations aren't loaded. The common translation has only been in the pipeline for a few days, but it seems worth it to use the new one because it throws an annoying error (especially locally where errors cause a page overlay), and Java Lab is generally not translated (for example, instructions are always in English).

## Links

- jira ticket: [CT-966](https://codedotorg.atlassian.net/browse/CT-966)


## Testing story
Tested locally that we no longer get the error and do get the starting painter message.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
