### PR TITLE
fix(workshops): session start and end times are the same across timezones

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -279,6 +279,7 @@
     "messageformat": "2.3.0",
     "ml-knn": "^3.0.0",
     "moment": "^2.29.4",
+    "moment-timezone": "^0.5.47",
     "object-fit-images": "^3.2.3",
     "papaparse": "^5.4.1",
     "path-browserify": "^1.0.1",

--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_time.jsx
@@ -1,7 +1,7 @@
 /**
  * Displays nicely-formatted session time for a workshop.
  */
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -12,14 +12,17 @@ export default class SessionTime extends React.Component {
     session: PropTypes.shape({
       start: PropTypes.string.isRequired,
       end: PropTypes.string.isRequired,
+      time_zone: PropTypes.string,
     }).isRequired,
   };
 
   render() {
+    const {session} = this.props;
+    const tz = session.time_zone || 'UTC';
     const formattedTime =
-      moment.utc(this.props.session.start).format(DATETIME_FORMAT) +
+      moment.utc(session.start).tz(tz).format(DATETIME_FORMAT) +
       '-' +
-      moment.utc(this.props.session.end).format(TIME_FORMAT);
+      moment.utc(session.end).tz(tz).format(TIME_FORMAT);
 
     return <div>{formattedTime}</div>;
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -274,12 +274,13 @@ export class WorkshopForm extends React.Component {
         return {
           id: session.id,
           session_format: session.format,
-          start: moment
-            .utc(session.date + ' ' + session.startTime, DATETIME_FORMAT)
-            .format(),
-          end: moment
-            .utc(session.date + ' ' + session.endTime, DATETIME_FORMAT)
-            .format(),
+          start: moment(`${session.date} ${session.startTime}`, DATETIME_FORMAT)
+            .toDate()
+            .toISOString(),
+          end: moment(`${session.date} ${session.endTime}`, DATETIME_FORMAT)
+            .toDate()
+            .toISOString(),
+          time_zone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         };
       })
       .concat(

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -312,9 +312,13 @@ export class WorkshopForm extends React.Component {
   }
 
   get workshopTimezone() {
-    const sessionTz =
-      this.state.sessions?.[0]?.timeZone ??
-      Intl.DateTimeFormat().resolvedOptions().timeZone;
+    // a new session is created using the user's local timezone
+    let sessionTz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    const editing = Boolean(this.props.workshop);
+    if (editing) {
+      // handle legacy sessions stored without timezone offset
+      sessionTz = this.props.workshop.sessions?.[0]?.time_zone || 'UTC';
+    }
     return moment.tz(sessionTz).format('z');
   }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -262,15 +262,15 @@ export class WorkshopForm extends React.Component {
         format: session.session_format,
         date: moment
           .utc(session.start)
-          .tz(session.time_zone)
+          .tz(session.time_zone || 'UTC')
           .format(DATE_FORMAT),
         startTime: moment
           .utc(session.start)
-          .tz(session.time_zone)
+          .tz(session.time_zone || 'UTC')
           .format(TIME_FORMAT),
         endTime: moment
           .utc(session.end)
-          .tz(session.time_zone)
+          .tz(session.time_zone || 'UTC')
           .format(TIME_FORMAT),
         timeZone: session.time_zone,
       };

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -260,9 +260,9 @@ export class WorkshopForm extends React.Component {
       return {
         id: session.id,
         format: session.session_format,
-        date: moment.utc(session.start).format(DATE_FORMAT),
-        startTime: moment.utc(session.start).format(TIME_FORMAT),
-        endTime: moment.utc(session.end).format(TIME_FORMAT),
+        date: moment.utc(session.start).local().format(DATE_FORMAT),
+        startTime: moment.utc(session.start).local().format(TIME_FORMAT),
+        endTime: moment.utc(session.end).local().format(TIME_FORMAT),
       };
     });
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -4,7 +4,7 @@
 import Checkbox from '@code-dot-org/component-library/checkbox';
 import $ from 'jquery';
 import _ from 'lodash';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 /* eslint-disable no-restricted-imports */
