### PR TITLE
Include hyperlink in green-marked test commit

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -206,7 +206,7 @@ def mark_dtt_green
   # untested changes green.
   test_branch_sha = GitUtils.git_revision_short
 
-  msg = "Automatically marking commit #{test_branch_sha} green"
+  msg = "Automatically marking commit <a href=\"#{GitHub.commit_url(test_branch_sha)}\">PR#{test_branch_sha}</a> green"
   ChatClient.log msg
   ChatClient.message 'deploy-status', msg
 

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -206,7 +206,7 @@ def mark_dtt_green
   # untested changes green.
   test_branch_sha = GitUtils.git_revision_short
 
-  msg = "Automatically marking commit <a href=\"#{GitHub.commit_url(test_branch_sha)}\">PR#{test_branch_sha}</a> green"
+  msg = "Automatically marking commit <a href=\"#{GitHub.commit_url(test_branch_sha)}\">#{test_branch_sha}</a> green"
   ChatClient.log msg
   ChatClient.message 'deploy-status', msg
 

--- a/bin/cron/deploy_to_levelbuilder
+++ b/bin/cron/deploy_to_levelbuilder
@@ -44,7 +44,7 @@ def new_commits?(commit)
 end
 
 def message_dtl_soon(pr_number)
-  "<!levelbuilders> Robo-DTL will deploy <a href=\"#{GitHub.url(pr_number)}\">PR #{pr_number}</a> in five " \
+  "<!levelbuilders> Robo-DTL will deploy <a href=\"#{GitHub.pr_url(pr_number)}\">PR #{pr_number}</a> in five " \
   'minutes. Please ping #developers or set "DTL: no" in #deploy-status if you wish to prevent this.'
 end
 

--- a/bin/cron/deploy_to_test
+++ b/bin/cron/deploy_to_test
@@ -33,7 +33,7 @@ def main
 
   ChatClient.message(
     'infra-test',
-    "robo-DTT created and merged <a href=\"#{GitHub.url(pr_number)}\">PR#{pr_number}</a>",
+    "robo-DTT created and merged <a href=\"#{GitHub.pr_url(pr_number)}\">PR#{pr_number}</a>",
     color: 'green'
   )
 rescue Exception => exception

--- a/bin/cron/merge_lb_to_staging
+++ b/bin/cron/merge_lb_to_staging
@@ -60,7 +60,7 @@ def main
 
   ChatClient.message(
     'staging',
-    "robo-DTS created and merged <a href=\"#{GitHub.url(pr_number)}\">PR#{pr_number}</a>",
+    "robo-DTS created and merged <a href=\"#{GitHub.pr_url(pr_number)}\">PR#{pr_number}</a>",
     color: 'green'
   )
 rescue Exception => exception

--- a/bin/dotd
+++ b/bin/dotd
@@ -129,15 +129,15 @@ def do_dtp(dotd_name)
     title: "DTP (Test > Production: #{test_green_commit})"
   )
   print_database_changes production_pr_number
-  dtp_auto_merged = should_i "merge DTP (#{GitHub.url(production_pr_number)})" do
+  dtp_auto_merged = should_i "merge DTP (#{GitHub.pr_url(production_pr_number)})" do
     DevelopersTopic.set_dtp "in progress (@#{dotd_name})"
     GitHub.merge_pull_request(
       production_pr_number,
       "DTP (Test > Production: #{test_green_commit})"
     )
   end
-  GitHub.open_url GitHub.url(production_pr_number) unless dtp_auto_merged
-  @logger.info "DTPs #{test_green_commit} in #{GitHub.url(production_pr_number)}"
+  GitHub.open_url GitHub.pr_url(production_pr_number) unless dtp_auto_merged
+  @logger.info "DTPs #{test_green_commit} in #{GitHub.pr_url(production_pr_number)}"
 end
 
 # Creates a DTL branch from the most recent green commit, creates a GitHub PR merging it to
@@ -156,8 +156,8 @@ def do_dtl(dotd_name)
     head: branch_name,
     title: "DTL (Test > Levelbuilder: #{test_green_commit})"
   )
-  puts "MERGED DTL: PR#{levelbuilder_pr_number} (#{GitHub.url(levelbuilder_pr_number)})"
-  @logger.info "DTLs #{test_green_commit} in #{GitHub.url(levelbuilder_pr_number)}"
+  puts "MERGED DTL: PR#{levelbuilder_pr_number} (#{GitHub.pr_url(levelbuilder_pr_number)})"
+  @logger.info "DTLs #{test_green_commit} in #{GitHub.pr_url(levelbuilder_pr_number)}"
 end
 
 # @return [String] The text for the DOTD menu prompt.
@@ -268,7 +268,7 @@ def dotd_menu(dotd_name)
         )
         puts <<-EOS.unindent
 
-          DTS (Levelbuilder > Staging): #{GitHub.url(dts_pr_number)}
+          DTS (Levelbuilder > Staging): #{GitHub.pr_url(dts_pr_number)}
 
         EOS
         @logger.info 'merges levelbuilder into staging'
@@ -281,7 +281,7 @@ def dotd_menu(dotd_name)
         )
         puts <<-EOS.unindent
 
