### PR TITLE
Revert "Speculative fix for flaky flappydrag UI test"

### DIFF
--- a/dashboard/test/ui/features/star_labs/flappydrag.feature
+++ b/dashboard/test/ui/features/star_labs/flappydrag.feature
@@ -6,6 +6,6 @@ Scenario: Connect two blocks from toolbox
   And I dismiss the login reminder
   And I wait to see ".blocklySvg"
   And I drag block "flap" to block "whenClick"
-  And I drag block "playSound" to block "flap" plus offset 0, 60
+  And I drag block "playSound" to block "flap"
   And I wait for 1 seconds
   Then block "playSound" is child of block "flap"


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#63569

Offset is too large for iphone/ipad. Will do more testing to figure out the best value for offset and then re-try.
