### PR TITLE
[Design2-263] DSCO - Tabs component - Use component-library package instead of apps/src/componentLibrary across apps directory

### DIFF
--- a/apps/src/aichat/views/ChatWorkspace.tsx
+++ b/apps/src/aichat/views/ChatWorkspace.tsx
@@ -1,5 +1,6 @@
 import {Button} from '@code-dot-org/component-library/button';
 import {FontAwesomeV6IconProps} from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import Tabs, {TabsProps} from '@code-dot-org/component-library/tabs';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 
@@ -10,7 +11,6 @@ import {
 } from '@cdo/apps/aichat/redux/aichatRedux';
 import TeacherOnboardingModal from '@cdo/apps/aichat/views/TeacherOnboardingModal';
 import ChatWarningModal from '@cdo/apps/aiComponentLibrary/warningModal/ChatWarningModal';
-import Tabs, {TabsProps} from '@cdo/apps/componentLibrary/tabs/Tabs';
 import {useAppDispatch, useAppSelector} from '@cdo/apps/util/reduxHooks';
 import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
 

--- a/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
+++ b/apps/src/aichat/views/ModelCustomizationWorkspace.tsx
@@ -1,9 +1,9 @@
 import {FontAwesomeV6IconProps} from '@code-dot-org/component-library/fontAwesomeV6Icon';
+import Tabs, {TabsProps} from '@code-dot-org/component-library/tabs';
 import React, {useCallback, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 
 import {AichatLevelProperties} from '@cdo/apps/aichat/types';
-import Tabs, {TabsProps} from '@cdo/apps/componentLibrary/tabs/Tabs';
 import {isReadOnlyWorkspace} from '@cdo/apps/lab2/lab2Redux';
 import {useAppSelector} from '@cdo/apps/util/reduxHooks';
 

--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -1,11 +1,11 @@
 // My Professional Learning landing page
 // studio.code.org/my-professional-learning
 
+import Tabs from '@code-dot-org/component-library/tabs';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 import {connect, useDispatch} from 'react-redux';
 
-import Tabs from '@cdo/apps/componentLibrary/tabs';
 import {Heading2} from '@cdo/apps/componentLibrary/typography';
 import DCDO from '@cdo/apps/dcdo';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';

--- a/apps/src/componentLibrary/tabs/Tabs.story.tsx
+++ b/apps/src/componentLibrary/tabs/Tabs.story.tsx
@@ -1,7 +1,7 @@
 import {Meta, StoryFn} from '@storybook/react';
 import React, {useState} from 'react';
 
-import {TabModel} from '@cdo/apps/componentLibrary/tabs/_Tab';
+import {TabModel} from './_Tab';
 
 import Tabs, {TabsProps} from './index';
 

--- a/apps/src/componentLibrary/tabs/Tabs.tsx
+++ b/apps/src/componentLibrary/tabs/Tabs.tsx
@@ -2,8 +2,9 @@ import classnames from 'classnames';
 import React, {useCallback, useEffect, useState} from 'react';
 
 import {ComponentSizeXSToL} from '@cdo/apps/componentLibrary/common/types';
-import _Tab, {TabModel} from '@cdo/apps/componentLibrary/tabs/_Tab';
-import _TabPanel from '@cdo/apps/componentLibrary/tabs/_TabPanel';
+
+import _Tab, {TabModel} from './_Tab';
+import _TabPanel from './_TabPanel';
 
 import moduleStyles from './tabs.module.scss';
 

--- a/apps/test/unit/componentLibrary/TabsTest.tsx
+++ b/apps/test/unit/componentLibrary/TabsTest.tsx
@@ -1,9 +1,8 @@
+import Tabs, {TabsProps} from '@code-dot-org/component-library/tabs';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import React, {useState} from 'react';
-
-import Tabs, {TabsProps} from '@cdo/apps/componentLibrary/tabs';
 
 describe('Design System - Tabs', () => {
   const valuesMap: Record<string, string> = {};


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### [Design2-263] DSCO - Tabs component - Use component-library package instead of apps/src/componentLibrary across apps directory

* Tabs component -  made /apps directory now use `@code-dot-org/component-library` instance instead of .`/apps/src/componentLibrary`

This PR only replaces `/apps/src/componentLibrary/tabs` usages with `@code-dot-org/component-library/tabs` usages. No visual changes are intended by this PR. In case of any regressions feel free to contact me or @stephenliang. In case it'll be urgent - feel free to revert, just please let us know what problem have you encountered.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [Design2-263](https://codedotorg.atlassian.net/browse/DESIGN2-263)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
