### PR TITLE
Remove OAuth route allowing users to view old signup flow

### DIFF
--- a/apps/src/signUpFlow/AccountType.tsx
+++ b/apps/src/signUpFlow/AccountType.tsx
@@ -17,11 +17,14 @@ import FreeCurriculumDialog from './FreeCurriculumDialog';
 import {
   ACCOUNT_TYPE_SESSION_KEY,
   USER_RETURN_TO_SESSION_KEY,
+  OAUTH_LOGIN_TYPE_SESSION_KEY,
 } from './signUpFlowConstants';
 
 import style from './signUpFlowStyles.module.scss';
 
 const AccountType: React.FunctionComponent = () => {
+  const [loginTypeAlreadySelected, setLoginTypeAlreadySelected] =
+    useState(false);
   const [isFreeCurriculumDialogOpen, setIsFreeCurriculumDialogOpen] =
     useState(false);
 
@@ -39,6 +42,29 @@ const AccountType: React.FunctionComponent = () => {
       {},
       PLATFORMS.BOTH
     );
+
+    // If sent here from trying to log in with OAuth without an account, log the OAuth type and have this page
+    // send to the final signup page instead of having them pick login type again.
+    let oauthType = sessionStorage.getItem(OAUTH_LOGIN_TYPE_SESSION_KEY);
+    if (oauthType) {
+      setLoginTypeAlreadySelected(true);
+
+      // Convert the name of the OAuth type so it lines up with our existing metrics for logging the login type
+      // selected.
+      if (oauthType === 'google_oauth2') {
+        oauthType = 'google';
+      } else if (oauthType === 'microsoft_v2_auth') {
+        oauthType = 'microsoft';
+      }
+
+      analyticsReporter.sendEvent(
+        EVENTS.SIGN_UP_LOGIN_TYPE_PICKED_EVENT,
+        {
+          'user login type': oauthType,
+        },
+        PLATFORMS.BOTH
+      );
+    }
   }, []);
 
   const selectAccountType = (accountType: string) => {
@@ -50,7 +76,20 @@ const AccountType: React.FunctionComponent = () => {
       PLATFORMS.BOTH
     );
     sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, accountType);
