### PR TITLE
Updating hover and selected styles, screenreader measures

### DIFF
--- a/apps/i18n/music/en_us.json
+++ b/apps/i18n/music/en_us.json
@@ -65,6 +65,7 @@
   "chordArpeggioRandom": "Arpeggio Random",
   "chordTogether": "Together",
   "feedback": "Feedback",
+  "measureLength": "Measure Length",
   "share": "Share",
   "shareComingSoon": "Sharing is under construction. Check back soon.",
   "startOver": "Start Over",

--- a/apps/src/music/views/SoundsPanel.tsx
+++ b/apps/src/music/views/SoundsPanel.tsx
@@ -179,7 +179,7 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
         }
       }}
       ref={isSelected ? currentSoundRefCallback : null}
-      aria-label={sound.name + sound.length}
+      aria-label={sound.name + musicI18n.measureLength() + sound.length}
       tabIndex={0}
       role="tabpanel"
     >
@@ -207,7 +207,13 @@ const SoundsPanelRow: React.FunctionComponent<SoundsPanelRowProps> = ({
         </div>
       )}
       <div className={styles.soundRowRight}>
-        <div className={classNames(styles.length, styles.lengthNoMarginRight)}>
+        <div
+          className={classNames(
+            styles.length,
+            styles.lengthNoMarginRight,
+            isSelected && styles.lengthNoMarginRightSelected
+          )}
+        >
           {getLengthRepresentation(sound.length)}
         </div>
       </div>

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -1,4 +1,4 @@
-@import "color.scss";
+@import 'color.scss';
 
 .soundsPanel {
   user-select: none;
@@ -102,6 +102,10 @@
 
     &:hover {
       background-color: $neutral_dark90;
+
+      .lengthNoMarginRight {
+        color: $neutral_dark30;
+      }
     }
 
     &:focus-visible {
@@ -162,6 +166,10 @@
 
     &NoMarginRight {
       margin-right: 0;
+
+      &Selected {
+        color: $neutral_dark20;
+      }
     }
   }
 


### PR DESCRIPTION
This PR does two things:

1. fixes contrast of measure count on both hover and select (leaves the non-hover and non-selected color the same to distinguish between that and the name)
2. Updates the screenreader to announce "Measure length" and adds that string to translations

(After: top is selected, row below is hovered)
<img width="799" alt="Screenshot 2025-02-05 at 1 59 42 PM" src="https://github.com/user-attachments/assets/20cd549a-e32f-40a4-9051-25c41d1a8e52" />

https://github.com/user-attachments/assets/f4d2385a-8d34-46be-b15f-621980dc2dc0



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CT-1015

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
