### PR TITLE
HoC 2025 - Remove instances of hoc_launch from codebase

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -160,12 +160,6 @@ def main
 
         # Schedule a reminder for the dotd to check Zendesk in 2 hours
         Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 7200, 'Reminder: check <https://codeorg.zendesk.com/agent/filters/44863373|Zendesk>')
-
-        # Check hoc_launch only on successful DTPs, so that we get about 1 reminder per
-        # day to bring staging, test and production to the same hoc_launch after a
-        # hoc_launch change. Note that this will only warn us if test and production
-        # (but not staging) are out of sync.
-        check_hoc_launch
       end
     else
       message = "<b>#{projects}</b> failed to build!" + time_message + log_link
@@ -203,19 +197,6 @@ def main
   # Return the same output and status code that BUILD returned.
   puts log
   status
-end
-
-def check_hoc_launch
-  hoc_launch = DCDO.get('hoc_launch', false)
-  if hoc_launch != CDO.default_hoc_launch
-    # The test machine cannot remember DCDO params, so its hoc_launch is controlled by
-    # CDO.default_hoc_launch.
-    msg = "<!here> #{rack_env} hoc_launch (#{hoc_launch.inspect}) and default_hoc_launch " \
-      "(#{CDO.default_hoc_launch.inspect}) are out of sync. Please update CDO.default_hoc_launch in " \
-      "github, DCDO hoc_launch in staging, and DCDO hoc_launch in production to the same values, so " \
-      "that our staging, test and production environments all show the same version of our site."
-    ChatClient.log msg
-  end
 end
 
 def mark_dtt_green

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -443,7 +443,6 @@ levelbuilder_mode:
 use_local_header_color:
 
 default_hoc_mode: false  # overridden by 'hoc_mode' DCDO param, except in :test
-default_hoc_launch: ''      # overridden by 'hoc_launch' DCDO param, except in :test
 hoc-2024-nov-launch: true # overridden by 'hoc-2024-nov-launch' DCDO param, except in :test
 
 # teacher_application_mode values: 'open', 'closing-soon', 'closed'

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -188,7 +188,6 @@ class HomeController < ApplicationController
       end
 
       @homepage_data[:isTeacher] = true
-      @homepage_data[:hocLaunch] = DCDO.get('hoc_launch', CDO.default_hoc_launch)
       @homepage_data[:joined_student_sections] = current_user&.sections_as_student_participant&.map(&:summarize_without_students)
       @homepage_data[:joined_pl_sections] = current_user&.sections_as_pl_participant&.map(&:summarize_without_students)
       @homepage_data[:announcement] = DCDO.get('announcement_override', nil)


### PR DESCRIPTION
Removes instances of the `hoc_launch` DCDO flag.

## Links
Jira ticket: [ACQ-2901](https://codedotorg.atlassian.net/browse/ACQ-2901)

## Followup 
I'll remove the flag from AWS once we can confirm passing tests and this PR is merged.