### PR TITLE
Python Lab: turn on console input

### DIFF
--- a/apps/src/pythonlab/pyodideWorkerManager.ts
+++ b/apps/src/pythonlab/pyodideWorkerManager.ts
@@ -5,7 +5,6 @@ import {setAndSaveSource} from '@cdo/apps/lab2/redux/lab2ProjectRedux';
 import {setLoadedCodeEnvironment} from '@cdo/apps/lab2/redux/systemRedux';
 import {MultiFileSource, ProjectFile} from '@cdo/apps/lab2/types';
 import {getStore} from '@cdo/apps/redux';
-import experiments from '@cdo/apps/util/experiments';
 import {createUuid} from '@cdo/apps/utils';
 
 import {AWAITING_INPUT, SENDING_INPUT} from './pythonHelpers/constants';
@@ -105,12 +104,8 @@ const setUpPyodideWorker = () => {
 };
 
 const canSupportInput = () => {
-  // We can support input if service workers are supported by the current browser
-  // and the python input experiment is enabled.
-  return (
-    'serviceWorker' in navigator &&
-    experiments.isEnabled(experiments.PYTHON_INPUT)
-  );
+  // We can support input if service workers are supported by the current browser.
+  return 'serviceWorker' in navigator;
 };
 
 const registerServiceWorker = async () => {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -61,8 +61,6 @@ experiments.TEACHER_LOCAL_NAV_V2 = 'teacher-local-nav-v2';
 experiments.CSP_VALIDATION_VIA_AI = 'csp_validation_via_ai';
 // Allows users to view the new version of the teacher homepage
 experiments.TEACHER_HOMEPAGE_V2 = 'teacher-homepage-v2';
-// Allow use of input in python lab
-experiments.PYTHON_INPUT = 'python-input';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
I added console input behind an experiment flag in #63549. It has been working in production for a few days now, so it seems safe to turn it on by default.

## Links
- jira ticket: [CT-1039](https://codedotorg.atlassian.net/browse/CT-1039)


## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
