### PR TITLE
Give Replication Groups Stack-Specific Descriptions

### DIFF
--- a/aws/cloudformation/components/cache.yml.erb
+++ b/aws/cloudformation/components/cache.yml.erb
@@ -7,7 +7,7 @@
   GeocoderGroup:
     Type: AWS::ElastiCache::ReplicationGroup
     Properties:
-      ReplicationGroupDescription: Geocoder Replication Group
+      ReplicationGroupDescription: <%="Geocoder Replication Group (#{stack_name})" %>
       NumCacheClusters: 3
 <%  if cache_node_type.include? 'cache.t2' -%>
       AutomaticFailoverEnabled: false

--- a/aws/cloudformation/components/session_store.yml.erb
+++ b/aws/cloudformation/components/session_store.yml.erb
@@ -9,7 +9,7 @@
   SessionStoreGroup:
     Type: AWS::ElastiCache::ReplicationGroup
     Properties:
-      ReplicationGroupDescription: Session Store Replication Group
+      ReplicationGroupDescription: <%="Session Store Replication Group (#{stack_name})" %>
       # 3 nodes of cache.r7g.xlarge will cost ($0.437 * 730 * 3) = ~$960/month
       # and provide just under 80GB of storage.
       CacheNodeType: <%= rack_env?(:production) ? 'cache.r7g.xlarge' : 'cache.t4g.micro' -%>


### PR DESCRIPTION
We for the most part only use these components in the production environment, but every so often we do spin up a full-stack adhoc and it would in general be nice to have better support for more prod-like environments. To that end, update the description for each of them to add stack-specific details.

Note that [the `ReplicationGroupDescription` property can be updated with no interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-replicationgroupdescription)

It would probably be preferable to give these entities more specific names than the current randomly-generated one, but it's not clear to me how to do that without service interruption.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Testing story

Tested with `bundle exec rake stack:lint` and `bundle exec rake stack:validate`

## Deployment strategy

This changeset should get deployed automatically by our standard DTP process