### PR TITLE
AI Chat: don't show chat history tab for unassigned student

### DIFF
--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -50,28 +50,26 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
     state => state.aichat
   );
   const isUserTeacher = useAppSelector(state => state.currentUser.isTeacher);
-  const viewAsUserId = useAppSelector(state => state.progress.viewAsUserId);
-  const currentLevelId = useAppSelector(state => state.progress.currentLevelId);
   const visibleItems = useSelector(selectAllVisibleMessages);
-
-  const students = useAppSelector(
-    state => state.teacherSections.selectedStudents
-  );
+  const selectedStudent = useAppSelector(({teacherSections, progress}) => {
+    const students = teacherSections.selectedStudents;
+    if (progress.viewAsUserId && progress.currentLevelId) {
+      return Object.values(students).find(
+        student => student.id === progress.viewAsUserId
+      );
+    }
+  });
 
   const dispatch = useAppDispatch();
 
-  const selectedStudentName = useMemo(() => {
-    if (viewAsUserId && currentLevelId) {
-      const selectedStudent = Object.values(students).find(
-        student => student.id === viewAsUserId
-      );
-      if (selectedStudent) {
-        dispatch(fetchStudentChatHistory(selectedStudent.id));
-        return getShortName(selectedStudent.name);
-      }
+  useEffect(() => {
+    if (selectedStudent) {
+      dispatch(fetchStudentChatHistory(selectedStudent.id));
     }
-    return null;
-  }, [viewAsUserId, students, dispatch, currentLevelId]);
+  }, [selectedStudent, dispatch]);
+
+  const selectedStudentName =
+    selectedStudent && getShortName(selectedStudent.name);
 
   // Teacher user is able to interact with chatbot.
   const canChatWithModel = useMemo(
@@ -93,12 +91,12 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
 
   useEffect(() => {
     // If we are viewing as a student, default to the student chat history tab if tab is not yet selected.
-    if (viewAsUserId && !selectedTab) {
+    if (selectedStudent && !selectedTab) {
       setSelectedTab(WorkspaceTeacherViewTab.STUDENT_CHAT_HISTORY);
-    } else if (!viewAsUserId) {
+    } else if (!selectedStudent) {
       setSelectedTab(null);
     }
-  }, [viewAsUserId, selectedTab]);
+  }, [selectedStudent, selectedTab]);
 
   const iconValue: FontAwesomeV6IconProps = {
     iconName: 'lock',
@@ -175,7 +173,7 @@ const ChatWorkspace: React.FunctionComponent<ChatWorkspaceProps> = ({
   return (
     <div id="chat-workspace-area" className={moduleStyles.chatWorkspace}>
       {ChatModal && <ChatModal onClose={onCloseModal} />}
-      {viewAsUserId ? (
+      {selectedStudent ? (
         <Tabs {...tabArgs} />
       ) : (
         <ChatEventsList events={visibleItems} />


### PR DESCRIPTION
Fast follow to https://github.com/code-dot-org/code-dot-org/pull/63555. While testing, I noticed that if you manually change the view as user ID in the URL to a student not in your section, you'll still see the chat history tab. We don't actually fetch the chat history for this student because we filter down to only valid students in the teacher's section, but we still show the tab because `viewAsUserId` is not null. I refactored this a bit so that we filter down to the correct student first, and then use that to drive the rest of the UI.

Before - chat history tab shows up with an empty name (hence the `'s chat history`)

<img width="1512" alt="Screenshot 2025-01-29 at 3 47 36 PM" src="https://github.com/user-attachments/assets/e6236ad8-9886-444a-9028-3bb3e98a5323" />


After (no chat history tab)

<img width="1512" alt="Screenshot 2025-01-29 at 3 42 23 PM" src="https://github.com/user-attachments/assets/ca840ff6-50bc-465d-b563-b35d1cec527c" />

## Testing story

Tested locally on levels + sublevels.