### PR TITLE
Add SecurityGroup for Load Balancers that Only Receive Requests from CloudFront

### DIFF
--- a/aws/cloudformation/vpc.yml.erb
+++ b/aws/cloudformation/vpc.yml.erb
@@ -116,7 +116,8 @@ Resources:
     Properties:
       GroupDescription: Enable SSH access to frontends from daemon.
       VpcId: {Ref: VPC}
-  ELBSecurityGroup:
+  # Used by Application Load Balancers that only serve traffic forwarded to it by CloudFront.
+  ALBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Inbound HTTP[S] from the public Internet, outbound HTTP[S] downstream
@@ -126,6 +127,42 @@ Resources:
           FromPort: 443
           ToPort: 443
           SourcePrefixListId: !Ref CloudFrontManagedPrefixList
+      SecurityGroupEgress:
+        # Forward HTTP requests to nginx on Web Application Server ("Front End") EC2 Instances.
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        # Forward HTTP requests to nginx on Web Application Server ("Front End") EC2 Instances.
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+        # Forward HTTP requests directly to Dashboard Puma on Web Application Server ("Front End") EC2 Instances.
+        - IpProtocol: tcp
+          FromPort: 9000
+          ToPort: 9000
+          CidrIp: 0.0.0.0/0
+        # Forward HTTP requests directly to Pegasus Puma on Web Application Server ("Front End") EC2 Instances.
+        - IpProtocol: tcp
+          FromPort: 9001
+          ToPort: 9001
+          CidrIp: 0.0.0.0/0
+  # Used by legacy Load Balancers that only serve traffic directly from the public internet (codeprojects.org).
+  ELBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Inbound HTTP[S] from the public Internet, outbound HTTP[S] downstream
+      VpcId: {Ref: VPC}
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
         # Forward HTTP requests to nginx on Web Application Server ("Front End") EC2 Instances.
         - IpProtocol: tcp

--- a/aws/cloudformation/vpc.yml.erb
+++ b/aws/cloudformation/vpc.yml.erb
@@ -5,6 +5,12 @@ self.class.include VPC
 ---
 AWSTemplateFormatVersion: 2010-09-09
 Description: VPC layer including all Subnets, NAT Gateway and Security Groups for Code.org infrastructure.
+Parameters:
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/LocationsOfEdgeServers.html#managed-prefix-list
+  CloudFrontManagedPrefixList:
+    Type: String
+    Default: pl-3b927c52 # us-east-1
+    Description: CloudFront Managed Prefix List for the current Region.
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -117,13 +123,9 @@ Resources:
       VpcId: {Ref: VPC}
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-          CidrIp: 0.0.0.0/0
+          SourcePrefixListId: !Ref CloudFrontManagedPrefixList
       SecurityGroupEgress:
         # Forward HTTP requests to nginx on Web Application Server ("Front End") EC2 Instances.
         - IpProtocol: tcp

--- a/aws/cloudformation/vpc.yml.erb
+++ b/aws/cloudformation/vpc.yml.erb
@@ -116,7 +116,7 @@ Resources:
     Properties:
       GroupDescription: Enable SSH access to frontends from daemon.
       VpcId: {Ref: VPC}
-  # Used by Application Load Balancers that only serve traffic forwarded to it by CloudFront.
+  # To be used by Application Load Balancers that only serve traffic forwarded to it by CloudFront.
   ALBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/aws/cloudformation/vpc.yml.erb
+++ b/aws/cloudformation/vpc.yml.erb
@@ -351,8 +351,12 @@ Outputs:
     Description: Security group for Gateway bastion server
     Value: {'Fn::GetAtt': [GatewaySecurityGroup, GroupId]}
     Export: {Name: !Sub "${AWS::StackName}-GatewaySecurityGroup"}
+  ALBSecurityGroup:
+    Description: Security Group for Application Load Balancers that only serve traffic forwarded to it by CloudFront.
+    Value: {'Fn::GetAtt': [ALBSecurityGroup, GroupId]}
+    Export: {Name: !Sub "${AWS::StackName}-ALBSecurityGroup"}
   ELBSecurityGroup:
-    Description: Security group for Load Balancer
+    Description: Security group for legacy Load Balancers that serve traffic directly from the public internet (such as codeprojects.org).
     Value: {'Fn::GetAtt': [ELBSecurityGroup, GroupId]}
     Export: {Name: !Sub "${AWS::StackName}-ELBSecurityGroup"}
   FrontendSecurityGroup:


### PR DESCRIPTION
Add a new SecurityGroup that we can use in the future to ensure that load balancers only process HTTP requests forwarded by a CloudFront Distribution. Eliminate non-SSL Inbound port 80 on these new load balancers.

We need to retain the current SecurityGroup for the codeprojects load balancer which receives HTTP requests directly from the public internet.

## Testing story

``` bash
code-dot-org % bundle exec rake stack:vpc:validate RAILS_ENV=production ADMIN=true

Finished stack:vpc:environment (less than a minute)
Pending update for stack `VPC`:
Add ALBSecurityGroup [AWS::EC2::SecurityGroup]
Finished stack:vpc:validate (less than a minute)
```


## Deployment strategy

``` bash
code-dot-org % bundle exec rake stack:vpc:start RAILS_ENV=production ADMIN=true
```

## Follow-up work

Implement CloudFormation logic to use the new SecurityGroup for load balancers that process HTTP requests for dashboard (studio.code.org), and our two primary pegasus sites (code.org and hourofcode.com).

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
