### PR TITLE
[Play Lab] generate code for the whole block stack

### DIFF
--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -3530,7 +3530,7 @@ exports.install = function (blockly, blockInstallOptions) {
     );
 
     var nextBlock = this.nextConnection && this.nextConnection.targetBlock();
-    var nextCode = Blockly.JavaScript.blockToCode(nextBlock, true);
+    var nextCode = Blockly.JavaScript.blockToCode(nextBlock);
     nextCode = Blockly.Generator.prefixLines(
       `${varName} = value;\n${nextCode}`,
       '  '


### PR DESCRIPTION
A user reported a bug following the Play Lab migration to Google Blockly:
> In play lab, there was a change very recently (like last week) that changed the look of the “if/else” code. Unfortunately it also changed something that doesn't allow it to exit the “if/else". I doesn't move on to the next line of code after the if/else. This just worked last week before the aesthetic change was made. I attached a picture to show what I am talking about.
![image](https://github.com/user-attachments/assets/9c788932-3f60-4362-b75a-5ee2747075be)

In the program above, the actor never moves 200 over, 200 down, nor does anything else below this point happen.

This was tricky to root cause but easy to fix. The issue is actually related to the `studio_ask` block and not the `controls_if` block. The block's generator function gets the code for its next block with `Blockly.JavaScript.blockToCode()`, but the signatures of this method differ between Google and CDO. This is explained in the [CDO Blockly wrapper](https://github.com/code-dot-org/code-dot-org/blob/mike/ask-generator/apps/src/blockly/cdoBlocklyWrapper.js#L221-L227):
```
  // The second argument to Google Blockly's blockToCode specifies whether to
  // generate code for the whole block stack or just the single block. The
  // second argument to Cdo Blockly's blockToCode specifies whether to generate
  // code for hidden blocks. However, across all apps code, opt_showHidden is
  // always true. So we can just ignore the second argument and pass true to Cdo
  // Blockly, which allows us to change the usage across apps code to treat the
  // second argument as opt_thisOnly rather than opt_showHidden.
```

What this means is that the CDO Blockly Wrapper was already ignoring the second argument, but Google Blockly was erroneously interpreting as a flag to just generate code for the single block and not the whole stack. By removing this argument, Google Blockly will generate code for the whole stack.

<img width="1121" alt="image" src="https://github.com/user-attachments/assets/01f19196-2dbe-4554-9971-b8f735932a8d" />


## Links
https://codeorg.zendesk.com/agent/tickets/525479

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
