### PR TITLE
Revert "levelbuilder content changes (-VijayaVersionYearNilUpdate)"

### DIFF
--- a/dashboard/config/scripts_json/6-12-computer-systems-and-devices.script_json
+++ b/dashboard/config/scripts_json/6-12-computer-systems-and-devices.script_json
@@ -4,11 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "unversioned"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:20 UTC",
+    "serialized_at": "2025-01-17 21:18:39 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -467,9 +468,6 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "test-jamila-multi-level-2025"
-        ],
         "progression": "Some Test Level Jamila Made"
       },
       "bonus": false,

--- a/dashboard/config/scripts_json/6-12-intro-to-programming-python.script_json
+++ b/dashboard/config/scripts_json/6-12-intro-to-programming-python.script_json
@@ -4,7 +4,8 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "unversioned"
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/csa-postap-se-and-computer-vision-2023.script_json
+++ b/dashboard/config/scripts_json/csa-postap-se-and-computer-vision-2023.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "ai"
       ],
+      "version_year": "unversioned",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": "csa-software-engineering",
-    "serialized_at": "2025-01-22 18:59:49 UTC",
+    "serialized_at": "2024-11-19 01:15:33 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csa-postap-se-and-computer-vision-2024.script_json
+++ b/dashboard/config/scripts_json/csa-postap-se-and-computer-vision-2024.script_json
@@ -16,11 +16,12 @@
         "ai"
       ],
       "tts": true,
+      "version_year": "unversioned",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": "csa-software-engineering",
-    "serialized_at": "2025-01-22 19:00:01 UTC",
+    "serialized_at": "2024-11-19 01:15:33 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csa-postap-se-and-computer-vision-2025.script_json
+++ b/dashboard/config/scripts_json/csa-postap-se-and-computer-vision-2025.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "ai"
       ],
+      "version_year": "unversioned",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": "csa-software-engineering",
-    "serialized_at": "2025-01-22 19:00:06 UTC",
+    "serialized_at": "2024-11-19 01:15:33 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd1-2017.script_json
+++ b/dashboard/config/scripts_json/csd1-2017.script_json
@@ -20,11 +20,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csd1-2017",
     "family_name": "csd1",
-    "serialized_at": "2025-01-22 18:59:12 UTC",
+    "serialized_at": "2024-11-19 01:15:41 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd1-2018.script_json
+++ b/dashboard/config/scripts_json/csd1-2018.script_json
@@ -11,11 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csd1",
-    "serialized_at": "2025-01-22 18:59:14 UTC",
+    "serialized_at": "2024-11-19 01:15:41 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd1-2019.script_json
+++ b/dashboard/config/scripts_json/csd1-2019.script_json
@@ -12,11 +12,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csd1",
-    "serialized_at": "2025-01-22 18:59:16 UTC",
+    "serialized_at": "2024-11-19 01:15:41 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd1-2022.script_json
+++ b/dashboard/config/scripts_json/csd1-2022.script_json
@@ -42,11 +42,12 @@
         "az-AZ"
       ],
       "tts": true,
+      "version_year": "2022",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:28 UTC",
+    "serialized_at": "2024-11-19 01:15:42 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd1-2023.script_json
+++ b/dashboard/config/scripts_json/csd1-2023.script_json
@@ -36,11 +36,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:34 UTC",
+    "serialized_at": "2024-11-19 01:15:42 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd1-2024.script_json
+++ b/dashboard/config/scripts_json/csd1-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:50 UTC",
+    "serialized_at": "2025-01-06 19:52:17 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd2-2017.script_json
+++ b/dashboard/config/scripts_json/csd2-2017.script_json
@@ -12,11 +12,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csd2-2017",
     "family_name": "csd2",
-    "serialized_at": "2025-01-22 18:59:12 UTC",
+    "serialized_at": "2024-11-19 01:15:43 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd2-2018.script_json
+++ b/dashboard/config/scripts_json/csd2-2018.script_json
@@ -22,11 +22,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csd2",
-    "serialized_at": "2025-01-22 18:59:14 UTC",
+    "serialized_at": "2024-11-19 01:15:44 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd2-2019.script_json
+++ b/dashboard/config/scripts_json/csd2-2019.script_json
@@ -13,11 +13,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csd2",
-    "serialized_at": "2025-01-22 18:59:17 UTC",
+    "serialized_at": "2024-11-19 01:15:44 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd2-2022.script_json
+++ b/dashboard/config/scripts_json/csd2-2022.script_json
@@ -40,11 +40,12 @@
         "az-AZ"
       ],
       "tts": true,
+      "version_year": "2022",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:29 UTC",
+    "serialized_at": "2024-11-19 01:15:46 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd2-2023.script_json
+++ b/dashboard/config/scripts_json/csd2-2023.script_json
@@ -25,11 +25,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:35 UTC",
+    "serialized_at": "2024-11-19 01:15:47 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd2-2024.script_json
+++ b/dashboard/config/scripts_json/csd2-2024.script_json
@@ -26,11 +26,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:52 UTC",
+    "serialized_at": "2024-11-19 01:15:48 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd3-2017.script_json
+++ b/dashboard/config/scripts_json/csd3-2017.script_json
@@ -12,11 +12,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csd3-2017",
     "family_name": "csd3",
-    "serialized_at": "2025-01-22 18:59:11 UTC",
+    "serialized_at": "2024-11-19 01:15:50 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd3-2018.script_json
+++ b/dashboard/config/scripts_json/csd3-2018.script_json
@@ -28,11 +28,12 @@
       "project_widget_visible": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csd3",
-    "serialized_at": "2025-01-22 18:59:13 UTC",
+    "serialized_at": "2024-11-19 01:15:50 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd3-2019.script_json
+++ b/dashboard/config/scripts_json/csd3-2019.script_json
@@ -29,11 +29,12 @@
       "project_widget_visible": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csd3",
-    "serialized_at": "2025-01-22 18:59:17 UTC",
+    "serialized_at": "2024-11-19 01:15:51 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd3-2022.script_json
+++ b/dashboard/config/scripts_json/csd3-2022.script_json
@@ -40,11 +40,12 @@
         "az-AZ"
       ],
       "tts": true,