@@ -260,9 +260,19 @@ export class WorkshopForm extends React.Component {
       return {
         id: session.id,
         format: session.session_format,
-        date: moment.utc(session.start).local().format(DATE_FORMAT),
-        startTime: moment.utc(session.start).local().format(TIME_FORMAT),
-        endTime: moment.utc(session.end).local().format(TIME_FORMAT),
+        date: moment
+          .utc(session.start)
+          .tz(session.time_zone)
+          .format(DATE_FORMAT),
+        startTime: moment
+          .utc(session.start)
+          .tz(session.time_zone)
+          .format(TIME_FORMAT),
+        endTime: moment
+          .utc(session.end)
+          .tz(session.time_zone)
+          .format(TIME_FORMAT),
+        timeZone: session.time_zone,
       };
     });
   }
@@ -271,16 +281,24 @@ export class WorkshopForm extends React.Component {
   prepareSessionsForApi(sessions, destroyedSessions) {
     return sessions
       .map(session => {
+        const timeZone =
+          session.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
         return {
           id: session.id,
           session_format: session.format,
-          start: moment(`${session.date} ${session.startTime}`, DATETIME_FORMAT)
-            .toDate()
+          start: moment
+            .tz(
+              `${session.date} ${session.startTime}`,
+              DATETIME_FORMAT,
+              timeZone
+            )
+            .utc()
             .toISOString(),
-          end: moment(`${session.date} ${session.endTime}`, DATETIME_FORMAT)
-            .toDate()
+          end: moment
+            .tz(`${session.date} ${session.endTime}`, DATETIME_FORMAT, timeZone)
+            .utc()
             .toISOString(),
-          time_zone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          time_zone: timeZone,
         };
       })
       .concat(
@@ -291,6 +309,13 @@ export class WorkshopForm extends React.Component {
           };
         })
       );
+  }
+
+  get workshopTimezone() {
+    const sessionTz =
+      this.state.sessions?.[0]?.timeZone ??
+      Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return moment.tz(sessionTz).format('z');
   }
 
   // Convert from [id, name, email] to an array of ids.
@@ -1121,7 +1146,7 @@ export class WorkshopForm extends React.Component {
       <Grid>
         <form>
           <Row>
-            <Col sm={4}>All workshop times are local:</Col>
+            <Col sm={4}>All workshop times are {this.workshopTimezone}:</Col>
           </Row>
           <SessionListFormPart
             sessions={this.state.sessions}

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -1,5 +1,6 @@
 import {assert, expect} from 'chai'; // eslint-disable-line no-restricted-imports
 import {mount} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import moment from 'moment-timezone';
 import React from 'react';
 import {FormControl} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import '../workshopFactory';
@@ -164,6 +165,73 @@ describe('WorkshopForm test', () => {
     // defaults to first session format option
     expect(sessionFormatDropdown.props().value).to.equal(
       PdSessionFormats[0].value
+    );
+  });
+
+  it("new workshop sessions are created with the user's local timezone", () => {
+    const easternTz = 'America/New_York';
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+      .mockReturnValueOnce({
+        timeZone: easternTz,
+      });
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <WorkshopForm
+            permission={new Permission([WorkshopAdmin])}
+            facilitatorCourses={[]}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const tzAbbreviation = moment.tz(easternTz).format('z');
+
+    expect(wrapper.find('WorkshopForm').find('Col').first().text()).to.equal(
+      `All workshop times are ${tzAbbreviation}:`
+    );
+  });
+
+  it('edits to workshop sessions are done in the original timezone', () => {
+    const easternTz = 'America/New_York';
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+      .mockReturnValueOnce({
+        timeZone: easternTz,
+      });
+
+    const workshop = Factory.build('workshop');
+    const [firstSession] = workshop.sessions;
+    const sessionTz = firstSession.time_zone; // America/Denver in workshop factory
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <WorkshopForm
+            permission={new Permission([WorkshopAdmin])}
+            facilitatorCourses={[]}
+            workshop={workshop}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const tzAbbreviation = moment.tz(sessionTz).format('z');
+
+    const workshopForm = wrapper.find('WorkshopForm');
+
+    const [formattedSessionData] = workshopForm
+      .instance()
+      .prepareSessionsForForm(workshop.sessions);
+
+    expect(formattedSessionData.startTime).to.equal('9:00am');
+    expect(formattedSessionData.endTime).to.equal('5:00pm');
+    expect(formattedSessionData.date).to.equal('2016-07-01');
+
+    expect(workshopForm.find('Col').first().text()).to.equal(
+      `All workshop times are ${tzAbbreviation}:`
     );
   });
 

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -235,6 +235,54 @@ describe('WorkshopForm test', () => {
     );
   });
 
