### PR TITLE
Add more login page instrumentation

### DIFF
--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -20,6 +20,8 @@ const EVENTS = {
   ACCOUNT_SETTINGS_PAGE_VISITED: 'Account Settings Page Visited',
   LOGIN_PAGE_VISITED: 'Login Page Visited',
   LOGIN_PAGE_CREATE_ACCOUNT_CLICKED: 'Login Page Create Account Button Clicked',
+  LOGIN_PAGE_SIGN_IN_CLICKED: 'Login Page Sign In Button Clicked',
+  LOGIN_PAGE_OAUTH_CLICKED: 'Login Page OAuth Button Clicked',
   CURRICULUM_FREE_DIALOG_BUTTON_CLICKED:
     'Curriculum Free Dialog Button Clicked',
   LMS_INFORMATION_BUTTON_CLICKED: 'LMS Information Button Clicked',

--- a/apps/src/sites/studio/pages/devise/sessions/_login.js
+++ b/apps/src/sites/studio/pages/devise/sessions/_login.js
@@ -21,4 +21,52 @@ $(document).ready(() => {
       PLATFORMS.STATSIG
     );
   });
+
+  document.getElementById('signin-button').addEventListener('click', () => {
+    analyticsReporter.sendEvent(
+      EVENTS.LOGIN_PAGE_SIGN_IN_CLICKED,
+      {},
+      PLATFORMS.STATSIG
+    );
+  });
+
+  document
+    .getElementById('google_oauth2-sign-in')
+    .addEventListener('click', () => {
+      analyticsReporter.sendEvent(
+        EVENTS.OAUTH_LOGIN_CLICKED,
+        {provider: 'google'},
+        PLATFORMS.STATSIG
+      );
+    });
+
+  document
+    .getElementById('facebook_oauth2-sign-in')
+    .addEventListener('click', () => {
+      analyticsReporter.sendEvent(
+        EVENTS.OAUTH_LOGIN_CLICKED,
+        {provider: 'facebook'},
+        PLATFORMS.STATSIG
+      );
+    });
+
+  document
+    .getElementById('microsoft_oauth2-sign-in')
+    .addEventListener('click', () => {
+      analyticsReporter.sendEvent(
+        EVENTS.OAUTH_LOGIN_CLICKED,
+        {provider: 'microsoft'},
+        PLATFORMS.STATSIG
+      );
+    });
+
+  document
+    .getElementById('clever_oauth2-sign-in')
+    .addEventListener('click', () => {
+      analyticsReporter.sendEvent(
+        EVENTS.OAUTH_LOGIN_CLICKED,
+        {provider: 'clever'},
+        PLATFORMS.STATSIG
+      );
+    });
 });

--- a/apps/src/sites/studio/pages/devise/sessions/_login.js
+++ b/apps/src/sites/studio/pages/devise/sessions/_login.js
@@ -6,7 +6,7 @@ import {USER_RETURN_TO_SESSION_KEY} from '@cdo/apps/signUpFlow/signUpFlowConstan
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 $(document).ready(() => {
-  analyticsReporter.sendEvent(EVENTS.LOGIN_PAGE_VISITED, {}, PLATFORMS.STATSIG);
+  analyticsReporter.sendEvent(EVENTS.LOGIN_PAGE_VISITED, {}, PLATFORMS.BOTH);
 
   const userReturnTo = getScriptData('userReturnTo');
 
@@ -18,7 +18,7 @@ $(document).ready(() => {
     analyticsReporter.sendEvent(
       EVENTS.LOGIN_PAGE_CREATE_ACCOUNT_CLICKED,
       {},
-      PLATFORMS.STATSIG
+      PLATFORMS.BOTH
     );
   });
 
@@ -26,7 +26,7 @@ $(document).ready(() => {
     analyticsReporter.sendEvent(
       EVENTS.LOGIN_PAGE_SIGN_IN_CLICKED,
       {},
-      PLATFORMS.STATSIG
+      PLATFORMS.BOTH
     );
   });
 
@@ -36,37 +36,33 @@ $(document).ready(() => {
       analyticsReporter.sendEvent(
         EVENTS.OAUTH_LOGIN_CLICKED,
         {provider: 'google'},
-        PLATFORMS.STATSIG
+        PLATFORMS.BOTH
       );
     });
 
-  document
-    .getElementById('facebook_oauth2-sign-in')
-    .addEventListener('click', () => {
-      analyticsReporter.sendEvent(
-        EVENTS.OAUTH_LOGIN_CLICKED,
-        {provider: 'facebook'},
-        PLATFORMS.STATSIG
-      );
-    });
+  document.getElementById('facebook-sign-in').addEventListener('click', () => {
+    analyticsReporter.sendEvent(
+      EVENTS.OAUTH_LOGIN_CLICKED,
+      {provider: 'facebook'},
+      PLATFORMS.BOTH
+    );
+  });
 
   document
-    .getElementById('microsoft_oauth2-sign-in')
+    .getElementById('microsoft_v2_auth-sign-in')
     .addEventListener('click', () => {
       analyticsReporter.sendEvent(
         EVENTS.OAUTH_LOGIN_CLICKED,
         {provider: 'microsoft'},
-        PLATFORMS.STATSIG
+        PLATFORMS.BOTH
       );
     });
 
-  document
-    .getElementById('clever_oauth2-sign-in')
-    .addEventListener('click', () => {
-      analyticsReporter.sendEvent(
-        EVENTS.OAUTH_LOGIN_CLICKED,
-        {provider: 'clever'},
-        PLATFORMS.STATSIG
-      );
-    });
+  document.getElementById('clever-sign-in').addEventListener('click', () => {
+    analyticsReporter.sendEvent(
+      EVENTS.OAUTH_LOGIN_CLICKED,
+      {provider: 'clever'},
+      PLATFORMS.BOTH
+    );
+  });
 });

