### PR TITLE
feat(workshops): replace virtual attribute with method

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -342,7 +342,6 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
       :fee,
       :regional_partner_id,
       :organizer_id,
-      :virtual,
       :suppress_email,
       :third_party_provider,
       {sessions_attributes: [:id, :start, :end, :session_format, :_destroy]},

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -185,11 +185,7 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
 
     new_workshop_params = workshop_params(can_update_regional_partner)
 
-    workshop_start_date = new_workshop_params[:sessions] ? Date.parse(new_workshop_params[:sessions].select {|s| s[:start]}.min_by {|s| Date.parse(s[:start])}[:start]) : @workshop.workshop_starting_date
-
-    if @workshop.virtual != new_workshop_params[:virtual] && user_cannot_freely_edit_virtual(new_workshop_params[:course], new_workshop_params[:subject], workshop_start_date)
-      render json: {error: "non-workshop-admin cannot change CSP/CSA Summer Workshop virtual field within a month of it starting."}, status: :bad_request
-    elsif @workshop.update(new_workshop_params)
+    if @workshop.update(new_workshop_params)
       notify if should_notify?
       render json: @workshop, serializer: Api::V1::Pd::WorkshopSerializer
     else
@@ -211,9 +207,7 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
       end
     end
 
-    if @workshop.virtual && user_cannot_freely_edit_virtual(@workshop.course, @workshop.subject, @workshop.workshop_starting_date)
-      render json: {error: "non-workshop-admin cannot create a virtual CSP/CSA Summer Workshop within a month of it starting."}, status: :bad_request
-    elsif @workshop.save
+    if @workshop.save
       render json: @workshop, serializer: Api::V1::Pd::WorkshopSerializer
     else
       render json: {errors: @workshop.errors.full_messages}, status: :bad_request
@@ -353,23 +347,5 @@ class Api::V1::Pd::WorkshopsController < ApplicationController
     allowed_params.delete :organizer_id unless current_user.permission?(UserPermission::WORKSHOP_ADMIN)
 
     params.require(:pd_workshop).permit(*allowed_params)
-  end
-
-  # Determine if the 'virtual' workshop field cannot be freely set/updated by the user.
-  # Returns true if the following are all true:
-  #   - it is a CSP or CSA Summer Workshop
-  #   - the user is not a Workshop Admin
-  #   - it is being created within a month of it starting (averaged to 30 days to avoid odd
-  #     behavior from time edge cases)
-  # If true, then setting/updating 'virtual' is limited:
-  #   - when creating this workshop, 'virtual' can only be set as false (i.e. 'in-person').
-  #   - when editing this workshop, 'virtual' cannot be changed.
-  private def user_cannot_freely_edit_virtual(course, subject, start_date)
-    (
-      [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSA].include?(course) &&
-      subject == Pd::Workshop::SUBJECT_SUMMER_WORKSHOP &&
-      !current_user.permission?(UserPermission::WORKSHOP_ADMIN) &&
-      (start_date - 30.days <= Time.zone.now && Time.zone.now <= start_date)
-    )
   end
 end

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -88,8 +88,8 @@ class Pd::WorkshopEnrollmentController < ApplicationController
               course_url: @workshop.course_url,
               fee: @workshop.fee,
               properties: nil,
-              virtual: @workshop.virtual,
               location_name: @workshop.friendly_location,