+      "version_year": "2022",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:30 UTC",
+    "serialized_at": "2024-11-19 01:15:55 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd3-2023.script_json
+++ b/dashboard/config/scripts_json/csd3-2023.script_json
@@ -45,11 +45,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:38 UTC",
+    "serialized_at": "2024-11-19 01:15:57 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd3-2024.script_json
+++ b/dashboard/config/scripts_json/csd3-2024.script_json
@@ -26,11 +26,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:54 UTC",
+    "serialized_at": "2024-11-19 01:15:59 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd4-2017.script_json
+++ b/dashboard/config/scripts_json/csd4-2017.script_json
@@ -12,11 +12,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csd4-2017",
     "family_name": "csd4",
-    "serialized_at": "2025-01-22 18:59:12 UTC",
+    "serialized_at": "2024-11-19 01:16:01 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd4-2018.script_json
+++ b/dashboard/config/scripts_json/csd4-2018.script_json
@@ -22,11 +22,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csd4",
-    "serialized_at": "2025-01-22 18:59:15 UTC",
+    "serialized_at": "2024-11-19 01:16:02 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd4-2019.script_json
+++ b/dashboard/config/scripts_json/csd4-2019.script_json
@@ -13,11 +13,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csd4",
-    "serialized_at": "2025-01-22 18:59:17 UTC",
+    "serialized_at": "2024-11-19 01:16:02 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd4-2022.script_json
+++ b/dashboard/config/scripts_json/csd4-2022.script_json
@@ -40,11 +40,12 @@
         "az-AZ"
       ],
       "tts": true,
+      "version_year": "2022",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:32 UTC",
+    "serialized_at": "2024-11-19 01:16:04 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd4-2023.script_json
+++ b/dashboard/config/scripts_json/csd4-2023.script_json
@@ -36,11 +36,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:36 UTC",
+    "serialized_at": "2024-11-19 01:16:05 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd4-2024.script_json
+++ b/dashboard/config/scripts_json/csd4-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:56 UTC",
+    "serialized_at": "2024-11-19 01:16:06 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd5-2017.script_json
+++ b/dashboard/config/scripts_json/csd5-2017.script_json
@@ -11,11 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csd5-2017",
     "family_name": "csd5",
-    "serialized_at": "2025-01-22 18:59:13 UTC",
+    "serialized_at": "2024-11-19 01:16:07 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd5-2018.script_json
+++ b/dashboard/config/scripts_json/csd5-2018.script_json
@@ -21,11 +21,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csd5",
-    "serialized_at": "2025-01-22 18:59:15 UTC",
+    "serialized_at": "2024-11-19 01:16:07 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd5-2019.script_json
+++ b/dashboard/config/scripts_json/csd5-2019.script_json
@@ -12,11 +12,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csd5",
-    "serialized_at": "2025-01-22 18:59:18 UTC",
+    "serialized_at": "2024-11-19 01:16:07 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd5-2022.script_json
+++ b/dashboard/config/scripts_json/csd5-2022.script_json
@@ -40,11 +40,12 @@
         "az-AZ"
       ],
       "tts": true,
+      "version_year": "2022",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:32 UTC",
+    "serialized_at": "2024-11-19 01:16:08 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd5-2023.script_json
+++ b/dashboard/config/scripts_json/csd5-2023.script_json
@@ -36,11 +36,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:37 UTC",
+    "serialized_at": "2024-11-19 01:16:08 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd5-2024.script_json
+++ b/dashboard/config/scripts_json/csd5-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:56 UTC",
+    "serialized_at": "2025-01-06 19:52:15 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd6-2017.script_json
+++ b/dashboard/config/scripts_json/csd6-2017.script_json
@@ -19,11 +19,12 @@
         "maker"
       ],
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csd6-2017",
     "family_name": "csd6",
-    "serialized_at": "2025-01-22 18:59:12 UTC",
+    "serialized_at": "2024-11-19 01:16:09 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd6-2018.script_json
+++ b/dashboard/config/scripts_json/csd6-2018.script_json
@@ -33,11 +33,12 @@
         "maker"
       ],
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csd6",
-    "serialized_at": "2025-01-22 18:59:14 UTC",
+    "serialized_at": "2024-11-19 01:16:10 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd6-2019.script_json
+++ b/dashboard/config/scripts_json/csd6-2019.script_json
@@ -24,11 +24,12 @@
         "maker"
       ],
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csd6",
-    "serialized_at": "2025-01-22 18:59:18 UTC",
+    "serialized_at": "2024-11-19 01:16:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd6-2020.script_json
+++ b/dashboard/config/scripts_json/csd6-2020.script_json
@@ -24,11 +24,12 @@
         "maker"
       ],
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2020"
     },
     "new_name": null,
     "family_name": "csd6",
-    "serialized_at": "2025-01-22 18:59:20 UTC",
+    "serialized_at": "2024-11-19 01:16:12 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd6-2021.script_json
+++ b/dashboard/config/scripts_json/csd6-2021.script_json
@@ -43,11 +43,12 @@
         "maker"
       ],
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": "csd6",
-    "serialized_at": "2025-01-22 18:59:21 UTC",
+    "serialized_at": "2024-11-19 01:16:14 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd6a-2023.script_json
+++ b/dashboard/config/scripts_json/csd6a-2023.script_json
@@ -17,11 +17,12 @@
         "maker"
       ],
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": "csd6",
-    "serialized_at": "2025-01-22 18:59:47 UTC",
+    "serialized_at": "2024-11-19 01:16:20 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd6a-2024.script_json
+++ b/dashboard/config/scripts_json/csd6a-2024.script_json
@@ -17,11 +17,12 @@
         "maker"
       ],
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": "csd6",
-    "serialized_at": "2025-01-22 18:59:57 UTC",
+    "serialized_at": "2025-01-08 21:47:33 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd7-2022.script_json
+++ b/dashboard/config/scripts_json/csd7-2022.script_json
@@ -42,11 +42,12 @@
         "ai"
       ],
       "tts": true,
