### PR TITLE
chore(frontend): do not commit yarn binaries

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,12 +2,6 @@
 
 # Yarn
 .yarn/*
-!.yarn/cache
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/sdks
-!.yarn/versions
 
 # Dependencies
 node_modules


### PR DESCRIPTION
Yarn binaries do not need to be committed to the repository. CI uses a cached yarn.
