### PR TITLE
Add Google Analytics finish sign up event to old sign up flow to unblock marketing

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -9,6 +9,7 @@ import {SELECT_COUNTRY} from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import {SchoolDataInputsContainer} from '@cdo/apps/templates/SchoolDataInputsContainer';
 import experiments from '@cdo/apps/util/experiments';
 import getScriptData from '@cdo/apps/util/getScriptData';
+import trackEvent from '@cdo/apps/util/trackEvent';
 import {NonSchoolOptions} from '@cdo/generated-scripts/sharedConstants';
 
 const TEACHER_ONLY_FIELDS = [
@@ -90,6 +91,8 @@ $(document).ready(() => {
       }
     }
     const sourceString = isLTI ? 'LTI' : '';
+
+    // Log to Statsig and Amplitude
     analyticsReporter.sendEvent(
       EVENTS.SIGN_UP_FINISHED_EVENT,
       {
@@ -101,6 +104,11 @@ $(document).ready(() => {
       },
       PLATFORMS.BOTH
     );
+
+    // Log to Google Analytics
+    trackEvent('sign_up', 'sign_up_success', {
+      value: user_type,
+    });
   });
 
   function cleanSchoolInfo() {


### PR DESCRIPTION
Add Google Analytics finish sign up event to old sign up flow to line up with the new sign up flow so the total numbers between our analytics platforms should hopefully line up better. Currently, if a user signs in with OAuth but they don't have an account then they are sent to the old signup flow, so adding this event will keep the counts more consistent until we can remove that route that allows users to view the old signup flow.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3063)

## Testing story
I wasn't able to quickly test this locally since it would involve OAuth which is difficult to test locally. I figured we want this out sooner rather than later.
