### PR TITLE
fix: split on first whitespace of slack topic to get the commit hash

### DIFF
--- a/lib/cdo/infra_test_topic.rb
+++ b/lib/cdo/infra_test_topic.rb
@@ -22,7 +22,7 @@ module InfraTestTopic
   def self.green_commit
     current_topic = Slack.get_topic('infra-test')
     return nil unless /:greenbeer:/.match?(current_topic)
-    current_topic[0..7]
+    current_topic.split.first
   end
 
   private_class_method def self.current_time_pacific


### PR DESCRIPTION
occasionally a longer hash is needed to fetch the commit from gh. this splits the slack topic on first whitespace rather than just taking the first few characters

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[Slack discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1737755425065849?thread_ts=1737755425.065849&cid=C0T0PNTM3)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
