### PR TITLE
Update default OpenGraph image on code.org

### DIFF
--- a/pegasus/sites.v3/code.org/public/images/default-og-image.png
+++ b/pegasus/sites.v3/code.org/public/images/default-og-image.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48e6e395e76c2bafa1aca1507d321924a2bee3fb25b1c41fbc5169374d79505c
-size 3308335
+oid sha256:e0dd6c83909e0ca4952af799f2df8afacfc43cdbb9deab0f543fd92855a5a33a
+size 180161

--- a/pegasus/sites.v3/code.org/public/images/social-media/default-og-image.png
+++ b/pegasus/sites.v3/code.org/public/images/social-media/default-og-image.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48e6e395e76c2bafa1aca1507d321924a2bee3fb25b1c41fbc5169374d79505c
-size 3308335
+oid sha256:e0dd6c83909e0ca4952af799f2df8afacfc43cdbb9deab0f543fd92855a5a33a
+size 180161


### PR DESCRIPTION
Updates the default OpenGraph image on https://code.org.

## Links
Jira ticket: [ACQ-3095](https://codedotorg.atlassian.net/browse/ACQ-3095)

## Testing story
Tested locally