### PR TITLE
feat(workshops): remove virtual dropdown

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -27,13 +27,11 @@ import {connect} from 'react-redux';
 import Select from 'react-select';
 
 import {
-  ActiveCourseWorkshops,
   Subjects,
   SubjectNames,
   HideFeeInformationSubjects,
   HideOnWorkshopMapSubjects,
   HideFundedSubjects,
-  VirtualOnlySubjects,
   NotFundedSubjects,
   MustSuppressEmailSubjects,
   ParticipantGroupTypes,
@@ -83,8 +81,6 @@ const INPUT_HEIGHT = 34;
 //  a) whether the workshop is occurring virtually, and
 //  b) if there's a third party responsible for the content/structure of the workshop.
 // These two things are stored as separate attributes in the workshop model.
-const virtualWorkshopTypes = ['regional', 'friday_institute'];
-const thirdPartyProviders = ['friday_institute'];
 
 export class WorkshopForm extends React.Component {
   static contextTypes = {
@@ -112,8 +108,6 @@ export class WorkshopForm extends React.Component {
       enrolled_teacher_count: PropTypes.number.isRequired,
       regional_partner_name: PropTypes.string,
       regional_partner_id: PropTypes.number,
-      virtual: PropTypes.bool,
-      third_party_provider: PropTypes.string,
       suppress_email: PropTypes.bool,
       organizer: PropTypes.shape({
         id: PropTypes.number,
@@ -157,9 +151,7 @@ export class WorkshopForm extends React.Component {
       showSaveConfirmation: false,
       showTypeOptionsHelpDisplay: false,
       regional_partner_id: '',
-      virtual: false,
       suppress_email: false,
-      third_party_provider: null,
       course_offerings: [],
       participant_group_type: '',
     };
@@ -183,9 +175,7 @@ export class WorkshopForm extends React.Component {
           'notes',
           'regional_partner_id',
           'organizer',
-          'virtual',
           'suppress_email',
-          'third_party_provider',
           'course_offerings',
           'participant_group_type',
         ])
@@ -440,34 +430,6 @@ export class WorkshopForm extends React.Component {
     return this.state.course && Subjects[this.state.course];
   }
 
-  // For summer workshops for CSP and CSA, only workshop admins can change
-  // the “Is this a virtual workshop” field within one month of the workshop
-  // in order to prevent people from changing this last minute without
-  // talking to us or the Friday institute.
-  checkCannotChangeIfWorkshopVirtual() {
-    return (
-      (this.state.course === ActiveCourseWorkshops.CSP ||
-        this.state.course === ActiveCourseWorkshops.CSA) &&
-      this.state.subject === SubjectNames.SUBJECT_SUMMER_WORKSHOP &&
-      !this.props.permission.has(WorkshopAdmin) &&
-      this.state.sessions.some(this.sessionStartsWithinMonth)
-    );
-  }
-
-  // Returns whether today is within a month before the given session (a month
-  // is represented as 30 days here for consistency and to align with behavior
-  // in workshop_controller.rb).
-  sessionStartsWithinMonth = session => {
-    const today = this.props.today;
-    const workshopDate = new Date(session.date);
-    const monthBeforeWorkshopDate = new Date(
-      workshopDate.getFullYear(),
-      workshopDate.getMonth(),
-      workshopDate.getDate() - 30
-    );
-    return monthBeforeWorkshopDate <= today && today <= workshopDate;
-  };
-
   renderWorkshopTypeOptions(validation) {
     const isCsf = this.state.course === 'CS Fundamentals';
     const isAdminCounselor = this.state.course === 'Admin/Counselor Workshop';
@@ -488,14 +450,6 @@ export class WorkshopForm extends React.Component {
       isAdminCounselor ||
       isCsfSubjectWithHiddenFundedField ||
       isBuildYourOwnWorkshop
-    );
-    const virtualWorkshopHelpTip = this.checkCannotChangeIfWorkshopVirtual() ? (
-      <p>
-        There is less than a month until your workshop. Please contact
-        partner@code.org to update this setting.
-      </p>
-    ) : (
-      <p>Please update your selection if/when your plans change.</p>
     );
 
     return (
@@ -537,28 +491,6 @@ export class WorkshopForm extends React.Component {
           </Col>
         </Row>
         <Row>
-          <Col sm={5}>
-            <FormGroup validationState={validation.style.virtual}>
-              <ControlLabel>
-                Is this a virtual workshop?
-                <HelpTip>{virtualWorkshopHelpTip}</HelpTip>
-              </ControlLabel>
-              <SelectIsVirtual
-                value={this.currentVirtualStatus()}
-                onChange={this.handleVirtualChange}
-                readOnly={
-                  this.props.readOnly ||
-                  VirtualOnlySubjects.includes(this.state.subject) ||
-                  this.checkCannotChangeIfWorkshopVirtual()
-                }
-                showVirtualOptions={
-                  !!this.props.workshop ||
-                  !this.checkCannotChangeIfWorkshopVirtual()
-                }
-              />
-              <HelpBlock>{validation.help.virtual}</HelpBlock>
-            </FormGroup>
-          </Col>
           {!isBuildYourOwnWorkshop && (
             <Col sm={5}>
               <FormGroup validationState={validation.style.suppress_email}>
@@ -737,9 +669,6 @@ export class WorkshopForm extends React.Component {
 
     // Don't ask if admins want to send updates with workshop changes for virtual workshops.
     // Update emails are suppressed for virtual workshops.
-    if (this.state.virtual) {
-      return false;
-    }
 
     // If location address is modified, then returned to blank,
     // this.state.location_address is a blank string instead of null.
@@ -810,31 +739,6 @@ export class WorkshopForm extends React.Component {
     return location;
   };
 
-  currentVirtualStatus = () => {
-    const {virtual, third_party_provider} = this.state;
-
-    // First, check if the third party provider is a valid
-    // virtual workshop type.
-    if (virtualWorkshopTypes.includes(third_party_provider)) {
-      return third_party_provider;
-    } else if (virtual) {
-      return 'regional';
-    } else {
-      return 'in_person';
-    }
-  };
-
-  handleVirtualChange = event => {
-    // This field gets its own handler so we can coerce its value to boolean
-    const value = event.target.value;
-    const virtual = virtualWorkshopTypes.includes(value);
-
-    this.setState({
-      virtual,
-      third_party_provider: thirdPartyProviders.includes(value) ? value : null,
-    });
-  };
-
   handleSuppressEmailChange = event => {
     // This field gets its own handler so we can coerce its value to boolean
     // before we save it to React state.
@@ -897,12 +801,6 @@ export class WorkshopForm extends React.Component {
       });
     }
 
-    if (VirtualOnlySubjects.includes(subject)) {
-      this.setState({
-        virtual: true,
-      });
-    }
-
     if (MustSuppressEmailSubjects.includes(subject)) {
       this.setState({
         suppress_email: true,
@@ -942,9 +840,7 @@ export class WorkshopForm extends React.Component {
       module: this.state.module,
       fee: this.state.fee ? this.state.fee : null,
       notes: this.state.notes,
-      virtual: this.state.virtual,
       suppress_email: this.state.suppress_email,
-      third_party_provider: this.state.third_party_provider,
       sessions_attributes: this.prepareSessionsForApi(
         this.state.sessions,
         this.state.destroyedSessions
@@ -1489,38 +1385,6 @@ export default connect(state => ({
   permission: state.workshopDashboard.permission,
   facilitatorCourses: state.workshopDashboard.facilitatorCourses,
 }))(WorkshopForm);
-
-const SelectIsVirtual = ({value, readOnly, onChange, showVirtualOptions}) => (
-  <FormControl
-    componentClass="select"
-    value={value}
-    id="virtual"
-    name="virtual"
-    onChange={onChange}
-    style={readOnly ? styles.readOnlyInput : undefined}
-    disabled={readOnly}
-  >
-    <option key={'in_person'} value={'in_person'}>
-      No, this is an in-person workshop.
-    </option>
-    {showVirtualOptions && (
-      <>
-        <option key={'friday_institute'} value={'friday_institute'}>
-          Yes, this is a Code.org-Friday Institute virtual workshop.
-        </option>
-        <option key={'regional'} value={'regional'}>
-          Yes, this is a regional virtual workshop.
-        </option>
-      </>
-    )}
-  </FormControl>
-);
-SelectIsVirtual.propTypes = {
-  value: PropTypes.string.isRequired,
-  readOnly: PropTypes.bool,
-  onChange: PropTypes.func.isRequired,
-  showVirtualOptions: PropTypes.bool.isRequired,
-};
 
 const SelectSuppressEmail = ({value, readOnly, onChange}) => (
   <FormControl

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -435,7 +435,6 @@ describe('WorkshopForm test', () => {
       });
 
       assert(wrapper.find('#funded').exists());
-      assert(wrapper.find('#virtual').exists());
       assert(wrapper.find('#suppress_email').exists());
     });
   });
@@ -557,51 +556,7 @@ describe('WorkshopForm test', () => {
       target: {name: 'subject', value: 'District'},
     });
 
-    assert(wrapper.find('#virtual').exists());
     assert(wrapper.find('#suppress_email').exists());
-  });
-
-  it('CSD, CSP, or CSA course with virtual subject locks virtual field to true', () => {
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <WorkshopForm
-            permission={new Permission([WorkshopAdmin])}
-            facilitatorCourses={[]}
-            today={getFakeToday(false)}
-            readOnly={false}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const courseField = wrapper.find('#course').first();
-
-    ['CS Principles', 'CS Discoveries', 'Computer Science A'].forEach(
-      courseName => {
-        courseField.simulate('change', {
-          target: {name: 'course', value: courseName},
-        });
-
-        const subjectField = wrapper.find('#subject').first();
-
-        // Selecting 'Virtual Workshop Kickoff' should make virtual field set to 'regional'
-        // (a.k.a. 'Yes, this is a regional virtual workshop.') and be disabled.
-        subjectField.simulate('change', {
-          target: {name: 'subject', value: 'Virtual Workshop Kickoff'},
-        });
-        expect(wrapper.find('#virtual').first().props().value).to.equal(
-          'regional'
-        );
-        assert(wrapper.find('#virtual').first().props().disabled);
-
-        // Changing subject from 'Virtual Workshop Kickoff' should make virtual field enabled again.
-        subjectField.simulate('change', {
-          target: {name: 'subject', value: 'Academic Year Workshop 1'},
-        });
-        assert(!wrapper.find('#virtual').first().props().disabled);
-      }
-    );
   });
 
   it('CSD, CSP, or CSA course with Teacher Con or Facilitator Weekend subject locks reminder field to false, otherwise unlocked and true', () => {
@@ -676,11 +631,6 @@ describe('WorkshopForm test', () => {
     subjectField.simulate('change', {
       target: {name: 'subject', value: 'Welcome'},
     });
-
-    assert(wrapper.find('#virtual').exists());
-    expect(wrapper.find('#virtual').first().props().value).to.equal(
-      'in_person'
-    );
 
     assert(wrapper.find('#suppress_email').exists());
     assert(wrapper.find('#suppress_email').first().props().value);
@@ -820,153 +770,6 @@ describe('WorkshopForm test', () => {
     );
 
     expect(wrapper.find('OrganizerFormPart')).to.have.lengthOf(0);
-  });
-
-  it('virtual field disabled for non-ws-admin for CSP/CSA summer workshop within a month of starting', () => {
-    const cspSummerWorkshopStartSoon = Factory.build(
-      'csp summer workshop starting within a month'
-    );
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <WorkshopForm
-            permission={new Permission([ProgramManager])}
-            facilitatorCourses={[]}
-            workshop={cspSummerWorkshopStartSoon}
-            today={getFakeToday(false)}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const virtualFormController = wrapper.find('#virtual').first();
-    assert(virtualFormController.props().disabled);
-  });
-
-  it('virtual field enabled for ws-admin for CSP/CSA summer workshop within a month of starting', () => {
-    const cspSummerWorkshopStartSoon = Factory.build(
-      'csp summer workshop starting within a month'
-    );
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <WorkshopForm
-            permission={new Permission([WorkshopAdmin])}
-            facilitatorCourses={[]}
-            workshop={cspSummerWorkshopStartSoon}
-            today={getFakeToday(false)}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const virtualFormController = wrapper.find('#virtual').first();
-    assert(!virtualFormController.props().disabled);
-  });
-
-  it('virtual field enabled for non-ws-admin for non-CSP/CSA summer workshop within a month of starting', () => {
-    const csdSummerWorkshopStartSoon = Factory.build(
-      'csd summer workshop starting within a month'
-    );
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <WorkshopForm
-            permission={new Permission([ProgramManager])}
-            facilitatorCourses={[]}
-            workshop={csdSummerWorkshopStartSoon}
-            today={getFakeToday(false)}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const virtualFormController = wrapper.find('#virtual').first();
-    assert(!virtualFormController.props().disabled);
-  });
-
-  it('virtual field enabled for non-ws-admin for CSP/CSA non-summer workshop within a month of starting', () => {
-    const cspAYW1WorkshopStartSoon = Factory.build(
-      'csp ayw1 workshop starting within a month'
-    );
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <WorkshopForm
-            permission={new Permission([ProgramManager])}
-            facilitatorCourses={[]}
-            workshop={cspAYW1WorkshopStartSoon}
-            today={getFakeToday(false)}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const virtualFormController = wrapper.find('#virtual').first();
-    assert(!virtualFormController.props().disabled);
-  });
-
-  it('virtual field enabled for non-ws-admin for CSP/CSA summer workshop over a month from starting', () => {
-    const cspSummerWorkshopStartOverMonth = Factory.build(
-      'csp summer workshop starting in over a month'
-    );
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <WorkshopForm
-            permission={new Permission([ProgramManager])}
-            facilitatorCourses={[]}
-            workshop={cspSummerWorkshopStartOverMonth}
-            today={getFakeToday(false)}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const virtualFormController = wrapper.find('#virtual').first();
-    assert(!virtualFormController.props().disabled);
-  });
-
-  it('virtual field disabled for non-ws-admin for CSP/CSA summer workshop within a month of starting and close to year turnover', () => {
-    const cspSummerWorkshopStartSoon = Factory.build(
-      'csp summer workshop starting within month of endOfYearFakeToday'
-    );
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <WorkshopForm
-            permission={new Permission([ProgramManager])}
-            facilitatorCourses={[]}
-            workshop={cspSummerWorkshopStartSoon}
-            today={getFakeToday(true)}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const virtualFormController = wrapper.find('#virtual').first();
-    assert(virtualFormController.props().disabled);
-  });
-
-  it('virtual field enabled for non-ws-admin for CSP/CSA summer workshop over a month from starting and close to year turnover', () => {
-    const cspSummerWorkshopStartOverMonth = Factory.build(
-      'csp summer workshop starting in over a month from endOfYearFakeToday'
-    );
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <WorkshopForm
-            permission={new Permission([ProgramManager])}
-            facilitatorCourses={[]}
-            workshop={cspSummerWorkshopStartOverMonth}
-            today={getFakeToday(true)}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const virtualFormController = wrapper.find('#virtual').first();
-    assert(!virtualFormController.props().disabled);
   });
 
   it('does not show module options when CSD and custom workshop subject are not selected', () => {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
removes the virtual input field from the workshop form and removes logic and tests around updating the virtual field.
 BEFORE:
![Screenshot 2025-02-19 at 9 28 45 AM](https://github.com/user-attachments/assets/1c90c1ee-b61c-4c10-ae9e-aa90e4889b44)


AFTER:
![Screenshot 2025-02-19 at 9 28 12 AM](https://github.com/user-attachments/assets/29053947-a5af-476e-8ea2-9df52ff2f326)




## Links
[jira](https://codedotorg.atlassian.net/browse/ACQ-2966)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
