### PR TITLE
[Music] Update tip text for Selected Library

### DIFF
--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -120,6 +120,12 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
               early music lab progressions - consider picking a newer library
               instead!
             </li>
+            <li>
+              The curriculum2024 library is currently just a staging ground for
+              sounds that we want to test out in scripts not intended for full
+              launch. Once those sounds are finalized, they will be put into the
+              launch2024 library in the appropriate form.
+            </li>
           </ul>
           <div>
             <SimpleDropdown

--- a/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
+++ b/apps/src/lab2/levelEditors/levelData/EditMusicLevelData.tsx
@@ -112,10 +112,15 @@ const EditMusicLevelData: React.FunctionComponent<EditMusicLevelDataProps> = ({
       />
       <CollapsibleSection headerContent="Library & Sounds">
         <div className={moduleStyles.section}>
-          <i>
-            Note that currently, all levels within a lesson must use the same
-            library.
-          </i>
+          <i>Tips for levelbuilders:</i>
+          <ul>
+            <li>Currently, only the launch2024 library supports Share/Remix</li>
+            <li>
+              The intro2024 library is no longer maintained but is still used in
+              early music lab progressions - consider picking a newer library
+              instead!
+            </li>
+          </ul>
           <div>
             <SimpleDropdown
               labelText="Selected Library"


### PR DESCRIPTION
Per recent discussion (https://codedotorg.slack.com/archives/C07UT279KM1/p1738778427629639), this updates the text above the library selection dropdown. As noted by @sanchitmalhotra126 and confirmed by @dancodedotorg we now can support loading a new library between levels. This outdated message is replaced with a new one that better reflects the current limitations and norms.

<img width="796" alt="image" src="https://github.com/user-attachments/assets/4462bd4b-a943-49d1-afc5-58eff16e8914" />


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
