### PR TITLE
Codebridge: bigger images in the console

### DIFF
--- a/apps/src/codebridge/Console/ConsoleManager.ts
+++ b/apps/src/codebridge/Console/ConsoleManager.ts
@@ -10,8 +10,8 @@ export default class ConsoleManager {
   // If the last line in terminalLines is a partial line or not (i.e. if it was terminated with a newline).
   private lastLineIsPartial: boolean;
 
-  private IMAGE_WIDTH = 400;
-  private IMAGE_HEIGHT = 400;
+  private IMAGE_WIDTH = 600;
+  private IMAGE_HEIGHT = 600;
 
   constructor(terminal: Terminal, terminalFitAddon: FitAddon) {
     this.terminal = terminal;


### PR DESCRIPTION
Make the images in the console fit in a 600x600 square rather than 400x400, as 400x400 didn't look good for rectangles (it will keep the dimensions of the image and be a max of 400x400, so the height ended up being too short).
### Before
<img width="1362" alt="Screenshot 2025-02-03 at 2 20 33 PM" src="https://github.com/user-attachments/assets/6ddea787-3588-400e-a374-164071f08b28" />

### After
<img width="1362" alt="Screenshot 2025-02-03 at 2 21 02 PM" src="https://github.com/user-attachments/assets/f0df7bc1-13f1-4d36-9a7a-b1b7ef4a721c" />


## Links
- [slack thread](https://codedotorg.slack.com/archives/C06JELCAPT9/p1738617401498959)

## Testing story
Tested locally



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
