### PR TITLE
Music: project background

### DIFF
--- a/dashboard/config/levels/custom/music/New Music Lab Project.level
+++ b/dashboard/config/levels/custom/music/New Music Lab Project.level
@@ -6,7 +6,7 @@
   "level_num": "custom",
   "user_id": 4,
   "properties": {
-    "background": "music-black",
+    "background": "background-dark",
     "is_project_level": "true",
     "encrypted": "false",
     "level_data": {


### PR DESCRIPTION
This is a small follow-up to https://github.com/code-dot-org/code-dot-org/pull/62905 which ensures that standalone Music Lab projects get the dark background and the accompanying [fix](https://github.com/code-dot-org/code-dot-org/pull/62905/files#diff-d3932967257c631dfe952a00b9251957c9c846276f31ce756d5b6908665c48fdR81-R83) so that the page header doesn't scroll.
