### PR TITLE
Evaluate Student Learning: log ULI for run and finish clicks in App Lab

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2805,6 +2805,13 @@ StudioApp.prototype.validateCodeChanged = function () {
   return project.isCurrentCodeDifferent(level.startBlocks);
 };
 
+StudioApp.prototype.analyticsData = function () {
+  return {
+    levelId: this.config.serverLevelId,
+    scriptId: this.config.scriptId,
+  };
+};
+
 /**
  * Set whether to alert user to empty blocks, short-circuiting all other tests.
  * @param {boolean} checkBlocks Whether to check for empty blocks.

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1071,7 +1071,6 @@ Applab.reset = function () {
  * @param callback {Function}
  */
 function runButtonClickWrapper(callback) {
-  console.log('App Lab run button clicked');
   $(window).trigger('run_button_pressed');
 
   const defaultScreenId = elementUtils.getDefaultScreenId();

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -15,7 +15,9 @@ import autogenerateML from '@cdo/apps/applab/ai';
 import * as aiConfig from '@cdo/apps/applab/ai/dropletConfig';
 import SmallFooter from '@cdo/apps/code-studio/components/SmallFooter';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
+import {logUserLevelInteraction} from '@cdo/apps/userLevelInteractionsLogger/userLevelInteractionsApi';
 import {workspace_running_background, white} from '@cdo/apps/util/color';
+import {UserLevelInteractions} from '@cdo/generated-scripts/sharedConstants';
 import commonMsg from '@cdo/locale';
 
 import annotationList from '../acemode/annotationList';
@@ -1069,6 +1071,7 @@ Applab.reset = function () {
  * @param callback {Function}
  */
 function runButtonClickWrapper(callback) {
+  console.log('App Lab run button clicked');
   $(window).trigger('run_button_pressed');
 
   const defaultScreenId = elementUtils.getDefaultScreenId();
@@ -1106,6 +1109,12 @@ Applab.runButtonClick = function () {
     Blockly.mainBlockSpace.traceOn(true);
   }
   Applab.execute();
+  const analyticsData = studioApp().analyticsData();
+  logUserLevelInteraction({
+    levelId: analyticsData.levelId,
+    scriptId: analyticsData.scriptId,
+    interaction: UserLevelInteractions.click_run,
+  });
 
   // Enable the Finish button if is present:
   var shareCell = document.getElementById('share-cell');
@@ -1290,6 +1299,12 @@ function onInterfaceModeChange(mode) {
 }
 
 Applab.onPuzzleFinish = function () {
+  const analyticsData = studioApp().analyticsData();
+  logUserLevelInteraction({
+    levelId: analyticsData.levelId,
+    scriptId: analyticsData.scriptId,
+    interaction: UserLevelInteractions.click_finish,
+  });
   Applab.onPuzzleComplete(false); // complete without submitting
 };
 


### PR DESCRIPTION
continuation of https://github.com/code-dot-org/code-dot-org/pull/62615

Added UserLevelInteraction logging for `click_run` and `click_finish` from App Lab. 

<img width="1238" alt="Screenshot 2025-02-06 at 2 35 03 PM" src="https://github.com/user-attachments/assets/c06a87f5-08c8-4a0a-b7a5-a6ce5a9ff4b9" />

<img width="1236" alt="Screenshot 2025-02-06 at 2 38 10 PM" src="https://github.com/user-attachments/assets/a1570227-d350-4474-aec7-fed2cc615dbd" />
