### PR TITLE
Log when workshop session attendance is marked

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance.jsx
@@ -10,6 +10,8 @@ import IdleTimer from 'react-idle-timer';
 import {connect} from 'react-redux';
 
 import fontConstants from '@cdo/apps/fontConstants';
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 
 import Spinner from '../../../../sharedComponents/Spinner';
 import VisibilitySensor from '../components/visibility_sensor';
@@ -132,6 +134,13 @@ export class SessionAttendance extends React.Component {
       this.setState({
         attendance: clonedAttendance,
       });
+
+      if (value.attended) {
+        analyticsReporter.sendEvent(EVENTS.WORKSHOP_ATTENDANCE_MARKED_EVENT, {
+          user_logged_own_attendance: false,
+          session_id: this.props.sessionId,
+        });
+      }
     }
     this.props.onSaved(value);
   };

--- a/apps/src/metrics/AnalyticsConstants.js
+++ b/apps/src/metrics/AnalyticsConstants.js
@@ -108,6 +108,9 @@ const EVENTS = {
   // Workshop enrollment
   WORKSHOP_ENROLLMENT_COMPLETED_EVENT: 'Workshop Enrollment Completed',
 
+  // Workshop session attendance
+  WORKSHOP_ATTENDANCE_MARKED_EVENT: 'Workshop Attendance Marked',
+
   // PD Application flow
   TEACHER_APP_VISITED_EVENT: '6-12 Teacher Application Visited',
   PAGE_CHANGED_EVENT: 'Page Changed',

--- a/apps/src/sites/studio/pages/pd/session_attendance/attendance_recorded.js
+++ b/apps/src/sites/studio/pages/pd/session_attendance/attendance_recorded.js
@@ -1,0 +1,12 @@
+import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
+import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import getScriptData from '@cdo/apps/util/getScriptData';
+
+// Execute after page has fully loaded so the Statsig/Amplitude event only fires on full page load
+$(() => {
+  const sessionId = getScriptData('sessionId');
+  analyticsReporter.sendEvent(EVENTS.WORKSHOP_ATTENDANCE_MARKED_EVENT, {
+    user_logged_own_attendance: true,
+    session_id: sessionId,
+  });
+});

--- a/apps/webpackEntryPoints.js
+++ b/apps/webpackEntryPoints.js
@@ -254,6 +254,7 @@ const PROFESSIONAL_DEVELOPMENT_ENTRIES = {
   'pd/workshop_enrollment/students_cannot_enroll': './src/sites/studio/pages/pd/workshop_enrollment/students_cannot_enroll.js',
   'pd/workshop_enrollment/new': './src/sites/studio/pages/pd/workshop_enrollment/new.js',
   'pd/workshop_enrollment/cancel': './src/sites/studio/pages/pd/workshop_enrollment/cancel.js',
+  'pd/session_attendance/attendance_recorded': './src/sites/studio/pages/pd/session_attendance/attendance_recorded.js',
 
   'pd/professional_learning_landing/index': './src/sites/studio/pages/pd/professional_learning_landing/index.js',
   'pd/regional_partner_mini_contact/new': './src/sites/studio/pages/pd/regional_partner_mini_contact/new.js',

--- a/dashboard/app/views/pd/session_attendance/attendance_recorded.html.haml
+++ b/dashboard/app/views/pd/session_attendance/attendance_recorded.html.haml
@@ -1,6 +1,8 @@
 - content_for(:head) do
   = stylesheet_link_tag 'css/pd', media: 'all'
 
+%script{src: webpack_asset_path('js/pd/session_attendance/attendance_recorded.js'), data: {sessionId: @session.id.to_json}}
+
 %h1 Attendance recorded
 
 .workshop-attendance-recorded


### PR DESCRIPTION
Logs to Statsig and Amplitude when a user is marked as attended for a workshop session. I had it specify the id of the session and also whether the user marked their own attendance or not (i.e. if a user visited `/pd/attend/[session_code]` themselves or if a workshop admin or organizer checked their attendance on the workshop dashboard).

### User marked their own attendance
![user logged own attendance](https://github.com/user-attachments/assets/c089eee4-7d31-4761-a904-3c3fedcc2c90)

### Workshop admin marked the user's attendance for them
![mark_as_admin](https://github.com/user-attachments/assets/d4543e07-0810-4aba-a53a-4f00510465c1)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3032)

## Testing story
Local testing.
