### PR TITLE
No level name in levels created in Aichat controller tests, wrap in transaction

### DIFF
--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -10,7 +10,7 @@ class AichatControllerTest < ActionController::TestCase
     @authorized_student1 = create(:follower, section: section).student_user
     @authorized_teacher2 = create :authorized_teacher
     @authorized_student2 = create(:follower, section: section).student_user
-    @level = create(:level, name: 'level1')
+    @level = create(:level)
     @script = create(:script)
     @script_level = create(:script_level, script: @script, levels: [@level])
     valid_student1_chat_message1 = {role: 'user', chatMessageText: 'hello from authorized student 1 - message 1', status: 'ok', timestamp: Time.now.to_i}

--- a/dashboard/test/controllers/aichat_requests_controller_test.rb
+++ b/dashboard/test/controllers/aichat_requests_controller_test.rb
@@ -1,13 +1,15 @@
 require 'test_helper'
 
 class AichatRequestsControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     @authorized_teacher1 = create :authorized_teacher
     unit_group = create :unit_group, name: 'exploring-gen-ai-2024'
     section = create :section, user: @authorized_teacher1, unit_group: unit_group
     @authorized_student1 = create(:follower, section: section).student_user
 
-    @level = create(:level, name: 'level1')
+    @level = create(:level)
     @script = create(:script)
 
     @default_model_customizations = {temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test"}.stringify_keys


### PR DESCRIPTION
We've noted some unit test flakiness in Drone recently that appear to be tied to a level name (`level1`) being used across tests. AichatController tests don't appear to need to specify a level name, so removing that argument. Also wrapping the whole test in a transaction via `use_transactional_test_case` to be safe (which matches the existing AichatController), although I'm not sure that is entirely necessary.

More discussion here: https://codedotorg.slack.com/archives/C046G4TRLEN/p1737669674404409