### PR TITLE
feat(marketing): remove builtInStyles on Heading and Paragraph components

### DIFF
--- a/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/heading/HeadingContentfulDefinition.ts
@@ -13,7 +13,7 @@ export const HeadingContentfulComponentDefinition: ComponentDefinition = {
     imageUrl:
       'https://images.ctfassets.net/90t6bu6vlf76/3kSwyMuHssbpZtr0hUAKyf/1f4d22b8e8bf3037bda3ff58d03ce293/component_heading_tooltip.png',
   },
-  builtInStyles: ['cfTextAlign', 'cfTextUnderline', 'cfWidth'],
+  builtInStyles: ['cfTextAlign'],
   variables: {
     visualAppearance: {
       displayName: 'Visual Appearance',

--- a/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
+++ b/frontend/apps/marketing/src/components/paragraph/ParagraphContentfulDefinition.ts
@@ -13,7 +13,7 @@ export const ParagraphContentfulComponentDefinition: ComponentDefinition = {
     imageUrl:
       'https://images.ctfassets.net/90t6bu6vlf76/5qoQl0G7ZKxKCI8VYBaCzl/19a21cd2fbb6b037c397fcbc417f70b1/component_paragraph_tooltip.png',
   },
-  builtInStyles: ['cfTextAlign', 'cfTextUnderline', 'cfWidth'],
+  builtInStyles: ['cfTextAlign'],
   variables: {
     visualAppearance: {
       displayName: 'Visual Appearance',


### PR DESCRIPTION
Removes the underline and width `builtInStyles` on the Heading and Paragraph components since they are not needed.

## Links
Jira ticket: https://codedotorg.atlassian.net/browse/[CMS-309](https://codedotorg.atlassian.net/browse/CMS-309)

## Testing story
Tested locally in Contentful

----

## Heading
<img width="1022" alt="Heading" src="https://github.com/user-attachments/assets/e7d478a5-fd80-469d-bda2-513d1b9285a1" />

## Paragraph
<img width="1022" alt="Paragraph" src="https://github.com/user-attachments/assets/a700a32e-39e0-4887-b601-3ce3250cfa54" />