+  it('edits to legacy workshop sessions without a timezone are done in UTC', () => {
+    const easternTz = 'America/New_York';
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+      .mockReturnValueOnce({
+        timeZone: easternTz,
+      });
+
+    const workshop = Factory.build('workshop');
+    const [firstSession] = workshop.sessions;
+    // remove time_zone and reset session time to 9-5 utc, like legacy sessions are in the db
+    firstSession.time_zone = null;
+    const start = new Date(firstSession.start);
+    const end = new Date(firstSession.end);
+    start.setHours(9);
+    end.setHours(17);
+    firstSession.start = start.toISOString();
+    firstSession.end = end.toISOString();
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <WorkshopForm
+            permission={new Permission([WorkshopAdmin])}
+            facilitatorCourses={[]}
+            workshop={workshop}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const tzAbbreviation = 'UTC';
+
+    const workshopForm = wrapper.find('WorkshopForm');
+
+    const [formattedSessionData] = workshopForm
+      .instance()
+      .prepareSessionsForForm(workshop.sessions);
+
+    expect(formattedSessionData.startTime).to.equal('9:00am');
+    expect(formattedSessionData.endTime).to.equal('5:00pm');
+    expect(formattedSessionData.date).to.equal('2016-07-01');
+
+    expect(workshopForm.find('Col').first().text()).to.equal(
+      `All workshop times are ${tzAbbreviation}:`
+    );
+  });
+
   it('edits form and can save', () => {
     const workshop = Factory.build('virtual workshop');
     const server = sinon.fakeServer.create();

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
@@ -12,7 +12,8 @@ import {
  */
 
 // For testing average middle of the year dates.
-const middleOfYearFakeToday = new Date(2016, 6, 1); // July 1st, 2016
+const middleOfYearFakeToday = new Date(2016, 6, 1, 15); // July 1st, 2016
+const middleOfYearFakeTodayEnd = new Date(2016, 6, 1, 23); // July 1st, 2016
 // For testing cases when wrapping around from December of one year to January of the next.
 const endOfYearFakeToday = new Date(2016, 12, 30); // December 30th, 2016
 
@@ -113,7 +114,8 @@ Factory.define('session')
   .sequence('id')
   .attr('code', 'TEST')
   .attr('start', middleOfYearFakeToday.toISOString())
-  .attr('end', middleOfYearFakeToday.toISOString())
+  .attr('end', middleOfYearFakeTodayEnd.toISOString())
+  .attr('time_zone', 'America/Denver')
   .attr('attendance_count', 0)
   .attr('session_format', PdSessionFormats[0].value)
   .attr('show_link?', false);

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -10303,6 +10303,7 @@ __metadata:
     mocha: ^10.6.0
     mock-firmata: 0.2.0
     moment: ^2.29.4
+    moment-timezone: ^0.5.47
     object-fit-images: ^3.2.3
     papaparse: ^5.4.1
     path-browserify: ^1.0.1
@@ -20866,6 +20867,15 @@ es6-shim@latest:
   dependencies:
     board-io: ^3.0.5
   checksum: b6b95409b02f3e4d2248d34e80b1175870f6bfb34f4bd3764c31fef6e40915a1c5c7452d8fbd84731015721053ed37745953cc3601a377f1a100050a5332d103
+  languageName: node
+  linkType: hard
+
+"moment-timezone@npm:^0.5.47":
+  version: 0.5.47
+  resolution: "moment-timezone@npm:0.5.47"
+  dependencies:
+    moment: ^2.29.4
+  checksum: 6288a9d653b902bd913f1dca24426ad71e5a98cd98684139e3ed74e635289e6acde62450735364fd3758d6ac836a1eaab859c08d0252587a377192f25f0bda5a
   languageName: node
   linkType: hard
 

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -345,7 +345,7 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
       :virtual,
       :suppress_email,
       :third_party_provider,
-      {sessions_attributes: [:id, :start, :end, :session_format, :_destroy]},
+      {sessions_attributes: [:id, :start, :end, :time_zone, :session_format, :_destroy]},
       :module,
       :participant_group_type
     ]

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -76,7 +76,7 @@ class Pd::Session < ApplicationRecord
 
   def tz_abbreviation
     return '' if time_zone.blank?
-    ActiveSupport::TimeZone[time_zone || 'UTC'].tzinfo.current_period.abbreviation.to_s
+    ActiveSupport::TimeZone[time_zone].tzinfo.current_period.abbreviation.to_s
   end
 
   def formatted_date_with_start_and_end_times

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -38,7 +38,7 @@ class Pd::Session < ApplicationRecord
 
   def starts_and_ends_on_the_same_day
     return unless start && self.end
-    unless start.to_datetime.to_date == self.end.to_datetime.to_date
+    unless start_time.to_date == end_time.to_date
       errors.add(:end, 'must occur on the same day as the start.')
     end
   end

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -32,6 +32,8 @@ class Pd::Session < ApplicationRecord
 
   before_validation :set_default_time_zone
 
+  before_update :prevent_time_zone_change
+
   validates_presence_of :start, :end
   validate :starts_and_ends_on_the_same_day
   validate :starts_before_ends
@@ -52,6 +54,12 @@ class Pd::Session < ApplicationRecord
 
   def set_default_time_zone
     self.time_zone = time_zone.present? && ActiveSupport::TimeZone[time_zone].present? ? time_zone : 'UTC'
+  end
+
+  def prevent_time_zone_change
+    if time_zone_changed?
+      self.time_zone = time_zone_was # Revert to the original time_zone
+    end
   end
 
   def start_time

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -30,6 +30,8 @@ class Pd::Session < ApplicationRecord
   belongs_to :workshop, class_name: 'Pd::Workshop', foreign_key: 'pd_workshop_id', optional: true
   has_many :attendances, class_name: 'Pd::Attendance', foreign_key: 'pd_session_id', dependent: :destroy
 
+  before_validation :set_default_time_zone
+
   validates_presence_of :start, :end
   validate :starts_and_ends_on_the_same_day
   validate :starts_before_ends
@@ -46,6 +48,10 @@ class Pd::Session < ApplicationRecord
     unless start < self.end
       errors.add(:end, 'must occur after the start.')
     end
+  end
+
+  def set_default_time_zone
+    self.time_zone = time_zone.present? && ActiveSupport::TimeZone[time_zone].present? ? time_zone : 'UTC'
   end
 
   def formatted_date

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -63,14 +63,19 @@ class Pd::Session < ApplicationRecord
   end
 
   def formatted_date
-    start.to_date.iso8601
+    start_time.to_date.iso8601
+  end
+
+  def tz_abbreviation
+    return '' if time_zone.blank?
+    ActiveSupport::TimeZone[time_zone || 'UTC'].tzinfo.current_period.abbreviation.to_s
   end
 
   def formatted_date_with_start_and_end_times
-    start_time = start.strftime('%l:%M%P').strip
-    end_time = self.end.strftime('%l:%M%P').strip
+    formatted_start = start_time.strftime('%l:%M%P').strip
+    formatted_end = end_time.strftime('%l:%M%P').strip
 
-    "#{formatted_date}, #{start_time}-#{end_time}"
+    "#{formatted_date}, #{formatted_start}-#{formatted_end} #{tz_abbreviation}".strip
   end
 
   def session_info_for_calendar
@@ -82,14 +87,14 @@ class Pd::Session < ApplicationRecord
   end
 
   def start_date_us_format
-    start.strftime('%b %d %Y').strip
+    start_time.strftime('%b %d %Y').strip
   end
 
   def start_date_with_start_and_end_times_us_format
-    start_time = start.strftime('%l:%M%P').strip
-    end_time = self.end.strftime('%l:%M%P').strip
+    formatted_start = start_time.strftime('%l:%M%P').strip
+    formatted_end = end_time.strftime('%l:%M%P').strip
 
-    "#{start_date_us_format}, #{start_time} - #{end_time}"
+    "#{start_date_us_format}, #{formatted_start} - #{formatted_end} #{tz_abbreviation}".strip
   end
 
   def hours

--- a/dashboard/app/models/pd/session.rb
+++ b/dashboard/app/models/pd/session.rb
@@ -54,6 +54,14 @@ class Pd::Session < ApplicationRecord
     self.time_zone = time_zone.present? && ActiveSupport::TimeZone[time_zone].present? ? time_zone : 'UTC'
   end
 
+  def start_time
+    start.in_time_zone(time_zone || 'UTC')
+  end
+
+  def end_time
+    self.end.in_time_zone(time_zone || 'UTC')
+  end
+
   def formatted_date
     start.to_date.iso8601
   end

--- a/dashboard/app/serializers/api/v1/pd/session_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/session_serializer.rb
@@ -15,7 +15,7 @@
 #
 
 class Api::V1::Pd::SessionSerializer < ActiveModel::Serializer
-  attributes :id, :start, :end, :code, :session_format, :show_link?, :attendance_count
+  attributes :id, :start, :end, :time_zone, :code, :session_format, :show_link?, :attendance_count
 
   def attendance_count
     Pd::Attendance.where(session: object).count

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -59,8 +59,7 @@ FactoryBot.define do
       duration_hours {6}
     end
     association :workshop, factory: :workshop
-    time_zone {'America/Denver'}
-    start {Time.current.in_time_zone(time_zone).change(hour: 9)}
+    start {Time.zone.today + 9.hours}
     self.end {start + duration_hours.hours}
     session_format {Pd::SharedWorkshopConstants::PD_SESSION_FORMATS.first[:value]}
 

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -59,7 +59,8 @@ FactoryBot.define do
       duration_hours {6}
     end
     association :workshop, factory: :workshop
-    start {Time.zone.today + 9.hours}
+    time_zone {'America/Denver'}
+    start {Time.current.in_time_zone(time_zone).change(hour: 9)}
     self.end {start + duration_hours.hours}
     session_format {Pd::SharedWorkshopConstants::PD_SESSION_FORMATS.first[:value]}
 

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -241,7 +241,7 @@ FactoryBot.define do
       sessions_from do
         Date.new(
           Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR.split('-').first.to_i, 7, 4
-        )
+        ).in_time_zone('America/Denver')
       end
 
       trait :csp do

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -241,7 +241,7 @@ FactoryBot.define do
       sessions_from do
         Date.new(
           Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR.split('-').first.to_i, 7, 4
-        ).in_time_zone('America/Denver')
+        )
       end
 
       trait :csp do

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -30,6 +30,11 @@ class Pd::SessionTest < ActiveSupport::TestCase
     assert_equal 'America/Denver', session.time_zone
   end
 
