### PR TITLE
Music: fix check for end

### DIFF
--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -186,20 +186,18 @@ const musicSlice = createSlice({
     },
     clearPlaybackEvents: state => {
       state.playbackEvents = [];
-      state.lastMeasure = 0;
     },
     clearOrderedFunctions: state => {
       state.orderedFunctions = [];
     },
-    addPlaybackEvents: (
-      state,
-      action: PayloadAction<{events: PlaybackEvent[]; lastMeasure: number}>
-    ) => {
-      state.playbackEvents.push(...action.payload.events);
-      state.lastMeasure = Math.max(
-        state.lastMeasure,
-        action.payload.lastMeasure
-      );
+    addPlaybackEvents: (state, action: PayloadAction<PlaybackEvent[]>) => {
+      state.playbackEvents.push(...action.payload);
+    },
+    setLastMeasure: (state, action: PayloadAction<number>) => {
+      state.lastMeasure = action.payload;
+    },
+    updateLastMeasure: (state, action: PayloadAction<number>) => {
+      state.lastMeasure = Math.max(state.lastMeasure, action.payload);
     },
     addOrderedFunctions: (
       state,
@@ -330,6 +328,8 @@ export const {
   clearPlaybackEvents,
   clearOrderedFunctions,
   addPlaybackEvents,
+  setLastMeasure,
+  updateLastMeasure,
   addOrderedFunctions,
   setSoundLoadingProgress,
   setStartingPlayheadPosition,

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -55,6 +55,8 @@ import {
   setShowInstructions,
   setInstructionsPosition,
   addPlaybackEvents,
+  setLastMeasure,
+  updateLastMeasure,
   addOrderedFunctions,
   clearPlaybackEvents,
   clearOrderedFunctions,
@@ -109,6 +111,8 @@ class UnconnectedMusicView extends React.Component {
     clearPlaybackEvents: PropTypes.func,
     clearOrderedFunctions: PropTypes.func,
     addPlaybackEvents: PropTypes.func,
+    setLastMeasure: PropTypes.func,
+    updateLastMeasure: PropTypes.func,
     addOrderedFunctions: PropTypes.func,
     currentlyPlayingBlockIds: PropTypes.array,
     setIsLoading: PropTypes.func,
@@ -625,10 +629,8 @@ class UnconnectedMusicView extends React.Component {
     this.sequencer.clear(this.getPlaybackEvents().length);
     this.musicBlocklyWorkspace.executeTrigger(id, triggerStartPosition);
     const playbackEvents = this.sequencer.getPlaybackEvents();
-    this.props.addPlaybackEvents({
-      events: playbackEvents,
-      lastMeasure: this.sequencer.getLastMeasure(),
-    });
+    this.props.addPlaybackEvents(playbackEvents);
+    this.props.updateLastMeasure(this.sequencer.getLastMeasure());
     this.props.addOrderedFunctions({
       orderedFunctions: this.sequencer.getOrderedFunctions?.() || [],
     });
@@ -663,10 +665,8 @@ class UnconnectedMusicView extends React.Component {
 
     this.sequencer.clear();
     this.musicBlocklyWorkspace.executeCompiledSong(this.playingTriggers);
-    this.props.addPlaybackEvents({
-      events: this.sequencer.getPlaybackEvents(),
-      lastMeasure: this.sequencer.getLastMeasure(),
-    });
+    this.props.addPlaybackEvents(this.sequencer.getPlaybackEvents());
+    this.props.setLastMeasure(this.sequencer.getLastMeasure());
     this.props.addOrderedFunctions({
       orderedFunctions: this.sequencer.getOrderedFunctions?.() || [],
     });
@@ -879,6 +879,8 @@ const MusicView = connect(
     clearOrderedFunctions: () => dispatch(clearOrderedFunctions()),
     addPlaybackEvents: playbackEvents =>
       dispatch(addPlaybackEvents(playbackEvents)),
+    setLastMeasure: number => dispatch(setLastMeasure(number)),
+    updateLastMeasure: number => dispatch(updateLastMeasure(number)),
     addOrderedFunctions: orderedFunctions =>
       dispatch(addOrderedFunctions(orderedFunctions)),
     setIsLoading: isLoading => dispatch(setIsLoading(isLoading)),


### PR DESCRIPTION
This fixes an issue introduced by https://github.com/code-dot-org/code-dot-org/pull/63428, in which modifying the program while music was playing could cause playback to stop.  Now, the music keeps playing.

The issue was that the last measure was being reset to 0 when the execution of the compiled song began, and the effect that checked for the end of the song would use that value, before the value was updated at the end of execution.  Now, the new last measure value is set at the end of execution.  Triggers can continue to extend it.