+              virtual: @workshop.virtual?,
               course_offerings: @workshop.course_offerings
             }
           ),

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -56,10 +56,6 @@ class Pd::Workshop < ApplicationRecord
   serialized_attrs [
     'fee',
 
-    # Indicates that this workshop will be conducted virtually, which triggers
-    # a different, virtual-specific post-workshop survey.
-    'virtual',
-
     # Allows a workshop to be associated with a third party
     # organization.
     # Only current allowed values are "friday_institute" and nil.
@@ -131,6 +127,10 @@ class Pd::Workshop < ApplicationRecord
     if VIRTUAL_ONLY_SUBJECTS.include?(subject) && !virtual?
       errors.add :properties, "Workshops with the subject #{subject} must be virtual"
     end
+  end
+
+  def virtual?
+    sessions.any? {|session| session.session_format == "virtual"}
   end
 
   # Whether enrollment in this workshop requires an application

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -79,7 +79,6 @@ class Pd::Workshop < ApplicationRecord
   validates_inclusion_of :on_map, in: [true, false]
   validates_inclusion_of :funded, in: [true, false]
   validates_inclusion_of :third_party_provider, in: %w(friday_institute), allow_nil: true
-  validate :friday_institute_workshops_must_be_virtual
   validate :virtual_only_subjects_must_be_virtual
   validate :not_funded_subjects_must_not_be_funded
 
@@ -114,12 +113,6 @@ class Pd::Workshop < ApplicationRecord
   def not_funded_subjects_must_not_be_funded
     if NOT_FUNDED_SUBJECTS.include?(subject) && funded?
       errors.add :properties, 'Admin/Counselor - Welcome workshop must not be funded.'
-    end
-  end
-
-  def friday_institute_workshops_must_be_virtual
-    if friday_institute? && !virtual?
-      errors.add :properties, 'Friday Institute workshops must be virtual'
     end
   end
 

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -4,7 +4,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
     :enrolled_teacher_count, :sessions, :account_required_for_attendance?,
     :enrollment_code, :pre_workshop_survey_url, :attended, :on_map, :funded, :funding_type, :ready_to_close?,
     :workshop_starting_date, :date_and_location_name, :regional_partner_name, :regional_partner_id,
-    :scholarship_workshop?, :can_delete, :created_at, :virtual, :suppress_email, :third_party_provider, :course_offerings, :module,
+    :scholarship_workshop?, :can_delete, :created_at, :virtual?, :suppress_email, :third_party_provider, :course_offerings, :module,
     :participant_group_type
 
   def sessions

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -505,78 +505,11 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test 'can create a virtual workshop with suppressed email' do
-    sign_in @organizer
-    post :create, params: {pd_workshop: workshop_params.merge(virtual: true, suppress_email: true)}
-    assert_response :success
-    assert response_workshop.virtual?
-  end
-
-  # this is a change from previous behavior that enforced virtual workshops suppressing emails
-  test 'can create a virtual workshop without suppressed email' do
-    sign_in @organizer
-    assert_creates(Pd::Workshop) do
-      post :create, params: {pd_workshop: workshop_params.merge(virtual: true, suppress_email: false)}
-      assert_response :success
-      assert response_workshop.virtual?
-      refute response_workshop.suppress_email?
-    end
-  end
-
   test 'can create a workshop with suppressed email' do
     sign_in @organizer
     post :create, params: {pd_workshop: workshop_params.merge(suppress_email: true)}
     assert_response :success
     assert response_workshop.suppress_email?
-  end
-
-  test 'setting virtual field as virtual when creating CSP/CSA summer workshop within a month of starting as a non-ws-admin raises error' do
-    skip 'test is flaky at the beginning of the month due to time differences'
-
-    sign_in @organizer
-
-    post :create, params: {pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP, funding_type: nil, virtual: true)}
-    assert_response :bad_request
-    assert_includes(response.body, 'non-workshop-admin cannot create a virtual CSP/CSA Summer Workshop within a month of it starting.')
-  end
-
-  test 'setting virtual field as virtual when creating CSP/CSA summer workshop within a month of starting as a ws-admin does not raise error' do
-    skip 'test is flaky at the beginning of the month due to time differences'
-
-    sign_in @workshop_admin
-
-    post :create, params: {pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP, funding_type: nil, virtual: true)}
-    assert_response :success
-  end
-
-  test 'setting virtual field as virtual when creating CSP/CSA summer workshop before a month of starting as a non-ws-admin does not raise error' do
-    skip 'test is flaky at the beginning of the month due to time differences'
-
-    sign_in @organizer
-    # Using '32.days' instead of '1.month' due to the inconsistency of the length of 'month' and it guarantees at least 1 month has passed.
-    session_start = (tomorrow_at 9) + 32.days
-    session_end = session_start + 8.hours
-
-    post :create, params: {pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP, funding_type: nil, virtual: true, sessions_attributes: [{start: session_start, end: session_end}])}
-    assert_response :success
-  end
-
-  test 'setting virtual field as virtual when creating CSP/CSA non-summer workshop within a month of starting as a non-ws-admin does not raise error' do
-    skip 'test is flaky at the beginning of the month due to time differences'
-
-    sign_in @organizer
-
-    post :create, params: {pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1, funding_type: nil, virtual: true)}
-    assert_response :success
-  end
-
-  test 'setting virtual field as virtual when creating non-CSP/CSA summer workshop within a month of starting as a non-ws-admin does not raise error' do
-    skip 'test is flaky at the beginning of the month due to time differences'
-
-    sign_in @organizer
-
-    post :create, params: {pd_workshop: workshop_params.merge(course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_CSD_SUMMER_WORKSHOP, funding_type: nil, virtual: true)}
-    assert_response :success
   end
 
   # Action: Destroy
