### PR TITLE
[Design2-263] DSCO - Chips component - Use component-library package instead of apps/src/componentLibrary across apps directory

### DIFF
--- a/apps/src/aiComponentLibrary/suggestedPrompt/SuggestedPrompts.tsx
+++ b/apps/src/aiComponentLibrary/suggestedPrompt/SuggestedPrompts.tsx
@@ -1,6 +1,5 @@
+import Chips from '@code-dot-org/component-library/chips';
 import React from 'react';
-
-import Chips from '@cdo/apps/componentLibrary/chips';
 
 import moduleStyles from './suggested-prompt.module.scss';
 

--- a/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
@@ -1,10 +1,10 @@
+import {Chips} from '@code-dot-org/component-library/chips';
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
 import {announcementShape} from '@cdo/apps/code-studio/announcementsRedux';
-import {Chips} from '@cdo/apps/componentLibrary/chips';
 import Link from '@cdo/apps/componentLibrary/link/Link';
 import {
   InstructionType,

--- a/apps/src/templates/sectionsRefresh/SingleSectionSetUp.jsx
+++ b/apps/src/templates/sectionsRefresh/SingleSectionSetUp.jsx
@@ -1,8 +1,8 @@
+import Chips from '@code-dot-org/component-library/chips';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import {queryParams} from '@cdo/apps/code-studio/utils';
-import Chips from '@cdo/apps/componentLibrary/chips';
 import {Heading2} from '@cdo/apps/componentLibrary/typography';
 import {ParticipantAudience} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 import {StudentGradeLevels} from '@cdo/generated-scripts/sharedConstants';

--- a/apps/test/unit/componentLibrary/ChipsTest.tsx
+++ b/apps/test/unit/componentLibrary/ChipsTest.tsx
@@ -1,9 +1,8 @@
+import Chips, {ChipsProps} from '@code-dot-org/component-library/chips';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, {useState} from 'react';
 import '@testing-library/jest-dom';
-
-import Chips, {ChipsProps} from '@cdo/apps/componentLibrary/chips';
 
 const options = [
   {value: 'chip1', label: 'Chip1'},


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [Design2-263] DSCO - Chips component - Use component-library package instead of apps/src/componentLibrary across apps directory

* Chips component -  made /apps directory now use `@code-dot-org/component-library` instance instead of ./apps/src/componentLibrary

This PR only replaces `/apps/src/componentLibrary/chips` usages with `@code-dot-org/component-library/chips` usages. No visual changes are intended by this PR. In case of any regressions feel free to contact me or @stephenliang. In case it'll be urgent - feel free to revert, just please let us know what problem have you encountered.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [Design2-263](https://codedotorg.atlassian.net/browse/DESIGN2-263)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
