### PR TITLE
feat(Video): add component definition for Contentful

### DIFF
--- a/frontend/apps/marketing/src/components/video/index.ts
+++ b/frontend/apps/marketing/src/components/video/index.ts
@@ -1,0 +1,5 @@
+import '@code-dot-org/component-library/video/index.css';
+
+// Export the Component Definition for use in Contentful Studio
+export {VideoContentfulComponentDefinition} from './videoContentfulDefinition';
+export {default} from '@code-dot-org/component-library/video';

--- a/frontend/apps/marketing/src/components/video/videoContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/video/videoContentfulDefinition.ts
@@ -1,0 +1,47 @@
+// Creates a definition for the Video component to be used in Contentful Studio
+import {ComponentDefinition} from '@contentful/experiences-sdk-react';
+
+export const VideoContentfulComponentDefinition: ComponentDefinition = {
+  id: 'video',
+  name: 'Video',
+  category: 'Custom Components',
+  thumbnailUrl:
+    'https://images.ctfassets.net/90t6bu6vlf76/34JWsHE14EP6EoqJyoa3vI/2328840aeb5c98b7483aa50f7ba7dcf0/component_video_thumbnail.png',
+  tooltip: {
+    description:
+      'Add a video frame to your layout. Supports title, download, and fallback options.',
+    imageUrl:
+      'https://images.ctfassets.net/90t6bu6vlf76/7I4Hd4Mf5rwUWgm8QfM1nu/1bdbedc97c9e2960a5444d23e0aabc20/component_video_tooltip.png',
+  },
+  variables: {
+    videoTitle: {
+      displayName: 'Video title',
+      type: 'Text',
+      group: 'content',
+      description:
+        'The title of the video. This will double as the caption under the video player.',
+    },
+    youTubeId: {
+      displayName: 'YouTube ID',
+      type: 'Text',
+      group: 'content',
+      description:
+        'The YouTube ID of the video. This is the unique identifier for the video on YouTube.',
+    },
+    videoFallback: {
+      displayName: 'Video fallback',
+      type: 'Text',
+      group: 'content',
+      description:
+        'This is the URL of the video that will be used in place of the YouTube video if YouTube is blocked.',
+    },
+    showCaption: {
+      displayName: 'Show video caption',
+      type: 'Boolean',
+      defaultValue: true,
+      group: 'style',
+      description:
+        'Check this to show a caption (video title) under the video player.',
+    },
+  },
+};

--- a/frontend/apps/marketing/src/components/video/videoContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/video/videoContentfulDefinition.ts
@@ -13,6 +13,8 @@ export const VideoContentfulComponentDefinition: ComponentDefinition = {
     imageUrl:
       'https://images.ctfassets.net/90t6bu6vlf76/7I4Hd4Mf5rwUWgm8QfM1nu/1bdbedc97c9e2960a5444d23e0aabc20/component_video_tooltip.png',
   },
+  // Adding an empty array here so no default style options show in the Design tab.
+  builtInStyles: [],
   variables: {
     videoTitle: {
       displayName: 'Video title',

--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -12,6 +12,7 @@ import Heading, {
 import Paragraph, {
   ParagraphContentfulComponentDefinition,
 } from '@/components/paragraph';
+import Video, {VideoContentfulComponentDefinition} from '@/components/video';
 
 import {
   defineComponents,
@@ -34,6 +35,11 @@ defineComponents(
     {
       component: Paragraph,
       definition: ParagraphContentfulComponentDefinition,
+    },
+    {
+      component: Video,
+      definition: VideoContentfulComponentDefinition,
+      options: {wrapContainerWidth: '100%'},
     },
   ],
   {

--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -39,7 +39,9 @@ defineComponents(
     {
       component: Video,
       definition: VideoContentfulComponentDefinition,
-      options: {wrapContainerWidth: '100%'},
+      options: {
+        wrapContainerWidth: '100%',
+      },
     },
   ],
   {

--- a/frontend/packages/component-library/package.json
+++ b/frontend/packages/component-library/package.json
@@ -268,7 +268,16 @@
       "import": "./dist/esm/typography/index.mjs",
       "require": "./dist/cjs/typography/index.js"
     },
-    "./typography/index.css": "./dist/esm/typography/index.css"
+    "./typography/index.css": "./dist/esm/typography/index.css",
+    "./video": {
+      "types": {
+        "import": "./dist/esm/video/index.d.mts",
+        "require": "./dist/cjs/video/index.d.ts"
+      },
+      "import": "./dist/esm/video/index.mjs",
+      "require": "./dist/cjs/video/index.js"
+    },
+    "./video/index.css": "./dist/esm/video/index.css"
   },
   "main": "components/index.ts",
   "files": [

--- a/frontend/packages/component-library/src/video/index.ts
+++ b/frontend/packages/component-library/src/video/index.ts
@@ -1,2 +1,4 @@
+'use client'
+
 export {default as Video, VideoProps} from './Video';
 export {default as default} from './Video';

--- a/frontend/packages/component-library/src/video/index.ts
+++ b/frontend/packages/component-library/src/video/index.ts
@@ -1,4 +1,5 @@
-'use client'
+// Add this to prevent a Next.js build error in Contentful
+'use client';
 
 export {default as Video, VideoProps} from './Video';
 export {default as default} from './Video';


### PR DESCRIPTION
Adds the Video component definition for use on Contentful.

## Links 
Jira ticket: [CMS-96](https://codedotorg.atlassian.net/browse/CMS-96)
Related PR: https://github.com/code-dot-org/code-dot-org/pull/63435

## Testing story
Tested locally on Contentful

----


https://github.com/user-attachments/assets/ab139575-b179-4cba-a73d-b43f7b18917a

## Fallback
<img width="1730" alt="Fallback" src="https://github.com/user-attachments/assets/c78e7f49-fa42-4ced-a488-adb53d6909f9" />

## Multiple videos w/ one fallback and one w/o
<img width="1730" alt="Screenshot 2025-02-03 at 9 13 44 AM" src="https://github.com/user-attachments/assets/34e70022-280e-434c-9e89-da67a4d4e58d" />



