### PR TITLE
Find and replace simple users/sign_up urls with users/new_sign_up/account_type

### DIFF
--- a/apps/src/code-studio/components/ShareDisallowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareDisallowedDialog.jsx
@@ -37,7 +37,7 @@ class ShareDisallowedDialog extends Component {
             />
             <Button
               useAsLink={true}
-              href={`/users/sign_up?user_return_to=${location.pathname}`}
+              href={`/users/new_sign_up/account_type?user_return_to=${location.pathname}`}
               text={i18n.createAccount()}
             />
           </div>

--- a/apps/src/signUpFlow/AccountType.tsx
+++ b/apps/src/signUpFlow/AccountType.tsx
@@ -17,11 +17,14 @@ import FreeCurriculumDialog from './FreeCurriculumDialog';
 import {
   ACCOUNT_TYPE_SESSION_KEY,
   USER_RETURN_TO_SESSION_KEY,
+  OAUTH_LOGIN_TYPE_SESSION_KEY,
 } from './signUpFlowConstants';
 
 import style from './signUpFlowStyles.module.scss';
 
 const AccountType: React.FunctionComponent = () => {
+  const [loginTypeAlreadySelected, setLoginTypeAlreadySelected] =
+    useState(false);
   const [isFreeCurriculumDialogOpen, setIsFreeCurriculumDialogOpen] =
     useState(false);
 
@@ -39,6 +42,29 @@ const AccountType: React.FunctionComponent = () => {
       {},
       PLATFORMS.BOTH
     );
+
+    // If sent here from trying to log in with OAuth without an account, log the OAuth type and have this page
+    // send to the final signup page instead of having them pick login type again.
+    let oauthType = sessionStorage.getItem(OAUTH_LOGIN_TYPE_SESSION_KEY);
+    if (oauthType) {
+      setLoginTypeAlreadySelected(true);
+
+      // Convert the name of the OAuth type so it lines up with our existing metrics for logging the login type
+      // selected.
+      if (oauthType === 'google_oauth2') {
+        oauthType = 'google';
+      } else if (oauthType === 'microsoft_v2_auth') {
+        oauthType = 'microsoft';
+      }
+
+      analyticsReporter.sendEvent(
+        EVENTS.SIGN_UP_LOGIN_TYPE_PICKED_EVENT,
+        {
+          'user login type': oauthType,
+        },
+        PLATFORMS.BOTH
+      );
+    }
   }, []);
 
   const selectAccountType = (accountType: string) => {
@@ -50,7 +76,20 @@ const AccountType: React.FunctionComponent = () => {
       PLATFORMS.BOTH
     );
     sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, accountType);