+      "version_year": "2022",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:33 UTC",
+    "serialized_at": "2024-11-19 01:16:26 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd7-2023.script_json
+++ b/dashboard/config/scripts_json/csd7-2023.script_json
@@ -29,11 +29,12 @@
         "ai"
       ],
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:40 UTC",
+    "serialized_at": "2024-11-19 01:16:28 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csd7-2024.script_json
+++ b/dashboard/config/scripts_json/csd7-2024.script_json
@@ -17,11 +17,12 @@
         "ai"
       ],
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:59 UTC",
+    "serialized_at": "2024-11-19 01:16:29 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp-create-2017.script_json
+++ b/dashboard/config/scripts_json/csp-create-2017.script_json
@@ -11,11 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csp-create-2017",
     "family_name": "csp-create",
-    "serialized_at": "2025-01-22 18:59:13 UTC",
+    "serialized_at": "2024-11-19 01:17:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp-create-2018.script_json
+++ b/dashboard/config/scripts_json/csp-create-2018.script_json
@@ -29,11 +29,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp-create",
-    "serialized_at": "2025-01-22 18:59:15 UTC",
+    "serialized_at": "2024-11-19 01:17:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp-create-2019.script_json
+++ b/dashboard/config/scripts_json/csp-create-2019.script_json
@@ -12,11 +12,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp-create",
-    "serialized_at": "2025-01-22 18:59:20 UTC",
+    "serialized_at": "2024-11-19 01:17:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp-explore-2017.script_json
+++ b/dashboard/config/scripts_json/csp-explore-2017.script_json
@@ -11,11 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csp-explore-2017",
     "family_name": "csp-explore",
-    "serialized_at": "2025-01-22 18:59:16 UTC",
+    "serialized_at": "2024-11-19 01:17:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp-explore-2018.script_json
+++ b/dashboard/config/scripts_json/csp-explore-2018.script_json
@@ -29,11 +29,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp-explore",
-    "serialized_at": "2025-01-22 18:59:15 UTC",
+    "serialized_at": "2024-11-19 01:17:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp-explore-2019.script_json
+++ b/dashboard/config/scripts_json/csp-explore-2019.script_json
@@ -12,11 +12,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp-explore",
-    "serialized_at": "2025-01-22 18:59:20 UTC",
+    "serialized_at": "2024-11-19 01:17:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp1-2017.script_json
+++ b/dashboard/config/scripts_json/csp1-2017.script_json
@@ -11,11 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csp1-2017",
     "family_name": "csp1",
-    "serialized_at": "2025-01-22 18:59:08 UTC",
+    "serialized_at": "2024-11-19 01:16:35 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp1-2018.script_json
+++ b/dashboard/config/scripts_json/csp1-2018.script_json
@@ -21,11 +21,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp1",
-    "serialized_at": "2025-01-22 18:59:14 UTC",
+    "serialized_at": "2024-11-19 01:16:35 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp1-2019.script_json
+++ b/dashboard/config/scripts_json/csp1-2019.script_json
@@ -12,11 +12,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp1",
-    "serialized_at": "2025-01-22 18:59:18 UTC",
+    "serialized_at": "2024-11-19 01:16:35 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp1-2022.script_json
+++ b/dashboard/config/scripts_json/csp1-2022.script_json
@@ -26,11 +26,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:22 UTC",
+    "serialized_at": "2024-11-19 01:16:36 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp1-2023.script_json
+++ b/dashboard/config/scripts_json/csp1-2023.script_json
@@ -26,11 +26,12 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:41 UTC",
+    "serialized_at": "2024-11-19 01:16:37 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp1-2024.script_json
+++ b/dashboard/config/scripts_json/csp1-2024.script_json
@@ -15,11 +15,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:00 UTC",
+    "serialized_at": "2024-11-19 01:16:37 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp10-2022.script_json
+++ b/dashboard/config/scripts_json/csp10-2022.script_json
@@ -27,11 +27,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:27 UTC",
+    "serialized_at": "2024-11-19 01:17:09 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp10-2023.script_json
+++ b/dashboard/config/scripts_json/csp10-2023.script_json
@@ -14,11 +14,12 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:46 UTC",
+    "serialized_at": "2024-11-19 01:17:10 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp10-2024.script_json
+++ b/dashboard/config/scripts_json/csp10-2024.script_json
@@ -15,11 +15,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:05 UTC",
+    "serialized_at": "2024-11-19 01:17:10 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp2-2017.script_json
+++ b/dashboard/config/scripts_json/csp2-2017.script_json
@@ -11,11 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csp2-2017",
     "family_name": "csp2",
-    "serialized_at": "2025-01-22 18:59:08 UTC",
+    "serialized_at": "2024-11-19 01:16:38 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp2-2018.script_json
+++ b/dashboard/config/scripts_json/csp2-2018.script_json
@@ -21,11 +21,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp2",
-    "serialized_at": "2025-01-22 18:59:15 UTC",
+    "serialized_at": "2024-11-19 01:16:38 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp2-2019.script_json
+++ b/dashboard/config/scripts_json/csp2-2019.script_json
@@ -12,11 +12,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp2",
-    "serialized_at": "2025-01-22 18:59:18 UTC",
+    "serialized_at": "2024-11-19 01:16:38 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp2-2022.script_json
+++ b/dashboard/config/scripts_json/csp2-2022.script_json
@@ -26,11 +26,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:23 UTC",
+    "serialized_at": "2024-11-19 01:16:39 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp2-2023.script_json
+++ b/dashboard/config/scripts_json/csp2-2023.script_json
@@ -26,11 +26,12 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:41 UTC",
+    "serialized_at": "2024-11-19 01:16:40 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp2-2024.script_json
+++ b/dashboard/config/scripts_json/csp2-2024.script_json
@@ -15,11 +15,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:00 UTC",
+    "serialized_at": "2024-11-19 01:16:40 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp3-2017.script_json
+++ b/dashboard/config/scripts_json/csp3-2017.script_json
@@ -12,11 +12,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csp3-2017",
     "family_name": "csp3",
