### PR TITLE
Python Lab: fix console input on production-like environments

### DIFF
--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -117,6 +117,8 @@ const registerServiceWorker = async () => {
   // No-op if service workers are not supported.
   if (canSupportInput()) {
     try {
+      // Do not move the url into a variable, because webpack needs it to be passed as
+      // a parmaeter to register() directly in order to set up inputServiceWorker as a service worker.
       const registration = await navigator.serviceWorker.register(
         new URL(
           './inputServiceWorker.js',

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -117,15 +117,23 @@ const registerServiceWorker = async () => {
   // No-op if service workers are not supported.
   if (canSupportInput()) {
     try {
-      const url = new URL(
-        './inputServiceWorker.js',
-        // @ts-expect-error because TypeScript does not like this syntax.
-        import.meta.url
+      const registration = await navigator.serviceWorker.register(
+        new URL(
+          './inputServiceWorker.js',
+          // @ts-expect-error because TypeScript does not like this syntax.
+          import.meta.url
+        )
       );
-      const registration = await navigator.serviceWorker.register(url);
-      if (registration.active) {
-        inputServiceWorker = registration.active;
-      }
+      // const url = new URL(
+      //   './inputServiceWorker.js',
+      //   // @ts-expect-error because TypeScript does not like this syntax.
+      //   import.meta.url
+      // );
+      // console.log({url});
+      // const registration = await navigator.serviceWorker.register(url);
+      // if (registration.active) {
+      //   inputServiceWorker = registration.active;
+      // }
 
       registration.addEventListener('updatefound', () => {
         const installingWorker = registration.installing;

--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -124,16 +124,6 @@ const registerServiceWorker = async () => {
           import.meta.url
         )
       );
-      // const url = new URL(
-      //   './inputServiceWorker.js',
-      //   // @ts-expect-error because TypeScript does not like this syntax.
-      //   import.meta.url
-      // );
-      // console.log({url});
-      // const registration = await navigator.serviceWorker.register(url);
-      // if (registration.active) {
-      //   inputServiceWorker = registration.active;
-      // }
 
       registration.addEventListener('updatefound', () => {
         const installingWorker = registration.installing;

--- a/apps/src/pythonlab/pythonHelpers/patches.ts
+++ b/apps/src/pythonlab/pythonHelpers/patches.ts
@@ -39,6 +39,9 @@ export const pythonlabInputModule = {
       false
     );
     request.send(null);
+    if (request.status !== 200) {
+      throw new Error('Failed to read input.');
+    }
     return request.responseText;
   },
 };


### PR DESCRIPTION
Follow up to #63549
The service worker script could not be found on production-like environments (it is behind an experiment flag, so this is only noticeable if you turn on the experiment and try to use input). It turns out webpack does some magic behind the scenes to properly register web workers and service workers, but only if you use very specific syntax. The relevant docs are [the webpack 5 release notes](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#native-worker-support) and the [webpack web worker guide](https://webpack.js.org/guides/web-workers/). You cannot store the url for a webworker or service worker as a variable and then pass that variable to `new Worker()` or `serviceWorker.register()`. You have to directly pass in the call to `new URL()` as a parameter instead, because webpack is doing some static analysis to set things up.

While I was working on this I noticed if the call to the service worker to get input returned a non-200, we would dump the whole error message into the console. I fixed this to instead throw an error, which will show up as a python error in the console that we failed to get input.

## Links
- [slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1738343478461319)

## Testing story
In order to repro this I had to run my local development with a production build (following steps [here](https://github.com/code-dot-org/code-dot-org/blob/449600100b583b3e8d3bdc69aa66b3711afc9dd8/apps/docs/build.md#using-minified-js-locally) for both using minified js and rails asset pipeline locally). I also had to clear my cache to get rid of the functional service worker.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
