### PR TITLE
[Design2-263] DSCO - Modal component - Use component-library package instead of apps/src/componentLibrary across apps directory

### DIFF
--- a/apps/src/templates/teacherNavigation/DashboardSectionSettings.tsx
+++ b/apps/src/templates/teacherNavigation/DashboardSectionSettings.tsx
@@ -1,7 +1,7 @@
+import Modal from '@code-dot-org/component-library/modal';
 import React from 'react';
 import {useBlocker} from 'react-router-dom';
 
-import Modal from '@cdo/apps/componentLibrary/modal/Modal';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 import i18n from '@cdo/locale';
 

--- a/apps/test/unit/componentLibrary/ModalTest.tsx
+++ b/apps/test/unit/componentLibrary/ModalTest.tsx
@@ -1,9 +1,8 @@
+import Modal, {ModalProps} from '@code-dot-org/component-library/modal';
 import {render, screen, fireEvent} from '@testing-library/react';
 import React from 'react';
 
 import '@testing-library/jest-dom';
-
-import Modal, {ModalProps} from '@cdo/apps/componentLibrary/modal';
 
 describe('Modal Component', () => {
   const defaultProps: ModalProps = {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [Design2-263] DSCO - Modal component - Use component-library package instead of apps/src/componentLibrary across apps directory

* Modal component -  made /apps directory now use `@code-dot-org/component-library` instance instead of ./apps/src/componentLibrary

This PR only replaces `/apps/src/componentLibrary/modal` usages with `@code-dot-org/component-library/modal` usages. No visual changes are intended by this PR. In case of any regressions feel free to contact me or @stephenliang. In case it'll be urgent - feel free to revert, just please let us know what problem have you encountered.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [Design2-263](https://codedotorg.atlassian.net/browse/DESIGN2-263)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
