### PR TITLE
Music: update sound type filters

### DIFF
--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -113,6 +113,7 @@ export default class MusicLibrary {
     this.name = name;
     this.libraryJson = libraryJson;
     this.allowedSounds = null;
+    this.availableSoundTypes = {};
 
     // Add notes for drum kits based on index if they don't already have them.
     for (const kit of libraryJson.kits) {
@@ -146,7 +147,6 @@ export default class MusicLibrary {
     this.hasRestrictedPacks = libraryJson.packs.some(pack => pack.restricted);
 
     // Take this opportunity to determine the available sound types in this library.
-    this.availableSoundTypes = {};
     this.determineAvailableSoundTypes();
   }
 
@@ -156,6 +156,9 @@ export default class MusicLibrary {
 
   setCurrentPackId(packId: string | null) {
     this.currentPackId = packId;
+
+    // Take this opportunity to update the available sound types in this library.
+    this.determineAvailableSoundTypes();
   }
 
   getHasRestrictedPacks(): boolean {
@@ -165,7 +168,9 @@ export default class MusicLibrary {
   // Determine the available sound types available in this library.
   // Only currently-allowed sounds from packs are included.
   private determineAvailableSoundTypes() {
-    const folders = this.getAllowedSounds();
+    const folders = this.getAvailableSounds();
+
+    this.availableSoundTypes = {};
 
     folders.forEach(folder => {
       folder.sounds.forEach(sound => {


### PR DESCRIPTION
The sound panel's filters now reflect the sound types available due to the currently-selected pack.

For example, if the default pack is chosen, the Vocals sound type is no longer listed.  But if the pack is changed to one with vocals, the Vocals sound type is listed.

### before

<img width="653" alt="Screenshot 2025-02-05 at 4 36 01 PM" src="https://github.com/user-attachments/assets/6e6763a2-ff70-4990-9a72-682245824b7b" />

### after

<img width="653" alt="Screenshot 2025-02-05 at 4 31 59 PM" src="https://github.com/user-attachments/assets/58f67314-452a-428e-87d0-3edcba6c8971" />
