### PR TITLE
Update Unit Family Sorting Logic to Accommodate `nil` Values in `version_year`

### DIFF
--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -501,6 +501,20 @@ class UnitTest < ActiveSupport::TestCase
     end
   end
 
+  test 'family_unit_versions returns values sorted by version year' do
+    # create units out of order
+    second = create :script, family_name: 'fake-family', version_year: '2017'
+    third = create :script, family_name: 'fake-family', version_year: '2018'
+    first = create :script, family_name: 'fake-family', version_year: '2016'
+    assert_equal [first, second, third], Unit.family_unit_versions('fake-family')
+  end
+
+  test 'family_unit_versions handles nil version year' do
+    actual_version = create :script, family_name: 'fake-family', version_year: '2017'
+    missing_version = create :script, family_name: 'fake-family'
+    assert_equal [actual_version, missing_version], Unit.family_unit_versions('fake-family')
+  end
+
   test 'self.latest_stable_version is nil if no unit versions in family are stable in locale' do
     create :script, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, supported_locales: ["it-it"]
     create :script, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable, supported_locales: ["it-it"]
@@ -525,6 +539,14 @@ class UnitTest < ActiveSupport::TestCase
 
   test 'self.latest_stable_version returns correct unit version in family if version_year is supplied' do
     unit_2017 = create :script, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    create :script, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+
+    assert_equal unit_2017, Unit.latest_stable_version('fake-family', version_year: '2017')
+  end
+
+  test 'self.lastest_stable_version supports some family members having nil version_years' do
+    unit_2017 = create :script, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    create :script, name: 's-2017', family_name: 'fake-family', version_year: nil, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
     create :script, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
 
     assert_equal unit_2017, Unit.latest_stable_version('fake-family', version_year: '2017')

--- a/dashboard/test/models/unit_test.rb
+++ b/dashboard/test/models/unit_test.rb
@@ -512,7 +512,7 @@ class UnitTest < ActiveSupport::TestCase
   test 'family_unit_versions handles nil version year' do
     actual_version = create :script, family_name: 'fake-family', version_year: '2017'
     missing_version = create :script, family_name: 'fake-family'
-    assert_equal [actual_version, missing_version], Unit.family_unit_versions('fake-family')
+    assert_equal [missing_version, actual_version], Unit.family_unit_versions('fake-family')
   end
 
   test 'self.latest_stable_version is nil if no unit versions in family are stable in locale' do
@@ -546,7 +546,7 @@ class UnitTest < ActiveSupport::TestCase
 
   test 'self.lastest_stable_version supports some family members having nil version_years' do
     unit_2017 = create :script, name: 's-2017', family_name: 'fake-family', version_year: '2017', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    create :script, name: 's-2017', family_name: 'fake-family', version_year: nil, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    create :script, name: 's-unknown', family_name: 'fake-family', version_year: nil, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
     create :script, name: 's-2018', family_name: 'fake-family', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
 
     assert_equal unit_2017, Unit.latest_stable_version('fake-family', version_year: '2017')


### PR DESCRIPTION
We recently attempted to set several unit families to a `nil` version year, but unfortunately for some reason only applied a partial update in at least one case. This revealed a long-standing bug in our application logic; when some units in a family have a `nil` version year and some other units in the family have a non-`nil` version year, our attempts to sort the entire family by version year will fail with `ArgumentError: comparison of NilClass with String failed`

The simple fix is to extract our existing attempts at sorting based on this field into a helper method which can normalize the values before sorting.

## Links

- [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1737665555436169)
- [Honeybadger error](https://app.honeybadger.io/projects/3240/faults/116676185)

## Testing story

Added some unit tests to cover this case, and also verified that with this fix in place I can successfully visit http://localhost-studio.code.org:3000/s/csd6a-2024

## Follow-up work

We should probably revisit this logic, and determine whether sorting by the version year on the unit itself is actually what we want to do in this case.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