+  test 'bad time_zone value results in UTC' do
+    session = create(:pd_session, time_zone: 'Bad/Zone')
+    assert_equal 'UTC', session.time_zone
+  end
+
   test 'formatted_date' do
     session = build :pd_session, start: DateTime.new(2016, 3, 1, 9).in_time_zone
     assert_equal '2016-03-01', session.formatted_date

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -30,8 +30,8 @@ class Pd::SessionTest < ActiveSupport::TestCase
   test 'formatted_date_with_start_and_end_times' do
     session = create(
       :pd_session,
-      start: DateTime.new(2016, 3, 1, 9).in_time_zone,
-      end: DateTime.new(2016, 3, 1, 17).in_time_zone
+      start: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 9),
+      end: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 17)
     )
 
     assert_equal '2016-03-01, 9:00am-5:00pm MST', session.formatted_date_with_start_and_end_times
@@ -90,12 +90,12 @@ class Pd::SessionTest < ActiveSupport::TestCase
     assert session_not_started.too_soon_for_attendance?
     refute session_not_started.too_late_for_attendance?
 
-    session_future = create :pd_session, workshop: workshop_started, start: Time.now + 1.day
+    session_future = create :pd_session, workshop: workshop_started, start: Time.current.in_time_zone('America/Denver') + 1.day
     refute session_future.open_for_attendance?
     assert session_future.too_soon_for_attendance?
     refute session_future.too_late_for_attendance?
 
