### PR TITLE
[Google Blockly] Prevent toolbox functions from being deleted twice | Prevent insertion markers from adding new procedures

### DIFF
--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
@@ -136,9 +136,10 @@ export const procedureDefMutator = {
 
   /**
    * Accepts a JSON serializable state value and applies it to the block.
+   * Overridden to support initial block states for the modal function editor,
+   * and legacy state for user-created functions and invisible blocks.
    * @param state The state to apply to this block (see saveExtraState above).
    */
-  // TODO: define a better type for state.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   loadExtraState: function (this: ProcedureBlock, state: Record<string, any>) {
     const map = this.workspace.getProcedureMap();
@@ -169,14 +170,21 @@ export const procedureDefMutator = {
       );
     }
 
+    // Customization: Sets the description field of the block.
     setBlockDescription(this, state['description']);
+
     this.doProcedureUpdate();
+
+    // Customization: Sets the initial delete/edit/move configuration of the block.
     if (!Blockly.useModalFunctionEditor) {
       this.setDeletable(state['initialDeleteConfig'] === false ? false : true);
       this.setEditable(state['initialEditConfig'] === false ? false : true);
       this.setMovable(state['initialMoveConfig'] === false ? false : true);
     }
+
     this.setStatements_(state['hasStatements'] === false ? false : true);
+
+    // Customization: Handles the legacy state for user-created functions and invisible blocks.
     this.userCreated = state['userCreated'];
     this.invisible = state['invisible'];
   },

