### PR TITLE
Create `AichatEventsController`

### DIFF
--- a/apps/src/aichat/aichatApi.ts
+++ b/apps/src/aichat/aichatApi.ts
@@ -21,15 +21,16 @@ import {extractFieldsToCheckForToxicity} from './utils';
 
 const ROOT_GENERAL_URL = '/aichat';
 const ROOT_REQUEST_URL = '/aichat_request';
+const ROOT_EVENT_URL = '/aichat_events';
 const paths = {
   START_CHAT_COMPLETION_URL: `${ROOT_REQUEST_URL}/start_chat_completion`,
   GET_CHAT_REQUEST_URL: `${ROOT_REQUEST_URL}/chat_request`,
   CHAT_COMPLETION_URL: `${ROOT_GENERAL_URL}/chat_completion`,
-  LOG_CHAT_EVENT_URL: `${ROOT_GENERAL_URL}/log_chat_event`,
-  STUDENT_CHAT_HISTORY_URL: `${ROOT_GENERAL_URL}/student_chat_history`,
+  LOG_CHAT_EVENT_URL: `${ROOT_EVENT_URL}/log_chat_event`,
+  STUDENT_CHAT_HISTORY_URL: `${ROOT_EVENT_URL}/student_chat_history`,
+  SUBMIT_TEACHER_FEEDBACK_URL: `${ROOT_EVENT_URL}/submit_teacher_feedback`,
   USER_HAS_AICHAT_ACCESS_URL: `${ROOT_GENERAL_URL}/user_has_access`,
   FIND_TOXICITY_URL: `${ROOT_GENERAL_URL}/find_toxicity`,
-  SUBMIT_TEACHER_FEEDBACK_URL: `${ROOT_GENERAL_URL}/submit_teacher_feedback`,
 };
 
 const MAX_POLLING_TIME_MS = 45000;

--- a/dashboard/app/controllers/aichat_controller.rb
+++ b/dashboard/app/controllers/aichat_controller.rb
@@ -1,106 +1,6 @@
 class AichatController < ApplicationController
   authorize_resource class: false
 
-  # params are newChatEvent: ChatEvent, aichatContext: {currentLevelId: number; scriptId: number; channelId: string;}
-  # POST /aichat/log_chat_event
-  def log_chat_event
-    begin
-      params.require([:newChatEvent, :aichatContext])
-    rescue ActionController::ParameterMissing
-      return render status: :bad_request, json: {}
-    end
-
-    context = params[:aichatContext]
-    event = params[:newChatEvent]
-
-    project_id = nil
-    if context[:channelId]
-      _, project_id = storage_decrypt_channel_id(context[:channelId])
-    end
-
-    begin
-      logged_event = AichatEvent.create!(
-        user_id: current_user.id,
-        level_id: context[:currentLevelId],
-        script_id: context[:scriptId],
-        project_id: project_id,
-        request_id: event[:requestId], # Only present if ChatEvent is a ChatMessage, otherwise nil
-        aichat_event: event
-      )
-    rescue StandardError => exception
-      return render status: :bad_request, json: {error: exception.message}
-    end
-
-    response_body = {
-      id: logged_event.id,
-      **logged_event.aichat_event
-    }
-
-    render(status: :ok, json: response_body)
-  end
-
-  # params are eventId: number, feedback?: 'clean_disagree' | 'profanity_agree' | 'profanity_disagree'
-  # POST /aichat/submit_teacher_feedback
-  # Update a given chat message with teacher feedback. If feedback is nil, remove any existing feedback.
-  # Also has the side effect of fixing up any chat events that were stored as strings.
-  def submit_teacher_feedback
-    begin
-      params.require([:eventId])
-    rescue ActionController::ParameterMissing
-      return render status: :bad_request, json: {}
-    end
-
-    chat_event_id = params[:eventId]
-    feedback = params[:feedback]
-
-    return render status: :bad_request, json: {} if feedback && !SharedConstants::AI_CHAT_TEACHER_FEEDBACK.value?(feedback)
-
-    begin
-      chat_event = AichatEvent.find(chat_event_id)
-      unless can_view_student_chat_history?(chat_event.user_id)
-        return render(status: :forbidden, json: {error: "Access denied for submitting teacher feedback."})
-      end
-
-      # Parse aichat_event if it's stored as a string
-      chat_event.aichat_event = JSON.parse(chat_event.aichat_event) if chat_event.aichat_event.is_a?(String)
-    rescue ActiveRecord::RecordNotFound
-      return render status: :not_found, json: {}
-    end
-
-    chat_event.aichat_event.delete('teacherFeedback') if chat_event.aichat_event['teacherFeedback']
-    chat_event.aichat_event['teacherFeedback'] = feedback if feedback
-    chat_event.save!
-
-    render status: :ok, json: {}
-  end
-
-  # params are studentUserId: number, levelId: number, scriptId: number
-  # GET /aichat/student_chat_history
-  def student_chat_history
-    # Request all chat events for a student at a given level/script.
-    begin
-      params.require([:studentUserId, :levelId, :scriptId])
-    rescue ActionController::ParameterMissing
-      return render status: :bad_request, json: {}
-    end
-
-    script_id = params[:scriptId]
-    level_id = params[:levelId]
-    student_user_id = params[:studentUserId]
-    unless can_view_student_chat_history?(student_user_id)
-      return render(status: :forbidden, json: {error: "Access denied for student chat history."})
-    end
-
-    aichat_events = AichatEvent.where(user_id: student_user_id, level_id: level_id, script_id: script_id).order(:created_at).map do |event|
-      chat_event = event[:aichat_event].is_a?(String) ? JSON.parse(event[:aichat_event]) : event[:aichat_event]
-      {
-        id: event.id,
-        **chat_event
-      }
-    end
-    render json: aichat_events
-  end
-
   # GET /aichat/user_has_access
   def user_has_access
     render(status: :ok, json: {userHasAccess: current_user&.has_aichat_access?})