-    session_past = create :pd_session, workshop: workshop_started, start: Time.now - 1.day, end: Time.now - 23.hours
+    session_past = create :pd_session, workshop: workshop_started, start: Time.current.in_time_zone('America/Denver') - 1.day, end: Time.current.in_time_zone('America/Denver') - 23.hours
     refute session_past.open_for_attendance?
     refute session_past.too_soon_for_attendance?
     assert session_past.too_late_for_attendance?

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -31,8 +31,8 @@ class Pd::SessionTest < ActiveSupport::TestCase
     session = create(
       :pd_session,
       time_zone: 'America/Denver',
-      start: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 9),
-      end: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 17)
+      start: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 9).utc.iso8601,
+      end: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 17).utc.iso8601
     )
 
     assert_equal '2016-03-01, 9:00am-5:00pm MST', session.formatted_date_with_start_and_end_times

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -34,7 +34,7 @@ class Pd::SessionTest < ActiveSupport::TestCase
       end: DateTime.new(2016, 3, 1, 17).in_time_zone
     )
 
-    assert_equal '2016-03-01, 9:00am-5:00pm', session.formatted_date_with_start_and_end_times
+    assert_equal '2016-03-01, 9:00am-5:00pm MST', session.formatted_date_with_start_and_end_times
   end
 
   test 'soft delete' do

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -22,6 +22,14 @@ class Pd::SessionTest < ActiveSupport::TestCase
     assert_equal 'End must occur after the start.', session.errors.full_messages[0]
   end
 
