### PR TITLE
Disable Activity Writes By Default

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -181,7 +181,7 @@ class ActivitiesController < ApplicationController
       level_source_id: @level_source.try(:id)
     }
 
-    allow_activity_writes = Gatekeeper.allows('activities', where: {script_name: @script_level.script.name}, default: true)
+    allow_activity_writes = Gatekeeper.allows('activities', where: {script_name: @script_level.script.name}, default: false)
     if allow_activity_writes
       @activity = Activity.new(attributes).tap(&:atomic_save!)
     end

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -127,8 +127,10 @@ class ActivitiesControllerTest < ActionController::TestCase
     # do all the logging
     @controller.expects :log_milestone
 
-    assert_creates(LevelSource, Activity, UserLevel, UserScript) do
-      post :milestone, params: @milestone_params
+    assert_creates(LevelSource, UserLevel, UserScript) do
+      assert_does_not_create(Activity) do
+        post :milestone, params: @milestone_params
+      end
     end
     assert_response :success
 
@@ -244,8 +246,8 @@ class ActivitiesControllerTest < ActionController::TestCase
     UserScript.create(user: @user, script: @script_level.script)
     UserLevel.create(level: @script_level.level, user: @user, script: @script_level.script)
 
-    assert_creates(LevelSource, Activity) do
-      assert_does_not_create(UserLevel, UserScript) do
+    assert_creates(LevelSource) do
+      assert_does_not_create(UserLevel, UserScript, Activity) do
         post :milestone, params: @milestone_params
       end
     end
@@ -259,8 +261,8 @@ class ActivitiesControllerTest < ActionController::TestCase
     # do all the logging
     @controller.expects :log_milestone
 
-    assert_creates(Activity, UserLevel, UserScript) do
-      assert_does_not_create(LevelSource) do
+    assert_creates(UserLevel, UserScript) do
+      assert_does_not_create(LevelSource, Activity) do
         post :milestone, params: @milestone_params.merge(program: "<hey>" * 10000)
       end
     end
@@ -285,8 +287,10 @@ class ActivitiesControllerTest < ActionController::TestCase
     # do all the logging
     @controller.expects :log_milestone
 
-    assert_creates(Activity, UserLevel, UserScript, LevelSource) do
-      post :milestone, params: @milestone_params.merge(program: "<hey>#{panda_panda}</hey>")
+    assert_creates(UserLevel, UserScript, LevelSource) do
+      assert_does_not_create(Activity) do
+        post :milestone, params: @milestone_params.merge(program: "<hey>#{panda_panda}</hey>")
+      end
     end
 
     assert_response :success
@@ -313,9 +317,11 @@ class ActivitiesControllerTest < ActionController::TestCase
     # do all the logging
     @controller.expects :log_milestone
 
-    assert_creates(LevelSource, Activity, UserLevel) do
-      post :milestone,
-        params: @milestone_params.merge(result: 'false', testResult: 10)
+    assert_creates(LevelSource, UserLevel) do
+      assert_does_not_create(Activity) do
+        post :milestone,
+          params: @milestone_params.merge(result: 'false', testResult: 10)
+      end
     end
 
     assert_response :success
@@ -326,13 +332,15 @@ class ActivitiesControllerTest < ActionController::TestCase
     # do all the logging
     @controller.expects :log_milestone
 
-    assert_creates(LevelSource, Activity, UserLevel) do
-      post :milestone,
-        params: @milestone_params.merge(
-          result: 'false',
-          testResult: 10,
-          image: Base64.encode64(@good_image)
-        )
+    assert_creates(LevelSource, UserLevel) do
+      assert_does_not_create(Activity) do
+        post :milestone,
+          params: @milestone_params.merge(
+            result: 'false',
+            testResult: 10,
+            image: Base64.encode64(@good_image)
+          )
+      end
     end
 
     # assert_equal @good_image.size, LevelSourceImage.last.image.size
@@ -347,16 +355,16 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     expect_s3_upload
 
-    original_activity_count = Activity.count
     original_user_level_count = UserLevel.count
 
     expected_created_classes = [LevelSource, UserLevel, LevelSourceImage]
 
     assert_creates(*expected_created_classes) do
-      post :milestone,
-        params: @milestone_params.merge(image: Base64.encode64(@good_image))
+      assert_does_not_create(Activity) do
+        post :milestone,
+          params: @milestone_params.merge(image: Base64.encode64(@good_image))
+      end
     end
