### PR TITLE
[POC] [Not for merge] Integration of Contentful with Teacher Dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -366,3 +366,5 @@ gem "json-schema", "~> 4.3"
 gem "csv"
 
 gem "async", "~> 1.32"
+
+gem 'contentful'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,9 @@ GEM
       fiber-annotation
       fiber-local
       json
+    contentful (2.17.1)
+      http (> 0.8, < 6.0)
+      multi_json (~> 1)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -632,9 +635,6 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     open-uri (0.1.0)
-      stringio
-      time
-      uri
     open_uri_redirections (0.2.1)
     orm_adapter (0.5.0)
     os (1.1.4)
@@ -877,7 +877,6 @@ GEM
       ip3country (~> 0.2.1)
       user_agent_parser (~> 2.15.0)
     stringex (2.5.2)
-    stringio (3.1.1)
     strscan (3.1.0)
     sysexits (1.2.0)
     syslog (0.1.2)
@@ -890,8 +889,6 @@ GEM
     thwait (0.2.0)
       e2mmap
     tilt (2.0.11)
-    time (0.3.0)
-      date
     timecop (0.8.1)
     timeout (0.3.2)
     timers (4.3.5)
@@ -909,7 +906,6 @@ GEM
     unf_ext (0.0.7.4)
     unicode-display_width (2.5.0)
     unicode_utils (1.4.0)
-    uri (0.13.0)
     user_agent_parser (2.15.0)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
@@ -987,6 +983,7 @@ DEPENDENCIES
   cld
   colorize
   composite_primary_keys (~> 13.0)
+  contentful
   crowdin-api (~> 1.10.0)
   csv
   cucumber

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -12,6 +12,7 @@ import GlobalEditionWrapper from '@cdo/apps/templates/GlobalEditionWrapper';
 import ProjectWidgetWithData from '@cdo/apps/templates/projects/ProjectWidgetWithData';
 import BorderedCallToAction from '@cdo/apps/templates/studioHomepages/BorderedCallToAction';
 import JoinSectionArea from '@cdo/apps/templates/studioHomepages/JoinSectionArea';
+import MarketingSidebar from '@cdo/apps/templates/teacherDashboard/MarketingSidebar';
 import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 
