### PR TITLE
Revert "Revert "Updating toggles to be screen reader accessible""

### DIFF
--- a/apps/src/templates/ToggleButton.jsx
+++ b/apps/src/templates/ToggleButton.jsx
@@ -24,6 +24,8 @@ class ToggleButton extends Component {
     return (
       <button
         type="button"
+        role="tab"
+        aria-selected={String(this.props.active)}
         id={this.props.id}
         style={this.getStyle()}
         className={'no-outline ' + (this.props.className || '')}

--- a/apps/src/templates/ToggleGroup.jsx
+++ b/apps/src/templates/ToggleGroup.jsx
@@ -49,7 +49,11 @@ class ToggleGroup extends Component {
       ? styles.flexButtonReverse
       : flex && styles.flexButtons;
 
-    return <span style={spanStyle}>{this.renderChildren()}</span>;
+    return (
+      <div role="tablist" style={spanStyle}>
+        {this.renderChildren()}
+      </div>
+    );
   }
 
   renderChildren() {

--- a/apps/src/templates/ToggleGroup.jsx
+++ b/apps/src/templates/ToggleGroup.jsx
@@ -50,9 +50,9 @@ class ToggleGroup extends Component {
       : flex && styles.flexButtons;
 
     return (
-      <div role="tablist" style={spanStyle}>
+      <span role="tablist" style={spanStyle}>
         {this.renderChildren()}
-      </div>
+      </span>
     );
   }
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#63583

I'm able to verify locally that the span moves the toggle back to the same line in the lesson of interest:
<img width="1051" alt="Screenshot 2025-01-30 at 9 35 44 AM" src="https://github.com/user-attachments/assets/8db8cdf4-5407-4f8c-ab19-761735c6165f" />

This was the failing eyes test:
![Screenshot 2025-01-29 at 3 47 18 PM](https://github.com/user-attachments/assets/6459b294-5a52-4b7e-9762-171bfb19965e)

