### PR TITLE
Gen AI Chat: footer logic cleanup

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -1,6 +1,5 @@
 import HttpClient from '@cdo/apps/util/HttpClient';
 import {
-  AiChatTeacherFeedback,
   AiInteractionStatus,
   AiRequestExecutionStatus,
 } from '@cdo/generated-scripts/sharedConstants';
@@ -16,6 +15,7 @@ import {
   ChatEvent,
   ChatMessage,
   DetectToxicityResponse,
+  FeedbackValue,
 } from './types';
 import {extractFieldsToCheckForToxicity} from './utils';
 
@@ -76,7 +76,7 @@ export async function postAichatCompletionMessage(
  */
 export async function postSubmitTeacherFeedback(
   eventId: number,
-  feedback: ValueOf<typeof AiChatTeacherFeedback>
+  feedback: FeedbackValue | undefined
 ) {
   const payload = {
     eventId,

--- a/apps/src/aichat/types.ts
+++ b/apps/src/aichat/types.ts
@@ -24,13 +24,16 @@ export interface ChatEvent {
   descriptionKey?: ChatEventDescriptionKey;
 }
 
+// Convenience type for the values of AiChatTeacherFeedback
+export type FeedbackValue = ValueOf<typeof AiChatTeacherFeedback>;
+
 export interface ChatMessage extends ChatEvent {
   chatMessageText: string;
   role: Role;
   status: ValueOf<typeof AiInteractionStatus>;
   requestId?: number;
   // If undefined, the teacher took no action or undid their action.
-  teacherFeedback?: ValueOf<typeof AiChatTeacherFeedback>;
+  teacherFeedback?: FeedbackValue;
 }
 
 export interface ModelUpdate extends ChatEvent {

--- a/apps/src/aichat/views/ChatMessageView.tsx
+++ b/apps/src/aichat/views/ChatMessageView.tsx
@@ -61,7 +61,12 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
   const NoProfanityFooter = () => (
     <TeacherFeedbackFooter
       isProfanityViolation={false}
-      chatMessage={chatMessage}
+      {...chatMessage}
+      // Note: ID should always be defined when viewing chat history,
+      // but is currently marked optional because the ChatEvent type
+      // is used for both chat history and live chat.
+      // TODO: Clean up types to separate server and client IDs.
+      id={chatMessage.id!}
     />
   );
 
@@ -70,7 +75,8 @@ const ChatMessageView: React.FunctionComponent<ChatMessageViewProps> = ({
       {showProfaneUserMessage && (
         <TeacherFeedbackFooter
           isProfanityViolation={true}
-          chatMessage={chatMessage}
+          {...chatMessage}
+          id={chatMessage.id!}
         />
       )}
       <div className={moduleStyles.showHideMessageButtonContainer}>

--- a/apps/src/aichat/views/teacher-feedback-footer.module.scss
+++ b/apps/src/aichat/views/teacher-feedback-footer.module.scss
@@ -41,6 +41,6 @@
   }
 }
 
-.assistanctFeedbackContainerOverride {
+.assistantFeedback {
   flex-direction: row-reverse;
 }


### PR DESCRIPTION
Some cleanup/refactoring following up from https://github.com/code-dot-org/code-dot-org/pull/62797, related to the teacher feedback footer component and associated redux code, namely:

- Split up the footer into sub-components, based on whether it belongs to a profanity message or non-profanity message as the options are totally different
- Simplify logic in footer components
- Pass message ID and feedback to Redux thunk, rather than the whole message, for clarity and simplicity.
- Change the `updateChatMessage` action so it's scoped specifically to updating feedback, and rename to `updateChatMessageFeedback`

Hopefully this should help clean up the code a little bit and will be useful in upcoming follow-ups and UI updates.

## Testing story

Tested locally. No functional/UI change to the footer.