### PR TITLE
Fix URLs on Apply links for 2025 application season

### DIFF
--- a/pegasus/sites.v3/code.org/public/professional-learning/middle-high.haml
+++ b/pegasus/sites.v3/code.org/public/professional-learning/middle-high.haml
@@ -111,7 +111,7 @@ theme: responsive_full_width
         .text-wrapper.col-50
           %h3=hoc_s(:pl_middle_high_cost_subhead)
           %p=hoc_s(:pl_middle_high_cost_desc)
-          %a.link-button{href: "/educate/professional-learning/program-information"}
+          %a.link-button{href: CDO.studio_url("/regional-partner-search")}
             =hoc_s(:call_to_action_learn_more_program_region)
       .clear
 

--- a/pegasus/sites.v3/code.org/views/pl_middle_high_programs.haml
+++ b/pegasus/sites.v3/code.org/views/pl_middle_high_programs.haml
@@ -65,7 +65,7 @@
           %a.link-button{href: "#subscribe-form"}
             =hoc_s(:call_to_action_applications_notify_me)
         - else
-          %a.link-button{href: "/educate/professional-learning/program-information", aria:{label: aria_label_primary[index]}}
+          %a.link-button{href: CDO.studio_url("/regional-partner-search"), aria:{label: aria_label_primary[index]}}
             =hoc_s(:call_to_action_apply_now)
           %a.link-button.secondary{href: button_url_secondary[index], aria:{label: aria_label_secondary[index]}}
             =hoc_s(:call_to_action_learn_more)


### PR DESCRIPTION
Updates links on https://professional-learning/middle-high to go to the Regional Partner Search page.

## Links
Jira ticket: [ACQ-3026](https://codedotorg.atlassian.net/browse/ACQ-3026)

## Testing story
Tested locally

----

https://github.com/user-attachments/assets/f36d224d-7fda-415a-9e34-eb96a8a2fa43

<img width="1157" alt="Screenshot 2025-01-23 at 10 25 49 AM" src="https://github.com/user-attachments/assets/824efc60-54ba-4e94-ae4f-8439a149b6c7" />