--- a/apps/src/sites/studio/pages/devise/sessions/_login.js
+++ b/apps/src/sites/studio/pages/devise/sessions/_login.js
@@ -34,7 +34,7 @@ $(document).ready(() => {
     .getElementById('google_oauth2-sign-in')
     .addEventListener('click', () => {
       analyticsReporter.sendEvent(
-        EVENTS.OAUTH_LOGIN_CLICKED,
+        EVENTS.LOGIN_PAGE_OAUTH_CLICKED,
         {provider: 'google'},
         PLATFORMS.BOTH
       );
@@ -42,7 +42,7 @@ $(document).ready(() => {
 
   document.getElementById('facebook-sign-in').addEventListener('click', () => {
     analyticsReporter.sendEvent(
-      EVENTS.OAUTH_LOGIN_CLICKED,
+      EVENTS.LOGIN_PAGE_OAUTH_CLICKED,
       {provider: 'facebook'},
       PLATFORMS.BOTH
     );
@@ -52,7 +52,7 @@ $(document).ready(() => {
     .getElementById('microsoft_v2_auth-sign-in')
     .addEventListener('click', () => {
       analyticsReporter.sendEvent(
-        EVENTS.OAUTH_LOGIN_CLICKED,
+        EVENTS.LOGIN_PAGE_OAUTH_CLICKED,
         {provider: 'microsoft'},
         PLATFORMS.BOTH
       );
@@ -60,7 +60,7 @@ $(document).ready(() => {
 
   document.getElementById('clever-sign-in').addEventListener('click', () => {
     analyticsReporter.sendEvent(
-      EVENTS.OAUTH_LOGIN_CLICKED,
+      EVENTS.LOGIN_PAGE_OAUTH_CLICKED,
       {provider: 'clever'},
       PLATFORMS.BOTH
     );


### PR DESCRIPTION
A few updates in this PR:
- sends existing events (login page visited and Sign Up Started) to Amplitude in addition to Statsig
- adds an event for the "log in" button being clicked (note: there is no validation here so users could absolutely press it multiple times)
- adds events for clicking the oauth buttons. This is one event for all oauth buttons, with the provider as an attribute

On "Sign In" button clicked
```
[STATSIG ANALYTICS EVENT]: Login Page Sign In Button Clicked. Payload: {"payload":{}}
[AMPLITUDE ANALYTICS EVENT]: Login Page Sign In Button Clicked. Payload: {"payload":{}}
```

Example oauth (google in this case):
```
[STATSIG ANALYTICS EVENT]: Login Page OAuth Button Clicked. Payload: {"payload":{"provider":"google"}}
[AMPLITUDE ANALYTICS EVENT]: Login Page OAuth Button Clicked. Payload: {"payload":{"provider":"google"}}
```