### PR TITLE
Always use start sources for predict levels

### DIFF
--- a/apps/src/codebridge/hooks/useInitialSources.ts
+++ b/apps/src/codebridge/hooks/useInitialSources.ts
@@ -51,6 +51,9 @@ export const useInitialSources = (defaultSources: ProjectSources) => {
     state => state.lab.levelProperties?.serializedMaze
   );
   const miniApp = useAppSelector(state => state.lab.levelProperties?.miniApp);
+  const isPredictLevel = useAppSelector(
+    state => state.lab.levelProperties?.predictSettings?.isPredictLevel
+  );
 
   const generateProjectSourceFromStartSource = useCallback(
     (startCode: MultiFileSource) => {
@@ -122,6 +125,10 @@ export const useInitialSources = (defaultSources: ProjectSources) => {
     if (isStartMode) {
       return startSources;
     }
+    if (isPredictLevel) {
+      // Predict levels never use sources loaded from the server, only the start sources.
+      return templateSources || startSources;
+    }
     if (isEditingExemplar || isViewingExemplar) {
       // If we are viewing exemplars sources and have no exemplar, we show a fallback
       // page from LabViewsRenderer. We fall back to template sources, if they exist,
@@ -142,6 +149,7 @@ export const useInitialSources = (defaultSources: ProjectSources) => {
     isViewingExemplar,
     labInitialSources,
     exemplarSource,
+    isPredictLevel,
   ]);
 
   return {


### PR DESCRIPTION
A case came up where a curriculum writer had a level set up, loaded the level, then went and changed the level to be a predict level. After the level was loaded once, we created a project for it in S3, and then once it was a predict level it continued to load that project. That meant that when edits were made to the predict level start sources, they didn't show up. Predict levels are not editable and version history is disabled, which made it hard for the level to be reset to the actual start code.

Predict levels should never try to load sources from the server, because we always want to use the start code. This change makes that explicit. The situation of having a project is unlikely (you have to load the level while it's not a predict level), but since version history is disabled on predict levels it's worth making this change. 

## Links

- [slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1738101477384469)
- jira ticket: [CT-985](https://codedotorg.atlassian.net/browse/CT-985)


## Testing story
Tested locally that predict levels still work as expected, and if you have progress on a level and it's converted to a predict level, you will see the start code when loading the level.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
