### PR TITLE
Fix section title on windows

### DIFF
--- a/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
+++ b/apps/src/templates/teacherNavigation/teacher-navigation.module.scss
@@ -160,8 +160,6 @@
   margin-bottom: 0;
   margin-top: 0;
   color: $light_primary_500;
-  letter-spacing: 0.48px;
-  font-size: 12px;
 }
 
 .skeletonHeaderSectionName {


### PR DESCRIPTION
Our fonts don't work correctly with even font sizes on Windows. For the section name in the page header, we can just remove the custom styles and just rely on our DCDO styles.