--- a/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/mutators/procedureDefMutator.ts
@@ -143,27 +143,30 @@ export const procedureDefMutator = {
   loadExtraState: function (this: ProcedureBlock, state: Record<string, any>) {
     const map = this.workspace.getProcedureMap();
     const procedureId = state['procedureId'];
-    const procedureFromMap = map.get(procedureId);
-    if (
-      procedureId &&
-      procedureId !== this.model_.getId() &&
-      procedureFromMap &&
-      (this.isInsertionMarker() || this.noBlockHasClaimedModel_(procedureId))
-    ) {
+    if (map.has(procedureId) && !state['fullSerialization']) {
       if (map.has(this.model_.getId())) {
         map.delete(this.model_.getId());
       }
-      this.model_ = procedureFromMap;
+      this.model_ = map.get(procedureId)!;
     }
 
-    if (state['params'] && !this.getProcedureModel().getParameters().length) {
-      for (let i = 0; i < state['params'].length; i++) {
-        const {name, id, paramId} = state['params'][i];
-        this.getProcedureModel().insertParameter(
-          new ObservableParameterModel(this.workspace, name, paramId, id),
-          i
-        );
+    const model = this.getProcedureModel();
+    const newParams: {name: string; id: string}[] = state['params'] ?? [];
+    const newIds = new Set(newParams.map(p => p.id));
+    const currParams = model.getParameters();
+    if (state['fullSerialization']) {
+      for (let i = currParams.length - 1; i >= 0; i--) {
+        if (!newIds.has(currParams[i].getId())) {
+          model.deleteParameter(i);
+        }
       }
+    }
+    for (let i = 0; i < newParams.length; i++) {
+      const {name, id, paramId} = state['params'][i];
+      this.getProcedureModel().insertParameter(
+        new ObservableParameterModel(this.workspace, name, paramId, id),
+        i
+      );
     }
 
     setBlockDescription(this, state['description']);

--- a/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
+++ b/apps/src/blockly/customBlocks/googleBlockly/proceduresBlocks.ts
@@ -93,7 +93,7 @@ export const blocks = GoogleBlockly.common.createBlockDefinitionsFromJsonArray([
       'procedure_caller_context_menu_mixin',
       'procedure_caller_onchange_mixin',
       'procedure_callernoreturn_get_def_block_mixin',
-      'procedure_call_do_update',
+      'procedure_call_overrides',
     ],
     mutator: 'procedure_caller_mutator',
   },
@@ -238,12 +238,8 @@ GoogleBlockly.Extensions.register(
   }
 );
 
-// Override the doProcedureUpdate function to heal the stack. Without this,
-// any child blocks connected to a call block would also get deleted.
-// Copied directly from
-// https://github.com/BeksOmega/blockly-samples/blob/7954a8fff50e41fa7c0f891e957bf9ed616361d6/plugins/block-shareable-procedures/src/blocks.ts#L1068
 GoogleBlockly.Extensions.register(
-  'procedure_call_do_update',
+  'procedure_call_overrides',
   function (this: ProcedureBlock) {
     const mixin = {
       /**
@@ -254,12 +250,19 @@ GoogleBlockly.Extensions.register(
 
       /**
        * Updates the shape of this block to reflect the state of the data model.
+       * Overriden to prevent deleting call blocks in a flyout.
+       * https://github.com/google/blockly-samples/issues/2484
        */
       doProcedureUpdate: function (this: ProcedureBlock) {
         if (!this.getProcedureModel()) return;
         const id = this.getProcedureModel().getId();
-        if (!this.getTargetWorkspace_().getProcedureMap().has(id)) {
-          this.dispose(/* Begin Customization*/ true /* End Customization*/);
+        if (
+          !this.getTargetWorkspace_().getProcedureMap().has(id) &&
+          // Begin customization
+          !this.workspace.isFlyout
+          // End customization
+        ) {
+          this.dispose(true);
           return;
         }
         this.updateName_();

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.ts
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.ts
@@ -716,16 +716,6 @@ export default class MusicBlocklyWorkspace {
         contents: [...existingToolbox.contents, ...blockList],
       };
       const workspace = this.workspace as GoogleBlockly.WorkspaceSvg;
-      // Remove any existing function call blocks before updating the toolbox.
-      // This is necessary to prevent the blocks from being deleted twice.
-      // (When a definition block is deleted, any matching call block is also deleted.)
-      workspace
-        .getFlyout()
-        ?.getWorkspace()
-        .getBlocksByType(BLOCK_TYPES.procedureCall)
-        .forEach(block => {
-          block.dispose();
-        });
       workspace.updateToolbox(updatedToolbox);
 
       if (workspace.RTL) {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -561,6 +561,16 @@ class UnconnectedMusicView extends React.Component {
       }
     }
 
+    // Remove any procedures that do not have definitions.
+    // This prevents extra call blocks from showing in the toolbox.
+    if (e.type === Blockly.Events.FINISHED_LOADING) {
+      const workspace = this.musicBlocklyWorkspace.workspace;
+      const procedureMap = workspace.getProcedureMap();
+      procedureMap
+        .getProcedures()
+        .filter(p => !Blockly.Procedures.getDefinition(p.getName(), workspace))
+        .forEach(p => procedureMap.delete(p.id));
+    }
     // Update undo status when blocks change.
     this.props.setUndoStatus({
       canUndo: this.musicBlocklyWorkspace.canUndo(),


### PR DESCRIPTION
@breville reported an issue where deleting a function breaks the toolbox:
https://codedotorg.atlassian.net/browse/LABS-1337

https://github.com/user-attachments/assets/477221db-a94a-4f5d-aea8-c8d7c103fd2a


## Investigation 1
When a flyout is refreshed, Blockly first cleans it up by deleting all blocks.
For functions, we use the `blocks-shareable-procedures` plugin, which is necessary to support the modal function editor in other labs. In this plugin, when a definition is updated, all call blocks are updated to make sure they have the right "shape" (e.g. parameters). The `doProcedureUpdate` block method is provided by the plugin as part of `procedure_caller_update_shape_mixin`. When a definition block is updated, this method is called on each call block. If the definition is deleted (ie. the target workspace no longer has the procedure), the call block is deleted. When the flyout contents is cleaned up, the deletion of the blank function block triggers a  `doProcedureUpdate` a call for each (old) call block in the flyout, deleting them. However, Blockly has also added these blocks to the list of blocks to delete as part of the cleanup process, which means it attempts to delete them twice. This is why we get an error about a block not being present in the workspace when `removeTopBlock` is called.

## Fixes Part 1
Interestingly, I had an encountered this issue myself last week when working on the new Toolbox Mode. I presumed, incorrectly, that it was unique to Music Lab. I snuck in a potential fix that is reverted in this branch: https://github.com/code-dot-org/code-dot-org/pull/63468/commits/d2a646bb4ca246925f2740c2e4ab1ad5beb387f8

Instead, I opted to implement a fix by overriding `doProcedureUpdate`. Now, this function won't delete a call block if it's in a flyout. As it turns out, we already had an override in place for this function, due to a different (now resolved) bug. I cleaned up some documentation around that old bug while I was here. This also prompted me to update the name of the mixin that contains the override, since it was outdated.

Finally, @breville pointed out that this issue is potentially related to a bug in which we see additionally numbered functions appearing in the flyout which never existed before:

https://github.com/user-attachments/assets/ca350172-d9ec-4399-ade0-7b240db9afa4

In this situation, the call blocks are made for procedures that exist in the procedure map but that do not have an associated definition block. The logic for the dynamic Functions flyout is customized in older labs, but Music Lab uses the standard callback from Blockly. This callback looks at the procedure map itself, rather than the actual definition blocks, to determine which functions exist. Rather than customize this flyout callback specifically for Music Lab, I opted instead to scan for procedures like this upon page load, and simply remove them. I tested this by copying the main.json from Brendan's affected project into my local project.
This wasn't satisfying because I hadn't determined how (or if) the issues were related. In fact, they weren't.

## Investigation 2

This issue as shown in the video clip above proved very challenging to diagnose, or even to reproduce. In my own tests, deleting the second function would result in extra call blocks in the toolbox only some of the time. By setting breakpoints, I was eventually able to determine the root cause during an instance where an extra procedure model would have been added to the map.

It turned out that deleting the block was unrelated. What was actually causing it was an insertion marker for the definition block that was created momentarily when the definition block was dragged near the stray call block on the workspace. You can see the gray insertion marker in this still, which I later grabbed from the same video embedded above:

<img width="414" alt="image" src="https://github.com/user-attachments/assets/163e75b1-f414-4d24-a017-33e00366c348" />

Insertion markers are rendered block SVGs designed to forecast the result of dropping a block in the current position. As such, they need to work sort of like blocks, but not fully. I observed that this issue could not be reproduced on Blockly's
own demo page which led me to look for differences between our site and theirs.
It turns out that our definition block's `loadExtraState` method was to blame. This function is responsible for applying state from JSON to the actual block. Because we use the shareable procedures plugin, we had to base this custom method on the original version from the plugin. However, unbeknownst to use, the plug had updated its definition of `loadExtraState` and we were now out of sync. A few relevant PRs:
- https://github.com/google/blockly-samples/pull/1863
- https://github.com/google/blockly-samples/pull/1874
- https://github.com/google/blockly-samples/pull/2125

The common thread with these changes relates to a new-ish (Blockly v10.2) `doFullSerialization` flag. Among other functions, this flag _doesn't_ get used with insertion markers. We need to update `loadExtraState` so that it respects whether or not the block is doing a full serialization. By re-syncing our definition with the plugin, this issue should be fully resolved.

https://github.com/user-attachments/assets/9a2dc649-7c25-43a6-b80a-73f89690ad86


## Links

https://codedotorg.atlassian.net/browse/LABS-1337
https://github.com/google/blockly-samples/issues/2484

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->


## Follow-up work

Once https://github.com/google/blockly-samples/issues/2484 is resolved, we may be able to remove our `doProcedureUpdate` override completely.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