-    "serialized_at": "2025-01-22 18:59:09 UTC",
+    "serialized_at": "2024-11-19 01:16:41 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp3-2018.script_json
+++ b/dashboard/config/scripts_json/csp3-2018.script_json
@@ -30,11 +30,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp3",
-    "serialized_at": "2025-01-22 18:59:15 UTC",
+    "serialized_at": "2024-11-19 01:16:41 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp3-2019.script_json
+++ b/dashboard/config/scripts_json/csp3-2019.script_json
@@ -13,11 +13,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp3",
-    "serialized_at": "2025-01-22 18:59:19 UTC",
+    "serialized_at": "2024-11-19 01:16:42 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp3-2022.script_json
+++ b/dashboard/config/scripts_json/csp3-2022.script_json
@@ -26,11 +26,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:24 UTC",
+    "serialized_at": "2024-11-19 01:16:43 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp3-2023.script_json
+++ b/dashboard/config/scripts_json/csp3-2023.script_json
@@ -26,11 +26,12 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:42 UTC",
+    "serialized_at": "2024-11-19 01:16:44 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp3-2024.script_json
+++ b/dashboard/config/scripts_json/csp3-2024.script_json
@@ -15,11 +15,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:01 UTC",
+    "serialized_at": "2024-11-19 01:16:44 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp4-2017.script_json
+++ b/dashboard/config/scripts_json/csp4-2017.script_json
@@ -11,11 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csp4-2017",
     "family_name": "csp4",
-    "serialized_at": "2025-01-22 18:59:09 UTC",
+    "serialized_at": "2024-11-19 01:16:46 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp4-2018.script_json
+++ b/dashboard/config/scripts_json/csp4-2018.script_json
@@ -29,11 +29,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp4",
-    "serialized_at": "2025-01-22 18:59:15 UTC",
+    "serialized_at": "2024-11-19 01:16:46 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp4-2019.script_json
+++ b/dashboard/config/scripts_json/csp4-2019.script_json
@@ -12,11 +12,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp4",
-    "serialized_at": "2025-01-22 18:59:19 UTC",
+    "serialized_at": "2024-11-19 01:16:46 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp4-2022.script_json
+++ b/dashboard/config/scripts_json/csp4-2022.script_json
@@ -26,11 +26,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:25 UTC",
+    "serialized_at": "2024-11-19 01:16:49 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp4-2023.script_json
+++ b/dashboard/config/scripts_json/csp4-2023.script_json
@@ -26,11 +26,12 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:43 UTC",
+    "serialized_at": "2024-11-19 01:16:50 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp4-2024.script_json
+++ b/dashboard/config/scripts_json/csp4-2024.script_json
@@ -15,11 +15,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:02 UTC",
+    "serialized_at": "2025-01-11 18:45:36 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp5-2017.script_json
+++ b/dashboard/config/scripts_json/csp5-2017.script_json
@@ -12,11 +12,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csp5-2017",
     "family_name": "csp5",
-    "serialized_at": "2025-01-22 18:59:09 UTC",
+    "serialized_at": "2024-11-19 01:16:53 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp5-2018.script_json
+++ b/dashboard/config/scripts_json/csp5-2018.script_json
@@ -30,11 +30,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp5",
-    "serialized_at": "2025-01-22 18:59:16 UTC",
+    "serialized_at": "2024-11-19 01:16:53 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp5-2019.script_json
+++ b/dashboard/config/scripts_json/csp5-2019.script_json
@@ -13,11 +13,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp5",
-    "serialized_at": "2025-01-22 18:59:19 UTC",
+    "serialized_at": "2024-11-19 01:16:54 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp5-2022.script_json
+++ b/dashboard/config/scripts_json/csp5-2022.script_json
@@ -26,11 +26,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:25 UTC",
+    "serialized_at": "2024-11-19 01:16:56 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp5-2023.script_json
+++ b/dashboard/config/scripts_json/csp5-2023.script_json
@@ -26,11 +26,12 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:43 UTC",
+    "serialized_at": "2024-11-19 01:16:57 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp5-2024.script_json
+++ b/dashboard/config/scripts_json/csp5-2024.script_json
@@ -15,11 +15,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:03 UTC",
+    "serialized_at": "2024-11-19 01:16:57 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp6-2022.script_json
+++ b/dashboard/config/scripts_json/csp6-2022.script_json
@@ -26,11 +26,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:26 UTC",
+    "serialized_at": "2024-11-19 01:16:59 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp6-2023.script_json
+++ b/dashboard/config/scripts_json/csp6-2023.script_json
@@ -26,11 +26,12 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:44 UTC",
+    "serialized_at": "2024-11-19 01:17:00 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp6-2024.script_json
+++ b/dashboard/config/scripts_json/csp6-2024.script_json
@@ -15,6 +15,7 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csp8-2022.script_json
+++ b/dashboard/config/scripts_json/csp8-2022.script_json
@@ -27,11 +27,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:26 UTC",
+    "serialized_at": "2024-11-19 01:17:04 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp8-2023.script_json
+++ b/dashboard/config/scripts_json/csp8-2023.script_json
@@ -14,11 +14,12 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:45 UTC",
+    "serialized_at": "2024-11-19 01:17:05 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp8-2024.script_json
+++ b/dashboard/config/scripts_json/csp8-2024.script_json
@@ -15,11 +15,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:04 UTC",
+    "serialized_at": "2024-11-19 01:17:06 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp9-2022.script_json
+++ b/dashboard/config/scripts_json/csp9-2022.script_json
@@ -27,11 +27,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:27 UTC",
+    "serialized_at": "2024-11-19 01:17:07 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp9-2023.script_json
+++ b/dashboard/config/scripts_json/csp9-2023.script_json
@@ -14,11 +14,12 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:45 UTC",
+    "serialized_at": "2024-11-19 01:17:07 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp9-2024.script_json
+++ b/dashboard/config/scripts_json/csp9-2024.script_json
@@ -15,11 +15,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:05 UTC",
+    "serialized_at": "2024-11-19 01:17:08 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csppostap-2017.script_json
+++ b/dashboard/config/scripts_json/csppostap-2017.script_json
@@ -13,11 +13,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2017"
     },
     "new_name": "csppostap-2017",
     "family_name": "csppostap",
-    "serialized_at": "2025-01-22 18:59:12 UTC",
+    "serialized_at": "2024-11-19 01:17:13 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csppostap-2018.script_json
+++ b/dashboard/config/scripts_json/csppostap-2018.script_json
@@ -54,11 +54,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csppostap",
-    "serialized_at": "2025-01-22 18:59:16 UTC",
+    "serialized_at": "2024-11-19 01:17:13 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csppostap-2019.script_json
+++ b/dashboard/config/scripts_json/csppostap-2019.script_json
@@ -23,11 +23,12 @@
       "project_sharing": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "use_legacy_lesson_plans": true