@@ -124,9 +24,5 @@ class AichatController < ApplicationController
     end
 
     render json: {flagged_fields: flagged_fields}.deep_transform_keys {|key| key.to_s.camelize(:lower)}
-  end
-
-  private def can_view_student_chat_history?(student_user_id)
-    User.find_by_id(student_user_id)&.student_of?(current_user)
   end
 end

--- a/dashboard/app/controllers/aichat_events_controller.rb
+++ b/dashboard/app/controllers/aichat_events_controller.rb
@@ -1,5 +1,5 @@
 class AichatEventsController < ApplicationController
-  authorize_resource
+  authorize_resource class: false
 
   # params are newChatEvent: ChatEvent, aichatContext: {currentLevelId: number; scriptId: number; channelId: string;}
   # POST /aichat_events/log_chat_event

--- a/dashboard/app/controllers/aichat_events_controller.rb
+++ b/dashboard/app/controllers/aichat_events_controller.rb
@@ -1,0 +1,107 @@
+class AichatEventsController < ApplicationController
+  authorize_resource
+
+  # params are newChatEvent: ChatEvent, aichatContext: {currentLevelId: number; scriptId: number; channelId: string;}
+  # POST /aichat_events/log_chat_event
+  def log_chat_event
+    begin
+      params.require([:newChatEvent, :aichatContext])
+    rescue ActionController::ParameterMissing
+      return render status: :bad_request, json: {}
+    end
+
+    context = params[:aichatContext]
+    event = params[:newChatEvent]
+
+    project_id = nil
+    if context[:channelId]
+      _, project_id = storage_decrypt_channel_id(context[:channelId])
+    end
+
+    begin
+      logged_event = AichatEvent.create!(
+        user_id: current_user.id,
+        level_id: context[:currentLevelId],
+        script_id: context[:scriptId],
+        project_id: project_id,
+        request_id: event[:requestId], # Only present if ChatEvent is a ChatMessage, otherwise nil
+        aichat_event: event
+      )
+    rescue StandardError => exception
+      return render status: :bad_request, json: {error: exception.message}
+    end
+
+    response_body = {
+      id: logged_event.id,
+      **logged_event.aichat_event
+    }
+
+    render(status: :ok, json: response_body)
+  end
+
+  # params are studentUserId: number, levelId: number, scriptId: number
+  # GET /aichat_events/student_chat_history
+  def student_chat_history
+    # Request all chat events for a student at a given level/script.
+    begin
+      params.require([:studentUserId, :levelId, :scriptId])
+    rescue ActionController::ParameterMissing
+      return render status: :bad_request, json: {}
+    end
+
+    script_id = params[:scriptId]
+    level_id = params[:levelId]
+    student_user_id = params[:studentUserId]
+    unless can_view_student_chat_history?(student_user_id)
+      return render(status: :forbidden, json: {error: "Access denied for student chat history."})
+    end
+
+    aichat_events = AichatEvent.where(user_id: student_user_id, level_id: level_id, script_id: script_id).order(:created_at).map do |event|
+      chat_event = event[:aichat_event].is_a?(String) ? JSON.parse(event[:aichat_event]) : event[:aichat_event]
+      {
+        id: event.id,
+        **chat_event
+      }
+    end
+    render json: aichat_events
+  end
+
+  # params are eventId: number, feedback?: 'clean_disagree' | 'profanity_agree' | 'profanity_disagree'
+  # POST /aichat_events/submit_teacher_feedback
+  # Update a given chat message with teacher feedback. If feedback is nil, remove any existing feedback.
+  # Also has the side effect of fixing up any chat events that were stored as strings.
+  def submit_teacher_feedback
+    begin
+      params.require([:eventId])
+    rescue ActionController::ParameterMissing
+      return render status: :bad_request, json: {}
+    end
+
+    chat_event_id = params[:eventId]
+    feedback = params[:feedback]
+
+    return render status: :bad_request, json: {} if feedback && !SharedConstants::AI_CHAT_TEACHER_FEEDBACK.value?(feedback)
+
+    begin
+      chat_event = AichatEvent.find(chat_event_id)
+      unless can_view_student_chat_history?(chat_event.user_id)
+        return render(status: :forbidden, json: {error: "Access denied for submitting teacher feedback."})
+      end
+
+      # Parse aichat_event if it's stored as a string
+      chat_event.aichat_event = JSON.parse(chat_event.aichat_event) if chat_event.aichat_event.is_a?(String)
+    rescue ActiveRecord::RecordNotFound
+      return render status: :not_found, json: {}
+    end
+
+    chat_event.aichat_event.delete('teacherFeedback') if chat_event.aichat_event['teacherFeedback']
+    chat_event.aichat_event['teacherFeedback'] = feedback if feedback
+    chat_event.save!
+
+    render status: :ok, json: {}
+  end
+
+  private def can_view_student_chat_history?(student_user_id)
+    User.find_by_id(student_user_id)&.student_of?(current_user)
+  end
+end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -494,18 +494,20 @@ class Ability
         user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
       end
 