-          DTT (Staging > Test): #{GitHub.url(dtt_pr_number)}
+          DTT (Staging > Test): #{GitHub.pr_url(dtt_pr_number)}
 
         EOS
         @logger.info 'manually DTTs from staging'

--- a/bin/i18n/create-prs.rb
+++ b/bin/i18n/create-prs.rb
@@ -65,7 +65,7 @@ class CreateI18nPullRequests
       title: "I18n sync In & Up #{Date.today.strftime('%m/%d')}"
     )
     GitHub.label_pull_request(in_up_pr, ["i18n"])
-    puts "Created In & Up PR: #{GitHub.url(in_up_pr)}"
+    puts "Created In & Up PR: #{GitHub.pr_url(in_up_pr)}"
   end
 
   def self.down_and_out
@@ -149,6 +149,6 @@ class CreateI18nPullRequests
     )
     GitHub.label_pull_request(down_out_pr, ["i18n"])
 
-    puts "Created Down & Out PR: #{GitHub.url(down_out_pr)}"
+    puts "Created Down & Out PR: #{GitHub.pr_url(down_out_pr)}"
   end
 end

--- a/lib/cdo/github.rb
+++ b/lib/cdo/github.rb
@@ -212,8 +212,15 @@ module GitHub
   # request number.
   # @param pr_number [Integer] The pull request number.
   # @return [String] The HTML URL for the pull request.
-  def self.url(pr_number)
+  def self.pr_url(pr_number)
     "https://github.com/#{REPO}/pull/#{pr_number}"
+  end
+
+  # Builds the GitHub URL from a commit SHA. Does not validate the commit SHA.
+  # @param commit_sha [String] The commit SHA.
+  # @return [String] The HTML URL for the commit.
+  def self.commit_url(commit_sha)
+    "https://github.com/#{REPO}/commit/#{commit_sha}"
   end
 
   # Octokit Documentation: http://octokit.github.io/octokit.rb/Octokit/Client/PullRequests.html#pull_merged

--- a/lib/test/cdo/test_github.rb
+++ b/lib/test/cdo/test_github.rb
@@ -1,6 +1,6 @@
 require_relative '../test_helper'
 require 'uri'
-require 'cdo/github'  # Adjust this if needed to correctly require the GitHub module
+require 'cdo/github'
 
 class GitHubTest < Minitest::Test
   TEST_REPO = "my-org/my-repo"

--- a/lib/test/cdo/test_github.rb
+++ b/lib/test/cdo/test_github.rb
@@ -1,0 +1,34 @@
+require_relative '../test_helper'
+require 'uri'
+require 'cdo/github'  # Adjust this if needed to correctly require the GitHub module
+
+class GitHubTest < Minitest::Test
+  TEST_REPO = "my-org/my-repo"
+
+  def setup
+    # Override the REPO constant to ensure it's being used in tested methods
+    GitHub.send(:remove_const, :REPO) if GitHub.const_defined?(:REPO)
+    GitHub.const_set(:REPO, TEST_REPO)
+  end
+
+  # Verify that the given URL is a valid URL for github.com
+  def assert_valid_github_url(url)
+    uri = URI.parse(url)
+    assert_equal "https", uri.scheme, "Expected HTTPS URL, got #{url}"
+    assert_equal "github.com", uri.host, "Expected a GitHub URL, got #{url}"
+  rescue URI::InvalidURIError
+    flunk "Expected a valid URL, got #{url}"
+  end
+
+  def test_pr_url_returns_valid_github_url
+    url = GitHub.pr_url(123)
+    assert_valid_github_url?(url)
+    assert_equal "https://github.com/#{TEST_REPO}/pull/123", url
+  end
+
+  def test_commit_url_returns_valid_github_url
+    url = GitHub.commit_url("abc123")
+    assert_valid_github_url?(url)
+    assert_equal "https://github.com/#{TEST_REPO}/commit/abc123", url
+  end
+end

--- a/lib/test/cdo/test_github.rb
+++ b/lib/test/cdo/test_github.rb
@@ -22,13 +22,13 @@ class GitHubTest < Minitest::Test
 
   def test_pr_url_returns_valid_github_url
     url = GitHub.pr_url(123)
-    assert_valid_github_url?(url)
+    assert_valid_github_url(url)
     assert_equal "https://github.com/#{TEST_REPO}/pull/123", url
   end
 
   def test_commit_url_returns_valid_github_url
     url = GitHub.commit_url("abc123")
-    assert_valid_github_url?(url)
+    assert_valid_github_url(url)
     assert_equal "https://github.com/#{TEST_REPO}/commit/abc123", url
   end
 end


### PR DESCRIPTION
This adds a clickable link to the end of the DTT output when the result is Green. This is helpful for verifying whether the particular DTT contains a commit you're looking for (like the overnight content scoops). Adding this took me down a short rabbit hole with a bit of refactoring.

* add commit_url method to GitHub module
* rename url to pr_url in GitHub module
* add boring starter tests to the GitHub module

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

* Added unit tests for `GitHub.commit_url` and `GitHub.pr_url`, but this won't really be tested until it survives the DTx in each affected environment.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