+      "use_legacy_lesson_plans": true,
+      "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csppostap",
-    "serialized_at": "2025-01-22 18:59:20 UTC",
+    "serialized_at": "2024-11-19 01:17:13 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/data-science-with-python-2024.script_json
+++ b/dashboard/config/scripts_json/data-science-with-python-2024.script_json
@@ -12,11 +12,12 @@
       "topic_tags": [
         "data_science"
       ],
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:18 UTC",
+    "serialized_at": "2025-01-22 02:14:44 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/exploring-gen-ai1-2024.script_json
+++ b/dashboard/config/scripts_json/exploring-gen-ai1-2024.script_json
@@ -15,11 +15,12 @@
         "ai"
       ],
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:19 UTC",
+    "serialized_at": "2025-01-22 02:17:41 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/exploring-gen-ai2-2024.script_json
+++ b/dashboard/config/scripts_json/exploring-gen-ai2-2024.script_json
@@ -15,11 +15,12 @@
         "ai"
       ],
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:19 UTC",
+    "serialized_at": "2025-01-22 02:00:54 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/fcs1a-beta-2024.script_json
+++ b/dashboard/config/scripts_json/fcs1a-beta-2024.script_json
@@ -17,11 +17,12 @@
         "maker"
       ],
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:09 UTC",
+    "serialized_at": "2025-01-13 18:42:15 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/fcs1b-beta-2024.script_json
+++ b/dashboard/config/scripts_json/fcs1b-beta-2024.script_json
@@ -17,11 +17,12 @@
         "maker"
       ],
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:09 UTC",
+    "serialized_at": "2025-01-13 18:40:00 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/fcs1c-beta-2024.script_json
+++ b/dashboard/config/scripts_json/fcs1c-beta-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:12 UTC",
+    "serialized_at": "2025-01-13 18:52:24 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/fcs2-beta-2024.script_json
+++ b/dashboard/config/scripts_json/fcs2-beta-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:06 UTC",
+    "serialized_at": "2025-01-13 18:41:22 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/fcs3-beta-2024.script_json
+++ b/dashboard/config/scripts_json/fcs3-beta-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:07 UTC",
+    "serialized_at": "2025-01-13 18:43:52 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/fcs4-beta-2024.script_json
+++ b/dashboard/config/scripts_json/fcs4-beta-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:07 UTC",
+    "serialized_at": "2025-01-13 18:41:00 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/fcs5-beta-2024.script_json
+++ b/dashboard/config/scripts_json/fcs5-beta-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:08 UTC",
+    "serialized_at": "2025-01-13 18:52:44 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/fcs6-beta-2024.script_json
+++ b/dashboard/config/scripts_json/fcs6-beta-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:08 UTC",
+    "serialized_at": "2025-01-13 18:42:37 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/focus-on-coding2-2024.script_json
+++ b/dashboard/config/scripts_json/focus-on-coding2-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:13 UTC",
+    "serialized_at": "2024-11-19 01:17:50 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/focus-on-creativity2-2024.script_json
+++ b/dashboard/config/scripts_json/focus-on-creativity2-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:14 UTC",
+    "serialized_at": "2024-11-19 01:18:02 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/focus-on-design-with-purpose2-2024.script_json
+++ b/dashboard/config/scripts_json/focus-on-design-with-purpose2-2024.script_json
@@ -14,11 +14,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2023",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:15 UTC",
+    "serialized_at": "2024-11-19 01:18:19 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/getting-started-with-code-game-design.script_json
+++ b/dashboard/config/scripts_json/getting-started-with-code-game-design.script_json
@@ -10,11 +10,12 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:19 UTC",
+    "serialized_at": "2025-01-13 23:51:52 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/getting-started-with-code-maker.script_json
+++ b/dashboard/config/scripts_json/getting-started-with-code-maker.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:19 UTC",
+    "serialized_at": "2025-01-13 23:50:58 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/getting-started-with-code.script_json
+++ b/dashboard/config/scripts_json/getting-started-with-code.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:19 UTC",
+    "serialized_at": "2025-01-13 23:50:39 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/intro-to-data-science-2024.script_json
+++ b/dashboard/config/scripts_json/intro-to-data-science-2024.script_json
@@ -17,11 +17,12 @@
       "topic_tags": [
         "data_science"
       ],
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:18 UTC",
+    "serialized_at": "2025-01-13 18:40:30 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/k5-maker-pilot-2024-1.script_json
+++ b/dashboard/config/scripts_json/k5-maker-pilot-2024-1.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:06 UTC",
+    "serialized_at": "2025-01-16 22:53:21 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/k5-maker-pilot-2024-2.script_json
+++ b/dashboard/config/scripts_json/k5-maker-pilot-2024-2.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:06 UTC",
+    "serialized_at": "2025-01-13 23:40:21 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/k5-maker-pilot-2024-3.script_json
+++ b/dashboard/config/scripts_json/k5-maker-pilot-2024-3.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:06 UTC",
+    "serialized_at": "2025-01-13 23:41:56 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/k5-maker-pilot-2024-4.script_json
+++ b/dashboard/config/scripts_json/k5-maker-pilot-2024-4.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:06 UTC",
+    "serialized_at": "2025-01-13 23:48:47 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/k5-maker-pilot-2024-5.script_json
+++ b/dashboard/config/scripts_json/k5-maker-pilot-2024-5.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:06 UTC",
+    "serialized_at": "2025-01-13 23:46:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/k5howaimakesdecisions.script_json
+++ b/dashboard/config/scripts_json/k5howaimakesdecisions.script_json
@@ -12,11 +12,12 @@
       "student_detail_progress_view": true,
       "topic_tags": [
         "ai"
-      ]
+      ],
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:17 UTC",
+    "serialized_at": "2025-01-13 23:52:43 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/k5maker.script_json
+++ b/dashboard/config/scripts_json/k5maker.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:17 UTC",
+    "serialized_at": "2025-01-13 23:45:12 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/k5maker4thgrade.script_json
+++ b/dashboard/config/scripts_json/k5maker4thgrade.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:18 UTC",
+    "serialized_at": "2025-01-13 23:37:05 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/k5maker5thgrade.script_json
+++ b/dashboard/config/scripts_json/k5maker5thgrade.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:18 UTC",
+    "serialized_at": "2025-01-13 23:40:43 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/k5microbitmaker.script_json
+++ b/dashboard/config/scripts_json/k5microbitmaker.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:17 UTC",
+    "serialized_at": "2025-01-13 23:49:06 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/k5plgamedesign.script_json
+++ b/dashboard/config/scripts_json/k5plgamedesign.script_json
@@ -10,11 +10,12 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:17 UTC",
+    "serialized_at": "2025-01-13 23:33:52 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/sandbox-pl-teaching-k5-music-lab.script_json
+++ b/dashboard/config/scripts_json/sandbox-pl-teaching-k5-music-lab.script_json
@@ -4,7 +4,8 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2025"
     },
     "new_name": null,
     "family_name": null,