-    navigateToHref(studio('/users/new_sign_up/login_type'));
+
+    // By default, navigate the user to the login type page after selecting their user
+    // type. However, if a user is sent to this page after trying to login through OAuth
+    // without an account, then they'll be sent to the appropriate finish signup page
+    // since they've already selected their login type.
+    if (loginTypeAlreadySelected) {
+      const finishSignupUrl =
+        accountType === 'teacher'
+          ? '/users/new_sign_up/finish_teacher_account'
+          : '/users/new_sign_up/finish_student_account';
+      navigateToHref(studio(finishSignupUrl));
+    } else {
+      navigateToHref(studio('/users/new_sign_up/login_type'));
+    }
   };
 
   const sendCurriculumAnalyticsEvent = () => {

--- a/apps/test/unit/signUpFlow/AccountTypeTest.tsx
+++ b/apps/test/unit/signUpFlow/AccountTypeTest.tsx
@@ -3,6 +3,15 @@ import React from 'react';
 
 import AccountType from '@cdo/apps/signUpFlow/AccountType';
 import locale from '@cdo/apps/signUpFlow/locale';
+import {OAUTH_LOGIN_TYPE_SESSION_KEY} from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {navigateToHref} from '@cdo/apps/utils';
+
+jest.mock('@cdo/apps/utils', () => ({
+  ...jest.requireActual('@cdo/apps/utils'),
+  navigateToHref: jest.fn(),
+}));
+
+const navigateToHrefMock = navigateToHref as jest.Mock;
 
 describe('SelectAccountType', () => {
   function renderDefault() {
@@ -18,12 +27,20 @@ describe('SelectAccountType', () => {
     // Renders student card title, one item from the list, and button
     screen.getByText(locale.im_a_student());
     screen.getByText(locale.save_projects_and_progress());
-    screen.getByText(locale.sign_up_as_a_student());
+    const studentButton = screen.getByText(locale.sign_up_as_a_student());
 
     // Renders teacher card title, one item from the list, and button
     screen.getByText(locale.im_a_teacher());
     screen.getByText(locale.create_classroom_sections());
-    screen.getByText(locale.sign_up_as_a_teacher());
+    const teacherButton = screen.getByText(locale.sign_up_as_a_teacher());
+
+    // Both buttons default to sending the user to the login type selection page
+    fireEvent.click(studentButton);
+    fireEvent.click(teacherButton);
+    expect(navigateToHrefMock).toHaveBeenCalledWith(
+      '/users/new_sign_up/login_type'
+    );
+    expect(navigateToHrefMock).toHaveBeenCalledTimes(2);
   });
 
   it('renders free curriculum popup dialog', () => {
@@ -48,5 +65,23 @@ describe('SelectAccountType', () => {
     expect(
       screen.queryByText(locale.our_commitment_to_free_curriculum())
     ).toBeNull();
+  });
+
+  it('buttons send user to the finish signup pages if login type already selected through oauth', () => {
+    sessionStorage.setItem(OAUTH_LOGIN_TYPE_SESSION_KEY, 'google_oauth2');
+
+    renderDefault();
+
+    fireEvent.click(screen.getByText(locale.sign_up_as_a_student()));
+    expect(navigateToHrefMock).toHaveBeenCalledWith(
+      '/users/new_sign_up/finish_student_account'
+    );
+
+    fireEvent.click(screen.getByText(locale.sign_up_as_a_teacher()));
+    expect(navigateToHrefMock).toHaveBeenCalledWith(
+      '/users/new_sign_up/finish_teacher_account'
+    );
+
+    sessionStorage.clear();
   });
 });

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -195,7 +195,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         email: user.email
     else
       # This is a new registration
-      register_new_user(user)
+      register_new_user(user, provider)
     end
   end
 
@@ -232,7 +232,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       end
       return redirect_to users_existing_account_path({provider: auth_hash.provider, email: user.email})
     else
-      register_new_user(user)
+      register_new_user(user, AuthenticationOption::GOOGLE)
     end
   end
 
@@ -268,7 +268,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     return redirect_to users_existing_account_path({provider: auth_hash.provider, email: user.email}) if existing_account
 
     # otherwise, this is a new registration
-    register_new_user(user)
+    register_new_user(user, AuthenticationOption::CLEVER)
   end
 
   private def find_user_by_credential
@@ -305,11 +305,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
-  private def register_new_user(user)
+  private def register_new_user(user, provider)
     PartialRegistration.persist_attributes(session, user)
 
     @form_data = {
-      email: user.email
+      email: user.email,
+      provider: provider
     }
     new_sign_up_url = determine_sign_up_url(user)
     render 'omniauth/redirect', layout: false, locals: {new_sign_up_url: new_sign_up_url}
@@ -318,13 +319,11 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private def determine_sign_up_url(user)
     user_type = cookies['new_sign_up_user_type']
     cookies.delete('new_sign_up_user_type')
-    if user_type == 'student'
-      return users_new_sign_up_finish_student_account_path
-    elsif user_type == 'teacher'
+    if user_type == 'teacher'
       return users_new_sign_up_finish_teacher_account_path
+    else
+      return users_new_sign_up_finish_student_account_path
     end
-    # We are in the old sign up flow -> redirect to old finish_sign_up page
-    return ''
   end
 
   private def extract_microsoft_data(auth)

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -319,10 +319,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private def determine_sign_up_url(user)
     user_type = cookies['new_sign_up_user_type']
     cookies.delete('new_sign_up_user_type')
-    if user_type == 'teacher'
+    if user_type == 'student'
+      return users_new_sign_up_finish_student_account_path
+    elsif user_type == 'teacher'
       return users_new_sign_up_finish_teacher_account_path
     else
-      return users_new_sign_up_finish_student_account_path
+      return users_new_sign_up_account_type_path
     end
   end
 

--- a/dashboard/app/views/omniauth/redirect.html.haml
+++ b/dashboard/app/views/omniauth/redirect.html.haml
@@ -5,21 +5,14 @@
     %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}
     %title= t('nav.user.loading')
 
-    -if new_sign_up_url.present?
-      :javascript
+    :javascript
         (function() {
           var email = "#{@form_data[:email]}";
+          var oauthType = "#{@form_data[:provider]}";
           sessionStorage.setItem('email', email);
+          sessionStorage.setItem('oauthType', oauthType);
           window.location.href = "#{new_sign_up_url}";
         })();
-    -else
-      = form_with(url: users_finish_sign_up_path, method: :post, html: {id: 'redirect-form'}) do |f|
-        = f.hidden_field "user[email]", value: @form_data[:email]
-
-      :javascript
-        window.onload = function() {
-          document.getElementById("redirect-form").submit()
-        };
 
   %body
     %p=t('nav.user.loading')

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -172,10 +172,7 @@ module OmniauthCallbacksControllerTests
 
     # Simulates an omniauth redirect which is done in Javascript
     def omniauth_redirect
-      post '/users/finish_sign_up', params: {
-        'user[email]': "test@code.org"
-      }
-      assert_template partial: '_finish_sign_up'
+      get '/users/new_sign_up/account_type'
     end
   end
 end

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -172,7 +172,10 @@ module OmniauthCallbacksControllerTests
 
     # Simulates an omniauth redirect which is done in Javascript
     def omniauth_redirect
-      get '/users/new_sign_up/account_type'
+      post '/users/finish_sign_up', params: {
+        'user[email]': "test@code.org"
+      }
+      assert_template partial: '_finish_sign_up'
     end
   end
 end


### PR DESCRIPTION
This PR updates the user flow where a user tries to sign in with an OAuth but does not have an account, so they are redirected to the signup flow. Currently, they are sent to the old signup flow. The new behavior is to send them to the first page of the new signup flow (selecting their user type), then instead of going to the next page (selecting their login type) since they've already chosen their login type we will send them to the finish signup page of their user type (student or teacher).

### User without account tries to sign in as a student with OAuth and is sent through new signup flow
https://github.com/user-attachments/assets/a8c79070-522f-4f96-8924-f14f172bf797

### User without account tries to sign in as a teacher with OAuth and is sent through new signup flow
https://github.com/user-attachments/assets/caceb219-128c-4982-853e-948b9d9658c6

### Signing in using OAuth to an existing account remains the same
https://github.com/user-attachments/assets/5f29552f-53f9-44cd-9bac-4fded6e65c34

### Regular flow with selecting OAuth on the login type page remains the same
https://github.com/user-attachments/assets/e6a343d7-702b-4df6-bd91-603414fc6349

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-3062)

## Testing story
Local testing and updating unit tests.

## Follow-up work
Removing all content of the old signup flow.