-    assert_equal original_activity_count + 1, Activity.count
     assert_equal original_user_level_count + 1, UserLevel.count
     refute_nil UserLevel.where(
       user_id: @user,
@@ -387,8 +395,8 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     expect_no_s3_upload
 
-    assert_creates(Activity, UserLevel) do
-      assert_does_not_create(LevelSource) do
+    assert_creates(UserLevel) do
+      assert_does_not_create(LevelSource, Activity) do
         post :milestone,
           params: @milestone_params.merge(
             program: program,
@@ -419,8 +427,8 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     expect_no_s3_upload
 
-    assert_creates(Activity, UserLevel) do
-      assert_does_not_create(LevelSource) do
+    assert_creates(UserLevel) do
+      assert_does_not_create(LevelSource, Activity) do
         post :milestone,
           params: @milestone_params.merge(
             program: program,
@@ -449,8 +457,8 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     expect_no_s3_upload
 
-    assert_creates(Activity, UserLevel) do
-      assert_does_not_create(LevelSource) do
+    assert_creates(UserLevel) do
+      assert_does_not_create(LevelSource, Activity) do
         post :milestone,
           params: @milestone_params.merge(
             program: program,
@@ -481,8 +489,8 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     expect_no_s3_upload
 
-    assert_creates(Activity, UserLevel) do
-      assert_does_not_create(LevelSource) do
+    assert_creates(UserLevel) do
+      assert_does_not_create(LevelSource, Activity) do
         post :milestone,
           params: @milestone_params.merge(
             program: program,
@@ -523,8 +531,8 @@ class ActivitiesControllerTest < ActionController::TestCase
       then.
       returns(existing_user_level)
 
-    assert_creates(LevelSource, Activity) do
-      assert_does_not_create(UserLevel) do
+    assert_creates(LevelSource) do
+      assert_does_not_create(UserLevel, Activity) do
         post :milestone, params: @milestone_params
       end
     end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -70,7 +70,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
-    assert_cached_queries(10) do
+    assert_cached_queries(9) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -87,7 +87,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
     setup_script_cache
-    assert_cached_queries(8) do
+    assert_cached_queries(7) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -103,7 +103,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     sl = create(:script, :with_levels, levels_count: 3).script_levels[2]
     params = {program: 'fake program', testResult: 0, result: 'false'}
 
-    assert_cached_queries(8) do
+    assert_cached_queries(7) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -36,11 +36,6 @@ module SeleniumBrowser
     # Replaces 'unexpected response' message with the actual parsed error from the JSON response, if provided.
     def create_response(code, body, content_type)
       super
-    rescue Selenium::WebDriver::Error::UnknownError => exception
-      puts exception
-      puts exception.message
-      puts exception.full_message
-      raise
     rescue Selenium::WebDriver::Error::WebDriverError => exception
       if (msg = exception.message.match(/unexpected response, code=(?<code>\d+).*\n(?<error>.*)/))
         error = msg[:error]

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -36,6 +36,11 @@ module SeleniumBrowser
     # Replaces 'unexpected response' message with the actual parsed error from the JSON response, if provided.
     def create_response(code, body, content_type)
       super
+    rescue Selenium::WebDriver::Error::UnknownError => exception
+      puts exception
+      puts exception.message
+      puts exception.full_message
+      raise
     rescue Selenium::WebDriver::Error::WebDriverError => exception
       if (msg = exception.message.match(/unexpected response, code=(?<code>\d+).*\n(?<error>.*)/))
         error = msg[:error]


### PR DESCRIPTION
A glitch in our dynamic config system revealed that we are still relying on a Gatekeeper config value in production in order to avoid attempting to write entries into the Activities table.

In the interest of minimizing differences between our environments (and reducing our reliance on ephemeral flags for guarding against user-facing errors), I propose we update the default value to match the value currently set in production.

## Links

- Original implementation: https://github.com/code-dot-org/code-dot-org/pull/18603
- Alternative fix: https://github.com/code-dot-org/code-dot-org/pull/63713
- [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1738714542110139)
- [Related Jira issue](https://codedotorg.atlassian.net/browse/INF-1596)

## Testing story

Updated existing unit tests appropriately

## Follow-up work

We should come up with a better long-term plan for the Activities model and table.