### PR TITLE
chore(marketing): update Heading component thumbnail image

### DIFF
--- a/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
@@ -6,7 +6,7 @@ export const HeadingContentfulComponentDefinition: ComponentDefinition = {
   name: 'Heading',
   category: 'Typography',
   thumbnailUrl:
-    'https://images.ctfassets.net/90t6bu6vlf76/LHRmOBd4IWYZuWScbJG3i/4fb4414e967bbca7aedd303d9409f03e/component_heading_thumbnail.png',
+    'https://images.ctfassets.net/90t6bu6vlf76/LHRmOBd4IWYZuWScbJG3i/0442e38966e91c0e2aca88fdb2b217ad/component_divider_thumbnail.png',
   tooltip: {
     description:
       'Use a heading to introduce a section or key content. Choose from different levels to maintain a clear content hierarchy.',


### PR DESCRIPTION
Updates the thumbnail image on the Heading component in Experiences on Contentful. I swapped the asset in Contentful and updated the url here. 

| Before | After |
| ---- | ---- |
| <img width="257" alt="Screenshot 2025-01-29 at 3 10 10 PM" src="https://github.com/user-attachments/assets/97dbdb2b-a3c2-488c-8dd5-a257c46d81f1" /> | <img width="257" alt="After" src="https://github.com/user-attachments/assets/6ac3bea3-50a9-40c9-8736-66e3bf834b12" /> |