### PR TITLE
AI Chat: simplify permissions check for teacher feedback

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -123,17 +123,13 @@ export async function postLogChatEvent(
 export async function getStudentChatHistory(
   studentUserId: number,
   levelId: number,
-  scriptId: number | null,
-  scriptLevelId: number | undefined
+  scriptId: number | null
 ): Promise<ChatEvent[]> {
   const params: Record<string, string> = {
     studentUserId: studentUserId.toString(),
     levelId: levelId.toString(),
     scriptId: scriptId?.toString() || '',
   };
-  if (scriptLevelId) {
-    params.scriptLevelId = scriptLevelId.toString();
-  }
   const response = await HttpClient.fetchJson<ChatEvent[]>(
     paths.STUDENT_CHAT_HISTORY_URL + '?' + new URLSearchParams(params)
   );

--- a/apps/src/aichat/redux/aichatRedux.ts
+++ b/apps/src/aichat/redux/aichatRedux.ts
@@ -7,10 +7,6 @@ import {
 
 import {Role} from '@cdo/apps/aiComponentLibrary/chatMessage/types';
 import {sendProgressReport} from '@cdo/apps/code-studio/progressRedux';
-import {
-  getCurrentScriptLevelId,
-  getCurrentLevel,
-} from '@cdo/apps/code-studio/progressReduxSelectors';
 import {TestResults} from '@cdo/apps/constants';
 import Lab2Registry from '@cdo/apps/lab2/Lab2Registry';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
@@ -613,18 +609,11 @@ export const fetchStudentChatHistory = createAsyncThunk(
   async (studentUserId: number, thunkAPI) => {
     const state = thunkAPI.getState() as RootState;
     // Post teacher's student's user id to backend and retrieve student's chat history.
-    const currentLevel = getCurrentLevel(state);
-    // The scriptLevelId is sent to the backend if the current level is a sublevel so that we can
-    // correctly check if the teacher has permission to view the student's chat history.
-    const scriptLevelId = currentLevel.parentLevelId
-      ? getCurrentScriptLevelId(state)
-      : undefined;
     try {
       const studentChatHistoryApiResponse = await getStudentChatHistory(
         studentUserId,
         parseInt(state.progress.currentLevelId || ''),
-        state.progress.scriptId,
-        scriptLevelId
+        state.progress.scriptId
       );
       thunkAPI.dispatch(setStudentChatHistory(studentChatHistoryApiResponse));
     } catch (error) {

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -57,7 +57,7 @@ class AichatController < ApplicationController
 
     begin
       chat_event = AichatEvent.find(chat_event_id)
-      unless can_view_student_chat_history?(chat_event.user_id, chat_event.level_id, chat_event.script_id)
+      unless can_view_student_chat_history?(chat_event.user_id)
         return render(status: :forbidden, json: {error: "Access denied for submitting teacher feedback."})
       end
 
@@ -74,7 +74,7 @@ class AichatController < ApplicationController
     render status: :ok, json: {}
   end
 
-  # params are studentUserId: number, levelId: number, scriptId: number, (optional) scriptLevelId: number
+  # params are studentUserId: number, levelId: number, scriptId: number
   # GET /aichat/student_chat_history
   def student_chat_history
     # Request all chat events for a student at a given level/script.
@@ -87,7 +87,7 @@ class AichatController < ApplicationController
     script_id = params[:scriptId]
     level_id = params[:levelId]
     student_user_id = params[:studentUserId]
-    unless can_view_student_chat_history?(student_user_id, level_id, script_id, params[:scriptLevelId])
+    unless can_view_student_chat_history?(student_user_id)
       return render(status: :forbidden, json: {error: "Access denied for student chat history."})
     end
 
@@ -126,25 +126,7 @@ class AichatController < ApplicationController
     render json: {flagged_fields: flagged_fields}.deep_transform_keys {|key| key.to_s.camelize(:lower)}
   end
 
-  private def can_view_student_chat_history?(student_user_id, level_id, script_id, script_level_id = nil)
-    # If a script level ID is provided, ensure it matches the level ID or that
-    # the level is a sublevel of the script level.
-    level = Level.find(level_id)
-    if script_level_id
-      script_level = ScriptLevel.cache_find(script_level_id.to_i)
-      same_level = script_level.oldest_active_level.id == level_id
-      is_sublevel = ParentLevelsChildLevel.exists?(child_level_id: level_id, parent_level_id: script_level.oldest_active_level.id)
-      return false unless same_level || is_sublevel
-    else
-      script_level = level.script_levels.find_by_script_id(script_id)
-    end
-
-    # Ensure that we have permission to view and provide feedback on student's chat events,
-    # i.e., student is in teacher section.
-    user = User.find(student_user_id)
-    unless can?(:view_as_user, script_level, user)
-      return false
-    end
-    true
+  private def can_view_student_chat_history?(student_user_id)
+    User.find_by_id(student_user_id)&.student_of?(current_user)
   end
 end


### PR DESCRIPTION
Fixes a permissions bug where teachers couldn't submit feedback on sublevels specifically. For a full breakdown see this [slack thread](https://codedotorg.slack.com/archives/C06UT1E2796/p1738023812401369?thread_ts=1738006430.582079&cid=C06UT1E2796), but essentially the fix here is to simplify the permissions check to just ensure that the given student is a student of the teacher, regardless of which level they're on.

## Testing story

Tested locally on sublevels and regular levels, with various permissions scenarios.

## Follow-up Work

Note that we perform a similar check for teachers viewing students' work on sublevels in lab2 [here](https://github.com/code-dot-org/code-dot-org/blob/b16fd6a7b7d158f2924502dc72c60d8cb7d6c757/dashboard/app/controllers/projects_controller.rb#L349), which we can probably simplify in the same way.