### PR TITLE
Add a unit selection dropdown to the calendar page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1587,6 +1587,7 @@
   "lesson": "Lesson",
   "lessonDuration": "0-1.5 hours",
   "lessons": "Lessons",
+  "lessonsFor": "Lessons for",
   "lessonContainsNoLevels": "This lesson contains no levels.",
   "lessonExtras": "Lesson Extras are turned off for the selected section",
   "lessonExtrasButton": "Go to Teacher Dashboard",

--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -80,10 +80,6 @@ export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
   ) {
     return;
   }
-  console.log('Loading courses with progress', {
-    selectedSection,
-    loadedSectionId: state.unitSelection.loadedSectionId,
-  });
   dispatch(startLoadingCoursesWithProgress());
 
   HttpClient.fetchJson(`/dashboardapi/section_courses/${selectedSection.id}`)

--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -15,7 +15,6 @@ const SET_LOADED_SECTION_ID = 'unitSelection/SET_LOADED_SECTION_ID';
 
 // Action creators
 export const setScriptId = scriptId => ({type: SET_SCRIPT, scriptId});
-export const setUnitName = unitName => ({type: SET_UNIT_NAME, unitName});
 export const setCoursesWithProgress = coursesWithProgress => ({
   type: SET_COURSES,
   coursesWithProgress,
@@ -49,10 +48,8 @@ const getSelectedUnit = state => {
   return unit;
 };
 
-export const getSelectedScriptName = state => {
-  return getSelectedUnit(state)
-    ? getSelectedUnit(state).key
-    : null || state.unitSelection.unitName;
+export const getSelectedUnitName = state => {
+  return getSelectedUnit(state) ? getSelectedUnit(state).key : null;
 };
 
 /* Get the user friendly name of a script(the unit or course name) */
@@ -119,7 +116,6 @@ export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
 // Initial state of unitSelectionRedux
 const initialState = {
   scriptId: null,
-  unitName: null,
   coursesWithProgress: [],
   isLoadingCoursesWithProgress: false,
   loadedSectionId: null,
@@ -142,15 +138,6 @@ export default function unitSelection(state = initialState, action) {
     return {
       ...state,
       scriptId: action.scriptId,
-    };
-  }
-
-  // TODO: instead of setting unit name here, we should be updating the sections list based on the selected section
-  // And adding the script information to the section object.
-  if (action.type === SET_UNIT_NAME) {
-    return {
-      ...state,
-      unitName: action.unitName,
     };
   }
 

--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -2,6 +2,8 @@
 // Tab specific reducers can import actions from this file
 // if they need to respond to a script changing.
 
+import HttpClient from '../util/HttpClient';
+
 // Action type constants
 export const SET_SCRIPT = 'unitSelection/SET_SCRIPT';
 export const SET_UNIT_NAME = 'unitSelection/SET_UNIT_NAME';
@@ -78,21 +80,14 @@ export const asyncLoadCoursesWithProgress = () => (dispatch, getState) => {
   ) {
     return;
   }
+  console.log('Loading courses with progress', {
+    selectedSection,
+    loadedSectionId: state.unitSelection.loadedSectionId,
+  });
   dispatch(startLoadingCoursesWithProgress());
 
-  fetch(`/dashboardapi/section_courses/${selectedSection.id}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-    },
-  })
-    .then(response => {
-      if (!response.ok) {
-        throw new Error(`Error(${response.status}: ${response.statusText})`);
-      }
-
-      return response.json();
-    })
+  HttpClient.fetchJson(`/dashboardapi/section_courses/${selectedSection.id}`)
+    .then(response => response?.value)
     .then(coursesWithProgress => {
       // Reorder coursesWithProgress so that the current section is at the top and other sections are in order from newest to oldest
       const reorderedCourses = [
@@ -130,6 +125,8 @@ export default function unitSelection(state = initialState, action) {
     return {
       ...state,
       coursesWithProgress: action.coursesWithProgress,
+      // This automatically selects the first unit of the first course
+      // unless a scriptId is already set
       scriptId: state.scriptId === null ? firstUnit?.id : state.scriptId,
     };
   }

--- a/apps/src/templates/UnitSelectorV2.jsx
+++ b/apps/src/templates/UnitSelectorV2.jsx
@@ -51,8 +51,6 @@ function UnitSelectorV2({
     }
   }, [sectionId, asyncLoadCoursesWithProgress]);
 
-  console.log('lfm', {selectedSectionCourse, coursesWithProgress});
-
   const unitId = React.useMemo(() => scriptId, [scriptId]);
   const onSelectUnit = React.useCallback(
     e => {

--- a/apps/src/templates/UnitSelectorV2.jsx
+++ b/apps/src/templates/UnitSelectorV2.jsx
@@ -33,6 +33,7 @@ const recordEvent = (eventName, sectionId, dataJson = {}) => {
 };
 
 function UnitSelectorV2({
+  filterToSelectedCourse = false,
   sectionId,
   scriptId,
   coursesWithProgress,
@@ -41,6 +42,7 @@ function UnitSelectorV2({
   asyncLoadCoursesWithProgress,
   isLoadingCourses,
   isLoadingSectionData,
+  selectedSectionCourse,
 }) {
   // Reload courses with progress when selected section changes.
   React.useEffect(() => {
@@ -48,6 +50,8 @@ function UnitSelectorV2({
       asyncLoadCoursesWithProgress();
     }
   }, [sectionId, asyncLoadCoursesWithProgress]);
+
+  console.log('lfm', {selectedSectionCourse, coursesWithProgress});
 
   const unitId = React.useMemo(() => scriptId, [scriptId]);
   const onSelectUnit = React.useCallback(
@@ -70,13 +74,17 @@ function UnitSelectorV2({
     [unitId, setScriptId, sectionId]
   );
 
-  const itemGroups = coursesWithProgress.map(version => ({
-    label: version.display_name,
-    groupItems: version.units.map(unit => ({
-      value: unit.id,
-      text: unit.name,
-    })),
-  }));
+  const itemGroups = coursesWithProgress
+    .filter(
+      version => !filterToSelectedCourse || version.id === selectedSectionCourse
+    )
+    .map(version => ({
+      label: version.display_name,
+      groupItems: version.units.map(unit => ({
+        value: unit.id,
+        text: unit.name,
+      })),
+    }));
 
   const loadingDropdown = () => (
     <div
@@ -109,6 +117,7 @@ function UnitSelectorV2({
 }
 
 UnitSelectorV2.propTypes = {
+  filterToSelectedCourse: PropTypes.bool,
   scriptId: PropTypes.number,
   sectionId: PropTypes.number,
   coursesWithProgress: PropTypes.array.isRequired,
@@ -117,6 +126,7 @@ UnitSelectorV2.propTypes = {
   asyncLoadCoursesWithProgress: PropTypes.func.isRequired,
   isLoadingCourses: PropTypes.bool,
   isLoadingSectionData: PropTypes.bool.isRequired,
+  selectedSectionCourse: PropTypes.any,
 };
 
 export const UnconnectedUnitSelectorV2 = UnitSelectorV2;
@@ -128,6 +138,9 @@ export default connect(
     coursesWithProgress: state.unitSelection.coursesWithProgress,
     isLoadingCourses: state.unitSelection.isLoadingCoursesWithProgress,
     isLoadingSectionData: state.teacherSections.isLoadingSectionData,
+    selectedSectionCourse:
+      state.teacherSections.sections[state.teacherSections.selectedSectionId]
+        ?.courseVersionId,
   }),
   dispatch => ({
     setScriptId(scriptId) {

--- a/apps/src/templates/manageStudents/ManageStudentsNameCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsNameCell.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 
-import {getSelectedScriptName} from '@cdo/apps/redux/unitSelectionRedux';
+import {getSelectedUnitName} from '@cdo/apps/redux/unitSelectionRedux';
 import {unitUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import i18n from '@cdo/locale';
 
@@ -90,7 +90,7 @@ const styles = {
 
 export default connect(
   state => ({
-    scriptName: getSelectedScriptName(state),
+    scriptName: getSelectedUnitName(state),
   }),
   dispatch => ({
     editStudent(id, studentInfo) {

--- a/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
+++ b/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
@@ -1,6 +1,6 @@
 import {
   SET_SCRIPT,
-  getSelectedScriptName,
+  getSelectedUnitName,
   doesCurrentCourseUseFeedback,
 } from '@cdo/apps/redux/unitSelectionRedux';
 
@@ -1080,7 +1080,7 @@ export const getExportableFeedbackData = state => {
 };
 
 export const isCurrentScriptCSD = state => {
-  const scriptName = getSelectedScriptName(state) || '';
+  const scriptName = getSelectedUnitName(state) || '';
   return scriptName.includes('csd');
 };
 

--- a/apps/src/templates/teacherDashboard/StatsTable.jsx
+++ b/apps/src/templates/teacherDashboard/StatsTable.jsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 
-import {getSelectedScriptName} from '@cdo/apps/redux/unitSelectionRedux';
+import {getSelectedUnitName} from '@cdo/apps/redux/unitSelectionRedux';
 import {unitUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import i18n from '@cdo/locale';
 
@@ -203,7 +203,7 @@ const styles = {
 
 export const UnconnectedStatsTable = StatsTable;
 export default connect(state => ({
-  scriptName: getSelectedScriptName(state),
+  scriptName: getSelectedUnitName(state),
   participantType:
     state.teacherSections.sections[state.teacherSections.selectedSectionId]
       .participantType,

--- a/apps/src/templates/teacherNavigation/CalendarEmptyState.tsx
+++ b/apps/src/templates/teacherNavigation/CalendarEmptyState.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {useSelector} from 'react-redux';
 
+import {getSelectedUnitName} from '@cdo/apps/redux/unitSelectionRedux';
 import CalendarNotAvailable from '@cdo/apps/templates/teacherNavigation/images/CalendarNotAvailable.svg';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
@@ -15,9 +16,7 @@ import {
 } from './EmptyStateUtils';
 
 export const CalendarEmptyState: React.FC = () => {
-  const unitName = useSelector(
-    (state: {unitSelection: {unitName: string}}) => state.unitSelection.unitName
-  );
+  const unitName = useSelector(state => getSelectedUnitName(state));
 
   const selectedSection = useAppSelector(selectedSectionSelector);
   const versionYear = useAppSelector(state => state.calendar?.versionYear);

--- a/apps/src/templates/teacherNavigation/CalendarEmptyState.tsx
+++ b/apps/src/templates/teacherNavigation/CalendarEmptyState.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {useSelector} from 'react-redux';
 
-import {getSelectedUnitName} from '@cdo/apps/redux/unitSelectionRedux';
 import CalendarNotAvailable from '@cdo/apps/templates/teacherNavigation/images/CalendarNotAvailable.svg';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
@@ -16,8 +14,6 @@ import {
 } from './EmptyStateUtils';
 
 export const CalendarEmptyState: React.FC = () => {
-  const unitName = useSelector(state => getSelectedUnitName(state));
-
   const selectedSection = useAppSelector(selectedSectionSelector);
   const versionYear = useAppSelector(state => state.calendar?.versionYear);
   const isLegacyScript = versionYear ? versionYear < 2021 : false;
@@ -25,7 +21,7 @@ export const CalendarEmptyState: React.FC = () => {
   const showNoCurriculumAssigned = !selectedSection.courseOfferingId;
   const emptyStateDetails = generateCalendarEmptyState(
     showNoCurriculumAssigned,
-    unitName,
+    selectedSection.unitName,
     selectedSection,
     isLegacyScript,
     hasCalendar

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -32,7 +32,8 @@ const WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS = [
 export const WEEK_WIDTH = 585;
 
 const UnitCalendar: React.FC = () => {
-  const [isLoading, setIsLoading] = useState(false); // it is only loading when you do the fetch
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasInitialLoad, setHasInitialLoad] = useState(false);
 
   const [weeklyInstructionalMinutes, setWeeklyInstructionalMinutes] =
     useState<string>(WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS[4].toString());
@@ -90,6 +91,7 @@ const UnitCalendar: React.FC = () => {
         (unitName !== calendarUnitName && unitName !== null))
     ) {
       setIsLoading(true);
+      setHasInitialLoad(true);
       HttpClient.fetchJson<UnitSummaryResponse>(
         `/dashboardapi/unit_summary/${unitToLoad}`
       )
@@ -145,7 +147,12 @@ const UnitCalendar: React.FC = () => {
     state => state.teacherSections.needsReload
   );
 
-  if (isLoading || isLoadingCoursesWithProgress || needsReload) {
+  if (
+    !hasInitialLoad ||
+    isLoading ||
+    isLoadingCoursesWithProgress ||
+    needsReload
+  ) {
     return <Spinner size={'large'} />;
   }
 

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -15,6 +15,8 @@ import HttpClient from '@cdo/apps/util/HttpClient';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 
+import UnitSelectorV2 from '../UnitSelectorV2';
+
 import {CalendarEmptyState} from './CalendarEmptyState';
 
 import styles from './teacher-navigation.module.scss';
@@ -132,6 +134,10 @@ const UnitCalendar: React.FC = () => {
       <div className={styles.calendarContentContainer}>
         {!isLoading && hasCalendar && (
           <div>
+            <UnitSelectorV2
+              className={styles.titleUnitSelectorDropdown}
+              filterToSelectedCourse={true}
+            />
             <div className={styles.minutesPerWeekWrapper}>
               <div className={styles.minutesPerWeekDescription}>
                 {i18n.instructionalMinutesPerWeek()}

--- a/apps/src/templates/teacherNavigation/UnitCalendar.tsx
+++ b/apps/src/templates/teacherNavigation/UnitCalendar.tsx
@@ -58,15 +58,18 @@ const UnitCalendar: React.FC = () => {
   );
 
   const unitToLoad = React.useMemo(
-    () => unitName || selectedSection.unitName,
+    () =>
+      selectedSection.unitName !== null
+        ? unitName || selectedSection.unitName
+        : null,
     [unitName, selectedSection.unitName]
   );
 
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    asyncLoadCoursesWithProgress();
-  }, []);
+    dispatch(asyncLoadCoursesWithProgress());
+  }, [dispatch]);
 
   useEffect(() => {
     if (!selectedSection.courseOfferingId || !unitToLoad) {
@@ -78,6 +81,7 @@ const UnitCalendar: React.FC = () => {
           versionYear: null,
         })
       );
+      setHasInitialLoad(true);
       return;
     }
 
@@ -88,7 +92,7 @@ const UnitCalendar: React.FC = () => {
       userId &&
       (hasCalendar === undefined ||
         calendarLessons === null ||
-        (unitName !== calendarUnitName && unitName !== null))
+        (unitToLoad !== calendarUnitName && unitName !== null))
     ) {
       setIsLoading(true);
       setHasInitialLoad(true);

--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsEmptyState.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsEmptyState.tsx
@@ -3,6 +3,7 @@ import {useSelector} from 'react-redux';
 import {generatePath} from 'react-router-dom';
 
 import {LinkButton} from '@cdo/apps/componentLibrary/button';
+import {getSelectedUnitName} from '@cdo/apps/redux/unitSelectionRedux';
 import NoLessonMaterialsAvailable from '@cdo/apps/templates/teacherNavigation/images/NoLessonMaterialsAvailable.png';
 import NoLessonMaterialsForLegacyCourses from '@cdo/apps/templates/teacherNavigation/images/NoLessonMaterialsForLegacyCourses.png';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -25,9 +26,7 @@ interface LessonMaterialsEmptyStateProps {
 export const LessonMaterialsEmptyState: React.FC<
   LessonMaterialsEmptyStateProps
 > = ({isLegacyScript, hasNoLessonsWithLessonPlans}) => {
-  const unitName = useSelector(
-    (state: {unitSelection: {unitName: string}}) => state.unitSelection.unitName
-  );
+  const unitName = useSelector(state => getSelectedUnitName(state));
 
   const selectedSection = useAppSelector(selectedSectionSelector);
   const showNoCurriculumAssigned = !selectedSection.courseOfferingId;

--- a/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsEmptyState.tsx
+++ b/apps/src/templates/teacherNavigation/lessonMaterials/LessonMaterialsEmptyState.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import {useSelector} from 'react-redux';
 import {generatePath} from 'react-router-dom';
 
 import {LinkButton} from '@cdo/apps/componentLibrary/button';
-import {getSelectedUnitName} from '@cdo/apps/redux/unitSelectionRedux';
 import NoLessonMaterialsAvailable from '@cdo/apps/templates/teacherNavigation/images/NoLessonMaterialsAvailable.png';
 import NoLessonMaterialsForLegacyCourses from '@cdo/apps/templates/teacherNavigation/images/NoLessonMaterialsForLegacyCourses.png';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
@@ -26,13 +24,11 @@ interface LessonMaterialsEmptyStateProps {
 export const LessonMaterialsEmptyState: React.FC<
   LessonMaterialsEmptyStateProps
 > = ({isLegacyScript, hasNoLessonsWithLessonPlans}) => {
-  const unitName = useSelector(state => getSelectedUnitName(state));
-
   const selectedSection = useAppSelector(selectedSectionSelector);
   const showNoCurriculumAssigned = !selectedSection.courseOfferingId;
   const emptyStateDetails = generateLessonMaterialsEmptyState(
     showNoCurriculumAssigned,
-    unitName,
+    selectedSection.unitName,
     selectedSection,
     isLegacyScript,
     hasNoLessonsWithLessonPlans

--- a/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
+++ b/apps/src/templates/teacherNavigation/selectedSectionLoader.ts
@@ -1,7 +1,7 @@
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import {getStore} from '@cdo/apps/redux';
-import {setScriptId, setUnitName} from '@cdo/apps/redux/unitSelectionRedux';
+import {setScriptId} from '@cdo/apps/redux/unitSelectionRedux';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';
 
 import {
@@ -70,7 +70,6 @@ export const setSelectedSectionData = (sectionData: any) => {
     getStore().dispatch(setShowSharingColumn(true));
   }
 
-  getStore().dispatch(setUnitName(sectionData.script.name));
   getStore().dispatch(setLoginType(sectionData.login_type));
   getStore().dispatch(setRosterProvider(sectionData.login_type));
   getStore().dispatch(setRosterProviderName(sectionData.login_type_name));

--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -151,18 +151,23 @@
   width: fit-content;
 }
 
-.minutesPerWeekWrapper {
+.calendarDropdowns {
   display: flex;
+  flex-direction: row;
+  gap: 24px;
   margin-bottom: 10px;
-  align-items: center;
 }
 
-.minutesPerWeekDescription {
-  font-weight: bold;
-  margin-right: 10px;
+.calendarUnitDropdown {
+  max-width: 240px;
 }
 
 .calendarDropdown {
-  width: fit-content;
-  margin-bottom: 0;
+  display: flex;
+  align-items: center;
+}
+
+.calendarDropdownDescription {
+  font-weight: bold;
+  margin-right: 10px;
 }

--- a/apps/src/templates/textResponses/TextResponses.jsx
+++ b/apps/src/templates/textResponses/TextResponses.jsx
@@ -7,7 +7,7 @@ import {connect} from 'react-redux';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import {
   setScriptId,
-  getSelectedScriptName,
+  getSelectedUnitName,
 } from '@cdo/apps/redux/unitSelectionRedux';
 import UnitSelector from '@cdo/apps/templates/sectionProgress/UnitSelector';
 import {loadTextResponsesFromServer} from '@cdo/apps/templates/textResponses/textReponsesDataApi';
@@ -171,7 +171,7 @@ export default connect(
   state => ({
     sectionId: state.teacherSections.selectedSectionId,
     scriptId: state.unitSelection.scriptId,
-    scriptName: getSelectedScriptName(state),
+    scriptName: getSelectedUnitName(state),
   }),
   dispatch => ({
     setScriptId(scriptId) {

--- a/apps/test/unit/redux/unitSelectionReduxTest.js
+++ b/apps/test/unit/redux/unitSelectionReduxTest.js
@@ -1,6 +1,6 @@
 import unitSelection, {
   setScriptId,
-  getSelectedScriptName,
+  getSelectedUnitName,
   getSelectedScriptDescription,
   setCoursesWithProgress,
 } from '@cdo/apps/redux/unitSelectionRedux';
@@ -15,7 +15,7 @@ describe('unitSelectionRedux', () => {
     expect(nextState.scriptId).toEqual(2);
   });
 
-  describe('getSelectedScriptName', () => {
+  describe('getSelectedUnitName', () => {
     it('returns the script name of the selected script', () => {
       const state = {
         unitSelection: {
@@ -23,18 +23,7 @@ describe('unitSelectionRedux', () => {
           coursesWithProgress: fakeCoursesWithProgress,
         },
       };
-      expect(getSelectedScriptName(state)).toEqual('csd1-2018');
-    });
-
-    it('returns unitName if script selected but no coursesWithProgress', () => {
-      const state = {
-        unitSelection: {
-          scriptId: 5,
-          unitName: 'csp1-2024',
-          coursesWithProgress: [],
-        },
-      };
-      expect(getSelectedScriptName(state)).toEqual('csp1-2024');
+      expect(getSelectedUnitName(state)).toEqual('csd1-2018');
     });
 
     it('returns null if no script is selected', () => {
@@ -44,7 +33,7 @@ describe('unitSelectionRedux', () => {
           coursesWithProgress: fakeCoursesWithProgress,
         },
       };
-      expect(getSelectedScriptName(state)).toBeUndefined();
+      expect(getSelectedUnitName(state)).toBeNull();
     });
   });
 

--- a/apps/test/unit/templates/teacherNavigation/UnitCalendarTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/UnitCalendarTest.tsx
@@ -13,7 +13,7 @@ import {
   stubRedux,
 } from '@cdo/apps/redux';
 import locales, {setLocaleCode} from '@cdo/apps/redux/localesRedux';
-import unitSelection, {setUnitName} from '@cdo/apps/redux/unitSelectionRedux';
+import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import currentUser, {
   setInitialData,
 } from '@cdo/apps/templates/currentUserRedux';
@@ -129,7 +129,6 @@ describe('UnitCalendar', () => {
     store.dispatch(setInitialData({id: 1, user_type: 'teacher'}));
     store.dispatch(setSections(SECTIONS));
     store.dispatch(selectSection(1));
-    store.dispatch(setUnitName('csd1-2024'));
 
     fetchSpy = jest.spyOn(HttpClient, 'fetchJson');
   });
@@ -197,7 +196,6 @@ describe('UnitCalendar', () => {
 
   it('tells users to select a curriculum when no curriculum assigned', async () => {
     store.dispatch(selectSection(9));
-    store.dispatch(setUnitName(null));
 
     await act(async () => {
       renderComponent();
@@ -211,7 +209,6 @@ describe('UnitCalendar', () => {
 
   it('tells users to select a unit when no unit assigned', async () => {
     store.dispatch(selectSection(10));
-    store.dispatch(setUnitName(null));
 
     await act(async () => {
       renderComponent();
@@ -226,7 +223,6 @@ describe('UnitCalendar', () => {
   });
 
   it('notifies users that the assigned curriculum is pre-2020', async () => {
-    store.dispatch(setUnitName('csd1-2020'));
     store.dispatch(selectSection(11));
     fetchSpy.mockResolvedValue({
       value: {

--- a/apps/test/unit/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainerTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainerTest.tsx
@@ -10,7 +10,7 @@ import {
   registerReducers,
   restoreRedux,
 } from '@cdo/apps/redux';
-import unitSelection, {setUnitName} from '@cdo/apps/redux/unitSelectionRedux';
+import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import teacherSections, {
   selectSection,
   setSections,
@@ -231,7 +231,6 @@ describe('LessonMaterialsContainer', () => {
 
     store = getStore();
 
-    store.dispatch(setUnitName('csd1-2024'));
     store.dispatch(setSections(SECTIONS));
     store.dispatch(selectSection(1));
 
@@ -360,7 +359,6 @@ describe('LessonMaterialsContainer', () => {
 
   it('tells users to select a unit when no unit assigned', async () => {
     store.dispatch(selectSection(10));
-    store.dispatch(setUnitName(null));
 
     await renderDefault();
 
@@ -373,7 +371,6 @@ describe('LessonMaterialsContainer', () => {
   });
 
   it('notifies users that the assigned curriculum is pre-2020', async () => {
-    store.dispatch(setUnitName('csd1-2020'));
     store.dispatch(selectSection(11));
 
     await renderDefault();

--- a/apps/test/unit/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainerTest.tsx
+++ b/apps/test/unit/templates/teacherNavigation/lessonMaterials/LessonMaterialsContainerTest.tsx
@@ -10,7 +10,9 @@ import {
   registerReducers,
   restoreRedux,
 } from '@cdo/apps/redux';
-import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
+import unitSelection, {
+  setCoursesWithProgress,
+} from '@cdo/apps/redux/unitSelectionRedux';
 import teacherSections, {
   selectSection,
   setSections,
@@ -86,6 +88,35 @@ const SECTIONS = [
     unitName: null,
     unitSelection: null,
     course_display_name: null,
+  },
+];
+
+const COURSES_WITH_PROGRESS = [
+  {
+    id: 123,
+    display_name: 'CSD',
+    units: [
+      {
+        id: 1,
+        version_year: 2023,
+        key: 'csd1-2024',
+        name: 'CSD unit 1',
+        position: null,
+      },
+    ],
+  },
+  {
+    id: 1234,
+    display_name: 'CSD1-2020',
+    units: [
+      {
+        id: 2,
+        version_year: 2020,
+        key: 'csd1-2020',
+        name: 'CSD1-2020 unit 1',
+        position: null,
+      },
+    ],
   },
 ];
 
@@ -233,6 +264,7 @@ describe('LessonMaterialsContainer', () => {
 
     store.dispatch(setSections(SECTIONS));
     store.dispatch(selectSection(1));
+    store.dispatch(setCoursesWithProgress(COURSES_WITH_PROGRESS));
 
     fetchSpy = jest.spyOn(HttpClient, 'fetchJson');
   });

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2025_01_16_214434) do
 
-  create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
     t.string "action"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "level_id"], name: "index_activities_on_user_id_and_level_id"
   end
 
-  create_table "activity_sections", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "activity_sections", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "lesson_activity_id", null: false
     t.string "key", null: false
     t.integer "position", null: false
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ai_tutor_interaction_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "ai_tutor_interaction_feedbacks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "ai_tutor_interaction_id", null: false
     t.integer "user_id", null: false
     t.boolean "thumbs_up"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "level_id", "script_id"], name: "index_ace_user_level_script"
   end
 
-  create_table "aichat_messages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "aichat_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "aichat_thread_id", null: false
     t.text "external_id", null: false
     t.integer "role", null: false
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "level_id", "script_id"], name: "index_acs_user_level_script"
   end
 
-  create_table "aichat_threads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "aichat_threads", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "external_id", null: false
     t.text "llm_version", null: false
@@ -133,7 +133,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_aichat_threads_on_user_id"
   end
 
-  create_table "assessment_activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "assessment_activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "script_id", null: false
@@ -145,7 +145,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "level_id", "script_id"], name: "index_assessment_activities_on_user_and_level_and_script"
   end
 
-  create_table "authentication_options", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "authentication_options", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "hashed_email", default: "", null: false
     t.string "credential_type", null: false
@@ -161,7 +161,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "deleted_at"], name: "index_authentication_options_on_user_id_and_deleted_at"
   end
 
-  create_table "authored_hint_view_requests", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "authored_hint_view_requests", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id"
     t.integer "level_id"
@@ -187,7 +187,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "script_id", "level_id", "hint_id"], name: "index_authored_hint_view_requests_on_all_related_ids"
   end
 
-  create_table "backpacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "backpacks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "storage_app_id", null: false
     t.datetime "created_at", null: false
@@ -196,7 +196,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_backpacks_on_user_id", unique: true
   end
 
-  create_table "blocks", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "blocks", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "pool", default: "", null: false
     t.string "category"
@@ -209,7 +209,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pool", "name"], name: "index_blocks_on_pool_and_name", unique: true
   end
 
-  create_table "callouts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "callouts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "element_id", limit: 1024, null: false
     t.string "localization_key", limit: 1024, null: false
     t.datetime "created_at"
@@ -220,7 +220,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.string "callout_text"
   end
 
-  create_table "cap_user_events", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "cap_user_events", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 64, null: false
     t.integer "user_id", null: false
     t.string "policy", limit: 16, null: false
@@ -233,7 +233,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_cap_user_events_on_user_id"
   end
 
-  create_table "census_state_course_codes", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "census_state_course_codes", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "state"
     t.string "course"
     t.datetime "created_at", null: false
@@ -241,7 +241,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["state", "course"], name: "index_census_state_course_codes_on_state_and_course", unique: true
   end
 
-  create_table "census_submission_form_maps", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "census_submission_form_maps", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "census_submission_id", null: false
     t.integer "form_id", null: false
     t.datetime "created_at", null: false
@@ -250,7 +250,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["form_id"], name: "index_census_submission_form_maps_on_form_id"
   end
 
-  create_table "census_submissions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "census_submissions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.string "submitter_email_address"
     t.string "submitter_name"
@@ -284,7 +284,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_year", "id"], name: "index_census_submissions_on_school_year_and_id"
   end
 
-  create_table "census_submissions_school_infos", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "census_submissions_school_infos", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "census_submission_id", null: false
     t.integer "school_info_id", null: false
     t.datetime "created_at", null: false
@@ -293,7 +293,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_info_id", "census_submission_id"], name: "school_info_id_census_submission", unique: true
   end
 
-  create_table "census_summaries", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "census_summaries", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "school_id", limit: 12, null: false
     t.integer "school_year", limit: 2, null: false
     t.string "teaches_cs", limit: 2
@@ -303,7 +303,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_id", "school_year"], name: "index_census_summaries_on_school_id_and_school_year", unique: true
   end
 
-  create_table "channel_tokens", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "channel_tokens", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "storage_app_id", null: false
     t.integer "level_id", null: false
     t.datetime "created_at"
@@ -327,7 +327,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["code_review_id"], name: "index_code_review_comments_on_code_review_id"
   end
 
-  create_table "code_review_group_members", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "code_review_group_members", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "code_review_group_id", null: false
     t.bigint "follower_id", null: false
     t.datetime "created_at", null: false
@@ -336,7 +336,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["follower_id"], name: "index_code_review_group_members_on_follower_id"
   end
 
-  create_table "code_review_groups", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "code_review_groups", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "section_id", null: false
     t.string "name"
     t.datetime "created_at", null: false
@@ -344,7 +344,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["section_id"], name: "index_code_review_groups_on_section_id"
   end
 
-  create_table "code_review_requests", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "code_review_requests", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.integer "level_id", null: false
@@ -357,7 +357,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "script_id", "level_id", "closed_at", "deleted_at"], name: "index_code_review_requests_unique", unique: true
   end
 
-  create_table "code_reviews", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "code_reviews", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "project_id", null: false
     t.integer "script_id", null: false
@@ -369,14 +369,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.virtual "active", type: :boolean, as: "if((`deleted_at` is null),true,NULL)"
-    t.virtual "open", type: :boolean, as: "if((`closed_at` is null),true,NULL)"
+    t.virtual "active", type: :boolean, as: "if(isnull(`deleted_at`),TRUE,NULL)"
+    t.virtual "open", type: :boolean, as: "if(isnull(`closed_at`),TRUE,NULL)"
     t.index ["project_id", "deleted_at"], name: "index_code_reviews_on_project_id_and_deleted_at"
     t.index ["user_id", "project_id", "open", "active"], name: "index_code_reviews_unique", unique: true
     t.index ["user_id", "script_id", "project_level_id", "closed_at", "deleted_at"], name: "index_code_reviews_for_peer_lookup"
   end
 
-  create_table "concepts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "concepts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -384,14 +384,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["video_key"], name: "index_concepts_on_video_key"
   end
 
-  create_table "concepts_levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "concepts_levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "concept_id"
     t.integer "level_id"
     t.index ["concept_id"], name: "index_concepts_levels_on_concept_id"
     t.index ["level_id"], name: "index_concepts_levels_on_level_id"
   end
 
-  create_table "contact_rollups_final", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_final", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.json "data", null: false
     t.datetime "created_at", null: false
@@ -399,7 +399,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["email"], name: "index_contact_rollups_final_on_email", unique: true
   end
 
-  create_table "contact_rollups_pardot_memory", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_pardot_memory", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.integer "pardot_id"
     t.datetime "pardot_id_updated_at"
@@ -415,7 +415,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pardot_id"], name: "index_contact_rollups_pardot_memory_on_pardot_id", unique: true
   end
 
-  create_table "contact_rollups_processed", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_processed", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.json "data", null: false
     t.datetime "created_at", null: false
@@ -423,7 +423,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["email"], name: "index_contact_rollups_processed_on_email", unique: true
   end
 
-  create_table "contact_rollups_raw", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_raw", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.string "sources", null: false
     t.json "data"
@@ -432,7 +432,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "contained_level_answers", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contained_level_answers", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "level_id", null: false
@@ -442,7 +442,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_id"], name: "index_contained_level_answers_on_level_id"
   end
 
-  create_table "contained_levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contained_levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "level_group_level_id", null: false
@@ -455,7 +455,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_group_level_id"], name: "index_contained_levels_on_level_group_level_id"
   end
 
-  create_table "course_offerings", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "course_offerings", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "display_name", null: false
     t.datetime "created_at", null: false
@@ -479,7 +479,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 
-  create_table "course_offerings_pd_workshops", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "course_offerings_pd_workshops", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "pd_workshop_id", null: false
     t.bigint "course_offering_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -488,7 +488,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_workshop_id"], name: "index_course_offerings_pd_workshops_on_pd_workshop_id"
   end
 
-  create_table "course_scripts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "course_scripts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "course_id", null: false
     t.integer "script_id", null: false
     t.integer "position", null: false
@@ -499,7 +499,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_id"], name: "index_course_scripts_on_script_id"
   end
 
-  create_table "course_versions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "course_versions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "display_name", null: false
     t.text "properties"
@@ -514,7 +514,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["course_offering_id"], name: "index_course_versions_on_course_offering_id"
   end
 
-  create_table "courses", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "courses", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
     t.datetime "created_at", null: false
@@ -522,7 +522,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name"], name: "index_courses_on_name"
   end
 
-  create_table "data_docs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "data_docs", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "name"
     t.text "content"
@@ -539,7 +539,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["project_id"], name: "index_datablock_storage_kvps_on_project_id"
   end
 
-  create_table "datablock_storage_library_manifest", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "datablock_storage_library_manifest", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.json "library_manifest"
     t.integer "singleton_guard", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -566,7 +566,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["project_id"], name: "index_datablock_storage_tables_on_project_id"
   end
 
-  create_table "delayed_jobs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "delayed_jobs", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -581,14 +581,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "donor_schools", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "donor_schools", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "nces_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "donors", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "donors", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "url"
     t.string "show"
@@ -600,7 +600,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "email_preferences", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "email_preferences", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.boolean "opt_in", null: false
     t.string "ip_address", null: false
@@ -611,7 +611,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["email"], name: "index_email_preferences_on_email", unique: true
   end
 
-  create_table "experiments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "experiments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", null: false
@@ -633,7 +633,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["start_at"], name: "index_experiments_on_start_at"
   end
 
-  create_table "featured_projects", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "featured_projects", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "storage_app_id"
     t.datetime "featured_at"
     t.datetime "unfeatured_at"
@@ -642,7 +642,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["topic"], name: "index_featured_projects_on_topic"
   end
 
-  create_table "followers", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "followers", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "student_user_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -652,7 +652,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["student_user_id"], name: "index_followers_on_student_user_id"
   end
 
-  create_table "foorm_forms", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "foorm_forms", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "version", null: false
     t.text "questions", null: false
@@ -662,7 +662,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name", "version"], name: "index_foorm_forms_on_name_and_version", unique: true
   end
 
-  create_table "foorm_libraries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "foorm_libraries", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "version", null: false
     t.boolean "published", null: false
@@ -671,7 +671,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name", "version"], name: "index_foorm_libraries_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_library_questions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "foorm_library_questions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "library_name", null: false
     t.integer "library_version", null: false
     t.string "question_name", null: false
@@ -682,7 +682,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["library_name", "library_version", "question_name"], name: "index_foorm_library_questions_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_simple_survey_forms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_forms", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "path", null: false
     t.string "kind"
     t.string "form_name", null: false
@@ -693,7 +693,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["path"], name: "index_foorm_simple_survey_forms_on_path"
   end
 
-  create_table "foorm_simple_survey_submissions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_submissions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "foorm_submission_id", null: false
     t.integer "user_id"
     t.bigint "simple_survey_form_id"
@@ -712,7 +712,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "frameworks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "frameworks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "shortcode", null: false
     t.string "name", null: false
     t.text "properties"
@@ -721,7 +721,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["shortcode"], name: "index_frameworks_on_shortcode", unique: true
   end
 
-  create_table "games", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "games", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -730,7 +730,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["intro_video_id"], name: "index_games_on_intro_video_id"
   end
 
-  create_table "hint_view_requests", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "hint_view_requests", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "script_id"
     t.integer "level_id"
@@ -742,7 +742,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_hint_view_requests_on_user_id"
   end
 
-  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "learning_goal_ai_evaluation_id", null: false
     t.bigint "teacher_id", null: false
     t.boolean "ai_feedback_approval", null: false
@@ -756,7 +756,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["learning_goal_ai_evaluation_id"], name: "index_feedback_on_learning_goal_ai_evaluation"
   end
 
-  create_table "learning_goal_ai_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_ai_evaluations", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "rubric_ai_evaluation_id", null: false
     t.bigint "learning_goal_id", null: false
     t.integer "understanding"
@@ -770,7 +770,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["rubric_ai_evaluation_id"], name: "index_learning_goal_ai_evaluations_on_rubric_ai_evaluation_id"
   end
 
-  create_table "learning_goal_evidence_levels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_evidence_levels", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "learning_goal_id", null: false
     t.integer "understanding", null: false
     t.text "teacher_description"
@@ -780,7 +780,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["learning_goal_id", "understanding"], name: "index_learning_goal_evidence_levels_on_lg_id_and_understanding", unique: true
   end
 
-  create_table "learning_goal_teacher_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_teacher_evaluations", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "teacher_id", null: false
     t.integer "learning_goal_id", null: false
@@ -796,7 +796,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "teacher_id"], name: "index_learning_goal_teacher_evaluations_on_user_and_teacher_id"
   end
 
-  create_table "learning_goals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "learning_goals", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.integer "position"
     t.integer "rubric_id", null: false
@@ -808,7 +808,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["rubric_id", "key"], name: "index_learning_goals_on_rubric_id_and_key", unique: true
   end
 
-  create_table "lesson_activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lesson_activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.string "key", null: false
     t.integer "position", null: false
@@ -819,7 +819,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lesson_id"], name: "index_lesson_activities_on_lesson_id"
   end
 
-  create_table "lesson_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lesson_groups", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.integer "script_id", null: false
     t.boolean "user_facing", default: true, null: false
@@ -830,35 +830,35 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_id", "key"], name: "index_lesson_groups_on_script_id_and_key", unique: true
   end
 
-  create_table "lessons_opportunity_standards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lessons_opportunity_standards", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "standard_id", null: false
     t.index ["lesson_id", "standard_id"], name: "index_lessons_opportunity_standards_on_lesson_id_and_standard_id", unique: true
     t.index ["standard_id", "lesson_id"], name: "index_lessons_opportunity_standards_on_standard_id_and_lesson_id"
   end
 
-  create_table "lessons_programming_expressions", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lessons_programming_expressions", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "programming_expression_id", null: false
     t.index ["lesson_id", "programming_expression_id"], name: "lesson_programming_expression", unique: true
     t.index ["programming_expression_id", "lesson_id"], name: "programming_expression_lesson"
   end
 
-  create_table "lessons_resources", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lessons_resources", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.integer "resource_id", null: false
     t.index ["lesson_id", "resource_id"], name: "index_lessons_resources_on_lesson_id_and_resource_id", unique: true
     t.index ["resource_id", "lesson_id"], name: "index_lessons_resources_on_resource_id_and_lesson_id"
   end
 
-  create_table "lessons_vocabularies", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lessons_vocabularies", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "vocabulary_id", null: false
     t.index ["lesson_id", "vocabulary_id"], name: "index_lessons_vocabularies_on_lesson_id_and_vocabulary_id", unique: true
     t.index ["vocabulary_id", "lesson_id"], name: "index_lessons_vocabularies_on_vocabulary_id_and_lesson_id"
   end
 
-  create_table "level_concept_difficulties", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "level_concept_difficulties", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "level_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -875,7 +875,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_id"], name: "index_level_concept_difficulties_on_level_id"
   end
 
-  create_table "level_source_images", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "level_source_images", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "level_source_id", unsigned: true
     t.binary "image", size: :medium
     t.datetime "created_at"
@@ -883,7 +883,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_source_id"], name: "index_level_source_images_on_level_source_id"
   end
 
-  create_table "level_sources", id: { type: :bigint, unsigned: true }, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "level_sources", id: { type: :bigint, unsigned: true }, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "level_id"
     t.string "md5", limit: 32, null: false
     t.string "data", limit: 20000, null: false
@@ -893,7 +893,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_id", "md5"], name: "index_level_sources_on_level_id_and_md5"
   end
 
-  create_table "level_sources_multi_types", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "level_sources_multi_types", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "level_source_id", null: false, unsigned: true
     t.integer "level_id", null: false
     t.text "data"
@@ -903,7 +903,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_source_id"], name: "index_level_sources_multi_types_on_level_source_id"
   end
 
-  create_table "levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "game_id"
     t.string "name", null: false
     t.datetime "created_at"
@@ -923,7 +923,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["type"], name: "index_levels_on_type"
   end
 
-  create_table "levels_script_levels", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "levels_script_levels", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "level_id", null: false
     t.integer "script_level_id", null: false
     t.index ["level_id"], name: "index_levels_script_levels_on_level_id"
@@ -931,14 +931,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_level_id"], name: "index_levels_script_levels_on_script_level_id"
   end
 
-  create_table "libraries", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "libraries", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "lti_courses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_courses", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "lti_integration_id", null: false
     t.bigint "lti_deployment_id", null: false
     t.string "context_id"
@@ -955,7 +955,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lti_integration_id"], name: "index_lti_courses_on_lti_integration_id"
   end
 
-  create_table "lti_deployments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_deployments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "deployment_id"
     t.bigint "lti_integration_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -965,14 +965,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
-  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "lti_deployment_id", null: false
     t.bigint "lti_user_identity_id", null: false
     t.index ["lti_deployment_id"], name: "index_lti_deployments_user_identities_on_lti_deployment_id"
     t.index ["lti_user_identity_id"], name: "index_lti_deployments_user_identities_on_lti_user_identity_id"
   end
 
-  create_table "lti_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_feedbacks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "satisfied", null: false
     t.string "locale"
@@ -982,7 +982,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_lti_feedbacks_on_user_id", unique: true
   end
 
-  create_table "lti_integrations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_integrations", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "platform_id", limit: 36, null: false
     t.string "issuer", null: false
@@ -999,7 +999,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["platform_id"], name: "index_lti_integrations_on_platform_id"
   end
 
-  create_table "lti_sections", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_sections", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "lti_course_id", null: false
     t.integer "section_id", null: false
     t.string "lms_section_id"
@@ -1011,7 +1011,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["section_id"], name: "index_lti_sections_on_section_id"
   end
 
-  create_table "lti_user_identities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lti_user_identities", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "subject", null: false
     t.bigint "lti_integration_id", null: false
     t.integer "user_id", null: false
@@ -1024,7 +1024,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_lti_user_identities_on_user_id"
   end
 
-  create_table "metrics", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "metrics", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "computed_on", null: false
@@ -1037,7 +1037,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.float "value", null: false
   end
 
-  create_table "new_feature_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "new_feature_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "form_key", null: false
     t.boolean "satisfied", null: false
@@ -1048,7 +1048,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_new_feature_feedbacks_on_user_id"
   end
 
-  create_table "objectives", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "objectives", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "properties"
     t.integer "lesson_id"
     t.datetime "created_at", null: false
@@ -1058,7 +1058,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lesson_id"], name: "index_objectives_on_lesson_id"
   end
 
-  create_table "paired_user_levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "paired_user_levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "driver_user_level_id", unsigned: true
     t.bigint "navigator_user_level_id", unsigned: true
     t.datetime "created_at", null: false
@@ -1067,7 +1067,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["navigator_user_level_id"], name: "index_paired_user_levels_on_navigator_user_level_id"
   end
 
-  create_table "parent_levels_child_levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "parent_levels_child_levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "parent_level_id", null: false
     t.integer "child_level_id", null: false
     t.integer "position"
@@ -1076,7 +1076,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["parent_level_id"], name: "index_parent_levels_child_levels_on_parent_level_id"
   end
 
-  create_table "parental_permission_requests", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "parental_permission_requests", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "parent_email", null: false
     t.string "uuid", limit: 36, null: false
@@ -1088,7 +1088,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["uuid"], name: "index_parental_permission_requests_on_uuid"
   end
 
-  create_table "pd_accepted_programs", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_accepted_programs", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "workshop_name", null: false
@@ -1097,7 +1097,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.integer "teacher_application_id"
   end
 
-  create_table "pd_application_emails", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_emails", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id", null: false
     t.string "application_status", null: false
     t.string "email_type", null: false
@@ -1107,14 +1107,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_application_id"], name: "index_pd_application_emails_on_pd_application_id"
   end
 
-  create_table "pd_application_tags", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_tags", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_pd_application_tags_on_name", unique: true
   end
 
-  create_table "pd_application_tags_applications", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_tags_applications", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id", null: false
     t.integer "pd_application_tag_id", null: false
     t.datetime "created_at", null: false
@@ -1123,7 +1123,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_application_tag_id"], name: "index_pd_application_tags_applications_on_pd_application_tag_id"
   end
 
-  create_table "pd_applications", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "type", null: false
     t.string "application_year", null: false
@@ -1153,14 +1153,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_applications_on_user_id"
   end
 
-  create_table "pd_applications_status_logs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications_status_logs", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "pd_application_id", null: false
     t.string "status", null: false
     t.datetime "timestamp", null: false
     t.integer "position", null: false
   end
 
-  create_table "pd_attendances", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_attendances", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_session_id", null: false
     t.integer "teacher_id"
     t.datetime "created_at"
@@ -1174,14 +1174,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["teacher_id"], name: "index_pd_attendances_on_teacher_id"
   end
 
-  create_table "pd_course_facilitators", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_course_facilitators", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "facilitator_id", null: false
     t.string "course", null: false
     t.index ["course"], name: "index_pd_course_facilitators_on_course"
     t.index ["facilitator_id", "course"], name: "index_pd_course_facilitators_on_facilitator_id_and_course", unique: true
   end
 
-  create_table "pd_district_payment_terms", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_district_payment_terms", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "school_district_id"
     t.string "course", null: false
     t.string "rate_type", null: false
@@ -1189,7 +1189,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_district_id", "course"], name: "index_pd_district_payment_terms_school_district_course"
   end
 
-  create_table "pd_enrollment_notifications", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_enrollment_notifications", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pd_enrollment_id", null: false
@@ -1197,7 +1197,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_enrollment_id"], name: "index_pd_enrollment_notifications_on_pd_enrollment_id"
   end
 
-  create_table "pd_enrollments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_enrollments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id", null: false
     t.string "name"
     t.string "first_name"
@@ -1220,7 +1220,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_enrollments_on_user_id"
   end
 
-  create_table "pd_facilitator_program_registrations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_facilitator_program_registrations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -1229,7 +1229,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "teachercon"], name: "index_pd_fac_prog_reg_on_user_id_and_teachercon", unique: true
   end
 
-  create_table "pd_facilitator_teachercon_attendances", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_facilitator_teachercon_attendances", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.date "tc1_arrive"
     t.date "tc1_depart"
@@ -1249,7 +1249,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_facilitator_teachercon_attendances_on_user_id"
   end
 
-  create_table "pd_fit_weekend1819_registrations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_fit_weekend1819_registrations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -1257,7 +1257,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_application_id"], name: "index_pd_fit_weekend1819_registrations_on_pd_application_id"
   end
 
-  create_table "pd_fit_weekend_registrations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_fit_weekend_registrations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.string "registration_year", null: false
     t.text "form_data"
@@ -1267,7 +1267,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["registration_year"], name: "index_pd_fit_weekend_registrations_on_registration_year"
   end
 
-  create_table "pd_international_opt_ins", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_international_opt_ins", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1275,7 +1275,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_international_opt_ins_on_user_id"
   end
 
-  create_table "pd_legacy_survey_summaries", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_legacy_survey_summaries", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "facilitator_id"
     t.string "course"
     t.string "subject"
@@ -1284,7 +1284,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "pd_misc_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_misc_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.text "answers"
@@ -1296,7 +1296,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_misc_surveys_on_user_id"
   end
 
-  create_table "pd_payment_terms", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_payment_terms", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.date "start_date", null: false
     t.date "end_date"
@@ -1308,7 +1308,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["regional_partner_id"], name: "index_pd_payment_terms_on_regional_partner_id"
   end
 
-  create_table "pd_post_course_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_post_course_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.text "answers"
@@ -1323,7 +1323,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_post_course_surveys_on_user_id"
   end
 
-  create_table "pd_pre_workshop_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_pre_workshop_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1331,7 +1331,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_enrollment_id"], name: "index_pd_pre_workshop_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_regional_partner_cohorts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_cohorts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id"
     t.integer "role", comment: "teacher or facilitator"
     t.string "year", comment: "free-form text year range, YYYY-YYYY, e.g. 2016-2017"
@@ -1345,14 +1345,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["summer_workshop_id"], name: "index_pd_regional_partner_cohorts_on_summer_workshop_id"
   end
 
-  create_table "pd_regional_partner_cohorts_users", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_cohorts_users", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_regional_partner_cohort_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_regional_partner_cohort_id"], name: "index_pd_regional_partner_cohorts_users_on_cohort_id"
     t.index ["user_id"], name: "index_pd_regional_partner_cohorts_users_on_user_id"
   end
 
-  create_table "pd_regional_partner_contacts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_contacts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "regional_partner_id"
     t.text "form_data"
@@ -1362,7 +1362,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_regional_partner_contacts_on_user_id"
   end
 
-  create_table "pd_regional_partner_mappings", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_mappings", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.string "state"
     t.string "zip_code"
@@ -1373,7 +1373,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["regional_partner_id"], name: "index_pd_regional_partner_mappings_on_regional_partner_id"
   end
 
-  create_table "pd_regional_partner_mini_contacts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_mini_contacts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "regional_partner_id"
     t.text "form_data"
@@ -1383,7 +1383,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_regional_partner_mini_contacts_on_user_id"
   end
 
-  create_table "pd_regional_partner_program_registrations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_program_registrations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data"
     t.integer "teachercon", null: false
@@ -1392,7 +1392,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "teachercon"], name: "index_pd_reg_part_prog_reg_on_user_id_and_teachercon"
   end
 
-  create_table "pd_scholarship_infos", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_scholarship_infos", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "application_year", null: false
     t.string "scholarship_status", null: false
@@ -1407,7 +1407,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_scholarship_infos_on_user_id"
   end
 
-  create_table "pd_sessions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_sessions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id"
     t.datetime "start", null: false
     t.datetime "end", null: false
@@ -1420,7 +1420,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_workshop_id"], name: "index_pd_sessions_on_pd_workshop_id"
   end
 
-  create_table "pd_survey_questions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_survey_questions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "form_id"
     t.text "questions", null: false, comment: "JSON Question data for this JotForm form."
     t.datetime "created_at", null: false
@@ -1429,7 +1429,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["form_id"], name: "index_pd_survey_questions_on_form_id", unique: true
   end
 
-  create_table "pd_teacher_applications", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_teacher_applications", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
@@ -1443,7 +1443,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_teacher_applications_on_user_id", unique: true
   end
 
-  create_table "pd_teachercon1819_registrations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_teachercon1819_registrations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -1455,7 +1455,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_teachercon1819_registrations_on_user_id"
   end
 
-  create_table "pd_teachercon_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_teachercon_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1463,7 +1463,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_enrollment_id"], name: "index_pd_teachercon_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_workshop_daily_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_daily_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.integer "user_id", null: false
@@ -1481,7 +1481,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_workshop_daily_surveys_on_user_id"
   end
 
-  create_table "pd_workshop_facilitator_daily_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_facilitator_daily_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.integer "user_id", null: false
@@ -1501,7 +1501,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_workshop_facilitator_daily_surveys_on_user_id"
   end
 
-  create_table "pd_workshop_survey_foorm_submissions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_survey_foorm_submissions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "foorm_submission_id", null: false
     t.integer "user_id", null: false
     t.integer "pd_session_id"
@@ -1517,7 +1517,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_workshop_survey_foorm_submissions_on_user_id"
   end
 
-  create_table "pd_workshops", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshops", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "organizer_id", null: false
     t.string "location_name"
     t.string "location_address"
@@ -1545,14 +1545,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["regional_partner_id"], name: "index_pd_workshops_on_regional_partner_id"
   end
 
-  create_table "pd_workshops_facilitators", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshops_facilitators", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_workshop_id"], name: "index_pd_workshops_facilitators_on_pd_workshop_id"
     t.index ["user_id"], name: "index_pd_workshops_facilitators_on_user_id"
   end
 
-  create_table "peer_reviews", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "peer_reviews", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "submitter_id"
     t.integer "reviewer_id"
     t.boolean "from_instructor", default: false, null: false
@@ -1571,7 +1571,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["submitter_id"], name: "index_peer_reviews_on_submitter_id"
   end
 
-  create_table "pilots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pilots", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "display_name", null: false
     t.boolean "allow_joining_via_url", null: false
@@ -1580,7 +1580,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name"], name: "index_pilots_on_name", unique: true
   end
 
-  create_table "plc_course_units", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_course_units", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "plc_course_id"
     t.string "unit_name"
     t.text "unit_description"
@@ -1593,14 +1593,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_id"], name: "index_plc_course_units_on_script_id"
   end
 
-  create_table "plc_courses", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_courses", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "course_id"
     t.index ["course_id"], name: "fk_rails_d5fc777f73"
   end
 
-  create_table "plc_enrollment_module_assignments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_enrollment_module_assignments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "plc_enrollment_unit_assignment_id"
     t.integer "plc_learning_module_id"
     t.datetime "created_at", null: false
@@ -1611,7 +1611,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_plc_enrollment_module_assignments_on_user_id"
   end
 
-  create_table "plc_enrollment_unit_assignments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_enrollment_unit_assignments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "plc_user_course_enrollment_id"
     t.integer "plc_course_unit_id"
     t.string "status"
@@ -1623,7 +1623,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_plc_enrollment_unit_assignments_on_user_id"
   end
 
-  create_table "plc_learning_modules", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_learning_modules", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1634,7 +1634,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["stage_id"], name: "index_plc_learning_modules_on_stage_id"
   end
 
-  create_table "plc_user_course_enrollments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_user_course_enrollments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "status"
     t.integer "plc_course_id"
     t.integer "user_id"
@@ -1644,7 +1644,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "plc_course_id"], name: "index_plc_user_course_enrollments_on_user_id_and_plc_course_id", unique: true
   end
 
-  create_table "potential_teachers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "potential_teachers", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
     t.integer "script_id"
@@ -1654,7 +1654,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_id"], name: "index_potential_teachers_on_script_id"
   end
 
-  create_table "programming_classes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "programming_classes", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "programming_environment_id"
     t.integer "programming_environment_category_id"
     t.string "key"
@@ -1671,7 +1671,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["key", "programming_environment_id"], name: "index_programming_classes_on_key_and_programming_environment_id", unique: true
   end
 
-  create_table "programming_environment_categories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "programming_environment_categories", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "programming_environment_id", null: false
     t.string "key", null: false
     t.string "name"
@@ -1683,7 +1683,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["programming_environment_id"], name: "index_programming_environment_categories_on_environment_id"
   end
 
-  create_table "programming_environments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "programming_environments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "properties"
     t.datetime "created_at", null: false
@@ -1692,7 +1692,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name"], name: "index_programming_environments_on_name", unique: true
   end
 
-  create_table "programming_expressions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "programming_expressions", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "category"
     t.text "properties"
@@ -1707,7 +1707,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["programming_environment_id"], name: "index_programming_expressions_on_programming_environment_id"
   end
 
-  create_table "programming_methods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "programming_methods", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "programming_class_id"
     t.string "key"
     t.integer "position"
@@ -1735,7 +1735,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
-  create_table "projects", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "projects", id: :integer, charset: "utf8mb4", force: :cascade do |t|
     t.integer "storage_id"
     t.text "value", size: :medium
     t.datetime "updated_at", null: false
@@ -1755,7 +1755,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["storage_id"], name: "storage_apps_storage_id_index"
   end
 
-  create_table "puzzle_ratings", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "puzzle_ratings", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "script_id"
     t.integer "level_id"
@@ -1766,7 +1766,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "script_id", "level_id"], name: "index_puzzle_ratings_on_user_id_and_script_id_and_level_id", unique: true
   end
 
-  create_table "queued_account_purges", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "queued_account_purges", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "reason_for_review"
     t.datetime "created_at", null: false
@@ -1774,7 +1774,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_queued_account_purges_on_user_id", unique: true
   end
 
-  create_table "reference_guides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "reference_guides", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.bigint "course_version_id", null: false
     t.string "parent_reference_guide_key"
@@ -1787,14 +1787,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["course_version_id", "parent_reference_guide_key"], name: "index_reference_guides_on_course_version_id_and_parent_key"
   end
 
-  create_table "regional_partner_program_managers", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "regional_partner_program_managers", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "program_manager_id", null: false
     t.integer "regional_partner_id", null: false
     t.index ["program_manager_id"], name: "index_regional_partner_program_managers_on_program_manager_id"
     t.index ["regional_partner_id"], name: "index_regional_partner_program_managers_on_regional_partner_id"
   end
 
-  create_table "regional_partners", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "regional_partners", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "group"
     t.boolean "urban"
@@ -1813,7 +1813,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.boolean "is_active", null: false
   end
 
-  create_table "regional_partners_school_districts", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "regional_partners_school_districts", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.integer "school_district_id", null: false
     t.string "course", comment: "Course for a given workshop"
@@ -1822,7 +1822,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_district_id"], name: "index_regional_partners_school_districts_on_school_district_id"
   end
 
-  create_table "resources", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "resources", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "url", null: false
     t.string "key", null: false
@@ -1834,7 +1834,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
   end
 
-  create_table "rubric_ai_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "rubric_ai_evaluations", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "requester_id", null: false
     t.bigint "rubric_id", null: false
@@ -1848,7 +1848,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_rubric_ai_evaluations_on_user_id"
   end
 
-  create_table "rubrics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "rubrics", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.integer "level_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -1856,7 +1856,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lesson_id", "level_id"], name: "index_rubrics_on_lesson_id_and_level_id", unique: true
   end
 
-  create_table "school_districts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "school_districts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "city", null: false
     t.string "state", null: false
@@ -1868,7 +1868,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["state"], name: "index_school_districts_on_state"
   end
 
-  create_table "school_infos", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "school_infos", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "country"
     t.string "school_type"
     t.integer "zip"
@@ -1888,7 +1888,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_name", "country", "school_type"], name: "index_school_infos_on_school_name_and_country_and_school_type"
   end
 
-  create_table "school_stats_by_years", primary_key: ["school_id", "school_year"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "school_stats_by_years", primary_key: ["school_id", "school_year"], charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "school_id", limit: 12, null: false, comment: "NCES public school ID"
     t.string "school_year", limit: 9, null: false, comment: "School Year"
     t.string "grades_offered_lo", limit: 2, comment: "Grades Offered - Lowest"
@@ -1925,7 +1925,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_id"], name: "index_school_stats_by_years_on_school_id"
   end
 
-  create_table "schools", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "schools", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "id", limit: 12, null: false, comment: "NCES public school ID"
     t.integer "school_district_id"
     t.string "name", null: false
@@ -1949,7 +1949,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["zip"], name: "index_schools_on_zip"
   end
 
-  create_table "script_levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "script_levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "script_id", null: false
     t.integer "chapter"
     t.datetime "created_at"
@@ -1969,7 +1969,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["stage_id"], name: "index_script_levels_on_stage_id"
   end
 
-  create_table "scripts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "scripts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1993,21 +1993,21 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["wrapup_video_id"], name: "index_scripts_on_wrapup_video_id"
   end
 
-  create_table "scripts_resources", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "scripts_resources", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "script_id"
     t.integer "resource_id"
     t.index ["resource_id", "script_id"], name: "index_scripts_resources_on_resource_id_and_script_id"
     t.index ["script_id", "resource_id"], name: "index_scripts_resources_on_script_id_and_resource_id", unique: true
   end
 
-  create_table "scripts_student_resources", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "scripts_student_resources", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "script_id"
     t.integer "resource_id"
     t.index ["resource_id", "script_id"], name: "index_scripts_student_resources_on_resource_id_and_script_id"
     t.index ["script_id", "resource_id"], name: "index_scripts_student_resources_on_script_id_and_resource_id", unique: true
   end
 
-  create_table "secret_pictures", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "secret_pictures", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "path", null: false
     t.datetime "created_at"
@@ -2016,28 +2016,28 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["path"], name: "index_secret_pictures_on_path", unique: true
   end
 
-  create_table "secret_words", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "secret_words", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "word", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["word"], name: "index_secret_words_on_word", unique: true
   end
 
-  create_table "section_hidden_scripts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "section_hidden_scripts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "section_id", null: false
     t.integer "script_id", null: false
     t.index ["script_id"], name: "index_section_hidden_scripts_on_script_id"
     t.index ["section_id"], name: "index_section_hidden_scripts_on_section_id"
   end
 
-  create_table "section_hidden_stages", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "section_hidden_stages", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "section_id", null: false
     t.integer "stage_id", null: false
     t.index ["section_id"], name: "index_section_hidden_stages_on_section_id"
     t.index ["stage_id"], name: "index_section_hidden_stages_on_stage_id"
   end
 
-  create_table "section_instructors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "section_instructors", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "instructor_id", null: false
     t.integer "section_id", null: false
     t.integer "invited_by_id"
@@ -2052,7 +2052,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["section_id"], name: "index_section_instructors_on_section_id"
   end
 
-  create_table "sections", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "sections", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "name"
     t.datetime "created_at"
@@ -2081,13 +2081,13 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_sections_on_user_id"
   end
 
-  create_table "seed_info", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "seed_info", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "table", null: false
     t.datetime "mtime"
     t.index ["table"], name: "index_seed_info_on_table"
   end
 
-  create_table "seeded_s3_objects", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "seeded_s3_objects", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "bucket"
     t.string "key"
     t.string "etag"
@@ -2096,7 +2096,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["bucket", "key", "etag"], name: "index_seeded_s3_objects_on_bucket_and_key_and_etag"
   end
 
-  create_table "shared_blockly_functions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "shared_blockly_functions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "level_type"
     t.integer "block_type", default: 0, null: false
@@ -2106,7 +2106,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.text "stack"
   end
 
-  create_table "sign_ins", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "sign_ins", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "sign_in_at", null: false
     t.integer "sign_in_count", null: false
@@ -2114,7 +2114,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_sign_ins_on_user_id"
   end
 
-  create_table "stages", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "stages", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "absolute_position"
     t.integer "script_id", null: false
@@ -2130,7 +2130,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_id", "key"], name: "index_stages_on_script_id_and_key", unique: true
   end
 
-  create_table "stages_standards", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "stages_standards", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "stage_id", null: false
     t.integer "standard_id", null: false
     t.datetime "created_at", null: false
@@ -2139,7 +2139,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["standard_id"], name: "index_stages_standards_on_standard_id"
   end
 
-  create_table "standard_categories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "standard_categories", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "shortcode", null: false
     t.integer "framework_id", null: false
     t.integer "parent_category_id"
@@ -2151,7 +2151,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["parent_category_id"], name: "index_standard_categories_on_parent_category_id"
   end
 
-  create_table "standards", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "standards", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "description"
     t.bigint "category_id"
     t.integer "framework_id"
@@ -2161,13 +2161,13 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["framework_id", "shortcode"], name: "index_standards_on_framework_id_and_shortcode"
   end
 
-  create_table "studio_people", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "studio_people", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "emails"
   end
 
-  create_table "survey_results", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "survey_results", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "kind"
     t.text "properties"
@@ -2177,7 +2177,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_survey_results_on_user_id"
   end
 
-  create_table "teacher_feedbacks", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "teacher_feedbacks", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.text "comment"
     t.integer "student_id"
     t.integer "level_id", null: false
@@ -2197,7 +2197,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["teacher_id"], name: "index_teacher_feedbacks_on_teacher_id"
   end
 
-  create_table "teacher_profiles", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "teacher_profiles", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "studio_person_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -2211,7 +2211,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["studio_person_id"], name: "index_teacher_profiles_on_studio_person_id"
   end
 
-  create_table "teacher_scores", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "teacher_scores", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.bigint "user_level_id", unsigned: true
     t.integer "teacher_id"
     t.integer "score"
@@ -2220,7 +2220,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_level_id"], name: "index_teacher_scores_on_user_level_id"
   end
 
-  create_table "unit_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
     t.datetime "created_at", null: false
@@ -2236,21 +2236,21 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["published_state"], name: "index_unit_groups_on_published_state"
   end
 
-  create_table "unit_groups_resources", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_resources", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_unit_groups_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_unit_groups_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "unit_groups_student_resources", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_student_resources", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_ug_student_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_ug_student_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "user_geos", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_geos", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -2266,7 +2266,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_user_geos_on_user_id"
   end
 
-  create_table "user_level_interactions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_level_interactions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "script_id", null: false
@@ -2281,7 +2281,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_user_level_interactions_on_user_id"
   end
 
-  create_table "user_levels", id: { type: :bigint, unsigned: true }, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_levels", id: { type: :bigint, unsigned: true }, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "attempts", default: 0, null: false
@@ -2299,7 +2299,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "script_id", "level_id", "deleted_at"], name: "index_user_levels_unique", unique: true
   end
 
-  create_table "user_ml_models", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_ml_models", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "model_id"
     t.string "name"
@@ -2312,7 +2312,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_user_ml_models_on_user_id"
   end
 
-  create_table "user_module_task_assignments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_module_task_assignments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_enrollment_module_assignment_id"
     t.integer "professional_learning_task_id"
     t.string "status"
@@ -2320,7 +2320,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_enrollment_module_assignment_id"], name: "task_assignment_to_module_assignment_index"
   end
 
-  create_table "user_permissions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_permissions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "permission", null: false
     t.datetime "created_at"
@@ -2328,7 +2328,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "permission"], name: "index_user_permissions_on_user_id_and_permission", unique: true
   end
 
-  create_table "user_proficiencies", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_proficiencies", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -2387,13 +2387,13 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_user_proficiencies_on_user_id", unique: true
   end
 
-  create_table "user_project_storage_ids", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "user_project_storage_ids", id: :integer, charset: "utf8", force: :cascade do |t|
     t.integer "user_id"
     t.index ["user_id"], name: "user_id", unique: true
     t.index ["user_id"], name: "user_storage_ids_user_id_index"
   end
 
-  create_table "user_school_infos", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_school_infos", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "start_date", null: false
     t.datetime "end_date"
@@ -2404,7 +2404,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_user_school_infos_on_user_id"
   end
 
-  create_table "user_scripts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_scripts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.datetime "started_at"
@@ -2419,7 +2419,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "script_id", "deleted_at"], name: "index_user_scripts_on_user_id_and_script_id_and_deleted_at", unique: true
   end
 
-  create_table "users", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.integer "studio_person_id"
     t.string "email", default: "", null: false
     t.string "parent_email"
@@ -2488,7 +2488,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["username", "deleted_at"], name: "index_users_on_username_and_deleted_at", unique: true
   end
 
-  create_table "videos", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "videos", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.string "youtube_code"
     t.datetime "created_at"
@@ -2498,7 +2498,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["key", "locale"], name: "index_videos_on_key_and_locale", unique: true
   end
 
-  create_table "vocabularies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "vocabularies", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "word", null: false
     t.text "definition", null: false

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2025_01_16_214434) do
 
-  create_table "activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
     t.string "action"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "level_id"], name: "index_activities_on_user_id_and_level_id"
   end
 
-  create_table "activity_sections", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "activity_sections", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "lesson_activity_id", null: false
     t.string "key", null: false
     t.integer "position", null: false
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ai_tutor_interaction_feedbacks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "ai_tutor_interaction_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "ai_tutor_interaction_id", null: false
     t.integer "user_id", null: false
     t.boolean "thumbs_up"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "level_id", "script_id"], name: "index_ace_user_level_script"
   end
 
-  create_table "aichat_messages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "aichat_messages", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "aichat_thread_id", null: false
     t.text "external_id", null: false
     t.integer "role", null: false
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "level_id", "script_id"], name: "index_acs_user_level_script"
   end
 
-  create_table "aichat_threads", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "aichat_threads", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "external_id", null: false
     t.text "llm_version", null: false
@@ -133,7 +133,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_aichat_threads_on_user_id"
   end
 
-  create_table "assessment_activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "assessment_activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "script_id", null: false
@@ -145,7 +145,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "level_id", "script_id"], name: "index_assessment_activities_on_user_and_level_and_script"
   end
 
-  create_table "authentication_options", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "authentication_options", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "hashed_email", default: "", null: false
     t.string "credential_type", null: false
@@ -161,7 +161,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "deleted_at"], name: "index_authentication_options_on_user_id_and_deleted_at"
   end
 
-  create_table "authored_hint_view_requests", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "authored_hint_view_requests", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id"
     t.integer "level_id"
@@ -187,7 +187,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "script_id", "level_id", "hint_id"], name: "index_authored_hint_view_requests_on_all_related_ids"
   end
 
-  create_table "backpacks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "backpacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "storage_app_id", null: false
     t.datetime "created_at", null: false
@@ -196,7 +196,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_backpacks_on_user_id", unique: true
   end
 
-  create_table "blocks", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "blocks", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "pool", default: "", null: false
     t.string "category"
@@ -209,7 +209,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pool", "name"], name: "index_blocks_on_pool_and_name", unique: true
   end
 
-  create_table "callouts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "callouts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "element_id", limit: 1024, null: false
     t.string "localization_key", limit: 1024, null: false
     t.datetime "created_at"
@@ -220,7 +220,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.string "callout_text"
   end
 
-  create_table "cap_user_events", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "cap_user_events", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 64, null: false
     t.integer "user_id", null: false
     t.string "policy", limit: 16, null: false
@@ -233,7 +233,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_cap_user_events_on_user_id"
   end
 
-  create_table "census_state_course_codes", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_state_course_codes", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "state"
     t.string "course"
     t.datetime "created_at", null: false
@@ -241,7 +241,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["state", "course"], name: "index_census_state_course_codes_on_state_and_course", unique: true
   end
 
-  create_table "census_submission_form_maps", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_submission_form_maps", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "census_submission_id", null: false
     t.integer "form_id", null: false
     t.datetime "created_at", null: false
@@ -250,7 +250,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["form_id"], name: "index_census_submission_form_maps_on_form_id"
   end
 
-  create_table "census_submissions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_submissions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.string "submitter_email_address"
     t.string "submitter_name"
@@ -284,7 +284,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_year", "id"], name: "index_census_submissions_on_school_year_and_id"
   end
 
-  create_table "census_submissions_school_infos", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_submissions_school_infos", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "census_submission_id", null: false
     t.integer "school_info_id", null: false
     t.datetime "created_at", null: false
@@ -293,7 +293,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_info_id", "census_submission_id"], name: "school_info_id_census_submission", unique: true
   end
 
-  create_table "census_summaries", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_summaries", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "school_id", limit: 12, null: false
     t.integer "school_year", limit: 2, null: false
     t.string "teaches_cs", limit: 2
@@ -303,7 +303,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_id", "school_year"], name: "index_census_summaries_on_school_id_and_school_year", unique: true
   end
 
-  create_table "channel_tokens", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "channel_tokens", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "storage_app_id", null: false
     t.integer "level_id", null: false
     t.datetime "created_at"
@@ -327,7 +327,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["code_review_id"], name: "index_code_review_comments_on_code_review_id"
   end
 
-  create_table "code_review_group_members", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_review_group_members", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "code_review_group_id", null: false
     t.bigint "follower_id", null: false
     t.datetime "created_at", null: false
@@ -336,7 +336,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["follower_id"], name: "index_code_review_group_members_on_follower_id"
   end
 
-  create_table "code_review_groups", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_review_groups", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "section_id", null: false
     t.string "name"
     t.datetime "created_at", null: false
@@ -344,7 +344,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["section_id"], name: "index_code_review_groups_on_section_id"
   end
 
-  create_table "code_review_requests", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_review_requests", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.integer "level_id", null: false
@@ -357,7 +357,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "script_id", "level_id", "closed_at", "deleted_at"], name: "index_code_review_requests_unique", unique: true
   end
 
-  create_table "code_reviews", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_reviews", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "project_id", null: false
     t.integer "script_id", null: false
@@ -369,14 +369,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.virtual "active", type: :boolean, as: "if(isnull(`deleted_at`),TRUE,NULL)"
-    t.virtual "open", type: :boolean, as: "if(isnull(`closed_at`),TRUE,NULL)"
+    t.virtual "active", type: :boolean, as: "if((`deleted_at` is null),true,NULL)"
+    t.virtual "open", type: :boolean, as: "if((`closed_at` is null),true,NULL)"
     t.index ["project_id", "deleted_at"], name: "index_code_reviews_on_project_id_and_deleted_at"
     t.index ["user_id", "project_id", "open", "active"], name: "index_code_reviews_unique", unique: true
     t.index ["user_id", "script_id", "project_level_id", "closed_at", "deleted_at"], name: "index_code_reviews_for_peer_lookup"
   end
 
-  create_table "concepts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "concepts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -384,14 +384,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["video_key"], name: "index_concepts_on_video_key"
   end
 
-  create_table "concepts_levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "concepts_levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "concept_id"
     t.integer "level_id"
     t.index ["concept_id"], name: "index_concepts_levels_on_concept_id"
     t.index ["level_id"], name: "index_concepts_levels_on_level_id"
   end
 
-  create_table "contact_rollups_final", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_final", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.json "data", null: false
     t.datetime "created_at", null: false
@@ -399,7 +399,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["email"], name: "index_contact_rollups_final_on_email", unique: true
   end
 
-  create_table "contact_rollups_pardot_memory", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_pardot_memory", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.integer "pardot_id"
     t.datetime "pardot_id_updated_at"
@@ -415,7 +415,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pardot_id"], name: "index_contact_rollups_pardot_memory_on_pardot_id", unique: true
   end
 
-  create_table "contact_rollups_processed", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_processed", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.json "data", null: false
     t.datetime "created_at", null: false
@@ -423,7 +423,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["email"], name: "index_contact_rollups_processed_on_email", unique: true
   end
 
-  create_table "contact_rollups_raw", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_raw", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.string "sources", null: false
     t.json "data"
@@ -432,7 +432,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "contained_level_answers", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "contained_level_answers", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "level_id", null: false
@@ -442,7 +442,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_id"], name: "index_contained_level_answers_on_level_id"
   end
 
-  create_table "contained_levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "contained_levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "level_group_level_id", null: false
@@ -455,7 +455,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_group_level_id"], name: "index_contained_levels_on_level_group_level_id"
   end
 
-  create_table "course_offerings", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "course_offerings", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "display_name", null: false
     t.datetime "created_at", null: false
@@ -479,7 +479,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 
-  create_table "course_offerings_pd_workshops", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "course_offerings_pd_workshops", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "pd_workshop_id", null: false
     t.bigint "course_offering_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -488,7 +488,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_workshop_id"], name: "index_course_offerings_pd_workshops_on_pd_workshop_id"
   end
 
-  create_table "course_scripts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "course_scripts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "course_id", null: false
     t.integer "script_id", null: false
     t.integer "position", null: false
@@ -499,7 +499,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_id"], name: "index_course_scripts_on_script_id"
   end
 
-  create_table "course_versions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "course_versions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "display_name", null: false
     t.text "properties"
@@ -514,7 +514,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["course_offering_id"], name: "index_course_versions_on_course_offering_id"
   end
 
-  create_table "courses", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "courses", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
     t.datetime "created_at", null: false
@@ -522,7 +522,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name"], name: "index_courses_on_name"
   end
 
-  create_table "data_docs", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "data_docs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "name"
     t.text "content"
@@ -539,7 +539,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["project_id"], name: "index_datablock_storage_kvps_on_project_id"
   end
 
-  create_table "datablock_storage_library_manifest", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "datablock_storage_library_manifest", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.json "library_manifest"
     t.integer "singleton_guard", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -566,7 +566,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["project_id"], name: "index_datablock_storage_tables_on_project_id"
   end
 
-  create_table "delayed_jobs", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "delayed_jobs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -581,14 +581,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "donor_schools", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "donor_schools", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "nces_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "donors", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "donors", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "url"
     t.string "show"
@@ -600,7 +600,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "email_preferences", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "email_preferences", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.boolean "opt_in", null: false
     t.string "ip_address", null: false
@@ -611,7 +611,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["email"], name: "index_email_preferences_on_email", unique: true
   end
 
-  create_table "experiments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "experiments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", null: false
@@ -633,7 +633,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["start_at"], name: "index_experiments_on_start_at"
   end
 
-  create_table "featured_projects", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "featured_projects", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "storage_app_id"
     t.datetime "featured_at"
     t.datetime "unfeatured_at"
@@ -642,7 +642,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["topic"], name: "index_featured_projects_on_topic"
   end
 
-  create_table "followers", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "followers", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "student_user_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -652,7 +652,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["student_user_id"], name: "index_followers_on_student_user_id"
   end
 
-  create_table "foorm_forms", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_forms", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "version", null: false
     t.text "questions", null: false
@@ -662,7 +662,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name", "version"], name: "index_foorm_forms_on_name_and_version", unique: true
   end
 
-  create_table "foorm_libraries", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_libraries", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "version", null: false
     t.boolean "published", null: false
@@ -671,7 +671,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name", "version"], name: "index_foorm_libraries_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_library_questions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_library_questions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "library_name", null: false
     t.integer "library_version", null: false
     t.string "question_name", null: false
@@ -682,7 +682,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["library_name", "library_version", "question_name"], name: "index_foorm_library_questions_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_simple_survey_forms", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_forms", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "path", null: false
     t.string "kind"
     t.string "form_name", null: false
@@ -693,7 +693,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["path"], name: "index_foorm_simple_survey_forms_on_path"
   end
 
-  create_table "foorm_simple_survey_submissions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_submissions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "foorm_submission_id", null: false
     t.integer "user_id"
     t.bigint "simple_survey_form_id"
@@ -712,7 +712,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "frameworks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "frameworks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "shortcode", null: false
     t.string "name", null: false
     t.text "properties"
@@ -721,7 +721,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["shortcode"], name: "index_frameworks_on_shortcode", unique: true
   end
 
-  create_table "games", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "games", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -730,7 +730,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["intro_video_id"], name: "index_games_on_intro_video_id"
   end
 
-  create_table "hint_view_requests", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "hint_view_requests", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "script_id"
     t.integer "level_id"
@@ -742,7 +742,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_hint_view_requests_on_user_id"
   end
 
-  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_ai_evaluation_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "learning_goal_ai_evaluation_id", null: false
     t.bigint "teacher_id", null: false
     t.boolean "ai_feedback_approval", null: false
@@ -756,7 +756,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["learning_goal_ai_evaluation_id"], name: "index_feedback_on_learning_goal_ai_evaluation"
   end
 
-  create_table "learning_goal_ai_evaluations", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_ai_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "rubric_ai_evaluation_id", null: false
     t.bigint "learning_goal_id", null: false
     t.integer "understanding"
@@ -770,7 +770,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["rubric_ai_evaluation_id"], name: "index_learning_goal_ai_evaluations_on_rubric_ai_evaluation_id"
   end
 
-  create_table "learning_goal_evidence_levels", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_evidence_levels", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "learning_goal_id", null: false
     t.integer "understanding", null: false
     t.text "teacher_description"
@@ -780,7 +780,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["learning_goal_id", "understanding"], name: "index_learning_goal_evidence_levels_on_lg_id_and_understanding", unique: true
   end
 
-  create_table "learning_goal_teacher_evaluations", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "learning_goal_teacher_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "teacher_id", null: false
     t.integer "learning_goal_id", null: false
@@ -796,7 +796,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "teacher_id"], name: "index_learning_goal_teacher_evaluations_on_user_and_teacher_id"
   end
 
-  create_table "learning_goals", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "learning_goals", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.integer "position"
     t.integer "rubric_id", null: false
@@ -808,7 +808,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["rubric_id", "key"], name: "index_learning_goals_on_rubric_id_and_key", unique: true
   end
 
-  create_table "lesson_activities", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lesson_activities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.string "key", null: false
     t.integer "position", null: false
@@ -819,7 +819,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lesson_id"], name: "index_lesson_activities_on_lesson_id"
   end
 
-  create_table "lesson_groups", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lesson_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.integer "script_id", null: false
     t.boolean "user_facing", default: true, null: false
@@ -830,35 +830,35 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_id", "key"], name: "index_lesson_groups_on_script_id_and_key", unique: true
   end
 
-  create_table "lessons_opportunity_standards", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_opportunity_standards", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "standard_id", null: false
     t.index ["lesson_id", "standard_id"], name: "index_lessons_opportunity_standards_on_lesson_id_and_standard_id", unique: true
     t.index ["standard_id", "lesson_id"], name: "index_lessons_opportunity_standards_on_standard_id_and_lesson_id"
   end
 
-  create_table "lessons_programming_expressions", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_programming_expressions", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "programming_expression_id", null: false
     t.index ["lesson_id", "programming_expression_id"], name: "lesson_programming_expression", unique: true
     t.index ["programming_expression_id", "lesson_id"], name: "programming_expression_lesson"
   end
 
-  create_table "lessons_resources", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_resources", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.integer "resource_id", null: false
     t.index ["lesson_id", "resource_id"], name: "index_lessons_resources_on_lesson_id_and_resource_id", unique: true
     t.index ["resource_id", "lesson_id"], name: "index_lessons_resources_on_resource_id_and_lesson_id"
   end
 
-  create_table "lessons_vocabularies", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_vocabularies", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "vocabulary_id", null: false
     t.index ["lesson_id", "vocabulary_id"], name: "index_lessons_vocabularies_on_lesson_id_and_vocabulary_id", unique: true
     t.index ["vocabulary_id", "lesson_id"], name: "index_lessons_vocabularies_on_vocabulary_id_and_lesson_id"
   end
 
-  create_table "level_concept_difficulties", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_concept_difficulties", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "level_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -875,7 +875,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_id"], name: "index_level_concept_difficulties_on_level_id"
   end
 
-  create_table "level_source_images", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_source_images", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "level_source_id", unsigned: true
     t.binary "image", size: :medium
     t.datetime "created_at"
@@ -883,7 +883,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_source_id"], name: "index_level_source_images_on_level_source_id"
   end
 
-  create_table "level_sources", id: { type: :bigint, unsigned: true }, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_sources", id: { type: :bigint, unsigned: true }, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "level_id"
     t.string "md5", limit: 32, null: false
     t.string "data", limit: 20000, null: false
@@ -893,7 +893,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_id", "md5"], name: "index_level_sources_on_level_id_and_md5"
   end
 
-  create_table "level_sources_multi_types", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_sources_multi_types", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "level_source_id", null: false, unsigned: true
     t.integer "level_id", null: false
     t.text "data"
@@ -903,7 +903,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["level_source_id"], name: "index_level_sources_multi_types_on_level_source_id"
   end
 
-  create_table "levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "game_id"
     t.string "name", null: false
     t.datetime "created_at"
@@ -923,7 +923,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["type"], name: "index_levels_on_type"
   end
 
-  create_table "levels_script_levels", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "levels_script_levels", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "level_id", null: false
     t.integer "script_level_id", null: false
     t.index ["level_id"], name: "index_levels_script_levels_on_level_id"
@@ -931,14 +931,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_level_id"], name: "index_levels_script_levels_on_script_level_id"
   end
 
-  create_table "libraries", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "libraries", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "lti_courses", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lti_courses", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lti_integration_id", null: false
     t.bigint "lti_deployment_id", null: false
     t.string "context_id"
@@ -955,7 +955,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lti_integration_id"], name: "index_lti_courses_on_lti_integration_id"
   end
 
-  create_table "lti_deployments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lti_deployments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "deployment_id"
     t.bigint "lti_integration_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -965,14 +965,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lti_integration_id"], name: "index_lti_deployments_on_lti_integration_id"
   end
 
-  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "lti_deployments_user_identities", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lti_deployment_id", null: false
     t.bigint "lti_user_identity_id", null: false
     t.index ["lti_deployment_id"], name: "index_lti_deployments_user_identities_on_lti_deployment_id"
     t.index ["lti_user_identity_id"], name: "index_lti_deployments_user_identities_on_lti_user_identity_id"
   end
 
-  create_table "lti_feedbacks", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lti_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.boolean "satisfied", null: false
     t.string "locale"
@@ -982,7 +982,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_lti_feedbacks_on_user_id", unique: true
   end
 
-  create_table "lti_integrations", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lti_integrations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "platform_id", limit: 36, null: false
     t.string "issuer", null: false
@@ -999,7 +999,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["platform_id"], name: "index_lti_integrations_on_platform_id"
   end
 
-  create_table "lti_sections", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lti_sections", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lti_course_id", null: false
     t.integer "section_id", null: false
     t.string "lms_section_id"
@@ -1011,7 +1011,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["section_id"], name: "index_lti_sections_on_section_id"
   end
 
-  create_table "lti_user_identities", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "lti_user_identities", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "subject", null: false
     t.bigint "lti_integration_id", null: false
     t.integer "user_id", null: false
@@ -1024,7 +1024,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_lti_user_identities_on_user_id"
   end
 
-  create_table "metrics", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "metrics", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "computed_on", null: false
@@ -1037,7 +1037,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.float "value", null: false
   end
 
-  create_table "new_feature_feedbacks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "new_feature_feedbacks", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "form_key", null: false
     t.boolean "satisfied", null: false
@@ -1048,7 +1048,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_new_feature_feedbacks_on_user_id"
   end
 
-  create_table "objectives", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "objectives", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "properties"
     t.integer "lesson_id"
     t.datetime "created_at", null: false
@@ -1058,7 +1058,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lesson_id"], name: "index_objectives_on_lesson_id"
   end
 
-  create_table "paired_user_levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "paired_user_levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "driver_user_level_id", unsigned: true
     t.bigint "navigator_user_level_id", unsigned: true
     t.datetime "created_at", null: false
@@ -1067,7 +1067,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["navigator_user_level_id"], name: "index_paired_user_levels_on_navigator_user_level_id"
   end
 
-  create_table "parent_levels_child_levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "parent_levels_child_levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "parent_level_id", null: false
     t.integer "child_level_id", null: false
     t.integer "position"
@@ -1076,7 +1076,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["parent_level_id"], name: "index_parent_levels_child_levels_on_parent_level_id"
   end
 
-  create_table "parental_permission_requests", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "parental_permission_requests", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "parent_email", null: false
     t.string "uuid", limit: 36, null: false
@@ -1088,7 +1088,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["uuid"], name: "index_parental_permission_requests_on_uuid"
   end
 
-  create_table "pd_accepted_programs", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_accepted_programs", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "workshop_name", null: false
@@ -1097,7 +1097,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.integer "teacher_application_id"
   end
 
-  create_table "pd_application_emails", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_emails", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id", null: false
     t.string "application_status", null: false
     t.string "email_type", null: false
@@ -1107,14 +1107,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_application_id"], name: "index_pd_application_emails_on_pd_application_id"
   end
 
-  create_table "pd_application_tags", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_tags", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_pd_application_tags_on_name", unique: true
   end
 
-  create_table "pd_application_tags_applications", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_tags_applications", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id", null: false
     t.integer "pd_application_tag_id", null: false
     t.datetime "created_at", null: false
@@ -1123,7 +1123,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_application_tag_id"], name: "index_pd_application_tags_applications_on_pd_application_tag_id"
   end
 
-  create_table "pd_applications", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "type", null: false
     t.string "application_year", null: false
@@ -1153,14 +1153,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_applications_on_user_id"
   end
 
-  create_table "pd_applications_status_logs", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications_status_logs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "pd_application_id", null: false
     t.string "status", null: false
     t.datetime "timestamp", null: false
     t.integer "position", null: false
   end
 
-  create_table "pd_attendances", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_attendances", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_session_id", null: false
     t.integer "teacher_id"
     t.datetime "created_at"
@@ -1174,14 +1174,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["teacher_id"], name: "index_pd_attendances_on_teacher_id"
   end
 
-  create_table "pd_course_facilitators", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_course_facilitators", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "facilitator_id", null: false
     t.string "course", null: false
     t.index ["course"], name: "index_pd_course_facilitators_on_course"
     t.index ["facilitator_id", "course"], name: "index_pd_course_facilitators_on_facilitator_id_and_course", unique: true
   end
 
-  create_table "pd_district_payment_terms", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_district_payment_terms", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "school_district_id"
     t.string "course", null: false
     t.string "rate_type", null: false
@@ -1189,7 +1189,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_district_id", "course"], name: "index_pd_district_payment_terms_school_district_course"
   end
 
-  create_table "pd_enrollment_notifications", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_enrollment_notifications", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pd_enrollment_id", null: false
@@ -1197,7 +1197,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_enrollment_id"], name: "index_pd_enrollment_notifications_on_pd_enrollment_id"
   end
 
-  create_table "pd_enrollments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_enrollments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id", null: false
     t.string "name"
     t.string "first_name"
@@ -1220,7 +1220,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_enrollments_on_user_id"
   end
 
-  create_table "pd_facilitator_program_registrations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_facilitator_program_registrations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -1229,7 +1229,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "teachercon"], name: "index_pd_fac_prog_reg_on_user_id_and_teachercon", unique: true
   end
 
-  create_table "pd_facilitator_teachercon_attendances", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_facilitator_teachercon_attendances", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.date "tc1_arrive"
     t.date "tc1_depart"
@@ -1249,7 +1249,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_facilitator_teachercon_attendances_on_user_id"
   end
 
-  create_table "pd_fit_weekend1819_registrations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_fit_weekend1819_registrations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -1257,7 +1257,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_application_id"], name: "index_pd_fit_weekend1819_registrations_on_pd_application_id"
   end
 
-  create_table "pd_fit_weekend_registrations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_fit_weekend_registrations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.string "registration_year", null: false
     t.text "form_data"
@@ -1267,7 +1267,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["registration_year"], name: "index_pd_fit_weekend_registrations_on_registration_year"
   end
 
-  create_table "pd_international_opt_ins", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_international_opt_ins", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1275,7 +1275,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_international_opt_ins_on_user_id"
   end
 
-  create_table "pd_legacy_survey_summaries", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_legacy_survey_summaries", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "facilitator_id"
     t.string "course"
     t.string "subject"
@@ -1284,7 +1284,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "pd_misc_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_misc_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.text "answers"
@@ -1296,7 +1296,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_misc_surveys_on_user_id"
   end
 
-  create_table "pd_payment_terms", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_payment_terms", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.date "start_date", null: false
     t.date "end_date"
@@ -1308,7 +1308,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["regional_partner_id"], name: "index_pd_payment_terms_on_regional_partner_id"
   end
 
-  create_table "pd_post_course_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_post_course_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.text "answers"
@@ -1323,7 +1323,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_post_course_surveys_on_user_id"
   end
 
-  create_table "pd_pre_workshop_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_pre_workshop_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1331,7 +1331,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_enrollment_id"], name: "index_pd_pre_workshop_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_regional_partner_cohorts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_cohorts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id"
     t.integer "role", comment: "teacher or facilitator"
     t.string "year", comment: "free-form text year range, YYYY-YYYY, e.g. 2016-2017"
@@ -1345,14 +1345,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["summer_workshop_id"], name: "index_pd_regional_partner_cohorts_on_summer_workshop_id"
   end
 
-  create_table "pd_regional_partner_cohorts_users", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_cohorts_users", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_regional_partner_cohort_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_regional_partner_cohort_id"], name: "index_pd_regional_partner_cohorts_users_on_cohort_id"
     t.index ["user_id"], name: "index_pd_regional_partner_cohorts_users_on_user_id"
   end
 
-  create_table "pd_regional_partner_contacts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_contacts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "regional_partner_id"
     t.text "form_data"
@@ -1362,7 +1362,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_regional_partner_contacts_on_user_id"
   end
 
-  create_table "pd_regional_partner_mappings", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_mappings", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.string "state"
     t.string "zip_code"
@@ -1373,7 +1373,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["regional_partner_id"], name: "index_pd_regional_partner_mappings_on_regional_partner_id"
   end
 
-  create_table "pd_regional_partner_mini_contacts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_mini_contacts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "regional_partner_id"
     t.text "form_data"
@@ -1383,7 +1383,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_regional_partner_mini_contacts_on_user_id"
   end
 
-  create_table "pd_regional_partner_program_registrations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_program_registrations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data"
     t.integer "teachercon", null: false
@@ -1392,7 +1392,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "teachercon"], name: "index_pd_reg_part_prog_reg_on_user_id_and_teachercon"
   end
 
-  create_table "pd_scholarship_infos", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_scholarship_infos", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "application_year", null: false
     t.string "scholarship_status", null: false
@@ -1407,7 +1407,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_scholarship_infos_on_user_id"
   end
 
-  create_table "pd_sessions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_sessions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id"
     t.datetime "start", null: false
     t.datetime "end", null: false
@@ -1420,7 +1420,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_workshop_id"], name: "index_pd_sessions_on_pd_workshop_id"
   end
 
-  create_table "pd_survey_questions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_survey_questions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id"
     t.text "questions", null: false, comment: "JSON Question data for this JotForm form."
     t.datetime "created_at", null: false
@@ -1429,7 +1429,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["form_id"], name: "index_pd_survey_questions_on_form_id", unique: true
   end
 
-  create_table "pd_teacher_applications", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_teacher_applications", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
@@ -1443,7 +1443,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_teacher_applications_on_user_id", unique: true
   end
 
-  create_table "pd_teachercon1819_registrations", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_teachercon1819_registrations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -1455,7 +1455,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_teachercon1819_registrations_on_user_id"
   end
 
-  create_table "pd_teachercon_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_teachercon_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1463,7 +1463,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["pd_enrollment_id"], name: "index_pd_teachercon_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_workshop_daily_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_daily_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.integer "user_id", null: false
@@ -1481,7 +1481,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_workshop_daily_surveys_on_user_id"
   end
 
-  create_table "pd_workshop_facilitator_daily_surveys", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_facilitator_daily_surveys", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.integer "user_id", null: false
@@ -1501,7 +1501,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_workshop_facilitator_daily_surveys_on_user_id"
   end
 
-  create_table "pd_workshop_survey_foorm_submissions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_survey_foorm_submissions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "foorm_submission_id", null: false
     t.integer "user_id", null: false
     t.integer "pd_session_id"
@@ -1517,7 +1517,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_pd_workshop_survey_foorm_submissions_on_user_id"
   end
 
-  create_table "pd_workshops", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshops", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "organizer_id", null: false
     t.string "location_name"
     t.string "location_address"
@@ -1545,14 +1545,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["regional_partner_id"], name: "index_pd_workshops_on_regional_partner_id"
   end
 
-  create_table "pd_workshops_facilitators", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshops_facilitators", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_workshop_id"], name: "index_pd_workshops_facilitators_on_pd_workshop_id"
     t.index ["user_id"], name: "index_pd_workshops_facilitators_on_user_id"
   end
 
-  create_table "peer_reviews", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "peer_reviews", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "submitter_id"
     t.integer "reviewer_id"
     t.boolean "from_instructor", default: false, null: false
@@ -1571,7 +1571,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["submitter_id"], name: "index_peer_reviews_on_submitter_id"
   end
 
-  create_table "pilots", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "pilots", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "display_name", null: false
     t.boolean "allow_joining_via_url", null: false
@@ -1580,7 +1580,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name"], name: "index_pilots_on_name", unique: true
   end
 
-  create_table "plc_course_units", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_course_units", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "plc_course_id"
     t.string "unit_name"
     t.text "unit_description"
@@ -1593,14 +1593,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_id"], name: "index_plc_course_units_on_script_id"
   end
 
-  create_table "plc_courses", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_courses", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "course_id"
     t.index ["course_id"], name: "fk_rails_d5fc777f73"
   end
 
-  create_table "plc_enrollment_module_assignments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_enrollment_module_assignments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "plc_enrollment_unit_assignment_id"
     t.integer "plc_learning_module_id"
     t.datetime "created_at", null: false
@@ -1611,7 +1611,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_plc_enrollment_module_assignments_on_user_id"
   end
 
-  create_table "plc_enrollment_unit_assignments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_enrollment_unit_assignments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "plc_user_course_enrollment_id"
     t.integer "plc_course_unit_id"
     t.string "status"
@@ -1623,7 +1623,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_plc_enrollment_unit_assignments_on_user_id"
   end
 
-  create_table "plc_learning_modules", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_learning_modules", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1634,7 +1634,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["stage_id"], name: "index_plc_learning_modules_on_stage_id"
   end
 
-  create_table "plc_user_course_enrollments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_user_course_enrollments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "status"
     t.integer "plc_course_id"
     t.integer "user_id"
@@ -1644,7 +1644,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "plc_course_id"], name: "index_plc_user_course_enrollments_on_user_id_and_plc_course_id", unique: true
   end
 
-  create_table "potential_teachers", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "potential_teachers", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
     t.integer "script_id"
@@ -1654,7 +1654,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_id"], name: "index_potential_teachers_on_script_id"
   end
 
-  create_table "programming_classes", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_classes", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "programming_environment_id"
     t.integer "programming_environment_category_id"
     t.string "key"
@@ -1671,7 +1671,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["key", "programming_environment_id"], name: "index_programming_classes_on_key_and_programming_environment_id", unique: true
   end
 
-  create_table "programming_environment_categories", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_environment_categories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "programming_environment_id", null: false
     t.string "key", null: false
     t.string "name"
@@ -1683,7 +1683,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["programming_environment_id"], name: "index_programming_environment_categories_on_environment_id"
   end
 
-  create_table "programming_environments", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_environments", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "properties"
     t.datetime "created_at", null: false
@@ -1692,7 +1692,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name"], name: "index_programming_environments_on_name", unique: true
   end
 
-  create_table "programming_expressions", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_expressions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "category"
     t.text "properties"
@@ -1707,7 +1707,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["programming_environment_id"], name: "index_programming_expressions_on_programming_environment_id"
   end
 
-  create_table "programming_methods", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_methods", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "programming_class_id"
     t.string "key"
     t.integer "position"
@@ -1735,7 +1735,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
-  create_table "projects", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "projects", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "storage_id"
     t.text "value", size: :medium
     t.datetime "updated_at", null: false
@@ -1755,7 +1755,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["storage_id"], name: "storage_apps_storage_id_index"
   end
 
-  create_table "puzzle_ratings", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "puzzle_ratings", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "script_id"
     t.integer "level_id"
@@ -1766,7 +1766,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "script_id", "level_id"], name: "index_puzzle_ratings_on_user_id_and_script_id_and_level_id", unique: true
   end
 
-  create_table "queued_account_purges", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "queued_account_purges", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "reason_for_review"
     t.datetime "created_at", null: false
@@ -1774,7 +1774,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_queued_account_purges_on_user_id", unique: true
   end
 
-  create_table "reference_guides", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "reference_guides", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.bigint "course_version_id", null: false
     t.string "parent_reference_guide_key"
@@ -1787,14 +1787,14 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["course_version_id", "parent_reference_guide_key"], name: "index_reference_guides_on_course_version_id_and_parent_key"
   end
 
-  create_table "regional_partner_program_managers", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "regional_partner_program_managers", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "program_manager_id", null: false
     t.integer "regional_partner_id", null: false
     t.index ["program_manager_id"], name: "index_regional_partner_program_managers_on_program_manager_id"
     t.index ["regional_partner_id"], name: "index_regional_partner_program_managers_on_regional_partner_id"
   end
 
-  create_table "regional_partners", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "regional_partners", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "group"
     t.boolean "urban"
@@ -1813,7 +1813,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.boolean "is_active", null: false
   end
 
-  create_table "regional_partners_school_districts", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "regional_partners_school_districts", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.integer "school_district_id", null: false
     t.string "course", comment: "Course for a given workshop"
@@ -1822,7 +1822,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_district_id"], name: "index_regional_partners_school_districts_on_school_district_id"
   end
 
-  create_table "resources", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "resources", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "url", null: false
     t.string "key", null: false
@@ -1834,7 +1834,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
   end
 
-  create_table "rubric_ai_evaluations", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "rubric_ai_evaluations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "requester_id", null: false
     t.bigint "rubric_id", null: false
@@ -1848,7 +1848,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_rubric_ai_evaluations_on_user_id"
   end
 
-  create_table "rubrics", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "rubrics", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.integer "level_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -1856,7 +1856,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["lesson_id", "level_id"], name: "index_rubrics_on_lesson_id_and_level_id", unique: true
   end
 
-  create_table "school_districts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "school_districts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "city", null: false
     t.string "state", null: false
@@ -1868,7 +1868,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["state"], name: "index_school_districts_on_state"
   end
 
-  create_table "school_infos", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "school_infos", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "country"
     t.string "school_type"
     t.integer "zip"
@@ -1888,7 +1888,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_name", "country", "school_type"], name: "index_school_infos_on_school_name_and_country_and_school_type"
   end
 
-  create_table "school_stats_by_years", primary_key: ["school_id", "school_year"], charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "school_stats_by_years", primary_key: ["school_id", "school_year"], charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "school_id", limit: 12, null: false, comment: "NCES public school ID"
     t.string "school_year", limit: 9, null: false, comment: "School Year"
     t.string "grades_offered_lo", limit: 2, comment: "Grades Offered - Lowest"
@@ -1925,7 +1925,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["school_id"], name: "index_school_stats_by_years_on_school_id"
   end
 
-  create_table "schools", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "schools", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "id", limit: 12, null: false, comment: "NCES public school ID"
     t.integer "school_district_id"
     t.string "name", null: false
@@ -1949,7 +1949,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["zip"], name: "index_schools_on_zip"
   end
 
-  create_table "script_levels", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "script_levels", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "script_id", null: false
     t.integer "chapter"
     t.datetime "created_at"
@@ -1969,7 +1969,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["stage_id"], name: "index_script_levels_on_stage_id"
   end
 
-  create_table "scripts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "scripts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1993,21 +1993,21 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["wrapup_video_id"], name: "index_scripts_on_wrapup_video_id"
   end
 
-  create_table "scripts_resources", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "scripts_resources", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "script_id"
     t.integer "resource_id"
     t.index ["resource_id", "script_id"], name: "index_scripts_resources_on_resource_id_and_script_id"
     t.index ["script_id", "resource_id"], name: "index_scripts_resources_on_script_id_and_resource_id", unique: true
   end
 
-  create_table "scripts_student_resources", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "scripts_student_resources", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "script_id"
     t.integer "resource_id"
     t.index ["resource_id", "script_id"], name: "index_scripts_student_resources_on_resource_id_and_script_id"
     t.index ["script_id", "resource_id"], name: "index_scripts_student_resources_on_script_id_and_resource_id", unique: true
   end
 
-  create_table "secret_pictures", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "secret_pictures", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "path", null: false
     t.datetime "created_at"
@@ -2016,28 +2016,28 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["path"], name: "index_secret_pictures_on_path", unique: true
   end
 
-  create_table "secret_words", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "secret_words", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "word", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["word"], name: "index_secret_words_on_word", unique: true
   end
 
-  create_table "section_hidden_scripts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "section_hidden_scripts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "section_id", null: false
     t.integer "script_id", null: false
     t.index ["script_id"], name: "index_section_hidden_scripts_on_script_id"
     t.index ["section_id"], name: "index_section_hidden_scripts_on_section_id"
   end
 
-  create_table "section_hidden_stages", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "section_hidden_stages", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "section_id", null: false
     t.integer "stage_id", null: false
     t.index ["section_id"], name: "index_section_hidden_stages_on_section_id"
     t.index ["stage_id"], name: "index_section_hidden_stages_on_stage_id"
   end
 
-  create_table "section_instructors", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "section_instructors", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "instructor_id", null: false
     t.integer "section_id", null: false
     t.integer "invited_by_id"
@@ -2052,7 +2052,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["section_id"], name: "index_section_instructors_on_section_id"
   end
 
-  create_table "sections", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "sections", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "name"
     t.datetime "created_at"
@@ -2081,13 +2081,13 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_sections_on_user_id"
   end
 
-  create_table "seed_info", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "seed_info", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "table", null: false
     t.datetime "mtime"
     t.index ["table"], name: "index_seed_info_on_table"
   end
 
-  create_table "seeded_s3_objects", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "seeded_s3_objects", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "bucket"
     t.string "key"
     t.string "etag"
@@ -2096,7 +2096,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["bucket", "key", "etag"], name: "index_seeded_s3_objects_on_bucket_and_key_and_etag"
   end
 
-  create_table "shared_blockly_functions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "shared_blockly_functions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "level_type"
     t.integer "block_type", default: 0, null: false
@@ -2106,7 +2106,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.text "stack"
   end
 
-  create_table "sign_ins", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "sign_ins", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "sign_in_at", null: false
     t.integer "sign_in_count", null: false
@@ -2114,7 +2114,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_sign_ins_on_user_id"
   end
 
-  create_table "stages", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "stages", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "absolute_position"
     t.integer "script_id", null: false
@@ -2130,7 +2130,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["script_id", "key"], name: "index_stages_on_script_id_and_key", unique: true
   end
 
-  create_table "stages_standards", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "stages_standards", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "stage_id", null: false
     t.integer "standard_id", null: false
     t.datetime "created_at", null: false
@@ -2139,7 +2139,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["standard_id"], name: "index_stages_standards_on_standard_id"
   end
 
-  create_table "standard_categories", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "standard_categories", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "shortcode", null: false
     t.integer "framework_id", null: false
     t.integer "parent_category_id"
@@ -2151,7 +2151,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["parent_category_id"], name: "index_standard_categories_on_parent_category_id"
   end
 
-  create_table "standards", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "standards", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "description"
     t.bigint "category_id"
     t.integer "framework_id"
@@ -2161,13 +2161,13 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["framework_id", "shortcode"], name: "index_standards_on_framework_id_and_shortcode"
   end
 
-  create_table "studio_people", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "studio_people", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "emails"
   end
 
-  create_table "survey_results", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "survey_results", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "kind"
     t.text "properties"
@@ -2177,7 +2177,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_survey_results_on_user_id"
   end
 
-  create_table "teacher_feedbacks", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "teacher_feedbacks", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "comment"
     t.integer "student_id"
     t.integer "level_id", null: false
@@ -2197,7 +2197,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["teacher_id"], name: "index_teacher_feedbacks_on_teacher_id"
   end
 
-  create_table "teacher_profiles", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "teacher_profiles", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "studio_person_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -2211,7 +2211,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["studio_person_id"], name: "index_teacher_profiles_on_studio_person_id"
   end
 
-  create_table "teacher_scores", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "teacher_scores", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "user_level_id", unsigned: true
     t.integer "teacher_id"
     t.integer "score"
@@ -2220,7 +2220,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_level_id"], name: "index_teacher_scores_on_user_level_id"
   end
 
-  create_table "unit_groups", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
     t.datetime "created_at", null: false
@@ -2236,21 +2236,21 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["published_state"], name: "index_unit_groups_on_published_state"
   end
 
-  create_table "unit_groups_resources", id: false, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_resources", id: false, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_unit_groups_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_unit_groups_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "unit_groups_student_resources", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_student_resources", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_ug_student_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_ug_student_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "user_geos", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_geos", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -2266,7 +2266,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_user_geos_on_user_id"
   end
 
-  create_table "user_level_interactions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_level_interactions", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "script_id", null: false
@@ -2281,7 +2281,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_user_level_interactions_on_user_id"
   end
 
-  create_table "user_levels", id: { type: :bigint, unsigned: true }, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_levels", id: { type: :bigint, unsigned: true }, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "attempts", default: 0, null: false
@@ -2299,7 +2299,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "script_id", "level_id", "deleted_at"], name: "index_user_levels_unique", unique: true
   end
 
-  create_table "user_ml_models", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_ml_models", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "model_id"
     t.string "name"
@@ -2312,7 +2312,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_user_ml_models_on_user_id"
   end
 
-  create_table "user_module_task_assignments", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_module_task_assignments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_enrollment_module_assignment_id"
     t.integer "professional_learning_task_id"
     t.string "status"
@@ -2320,7 +2320,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_enrollment_module_assignment_id"], name: "task_assignment_to_module_assignment_index"
   end
 
-  create_table "user_permissions", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_permissions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "permission", null: false
     t.datetime "created_at"
@@ -2328,7 +2328,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "permission"], name: "index_user_permissions_on_user_id_and_permission", unique: true
   end
 
-  create_table "user_proficiencies", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_proficiencies", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -2387,13 +2387,13 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_user_proficiencies_on_user_id", unique: true
   end
 
-  create_table "user_project_storage_ids", id: :integer, charset: "utf8", force: :cascade do |t|
+  create_table "user_project_storage_ids", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "user_id"
     t.index ["user_id"], name: "user_id", unique: true
     t.index ["user_id"], name: "user_storage_ids_user_id_index"
   end
 
-  create_table "user_school_infos", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_school_infos", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "start_date", null: false
     t.datetime "end_date"
@@ -2404,7 +2404,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id"], name: "index_user_school_infos_on_user_id"
   end
 
-  create_table "user_scripts", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_scripts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.datetime "started_at"
@@ -2419,7 +2419,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["user_id", "script_id", "deleted_at"], name: "index_user_scripts_on_user_id_and_script_id_and_deleted_at", unique: true
   end
 
-  create_table "users", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "studio_person_id"
     t.string "email", default: "", null: false
     t.string "parent_email"
@@ -2488,7 +2488,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["username", "deleted_at"], name: "index_users_on_username_and_deleted_at", unique: true
   end
 
-  create_table "videos", id: :integer, charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "videos", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.string "youtube_code"
     t.datetime "created_at"
@@ -2498,7 +2498,7 @@ ActiveRecord::Schema.define(version: 2025_01_16_214434) do
     t.index ["key", "locale"], name: "index_videos_on_key_and_locale", unique: true
   end
 
-  create_table "vocabularies", charset: "utf8", collation: "utf8_unicode_ci", force: :cascade do |t|
+  create_table "vocabularies", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "word", null: false
     t.text "definition", null: false


### PR DESCRIPTION
Adds a unit selection dropdown to the calendar page

https://github.com/user-attachments/assets/b5c58d9d-35d5-4e6b-9e9d-9168165c4300

The assigned unit is automatically selected. Only the units in the assigned course are available for selection

## Links
https://codedotorg.atlassian.net/browse/TEACH-1301
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