@@ -161,128 +162,131 @@ export const UnconnectedTeacherHomepage = ({
   }
 
   return (
-    <div>
-      <HeaderBanner
-        headingText={i18n.homepageHeading()}
-        backgroundUrl={backgroundUrl}
-        backgroundImageStyling={{backgroundPosition: '90% 30%'}}
-      />
-      <div className={'container main'}>
-        <ProtectedStatefulDiv ref={flashes} />
-        <ProtectedStatefulDiv ref={teacherReminders} />
-        {showNpsSurvey && <NpsSurveyBlock />}
-        {specialAnnouncement && (
-          <GlobalEditionWrapper
-            component={MarketingAnnouncementBanner}
-            componentId="MarketingAnnouncementBanner"
-            props={{
-              announcement: specialAnnouncement,
-              marginBottom: '30px',
-            }}
-          />
-        )}
-        {announcement && showAnnouncement && (
-          <div>
-            <Notification
-              type={announcement.type || 'bullhorn'}
-              notice={announcement.heading}
-              details={announcement.description}
-              dismissible={true}
-              buttonText={announcement.buttonText}
-              buttonLink={announcement.link}
-              newWindow={true}
+    <div style={{display: 'flex'}}>
+      <div>
+        <HeaderBanner
+          headingText={i18n.homepageHeading()}
+          backgroundUrl={backgroundUrl}
+          backgroundImageStyling={{backgroundPosition: '90% 30%'}}
+        />
+        <div className={'container main'}>
+          <ProtectedStatefulDiv ref={flashes} />
+          <ProtectedStatefulDiv ref={teacherReminders} />
+          {showNpsSurvey && <NpsSurveyBlock />}
+          {specialAnnouncement && (
+            <GlobalEditionWrapper
+              component={MarketingAnnouncementBanner}
+              componentId="MarketingAnnouncementBanner"
+              props={{
+                announcement: specialAnnouncement,
+                marginBottom: '30px',
+              }}
             />
-            <div style={styles.clear} />
-          </div>
-        )}
-        {!showAnnouncement && <br />}
-        {showFinishTeacherApplication && (
-          <BorderedCallToAction
-            headingText="Return to Your Application"
-            descriptionText="Finish applying for our Professional Learning Program"
-            buttonText="Finish Application"
-            buttonUrl="/pd/application/teacher"
-            solidBorder={true}
-          />
-        )}
-        {showPLBanner && <ProfessionalLearningSkinnyBanner />}
-        {showReturnToReopenedTeacherApplication && (
-          <BorderedCallToAction
-            headingText="Return to Your Application"
-            descriptionText="Your Regional Partner has requested updates to your Professional Learning Application."
-            buttonText="Return to Application"
-            buttonUrl="/pd/application/teacher"
-            solidBorder={true}
-          />
-        )}
-        {displayCensusBanner && (
-          <div>
-            <CensusTeacherBanner
-              schoolYear={schoolYear}
-              existingSchoolInfo={existingSchoolInfo}
-              question={censusQuestion}
-              teaches={censusBannerTeachesSelection}
-              inClass={censusBannerInClassSelection}
-              teacherId={teacherId}
-              teacherName={teacherName}
-              teacherEmail={teacherEmail}
-              onSubmitSuccess={() => dismissCensusBanner(null, null)}
-              onDismiss={() => dismissAndHideCensusBanner()}
-              onPostpone={() => postponeCensusBanner()}
-              onTeachesChange={event =>
-                setCensusBannerTeachesSelection(
-                  event.target.id === 'teachesYes'
-                )
-              }
-              onInClassChange={event =>
-                setCensusBannerInClassSelection(event.target.id === 'inClass')
-              }
+          )}
+          {announcement && showAnnouncement && (
+            <div>
+              <Notification
+                type={announcement.type || 'bullhorn'}
+                notice={announcement.heading}
+                details={announcement.description}
+                dismissible={true}
+                buttonText={announcement.buttonText}
+                buttonLink={announcement.link}
+                newWindow={true}
+              />
+              <div style={styles.clear} />
+            </div>
+          )}
+          {!showAnnouncement && <br />}
+          {showFinishTeacherApplication && (
+            <BorderedCallToAction
+              headingText="Return to Your Application"
+              descriptionText="Finish applying for our Professional Learning Program"
+              buttonText="Finish Application"
+              buttonUrl="/pd/application/teacher"
+              solidBorder={true}
             />
-            <br />
-          </div>
-        )}
-        {showAFEBanner && (
-          <div>
-            <DonorTeacherBanner source="teacher_home" />
-            <div style={styles.clear} />
-          </div>
-        )}
-        <TeacherSections />
-        <RecentCourses
-          courses={courses}
-          topCourse={topCourse}
-          showAllCoursesLink={true}
-          isTeacher={true}
-          hasFeedback={false}
-        />
-        {hasFeedback && (plCourses?.length > 0 || topPlCourse) && (
-          <ParticipantFeedbackNotification
-            studentId={teacherId}
-            isProfessionalLearningCourse={true}
-          />
-        )}
-        <GlobalEditionWrapper
-          component={TeacherResources}
-          componentId="TeacherResources"
-        />
-        {showIncubatorBanner && (
-          <GlobalEditionWrapper
-            component={IncubatorBanner}
-            componentId="IncubatorBanner"
-          />
-        )}
-        <ProjectWidgetWithData
-          canViewFullList={true}
-          canViewAdvancedTools={canViewAdvancedTools}
-        />
-        <section>
-          <JoinSectionArea
-            initialJoinedStudentSections={joinedStudentSections}
-            initialJoinedPlSections={joinedPlSections}
+          )}
+          {showPLBanner && <ProfessionalLearningSkinnyBanner />}
+          {showReturnToReopenedTeacherApplication && (
+            <BorderedCallToAction
+              headingText="Return to Your Application"
+              descriptionText="Your Regional Partner has requested updates to your Professional Learning Application."
+              buttonText="Return to Application"
+              buttonUrl="/pd/application/teacher"
+              solidBorder={true}
+            />
+          )}
+          {displayCensusBanner && (
+            <div>
+              <CensusTeacherBanner
+                schoolYear={schoolYear}
+                existingSchoolInfo={existingSchoolInfo}
+                question={censusQuestion}
+                teaches={censusBannerTeachesSelection}
+                inClass={censusBannerInClassSelection}
+                teacherId={teacherId}
+                teacherName={teacherName}
+                teacherEmail={teacherEmail}
+                onSubmitSuccess={() => dismissCensusBanner(null, null)}
+                onDismiss={() => dismissAndHideCensusBanner()}
+                onPostpone={() => postponeCensusBanner()}
+                onTeachesChange={event =>
+                  setCensusBannerTeachesSelection(
+                    event.target.id === 'teachesYes'
+                  )
+                }
+                onInClassChange={event =>
+                  setCensusBannerInClassSelection(event.target.id === 'inClass')
+                }
+              />
+              <br />
+            </div>
+          )}
+          {showAFEBanner && (
+            <div>
+              <DonorTeacherBanner source="teacher_home" />
+              <div style={styles.clear} />
+            </div>
+          )}
+          <TeacherSections />
+          <RecentCourses
+            courses={courses}
+            topCourse={topCourse}
+            showAllCoursesLink={true}
             isTeacher={true}
+            hasFeedback={false}
           />
-        </section>
+          {hasFeedback && (plCourses?.length > 0 || topPlCourse) && (
+            <ParticipantFeedbackNotification
+              studentId={teacherId}
+              isProfessionalLearningCourse={true}
+            />
+          )}
+          <GlobalEditionWrapper
+            component={TeacherResources}
+            componentId="TeacherResources"
+          />
+          {showIncubatorBanner && (
+            <GlobalEditionWrapper
+              component={IncubatorBanner}
+              componentId="IncubatorBanner"
+            />
+          )}
+          <ProjectWidgetWithData
+            canViewFullList={true}
+            canViewAdvancedTools={canViewAdvancedTools}
+          />
+          <section>
+            <JoinSectionArea
+              initialJoinedStudentSections={joinedStudentSections}
+              initialJoinedPlSections={joinedPlSections}
+              isTeacher={true}
+            />
+          </section>
+        </div>
       </div>
+      <MarketingSidebar />
     </div>
   );
 };