-      can [:log_chat_event, :find_toxicity], :aichat do
+      can :find_toxicity, :aichat do
+        user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
+      end
+
+      can [:log_chat_event], AichatEvent do
         user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
       end
 
       # Additional logic that confirms that a given teacher should have access
       # to a given student's chat history is in aichat_controller.
-      can :student_chat_history, :aichat do
+      can [:student_chat_history, :submit_teacher_feedback], AichatEvent do
         user.teacher_can_access_ai_chat?
       end
-      can :submit_teacher_feedback, :aichat do
-        user.teacher_can_access_ai_chat?
-      end
+
       can :user_has_access, :aichat
     end
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -498,13 +498,13 @@ class Ability
         user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
       end
 
-      can [:log_chat_event], AichatEvent do
+      can :log_chat_event, :aichat_event do
         user.teacher_can_access_ai_chat? || user.student_can_access_ai_chat?
       end
 
       # Additional logic that confirms that a given teacher should have access
       # to a given student's chat history is in aichat_controller.
-      can [:student_chat_history, :submit_teacher_feedback], AichatEvent do
+      can [:student_chat_history, :submit_teacher_feedback], :aichat_event do
         user.teacher_can_access_ai_chat?
       end
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -503,7 +503,7 @@ class Ability
       end
 
       # Additional logic that confirms that a given teacher should have access
-      # to a given student's chat history is in aichat_controller.
+      # to a given student's chat history is in aichat_events_controller.
       can [:student_chat_history, :submit_teacher_feedback], :aichat_event do
         user.teacher_can_access_ai_chat?
       end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1203,9 +1203,10 @@ Dashboard::Application.routes.draw do
     post '/aichat_request/start_chat_completion', to: 'aichat_requests#start_chat_completion'
     get '/aichat_request/chat_request/:id', to: 'aichat_requests#chat_request'
 
-    post '/aichat/log_chat_event', to: 'aichat#log_chat_event'
-    post '/aichat/submit_teacher_feedback', to: 'aichat#submit_teacher_feedback'
-    get '/aichat/student_chat_history', to: 'aichat#student_chat_history'
+    post '/aichat_events/log_chat_event', to: 'aichat_events#log_chat_event'
+    post '/aichat_events/submit_teacher_feedback', to: 'aichat_events#submit_teacher_feedback'
+    get '/aichat_events/student_chat_history', to: 'aichat_events#student_chat_history'
+
     get '/aichat/user_has_access', to: 'aichat#user_has_access'
     post '/aichat/find_toxicity', to: 'aichat#find_toxicity'
 

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -53,7 +53,7 @@ class AichatControllerTest < ActionController::TestCase
 
   [:student, :teacher].each do |user|
     test_user_gets_response_for :find_toxicity,
-      name: "#{user}_no_access_#{action}_test",
+      name: "#{user}_no_access_find_toxicity_test",
       user: user,
       method: :post,
       response: :forbidden

--- a/dashboard/test/controllers/aichat_controller_test.rb
+++ b/dashboard/test/controllers/aichat_controller_test.rb
@@ -8,163 +8,12 @@ class AichatControllerTest < ActionController::TestCase
     unit_group = create :unit_group, name: 'exploring-gen-ai-2024'
     section = create :section, user: @authorized_teacher1, unit_group: unit_group
     @authorized_student1 = create(:follower, section: section).student_user
