### PR TITLE
Adds role=dialog to aria-modal for passing a11y role support

### DIFF
--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -325,6 +325,7 @@ const SoundsPanel: React.FunctionComponent<SoundsPanelProps> = ({
         id="sounds-panel"
         className={classNames(styles.soundsPanel)}
         aria-modal
+        role="dialog"
       >
         <div id="hidden-item" tabIndex={0} role="button" />
         {showSoundFilters && (


### PR DESCRIPTION
The aria-modal label alone is not yet supported in all browsers. I added role="dialog" here to match what we do elsewhere in our codebase. 

I was able to verify that the focus state still moves into and out of the dialog accordingly (tab, esc keys, respectively). 

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-995

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
