### PR TITLE
Remove auto-attendance for Build Your Own workshops

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -61,14 +61,6 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
 
         if @workshop.course == COURSE_BUILD_YOUR_OWN
           enrollment.update!(enrollment_params)
-
-          # Mark attendance for all sessions in Build Your Own workshops (we are not tracking attendance in
-          # this way for Build Your Own workshops, but we want to ensure that functionality for emails,
-          # certificates, etc. remains the same).
-          @workshop.sessions.each do |session|
-            attendance = Pd::Attendance.find_restore_or_create_by! session: session, teacher: user, enrollment: enrollment
-            attendance.update! marked_by_user: user
-          end
         else
           enrollment.update!(enrollment_params.merge(school_info_attributes: school_info_params))
           user&.update_school_info(enrollment.school_info)

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -414,34 +414,6 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ActionController::TestCas
     assert_response 404
   end
 
-  test 'creating an enrollment for Build Your Own workshops marks user as attended for all sessions' do
-    user = create :teacher
-    num_workshop_sessions = 3
-    byo_workshop = create :pd_workshop,
-      funded: false,
-      course: Pd::Workshop::COURSE_BUILD_YOUR_OWN,
-      subject: nil,
-      course_offerings: [] << (create :course_offering),
-      num_sessions: num_workshop_sessions
-    params = enrollment_test_params(user).merge(
-      {
-        user_id: user.id,
-        workshop_id: byo_workshop.id
-      }
-    )
-
-    assert_equal 0, Pd::Attendance.for_workshop(byo_workshop).count
-
-    post :create, params: params
-
-    workshop_attendance = Pd::Attendance.for_workshop(byo_workshop)
-
-    assert_equal num_workshop_sessions, workshop_attendance.count
-    workshop_attendance.each do |attendance|
-      assert_equal user.id, attendance.teacher_id
-    end
-  end
-
   test 'admin can update scholarship info' do
     workshop = create :summer_workshop
     enrollment = create :pd_enrollment, :from_user, workshop: workshop


### PR DESCRIPTION
We previously automatically marked users as attended for Build Your Own workshops, but now that we're broadening the capabilities and uses of Build Your Own workshops we want to return to the behavior all other workshops use. This PR just undoes the changes from [the PR that set up auto-attendance](https://github.com/code-dot-org/code-dot-org/pull/60091).

### Demo
#### After enrolling
After the user enrolled, their attendance was not auto-marked on the front-end:
![session 1 no attendance](https://github.com/user-attachments/assets/8f0672aa-1404-49b6-991c-3bad4125286b)

And there were no records of it in our `pd_attendances` db (i.e. no attendance records with a `pd_session_id` of the session's id: 7):
![attendance records after enrolling NO W SESSIONS 7 or 8](https://github.com/user-attachments/assets/c0945563-1813-4725-9329-082ab26663dd)

#### After marking attendance:
After visiting the attendance link, the attendance is shown as marked:
![after visiting workshop attendance link](https://github.com/user-attachments/assets/f3cbe1e1-755c-45f5-9ce7-7fc8a610848c)

This is reflected in the `pd_attendances` db:
![added attendance to db](https://github.com/user-attachments/assets/01de9076-3ef9-4088-af4a-61ab2f09aa63)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2666)
PR that originally added the auto-attendance functionality: [here](https://github.com/code-dot-org/code-dot-org/pull/60091)

## Testing story
Local testing and updating unit tests.