-    @authorized_teacher2 = create :authorized_teacher
-    @authorized_student2 = create(:follower, section: section).student_user
-    @level = create(:level)
-    @script = create(:script)
-    @script_level = create(:script_level, script: @script, levels: [@level])
-    valid_student1_chat_message1 = {role: 'user', chatMessageText: 'hello from authorized student 1 - message 1', status: 'ok', timestamp: Time.now.to_i}
-    valid_student1_chat_message2 = {role: 'user', chatMessageText: 'hello from authorized student 1 - message 2', status: 'ok', timestamp: Time.now.to_i}
-    valid_student2_chat_message = {role: 'user', chatMessageText: 'hello from authorized student 2', status: 'ok', timestamp: Time.now.to_i}
-    valid_teacher1_chat_message = {role: 'user', chatMessageText: 'hello from authorized teacher 1', status: 'ok', timestamp: Time.now.to_i}
-    # Store 4 chat_events in AichatEvents table: 2 for authorized student1, 1 for authorized teacher, 1 for authorized student2
-    @student1_aichat_event1 = create(:aichat_event, user_id: @authorized_student1.id, level_id: @level.id, script_id: @script.id, aichat_event: valid_student1_chat_message1)
-    @student1_aichat_event2 = create(:aichat_event, user_id: @authorized_student1.id, level_id: @level.id, script_id: @script.id, aichat_event: valid_student1_chat_message2)
-    @teacher1_aichat_event = create(:aichat_event, user_id: @authorized_teacher1.id, level_id: @level.id, script_id: @script.id, aichat_event: valid_teacher1_chat_message)
-    @student2_aichat_event = create(:aichat_event, user_id: @authorized_student2.id, level_id: @level.id, script_id: @script.id, aichat_event: valid_student2_chat_message)
-    @default_model_customizations = {temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test"}.stringify_keys
-    @student1_aichat_request = create(:aichat_request, user_id: @authorized_student1.id, model_customizations: @default_model_customizations.to_json, stored_messages: [].to_json, new_message: valid_student1_chat_message1.to_json, execution_status: SharedConstants::AI_REQUEST_EXECUTION_STATUS[:SUCCESS])
-    @default_aichat_context = {
-      currentLevelId: @level.id,
-      scriptId: @script.id,
-      channelId: "test"
-    }
-    @common_params = {
-      storedMessages: [],
-      aichatModelCustomizations: @default_model_customizations,
-      aichatContext: @default_aichat_context
-    }
-
-    @valid_params_student1_chat_history = {
-      studentUserId: @authorized_student1.id,
-      levelId: @level.id,
-      scriptId: @script.id,
-    }
-
-    @valid_params_log_chat_event = {
-      newChatEvent: valid_student1_chat_message1,
-      aichatContext: @default_aichat_context
-    }
-    @missing_aichat_context_params = @valid_params_log_chat_event.except(:aichatContext)
-
-    @project_id = 456
   end
 
-  setup do
-    @assistant_response = "This is an assistant response from Sagemaker"
-    AichatSagemakerHelper.stubs(:get_sagemaker_assistant_response).returns(@assistant_response)
-    @controller.stubs(:storage_decrypt_channel_id).returns([123, @project_id])
-    Cdo::Throttle.stubs(:throttle).returns(false)
-  end
-
-  users = [:student, :teacher]
-  [
-    :log_chat_event,
-    :student_chat_history,
-    :find_toxicity,
-    :submit_teacher_feedback,
-  ].each do |action, method = :post, params = {}|
-    users.each do |user|
-      test_user_gets_response_for action,
-        name: "#{user}_no_access_#{action}_test",
-        user: user,
-        method: method,
-        params: params,
-        response: :forbidden
-    end
-  end
-
-  # log_chat_event tests
-  test 'authorized teacher has access to log_chat_event test' do
-    sign_in(@authorized_teacher1)
-    post :log_chat_event, params: @valid_params_log_chat_event, as: :json
-    assert_response :success
-  end
-
-  test 'student of authorized teacher has access to log_chat_event test' do
-    sign_in(@authorized_student1)
-    post :log_chat_event, params: @valid_params_log_chat_event, as: :json
-    assert_response :success
-  end
-
-  test 'Bad request if missing param for log_chat_event' do
-    sign_in(@authorized_teacher1)
-    post :log_chat_event, params: @missing_aichat_context_params, as: :json
-    assert_response :bad_request
-  end
-
-  test 'log_chat_event logs successfully to AichatEvents table' do
-    sign_in(@authorized_student1)
-    post :log_chat_event, params: @valid_params_log_chat_event, as: :json
-
-    assert_response :success
-    event_id = json_response['id']
-    assert_equal json_response, @valid_params_log_chat_event[:newChatEvent].merge(id: event_id).stringify_keys
-    aichat_event_row = AichatEvent.find(event_id)
-    stored_aichat_event = aichat_event_row.aichat_event
-    assert_equal stored_aichat_event['timestamp'], @valid_params_log_chat_event[:newChatEvent][:timestamp]
-  end
-
-  test 'log_chat_event logs requestId successfully to AichatEvents table' do
-    sign_in(@authorized_student1)
-
-    # need a valid requestId for foreign key constraint
-    request_id = @student1_aichat_request.id
-    params = @valid_params_log_chat_event.merge(newChatEvent: @valid_params_log_chat_event[:newChatEvent].merge(requestId: request_id))
-
-    post :log_chat_event, params: params, as: :json
-
-    assert_response :success
-    event_id = json_response['id']
-    assert_equal json_response, params[:newChatEvent].merge(id: event_id).stringify_keys
-    aichat_event_row = AichatEvent.find(event_id)
-    stored_aichat_event = aichat_event_row.aichat_event
-    assert_equal request_id, stored_aichat_event['requestId']
-  end
-
-  test 'Bad request if required params are not included for student_chat_history' do
-    sign_in(@authorized_teacher1)
-    get :student_chat_history, params: {studentId: @authorized_student1.id}, as: :json
-    assert_response :bad_request
-  end
-
-  test 'student of authorized teacher does not have access to student_chat_history test' do
-    sign_in(@authorized_student1)
-    get :student_chat_history, params: @valid_params_student1_chat_history, as: :json
-    assert_response :forbidden
-  end
-
-  test 'authorized teacher has access to student_chat_history if teacher of student' do
-    sign_in(@authorized_teacher1)
-    get :student_chat_history, params: @valid_params_student1_chat_history, as: :json
-    assert_response :success
-  end
-
-  test 'authorized teacher does not have access to student_chat_history if not teacher of student' do
-    sign_in(@authorized_teacher2)
-    get :student_chat_history, params: @valid_params_student1_chat_history, as: :json
-    assert_response :forbidden
-  end
-
-  test 'student_chat_history successfully returns list of student aichat_events' do
-    sign_in(@authorized_teacher1)
-    post :student_chat_history, params: @valid_params_student1_chat_history, as: :json
-    assert_response :success
-    chat_events_array = json_response
-    # 2 chat event stored for authorized student1 in AichatEvents table so 2 chat events returned
-    # in ascending order.
-    assert_equal chat_events_array.length, 2
-    chat_event1_response = chat_events_array.first
-    chat_event2_response = chat_events_array.last
-    chat_event1_stored = AichatEvent.find(@student1_aichat_event1.id).aichat_event
-    chat_event2_stored = AichatEvent.find(@student1_aichat_event2.id).aichat_event
-    assert_equal chat_event1_response.keys.sort, %w(id role chatMessageText status timestamp).sort
-
-    assert_equal chat_event1_response["chatMessageText"], chat_event1_stored["chatMessageText"]
-    assert_equal chat_event2_response["chatMessageText"], chat_event2_stored["chatMessageText"]
-  end
-
+  # *****
   # user_has_access tests
+  # *****
+
   test 'signed out user does not have access to user_has_access test' do
     get :user_has_access, format: :json
     assert_response :forbidden
@@ -196,6 +45,18 @@ class AichatControllerTest < ActionController::TestCase
     get :user_has_access, format: :json
     assert_response :success
     assert_equal json_response['userHasAccess'], true
+  end
+
+  # *****
+  # find_toxicity tests
+  # *****
+
+  [:student, :teacher].each do |user|
+    test_user_gets_response_for :find_toxicity,
+      name: "#{user}_no_access_#{action}_test",
+      user: user,
+      method: :post,
+      response: :forbidden
   end
 
   test 'find_toxicity returns toxicity if detected in system prompt' do
@@ -266,50 +127,5 @@ class AichatControllerTest < ActionController::TestCase
     post :find_toxicity, params: {systemPrompt: system_prompt, retrievalContexts: retrieval_contexts, locale: locale}, as: :json
     assert_response :success
     assert_equal expected_response, json_response
-  end
-
-  # Submit teacher feedback tests
-  test 'submit_teacher_feedback returns bad request if eventId is missing' do
-    sign_in(@authorized_teacher1)
-    post :submit_teacher_feedback, params: {feedback: SharedConstants::AI_CHAT_TEACHER_FEEDBACK[:CLEAN_DISAGREE]}, as: :json
-    assert_response :bad_request
-  end
-
-  test 'submit_teacher_feedback returns bad request if feedback is invalid' do
-    sign_in(@authorized_teacher1)
-    post :submit_teacher_feedback, params: {eventId: @student1_aichat_event1.id, feedback: 'invalid'}, as: :json
-    assert_response :bad_request
-  end
-
-  test 'submit_teacher_feedback returns forbidden if user is not an authorized teacher' do
-    sign_in(@authorized_student1)
-    post :submit_teacher_feedback, params: {eventId: @student1_aichat_event1.id, feedback: SharedConstants::AI_CHAT_TEACHER_FEEDBACK[:CLEAN_DISAGREE]}, as: :json
-    assert_response :forbidden
-  end
-
-  test 'submit_teacher_feedback returns forbidden if the user is not the teacher of the requested student' do
-    sign_in(@authorized_teacher2)
-    post :submit_teacher_feedback, params: {eventId: @student1_aichat_event1.id, feedback: SharedConstants::AI_CHAT_TEACHER_FEEDBACK[:CLEAN_DISAGREE]}, as: :json
-    assert_response :forbidden
-  end
-
-  test 'submit_teacher_feedback updates teacher feedback in AichatEvent' do
-    feedback = SharedConstants::AI_CHAT_TEACHER_FEEDBACK[:CLEAN_DISAGREE]
-    sign_in(@authorized_teacher1)
-    post :submit_teacher_feedback, params: {eventId: @student1_aichat_event1.id, feedback: feedback}, as: :json
-    assert_response :success
-    @student1_aichat_event1.reload
-    assert_equal @student1_aichat_event1.aichat_event['teacherFeedback'], feedback
-  end
-
-  test 'submit_teacher_feedback clears feedback if no feedback is provided' do
-    @student1_aichat_event1.aichat_event['teacherFeedback'] = SharedConstants::AI_CHAT_TEACHER_FEEDBACK[:CLEAN_DISAGREE]
-    @student1_aichat_event1.save!
-
-    sign_in(@authorized_teacher1)
-    post :submit_teacher_feedback, params: {eventId: @student1_aichat_event1.id}, as: :json
-    assert_response :success
-    @student1_aichat_event1.reload
-    assert_nil @student1_aichat_event1.aichat_event['teacherFeedback']
   end
 end

--- a/dashboard/test/controllers/aichat_events_controller_test.rb
+++ b/dashboard/test/controllers/aichat_events_controller_test.rb
@@ -1,0 +1,208 @@
+require 'test_helper'
+
+class AichatEventsControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
+
+  setup_all do
+    @authorized_teacher1 = create :authorized_teacher
+    @authorized_teacher2 = create :authorized_teacher
+    unit_group = create :unit_group, name: 'exploring-gen-ai-2024'
+    section = create :section, user: @authorized_teacher1, unit_group: unit_group
+    @authorized_student1 = create(:follower, section: section).student_user
+
+    @level = create(:level)
+    @script = create(:script)
+
+    @valid_student1_chat_message1 = {role: 'user', chatMessageText: 'hello from authorized student 1 - message 1', status: 'ok', timestamp: Time.now.to_i}
+    valid_student1_chat_message2 = {role: 'user', chatMessageText: 'hello from authorized student 1 - message 2', status: 'ok', timestamp: Time.now.to_i}
+
+    @student1_aichat_event1 = create(:aichat_event, user_id: @authorized_student1.id, level_id: @level.id, script_id: @script.id, aichat_event: @valid_student1_chat_message1)
+    @student1_aichat_event2 = create(:aichat_event, user_id: @authorized_student1.id, level_id: @level.id, script_id: @script.id, aichat_event: valid_student1_chat_message2)
+
+    @valid_params_log_chat_event = {
+      newChatEvent: @valid_student1_chat_message1,
+      aichatContext: {
+        currentLevelId: @level.id,
+        scriptId: @script.id,
+        channelId: "test"
+      }
+    }
+
+    @valid_params_student1_chat_history = {
+      studentUserId: @authorized_student1.id,
+      levelId: @level.id,
+      scriptId: @script.id,
+    }
+  end
+
+  setup do
+    @controller.stubs(:storage_decrypt_channel_id).returns([123, 456])
+  end
+
+  users = [:student, :teacher]
+  [
+    :log_chat_event,
+    :submit_teacher_feedback,
+    [:student_chat_history, :get]
+  ].each do |action, method = :post|
+    users.each do |user|
+      test_user_gets_response_for action,
+        name: "#{user}_no_access_#{action}_test",
+        user: user,
+        method: method,
+        response: :forbidden
+    end
+  end
+
+  # *****
+  # log_chat_event tests
+  # *****
+
+  test 'authorized teacher has access to log_chat_event test' do
+    sign_in(@authorized_teacher1)
+    post :log_chat_event, params: @valid_params_log_chat_event, as: :json
+    assert_response :success
+  end
+
+  test 'student of authorized teacher has access to log_chat_event test' do
+    sign_in(@authorized_student1)
+    post :log_chat_event, params: @valid_params_log_chat_event, as: :json
+    assert_response :success
+  end
+
+  test 'Bad request if missing param for log_chat_event' do
+    sign_in(@authorized_teacher1)
+    post :log_chat_event, params: @valid_params_log_chat_event.except(:aichatContext), as: :json
+    assert_response :bad_request
+  end
+
+  test 'log_chat_event logs successfully to AichatEvents table' do
+    sign_in(@authorized_student1)
+    post :log_chat_event, params: @valid_params_log_chat_event, as: :json
+
+    assert_response :success
+    event_id = json_response['id']
+    assert_equal json_response, @valid_params_log_chat_event[:newChatEvent].merge(id: event_id).stringify_keys
+    aichat_event_row = AichatEvent.find(event_id)
+    stored_aichat_event = aichat_event_row.aichat_event
+    assert_equal stored_aichat_event['timestamp'], @valid_params_log_chat_event[:newChatEvent][:timestamp]
+  end
+
+  test 'log_chat_event logs requestId successfully to AichatEvents table' do
+    sign_in(@authorized_student1)
+
+    # need a valid requestId for foreign key constraint
+    model_customizations = {temperature: 0.5, retrievalContexts: ["test"], systemPrompt: "test"}.stringify_keys
+    request = create(:aichat_request,
+      user_id: @authorized_student1.id,
+      model_customizations: model_customizations.to_json,
+      stored_messages: [].to_json,
+      new_message: @valid_student1_chat_message1.to_json,
+      execution_status: SharedConstants::AI_REQUEST_EXECUTION_STATUS[:SUCCESS]
+    )
+    params = @valid_params_log_chat_event.merge(newChatEvent: @valid_params_log_chat_event[:newChatEvent].merge(requestId: request.id))
+
+    post :log_chat_event, params: params, as: :json
+
+    assert_response :success
+    event_id = json_response['id']
+    assert_equal json_response, params[:newChatEvent].merge(id: event_id).stringify_keys
+    aichat_event_row = AichatEvent.find(event_id)
+    stored_aichat_event = aichat_event_row.aichat_event
+    assert_equal request.id, stored_aichat_event['requestId']
+  end
+
+  # *****
+  # student_chat_history tests
+  # *****
+
+  test 'Bad request if required params are not included for student_chat_history' do
+    sign_in(@authorized_teacher1)
+    get :student_chat_history, params: {studentId: @authorized_student1.id}, as: :json
+    assert_response :bad_request
+  end
+
+  test 'student of authorized teacher does not have access to student_chat_history test' do
+    sign_in(@authorized_student1)
+    get :student_chat_history, params: @valid_params_student1_chat_history, as: :json
+    assert_response :forbidden
+  end
+
+  test 'authorized teacher has access to student_chat_history if teacher of student' do
+    sign_in(@authorized_teacher1)
+    get :student_chat_history, params: @valid_params_student1_chat_history, as: :json
+    assert_response :success
+  end
+
+  test 'authorized teacher does not have access to student_chat_history if not teacher of student' do
+    sign_in(@authorized_teacher2)
+    get :student_chat_history, params: @valid_params_student1_chat_history, as: :json
+    assert_response :forbidden
+  end
+
+  test 'student_chat_history successfully returns list of student aichat_events' do
+    sign_in(@authorized_teacher1)
+    post :student_chat_history, params: @valid_params_student1_chat_history, as: :json
+    assert_response :success
+    chat_events_array = json_response
+    # 2 chat event stored for authorized student1 in AichatEvents table so 2 chat events returned
+    # in ascending order.
+    assert_equal chat_events_array.length, 2
+    chat_event1_response = chat_events_array.first
+    chat_event2_response = chat_events_array.last
+    chat_event1_stored = AichatEvent.find(@student1_aichat_event1.id).aichat_event
+    chat_event2_stored = AichatEvent.find(@student1_aichat_event2.id).aichat_event
+    assert_equal chat_event1_response.keys.sort, %w(id role chatMessageText status timestamp).sort
+
+    assert_equal chat_event1_response["chatMessageText"], chat_event1_stored["chatMessageText"]
+    assert_equal chat_event2_response["chatMessageText"], chat_event2_stored["chatMessageText"]
+  end
+
+  # *****
+  # submit_teacher_feedback tests
+  # *****
+
+  test 'submit_teacher_feedback returns bad request if eventId is missing' do
+    sign_in(@authorized_teacher1)
+    post :submit_teacher_feedback, params: {feedback: SharedConstants::AI_CHAT_TEACHER_FEEDBACK[:CLEAN_DISAGREE]}, as: :json
+    assert_response :bad_request
+  end
+
+  test 'submit_teacher_feedback returns bad request if feedback is invalid' do
+    sign_in(@authorized_teacher1)
+    post :submit_teacher_feedback, params: {eventId: @student1_aichat_event1.id, feedback: 'invalid'}, as: :json
+    assert_response :bad_request
+  end
+
+  test 'submit_teacher_feedback returns forbidden if user is not an authorized teacher' do
+    sign_in(@authorized_student1)
+    post :submit_teacher_feedback, params: {eventId: @student1_aichat_event1.id, feedback: SharedConstants::AI_CHAT_TEACHER_FEEDBACK[:CLEAN_DISAGREE]}, as: :json
+    assert_response :forbidden
+  end
+
+  test 'submit_teacher_feedback returns forbidden if the user is not the teacher of the requested student' do
+    sign_in(@authorized_teacher2)
+    post :submit_teacher_feedback, params: {eventId: @student1_aichat_event1.id, feedback: SharedConstants::AI_CHAT_TEACHER_FEEDBACK[:CLEAN_DISAGREE]}, as: :json
+    assert_response :forbidden
+  end
+
+  test 'submit_teacher_feedback updates teacher feedback in AichatEvent' do
+    feedback = SharedConstants::AI_CHAT_TEACHER_FEEDBACK[:CLEAN_DISAGREE]
+    sign_in(@authorized_teacher1)
+    post :submit_teacher_feedback, params: {eventId: @student1_aichat_event1.id, feedback: feedback}, as: :json
+    assert_response :success
+    @student1_aichat_event1.reload
+    assert_equal @student1_aichat_event1.aichat_event['teacherFeedback'], feedback
+  end
+
+  test 'submit_teacher_feedback clears feedback if no feedback is provided' do
+    @student1_aichat_event1.aichat_event['teacherFeedback'] = SharedConstants::AI_CHAT_TEACHER_FEEDBACK[:CLEAN_DISAGREE]
+    @student1_aichat_event1.save!
+
+    sign_in(@authorized_teacher1)
+    post :submit_teacher_feedback, params: {eventId: @student1_aichat_event1.id}, as: :json
+    assert_response :success
+    @student1_aichat_event1.reload
+    assert_nil @student1_aichat_event1.aichat_event['teacherFeedback']
+  end
+end

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -964,8 +964,8 @@ class AbilityTest < ActiveSupport::TestCase
     [:start_chat_completion, :chat_request].each do |action|
       assert Ability.new(teacher).can? action, :aichat_request
     end
-    assert Ability.new(teacher).can? :log_chat_event, :aichat
-    assert Ability.new(teacher).can? :student_chat_history, :aichat
+    assert Ability.new(teacher).can? :log_chat_event, :aichat_event
+    assert Ability.new(teacher).can? :student_chat_history, :aichat_event
   end
 
   test 'teacher not meeting AI Chat access requirements cannot perform AI Chat actions' do
@@ -974,8 +974,8 @@ class AbilityTest < ActiveSupport::TestCase
     [:start_chat_completion, :chat_request].each do |action|
       refute Ability.new(teacher).can? action, :aichat_request
     end
-    refute Ability.new(teacher).can? :log_chat_event, :aichat
-    refute Ability.new(teacher).can? :student_chat_history, :aichat
+    refute Ability.new(teacher).can? :log_chat_event, :aichat_event
+    refute Ability.new(teacher).can? :student_chat_history, :aichat_event
   end
 
   test 'student meeting AI Chat access requirements can perform AI Chat actions' do
@@ -984,7 +984,7 @@ class AbilityTest < ActiveSupport::TestCase
     [:start_chat_completion, :chat_request].each do |action|
       assert Ability.new(student).can? action, :aichat_request
     end
-    assert Ability.new(student).can? :log_chat_event, :aichat
+    assert Ability.new(student).can? :log_chat_event, :aichat_event
   end
 
   test 'student not meeting AI Chat access requirements cannot perform AI Chat actions' do
@@ -993,7 +993,7 @@ class AbilityTest < ActiveSupport::TestCase
     [:start_chat_completion, :chat_request].each do |action|
       refute Ability.new(student).can? action, :aichat_request
     end
-    refute Ability.new(student).can? :log_chat_event, :aichat
+    refute Ability.new(student).can? :log_chat_event, :aichat_event
   end
 
   private def put_students_in_section_and_code_review_group(students, section)


### PR DESCRIPTION
Pulls out our three controller actions that deal directly with the `AichatEvent` model from our generic `AichatController` and into a more scoped `AichatEventsController`. Those actions are:
- `log_chat_event`: logs events as they happen in the chat (load page, submit chat request, etc)
- `submit_teacher_feedback`: allows teachers to give feedback on whether a chat was flagged correctly/incorrectly
- `student_chat_history`: returns a collection of student chat history for teachers to view

I made no changes to the guts of any of the controller actions (straight copy). I did some slight cleanup within the test files (eg, moving test fixture creation that are only used in a single test into the single test they're used, rather than in the `setup_all` block), but nothing major (almost entirely copy/paste).

**🧹 There are no expected behavioral changes in this PR, organizational only. 🧹**

## Links

- Earlier similar PR that created a `AichatRequestsController`: https://github.com/code-dot-org/code-dot-org/pull/63411

## Testing story

I tested manually that each of the moved controller actions were still working as I interacted with them as a teacher. Unit tests are still passing as well.