### PR TITLE
Codebridge: scroll the file browser

### DIFF
--- a/apps/src/codebridge/FileBrowser/index.tsx
+++ b/apps/src/codebridge/FileBrowser/index.tsx
@@ -160,34 +160,36 @@ export const FileBrowser = React.memo(() => {
       className={moduleStyles['file-browser']}
       rightHeaderContent={!isReadOnly && <FileBrowserHeaderPopUpButton />}
     >
-      <DndContext onDragEnd={handleDragEnd} sensors={sensors}>
-        <DndDataContextProvider
-          value={{dragData, dropData}}
-          dndMonitor={dndMonitor}
-        >
-          <Droppable
-            data={{id: DEFAULT_FOLDER_ID}}
-            className={classNames(
-              moduleStyles.droppableArea,
-              moduleStyles.expandedDroppableArea,
-              {
-                [moduleStyles.acceptingDrop]:
-                  DEFAULT_FOLDER_ID === dropData?.id,
-              }
-            )}
+      <div className={moduleStyles.fileBrowserContents}>
+        <DndContext onDragEnd={handleDragEnd} sensors={sensors}>
+          <DndDataContextProvider
+            value={{dragData, dropData}}
+            dndMonitor={dndMonitor}
           >
-            <ul id="uitest-files-list">
-              <InnerFileBrowser
-                parentId={DEFAULT_FOLDER_ID}
-                folders={source.folders}
-                files={source.files}
-                setFileType={setFileType}
-                appName={appName}
-              />
-            </ul>
-          </Droppable>
-        </DndDataContextProvider>
-      </DndContext>
+            <Droppable
+              data={{id: DEFAULT_FOLDER_ID}}
+              className={classNames(
+                moduleStyles.droppableArea,
+                moduleStyles.expandedDroppableArea,
+                {
+                  [moduleStyles.acceptingDrop]:
+                    DEFAULT_FOLDER_ID === dropData?.id,
+                }
+              )}
+            >
+              <ul id="uitest-files-list">
+                <InnerFileBrowser
+                  parentId={DEFAULT_FOLDER_ID}
+                  folders={source.folders}
+                  files={source.files}
+                  setFileType={setFileType}
+                  appName={appName}
+                />
+              </ul>
+            </Droppable>
+          </DndDataContextProvider>
+        </DndContext>
+      </div>
     </PanelContainer>
   );
 });

--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -17,12 +17,6 @@
   scrollbar-color: $light_gray_500 $light_gray_950;
 }
 
-.fileBrowserContents::-webkit-scrollbar {
-  background: $light_gray_950;
-  width: 10px;
-  height: 10px;
-}
-
 .file-browser ul {
   list-style: none;
   margin: 0;

--- a/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
+++ b/apps/src/codebridge/FileBrowser/styles/filebrowser.module.scss
@@ -4,11 +4,23 @@
   height: 100%;
   background-color: $light_gray_950;
   color: $white;
+  overflow: hidden;
 }
 
 .fileBrowserHeader {
   background-color: $light_gray_950;
   border-bottom: 1px solid #54595E;
+}
+
+.fileBrowserContents {
+  overflow-y: auto;
+  scrollbar-color: $light_gray_500 $light_gray_950;
+}
+
+.fileBrowserContents::-webkit-scrollbar {
+  background: $light_gray_950;
+  width: 10px;
+  height: 10px;
 }
 
 .file-browser ul {


### PR DESCRIPTION
Previously, if there were more files in the file browser than fit in the window, it would not scroll and you wouldn't be able to see the files at the bottom of the list. This makes the file browser scroll.

## Screenshots
The way Firefox and Chrome style scrollbars is different from Safari. We have already applied a custom scrollbar to Safari for codebridge which I cannot seem to override for this element, but I think the Safari version looks good enough. That same background color looked bad on Firefox and Chrome because there is a border around the scrollbar thumb, and the background color is the same as the editor, so the scrollbar looks more like an extension of the editor.

## Firefox/Chrome
<img width="159" alt="Screenshot 2025-02-03 at 10 40 08 AM" src="https://github.com/user-attachments/assets/97fddee8-188d-49b3-bf05-ed6e18bc424c" />

## Safari
![Screenshot 2025-02-03 at 10 41 37 AM](https://github.com/user-attachments/assets/1c8f490d-c15d-4177-8afc-0168462ed325)

## Links
- jira ticket: [CT-911](https://codedotorg.atlassian.net/browse/CT-911)


## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
