### PR TITLE
Evaluate Student Learning: add initial ULI logging for JavaLab

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -11,7 +11,8 @@ import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import Neighborhood from '@cdo/apps/miniApps/neighborhood/Neighborhood';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import javalabMsg from '@cdo/javalab/locale';
-
+import {logUserLevelInteraction} from '@cdo/apps/userLevelInteractionsLogger/userLevelInteractionsApi';
+import {UserLevelInteractions} from '@cdo/generated-scripts/sharedConstants';
 import BackpackClientApi from '../code-studio/components/backpack/BackpackClientApi';
 import {
   getContainedLevelResultInfo,
@@ -102,6 +103,7 @@ Javalab.prototype.init = function (config) {
   this.skin = config.skin;
   this.level = config.level;
   this.levelIdForAnalytics = config.serverLevelId;
+  this.scriptIdForAnalytics = config.serverScriptId;
   // Sets display theme based on displayTheme user preference
   this.displayTheme = getDisplayThemeFromString(config.displayTheme);
   this.isStartMode = !!config.level.editBlocks;
@@ -367,6 +369,11 @@ Javalab.prototype.onRun = function () {
   }
 
   this.miniApp?.reset?.();
+  logUserLevelInteraction({
+    levelId: this.levelIdForAnalytics,
+    scriptId: this.scriptIdForAnalytics,
+    interaction: UserLevelInteractions.click_run,
+  });
   analyticsReporter.sendEvent(EVENTS.JAVALAB_RUN_BUTTON_CLICK, {
     levelId: this.levelIdForAnalytics,
   });

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -10,9 +10,10 @@ import {EVENTS} from '@cdo/apps/metrics/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/metrics/AnalyticsReporter';
 import Neighborhood from '@cdo/apps/miniApps/neighborhood/Neighborhood';
 import {getStore, registerReducers} from '@cdo/apps/redux';
-import javalabMsg from '@cdo/javalab/locale';
 import {logUserLevelInteraction} from '@cdo/apps/userLevelInteractionsLogger/userLevelInteractionsApi';
 import {UserLevelInteractions} from '@cdo/generated-scripts/sharedConstants';
+import javalabMsg from '@cdo/javalab/locale';
+
 import BackpackClientApi from '../code-studio/components/backpack/BackpackClientApi';
 import {
   getContainedLevelResultInfo,
@@ -383,6 +384,11 @@ Javalab.prototype.onRun = function () {
 Javalab.prototype.onTest = function () {
   const validation = this.level.validation;
   const validated = !!validation && Object.keys(validation).length !== 0;
+  logUserLevelInteraction({
+    levelId: this.levelIdForAnalytics,
+    scriptId: this.scriptIdForAnalytics,
+    interaction: UserLevelInteractions.click_validate,
+  });
   analyticsReporter.sendEvent(EVENTS.JAVALAB_TEST_BUTTON_CLICK, {
     levelId: this.levelIdForAnalytics,
     validated: validated,


### PR DESCRIPTION
Very similar to: https://github.com/code-dot-org/code-dot-org/pull/63698

This adds creating a UserLevelInteraction when "Run" and "Test" are clicked from JavaLab. 

<img width="1232" alt="Screenshot 2025-02-05 at 2 14 17 PM" src="https://github.com/user-attachments/assets/0ff1cb72-ac11-4a1a-8891-aec44e59e05d" />

Follow up work:
- Checking production to ensure these writes from JavaLab are logging as expected
- JavaLab has a test button even when there are no tests to run, so data analysis might need to take that into consideration
- If code_version isn't sufficient we might need to investigate a way to store or reference a code snapshot that is updated more frequently
- Potentially logging clicks on "Documentation" similar to logging clicks on Help&Tips from other Labs
- Additional logging from App Lab and potentially expanding to Music Lab