### PR TITLE
Add link back to parent level(s) in Lab2 extra links

### DIFF
--- a/apps/src/lab2/types.ts
+++ b/apps/src/lab2/types.ts
@@ -327,10 +327,8 @@ export interface ExtraLinksLevelData {
   can_clone: boolean;
   can_delete: boolean;
   level_name: string;
-  script_level_path_links: {
-    script: string;
-    path: string;
-  }[];
+  script_level_path_links: ScriptLevelPathLink[];
+  parent_level_path_links: ParentLevelPathLink[];
   is_standalone_project: boolean;
 }
 export interface ExtraLinksProjectData {
@@ -351,4 +349,16 @@ export interface ProjectVersion {
   versionId: string;
   lastModified: string;
   isLatest: boolean;
+}
+
+export interface ScriptLevelPathLink {
+  script: string;
+  path: string;
+}
+
+export interface ParentLevelPathLink {
+  level_name: string;
+  path: string;
+  kind: string;
+  position: string;
 }

--- a/apps/src/lab2/views/ExtraLinksModal.tsx
+++ b/apps/src/lab2/views/ExtraLinksModal.tsx
@@ -8,7 +8,12 @@ import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import * as utils from '@cdo/apps/utils';
 import {FeaturedProjectStatus} from '@cdo/generated-scripts/sharedConstants';
 
-import {ExtraLinksLevelData, ExtraLinksProjectData} from '../types';
+import {
+  ExtraLinksLevelData,
+  ExtraLinksProjectData,
+  ParentLevelPathLink,
+  ScriptLevelPathLink,
+} from '../types';
 
 import moduleStyles from './extra-links.module.scss';
 
@@ -191,6 +196,9 @@ const ExtraLinksModal: React.FunctionComponent<ExtraLinksModalProps> = ({
       />
       <ScriptLevelPathLinks
         scriptLevelPathLinks={levelLinkData.script_level_path_links}
+      />
+      <ParentLevelPathLinks
+        parentLevelPathLinks={levelLinkData.parent_level_path_links}
       />
       <ProjectLinkData
         isStandaloneProject={isStandaloneProject}
@@ -436,10 +444,7 @@ const ProjectLinkData: React.FunctionComponent<ProjectLinkDataProps> = ({
 };
 
 interface ScriptLevelPathLinksProps {
-  scriptLevelPathLinks?: {
-    script: string;
-    path: string;
-  }[];
+  scriptLevelPathLinks?: ScriptLevelPathLink[];
 }
 
 const ScriptLevelPathLinks: React.FunctionComponent<
@@ -458,6 +463,34 @@ const ScriptLevelPathLinks: React.FunctionComponent<
           <li key={link.path}>
             <a href={'/s/' + link.script}>{link.script}</a> as{' '}
             <a href={link.path}>{link.path}</a>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+interface ParentLevelPathLinksProps {
+  parentLevelPathLinks?: ParentLevelPathLink[];
+}
+
+const ParentLevelPathLinks: React.FunctionComponent<
+  ParentLevelPathLinksProps
+> = ({parentLevelPathLinks}) => {
+  if (!parentLevelPathLinks) {
+    return null;
+  }
+  return (
+    <>
+      <StrongText>
+        This level is in {Object.entries(parentLevelPathLinks).length} other
+        levels:
+      </StrongText>
+      <ul>
+        {parentLevelPathLinks.map(link => (
+          <li key={link.path}>
+            {link.kind} in <a href={link.path}>{link.level_name}</a> (position{' '}
+            {link.position})
           </li>
         ))}
       </ul>

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -591,10 +591,20 @@ class LevelsController < ApplicationController
         path: script_level_path
       }
     end
+
+    parent_level_path_links = []
+    @level.levels_parent_levels&.each do |levels_parent_level|
+      parent_level_path_links << {
+        level_name: levels_parent_level.parent_level.name,
+        path: level_url(levels_parent_level.parent_level),
+        kind: levels_parent_level.kind,
+        position: levels_parent_level.position
+      }
+    end
     # TODO: Not present here, but present in original extra links. Some of these can be handled on the client side.
     # Anything project-specific should be handled via a separate API, as this controller has no context for projects.
-    # Gamelab show animation json, list contained levels, Blockly start/toolbox/etc, Blockly helpers, list of parent
-    # levels, all project validator links (should be handled elsewhere), abuse handlers (should be handled elsewhere).
+    # Gamelab show animation json, list contained levels, Blockly start/toolbox/etc, Blockly helpers, are not included yet
+    # as they are not needed yet.
 
     render json: {
       links: links,
@@ -602,6 +612,7 @@ class LevelsController < ApplicationController
       can_delete: can?(:delete, @level),
       level_name: @level.name,
       script_level_path_links: script_level_path_links,
+      parent_level_path_links: parent_level_path_links
     }
   end
 

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -603,8 +603,7 @@ class LevelsController < ApplicationController
     end
     # TODO: Not present here, but present in original extra links. Some of these can be handled on the client side.
     # Anything project-specific should be handled via a separate API, as this controller has no context for projects.
-    # Gamelab show animation json, list contained levels, Blockly start/toolbox/etc, Blockly helpers, are not included yet
-    # as they are not needed yet.
+    # Gamelab show animation json, list contained levels, Blockly helpers, are not included yet as they are not needed yet.
 
     render json: {
       links: links,


### PR DESCRIPTION
The original extra links has a list of the parent levels for the current level. This adds that list to the lab2 extra links box.

### Level with a parent
![Screenshot 2025-01-29 at 2 58 59 PM](https://github.com/user-attachments/assets/8209a6df-619e-42a4-97fb-1b34cabbf5ef)


### Level without a parent
![Screenshot 2025-01-29 at 2 58 41 PM](https://github.com/user-attachments/assets/edb8968f-9738-4af7-8e3d-49f8a08ec32d)

### Old version
![Screenshot 2025-01-29 at 2 59 29 PM](https://github.com/user-attachments/assets/d4fc8509-bcad-47c5-84d8-0ee167687762)


## Links
- jira ticket: [CT-988](https://codedotorg.atlassian.net/browse/CT-988)


## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
