### PR TITLE
Using studio.code.org for OneTrust scripts

### DIFF
--- a/shared/haml/onetrust_cookie_scripts.haml
+++ b/shared/haml/onetrust_cookie_scripts.haml
@@ -33,7 +33,9 @@
 -# domain was given.
 - one_trust_domain = one_trust_domains.dig(domain, 'domain_scripts', cookie_script_env)
 - if cookie_script_env != 'off' && one_trust_domain.present?
-  - base_url = onetrust_version == 'self_hosted' ? "/onetrust/#{one_trust_domains.dig(domain, 'path')}" : "https://cdn.cookielaw.org"
+  - self_hosted_path = "/onetrust/#{one_trust_domains.dig(domain, 'path')}"
+  - self_hosted_base_url = (domain == 'code.org') ? CDO.studio_url(self_hosted_path) : CDO.hourofcode_url(self_hosted_path)
+  - base_url = onetrust_version == 'self_hosted' ? self_hosted_base_url : "https://cdn.cookielaw.org"
   - auto_block_src = "#{base_url}/consent/#{one_trust_domain}/OtAutoBlock.js"
   - consent_banner_src = "#{base_url}/scripttemplates/otSDKStub.js"
   %script{src: auto_block_src, type: 'text/javascript', charset: 'UTF-8'}


### PR DESCRIPTION
Issue: When visiting a `https://code.org` URL, requesting the OneTrust scripts returns a 404.
Cause: The OneTrust scripts are available only under `https://studio.code.org`.
Fix: Use a `studio.code.org` URL for OneTrust script requests on all studio.code.org and code.org pages.
 
TODO - talk to infra team about the correct path.

## Links
* [Jira](https://codedotorg.atlassian.net/browse/P20-1399)
## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
