### PR TITLE
[Design2-263] DSCO - Link component - Use component-library package instead of apps/src/componentLibrary across apps directory

### DIFF
--- a/apps/src/accounts/AccountInformation/index.tsx
+++ b/apps/src/accounts/AccountInformation/index.tsx
@@ -1,11 +1,11 @@
 import Alert, {alertTypes} from '@code-dot-org/component-library/alert';
 import {Button} from '@code-dot-org/component-library/button';
+import Link from '@code-dot-org/component-library/link';
 import classNames from 'classnames';
 import React, {useEffect, useMemo, useState} from 'react';
 
 import {hashEmail} from '@cdo/apps/code-studio/hashEmail';
 import {SimpleDropdown} from '@cdo/apps/componentLibrary/dropdown';
-import Link from '@cdo/apps/componentLibrary/link/Link';
 import TextField from '@cdo/apps/componentLibrary/textField/TextField';
 import {Heading2} from '@cdo/apps/componentLibrary/typography';
 import {getAuthenticityToken} from '@cdo/apps/util/AuthenticityTokenStore';

--- a/apps/src/accounts/ChangeEmail/ChangeEmailForm.tsx
+++ b/apps/src/accounts/ChangeEmail/ChangeEmailForm.tsx
@@ -1,7 +1,7 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import Link from '@code-dot-org/component-library/link';
 import React, {useState} from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link/Link';
 import {RadioButtonsGroup} from '@cdo/apps/componentLibrary/radioButton';
 import TextField from '@cdo/apps/componentLibrary/textField/TextField';
 import Typography from '@cdo/apps/componentLibrary/typography/Typography';

--- a/apps/src/aichat/views/TeacherOnboardingModal.tsx
+++ b/apps/src/aichat/views/TeacherOnboardingModal.tsx
@@ -1,7 +1,7 @@
 import Button, {buttonColors} from '@code-dot-org/component-library/button';