@@ -1017,9 +1018,6 @@
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "ML-Events"
-        ]
       },
       "bonus": false,
       "seeding_key": {

--- a/dashboard/config/scripts_json/sandbox-teaching-getting-started.script_json
+++ b/dashboard/config/scripts_json/sandbox-teaching-getting-started.script_json
@@ -6,11 +6,12 @@
     "properties": {
       "content_area": "other",
       "curriculum_umbrella": "Pedagogy special topics selfpaced pl",
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2025"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:20 UTC",
+    "serialized_at": "2024-12-13 18:34:34 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -513,9 +514,6 @@
       "activity_section_position": 4,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "1SP-VPL-24-mod1-Certificate_1"
-        ],
         "progression": "Overview"
       },
       "bonus": false,
@@ -563,9 +561,6 @@
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "1OPD-K5 Begin_2023_K5CSConcepts_TextPage"
-        ],
         "progression": "Welcome to Code.org"
       },
       "bonus": false,
@@ -838,9 +833,6 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "1SP-VPL-21-mod2-Task-StudentView_physical-computing_1"
-        ],
         "progression": "Student View vs Teacher View"
       },
       "bonus": false,
@@ -963,9 +955,6 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "1SP-VPL-21-mod2-NavigatingLessonPlans_physical-computing_1"
-        ],
         "progression": "Explore Course Lesson Plans"
       },
       "bonus": false,
@@ -1063,9 +1052,6 @@
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "1PL_getting_started_assessmentsandgrading"
-        ],
         "progression": "Assessments and Grading"
       },
       "bonus": false,
@@ -1138,9 +1124,6 @@
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "Getting-Started_PL-Resources"
-        ],
         "progression": "Explore Additional Teacher Resources"
       },
       "bonus": false,

--- a/dashboard/config/scripts_json/sandbox-welcome-to-maker.script_json
+++ b/dashboard/config/scripts_json/sandbox-welcome-to-maker.script_json
@@ -7,11 +7,12 @@
       "curriculum_umbrella": "K-5 Special topics curriculum selfpaced pl",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:17 UTC",
