### PR TITLE
Updating Musiclab buttons to tablist for screenreader

### DIFF
--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -92,6 +92,7 @@ const FolderPanelRow: React.FunctionComponent<FolderPanelRowProps> = ({
       aria-label={folder.name}
       tabIndex={0}
       role="tab"
+      aria-selected={isSelected}
     >
       <div className={styles.folderRowLeft}>
         {imageSrc && (
@@ -180,7 +181,8 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
       ref={isSelected ? currentSoundRefCallback : null}
       aria-label={sound.name}
       tabIndex={0}
-      role="button"
+      role="tabpanel"
+      aria-labelledby={sound.type}
     >
       <div className={styles.soundRowLeft}>
         <FontAwesomeV6Icon
@@ -357,6 +359,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
             <div
               id="sounds-panel-left"
               role="tablist"
+              aria-orientation="vertical"
               className={styles.leftColumn}
             >
               {folders.map((folder, folderIndex) => {

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -182,7 +182,6 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
       aria-label={sound.name}
       tabIndex={0}
       role="tabpanel"
-      aria-labelledby={sound.type}
     >
       <div className={styles.soundRowLeft}>
         <FontAwesomeV6Icon

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -179,7 +179,7 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
         }
       }}
       ref={isSelected ? currentSoundRefCallback : null}
-      aria-label={sound.name}
+      aria-label={sound.name + sound.length}
       tabIndex={0}
       role="tabpanel"
     >

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -91,7 +91,7 @@ const FolderPanelRow: React.FunctionComponent<FolderPanelRowProps> = ({
       ref={isSelected ? currentFolderRefCallback : null}
       aria-label={folder.name}
       tabIndex={0}
-      role="button"
+      role="tab"
     >
       <div className={styles.folderRowLeft}>
         {imageSrc && (
@@ -354,7 +354,11 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
         )}
         <div id="sounds-panel-body" className={styles.soundsPanelBody}>
           {mode === 'packs' && (
-            <div id="sounds-panel-left" className={styles.leftColumn}>
+            <div
+              id="sounds-panel-left"
+              role="tablist"
+              className={styles.leftColumn}
+            >
               {folders.map((folder, folderIndex) => {
                 return (
                   <FolderPanelRow


### PR DESCRIPTION
These buttons were not clear from a screenreader perspective that they are a tablist of 4 options. This PR updates the role of the buttons so the screenreader can recognize their true function.

The 'beats, bass, leads, effects' list:
![0ea00756-ab20-11ef-8c7f-07f54ed9b06a](https://github.com/user-attachments/assets/d896f82d-0f57-4b79-bd89-f4ce40fe94b1)


Before:
https://github.com/user-attachments/assets/4f55b77e-c204-46f8-8a17-d1854be4bdf7

After:
https://github.com/user-attachments/assets/50134aa6-77d6-445f-a46a-47a26be03bc7



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-990

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
