### PR TITLE
[Design2-263] DSCO - Dialog component - Use component-library package instead of apps/src/componentLibrary across apps directory

### DIFF
--- a/apps/src/componentLibrary/dialog/Dialog.tsx
+++ b/apps/src/componentLibrary/dialog/Dialog.tsx
@@ -1,8 +1,8 @@
 import {Button, ButtonProps} from '@code-dot-org/component-library/button';
+import {CustomDialog} from '@code-dot-org/component-library/dialog';
 import classnames from 'classnames';
 import React, {HTMLAttributes, ReactNode} from 'react';
 
-import CustomDialog from '@cdo/apps/componentLibrary/dialog/CustomDialog';
 import FontAwesomeV6Icon, {
   FontAwesomeV6IconProps,
 } from '@cdo/apps/componentLibrary/fontAwesomeV6Icon';

--- a/apps/src/componentLibrary/modal/Modal.tsx
+++ b/apps/src/componentLibrary/modal/Modal.tsx
@@ -1,8 +1,8 @@
 import {Button, ButtonProps} from '@code-dot-org/component-library/button';
+import {CustomDialog} from '@code-dot-org/component-library/dialog';
 import classnames from 'classnames';
 import React, {HTMLAttributes, ReactNode} from 'react';
 
-import CustomDialog from '@cdo/apps/componentLibrary/dialog/CustomDialog';
 import {BodyTwoText, Heading3} from '@cdo/apps/componentLibrary/typography';
 
 import moduleStyles from './modal.module.scss';

--- a/apps/test/unit/componentLibrary/CustomDialogTest.tsx
+++ b/apps/test/unit/componentLibrary/CustomDialogTest.tsx
@@ -1,11 +1,10 @@
-import {render, screen, fireEvent} from '@testing-library/react';
-import React from 'react';
-import '@testing-library/jest-dom';
-
 import {
   CustomDialog,
   CustomDialogProps,
-} from '@cdo/apps/componentLibrary/dialog';
+} from '@code-dot-org/component-library/dialog';
+import {render, screen, fireEvent} from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
 
 describe('CustomDialog Component', () => {
   const defaultProps: CustomDialogProps = {

--- a/apps/test/unit/componentLibrary/DialogTest.tsx
+++ b/apps/test/unit/componentLibrary/DialogTest.tsx
@@ -1,9 +1,8 @@
+import Dialog, {DialogProps} from '@code-dot-org/component-library/dialog';
 import {render, screen, fireEvent} from '@testing-library/react';
 import React from 'react';
 
 import '@testing-library/jest-dom';
-
-import Dialog, {DialogProps} from '@cdo/apps/componentLibrary/dialog';
 
 describe('Dialog Component', () => {
   const defaultProps: DialogProps = {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [Design2-263] DSCO - Dialog component - Use component-library package instead of apps/src/componentLibrary across apps directory

* Dialog component -  made /apps directory now use `@code-dot-org/component-library` instance instead of ./apps/src/componentLibrary

This PR only replaces `/apps/src/componentLibrary/dialog` usages with `@code-dot-org/component-library/dialog` usages. No visual changes are intended by this PR. In case of any regressions feel free to contact me or @stephenliang. In case it'll be urgent - feel free to revert, just please let us know what problem have you encountered.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [Design2-263](https://codedotorg.atlassian.net/browse/DESIGN2-263)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