-    navigateToHref(studio('/users/new_sign_up/login_type'));
+
+    // By default, navigate the user to the login type page after selecting their user
+    // type. However, if a user is sent to this page after trying to login through OAuth
+    // without an account, then they'll be sent to the appropriate finish signup page
+    // since they've already selected their login type.
+    if (loginTypeAlreadySelected) {
+      const finishSignupUrl =
+        accountType === 'teacher'
+          ? '/users/new_sign_up/finish_teacher_account'
+          : '/users/new_sign_up/finish_student_account';
+      navigateToHref(studio(finishSignupUrl));
+    } else {
+      navigateToHref(studio('/users/new_sign_up/login_type'));
+    }
   };
 
   const sendCurriculumAnalyticsEvent = () => {

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -4,17 +4,17 @@ import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imp
 import {studio, pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
-import {ACCOUNT_TYPE_SESSION_KEY} from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import color from '@cdo/apps/util/color';
 
 const RETURN_TO = `user_return_to=${pegasus('/afe')}`;
-const SIGN_UP_URL = studio(`/users/new_sign_up/account_type?${RETURN_TO}`);
+const SIGN_UP_URL = studio(
+  `/users/sign_up?user[user_type]=teacher&${RETURN_TO}`
+);
 const SIGN_IN_URL = studio(`/users/sign_in?${RETURN_TO}`);
 
 export default class AmazonFutureEngineerAccountConfirmation extends React.Component {
   signUpButtonPress = () => {
     analyticsReporter.sendEvent(EVENTS.AFE_SIGN_UP_BUTTON_PRESS);
-    sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, 'teacher');
     window.location = SIGN_UP_URL;
   };
 

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -4,17 +4,17 @@ import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imp
 import {studio, pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
+import {ACCOUNT_TYPE_SESSION_KEY} from '@cdo/apps/signUpFlow/signUpFlowConstants';
 import color from '@cdo/apps/util/color';
 
 const RETURN_TO = `user_return_to=${pegasus('/afe')}`;
-const SIGN_UP_URL = studio(
-  `/users/sign_up?user[user_type]=teacher&${RETURN_TO}`
-);
+const SIGN_UP_URL = studio(`/users/new_sign_up/account_type?${RETURN_TO}`);
 const SIGN_IN_URL = studio(`/users/sign_in?${RETURN_TO}`);
 
 export default class AmazonFutureEngineerAccountConfirmation extends React.Component {
   signUpButtonPress = () => {
     analyticsReporter.sendEvent(EVENTS.AFE_SIGN_UP_BUTTON_PRESS);
+    sessionStorage.setItem(ACCOUNT_TYPE_SESSION_KEY, 'teacher');
     window.location = SIGN_UP_URL;
   };
 

--- a/apps/src/templates/certificates/congratsBeyondHocActivityCards.js
+++ b/apps/src/templates/certificates/congratsBeyondHocActivityCards.js
@@ -28,7 +28,7 @@ const CourseCatalog = {
 const CreateAccount = {
   title: i18n.createAccount(),
   description: i18n.createAccountDesc(),
-  link: '/users/sign_up',
+  link: '/users/new_sign_up/account_type',
   image: 'create-account',
   buttonText: i18n.createAccount(),
 };
@@ -36,7 +36,7 @@ const CreateAccount = {
 const CreateAccountApplab = {
   title: i18n.createAccount(),
   description: i18n.createAccountApplabDesc(),
-  link: '/users/sign_up',
+  link: '/users/new_sign_up/account_type',
   image: 'create-account',
   buttonText: i18n.createAccount(),
 };

--- a/apps/src/templates/manageStudents/ManageStudentsLoginInfo.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsLoginInfo.jsx
@@ -175,7 +175,7 @@ class ManageStudentsLoginInfo extends Component {
             <SafeMarkdown
               markdown={renderStep(
                 i18n.setUpClassEmail1({
-                  createAccountLink: `${studioUrlPrefix}/users/sign_up`,
+                  createAccountLink: `${studioUrlPrefix}/users/new_sign_up/account_type`,
                 })
               )}
             />

--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -182,7 +182,7 @@ class EmailLogins extends React.Component {
         <ol>
           <li>
             {i18n.loginInfo_joinStep1({
-              url: `${studioUrlPrefix}/users/sign_up`,
+              url: `${studioUrlPrefix}/users/new_sign_up/account_type`,
             })}
             <br />
             <img

--- a/apps/test/unit/signUpFlow/AccountTypeTest.tsx
+++ b/apps/test/unit/signUpFlow/AccountTypeTest.tsx
@@ -3,6 +3,15 @@ import React from 'react';
 
 import AccountType from '@cdo/apps/signUpFlow/AccountType';
 import locale from '@cdo/apps/signUpFlow/locale';
+import {OAUTH_LOGIN_TYPE_SESSION_KEY} from '@cdo/apps/signUpFlow/signUpFlowConstants';
+import {navigateToHref} from '@cdo/apps/utils';
+
+jest.mock('@cdo/apps/utils', () => ({
+  ...jest.requireActual('@cdo/apps/utils'),
+  navigateToHref: jest.fn(),
+}));
+
+const navigateToHrefMock = navigateToHref as jest.Mock;
 
 describe('SelectAccountType', () => {
   function renderDefault() {
@@ -18,12 +27,20 @@ describe('SelectAccountType', () => {
     // Renders student card title, one item from the list, and button
     screen.getByText(locale.im_a_student());
     screen.getByText(locale.save_projects_and_progress());
-    screen.getByText(locale.sign_up_as_a_student());
+    const studentButton = screen.getByText(locale.sign_up_as_a_student());
 
     // Renders teacher card title, one item from the list, and button
     screen.getByText(locale.im_a_teacher());
     screen.getByText(locale.create_classroom_sections());
-    screen.getByText(locale.sign_up_as_a_teacher());
+    const teacherButton = screen.getByText(locale.sign_up_as_a_teacher());
+
+    // Both buttons default to sending the user to the login type selection page
+    fireEvent.click(studentButton);
+    fireEvent.click(teacherButton);
+    expect(navigateToHrefMock).toHaveBeenCalledWith(
+      '/users/new_sign_up/login_type'
+    );
+    expect(navigateToHrefMock).toHaveBeenCalledTimes(2);
   });
 
   it('renders free curriculum popup dialog', () => {
@@ -48,5 +65,23 @@ describe('SelectAccountType', () => {
     expect(
       screen.queryByText(locale.our_commitment_to_free_curriculum())
     ).toBeNull();
+  });
+
+  it('buttons send user to the finish signup pages if login type already selected through oauth', () => {
+    sessionStorage.setItem(OAUTH_LOGIN_TYPE_SESSION_KEY, 'google_oauth2');
+
+    renderDefault();
+
+    fireEvent.click(screen.getByText(locale.sign_up_as_a_student()));
+    expect(navigateToHrefMock).toHaveBeenCalledWith(
+      '/users/new_sign_up/finish_student_account'
+    );
+
+    fireEvent.click(screen.getByText(locale.sign_up_as_a_teacher()));
+    expect(navigateToHrefMock).toHaveBeenCalledWith(
+      '/users/new_sign_up/finish_teacher_account'
+    );
+
+    sessionStorage.clear();
   });
 });

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -81,7 +81,7 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
         render json: {
           workshop_enrollment_status: RESPONSE_MESSAGES[:SUCCESS],
           account_exists: user.present?,
-          sign_up_url: url_for('/users/sign_up'),
+          sign_up_url: url_for('/users/new_sign_up/account_type'),
           cancel_url: url_for(action: :cancel, controller: '/pd/workshop_enrollment', code: enrollment.code)
         }
       rescue ActiveRecord::ValueTooLong

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -195,7 +195,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         email: user.email
     else
       # This is a new registration
-      register_new_user(user)
+      register_new_user(user, provider)
     end
   end
 
@@ -232,7 +232,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       end
       return redirect_to users_existing_account_path({provider: auth_hash.provider, email: user.email})
     else
-      register_new_user(user)
+      register_new_user(user, AuthenticationOption::GOOGLE)
     end
   end
 
@@ -268,7 +268,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     return redirect_to users_existing_account_path({provider: auth_hash.provider, email: user.email}) if existing_account
 
     # otherwise, this is a new registration
-    register_new_user(user)
+    register_new_user(user, AuthenticationOption::CLEVER)
   end
 
   private def find_user_by_credential
@@ -305,11 +305,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
-  private def register_new_user(user)
+  private def register_new_user(user, provider)
     PartialRegistration.persist_attributes(session, user)
 
     @form_data = {
-      email: user.email
+      email: user.email,
+      provider: provider
     }
     new_sign_up_url = determine_sign_up_url(user)
     render 'omniauth/redirect', layout: false, locals: {new_sign_up_url: new_sign_up_url}
@@ -318,13 +319,11 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private def determine_sign_up_url(user)
     user_type = cookies['new_sign_up_user_type']
     cookies.delete('new_sign_up_user_type')
-    if user_type == 'student'
-      return users_new_sign_up_finish_student_account_path
-    elsif user_type == 'teacher'
+    if user_type == 'teacher'
       return users_new_sign_up_finish_teacher_account_path
+    else
+      return users_new_sign_up_finish_student_account_path
     end
-    # We are in the old sign up flow -> redirect to old finish_sign_up page
-    return ''
   end
 
   private def extract_microsoft_data(auth)

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -319,10 +319,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private def determine_sign_up_url(user)
     user_type = cookies['new_sign_up_user_type']
     cookies.delete('new_sign_up_user_type')
-    if user_type == 'teacher'
+    if user_type == 'student'
+      return users_new_sign_up_finish_student_account_path
+    elsif user_type == 'teacher'
       return users_new_sign_up_finish_teacher_account_path
     else
-      return users_new_sign_up_finish_student_account_path
+      return users_new_sign_up_account_type_path
     end
   end
 

--- a/dashboard/app/views/omniauth/redirect.html.haml
+++ b/dashboard/app/views/omniauth/redirect.html.haml
@@ -5,21 +5,14 @@
     %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}
     %title= t('nav.user.loading')
 
-    -if new_sign_up_url.present?
-      :javascript
+    :javascript
         (function() {
           var email = "#{@form_data[:email]}";
+          var oauthType = "#{@form_data[:provider]}";
           sessionStorage.setItem('email', email);
+          sessionStorage.setItem('oauthType', oauthType);
           window.location.href = "#{new_sign_up_url}";
         })();
-    -else
-      = form_with(url: users_finish_sign_up_path, method: :post, html: {id: 'redirect-form'}) do |f|
-        = f.hidden_field "user[email]", value: @form_data[:email]
-
-      :javascript
-        window.onload = function() {
-          document.getElementById("redirect-form").submit()
-        };
 
   %body
     %p=t('nav.user.loading')

--- a/dashboard/app/views/teacher_mailer/hour_of_code_tutorial_email.html.haml
+++ b/dashboard/app/views/teacher_mailer/hour_of_code_tutorial_email.html.haml
@@ -5,7 +5,7 @@
   = t('hoc_tutorial_email_content.intro_step_by_step_guide')
 %ol
   %li
-    != I18n.t('hoc_tutorial_email_content.sign_up_step', url: CDO.studio_url('/users/sign_up'), markdown: true)
+    != I18n.t('hoc_tutorial_email_content.sign_up_step', url: CDO.studio_url('/users/new_sign_up/account_type'), markdown: true)
   %li
     != I18n.t('hoc_tutorial_email_content.create_classroom_section', section_setup_url: CDO.studio_url('/home?openAddSectionDialog=true&participantType=student'), guide_url: 'https://support.code.org/hc/en-us/articles/115000488132-Creating-a-classroom-section', markdown: true)
   %li

--- a/dashboard/config/scripts/opd_k5_stage9start.external
+++ b/dashboard/config/scripts/opd_k5_stage9start.external
@@ -15,7 +15,7 @@ By completing Stage 10, you will:
 
 ***
 
-A screenshot of the Teacher Dashboard is below. You will need to log into your Code.org teacher account in order to see it – once you are logged in, it should the default screen that you see on the Code.org website. If you do not have a teacher account, you can **[sign up for one here](https://studio.code.org/users/sign_up)**.
+A screenshot of the Teacher Dashboard is below. You will need to log into your Code.org teacher account in order to see it – once you are logged in, it should the default screen that you see on the Code.org website. If you do not have a teacher account, you can **[sign up for one here](https://studio.code.org/users/new_sign_up/account_type)**.
 
 ![](https://images.code.org/d6345709495f764a71d9cb0994dbd7e4-image-1549064603589.png)
 MARKDOWN

--- a/dashboard/config/scripts/opd_k5_stage9start2.external
+++ b/dashboard/config/scripts/opd_k5_stage9start2.external
@@ -3,7 +3,7 @@ skip_dialog true
 markdown <<MARKDOWN
 # Planning > Teacher Dashboard
 
-Below is a view of the Code.org Teacher Dashboad. If you do not have a Code.org teacher account yet, you will have to [sign up for one](https://studio.code.org/users/sign_up) in order to see this page. Once you have an account and you are signed in, you should see this as the default page when you go to the [Code.org](code.org) website.
+Below is a view of the Code.org Teacher Dashboad. If you do not have a Code.org teacher account yet, you will have to [sign up for one](https://studio.code.org/users/new_sign_up/account_type) in order to see this page. Once you have an account and you are signed in, you should see this as the default page when you go to the [Code.org](code.org) website.
 
 Throughout the rest of this stage, we will explore more what you can do as a teacher on Code.org. 
 ![](https://images.code.org/0d0924596c1f73484b2c6da540a0507e-image-1549061913651.57.39 PM.png)

--- a/dashboard/config/scripts/opd_k5_stage9start_copy.external
+++ b/dashboard/config/scripts/opd_k5_stage9start_copy.external
@@ -5,7 +5,7 @@ markdown <<MARKDOWN
 
 It's time to start planning your instruction. In this stage, we'll be touring other areas of the Code.org platform and the **<a href="http://studio.code.org/" target="blank" rel="noopener noreferrer">Teacher Dashboard</a>**.
 
-A screenshot of the Teacher Dashboard is below. You will need to log into your Code.org teacher account in order to see it. Once you are logged in, it should be the default screen that you see on the Code.org website. If you do not have a teacher account, you can **<a href="https://studio.code.org/users/sign_up" target="blank" rel="noopener noreferrer">sign up for one here</a>**.
+A screenshot of the Teacher Dashboard is below. You will need to log into your Code.org teacher account in order to see it. Once you are logged in, it should be the default screen that you see on the Code.org website. If you do not have a teacher account, you can **<a href="https://studio.code.org/users/new_sign_up/account_type" target="blank" rel="noopener noreferrer">sign up for one here</a>**.
 
 <a href="http://studio.code.org/" target="blank" rel="noopener noreferrer">![](https://images.code.org/d6345709495f764a71d9cb0994dbd7e4-image-1549064603589.png)</a>
 MARKDOWN

--- a/dashboard/config/scripts/opd_k5_stage9start_copy_2020.external
+++ b/dashboard/config/scripts/opd_k5_stage9start_copy_2020.external
@@ -5,7 +5,7 @@ markdown <<MARKDOWN
 
 It's time to start planning your instruction. In this stage, we'll be touring other areas of the Code.org platform and the **<a href="http://studio.code.org/" target="blank" rel="noopener noreferrer">Teacher Dashboard</a>**.
 
-A screenshot of the Teacher Dashboard is below. You will need to log into your Code.org teacher account in order to see it. Once you are logged in, it should be the default screen that you see on the Code.org website. If you do not have a teacher account, you can **<a href="https://studio.code.org/users/sign_up" target="blank" rel="noopener noreferrer">sign up for one here</a>**.
+A screenshot of the Teacher Dashboard is below. You will need to log into your Code.org teacher account in order to see it. Once you are logged in, it should be the default screen that you see on the Code.org website. If you do not have a teacher account, you can **<a href="https://studio.code.org/users/new_sign_up/account_type" target="blank" rel="noopener noreferrer">sign up for one here</a>**.
 
 <a href="http://studio.code.org/" target="blank" rel="noopener noreferrer">![](https://images.code.org/d6345709495f764a71d9cb0994dbd7e4-image-1549064603589.png)</a>
 MARKDOWN

--- a/dashboard/config/scripts/opd_k5_stage9start_copy_2021.external
+++ b/dashboard/config/scripts/opd_k5_stage9start_copy_2021.external
@@ -5,7 +5,7 @@ markdown <<MARKDOWN
 
 It's time to start planning your instruction. In this stage, we'll be touring other areas of the Code.org platform and the **<a href="http://studio.code.org/" target="blank" rel="noopener noreferrer">Teacher Dashboard</a>**.
 
-A screenshot of the Teacher Dashboard is below. You will need to log into your Code.org teacher account in order to see it. Once you are logged in, it should be the default screen that you see on the Code.org website. If you do not have a teacher account, you can **<a href="https://studio.code.org/users/sign_up" target="blank" rel="noopener noreferrer">sign up for one here</a>**.
+A screenshot of the Teacher Dashboard is below. You will need to log into your Code.org teacher account in order to see it. Once you are logged in, it should be the default screen that you see on the Code.org website. If you do not have a teacher account, you can **<a href="https://studio.code.org/users/new_sign_up/account_type" target="blank" rel="noopener noreferrer">sign up for one here</a>**.
 
 <a href="http://studio.code.org/" target="blank" rel="noopener noreferrer">![](https://images.code.org/d6345709495f764a71d9cb0994dbd7e4-image-1549064603589.png)</a>
 MARKDOWN

--- a/dashboard/config/scripts/opd_k5_stage9start_dani.external
+++ b/dashboard/config/scripts/opd_k5_stage9start_dani.external
@@ -15,7 +15,7 @@ By completing Stage 10, you will:
 
 ***
 
-A screenshot of the Teacher Dashboard is below. You will need to log into your Code.org teacher account in order to see it – once you are logged in, it should the default screen that you see on the Code.org website. If you do not have a teacher account, you can **[sign up for one here](https://studio.code.org/users/sign_up)**.
+A screenshot of the Teacher Dashboard is below. You will need to log into your Code.org teacher account in order to see it – once you are logged in, it should the default screen that you see on the Code.org website. If you do not have a teacher account, you can **[sign up for one here](https://studio.code.org/users/new_sign_up/account_type)**.
 
 ![](https://images.code.org/d6345709495f764a71d9cb0994dbd7e4-image-1549064603589.png)
 MARKDOWN

--- a/dashboard/test/integration/omniauth/facebook_test.rb
+++ b/dashboard/test/integration/omniauth/facebook_test.rb
@@ -119,17 +119,6 @@ module OmniauthCallbacksControllerTests
       )
     end
 
-    test 'user_type is usually unset on finish_sign_up' do
-      mock_oauth
-
-      get '/users/sign_up'
-      sign_in_through_facebook
-      omniauth_redirect
-
-      assert_template partial: '_finish_sign_up'
-      assert_nil assigns(:user).user_type
-    end
-
     private def mock_oauth
       mock_oauth_for AuthenticationOption::FACEBOOK, generate_auth_hash(
         provider: AuthenticationOption::FACEBOOK

--- a/dashboard/test/integration/omniauth/facebook_test.rb
+++ b/dashboard/test/integration/omniauth/facebook_test.rb
@@ -119,6 +119,17 @@ module OmniauthCallbacksControllerTests
       )
     end
 
+    test 'user_type is usually unset on finish_sign_up' do
+      mock_oauth
+
+      get '/users/sign_up'
+      sign_in_through_facebook
+      omniauth_redirect
+
+      assert_template partial: '_finish_sign_up'
+      assert_nil assigns(:user).user_type
+    end
+
     private def mock_oauth
       mock_oauth_for AuthenticationOption::FACEBOOK, generate_auth_hash(
         provider: AuthenticationOption::FACEBOOK

--- a/dashboard/test/integration/omniauth/google_oauth2_test.rb
+++ b/dashboard/test/integration/omniauth/google_oauth2_test.rb
@@ -130,15 +130,6 @@ module OmniauthCallbacksControllerTests
     #   )
     # end
 
-    test 'user_type is usually unset on finish_sign_up' do
-      mock_oauth
-
-      get '/users/sign_up'
-      sign_in_through_google
-      omniauth_redirect
-      assert_nil assigns(:user).user_type
-    end
-
     # @return [OmniAuth::AuthHash] that will be passed to the callback when test-mode OAuth is invoked
     private def mock_oauth
       mock_oauth_for AuthenticationOption::GOOGLE, generate_auth_hash(

--- a/dashboard/test/integration/omniauth/google_oauth2_test.rb
+++ b/dashboard/test/integration/omniauth/google_oauth2_test.rb
@@ -130,6 +130,15 @@ module OmniauthCallbacksControllerTests
     #   )
     # end
 
+    test 'user_type is usually unset on finish_sign_up' do
+      mock_oauth
+
+      get '/users/sign_up'
+      sign_in_through_google
+      omniauth_redirect
+      assert_nil assigns(:user).user_type
+    end
+
     # @return [OmniAuth::AuthHash] that will be passed to the callback when test-mode OAuth is invoked
     private def mock_oauth
       mock_oauth_for AuthenticationOption::GOOGLE, generate_auth_hash(

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -169,13 +169,5 @@ module OmniauthCallbacksControllerTests
       study_requests = @firehose_requests.select {|e| e[1][:study] == SignUpTracking::STUDY_NAME && e[0] == :analysis}
       assert_empty study_requests
     end
-
-    # Simulates an omniauth redirect which is done in Javascript
-    def omniauth_redirect
-      post '/users/finish_sign_up', params: {
-        'user[email]': "test@code.org"
-      }
-      assert_template partial: '_finish_sign_up'
-    end
   end
 end

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -169,5 +169,10 @@ module OmniauthCallbacksControllerTests
       study_requests = @firehose_requests.select {|e| e[1][:study] == SignUpTracking::STUDY_NAME && e[0] == :analysis}
       assert_empty study_requests
     end
+
+    # Simulates an omniauth redirect which is done in Javascript
+    def omniauth_redirect
+      redirect_to new_sign_up_url
+    end
   end
 end

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -172,7 +172,10 @@ module OmniauthCallbacksControllerTests
 
     # Simulates an omniauth redirect which is done in Javascript
     def omniauth_redirect
-      redirect_to new_sign_up_url
+      post '/users/finish_sign_up', params: {
+        'user[email]': "test@code.org"
+      }
+      assert_template partial: '_finish_sign_up'
     end
   end
 end

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -172,10 +172,7 @@ module OmniauthCallbacksControllerTests
 
     # Simulates an omniauth redirect which is done in Javascript
     def omniauth_redirect
-      post '/users/finish_sign_up', params: {
-        'user[email]': "test@code.org"
-      }
-      assert_template partial: '_finish_sign_up'
+      get '/users/new_sign_up/account_type'
     end
   end
 end

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -172,7 +172,10 @@ module OmniauthCallbacksControllerTests
 
     # Simulates an omniauth redirect which is done in Javascript
     def omniauth_redirect
-      get '/users/new_sign_up/account_type'
+      post '/users/finish_sign_up', params: {
+        'user[email]': "test@code.org"
+      }
+      assert_template partial: '_finish_sign_up'
     end
   end
 end

--- a/pegasus/sites.v3/code.org/public/curriculum/coding-with-ai.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/coding-with-ai.haml
@@ -40,7 +40,7 @@ theme: responsive_full_width
         %p.no-margin-bottom
           =hoc_s("coding_with_ai_page.support.desc", markdown: :inline)
       .button-wrapper
-        %a.link-button{href: CDO.studio_url("/users/sign_up")}
+        %a.link-button{href: CDO.studio_url("/users/new_sign_up/account_type")}
           =hoc_s("coding_with_ai_page.support.button")
 
 %section

--- a/pegasus/sites.v3/code.org/public/curriculum/computer-vision.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/computer-vision.haml
@@ -37,7 +37,7 @@ theme: responsive_full_width
             =hoc_s("game_design_page.resources.heading")
           %p.no-margin-bottom
             =hoc_s("game_design_page.resources.desc", markdown: :inline)
-        %a.link-button{href: CDO.studio_url("/users/sign_up")}
+        %a.link-button{href: CDO.studio_url("/users/new_sign_up/account_type")}
           =hoc_s("game_design_page.resources.button")
 
   %section#curricula

--- a/pegasus/sites.v3/code.org/public/curriculum/csa.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/csa.haml
@@ -60,7 +60,7 @@ theme: responsive_full_width
 
 %section.bg-neutral-light
   .wrapper
-    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
+    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/new_sign_up/account_type")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/curriculum/csc.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/csc.haml
@@ -98,7 +98,7 @@ theme: responsive_full_width
 
 %section.bg-neutral-light
   .wrapper
-    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
+    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/new_sign_up/account_type")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/curriculum/csd.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/csd.haml
@@ -101,7 +101,7 @@ theme: responsive_full_width
 
 %section.bg-neutral-light
   .wrapper
-    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
+    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/new_sign_up/account_type")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/curriculum/csf.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/csf.haml
@@ -96,7 +96,7 @@ theme: responsive_full_width
 
 %section.bg-neutral-light
   .wrapper
-    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
+    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/new_sign_up/account_type")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/curriculum/csp.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/csp.haml
@@ -57,7 +57,7 @@ theme: responsive_full_width
 
 %section.bg-neutral-light
   .wrapper
-    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
+    = view :"tabs_section/resources/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/new_sign_up/account_type")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/public/curriculum/game-design.haml
+++ b/pegasus/sites.v3/code.org/public/curriculum/game-design.haml
@@ -37,7 +37,7 @@ theme: responsive_full_width
           =hoc_s("game_design_page.resources.heading")
         %p.no-margin-bottom
           =hoc_s("game_design_page.resources.desc", markdown: :inline)
-      %a.link-button{href: CDO.studio_url("/users/sign_up")}
+      %a.link-button{href: CDO.studio_url("/users/new_sign_up/account_type")}
         =hoc_s("game_design_page.resources.button")
 
 %section#curricula

--- a/pegasus/sites.v3/code.org/public/global/fa/index.haml
+++ b/pegasus/sites.v3/code.org/public/global/fa/index.haml
@@ -14,7 +14,7 @@ theme: responsive_full_width
       %h1.white=hoc_s(:"farsi_site.farsi_homepage_hero_title")
       %p.body-three.white
         =hoc_s(:"farsi_site.farsi_homepage_hero_description")
-      %a{href: CDO.studio_url("/users/sign_up"), class: "link-button"}
+      %a{href: CDO.studio_url("/users/new_sign_up/account_type"), class: "link-button"}
         =hoc_s(:"farsi_site.farsi_homepage_hero_button")
     %figure.col-45{style: "float: right; margin-top: 1.25rem;"}
       %img.rounded-corners.box-shadow-primary{src: "/images/global/fa/farsi-image-1.png", alt: "", style: "position: relative; width: 100%;"}

--- a/pegasus/sites.v3/code.org/public/global/fa/teacher.haml
+++ b/pegasus/sites.v3/code.org/public/global/fa/teacher.haml
@@ -15,7 +15,7 @@ theme: responsive_full_width
       %p=hoc_s(:teach_page_top_desc_01)
       %p.body-three
         =hoc_s(:teach_page_top_desc_02)
-      %a{href: CDO.studio_url("/users/sign_up"), class: "link-button"}
+      %a{href: CDO.studio_url("/users/new_sign_up/account_type"), class: "link-button"}
         =hoc_s(:call_to_action_sign_up_free)
     %figure.col-45{style: "float: right; margin-top: 1.25rem;"}
       %img.rounded-corners.box-shadow-primary{src: "/images/global/fa/farsi-image-3.png", alt: "", style: "position: relative; width: 100%;"}
@@ -42,7 +42,7 @@ theme: responsive_full_width
 
 %section.resources.bg-neutral-light
   .wrapper
-    = view :"global/fa/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/sign_up")})
+    = view :"global/fa/resources_tabs", resources_heading: hoc_s(:resources_tabs_heading), resources_desc: hoc_s(:resources_tabs_desc, markdown: :inline, locals: {sign_up_url: CDO.studio_url("/users/new_sign_up/account_type")})
 
 %section
   .wrapper

--- a/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_progress.haml
+++ b/pegasus/sites.v3/code.org/views/global/fa/resources_tabs_content_progress.haml
@@ -5,5 +5,5 @@
     %h3=hoc_s(:"resources_tabs.progress.heading")
     %p.body-three
       =hoc_s(:"resources_tabs.progress.desc")
-    %a.link-button{href: CDO.studio_url("/users/sign_up"), target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button{href: CDO.studio_url("/users/new_sign_up/account_type"), target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:"resources_tabs.progress.call_to_action")

--- a/pegasus/sites.v3/code.org/views/tabs_section/resources/resources_tabs_content_progress.haml
+++ b/pegasus/sites.v3/code.org/views/tabs_section/resources/resources_tabs_content_progress.haml
@@ -5,5 +5,5 @@
     %h3=hoc_s(:"resources_tabs.progress.heading")
     %p.body-three
       =hoc_s(:"resources_tabs.progress.desc")
-    %a.link-button{href: CDO.studio_url("/users/sign_up"), target: "_blank", rel: "noopener noreferrer"}
+    %a.link-button{href: CDO.studio_url("/users/new_sign_up/account_type"), target: "_blank", rel: "noopener noreferrer"}
       =hoc_s(:"resources_tabs.progress.call_to_action")

--- a/pegasus/sites.v3/hourofcode.com/public/beyond.redirect
+++ b/pegasus/sites.v3/hourofcode.com/public/beyond.redirect
@@ -1,1 +1,1 @@
-https://studio.code.org/users/sign_up
+https://studio.code.org/users/new_sign_up/account_type

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -97,7 +97,7 @@
     .header_button.header_user#header_user_signin
       %span= I18n.t("#{loc_prefix}signin")
   -# Hides the Create account button on the sign up page
-  - if !request.path_info.start_with?('/users/new_sign_up')
+  - if request.path_info != '/users/sign_up' && !request.path_info.start_with?('/users/new_sign_up')
     %a.linktag{href: CDO.studio_url('users/new_sign_up/account_type'), class: 'button-create-account desktop', id: 'create_account_button'}
       .header_button.header_user#header_user_create_account
         %span= I18n.t("#{loc_prefix}create_account_low_cap")

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -97,7 +97,7 @@
     .header_button.header_user#header_user_signin
       %span= I18n.t("#{loc_prefix}signin")
   -# Hides the Create account button on the sign up page
-  - if request.path_info != '/users/sign_up' && !request.path_info.start_with?('/users/new_sign_up')
+  - if !request.path_info.start_with?('/users/new_sign_up')
     %a.linktag{href: CDO.studio_url('users/new_sign_up/account_type'), class: 'button-create-account desktop', id: 'create_account_button'}
       .header_button.header_user#header_user_create_account
         %span= I18n.t("#{loc_prefix}create_account_low_cap")


### PR DESCRIPTION
Find and replace simple `users/sign_up` urls with `users/new_sign_up/account_type` (all listed in [this Jira ticket](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2868)). Ones that require any work beyond a simple find/replace will be in a separate PR to not make any 1 signup cleanup PR too big.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?assignee=60d62161f65054006980bd71&selectedIssue=ACQ-2868)