+    "serialized_at": "2025-01-13 23:51:25 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-ai-101-mod1.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-ai-101-mod1.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:12 UTC",
+    "serialized_at": "2025-01-13 23:53:44 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-ai-101-mod2.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-ai-101-mod2.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:12 UTC",
+    "serialized_at": "2025-01-13 23:54:36 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-ai-101-mod3.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-ai-101-mod3.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:12 UTC",
+    "serialized_at": "2025-01-13 23:56:03 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-ai-101-mod4.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-ai-101-mod4.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:12 UTC",
+    "serialized_at": "2025-01-13 23:53:18 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-ai-101-mod5.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-ai-101-mod5.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:12 UTC",
+    "serialized_at": "2025-01-13 23:55:32 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-aiml1-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-aiml1-2024.script_json
@@ -12,11 +12,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2025-01-13 19:54:01 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-aiml1.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-aiml1.script_json
@@ -12,11 +12,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:49 UTC",
+    "serialized_at": "2025-01-13 18:53:25 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-aiml2-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-aiml2-2024.script_json
@@ -12,11 +12,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:12 UTC",
+    "serialized_at": "2025-01-13 21:44:53 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-aiml2.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-aiml2.script_json
@@ -12,11 +12,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:49 UTC",
+    "serialized_at": "2025-01-13 19:40:03 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-coding-with-ai-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-coding-with-ai-2024.script_json
@@ -12,11 +12,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:17 UTC",
+    "serialized_at": "2025-01-13 22:02:08 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-coding-with-ai.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-coding-with-ai.script_json
@@ -9,11 +9,12 @@
       "is_migrated": true,
       "topic_tags": [
         "ai"
-      ]
+      ],
+      "version_year": "unversioned"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:16 UTC",
+    "serialized_at": "2025-01-13 22:02:56 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-computer-vision-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-computer-vision-2024.script_json
@@ -12,11 +12,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:17 UTC",
+    "serialized_at": "2025-01-13 22:03:15 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-computer-vision.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-computer-vision.script_json
@@ -9,11 +9,12 @@
       "is_migrated": true,
       "topic_tags": [
         "ai"
-      ]
+      ],
+      "version_year": "unversioned"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:16 UTC",
+    "serialized_at": "2025-01-13 22:03:34 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit1-1-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit1-1-2023.script_json
@@ -10,11 +10,12 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:49 UTC",
+    "serialized_at": "2025-01-13 21:56:38 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit1-1-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit1-1-2024.script_json
@@ -10,11 +10,12 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 21:49:56 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit1-2-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit1-2-2023.script_json
@@ -10,11 +10,12 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:49 UTC",
+    "serialized_at": "2025-01-13 21:56:16 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit1-2-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit1-2-2024.script_json
@@ -10,11 +10,12 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 19:46:41 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit2-1-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit2-1-2023.script_json
@@ -6,11 +6,12 @@
     "properties": {
       "content_area": "self_paced_pl_6_8",
       "curriculum_umbrella": "Self-paced PL - CSD",
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:49 UTC",
+    "serialized_at": "2025-01-13 21:45:38 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit2-1-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit2-1-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 21:49:26 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit2-2-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit2-2-2023.script_json
@@ -6,11 +6,12 @@
     "properties": {
       "content_area": "self_paced_pl_6_8",
       "curriculum_umbrella": "Self-paced PL - CSD",
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:49 UTC",
+    "serialized_at": "2025-01-13 21:47:56 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit2-2-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit2-2-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 21:18:27 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit3-1-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit3-1-2023.script_json
@@ -6,11 +6,12 @@
     "properties": {
       "content_area": "self_paced_pl_6_8",
       "curriculum_umbrella": "Self-paced PL - CSD",
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:49 UTC",
+    "serialized_at": "2025-01-13 21:59:30 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit3-1-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit3-1-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 19:45:51 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit3-2-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit3-2-2023.script_json
@@ -6,11 +6,12 @@
     "properties": {
       "content_area": "self_paced_pl_6_8",
       "curriculum_umbrella": "Self-paced PL - CSD",
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:50 UTC",
+    "serialized_at": "2025-01-13 21:20:16 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit3-2-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit3-2-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 21:51:59 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit4-1-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit4-1-2023.script_json
@@ -6,11 +6,12 @@
     "properties": {
       "content_area": "self_paced_pl_6_8",
       "curriculum_umbrella": "Self-paced PL - CSD",
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:50 UTC",
+    "serialized_at": "2025-01-13 19:47:25 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit4-1-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit4-1-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:12 UTC",
+    "serialized_at": "2025-01-13 21:51:07 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit4-2-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit4-2-2023.script_json
@@ -6,11 +6,12 @@
     "properties": {
       "content_area": "self_paced_pl_6_8",
       "curriculum_umbrella": "Self-paced PL - CSD",
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:50 UTC",
+    "serialized_at": "2025-01-13 19:42:23 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit4-2-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit4-2-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:12 UTC",
+    "serialized_at": "2025-01-13 19:47:03 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit5-1-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit5-1-2023.script_json
@@ -6,11 +6,12 @@
     "properties": {
       "content_area": "self_paced_pl_6_8",
       "curriculum_umbrella": "Self-paced PL - CSD",
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:50 UTC",
+    "serialized_at": "2025-01-13 21:55:17 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit5-1-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit5-1-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 21:59:52 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit5-2-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit5-2-2023.script_json
@@ -6,11 +6,12 @@
     "properties": {
       "content_area": "self_paced_pl_6_8",
       "curriculum_umbrella": "Self-paced PL - CSD",
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:50 UTC",
+    "serialized_at": "2025-01-13 19:39:35 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd-unit5-2-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd-unit5-2-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2025-01-16 22:51:04 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd1-2021.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd1-2021.script_json
@@ -20,11 +20,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2021"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:22 UTC",
+    "serialized_at": "2025-01-13 21:21:10 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd1-2022.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd1-2022.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2022"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:34 UTC",
+    "serialized_at": "2025-01-13 21:18:52 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd1-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd1-2023.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-13 19:47:44 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd1-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd1-2024.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 19:39:10 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd2-2021.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd2-2021.script_json
@@ -19,11 +19,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2021"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:22 UTC",
+    "serialized_at": "2025-01-13 21:19:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd2-2022.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd2-2022.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2022"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:34 UTC",
+    "serialized_at": "2025-01-13 18:53:57 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd2-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd2-2023.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-13 19:36:56 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd2-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd2-2024.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 21:53:00 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd3-2021.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd3-2021.script_json
@@ -20,11 +20,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2021"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:22 UTC",
+    "serialized_at": "2025-01-13 21:46:30 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd3-2022.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd3-2022.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2022"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:34 UTC",
+    "serialized_at": "2025-01-13 21:50:18 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd3-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd3-2023.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-13 21:54:52 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd3-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd3-2024.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 22:00:15 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd4-2021.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd4-2021.script_json
@@ -19,11 +19,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2021"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:22 UTC",
+    "serialized_at": "2025-01-13 19:41:54 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd4-2022.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd4-2022.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2022"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:34 UTC",
+    "serialized_at": "2025-01-13 21:20:52 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd4-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd4-2023.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-13 19:36:18 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd4-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd4-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 21:51:30 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd5-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd5-2023.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "has_verified_resources": true,
       "is_migrated": true,
-      "student_detail_progress_view": true
+      "student_detail_progress_view": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-16 22:51:33 UTC",
     "published_state": "in_development",
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csd5-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csd5-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSD",
       "has_verified_resources": true,
       "is_migrated": true,
-      "student_detail_progress_view": true
+      "student_detail_progress_view": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:10 UTC",
+    "serialized_at": "2025-01-13 19:37:40 UTC",
     "published_state": "in_development",
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp1-2021.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp1-2021.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2021"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:22 UTC",
+    "serialized_at": "2025-01-13 23:16:01 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp1-2022.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp1-2022.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2022"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:34 UTC",
+    "serialized_at": "2025-01-13 23:24:05 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp1-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp1-2023.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-13 23:13:34 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp1-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp1-2024.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2025-01-13 23:17:28 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp2-2021.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp2-2021.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSP",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2021"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:22 UTC",
+    "serialized_at": "2025-01-13 23:22:23 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp2-2022.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp2-2022.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSP",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2022"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:34 UTC",
+    "serialized_at": "2025-01-13 23:18:27 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp2-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp2-2023.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-13 23:06:09 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp2-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp2-2024.script_json
@@ -9,11 +9,12 @@
       "has_verified_resources": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2025-01-16 22:52:41 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp3-2021.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp3-2021.script_json
@@ -7,11 +7,12 @@
       "content_area": "self_paced_pl_9_12",
       "curriculum_umbrella": "Self-paced PL - CSP",
       "is_migrated": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2021"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:22 UTC",
+    "serialized_at": "2025-01-13 22:59:28 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp3-2022.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp3-2022.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSP",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2022"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:34 UTC",
+    "serialized_at": "2025-01-13 23:17:02 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp3-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp3-2023.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSP",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-13 23:16:33 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp3-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp3-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSP",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2025-01-13 23:21:44 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp4-2021.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp4-2021.script_json
@@ -7,11 +7,12 @@
       "content_area": "self_paced_pl_9_12",
       "curriculum_umbrella": "Self-paced PL - CSP",
       "is_migrated": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2021"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:22 UTC",
+    "serialized_at": "2025-01-13 23:24:28 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp4-2022.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp4-2022.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSP",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2022"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:34 UTC",
+    "serialized_at": "2025-01-13 23:23:43 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp4-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp4-2023.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSP",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:49 UTC",
+    "serialized_at": "2025-01-13 23:19:05 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-csp4-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-csp4-2024.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSP",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2025-01-13 23:18:09 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-equitymodule-unit1.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-equitymodule-unit1.script_json
@@ -6,11 +6,12 @@
     "properties": {
       "content_area": "skills_focused_self_paced_pl",
       "curriculum_umbrella": "Self-paced PL - Pedagogy special topics",
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:20 UTC",
+    "serialized_at": "2025-01-13 23:55:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -873,9 +874,6 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "self-paced-equity-U1L3-read-reflect"
-        ],
         "progression": "Your Students' Identities"
       },
       "bonus": false,

--- a/dashboard/config/scripts_json/self-paced-pl-equitymodule-unit2.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-equitymodule-unit2.script_json
@@ -4,11 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "is_migrated": true
+      "is_migrated": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:20 UTC",
+    "serialized_at": "2025-01-10 22:43:03 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-exploring-gen-ai.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-exploring-gen-ai.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "ai"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:20 UTC",
+    "serialized_at": "2025-01-13 22:01:09 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-foundations-getting-started.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-foundations-getting-started.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - Foundations of CS and AI",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:17 UTC",
+    "serialized_at": "2025-01-13 23:26:26 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-foundations-intro.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-foundations-intro.script_json
@@ -10,11 +10,12 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2024",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:17 UTC",
+    "serialized_at": "2025-01-13 23:25:35 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-foundations-teaching-cs.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-foundations-teaching-cs.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - Foundations of CS and AI",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:17 UTC",
+    "serialized_at": "2025-01-13 23:25:07 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-foundations-unit1.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-foundations-unit1.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:16 UTC",
+    "serialized_at": "2025-01-13 23:28:30 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-foundations-unit2.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-foundations-unit2.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - Foundations of CS and AI",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:16 UTC",
+    "serialized_at": "2025-01-13 23:26:04 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-foundations-unit3.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-foundations-unit3.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - Foundations of CS and AI",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:16 UTC",
+    "serialized_at": "2025-01-13 23:27:24 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-foundations-unit4.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-foundations-unit4.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - Foundations of CS and AI",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:16 UTC",
+    "serialized_at": "2025-01-13 23:27:51 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-k5-2024-1.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-k5-2024-1.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSF",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:59 UTC",
+    "serialized_at": "2025-01-13 23:43:23 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-k5-2024-2.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-k5-2024-2.script_json
@@ -8,11 +8,12 @@
       "curriculum_umbrella": "Self-paced PL - CSF",
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:59 UTC",
+    "serialized_at": "2025-01-13 23:46:59 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-k5-getting-started.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-k5-getting-started.script_json
@@ -10,11 +10,12 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:46 UTC",
+    "serialized_at": "2025-01-13 23:41:38 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-microbit-2024-1.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-microbit-2024-1.script_json
@@ -9,11 +9,12 @@
       "is_migrated": true,
       "topic_tags": [
         "maker"
-      ]
+      ],
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:06 UTC",
+    "serialized_at": "2025-01-13 21:53:23 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-microbit-2024-2.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-microbit-2024-2.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:06 UTC",
+    "serialized_at": "2025-01-13 21:44:21 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-microbit-2024-6.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-microbit-2024-6.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:06 UTC",
+    "serialized_at": "2025-01-13 21:19:30 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-microbit1-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-microbit1-2024.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2025-01-13 19:19:00 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-microbit1.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-microbit1.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-13 22:00:38 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-microbit2-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-microbit2-2024.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2025-01-13 21:19:59 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-microbit2.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-microbit2.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-13 21:52:37 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-physical-computing1-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-physical-computing1-2023.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-13 21:47:34 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-physical-computing1-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-physical-computing1-2024.script_json
@@ -11,11 +11,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2025-01-13 21:46:08 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-physical-computing1.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-physical-computing1.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2022"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:40 UTC",
+    "serialized_at": "2025-01-13 21:59:06 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-physical-computing2-2023.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-physical-computing2-2023.script_json
@@ -12,11 +12,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2023"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:48 UTC",
+    "serialized_at": "2025-01-13 19:19:42 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-physical-computing2-2024.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-physical-computing2-2024.script_json
@@ -12,11 +12,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2025-01-13 21:55:42 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/self-paced-pl-physical-computing2.script_json
+++ b/dashboard/config/scripts_json/self-paced-pl-physical-computing2.script_json
@@ -13,11 +13,12 @@
       "topic_tags": [
         "maker"
       ],
-      "tts": true
+      "tts": true,
+      "version_year": "2022"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 18:59:40 UTC",
+    "serialized_at": "2025-01-13 21:50:42 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/vpl-csa-2024-m7.script_json
+++ b/dashboard/config/scripts_json/vpl-csa-2024-m7.script_json
@@ -9,11 +9,12 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2024-11-19 01:19:49 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/vpl-csa-2024-m8.script_json
+++ b/dashboard/config/scripts_json/vpl-csa-2024-m8.script_json
@@ -9,11 +9,12 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2024-11-19 01:19:49 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/vpl-csp-2024-m7.script_json
+++ b/dashboard/config/scripts_json/vpl-csp-2024-m7.script_json
@@ -9,11 +9,12 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2024-11-19 01:19:57 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/vpl-csp-2024-m8.script_json
+++ b/dashboard/config/scripts_json/vpl-csp-2024-m8.script_json
@@ -9,11 +9,12 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "tts": true
+      "tts": true,
+      "version_year": "2024"
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2025-01-22 19:00:11 UTC",
+    "serialized_at": "2024-11-19 01:19:57 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,


### PR DESCRIPTION
This reverts commit 8e20018fb070a52e85fba9cb792737c08c85a046.

The changes to set version_year to nil broke loading a bunch of CSD units. Reverting this change to set version_year to nil as the impact of this could be more widespread

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
