### PR TITLE
feat(marketing): remove default Heading component in Contentful

### DIFF
--- a/frontend/apps/marketing/src/contentful/register-custom-components.ts
+++ b/frontend/apps/marketing/src/contentful/register-custom-components.ts
@@ -45,9 +45,6 @@ defineComponents(
     },
   ],
   {
-    enabledBuiltInComponents: [
-      CONTENTFUL_COMPONENTS.heading.id, // Remove this once Heading component is implemented
-      CONTENTFUL_COMPONENTS.image.id,
-    ],
+    enabledBuiltInComponents: [CONTENTFUL_COMPONENTS.image.id],
   },
 );


### PR DESCRIPTION
Removes the default Heading component in Contentful Experiences sidebar so content editors can use our custom Heading component.

## Links
Jira ticket: [CMS-308](https://codedotorg.atlassian.net/browse/CMS-308)

## Testing story
Tested locally in Contentful

----

<img width="259" alt="Screenshot 2025-02-06 at 8 50 15 AM" src="https://github.com/user-attachments/assets/c6c0270d-d4da-44cd-8531-af4ed2fb0528" />