@@ -735,30 +668,6 @@ class Api::V1::Pd::WorkshopsControllerTest < ActionController::TestCase
     user: -> {@facilitator},
     params: -> {{id: @workshop.id, pd_workshop: workshop_params}}
   )
-
-  test 'can update a workshop to be virtual with suppressed email' do
-    sign_in @organizer
-    workshop = create :workshop, organizer: @organizer
-    refute workshop.virtual?
-
-    put :update, params: {id: workshop.id, pd_workshop: workshop_params.merge(virtual: true, suppress_email: true)}
-    assert_response :success
-    workshop.reload
-    assert workshop.virtual?
-  end
-
-  # this is a change from previous behavior that enforced virtual workshops suppressing emails
-  test 'can update a workshop to be virtual without suppressed email' do
-    sign_in @organizer
-    workshop = create :workshop, organizer: @organizer
-    refute workshop.virtual?
-
-    put :update, params: {id: workshop.id, pd_workshop: workshop_params.merge(virtual: true, suppress_email: false)}
-    assert_response :success
-    workshop.reload
-    assert workshop.virtual?
-    refute workshop.suppress_email?
-  end
 
   test 'can update a workshop to have suppressed email' do
     sign_in @organizer

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
   factory :workshop, class: 'Pd::Workshop', aliases: [:pd_workshop] do
     transient do
       num_sessions {1}
+      virtual {false}
       num_facilitators {0}
       sessions_from {Time.zone.today + 9.hours} # Start time of the first session, then one per day after that.
       each_session_hours {6}
@@ -74,7 +75,8 @@ FactoryBot.define do
           params = [{
             workshop: workshop,
             start: evaluator.sessions_from + i.days,
-            duration_hours: evaluator.each_session_hours
+            duration_hours: evaluator.each_session_hours,
+            session_format: evaluator.virtual ? 'virtual' : 'in_person'
           }]
           params.prepend :with_assigned_code if evaluator.assign_session_code
           workshop.sessions << build(:pd_session, *params)

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1561,15 +1561,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert workshop.valid?
   end
 
-  test 'friday_institute workshops must be virtual' do
-    workshop = build :workshop, third_party_provider: 'friday_institute', virtual: false
-    refute workshop.valid?
-
-    workshop.virtual = true
-    workshop.suppress_email = true
-    assert workshop.valid?
-  end
-
   test 'workshops third_party_provider must be nil or from specified list' do
     workshop = build :workshop, third_party_provider: 'unknown_pd_provider'
     refute workshop.valid?

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1138,7 +1138,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   test 'workshops not suppressing reminders by default will suppress_reminders once suppress_email is set' do
     workshop = build :workshop
 
-    workshop.virtual = false
     refute workshop.suppress_reminders?
 
     workshop.suppress_email = true
@@ -1521,7 +1520,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop = build :workshop
 
     # Non-virtual workshops may suppress email or not
-    workshop.virtual = false
     workshop.suppress_email = false
     assert workshop.valid?
 
@@ -1529,7 +1527,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert workshop.valid?
 
     # Virtual workshops may suppress email or not (change from previous behavior)
-    workshop.virtual = true
+    workshop.sessions.first.session_format = 'virtual'
     workshop.suppress_email = false
     assert workshop.valid?
 
@@ -1552,7 +1550,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop = build :pd_workshop,
       course: COURSE_CSP,
       subject: SUBJECT_CSP_WORKSHOP_1,
-      virtual: false,
       suppress_email: true
 
     assert workshop.valid?
@@ -1560,7 +1557,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop.subject = VIRTUAL_ONLY_SUBJECTS.first
     refute workshop.valid?
 
-    workshop.virtual = true
+    workshop.sessions.first.session_format = 'virtual'
     assert workshop.valid?
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This removes the `virtual` serialized attribute on the workshop model and replaces it with a method that checks if any of the workshop sessions have a `virtual` session_format. it also required removing some logic and permissions around updating the workshop.virtual field, which doesn't exist anymore. 

## Links
[slack convo](https://codedotorg.slack.com/archives/C0453TUMLE7/p1738262701243859?thread_ts=1738258525.411399&cid=C0453TUMLE7)
[jira](https://codedotorg.atlassian.net/browse/ACQ-2965)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
