### PR TITLE
restore csp3-research-mxghyt.script_json

### DIFF
--- a/dashboard/config/scripts_json/csp3-research-mxghyt.script_json
+++ b/dashboard/config/scripts_json/csp3-research-mxghyt.script_json
@@ -1,0 +1,4772 @@
+{
+  "script": {
+    "name": "csp3-research-mxghyt",
+    "wrapup_video_id": null,
+    "login_required": true,
+    "properties": {
+      "announcements": [
+        {
+          "notice": "Check out the CSP mid-course survey",
+          "details": "We recently added a mid-course survey to the end of Unit 3.  Please allow your students some time to complete it.",
+          "link": "",
+          "type": "success",
+          "key": "3fec9534-8c5b-4e4f-86a9-e69934fc4387"
+        }
+      ],
+      "content_area": "curriculum_9_12",
+      "curriculum_umbrella": "CSP",
+      "hideable_lessons": true,
+      "is_migrated": true,
+      "student_detail_progress_view": true,
+      "use_legacy_lesson_plans": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2024-11-19 01:16:45 UTC",
+    "published_state": null,
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "csp3-research-mxghyt"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp3_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Programming Languages and Algorithms"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "cspAssessment",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter Assessment"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-research-mxghyt"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "The Need For Programming Languages",
+      "name": "The Need For Programming Languages",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "The Need for Algorithms",
+      "name": "The Need for Algorithms",
+      "absolute_position": 2,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Creativity in Algorithms",
+      "name": "Creativity in Algorithms",
+      "absolute_position": 3,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Using Simple Commands",
+      "name": "Using Simple Commands",
+      "absolute_position": 4,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Creating Functions",
+      "name": "Creating Functions",
+      "absolute_position": 5,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Functions and Top-Down Design",
+      "name": "Functions and Top-Down Design",
+      "absolute_position": 6,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "APIs and Function Parameters",
+      "name": "APIs and Function Parameters",
+      "absolute_position": 7,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Creating functions with Parameters",
+      "name": "Creating functions with Parameters",
+      "absolute_position": 8,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Looping and Random Numbers",
+      "name": "Looping and Random Numbers",
+      "absolute_position": 9,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Practice PT - Design a Digital Scene",
+      "name": "Practice PT - Design a Digital Scene",
+      "absolute_position": 10,
+      "lockable": false,
+      "has_lesson_plan": true,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Unit 3 Chapter 1 Assessment",
+      "name": "Unit 3 Chapter 1 Assessment",
+      "absolute_position": 11,
+      "lockable": true,
+      "has_lesson_plan": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Please complete the CSP Mid-course survey",
+      "name": "Please complete the CSP Mid-course survey",
+      "absolute_position": 12,
+      "lockable": true,
+      "has_lesson_plan": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Please complete the CSP Mid-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-research-mxghyt"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "4a235b04-7015-4191-ba96-18db9d4f75af",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "4a235b04-7015-4191-ba96-18db9d4f75af",
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "346f0c43-cca7-484c-b490-f0575f3fab54",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "346f0c43-cca7-484c-b490-f0575f3fab54",
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "d40409cb-d8d2-47e1-ba2c-2dd39d3805e7",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "d40409cb-d8d2-47e1-ba2c-2dd39d3805e7",
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "c9a835df-85d5-4b8d-9d46-32f8c39b3a63",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "c9a835df-85d5-4b8d-9d46-32f8c39b3a63",
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "ab0eef3b-bc4a-4991-9d4f-b11d07d2a06a",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "ab0eef3b-bc4a-4991-9d4f-b11d07d2a06a",
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "5734448c-c664-459f-8472-9014d500f477",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "5734448c-c664-459f-8472-9014d500f477",
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "e72f3b31-14d4-44a5-8ad1-cb0cda345666",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "e72f3b31-14d4-44a5-8ad1-cb0cda345666",
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a",
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "18a75e49-1a3b-4154-b853-594a1024dc5b",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "18a75e49-1a3b-4154-b853-594a1024dc5b",
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "ececbdac-98aa-40d9-b260-d44af6898db8",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "ececbdac-98aa-40d9-b260-d44af6898db8",
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "87915caa-e23f-4fc2-b4a2-afbc4c68ef45",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "87915caa-e23f-4fc2-b4a2-afbc4c68ef45",
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "e9ea31b7-4927-4c5e-8991-b8fccba1d3a9",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "e9ea31b7-4927-4c5e-8991-b8fccba1d3a9",
+        "lesson.key": "Please complete the CSP Mid-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-research-mxghyt"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "d6ab7dd6-2fb0-4286-b637-3e89772c3a83",
+      "position": 1,
+      "properties": {
+        "progression_name": "Lesson Vocabulary & Resources"
+      },
+      "seeding_key": {
+        "activity_section.key": "d6ab7dd6-2fb0-4286-b637-3e89772c3a83",
+        "lesson_activity.key": "4a235b04-7015-4191-ba96-18db9d4f75af"
+      }
+    },
+    {
+      "key": "208eb4cb-4f81-4211-9597-03a48222b5df",
+      "position": 2,
+      "properties": {
+        "progression_name": "Check Your Understanding"
+      },
+      "seeding_key": {
+        "activity_section.key": "208eb4cb-4f81-4211-9597-03a48222b5df",
+        "lesson_activity.key": "4a235b04-7015-4191-ba96-18db9d4f75af"
+      }
+    },
+    {
+      "key": "f77e4ecc-8174-4706-813c-b38185245864",
+      "position": 3,
+      "properties": {
+        "name": "Quick Check-In",
+        "progression_name": "Quick Check-In"
+      },
+      "seeding_key": {
+        "activity_section.key": "f77e4ecc-8174-4706-813c-b38185245864",
+        "lesson_activity.key": "4a235b04-7015-4191-ba96-18db9d4f75af"
+      }
+    },
+    {
+      "key": "2a38d481-6cf8-4a5b-b7a3-57906be6669a",
+      "position": 1,
+      "properties": {
+        "name": "Lesson Vocabulary & Resources",
+        "progression_name": "Lesson Vocabulary & Resources"
+      },
+      "seeding_key": {
+        "activity_section.key": "2a38d481-6cf8-4a5b-b7a3-57906be6669a",
+        "lesson_activity.key": "346f0c43-cca7-484c-b490-f0575f3fab54"
+      }
+    },
+    {
+      "key": "3d1a4a16-a7e7-4bd1-b80e-27b6cb137608",
+      "position": 1,
+      "properties": {
+        "name": "Lesson Vocabulary & Resources",
+        "progression_name": "Lesson Vocabulary & Resources"
+      },
+      "seeding_key": {
+        "activity_section.key": "3d1a4a16-a7e7-4bd1-b80e-27b6cb137608",
+        "lesson_activity.key": "d40409cb-d8d2-47e1-ba2c-2dd39d3805e7"
+      }
+    },
+    {
+      "key": "4d90b776-9c5a-4874-9efb-2264d95aa59a",
+      "position": 1,
+      "properties": {
+        "progression_name": "Lesson Vocabulary & Resources"
+      },
+      "seeding_key": {
+        "activity_section.key": "4d90b776-9c5a-4874-9efb-2264d95aa59a",
+        "lesson_activity.key": "c9a835df-85d5-4b8d-9d46-32f8c39b3a63"
+      }
+    },
+    {
+      "key": "27124322-ec91-4046-b978-c1d141f29a2c",
+      "position": 2,
+      "properties": {
+        "progression_name": "Turtle Programming"
+      },
+      "seeding_key": {
+        "activity_section.key": "27124322-ec91-4046-b978-c1d141f29a2c",
+        "lesson_activity.key": "c9a835df-85d5-4b8d-9d46-32f8c39b3a63"
+      }
+    },
+    {
+      "key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e",
+      "position": 3,
+      "properties": {
+        "progression_name": "Introducing Simple Commands and Subgoals"
+      },
+      "seeding_key": {
+        "activity_section.key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e",
+        "lesson_activity.key": "c9a835df-85d5-4b8d-9d46-32f8c39b3a63"
+      }
+    },
+    {
+      "key": "44e26ccc-ec9f-4643-bf15-814d79916d5e",
+      "position": 4,
+      "properties": {
+        "progression_name": "Challenge: Draw a 3x3 Grid Using Turtle Commands"
+      },
+      "seeding_key": {
+        "activity_section.key": "44e26ccc-ec9f-4643-bf15-814d79916d5e",
+        "lesson_activity.key": "c9a835df-85d5-4b8d-9d46-32f8c39b3a63"
+      }
+    },
+    {
+      "key": "5356c465-63c9-4be1-91eb-58407ba7003d",
+      "position": 5,
+      "properties": {
+        "name": "Check Your Understanding",
+        "progression_name": "Check Your Understanding"
+      },
+      "seeding_key": {
+        "activity_section.key": "5356c465-63c9-4be1-91eb-58407ba7003d",
+        "lesson_activity.key": "c9a835df-85d5-4b8d-9d46-32f8c39b3a63"
+      }
+    },
+    {
+      "key": "17ae2965-046c-442a-9340-b0d1728eca08",
+      "position": 1,
+      "properties": {
+        "progression_name": "Lesson Vocabulary & Resources"
+      },
+      "seeding_key": {
+        "activity_section.key": "17ae2965-046c-442a-9340-b0d1728eca08",
+        "lesson_activity.key": "ab0eef3b-bc4a-4991-9d4f-b11d07d2a06a"
+      }
+    },
+    {
+      "key": "e3b9756f-0e1b-4e9f-813a-762bb9d256cb",
+      "position": 2,
+      "properties": {
+        "progression_name": "Defining and Calling Functions"
+      },
+      "seeding_key": {
+        "activity_section.key": "e3b9756f-0e1b-4e9f-813a-762bb9d256cb",
+        "lesson_activity.key": "ab0eef3b-bc4a-4991-9d4f-b11d07d2a06a"
+      }
+    },
+    {
+      "key": "000bc98d-6824-4ed3-b734-cfcf72a27ee2",
+      "position": 3,
+      "properties": {
+        "progression_name": "Using Functions With Turtle Commands"
+      },
+      "seeding_key": {
+        "activity_section.key": "000bc98d-6824-4ed3-b734-cfcf72a27ee2",
+        "lesson_activity.key": "ab0eef3b-bc4a-4991-9d4f-b11d07d2a06a"
+      }
+    },
+    {
+      "key": "c184ab33-33f8-4c83-b17a-b9e5e0e739ab",
+      "position": 4,
+      "properties": {
+        "progression_name": "(new) Abstraction in Programming"
+      },
+      "seeding_key": {
+        "activity_section.key": "c184ab33-33f8-4c83-b17a-b9e5e0e739ab",
+        "lesson_activity.key": "ab0eef3b-bc4a-4991-9d4f-b11d07d2a06a"
+      }
+    },
+    {
+      "key": "e241aaf6-20c3-4727-872e-64fde6b862ab",
+      "position": 5,
+      "properties": {
+        "progression_name": "Using Functions With Turtle Commands"
+      },
+      "seeding_key": {
+        "activity_section.key": "e241aaf6-20c3-4727-872e-64fde6b862ab",
+        "lesson_activity.key": "ab0eef3b-bc4a-4991-9d4f-b11d07d2a06a"
+      }
+    },
+    {
+      "key": "16c1870b-7209-4407-8bb8-b101156ced2d",
+      "position": 6,
+      "properties": {
+        "progression_name": "Challenge: Draw a Diamond Using Functions"
+      },
+      "seeding_key": {
+        "activity_section.key": "16c1870b-7209-4407-8bb8-b101156ced2d",
+        "lesson_activity.key": "ab0eef3b-bc4a-4991-9d4f-b11d07d2a06a"
+      }
+    },
+    {
+      "key": "c0a562c4-946c-41d3-b3c1-b8b18ae32bb7",
+      "position": 7,
+      "properties": {
+        "name": "Check Your Understanding",
+        "progression_name": "Check Your Understanding"
+      },
+      "seeding_key": {
+        "activity_section.key": "c0a562c4-946c-41d3-b3c1-b8b18ae32bb7",
+        "lesson_activity.key": "ab0eef3b-bc4a-4991-9d4f-b11d07d2a06a"
+      }
+    },
+    {
+      "key": "3ca12f56-ed8d-42fd-abd4-04268247b4ac",
+      "position": 1,
+      "properties": {
+        "progression_name": "Lesson Vocabulary & Resources"
+      },
+      "seeding_key": {
+        "activity_section.key": "3ca12f56-ed8d-42fd-abd4-04268247b4ac",
+        "lesson_activity.key": "5734448c-c664-459f-8472-9014d500f477"
+      }
+    },
+    {
+      "key": "78684ca4-ee3b-45c5-bf04-3dfb79cdf54c",
+      "position": 2,
+      "properties": {
+        "progression_name": "Using Functions with Turtle Commands"
+      },
+      "seeding_key": {
+        "activity_section.key": "78684ca4-ee3b-45c5-bf04-3dfb79cdf54c",
+        "lesson_activity.key": "5734448c-c664-459f-8472-9014d500f477"
+      }
+    },
+    {
+      "key": "627f3601-fbfd-46e8-9eb1-c8e678131559",
+      "position": 3,
+      "properties": {
+        "progression_name": "(new)AP Practice Response - Design Process"
+      },
+      "seeding_key": {
+        "activity_section.key": "627f3601-fbfd-46e8-9eb1-c8e678131559",
+        "lesson_activity.key": "5734448c-c664-459f-8472-9014d500f477"
+      }
+    },
+    {
+      "key": "6a3ae4a8-fc6e-44f6-9866-335e7f17c436",
+      "position": 4,
+      "properties": {
+        "name": "Check Your Understanding",
+        "progression_name": "Check Your Understanding"
+      },
+      "seeding_key": {
+        "activity_section.key": "6a3ae4a8-fc6e-44f6-9866-335e7f17c436",
+        "lesson_activity.key": "5734448c-c664-459f-8472-9014d500f477"
+      }
+    },
+    {
+      "key": "26128992-4983-4196-bc1d-079bfd5d7fe1",
+      "position": 1,
+      "properties": {
+        "progression_name": "Lesson Vocabulary & Resources"
+      },
+      "seeding_key": {
+        "activity_section.key": "26128992-4983-4196-bc1d-079bfd5d7fe1",
+        "lesson_activity.key": "e72f3b31-14d4-44a5-8ad1-cb0cda345666"
+      }
+    },
+    {
+      "key": "ee4d6410-897e-4821-9f92-83cead67af02",
+      "position": 2,
+      "properties": {
+        "progression_name": "Introduction to Parameters"
+      },
+      "seeding_key": {
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02",
+        "lesson_activity.key": "e72f3b31-14d4-44a5-8ad1-cb0cda345666"
+      }
+    },
+    {
+      "key": "a1781451-9b61-44a2-9f2d-b405afd381c7",
+      "position": 3,
+      "properties": {
+        "progression_name": "Make Your Own Turtle Drawing"
+      },
+      "seeding_key": {
+        "activity_section.key": "a1781451-9b61-44a2-9f2d-b405afd381c7",
+        "lesson_activity.key": "e72f3b31-14d4-44a5-8ad1-cb0cda345666"
+      }
+    },
+    {
+      "key": "69b648d7-d8d7-44e5-af00-54a178ec2f0c",
+      "position": 4,
+      "properties": {
+        "progression_name": "(new)AP Practice Response - Score a student response"
+      },
+      "seeding_key": {
+        "activity_section.key": "69b648d7-d8d7-44e5-af00-54a178ec2f0c",
+        "lesson_activity.key": "e72f3b31-14d4-44a5-8ad1-cb0cda345666"
+      }
+    },
+    {
+      "key": "9870a016-49f6-43c9-aa81-c22660086b50",
+      "position": 5,
+      "properties": {
+        "name": "Check Your Understanding",
+        "progression_name": "Check Your Understanding"
+      },
+      "seeding_key": {
+        "activity_section.key": "9870a016-49f6-43c9-aa81-c22660086b50",
+        "lesson_activity.key": "e72f3b31-14d4-44a5-8ad1-cb0cda345666"
+      }
+    },
+    {
+      "key": "0ade1273-abba-4835-bc59-769ccfbd3d6c",
+      "position": 1,
+      "properties": {
+        "progression_name": "Lesson Vocabulary & Resources"
+      },
+      "seeding_key": {
+        "activity_section.key": "0ade1273-abba-4835-bc59-769ccfbd3d6c",
+        "lesson_activity.key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a"
+      }
+    },
+    {
+      "key": "d63894ee-364f-48b6-9c2c-a1ed6ca1e4dd",
+      "position": 2,
+      "properties": {
+        "progression_name": "Functions with Parameters"
+      },
+      "seeding_key": {
+        "activity_section.key": "d63894ee-364f-48b6-9c2c-a1ed6ca1e4dd",
+        "lesson_activity.key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a"
+      }
+    },
+    {
+      "key": "68982125-ad77-4aad-91bf-099d8a615706",
+      "position": 3,
+      "properties": {
+        "progression_name": "Drawing Shapes With Parameters"
+      },
+      "seeding_key": {
+        "activity_section.key": "68982125-ad77-4aad-91bf-099d8a615706",
+        "lesson_activity.key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a"
+      }
+    },
+    {
+      "key": "287af6d8-1124-43dc-99ad-482087ce16c7",
+      "position": 4,
+      "properties": {
+        "progression_name": "Check Your Understanding: Defining Functions"
+      },
+      "seeding_key": {
+        "activity_section.key": "287af6d8-1124-43dc-99ad-482087ce16c7",
+        "lesson_activity.key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a"
+      }
+    },
+    {
+      "key": "f9668e92-fb0f-4724-b15f-90406baac7bf",
+      "position": 5,
+      "properties": {
+        "progression_name": "(new) How to add comments to code"
+      },
+      "seeding_key": {
+        "activity_section.key": "f9668e92-fb0f-4724-b15f-90406baac7bf",
+        "lesson_activity.key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a"
+      }
+    },
+    {
+      "key": "fc42744a-2c36-439b-b633-1f9aeecaf071",
+      "position": 6,
+      "properties": {
+        "progression_name": "Under the Sea Drawing with Parameters"
+      },
+      "seeding_key": {
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071",
+        "lesson_activity.key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a"
+      }
+    },
+    {
+      "key": "c8d7b942-ac7b-4fa8-ad7a-40f25ef88421",
+      "position": 7,
+      "properties": {
+        "progression_name": "Check Your Understanding: Using Random Numbers"
+      },
+      "seeding_key": {
+        "activity_section.key": "c8d7b942-ac7b-4fa8-ad7a-40f25ef88421",
+        "lesson_activity.key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a"
+      }
+    },
+    {
+      "key": "b6b627ac-6cec-4294-b2d9-645388c6eef2",
+      "position": 8,
+      "properties": {
+        "progression_name": "Challenge: Continue Your Drawing With More Functions"
+      },
+      "seeding_key": {
+        "activity_section.key": "b6b627ac-6cec-4294-b2d9-645388c6eef2",
+        "lesson_activity.key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a"
+      }
+    },
+    {
+      "key": "848e73b1-5231-42a8-8e76-edba8912d5f7",
+      "position": 9,
+      "properties": {
+        "progression_name": "(new)AP Practice Response - Managing Complexity"
+      },
+      "seeding_key": {
+        "activity_section.key": "848e73b1-5231-42a8-8e76-edba8912d5f7",
+        "lesson_activity.key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a"
+      }
+    },
+    {
+      "key": "d6d9b4ce-b931-4a6b-b3a6-b54c36503294",
+      "position": 10,
+      "properties": {
+        "name": "Check Your Understanding",
+        "progression_name": "Check Your Understanding"
+      },
+      "seeding_key": {
+        "activity_section.key": "d6d9b4ce-b931-4a6b-b3a6-b54c36503294",
+        "lesson_activity.key": "c852a5f8-8c36-4c26-b9d3-c172fa341c8a"
+      }
+    },
+    {
+      "key": "f80daf42-c153-4da8-a8a5-b05bc7ca9367",
+      "position": 1,
+      "properties": {
+        "progression_name": "Lesson Vocabulary & Resources"
+      },
+      "seeding_key": {
+        "activity_section.key": "f80daf42-c153-4da8-a8a5-b05bc7ca9367",
+        "lesson_activity.key": "18a75e49-1a3b-4154-b853-594a1024dc5b"
+      }
+    },
+    {
+      "key": "34ccda19-40c9-4e4a-9a4b-c07ece4c448a",
+      "position": 2,
+      "properties": {
+        "progression_name": "Using Loops"
+      },
+      "seeding_key": {
+        "activity_section.key": "34ccda19-40c9-4e4a-9a4b-c07ece4c448a",
+        "lesson_activity.key": "18a75e49-1a3b-4154-b853-594a1024dc5b"
+      }
+    },
+    {
+      "key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501",
+      "position": 3,
+      "properties": {
+        "progression_name": "Introduction to Loops"
+      },
+      "seeding_key": {
+        "activity_section.key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501",
+        "lesson_activity.key": "18a75e49-1a3b-4154-b853-594a1024dc5b"
+      }
+    },
+    {
+      "key": "46288bbe-0c54-4a4b-a027-35d5054c6faf",
+      "position": 4,
+      "properties": {
+        "progression_name": "Using Loops to Add Detail to Your Drawing"
+      },
+      "seeding_key": {
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf",
+        "lesson_activity.key": "18a75e49-1a3b-4154-b853-594a1024dc5b"
+      }
+    },
+    {
+      "key": "eac13cbb-82a8-450b-ab74-f1bb2ccf9665",
+      "position": 5,
+      "properties": {
+        "progression_name": "Project: Under the Sea"
+      },
+      "seeding_key": {
+        "activity_section.key": "eac13cbb-82a8-450b-ab74-f1bb2ccf9665",
+        "lesson_activity.key": "18a75e49-1a3b-4154-b853-594a1024dc5b"
+      }
+    },
+    {
+      "key": "209caa2a-8586-4b13-8300-75f4bf50ea62",
+      "position": 6,
+      "properties": {
+        "progression_name": "(new)AP Practice Response - Identify the Abstraction"
+      },
+      "seeding_key": {
+        "activity_section.key": "209caa2a-8586-4b13-8300-75f4bf50ea62",
+        "lesson_activity.key": "18a75e49-1a3b-4154-b853-594a1024dc5b"
+      }
+    },
+    {
+      "key": "9b397bf7-ee9c-451e-beac-ae360d369a23",
+      "position": 7,
+      "properties": {
+        "name": "Check Your Understanding",
+        "progression_name": "Check Your Understanding"
+      },
+      "seeding_key": {
+        "activity_section.key": "9b397bf7-ee9c-451e-beac-ae360d369a23",
+        "lesson_activity.key": "18a75e49-1a3b-4154-b853-594a1024dc5b"
+      }
+    },
+    {
+      "key": "4d6db1c1-4057-4f6c-a6ee-9cefeabd7400",
+      "position": 1,
+      "properties": {
+        "progression_name": "Lesson Vocabulary & Resources"
+      },
+      "seeding_key": {
+        "activity_section.key": "4d6db1c1-4057-4f6c-a6ee-9cefeabd7400",
+        "lesson_activity.key": "ececbdac-98aa-40d9-b260-d44af6898db8"
+      }
+    },
+    {
+      "key": "aacb9492-2fcd-43d4-90de-ec7b63a9a77d",
+      "position": 2,
+      "properties": {
+        "progression_name": "Design Your Components"
+      },
+      "seeding_key": {
+        "activity_section.key": "aacb9492-2fcd-43d4-90de-ec7b63a9a77d",
+        "lesson_activity.key": "ececbdac-98aa-40d9-b260-d44af6898db8"
+      }
+    },
+    {
+      "key": "7fde4e9f-210c-4f24-9c78-2fffa3c2621c",
+      "position": 3,
+      "properties": {
+        "progression_name": "How To: Share Code with Teammates"
+      },
+      "seeding_key": {
+        "activity_section.key": "7fde4e9f-210c-4f24-9c78-2fffa3c2621c",
+        "lesson_activity.key": "ececbdac-98aa-40d9-b260-d44af6898db8"
+      }
+    },
+    {
+      "key": "e372f6a7-6fd8-48d5-95a3-3017b0e6d07d",
+      "position": 4,
+      "properties": {
+        "name": "Challenge: Design Your Digital Scene",
+        "progression_name": "Challenge: Design Your Digital Scene"
+      },
+      "seeding_key": {
+        "activity_section.key": "e372f6a7-6fd8-48d5-95a3-3017b0e6d07d",
+        "lesson_activity.key": "ececbdac-98aa-40d9-b260-d44af6898db8"
+      }
+    },
+    {
+      "key": "ff1cd44b-d3da-4b57-b1fb-83e7c3c42352",
+      "position": 1,
+      "properties": {
+        "progression_name": "Pre-test reflection"
+      },
+      "seeding_key": {
+        "activity_section.key": "ff1cd44b-d3da-4b57-b1fb-83e7c3c42352",
+        "lesson_activity.key": "87915caa-e23f-4fc2-b4a2-afbc4c68ef45"
+      }
+    },
+    {
+      "key": "495d4546-96eb-47f8-b501-688a91666d6d",
+      "position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "495d4546-96eb-47f8-b501-688a91666d6d",
+        "lesson_activity.key": "87915caa-e23f-4fc2-b4a2-afbc4c68ef45"
+      }
+    },
+    {
+      "key": "5ac771a7-5ebd-4044-ab8f-1da685a512e1",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "5ac771a7-5ebd-4044-ab8f-1da685a512e1",
+        "lesson_activity.key": "e9ea31b7-4927-4c5e-8991-b8fccba1d3a9"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "v2 U3L01 Student Lesson Introduction"
+        ],
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L01 Student Lesson Introduction"
+        ],
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "d6ab7dd6-2fb0-4286-b637-3e89772c3a83"
+      },
+      "level_keys": [
+        "v2 U3L01 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L01 Assessment1"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment1"
+        ],
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "208eb4cb-4f81-4211-9597-03a48222b5df"
+      },
+      "level_keys": [
+        "U3L01 Assessment1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "activity_section_position": 2,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L01 Assessment3"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment3"
+        ],
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "208eb4cb-4f81-4211-9597-03a48222b5df"
+      },
+      "level_keys": [
+        "U3L01 Assessment3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+        ],
+        "progression": "Quick Check-In"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+        ],
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "f77e4ecc-8174-4706-813c-b38185245864"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "v2 U3L02 Student Lesson Introduction"
+        ],
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L02 Student Lesson Introduction"
+        ],
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "2a38d481-6cf8-4a5b-b7a3-57906be6669a"
+      },
+      "level_keys": [
+        "v2 U3L02 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "v2 U3L03 Student Lesson Introduction"
+        ],
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L03 Student Lesson Introduction"
+        ],
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3d1a4a16-a7e7-4bd1-b80e-27b6cb137608"
+      },
+      "level_keys": [
+        "v2 U3L03 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L04 Student Lesson Introduction"
+        ],
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L04 Student Lesson Introduction"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "4d90b776-9c5a-4874-9efb-2264d95aa59a"
+      },
+      "level_keys": [
+        "SG U3L04 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG csp_applab_turtle"
+        ],
+        "progression": "Turtle Programming"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG csp_applab_turtle"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "27124322-ec91-4046-b978-c1d141f29a2c"
+      },
+      "level_keys": [
+        "SG csp_applab_turtle"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L2 Using Simple Commands part 1"
+        ],
+        "progression": "Introducing Simple Commands and Subgoals"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L2 Using Simple Commands part 1"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e"
+      },
+      "level_keys": [
+        "SG U3L2 Using Simple Commands part 1"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SGU3L2A Introducing Subgoals"
+        ],
+        "progression": "Introducing Simple Commands and Subgoals"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SGU3L2A Introducing Subgoals"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e"
+      },
+      "level_keys": [
+        "SGU3L2A Introducing Subgoals"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "activity_section_position": 3,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L2 Using Simple Commands"
+        ],
+        "progression": "Introducing Simple Commands and Subgoals"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L2 Using Simple Commands"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e"
+      },
+      "level_keys": [
+        "SG U3L2 Using Simple Commands"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "activity_section_position": 4,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L2_TurtleSquare_right"
+        ],
+        "progression": "Introducing Simple Commands and Subgoals"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L2_TurtleSquare_right"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e"
+      },
+      "level_keys": [
+        "SG U3L2_TurtleSquare_right"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "activity_section_position": 5,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG Add Subgoals practice"
+        ],
+        "progression": "Introducing Simple Commands and Subgoals"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG Add Subgoals practice"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e"
+      },
+      "level_keys": [
+        "SG Add Subgoals practice"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L2_Turtle3by3Grid"
+        ],
+        "progression": "Challenge: Draw a 3x3 Grid Using Turtle Commands"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L2_Turtle3by3Grid"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "44e26ccc-ec9f-4643-bf15-814d79916d5e"
+      },
+      "level_keys": [
+        "SG U3L2_Turtle3by3Grid"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 9,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L02 Assessment"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Assessment"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "5356c465-63c9-4be1-91eb-58407ba7003d"
+      },
+      "level_keys": [
+        "U3L02 Assessment"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 10,
+      "activity_section_position": 2,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L02 Free Response Getting Started"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "5356c465-63c9-4be1-91eb-58407ba7003d"
+      },
+      "level_keys": [
+        "U3L02 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 11,
+      "activity_section_position": 3,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "5356c465-63c9-4be1-91eb-58407ba7003d"
+      },
+      "level_keys": [
+        "csp_U3_square_v_rect_FR"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 12,
+      "activity_section_position": 4,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L02 Free Response Wrap Up"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "5356c465-63c9-4be1-91eb-58407ba7003d"
+      },
+      "level_keys": [
+        "U3L02 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG v2 U3L05 Student Lesson Introduction"
+        ],
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L05 Student Lesson Introduction"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "17ae2965-046c-442a-9340-b0d1728eca08"
+      },
+      "level_keys": [
+        "SG v2 U3L05 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG csp_applab_functions"
+        ],
+        "progression": "Defining and Calling Functions"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG csp_applab_functions"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "e3b9756f-0e1b-4e9f-813a-762bb9d256cb"
+      },
+      "level_keys": [
+        "SG csp_applab_functions"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L03 Define and use turnAround"
+        ],
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 Define and use turnAround"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "000bc98d-6824-4ed3-b734-cfcf72a27ee2"
+      },
+      "level_keys": [
+        "SG U3L03 Define and use turnAround"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L03 Draw a T using turnAround"
+        ],
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 Draw a T using turnAround"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "000bc98d-6824-4ed3-b734-cfcf72a27ee2"
+      },
+      "level_keys": [
+        "SG U3L03 Draw a T using turnAround"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "activity_section_position": 3,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L03 define turnRight and draw a rectangle"
+        ],
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 define turnRight and draw a rectangle"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "000bc98d-6824-4ed3-b734-cfcf72a27ee2"
+      },
+      "level_keys": [
+        "SG U3L03 define turnRight and draw a rectangle"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG CSP Abstraction in Programming 2"
+        ],
+        "progression": "(new) Abstraction in Programming"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG CSP Abstraction in Programming 2"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c184ab33-33f8-4c83-b17a-b9e5e0e739ab"
+      },
+      "level_keys": [
+        "SG CSP Abstraction in Programming 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 7,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L03 - draw rect function"
+        ],
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 - draw rect function"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "e241aaf6-20c3-4727-872e-64fde6b862ab"
+      },
+      "level_keys": [
+        "SG U3L03 - draw rect function"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 8,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L03 - draw step"
+        ],
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 - draw step"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "e241aaf6-20c3-4727-872e-64fde6b862ab"
+      },
+      "level_keys": [
+        "SG U3L03 - draw step"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 9,
+      "activity_section_position": 3,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L03 Three Steps"
+        ],
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 Three Steps"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "e241aaf6-20c3-4727-872e-64fde6b862ab"
+      },
+      "level_keys": [
+        "SG U3L03 Three Steps"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 10,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L03 draw diamond"
+        ],
+        "progression": "Challenge: Draw a Diamond Using Functions"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 draw diamond"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "16c1870b-7209-4407-8bb8-b101156ced2d"
+      },
+      "level_keys": [
+        "SG U3L03 draw diamond"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 11,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L03 - multiselect - properties of functions"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c0a562c4-946c-41d3-b3c1-b8b18ae32bb7"
+      },
+      "level_keys": [
+        "U3L03 - multiselect - properties of functions"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 12,
+      "activity_section_position": 2,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L03 Assessment"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Assessment"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c0a562c4-946c-41d3-b3c1-b8b18ae32bb7"
+      },
+      "level_keys": [
+        "U3L03 Assessment"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 13,
+      "activity_section_position": 3,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L03 Free Response Wrap Up"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c0a562c4-946c-41d3-b3c1-b8b18ae32bb7"
+      },
+      "level_keys": [
+        "U3L03 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 14,
+      "activity_section_position": 4,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "csp_U3_plan_code_FR"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c0a562c4-946c-41d3-b3c1-b8b18ae32bb7"
+      },
+      "level_keys": [
+        "csp_U3_plan_code_FR"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG v2 U3L6 Student Lesson Introduction"
+        ],
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L6 Student Lesson Introduction"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3ca12f56-ed8d-42fd-abd4-04268247b4ac"
+      },
+      "level_keys": [
+        "SG v2 U3L6 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L04 - snowflake"
+        ],
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L04 - snowflake"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "78684ca4-ee3b-45c5-bf04-3dfb79cdf54c"
+      },
+      "level_keys": [
+        "SG U3L04 - snowflake"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L04 - 3 by 3 with functions"
+        ],
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L04 - 3 by 3 with functions"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "78684ca4-ee3b-45c5-bf04-3dfb79cdf54c"
+      },
+      "level_keys": [
+        "SG U3L04 - 3 by 3 with functions"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3-AP-Practice-FR-design-process"
+        ],
+        "progression": "(new)AP Practice Response - Design Process"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "627f3601-fbfd-46e8-9eb1-c8e678131559"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-design-process"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 5,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L04 Assessment1"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment1"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "6a3ae4a8-fc6e-44f6-9866-335e7f17c436"
+      },
+      "level_keys": [
+        "U3L04 Assessment1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 6,
+      "activity_section_position": 2,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L04 Assessment2"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment2"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "6a3ae4a8-fc6e-44f6-9866-335e7f17c436"
+      },
+      "level_keys": [
+        "U3L04 Assessment2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 7,
+      "activity_section_position": 3,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L04 Free Response Wrap Up"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "6a3ae4a8-fc6e-44f6-9866-335e7f17c436"
+      },
+      "level_keys": [
+        "U3L04 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG v2 U3L07 Student Lesson Introduction"
+        ],
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L07 Student Lesson Introduction"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "26128992-4983-4196-bc1d-079bfd5d7fe1"
+      },
+      "level_keys": [
+        "SG v2 U3L07 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L06 - moveForwardwithParams"
+        ],
+        "progression": "Introduction to Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 - moveForwardwithParams"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      },
+      "level_keys": [
+        "SG U3L06 - moveForwardwithParams"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L06 Challenge 1 triangle"
+        ],
+        "progression": "Introduction to Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 1 triangle"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 1 triangle"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "activity_section_position": 3,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 More Subgoals"
+        ],
+        "progression": "Introduction to Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 More Subgoals"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      },
+      "level_keys": [
+        "SG U3L07 More Subgoals"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "activity_section_position": 4,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L06 Challenge 2 purple square"
+        ],
+        "progression": "Introduction to Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 2 purple square"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 2 purple square"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "activity_section_position": 5,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L06 Challenge 3 fill pink"
+        ],
+        "progression": "Introduction to Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 3 fill pink"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 3 fill pink"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 7,
+      "activity_section_position": 6,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L06 Challenge 4 bullseye"
+        ],
+        "progression": "Introduction to Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 4 bullseye"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 4 bullseye"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 8,
+      "activity_section_position": 7,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L06 Challenge 6 squiggles"
+        ],
+        "progression": "Introduction to Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 6 squiggles"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 6 squiggles"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 9,
+      "activity_section_position": 8,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L06 Challenge 5 overlapping circles"
+        ],
+        "progression": "Introduction to Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 5 overlapping circles"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 5 overlapping circles"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 10,
+      "activity_section_position": 9,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L06 Challenge 7 smiley face"
+        ],
+        "progression": "Introduction to Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 7 smiley face"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 7 smiley face"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 11,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L06 Challenge 8 make your own"
+        ],
+        "progression": "Make Your Own Turtle Drawing"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 8 make your own"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "a1781451-9b61-44a2-9f2d-b405afd381c7"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 8 make your own"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 12,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response"
+        ],
+        "progression": "(new)AP Practice Response - Score a student response"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "69b648d7-d8d7-44e5-af00-54a178ec2f0c"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-score-abstraction-response"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 13,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L06 Assessment2"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment2"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9870a016-49f6-43c9-aa81-c22660086b50"
+      },
+      "level_keys": [
+        "U3L06 Assessment2"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 14,
+      "activity_section_position": 2,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L06-API-multichoice"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06-API-multichoice"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9870a016-49f6-43c9-aa81-c22660086b50"
+      },
+      "level_keys": [
+        "U3L06-API-multichoice"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 15,
+      "activity_section_position": 3,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L06 Assessment"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9870a016-49f6-43c9-aa81-c22660086b50"
+      },
+      "level_keys": [
+        "U3L06 Assessment"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 16,
+      "activity_section_position": 4,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9870a016-49f6-43c9-aa81-c22660086b50"
+      },
+      "level_keys": [
+        "csp3_U3_turtle_subgoal_mc_levelgroup"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG v2 U3L08 Student Lesson Introduction"
+        ],
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L08 Student Lesson Introduction"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "0ade1273-abba-4835-bc59-769ccfbd3d6c"
+      },
+      "level_keys": [
+        "SG v2 U3L08 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG csp_applab_functions_parameters"
+        ],
+        "progression": "Functions with Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG csp_applab_functions_parameters"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "d63894ee-364f-48b6-9c2c-a1ed6ca1e4dd"
+      },
+      "level_keys": [
+        "SG csp_applab_functions_parameters"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L08 - drawSquareWithParam"
+        ],
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - drawSquareWithParam"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "68982125-ad77-4aad-91bf-099d8a615706"
+      },
+      "level_keys": [
+        "SG U3L08 - drawSquareWithParam"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - createTriangleParam"
+        ],
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - createTriangleParam"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "68982125-ad77-4aad-91bf-099d8a615706"
+      },
+      "level_keys": [
+        "SG U3L07 - createTriangleParam"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "activity_section_position": 3,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L08 - squareTwoParams"
+        ],
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - squareTwoParams"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "68982125-ad77-4aad-91bf-099d8a615706"
+      },
+      "level_keys": [
+        "SG U3L08 - squareTwoParams"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 6,
+      "activity_section_position": 4,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L08 - createTwoParamTriangle"
+        ],
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - createTwoParamTriangle"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "68982125-ad77-4aad-91bf-099d8a615706"
+      },
+      "level_keys": [
+        "SG U3L08 - createTwoParamTriangle"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 7,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "SG csp_U3_turtle_subgoal_q3_mc"
+        ],
+        "progression": "Check Your Understanding: Defining Functions"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG csp_U3_turtle_subgoal_q3_mc"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "287af6d8-1124-43dc-99ad-482087ce16c7"
+      },
+      "level_keys": [
+        "SG csp_U3_turtle_subgoal_q3_mc"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 8,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3 whats a comment"
+        ],
+        "progression": "(new) How to add comments to code"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3 whats a comment"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "f9668e92-fb0f-4724-b15f-90406baac7bf"
+      },
+      "level_keys": [
+        "SG U3 whats a comment"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 9,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L08 how to add comments"
+        ],
+        "progression": "(new) How to add comments to code"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 how to add comments"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "f9668e92-fb0f-4724-b15f-90406baac7bf"
+      },
+      "level_keys": [
+        "SG U3L08 how to add comments"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 10,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L08 - introUnderTheSea"
+        ],
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - introUnderTheSea"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      },
+      "level_keys": [
+        "SG U3L08 - introUnderTheSea"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 11,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L08 - paramsToStarfish"
+        ],
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - paramsToStarfish"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      },
+      "level_keys": [
+        "SG U3L08 - paramsToStarfish"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 12,
+      "activity_section_position": 3,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L08 - seaGrass"
+        ],
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - seaGrass"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      },
+      "level_keys": [
+        "SG U3L08 - seaGrass"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 13,
+      "activity_section_position": 4,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L08 - fish"
+        ],
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - fish"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      },
+      "level_keys": [
+        "SG U3L08 - fish"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 14,
+      "activity_section_position": 5,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L08 - multiParamFish"
+        ],
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - multiParamFish"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      },
+      "level_keys": [
+        "SG U3L08 - multiParamFish"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 15,
+      "activity_section_position": 6,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L08 - randomInput"
+        ],
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - randomInput"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      },
+      "level_keys": [
+        "SG U3L08 - randomInput"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 16,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "csp_U3_subgoal_q4_mc"
+        ],
+        "progression": "Check Your Understanding: Using Random Numbers"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c8d7b942-ac7b-4fa8-ad7a-40f25ef88421"
+      },
+      "level_keys": [
+        "csp_U3_subgoal_q4_mc"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 17,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L08 - freePlay"
+        ],
+        "progression": "Challenge: Continue Your Drawing With More Functions"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - freePlay"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "b6b627ac-6cec-4294-b2d9-645388c6eef2"
+      },
+      "level_keys": [
+        "SG U3L08 - freePlay"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 18,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3-AP-Practice-FR-manage-complexity"
+        ],
+        "progression": "(new)AP Practice Response - Managing Complexity"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "848e73b1-5231-42a8-8e76-edba8912d5f7"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-manage-complexity"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 19,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L08 Assessment1"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment1"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "d6d9b4ce-b931-4a6b-b3a6-b54c36503294"
+      },
+      "level_keys": [
+        "U3L08 Assessment1"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 20,
+      "activity_section_position": 2,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L08 Assessment2"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment2"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "d6d9b4ce-b931-4a6b-b3a6-b54c36503294"
+      },
+      "level_keys": [
+        "U3L08 Assessment2"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG v2 U3L09 Student Lesson Introduction"
+        ],
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L09 Student Lesson Introduction"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "f80daf42-c153-4da8-a8a5-b05bc7ca9367"
+      },
+      "level_keys": [
+        "SG v2 U3L09 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 2,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG csp_applab_loops"
+        ],
+        "progression": "Using Loops"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG csp_applab_loops"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "34ccda19-40c9-4e4a-9a4b-c07ece4c448a"
+      },
+      "level_keys": [
+        "SG csp_applab_loops"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 3,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - introSquare"
+        ],
+        "progression": "Introduction to Loops"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - introSquare"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501"
+      },
+      "level_keys": [
+        "SG U3L07 - introSquare"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 4,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - randomSquare"
+        ],
+        "progression": "Introduction to Loops"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - randomSquare"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501"
+      },
+      "level_keys": [
+        "SG U3L07 - randomSquare"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 5,
+      "activity_section_position": 3,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "SG subgoals_U3_turtle_prediction_FR"
+        ],
+        "progression": "Introduction to Loops"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG subgoals_U3_turtle_prediction_FR"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501"
+      },
+      "level_keys": [
+        "SG subgoals_U3_turtle_prediction_FR"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 6,
+      "activity_section_position": 4,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - randomDots1"
+        ],
+        "progression": "Introduction to Loops"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - randomDots1"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501"
+      },
+      "level_keys": [
+        "SG U3L07 - randomDots1"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 7,
+      "activity_section_position": 5,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - loopsWithRandom"
+        ],
+        "progression": "Introduction to Loops"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - loopsWithRandom"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501"
+      },
+      "level_keys": [
+        "SG U3L07 - loopsWithRandom"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 8,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - topDownDesign"
+        ],
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - topDownDesign"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      },
+      "level_keys": [
+        "SG U3L07 - topDownDesign"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 9,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - bubbles"
+        ],
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - bubbles"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      },
+      "level_keys": [
+        "SG U3L07 - bubbles"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 10,
+      "activity_section_position": 3,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - fish"
+        ],
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - fish"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      },
+      "level_keys": [
+        "SG U3L07 - fish"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 11,
+      "activity_section_position": 4,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - seaStar"
+        ],
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - seaStar"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      },
+      "level_keys": [
+        "SG U3L07 - seaStar"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 12,
+      "activity_section_position": 5,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - seaGrass"
+        ],
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - seaGrass"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      },
+      "level_keys": [
+        "SG U3L07 - seaGrass"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 13,
+      "activity_section_position": 6,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - allSeaGrass"
+        ],
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - allSeaGrass"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      },
+      "level_keys": [
+        "SG U3L07 - allSeaGrass"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 14,
+      "activity_section_position": 7,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - sunBeams"
+        ],
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - sunBeams"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      },
+      "level_keys": [
+        "SG U3L07 - sunBeams"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 15,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG U3L07 - Free Play Loops and Random"
+        ],
+        "progression": "Project: Under the Sea"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - Free Play Loops and Random"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "eac13cbb-82a8-450b-ab74-f1bb2ccf9665"
+      },
+      "level_keys": [
+        "SG U3L07 - Free Play Loops and Random"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 16,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction"
+        ],
+        "progression": "(new)AP Practice Response - Identify the Abstraction"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "209caa2a-8586-4b13-8300-75f4bf50ea62"
+      },
+      "level_keys": [
+        "U3-AP-Practice-Choose-The-Abstraction"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 17,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L07 - MC remove line of code loops"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9b397bf7-ee9c-451e-beac-ae360d369a23"
+      },
+      "level_keys": [
+        "U3L07 - MC remove line of code loops"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 18,
+      "activity_section_position": 2,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "U3L07 Free Response Reflection"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9b397bf7-ee9c-451e-beac-ae360d369a23"
+      },
+      "level_keys": [
+        "U3L07 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 19,
+      "activity_section_position": 3,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "subgoals_u3_top_down_FR"
+        ],
+        "progression": "Check Your Understanding"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9b397bf7-ee9c-451e-beac-ae360d369a23"
+      },
+      "level_keys": [
+        "subgoals_u3_top_down_FR"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "SG v2 U3L10 Student Lesson Introduction"
+        ],
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L10 Student Lesson Introduction"
+        ],
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "4d6db1c1-4057-4f6c-a6ee-9cefeabd7400"
+      },
+      "level_keys": [
+        "SG v2 U3L10 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "U3L08 - individualCode"
+        ],
+        "progression": "Design Your Components"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - individualCode"
+        ],
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "aacb9492-2fcd-43d4-90de-ec7b63a9a77d"
+      },
+      "level_keys": [
+        "U3L08 - individualCode"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "How To: Share Code with Teammates"
+        ],
+        "progression": "How To: Share Code with Teammates"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates"
+        ],
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "7fde4e9f-210c-4f24-9c78-2fffa3c2621c"
+      },
+      "level_keys": [
+        "How To: Share Code with Teammates"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "U3L08 - digitalScene"
+        ],
+        "progression": "Challenge: Design Your Digital Scene"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - digitalScene"
+        ],
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "e372f6a7-6fd8-48d5-95a3-3017b0e6d07d"
+      },
+      "level_keys": [
+        "U3L08 - digitalScene"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "progression": "Pre-test reflection",
+        "variants": {
+          "csp_affirmation_intervention_3": {
+            "active": false
+          }
+        }
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ff1cd44b-d3da-4b57-b1fb-83e7c3c42352"
+      },
+      "level_keys": [
+        "csp_affirmation_control_3",
+        "csp_affirmation_intervention_3"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 2,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+        ]
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+        ],
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "495d4546-96eb-47f8-b501-688a91666d6d"
+      },
+      "level_keys": [
+        "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": true,
+      "properties": {
+        "level_keys": [
+          "csp-post-survey-2017-levelgroup"
+        ]
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2017-levelgroup"
+        ],
+        "lesson.key": "Please complete the CSP Mid-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "5ac771a7-5ebd-4044-ab8f-1da685a512e1"
+      },
+      "level_keys": [
+        "csp-post-survey-2017-levelgroup"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L01 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L01 Student Lesson Introduction"
+        ],
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "d6ab7dd6-2fb0-4286-b637-3e89772c3a83"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment1",
+        "script_level.level_keys": [
+          "U3L01 Assessment1"
+        ],
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "208eb4cb-4f81-4211-9597-03a48222b5df"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment3",
+        "script_level.level_keys": [
+          "U3L01 Assessment3"
+        ],
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "208eb4cb-4f81-4211-9597-03a48222b5df"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-4-levelgroup-U3Ch1",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+        ],
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "f77e4ecc-8174-4706-813c-b38185245864"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L02 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L02 Student Lesson Introduction"
+        ],
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "2a38d481-6cf8-4a5b-b7a3-57906be6669a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L03 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L03 Student Lesson Introduction"
+        ],
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3d1a4a16-a7e7-4bd1-b80e-27b6cb137608"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L04 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG U3L04 Student Lesson Introduction"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "4d90b776-9c5a-4874-9efb-2264d95aa59a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG csp_applab_turtle",
+        "script_level.level_keys": [
+          "SG csp_applab_turtle"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "27124322-ec91-4046-b978-c1d141f29a2c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L2 Using Simple Commands part 1",
+        "script_level.level_keys": [
+          "SG U3L2 Using Simple Commands part 1"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SGU3L2A Introducing Subgoals",
+        "script_level.level_keys": [
+          "SGU3L2A Introducing Subgoals"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L2 Using Simple Commands",
+        "script_level.level_keys": [
+          "SG U3L2 Using Simple Commands"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L2_TurtleSquare_right",
+        "script_level.level_keys": [
+          "SG U3L2_TurtleSquare_right"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG Add Subgoals practice",
+        "script_level.level_keys": [
+          "SG Add Subgoals practice"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3e4c25e5-e800-485f-9dd1-bc61eb6b4a9e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L2_Turtle3by3Grid",
+        "script_level.level_keys": [
+          "SG U3L2_Turtle3by3Grid"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "44e26ccc-ec9f-4643-bf15-814d79916d5e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Assessment",
+        "script_level.level_keys": [
+          "U3L02 Assessment"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "5356c465-63c9-4be1-91eb-58407ba7003d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "5356c465-63c9-4be1-91eb-58407ba7003d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_square_v_rect_FR",
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "5356c465-63c9-4be1-91eb-58407ba7003d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up"
+        ],
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "5356c465-63c9-4be1-91eb-58407ba7003d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L05 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L05 Student Lesson Introduction"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "17ae2965-046c-442a-9340-b0d1728eca08"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG csp_applab_functions",
+        "script_level.level_keys": [
+          "SG csp_applab_functions"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "e3b9756f-0e1b-4e9f-813a-762bb9d256cb"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 Define and use turnAround",
+        "script_level.level_keys": [
+          "SG U3L03 Define and use turnAround"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "000bc98d-6824-4ed3-b734-cfcf72a27ee2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 Draw a T using turnAround",
+        "script_level.level_keys": [
+          "SG U3L03 Draw a T using turnAround"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "000bc98d-6824-4ed3-b734-cfcf72a27ee2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 define turnRight and draw a rectangle",
+        "script_level.level_keys": [
+          "SG U3L03 define turnRight and draw a rectangle"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "000bc98d-6824-4ed3-b734-cfcf72a27ee2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG CSP Abstraction in Programming 2",
+        "script_level.level_keys": [
+          "SG CSP Abstraction in Programming 2"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c184ab33-33f8-4c83-b17a-b9e5e0e739ab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 - draw rect function",
+        "script_level.level_keys": [
+          "SG U3L03 - draw rect function"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "e241aaf6-20c3-4727-872e-64fde6b862ab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 - draw step",
+        "script_level.level_keys": [
+          "SG U3L03 - draw step"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "e241aaf6-20c3-4727-872e-64fde6b862ab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 Three Steps",
+        "script_level.level_keys": [
+          "SG U3L03 Three Steps"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "e241aaf6-20c3-4727-872e-64fde6b862ab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 draw diamond",
+        "script_level.level_keys": [
+          "SG U3L03 draw diamond"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "16c1870b-7209-4407-8bb8-b101156ced2d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - multiselect - properties of functions",
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c0a562c4-946c-41d3-b3c1-b8b18ae32bb7"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Assessment",
+        "script_level.level_keys": [
+          "U3L03 Assessment"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c0a562c4-946c-41d3-b3c1-b8b18ae32bb7"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c0a562c4-946c-41d3-b3c1-b8b18ae32bb7"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_plan_code_FR",
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR"
+        ],
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c0a562c4-946c-41d3-b3c1-b8b18ae32bb7"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L6 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L6 Student Lesson Introduction"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "3ca12f56-ed8d-42fd-abd4-04268247b4ac"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L04 - snowflake",
+        "script_level.level_keys": [
+          "SG U3L04 - snowflake"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "78684ca4-ee3b-45c5-bf04-3dfb79cdf54c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L04 - 3 by 3 with functions",
+        "script_level.level_keys": [
+          "SG U3L04 - 3 by 3 with functions"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "78684ca4-ee3b-45c5-bf04-3dfb79cdf54c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-design-process",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "627f3601-fbfd-46e8-9eb1-c8e678131559"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment1",
+        "script_level.level_keys": [
+          "U3L04 Assessment1"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "6a3ae4a8-fc6e-44f6-9866-335e7f17c436"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment2",
+        "script_level.level_keys": [
+          "U3L04 Assessment2"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "6a3ae4a8-fc6e-44f6-9866-335e7f17c436"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up"
+        ],
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "6a3ae4a8-fc6e-44f6-9866-335e7f17c436"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L07 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L07 Student Lesson Introduction"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "26128992-4983-4196-bc1d-079bfd5d7fe1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 - moveForwardwithParams",
+        "script_level.level_keys": [
+          "SG U3L06 - moveForwardwithParams"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 1 triangle",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 1 triangle"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 More Subgoals",
+        "script_level.level_keys": [
+          "SG U3L07 More Subgoals"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 2 purple square",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 2 purple square"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 3 fill pink",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 3 fill pink"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 4 bullseye",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 4 bullseye"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 6 squiggles",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 6 squiggles"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 5 overlapping circles",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 5 overlapping circles"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 7 smiley face",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 7 smiley face"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ee4d6410-897e-4821-9f92-83cead67af02"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 8 make your own",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 8 make your own"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "a1781451-9b61-44a2-9f2d-b405afd381c7"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-score-abstraction-response",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "69b648d7-d8d7-44e5-af00-54a178ec2f0c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment2",
+        "script_level.level_keys": [
+          "U3L06 Assessment2"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9870a016-49f6-43c9-aa81-c22660086b50"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06-API-multichoice",
+        "script_level.level_keys": [
+          "U3L06-API-multichoice"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9870a016-49f6-43c9-aa81-c22660086b50"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment",
+        "script_level.level_keys": [
+          "U3L06 Assessment"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9870a016-49f6-43c9-aa81-c22660086b50"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3_U3_turtle_subgoal_mc_levelgroup",
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup"
+        ],
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9870a016-49f6-43c9-aa81-c22660086b50"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L08 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L08 Student Lesson Introduction"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "0ade1273-abba-4835-bc59-769ccfbd3d6c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG csp_applab_functions_parameters",
+        "script_level.level_keys": [
+          "SG csp_applab_functions_parameters"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "d63894ee-364f-48b6-9c2c-a1ed6ca1e4dd"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - drawSquareWithParam",
+        "script_level.level_keys": [
+          "SG U3L08 - drawSquareWithParam"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "68982125-ad77-4aad-91bf-099d8a615706"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - createTriangleParam",
+        "script_level.level_keys": [
+          "SG U3L07 - createTriangleParam"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "68982125-ad77-4aad-91bf-099d8a615706"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - squareTwoParams",
+        "script_level.level_keys": [
+          "SG U3L08 - squareTwoParams"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "68982125-ad77-4aad-91bf-099d8a615706"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - createTwoParamTriangle",
+        "script_level.level_keys": [
+          "SG U3L08 - createTwoParamTriangle"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "68982125-ad77-4aad-91bf-099d8a615706"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG csp_U3_turtle_subgoal_q3_mc",
+        "script_level.level_keys": [
+          "SG csp_U3_turtle_subgoal_q3_mc"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "287af6d8-1124-43dc-99ad-482087ce16c7"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3 whats a comment",
+        "script_level.level_keys": [
+          "SG U3 whats a comment"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "f9668e92-fb0f-4724-b15f-90406baac7bf"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 how to add comments",
+        "script_level.level_keys": [
+          "SG U3L08 how to add comments"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "f9668e92-fb0f-4724-b15f-90406baac7bf"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - introUnderTheSea",
+        "script_level.level_keys": [
+          "SG U3L08 - introUnderTheSea"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - paramsToStarfish",
+        "script_level.level_keys": [
+          "SG U3L08 - paramsToStarfish"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - seaGrass",
+        "script_level.level_keys": [
+          "SG U3L08 - seaGrass"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - fish",
+        "script_level.level_keys": [
+          "SG U3L08 - fish"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - multiParamFish",
+        "script_level.level_keys": [
+          "SG U3L08 - multiParamFish"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - randomInput",
+        "script_level.level_keys": [
+          "SG U3L08 - randomInput"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "fc42744a-2c36-439b-b633-1f9aeecaf071"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_subgoal_q4_mc",
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "c8d7b942-ac7b-4fa8-ad7a-40f25ef88421"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - freePlay",
+        "script_level.level_keys": [
+          "SG U3L08 - freePlay"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "b6b627ac-6cec-4294-b2d9-645388c6eef2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-manage-complexity",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "848e73b1-5231-42a8-8e76-edba8912d5f7"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment1",
+        "script_level.level_keys": [
+          "U3L08 Assessment1"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "d6d9b4ce-b931-4a6b-b3a6-b54c36503294"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment2",
+        "script_level.level_keys": [
+          "U3L08 Assessment2"
+        ],
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "d6d9b4ce-b931-4a6b-b3a6-b54c36503294"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L09 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L09 Student Lesson Introduction"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "f80daf42-c153-4da8-a8a5-b05bc7ca9367"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG csp_applab_loops",
+        "script_level.level_keys": [
+          "SG csp_applab_loops"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "34ccda19-40c9-4e4a-9a4b-c07ece4c448a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - introSquare",
+        "script_level.level_keys": [
+          "SG U3L07 - introSquare"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - randomSquare",
+        "script_level.level_keys": [
+          "SG U3L07 - randomSquare"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG subgoals_U3_turtle_prediction_FR",
+        "script_level.level_keys": [
+          "SG subgoals_U3_turtle_prediction_FR"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - randomDots1",
+        "script_level.level_keys": [
+          "SG U3L07 - randomDots1"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - loopsWithRandom",
+        "script_level.level_keys": [
+          "SG U3L07 - loopsWithRandom"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "20db9f34-0208-4a3d-86f7-ccfcbcde7501"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - topDownDesign",
+        "script_level.level_keys": [
+          "SG U3L07 - topDownDesign"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - bubbles",
+        "script_level.level_keys": [
+          "SG U3L07 - bubbles"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - fish",
+        "script_level.level_keys": [
+          "SG U3L07 - fish"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - seaStar",
+        "script_level.level_keys": [
+          "SG U3L07 - seaStar"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - seaGrass",
+        "script_level.level_keys": [
+          "SG U3L07 - seaGrass"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - allSeaGrass",
+        "script_level.level_keys": [
+          "SG U3L07 - allSeaGrass"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - sunBeams",
+        "script_level.level_keys": [
+          "SG U3L07 - sunBeams"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "46288bbe-0c54-4a4b-a027-35d5054c6faf"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - Free Play Loops and Random",
+        "script_level.level_keys": [
+          "SG U3L07 - Free Play Loops and Random"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "eac13cbb-82a8-450b-ab74-f1bb2ccf9665"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-Choose-The-Abstraction",
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "209caa2a-8586-4b13-8300-75f4bf50ea62"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - MC remove line of code loops",
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9b397bf7-ee9c-451e-beac-ae360d369a23"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 Free Response Reflection",
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9b397bf7-ee9c-451e-beac-ae360d369a23"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_u3_top_down_FR",
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR"
+        ],
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "9b397bf7-ee9c-451e-beac-ae360d369a23"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L10 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L10 Student Lesson Introduction"
+        ],
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "4d6db1c1-4057-4f6c-a6ee-9cefeabd7400"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - individualCode",
+        "script_level.level_keys": [
+          "U3L08 - individualCode"
+        ],
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "aacb9492-2fcd-43d4-90de-ec7b63a9a77d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How To: Share Code with Teammates",
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates"
+        ],
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "7fde4e9f-210c-4f24-9c78-2fffa3c2621c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - digitalScene",
+        "script_level.level_keys": [
+          "U3L08 - digitalScene"
+        ],
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "e372f6a7-6fd8-48d5-95a3-3017b0e6d07d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_intervention_3",
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ff1cd44b-d3da-4b57-b1fb-83e7c3c42352"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_control_3",
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "ff1cd44b-d3da-4b57-b1fb-83e7c3c42352"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 3 Ch1 Cumulative Assessment MC Group",
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+        ],
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "495d4546-96eb-47f8-b501-688a91666d6d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2017-levelgroup",
+        "script_level.level_keys": [
+          "csp-post-survey-2017-levelgroup"
+        ],
+        "lesson.key": "Please complete the CSP Mid-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-research-mxghyt",
+        "activity_section.key": "5ac771a7-5ebd-4044-ab8f-1da685a512e1"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ],
+  "rubrics": [
+
+  ],
+  "learning_goals": [
+
+  ],
+  "learning_goal_evidence_levels": [
+
+  ]
+}


### PR DESCRIPTION
this fixes an issue caused by these 2 PRs:
* https://github.com/code-dot-org/code-dot-org/pull/63387
* https://github.com/code-dot-org/code-dot-org/pull/59347

the 2nd PR inadvertently depends on `rake seed` or `rake build` having been run after the 1st PR. Otherwise you get this error: https://codedotorg.slack.com/archives/C046G4TRLEN/p1738357640914509

by restoring the removed unit, the resources and vocab will be removed as part of `rake seed`, prior to attempting to remove them from the unit.