+  test 'prevent_time_zone_change' do
+    session = create(:pd_session, time_zone: 'America/Denver')
+    assert_equal 'America/Denver', session.time_zone
+
+    session.update!(time_zone: 'America/New_York')
+    assert_equal 'America/Denver', session.time_zone
+  end
+
   test 'formatted_date' do
     session = build :pd_session, start: DateTime.new(2016, 3, 1, 9).in_time_zone
     assert_equal '2016-03-01', session.formatted_date

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -30,6 +30,7 @@ class Pd::SessionTest < ActiveSupport::TestCase
   test 'formatted_date_with_start_and_end_times' do
     session = create(
       :pd_session,
+      time_zone: 'America/Denver',
       start: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 9),
       end: Time.current.in_time_zone('America/Denver').change(year: 2016, month: 3, day: 1, hour: 17)
     )
@@ -90,12 +91,12 @@ class Pd::SessionTest < ActiveSupport::TestCase
     assert session_not_started.too_soon_for_attendance?
     refute session_not_started.too_late_for_attendance?
 
-    session_future = create :pd_session, workshop: workshop_started, start: Time.current.in_time_zone('America/Denver') + 1.day
+    session_future = create :pd_session, workshop: workshop_started, start: Time.now + 1.day
     refute session_future.open_for_attendance?
     assert session_future.too_soon_for_attendance?
     refute session_future.too_late_for_attendance?
 
-    session_past = create :pd_session, workshop: workshop_started, start: Time.current.in_time_zone('America/Denver') - 1.day, end: Time.current.in_time_zone('America/Denver') - 23.hours
+    session_past = create :pd_session, workshop: workshop_started, start: Time.now - 1.day, end: Time.now - 23.hours
     refute session_past.open_for_attendance?
     refute session_past.too_soon_for_attendance?
     assert session_past.too_late_for_attendance?

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -51,6 +51,22 @@ class Pd::SessionTest < ActiveSupport::TestCase
     assert_equal '2016-03-01, 9:00am-5:00pm MST', session.formatted_date_with_start_and_end_times
   end
 
+  test 'formatted_date_with_start_and_end_times no time_zone' do
+    session = create(
+      :pd_session,
+      start: Time.current.in_time_zone('UTC').change(year: 2016, month: 3, day: 1, hour: 9).utc.iso8601,
+      end: Time.current.in_time_zone('UTC').change(year: 2016, month: 3, day: 1, hour: 17).utc.iso8601
+    )
+
+    assert_equal 'UTC', session.time_zone
+
+    # override validation on create that defaults new sessions to UTC timezone if not provided
+    # to reproduce a legacy session with no time_zone
+    session.time_zone = nil
+
+    assert_equal '2016-03-01, 9:00am-5:00pm', session.formatted_date_with_start_and_end_times
+  end
+
   test 'soft delete' do
     session = create :pd_session
     attendance = create :pd_attendance, session: session


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This pr ensures the front end api request to create sessions sends the `start` and `end` dates as utc, offset by the user's local timezone.

`moment.utc` assumes the value passed is already in utc, but we need to offset it by the user's local timezone.
```
moment.utc('2025-01-31 09:00:00', 'YYYY-MM-DD HH:mm:ss').format(); 
// 2025-01-31T09:00:00Z

moment.tz('2025-01-31 09:00:00', 'YYYY-MM-DD HH:mm:ss', 'America/Denver').utc().toISOString()
// 2025-01-31T16:00:00.000Z
```

We also need to store the timezone of the user who created the workshop session, as this is needed to add a timezone abbreviation for date formatting happening server side, like for emails. 

After a session is created, the original timezone is always used for any updates to the session. for example, a session originally created in MST will show a label in the form saying `All times are MST`, and a user editing the session from EST will see the same label, and the existing times will be adjusted to the session timezone, not the timezone of the user editing. videos below 👇

creating a new workshop uses the user's local system timezone:

https://github.com/user-attachments/assets/f12319eb-a1d6-4b58-bf67-d67ac9687746

editing an existing session uses the existing session's timezone, defaulting to UTC for backwards compatibility with existing sessions:

https://github.com/user-attachments/assets/26c7d800-32a0-46f0-a669-d84447d1c4ff


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
