### PR TITLE
feat(workshops): create workshop configs shared constant

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -179,6 +179,7 @@ def main
         CSD_CUSTOM_WORKSHOP_MODULES
         PARTICIPANT_GROUP_TYPES
         PD_SESSION_FORMATS
+        WORKSHOP_COURSE_CONFIGS
       ),
       source_module: Pd::SharedWorkshopConstants,
       transform_keys: false

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -304,5 +304,93 @@ module Pd
       {value: 'in_person', label: 'In-Person', enum_value: 0},
       {value: 'virtual', label: 'Digital', enum_value: 1}
     ].freeze
+
+    SESSION_FIELDS = {
+      start: {
+        required: true
+      },
+      end: {
+        required: true
+      },
+      session_format: {
+        required: true,
+        options: PD_SESSION_FORMATS
+      },
+      location_name: {
+        required: false
+      },
+      location_address: {
+        required: false
+      },
+      meeting_link: {
+        required: false
+      },
+    }
+
+    COMMON_COURSE_FIELDS = {
+      name: {
+        required: true
+      },
+      capacity: {
+        required: true
+      },
+      notes: {
+        required: false
+      },
+      suppress_email: {
+        required: false
+      },
+      regional_partner_id: {
+        required: false
+      },
+      organizer_id: {
+        required: false
+      },
+      facilitators: {
+        required: false
+      },
+    }
+
+    WORKSHOP_COURSE_CONFIGS = [
+      {
+        slug: COURSE_CSF.parameterize(separator: "_"),
+        label: COURSE_CSF,
+        session_fields: SESSION_FIELDS,
+        fields: COMMON_COURSE_FIELDS.merge(subject: {required: true, options: SUBJECTS[COURSE_CSF].map {|s| {value: s, label: s}}})
+      },
+      {
+        slug: COURSE_CSP.parameterize(separator: "_"),
+        label: COURSE_CSP,
+        session_fields: SESSION_FIELDS,
+        fields: COMMON_COURSE_FIELDS.merge(subject: {required: true, options: SUBJECTS[COURSE_CSP].map {|s| {value: s, label: s}}})
+      },
+      {
+        slug: COURSE_CSD.parameterize(separator: "_"),
+        label: COURSE_CSD,
+        session_fields: SESSION_FIELDS,
+        fields: COMMON_COURSE_FIELDS.merge(subject: {required: true, options: SUBJECTS[COURSE_CSD].map {|s| {value: s, label: s}}})
+      },
+      {
+        slug: COURSE_CSA.parameterize(separator: "_"),
+        label: COURSE_CSA,
+        session_fields: SESSION_FIELDS,
+        fields: COMMON_COURSE_FIELDS.merge(subject: {required: true, options: SUBJECTS[COURSE_CSA].map {|s| {value: s, label: s}}})
+      },
+      {
+        slug: COURSE_ADMIN_COUNSELOR.parameterize(separator: "_"),
+        label: COURSE_ADMIN_COUNSELOR,
+        session_fields: SESSION_FIELDS,
+        fields: COMMON_COURSE_FIELDS.merge(subject: {required: true, options: SUBJECTS[COURSE_ADMIN_COUNSELOR].map {|s| {value: s, label: s}}})
+      },
+      {
+        slug: COURSE_BUILD_YOUR_OWN.parameterize(separator: "_"),
+        label: COURSE_BUILD_YOUR_OWN,
+        session_fields: SESSION_FIELDS,
+        fields: COMMON_COURSE_FIELDS.merge(
+          course_offerings: {required: true},
+          participant_group_type: {required: true, options: PARTICIPANT_GROUP_TYPES.map {|s| {value: s, label: s}}}
+        )
+      }
+    ].freeze
   end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adds a constant for workshop course configs, which is an array of objects containing the fields to display, whether they're required for the course, and options for some of the select fields. The config objects will be used in back end validation of new and edited workshops, and will be passed to the form component on the front end to render the correct fields

## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-3082)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