+import Link from '@code-dot-org/component-library/link';
 import React from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link/Link';
 import {
   BodyOneText,
   BodyTwoText,

--- a/apps/src/code-studio/pd/professional_learning_landing/SelfPacedProgressTable.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/SelfPacedProgressTable.jsx
@@ -1,8 +1,8 @@
 import {LinkButton} from '@code-dot-org/component-library/button';
+import Link from '@code-dot-org/component-library/link';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link';
 import {
   BodyThreeText,
   BodyFourText,

--- a/apps/src/componentLibrary/alert/Alert.tsx
+++ b/apps/src/componentLibrary/alert/Alert.tsx
@@ -1,12 +1,12 @@
 import FontAwesomeV6Icon, {
   FontAwesomeV6IconProps,
 } from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import Link, {LinkProps} from '@code-dot-org/component-library/link';
 import classnames from 'classnames';
 import React, {HTMLAttributes, useMemo} from 'react';
 
 import CloseButton from '@cdo/apps/componentLibrary/closeButton';
 import {ComponentSizeXSToL} from '@cdo/apps/componentLibrary/common/types';
-import Link, {LinkProps} from '@cdo/apps/componentLibrary/link';
 
 import moduleStyles from './alert.module.scss';
 

--- a/apps/src/componentLibrary/breadcrumbs/Breadcrumbs.tsx
+++ b/apps/src/componentLibrary/breadcrumbs/Breadcrumbs.tsx
@@ -1,9 +1,9 @@
 import FontAwesomeV6Icon from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import Link, {LinkWithText} from '@code-dot-org/component-library/link';
 import classNames from 'classnames';
 import React from 'react';
 
 import {ComponentSizeXSToL} from '@cdo/apps/componentLibrary/common/types';
-import Link, {LinkWithText} from '@cdo/apps/componentLibrary/link';
 
 import moduleStyles from './breadcrumbs.module.scss';
 

--- a/apps/src/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -1,7 +1,7 @@
+import Link from '@code-dot-org/component-library/link';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link/Link';
 import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import HelpTip from '@cdo/apps/sharedComponents/HelpTip';

--- a/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/levelbuilder/unit-editor/UnitEditor.jsx
@@ -1,11 +1,11 @@
 import {Chips} from '@code-dot-org/component-library/chips';
+import Link from '@code-dot-org/component-library/link';
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 
 import {announcementShape} from '@cdo/apps/code-studio/announcementsRedux';
-import Link from '@cdo/apps/componentLibrary/link/Link';
 import {
   InstructionType,
   PublishedState,

--- a/apps/src/sharedComponents/footer/CopyrightDialog/index.tsx
+++ b/apps/src/sharedComponents/footer/CopyrightDialog/index.tsx
@@ -1,6 +1,6 @@
+import Link from '@code-dot-org/component-library/link';
 import React from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link';
 import {BodyThreeText, Heading3} from '@cdo/apps/componentLibrary/typography';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import AccessibleDialog from '@cdo/apps/sharedComponents/AccessibleDialog';

--- a/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/index.tsx
+++ b/apps/src/simpleSignUp/lti/link/LtiLinkAccountPage/index.tsx
@@ -1,6 +1,6 @@
+import Link from '@code-dot-org/component-library/link';
 import React, {useContext} from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link';
 import {LtiProviderContext} from '@cdo/apps/simpleSignUp/lti/link/LtiLinkAccountPage/context';
 import {navigateToHref} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';

--- a/apps/src/simpleSignUp/workshop/WorkshopLinkAccountPage.tsx
+++ b/apps/src/simpleSignUp/workshop/WorkshopLinkAccountPage.tsx
@@ -1,6 +1,6 @@
+import Link from '@code-dot-org/component-library/link';
 import React from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link';
 import AccountBanner from '@cdo/apps/templates/account/AccountBanner';
 import AccountCard from '@cdo/apps/templates/account/AccountCard';
 import i18n from '@cdo/locale';

--- a/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/ExpandedCurriculumCatalogCard.jsx
@@ -3,11 +3,11 @@ import {
   buttonColors,
   LinkButton,
 } from '@code-dot-org/component-library/button';
+import Link from '@code-dot-org/component-library/link';
 import {TextLink} from '@dsco_/link';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef} from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link';
 import {
   BodyTwoText,
   Heading3,

--- a/apps/src/templates/globalEdition/RegionSwitchConfirm/index.tsx
+++ b/apps/src/templates/globalEdition/RegionSwitchConfirm/index.tsx
@@ -1,8 +1,8 @@
 import Button from '@code-dot-org/component-library/button';
+import Link from '@code-dot-org/component-library/link';
 import React, {useCallback, useState, useEffect} from 'react';
 import {Fade} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
-import Link from '@cdo/apps/componentLibrary/link/Link';
 import {Heading1} from '@cdo/apps/componentLibrary/typography';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';

--- a/apps/src/templates/policy_compliance/AgeGatedSectionsModal/AgeGatedSectionsModal.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedSectionsModal/AgeGatedSectionsModal.tsx
@@ -1,7 +1,7 @@
+import Link from '@code-dot-org/component-library/link';
 import React, {useEffect} from 'react';
 import {useSelector} from 'react-redux';
 
-import Link from '@cdo/apps/componentLibrary/link';
 import Typography from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';

--- a/apps/src/templates/policy_compliance/AgeGatedSectionsModal/AgeGatedSectionsTable.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedSectionsModal/AgeGatedSectionsTable.tsx
@@ -1,10 +1,10 @@
+import Link from '@code-dot-org/component-library/link';
 import {orderBy} from 'lodash';
 import React from 'react';
 import * as Table from 'reactabular-table';
 // @ts-expect-error sortabular doesn't define it's types.
 import * as sort from 'sortabular';
 
-import Link from '@cdo/apps/componentLibrary/link';
 import Typography from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';

--- a/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
+++ b/apps/src/templates/policy_compliance/AgeGatedStudentsModal/AgeGatedStudentsModal.tsx
@@ -1,6 +1,6 @@
+import Link from '@code-dot-org/component-library/link';
 import React, {useEffect} from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link';
 import Typography from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';

--- a/apps/src/templates/projects/submitProjectDialog/SubmitProjectDialog.tsx
+++ b/apps/src/templates/projects/submitProjectDialog/SubmitProjectDialog.tsx
@@ -1,8 +1,8 @@
 import Alert from '@code-dot-org/component-library/alert';
 import Button from '@code-dot-org/component-library/button';
+import Link from '@code-dot-org/component-library/link';
 import React, {useCallback, useEffect, useState} from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link/Link';
 import {BodyTwoText, Heading3} from '@cdo/apps/componentLibrary/typography';
 import {EVENTS, PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';

--- a/apps/src/templates/rubrics/RubricSettings.jsx
+++ b/apps/src/templates/rubrics/RubricSettings.jsx
@@ -1,3 +1,4 @@
+import Link from '@code-dot-org/component-library/link';
 import classnames from 'classnames';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
@@ -5,7 +6,6 @@ import React, {useEffect, useState, useMemo, useCallback} from 'react';
 import {CSVLink} from 'react-csv';
 import {connect} from 'react-redux';
 
-import Link from '@cdo/apps/componentLibrary/link/Link';
 import Toggle from '@cdo/apps/componentLibrary/toggle/Toggle';
 import {
   BodyTwoText,

--- a/apps/src/templates/sectionProgressV2/IconKey.jsx
+++ b/apps/src/templates/sectionProgressV2/IconKey.jsx
@@ -1,7 +1,7 @@
+import Link from '@code-dot-org/component-library/link';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link';
 import {Heading6} from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';

--- a/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
+++ b/apps/src/templates/sectionProgressV2/SectionProgressSelector.jsx
@@ -1,3 +1,4 @@
+import Link from '@code-dot-org/component-library/link';
 import classNames from 'classnames';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
@@ -5,7 +6,6 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {connect} from 'react-redux';
 
 import {queryParams} from '@cdo/apps/code-studio/utils';
-import Link from '@cdo/apps/componentLibrary/link';
 import DCDO from '@cdo/apps/dcdo';
 import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';

--- a/apps/src/templates/teacherDashboard/LmsInformationalCard/index.tsx
+++ b/apps/src/templates/teacherDashboard/LmsInformationalCard/index.tsx
@@ -1,6 +1,6 @@
+import Link from '@code-dot-org/component-library/link';
 import React from 'react';
 
-import Link from '@cdo/apps/componentLibrary/link';
 import Typography from '@cdo/apps/componentLibrary/typography/Typography';
 import {PLATFORMS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';

--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -1,9 +1,9 @@
+import Link from '@code-dot-org/component-library/link';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {connect} from 'react-redux';
 
 import {disabledBubblesSupportArticle} from '@cdo/apps/code-studio/disabledBubbles';
-import Link from '@cdo/apps/componentLibrary/link';
 import Button from '@cdo/apps/legacySharedComponents/Button';
 import {getStore} from '@cdo/apps/redux';
 import {sectionShape} from '@cdo/apps/templates/teacherDashboard/shapes';

--- a/apps/test/unit/componentLibrary/LinkTest.tsx
+++ b/apps/test/unit/componentLibrary/LinkTest.tsx
@@ -1,9 +1,8 @@
+import Link from '@code-dot-org/component-library/link';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import React from 'react';
-
-import Link from '@cdo/apps/componentLibrary/link';
 
 describe('Design System - Link', () => {
   it('renders with correct text when passed as children prop', () => {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [Design2-263] DSCO - Link component - Use component-library package instead of apps/src/componentLibrary across apps directory

* Link component -  made /apps directory now use `@code-dot-org/component-library` instance instead of ./apps/src/componentLibrary

This PR only replaces `/apps/src/componentLibrary/link` usages with `@code-dot-org/component-library/link` usages. No visual changes are intended by this PR. In case of any regressions feel free to contact me or @stephenliang. In case it'll be urgent - feel free to revert, just please let us know what problem have you encountered.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [Design2-263](https://codedotorg.atlassian.net/browse/DESIGN2-263)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
