### PR TITLE
Update Session Store Evictions Alarm

### DIFF
--- a/aws/cloudformation/components/session_store.yml.erb
+++ b/aws/cloudformation/components/session_store.yml.erb
@@ -70,10 +70,13 @@
   SessionStoreEvictionsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: <%="Redis Session Store High Eviction Rate (#{stack_name})" %>
-      AlarmDescription: We're seeing a lot of evictions from the Redis session store.
-        A steady amount of evictions is not a bad thing, but a rapid increase in
-        eviction rate could be a sign of other instability.
+      AlarmName: <%="Redis Session Store Evictions (#{stack_name})" %>
+      AlarmDescription: We're seeing evictions from the Redis session store. We
+        expect to remain under 100% usage in this cluster; evictions are a sign
+        that we have exceeded that. A low number of evictions should not have a
+        user-facing impact, since we intentionally store session data for
+        longer than it is needed, but any amount of evictions represents an
+        early warning sign that we should scale this cluster up.
       ActionsEnabled: true
       AlarmActions:
         - !Ref InfraLowPriority
@@ -86,9 +89,7 @@
       Period: 300
       EvaluationPeriods: 5
       DatapointsToAlarm: 3
-      # TODO infra: update this threshold and upgrade the alarm to Urgent once
-      # we've confirmed that this threshold and implementation are practical.
-      Threshold: 20000
+      Threshold: 0
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: missing
   SessionStoreNetworkBytesInAlarm:


### PR DESCRIPTION
We no longer expect some amount of evictions in this store as part of normal usage, so we can trivially update the existing alarm to notify us about any number of evictions rather than an arbitrary threshold.

## Testing story

Tested with `bundle exec rake stack:lint` and `bundle exec rake stack:validate`

## Deployment strategy

This changeset should get deployed automatically by our standard DTP process