### PR TITLE
Remove unused i18n lazy loading from test env config

### DIFF
--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -19,24 +19,6 @@ Dashboard::Application.configure do
 
   is_ci = !!ENV.fetch('CI', nil)
 
-  # test environment should use precompiled, minified, digested assets like production,
-  # unless it's being used for unit tests.
-  ci_test = !!(ENV['UNIT_TEST'] || is_ci)
-
-  unless ci_test
-    # Compress JavaScripts and CSS.
-    # webpack handles js compression for us
-    # config.assets.js_compressor = :uglifier
-    # config.assets.css_compressor = :sass
-
-    # Version of your assets, change this if you want to expire all your assets.
-    config.assets.version = '1.0'
-
-    # Avoid loading all i18n files up front, which can significantly slow down initialization.
-    # Instead, it only loads i18n files that belong to the current locale.
-    config.i18n.backend = Cdo::I18n::LazyLoadableBackend.new(lazy_load: true)
-  end
-
   # In CI environments (ie, Drone), stub relevant AWS services (currently just SageMaker)
   # so we can run UI tests for our AI Chat (ie, Generative AI) lab.
   if is_ci
@@ -50,10 +32,8 @@ Dashboard::Application.configure do
   config.action_controller.perform_caching = false
 
   # Disable Rails.cache when running unit tests.
-  config.cache_store = :memory_store, {size: 64.megabytes} if ci_test
-
-  # config.action_mailer.raise_delivery_errors = true
-  # config.action_mailer.delivery_method = :smtp
+  # Also disabled in Drone, although unsure sure if this is strictly desired.
+  config.cache_store = :memory_store, {size: 64.megabytes} if ENV['UNIT_TEST'] || is_ci
 
   # Show mail previews (rails/mailers).
   # See http://edgeguides.rubyonrails.org/action_mailer_basics.html#previewing-emails


### PR DESCRIPTION
Cleans up some unused code from our test environment config. The lazy loading piece is not actually being used right now, but Artem is going to take a work item to find the right way to implement it (thanks Artem!)

More discussion in [this (to be closed) PR](https://github.com/code-dot-org/code-dot-org/pull/61381/files) and [this Slack thread](https://codedotorg.slack.com/archives/C046G4TRLEN/p1726002872596669?thread_ts=1725999044.328009&cid=C046G4TRLEN). 