### PR TITLE
chore: rename the marketing app cicd

### DIFF
--- a/.github/workflows/marketing-app-cicd.yml
+++ b/.github/workflows/marketing-app-cicd.yml
@@ -1,7 +1,8 @@
 # Currently, only the `marketing` app has a Dockerfile. This workflow is intended to be expanded upon in the future to include other apps that have Dockerfiles.
 # Future iterations of this workflow will include a matrix strategy to build and publish Docker images for all apps that have Dockerfiles.
 
-name: Build, Push, and Deploy Marketing App
+# The name does not use spaces due to https://github.com/integrations/slack/issues/1790
+name: Marketing-App-CICD
 
 # Configures this workflow to run every time a change is pushed to `frontend`
 on:


### PR DESCRIPTION
This PR:

1. renames the github workflow to better reflect this is for the marketing app
2. Updates the name of the workflow to workaround [this slack integration issue](https://github.com/integrations/slack/issues/1790)