--- a/apps/src/templates/teacherDashboard/MarketingSidebar/index.tsx
+++ b/apps/src/templates/teacherDashboard/MarketingSidebar/index.tsx
@@ -1,0 +1,48 @@
+import {LinkButton} from '@code-dot-org/component-library/button';
+import Typography from '@code-dot-org/component-library/typography';
+import React, {useEffect, useState} from 'react';
+
+const MarketingSidebar = () => {
+  const [marketingCampaigns, setMarketingCampaigns] = useState();
+
+  useEffect(() => {
+    if (marketingCampaigns === undefined) {
+      fetch('/marketing/v1/teacher-dashboard')
+        .then(response => response.json())
+        .then(response => {
+          setMarketingCampaigns(response);
+        });
+    }
+  });
+
+  const renderCampaigns = () => {
+    return marketingCampaigns.map((campaign, index) => {
+      return (
+        <div
+          style={{
+            padding: '8px',
+            backgroundColor: index % 2 === 1 ? 'lightgrey' : 'white',
+          }}
+        >
+          <Typography visualAppearance={'heading-sm'} semanticTag={'h4'}>
+            {campaign.campaign_name}
+          </Typography>
+          <Typography semanticTag={'p'} visualAppearance={'body-four'}>
+            {campaign.short_description}
+          </Typography>
+          <LinkButton href={campaign.campaign_url} text={'Learn More'} />
+        </div>
+      );
+    });
+  };
+
+  return marketingCampaigns ? (
+    <div style={{display: 'flex', flexDirection: 'column'}}>
+      {renderCampaigns()}
+    </div>
+  ) : (
+    <div>Loading</div>
+  );
+};
+
+export default MarketingSidebar;

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -661,3 +661,6 @@ active_job_backend_rolling_restart_in_n_batches: 2
 
 # aiproxy credentials
 aiproxy_api_key: !Secret
+
+# Contentful
+contentful_api_key: !Secret

--- a/dashboard/app/controllers/marketing/v1/marketing_controller.rb
+++ b/dashboard/app/controllers/marketing/v1/marketing_controller.rb
@@ -1,0 +1,25 @@
+require 'services/marketing'
+
+module Marketing
+  module V1
+    class MarketingController < ApplicationController
+      # GET /marketing/v1/teacher-dashboard
+      def teacher_dashboard
+        return head :forbidden unless current_user&.teacher?
+
+        client = Contentful::Client.new(
+          space: '90t6bu6vlf76',
+          access_token: CDO.contentful_api_key,
+          api_url: 'preview.contentful.com'
+        )
+
+        entry = client.entry('43vF4jLNr5VuzOBw7dJ7nq', locale: 'en-US')
+        fields = entry.fields[:items_in_this_list].map(&:fields)
+
+        render json: fields
+      rescue ArgumentError => exception
+        render json: {error: exception.message}, status: :bad_request
+      end
+    end
+  end
+end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -675,6 +675,14 @@ Dashboard::Application.routes.draw do
       end
     end
 
+    namespace :marketing do
+      namespace :v1 do
+        controller :marketing do
+          get 'teacher-dashboard', action: :teacher_dashboard
+        end
+      end
+    end
+
     # OAuth endpoints
     get '/oauth/jwks', to: 'oauth_jwks#jwks'
 

--- a/dashboard/lib/services/marketing.rb
+++ b/dashboard/lib/services/marketing.rb
@@ -1,0 +1,14 @@
+require 'contentful'
+
+module Services
+  module Marketing
+    class TeacherDashboard < Services::Base
+      def initialize(current_user)
+        @user = current_user
+      end
+
+      def call
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR shows an example of how to integrate with Contentful to load marketing campaigns on the teacher dashboard. Note that this PR is not meant to be best practices code nor intended to be merged, it is a very quick test to integrate with Contentful and render some react components client-side.

---

# Demo

[Screencast From 2025-01-28 14-15-27.webm](https://github.com/user-attachments/assets/4f2ea1d6-0367-4669-8340-bcfe287487df)


---

# Potential Implementation

## Model

1. Update the `List` content type to allow list of campaigns
2. Use the `Campaign` content type
3. Create a List of Campaigns entry, and record the identifier for it.

## Technical

1. Install the [Contentful Gem](https://www.contentful.com/developers/docs/ruby/)
2. Use the Ruby SDK to dereference the entry. Note: you will need to dereference nested objects.
3. Create a new API Secret for dashboard and add Contentful API Secrets per secrets management document
4. Consider using Rails Engines
5. Create `Marketing` module
6. Create a new API `GetTeacherDashboardMarketingCampaigns` and associated backend design patterns potentially using recent rails best practices such as Policy, Service, and Query.
7. Use `@code-dot-org/component-library` components
8. Construct react component to read API via lazy-load, react component to be constructed normally