### PR TITLE
Updating toggles to be screen reader accessible

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2628,7 +2628,6 @@
   "seeCurriculumDetails": "See curriculum details",
   "seePrivacyPolicy": "(See our privacy policy)",
   "select": "Select",
-  "selected": "Selected",
   "selectACourse": "Select a course or unit",
   "selectAStudentToEvaluateAlert": "Select a student from the dropdown menu to view and evaluate their work.",
   "selectASectionToEvaluateAlert": "Select a section from the dropdown menu to evaluate student work.",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2628,6 +2628,7 @@
   "seeCurriculumDetails": "See curriculum details",
   "seePrivacyPolicy": "(See our privacy policy)",
   "select": "Select",
+  "selected": "Selected",
   "selectACourse": "Select a course or unit",
   "selectAStudentToEvaluateAlert": "Select a student from the dropdown menu to view and evaluate their work.",
   "selectASectionToEvaluateAlert": "Select a section from the dropdown menu to evaluate student work.",

--- a/apps/src/templates/ToggleButton.jsx
+++ b/apps/src/templates/ToggleButton.jsx
@@ -24,6 +24,8 @@ class ToggleButton extends Component {
     return (
       <button
         type="button"
+        role="tab"
+        aria-selected={String(this.props.active)}
         id={this.props.id}
         style={this.getStyle()}
         className={'no-outline ' + (this.props.className || '')}

--- a/apps/src/templates/ToggleGroup.jsx
+++ b/apps/src/templates/ToggleGroup.jsx
@@ -49,7 +49,11 @@ class ToggleGroup extends Component {
       ? styles.flexButtonReverse
       : flex && styles.flexButtons;
 
-    return <span style={spanStyle}>{this.renderChildren()}</span>;
+    return (
+      <div role="tablist" style={spanStyle}>
+        {this.renderChildren()}
+      </div>
+    );
   }
 
   renderChildren() {

--- a/apps/src/templates/progress/ProgressDetailToggle.jsx
+++ b/apps/src/templates/progress/ProgressDetailToggle.jsx
@@ -96,7 +96,7 @@ class ProgressDetailToggle extends React.Component {
           <img
             src={isSummaryView ? images.summaryActive : images.summaryInactive}
             style={styles.icon}
-            alt={i18n.summaryView()}
+            alt={i18n.summaryView() + (isSummaryView ? i18n.selected() : '')}
           />
         </button>
         <button
@@ -112,7 +112,7 @@ class ProgressDetailToggle extends React.Component {
           <img
             src={isSummaryView ? images.detailInactive : images.detailActive}
             style={styles.icon}
-            alt={i18n.detailView()}
+            alt={i18n.detailView() + (!isSummaryView ? i18n.selected() : '')}
           />
         </button>
       </ToggleGroup>

--- a/apps/src/templates/progress/ProgressDetailToggle.jsx
+++ b/apps/src/templates/progress/ProgressDetailToggle.jsx
@@ -96,7 +96,7 @@ class ProgressDetailToggle extends React.Component {
           <img
             src={isSummaryView ? images.summaryActive : images.summaryInactive}
             style={styles.icon}
-            alt={i18n.summaryView() + (isSummaryView ? i18n.selected() : '')}
+            alt={i18n.summaryView()}
           />
         </button>
         <button
@@ -112,7 +112,7 @@ class ProgressDetailToggle extends React.Component {
           <img
             src={isSummaryView ? images.detailInactive : images.detailActive}
             style={styles.icon}
-            alt={i18n.detailView() + (!isSummaryView ? i18n.selected() : '')}
+            alt={i18n.detailView()}
           />
         </button>
       </ToggleGroup>


### PR DESCRIPTION
I was going to just update the summary page toggles but figured while I'm here, I can make all the toggles screen reader accessible! There was no way for a non-sighted user to tell which of the two tabs were selected. Now that status is read aloud (without too many style changes, though our design system tab updates apply).

In case it's helpful to document my failed approaches:

My initial approach was to change the ProgressDetailToggle file directly so as not to mess with the other toggles. The issue here is that downstream files like ToggleGroup and ToggleButton wouldn't play nicely with styling, and the other uses of these files wouldn't receive the accessibility updates. 

I also considered adding 'selected' to the alt text (and adding that to the translation file) but it's not the *right* approach here, as a screen reader user is expecting the 'tab selected' language to happen in a certain order. 

Before:
https://github.com/user-attachments/assets/7472ae54-ad49-4387-9852-ddbb76aa5136


After:
https://github.com/user-attachments/assets/44eb19de-de82-4c0b-af63-3a3a680ed185


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-674

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
