### PR TITLE
Codebridge console: add window resize handler

### DIFF
--- a/apps/src/codebridge/Console/Console.tsx
+++ b/apps/src/codebridge/Console/Console.tsx
@@ -110,6 +110,7 @@ const Console: React.FunctionComponent = () => {
     terminal.open(terminalRef.current);
     terminal.onData(onData);
     fitAddon.fit();
+    window.addEventListener('resize', () => fitAddon.fit());
 
     // Right now we are tracking lines from the previous console so we can replay them here.
     // We may be able to avoid this after


### PR DESCRIPTION
The codebridge console wasn't re-fitting itself to its container when the window resized, which could lead to text having unnecessary weird line breaks:
 
<img width="748" alt="Screenshot 2025-01-30 at 3 14 44 PM" src="https://github.com/user-attachments/assets/59c8372a-1b26-473c-a164-aa1d23aaa3ab" />

The fix to this was to add a resize handler and call `fit` when it fires. Now you can resize the window and the console resizes appropriately:

https://github.com/user-attachments/assets/e0fc10d6-8b6c-488d-8f52-b2a1a4b64eeb


## Links
- jira ticket: [CT-1032](https://codedotorg.atlassian.net/browse/CT-1032)


## Testing story
Tested locally



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
