### PR TITLE
Update stats on code.org homepage - Jan 2025

### DIFF
--- a/pegasus/sites.v3/code.org/views/stats_homepage.haml
+++ b/pegasus/sites.v3/code.org/views/stats_homepage.haml
@@ -1,9 +1,9 @@
 :ruby
-  student_accounts = "92M"
-  female_students = "39M"
+  student_accounts = "99M"
+  female_students = "42M"
   project_count = fetch_project_count['rounded_down_millions']
   project_count = project_count.to_s + "M"
-  teacher_users = "2.7M"
+  teacher_users = "2.9M"
   states_policy_change = "50"
 
   top_statistic_number = student_accounts


### PR DESCRIPTION
Updates the stats on the https://code.org homepage. 

**Reviewer note:** the "projects" stat is populated dynamically on production so it's not the same locally. 

👀 **DOTD note:** this will likely have Eyes diffs on the homepage.

## Links
Jira ticket: [ACQ-3040](https://codedotorg.atlassian.net/browse/ACQ-3040)

## Testing story
Tested locally

----

| Before | After |
| ---- | ---- |
| <img width="1354" alt="Before" src="https://github.com/user-attachments/assets/929bada6-ea7a-4411-bccc-8114f675e85d" /> | <img width="1354" alt="After" src="https://github.com/user-attachments/assets/38c64991-2cd9-46b5-a574-219803457dcc" /> |

