### PR TITLE
Refactor usage of `OpenaiChatHelper` to better support separate API keys

### DIFF
--- a/dashboard/app/controllers/ai_tutor_interactions_controller.rb
+++ b/dashboard/app/controllers/ai_tutor_interactions_controller.rb
@@ -26,7 +26,7 @@ class AiTutorInteractionsController < ApplicationController
       :ai_response
     )
     ai_tutor_interaction_params[:user_id] = current_user.id
-    ai_tutor_interaction_params[:ai_model_version] = SharedConstants::AI_TUTOR_CHAT_MODEL_VERISON
+    ai_tutor_interaction_params[:ai_model_version] = SharedConstants::AI_TUTOR_CHAT_MODEL_VERSION
     project_data = get_project_and_version_id(ai_tutor_interaction_params[:level_id], ai_tutor_interaction_params[:script_id])
     ai_tutor_interaction_params[:project_id] = project_data[:project_id]
     ai_tutor_interaction_params[:project_version_id] = project_data[:version_id]

--- a/dashboard/app/controllers/openai_chat_controller.rb
+++ b/dashboard/app/controllers/openai_chat_controller.rb
@@ -24,8 +24,13 @@ class OpenaiChatController < ApplicationController
 
     messages = prepend_system_prompt(system_prompt, params[:messages])
 
-    response = OpenaiChatHelper.request_chat_completion(messages)
-    chat_completion_return_message = OpenaiChatHelper.get_chat_completion_response_message(response)
+    openai_client = OpenaiChatHelper.aitutor_client
+    response = openai_client.request_chat_completion(messages)
+    # Parse the response JSON and return the chat response message and status
+    response_body = JSON.parse(response.body)
+    response_body = response_body['choices'][0]['message'] if response.code == 200
+    chat_completion_return_message =  {status: response.code, json: response_body}
+
     # We currently allow PII flagged content through to OpenAI because false positives were impacting user experience.
     # We send the flagged content along in the request so we can log it for analysis.
     chat_completion_return_message[:json][:safety_status] = filter_result.type if filter_result

--- a/dashboard/app/controllers/openai_chat_controller.rb
+++ b/dashboard/app/controllers/openai_chat_controller.rb
@@ -44,7 +44,7 @@ class OpenaiChatController < ApplicationController
   end
 
   private def client
-    OpenaiChatHelper.new(API_KEY, MODEL)
+    OpenaiChatHelper::Client.new(API_KEY, MODEL)
   end
 
   private def prepend_system_prompt(system_prompt, messages)

--- a/dashboard/app/controllers/openai_chat_controller.rb
+++ b/dashboard/app/controllers/openai_chat_controller.rb
@@ -1,6 +1,8 @@
 class OpenaiChatController < ApplicationController
-  include OpenaiChatHelper
   authorize_resource class: false
+
+  API_KEY = CDO.openai_chat_completion_api_key
+  MODEL = SharedConstants::AI_TUTOR_CHAT_MODEL_VERSION
 
   # POST /openai/chat_completion
   def chat_completion
@@ -24,8 +26,7 @@ class OpenaiChatController < ApplicationController
 
     messages = prepend_system_prompt(system_prompt, params[:messages])
 
-    openai_client = OpenaiChatHelper.aitutor_client
-    response = openai_client.request_chat_completion(messages)
+    response = client.request_chat_completion(messages)
     # Parse the response JSON and return the chat response message and status
     response_body = JSON.parse(response.body)
     response_body = response_body['choices'][0]['message'] if response.code == 200
@@ -40,6 +41,10 @@ class OpenaiChatController < ApplicationController
 
   def has_required_messages_param?
     params[:messages].present?
+  end
+
+  private def client
+    OpenaiChatHelper.new(API_KEY, MODEL)
   end
 
   private def prepend_system_prompt(system_prompt, messages)

--- a/dashboard/app/controllers/openai_chat_controller.rb
+++ b/dashboard/app/controllers/openai_chat_controller.rb
@@ -27,7 +27,6 @@ class OpenaiChatController < ApplicationController
     messages = prepend_system_prompt(system_prompt, params[:messages])
 
     response = client.request_chat_completion(messages)
-    # Parse the response JSON and return the chat response message and status
     response_body = JSON.parse(response.body)
     response_body = response_body['choices'][0]['message'] if response.code == 200
     chat_completion_return_message =  {status: response.code, json: response_body}

--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -14,8 +14,7 @@ module AichatOpenaiHelper
 
     request_chat_completion(
       messages,
-      aichat_model_customizations['temperature'],
-      SharedConstants::AICHAT_MODEL_VERSION
+      aichat_model_customizations['temperature']
     )
   end
 
@@ -34,12 +33,9 @@ module AichatOpenaiHelper
     ]
   end
 
-  def self.request_chat_completion(messages, temperature, model_version)
-    http_response = OpenaiChatHelper.request_chat_completion(
-      messages,
-      temperature,
-      model_version
-    )
+  def self.request_chat_completion(messages, temperature)
+    openai_client = OpenaiChatHelper.aichat_base_model_client
+    http_response = openai_client.request_chat_completion(messages, temperature)
     JSON.parse(http_response.body)['choices'][0]['message']['content']
   end
 

--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -50,6 +50,6 @@ module AichatOpenaiHelper
   end
 
   def self.client
-    OpenaiChatHelper.new(API_KEY, MODEL)
+    OpenaiChatHelper::Client.new(API_KEY, MODEL)
   end
 end

--- a/dashboard/app/helpers/aichat_openai_helper.rb
+++ b/dashboard/app/helpers/aichat_openai_helper.rb
@@ -4,6 +4,9 @@
 # This module is structured very similarly to the AichatSagemakerHelper module,
 # which manages AI Chat lab's interaction with models that use AWS Sagemaker.
 module AichatOpenaiHelper
+  API_KEY = CDO.openai_chat_completion_api_key
+  MODEL = SharedConstants::AICHAT_MODEL_VERSION
+
   def self.get_openai_assistant_response(aichat_model_customizations, stored_messages, new_message, level_id)
     messages = format_messages(
       aichat_model_customizations,
@@ -34,8 +37,7 @@ module AichatOpenaiHelper
   end
 
   def self.request_chat_completion(messages, temperature)
-    openai_client = OpenaiChatHelper.aichat_base_model_client
-    http_response = openai_client.request_chat_completion(messages, temperature)
+    http_response = client.request_chat_completion(messages, temperature)
     JSON.parse(http_response.body)['choices'][0]['message']['content']
   end
 
@@ -45,5 +47,9 @@ module AichatOpenaiHelper
     instructions << (system_prompt + " ") unless system_prompt.empty?
     instructions << retrieval_contexts.join(" ") if retrieval_contexts
     instructions
+  end
+
+  def self.client
+    OpenaiChatHelper.new(API_KEY, MODEL)
   end
 end

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -42,7 +42,8 @@ module AichatSafetyHelper
       # replying with something other valid expected output.
       attempts = 1
       Retryable.retryable(tries: 2) do
-        openai_response = OpenaiChatHelper.request_safety_check(text, get_safety_system_prompt)
+        openai_client = OpenaiChatHelper.aichat_safety_client
+        openai_response = openai_client.request_safety_check(text, get_safety_system_prompt)
         evaluation = JSON.parse(openai_response)['choices'][0]['message']['content']
         unless VALID_EVALUATION_RESPONSES_SIMPLE.include?(evaluation)
           report_openai_safety_check("InvalidResponse")

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -47,10 +47,10 @@ module AichatSafetyHelper
       attempts = 1
       Retryable.retryable(tries: 2) do
         messages = safety_check_messages(text)
-        openai_response = client.request_chat_completion(messages, 1)
+        response = client.request_chat_completion(messages, 1)
         raise "OpenAI request failed with status #{response.code}: #{response.body}" unless response.success?
 
-        evaluation = JSON.parse(openai_response.body)['choices'][0]['message']['content']
+        evaluation = JSON.parse(response.body)['choices'][0]['message']['content']
         unless VALID_EVALUATION_RESPONSES_SIMPLE.include?(evaluation)
           report_openai_safety_check("InvalidResponse")
           attempts += 1
@@ -69,7 +69,7 @@ module AichatSafetyHelper
     end
 
     private def client
-      OpenaiChatHelper.new(API_KEY, MODEL)
+      OpenaiChatHelper::Client.new(API_KEY, MODEL)
     end
 
     private def comprehend_enabled?(role)

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -3,6 +3,9 @@ require 'cdo/aws/metrics'
 # Provides functionality to detect toxicity in user input and model output used in the AI Chat Lab.
 # Uses various services to check for profanity and toxicity based on DCDO settings.
 module AichatSafetyHelper
+  API_KEY = CDO.openai_aichat_safety_api_key
+  MODEL = SharedConstants::AICHAT_MODEL_VERSION
+
   class ToxicityDetector
     DEFAULT_TOXICITY_THRESHOLD_USER_INPUT = 0.3
     DEFAULT_TOXICITY_THRESHOLD_MODEL_OUTPUT = 0.5
@@ -44,10 +47,7 @@ module AichatSafetyHelper
       attempts = 1
       Retryable.retryable(tries: 2) do
         messages = safety_check_messages(text)
-        openai_client = OpenaiChatHelper.aichat_safety_client
-
-        # temperature wasn't explicitly provided and openai defaults to 1
-        openai_response = openai_client.request_chat_completion(messages, 1)
+        openai_response = client.request_chat_completion(messages, 1)
         raise "OpenAI request failed with status #{response.code}: #{response.body}" unless response.success?
 
         evaluation = JSON.parse(openai_response.body)['choices'][0]['message']['content']
@@ -66,6 +66,10 @@ module AichatSafetyHelper
       latency = Time.now - start_time
       report_openai_safety_latency(latency, attempts)
       details
+    end
+
+    private def client
+      OpenaiChatHelper.new(API_KEY, MODEL)
     end
 
     private def comprehend_enabled?(role)

--- a/dashboard/app/helpers/aichat_safety_helper.rb
+++ b/dashboard/app/helpers/aichat_safety_helper.rb
@@ -34,6 +34,7 @@ module AichatSafetyHelper
       end
     end
 
+    # Used to check safety content given text with the given moderation system prompt.
     private def openai_safety_check(text)
       details = nil
       start_time = Time.now
@@ -42,9 +43,14 @@ module AichatSafetyHelper
       # replying with something other valid expected output.
       attempts = 1
       Retryable.retryable(tries: 2) do
+        messages = safety_check_messages(text)
         openai_client = OpenaiChatHelper.aichat_safety_client
-        openai_response = openai_client.request_safety_check(text, get_safety_system_prompt)
-        evaluation = JSON.parse(openai_response)['choices'][0]['message']['content']
+
+        # temperature wasn't explicitly provided and openai defaults to 1
+        openai_response = openai_client.request_chat_completion(messages, 1)
+        raise "OpenAI request failed with status #{response.code}: #{response.body}" unless response.success?
+
+        evaluation = JSON.parse(openai_response.body)['choices'][0]['message']['content']
         unless VALID_EVALUATION_RESPONSES_SIMPLE.include?(evaluation)
           report_openai_safety_check("InvalidResponse")
           attempts += 1
@@ -96,6 +102,20 @@ module AichatSafetyHelper
 
     private def get_safety_system_prompt_version
       'V0'
+    end
+
+    # Format messages with text to be checked for safety and moderation system prompt.
+    private def safety_check_messages(text)
+      [
+        {
+          role: "system",
+          content: get_safety_system_prompt
+        },
+        {
+          role: "user",
+          content: text
+        }
+      ]
     end
 
     private def report_openai_safety_check(metric_name, num_attempts = 1)

--- a/dashboard/app/helpers/openai_chat_helper.rb
+++ b/dashboard/app/helpers/openai_chat_helper.rb
@@ -1,56 +1,34 @@
-module OpenaiChatHelper
+class OpenaiChatHelper
+  attr_accessor :api_key, :model
+
   OPEN_AI_URL = "https://api.openai.com/v1/chat/completions"
-  OPENAI_CHAT_COMPLETION_API_KEY = CDO.openai_chat_completion_api_key
-  TEMPERATURE = 0
-  OPENAI_AICHAT_SAFETY_API_KEY = CDO.openai_aichat_safety_api_key
+  DEFAULT_TEMPERATURE = 0
 
-  # We should always specify a version for the LLM so the results don't unexpectedly change.
-  GPT_MODEL = SharedConstants::AI_TUTOR_CHAT_MODEL_VERISON
-  AICHAT_GPT_MODEL = SharedConstants::AICHAT_MODEL_VERSION
-
-  # A class that takes in an API key and a model type in the constructor and
-  # provides a method to request chat completions from the OpenAI API.
-  class OpenAIChatRequester
-    attr_accessor :api_key, :model
-
-    def initialize(api_key, model)
-      @api_key = api_key
-      @model = model
-    end
-
-    def request_chat_completion(messages, temperature = TEMPERATURE)
-      # Set up the API endpoint URL and request headers
-      headers = {
-        "Content-Type" => "application/json",
-        "Authorization" => "Bearer #{api_key}"
-      }
-      headers["OpenAI-Organization"] = CDO.openai_chat_completion_org_id if CDO.openai_chat_completion_org_id
-
-      data = {
-        model: model,
-        temperature: temperature,
-        messages: messages
-      }
-
-      HTTParty.post(
-        OPEN_AI_URL,
-        headers: headers,
-        body: data.to_json,
-        open_timeout: DCDO.get('openai_http_open_timeout', 5),
-        read_timeout: DCDO.get('openai_http_read_timeout', 30)
-      )
-    end
+  def initialize(api_key, model)
+    @api_key = api_key
+    @model = model
   end
 
-  def self.aichat_base_model_client
-    OpenAIChatRequester.new(OPENAI_CHAT_COMPLETION_API_KEY, AICHAT_GPT_MODEL)
-  end
+  def request_chat_completion(messages, temperature = DEFAULT_TEMPERATURE)
+    # Set up the API endpoint URL and request headers
+    headers = {
+      "Content-Type" => "application/json",
+      "Authorization" => "Bearer #{api_key}"
+    }
+    headers["OpenAI-Organization"] = CDO.openai_chat_completion_org_id if CDO.openai_chat_completion_org_id
 
-  def self.aichat_safety_client
-    OpenAIChatRequester.new(OPENAI_AICHAT_SAFETY_API_KEY, AICHAT_GPT_MODEL)
-  end
+    data = {
+      model: model,
+      temperature: temperature,
+      messages: messages
+    }
 
-  def self.aitutor_client
-    OpenAIChatRequester.new(OPENAI_CHAT_COMPLETION_API_KEY, GPT_MODEL)
+    HTTParty.post(
+      OPEN_AI_URL,
+      headers: headers,
+      body: data.to_json,
+      open_timeout: DCDO.get('openai_http_open_timeout', 5),
+      read_timeout: DCDO.get('openai_http_read_timeout', 30)
+    )
   end
 end

--- a/dashboard/app/helpers/openai_chat_helper.rb
+++ b/dashboard/app/helpers/openai_chat_helper.rb
@@ -40,41 +40,6 @@ module OpenaiChatHelper
         read_timeout: DCDO.get('openai_http_read_timeout', 30)
       )
     end
-
-    # Used to check safety content given text with the given moderation system prompt.
-    def request_safety_check(text, safety_system_prompt)
-      # Set up the API endpoint URL and request headers
-      headers = {
-        "Content-Type" => "application/json",
-        "Authorization" => "Bearer #{api_key}"
-      }
-
-      # Format messages with text to be checked for safety and moderation system prompt.
-      messages = [
-        {
-          role: "system",
-          content: safety_system_prompt
-        },
-        {
-          role: "user",
-          content: text
-        }
-      ]
-      data = {
-        model: model,
-        messages: messages
-      }
-
-      response = HTTParty.post(
-        OPEN_AI_URL,
-        headers: headers,
-        body: data.to_json,
-        open_timeout: DCDO.get('openai_http_open_timeout', 5),
-        read_timeout: DCDO.get('openai_http_read_timeout', 30)
-      )
-      raise "OpenAI request failed with status #{response.code}: #{response.body}" unless response.success?
-      response.body
-    end
   end
 
   def self.aichat_base_model_client

--- a/dashboard/app/helpers/openai_chat_helper.rb
+++ b/dashboard/app/helpers/openai_chat_helper.rb
@@ -8,67 +8,84 @@ module OpenaiChatHelper
   GPT_MODEL = SharedConstants::AI_TUTOR_CHAT_MODEL_VERISON
   AICHAT_GPT_MODEL = SharedConstants::AICHAT_MODEL_VERSION
 
-  def self.request_chat_completion(messages, temperature = TEMPERATURE, model = GPT_MODEL)
-    # Set up the API endpoint URL and request headers
-    headers = {
-      "Content-Type" => "application/json",
-      "Authorization" => "Bearer #{OPENAI_CHAT_COMPLETION_API_KEY}"
-    }
-    headers["OpenAI-Organization"] = CDO.openai_chat_completion_org_id if CDO.openai_chat_completion_org_id
+  # A class that takes in an API key and a model type in the constructor and
+  # provides a method to request chat completions from the OpenAI API.
+  class OpenAIChatRequester
+    attr_accessor :api_key, :model
 
-    data = {
-      model: model,
-      temperature: temperature,
-      messages: messages
-    }
+    def initialize(api_key, model)
+      @api_key = api_key
+      @model = model
+    end
 
-    HTTParty.post(
-      OPEN_AI_URL,
-      headers: headers,
-      body: data.to_json,
-      open_timeout: DCDO.get('openai_http_open_timeout', 5),
-      read_timeout: DCDO.get('openai_http_read_timeout', 30)
-    )
-  end
-
-  # Used to check safety content given text with the given moderation system prompt.
-  def self.request_safety_check(text, safety_system_prompt)
-    # Set up the API endpoint URL and request headers
-    headers = {
-      "Content-Type" => "application/json",
-      "Authorization" => "Bearer #{OPENAI_AICHAT_SAFETY_API_KEY}"
-    }
-    # Format messages with text to be checked for safety and moderation system prompt.
-    messages = [
-      {
-        role: "system",
-        content: safety_system_prompt
-      },
-      {
-        role: "user",
-        content: text
+    def request_chat_completion(messages, temperature = TEMPERATURE)
+      # Set up the API endpoint URL and request headers
+      headers = {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer #{api_key}"
       }
-    ]
-    data = {
-      model: AICHAT_GPT_MODEL,
-      messages: messages
-    }
+      headers["OpenAI-Organization"] = CDO.openai_chat_completion_org_id if CDO.openai_chat_completion_org_id
 
-    response = HTTParty.post(
-      OPEN_AI_URL,
-      headers: headers,
-      body: data.to_json,
-      open_timeout: DCDO.get('openai_http_open_timeout', 5),
-      read_timeout: DCDO.get('openai_http_read_timeout', 30)
-    )
-    raise "OpenAI request failed with status #{response.code}: #{response.body}" unless response.success?
-    response.body
+      data = {
+        model: model,
+        temperature: temperature,
+        messages: messages
+      }
+
+      HTTParty.post(
+        OPEN_AI_URL,
+        headers: headers,
+        body: data.to_json,
+        open_timeout: DCDO.get('openai_http_open_timeout', 5),
+        read_timeout: DCDO.get('openai_http_read_timeout', 30)
+      )
+    end
+
+    # Used to check safety content given text with the given moderation system prompt.
+    def request_safety_check(text, safety_system_prompt)
+      # Set up the API endpoint URL and request headers
+      headers = {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer #{api_key}"
+      }
+
+      # Format messages with text to be checked for safety and moderation system prompt.
+      messages = [
+        {
+          role: "system",
+          content: safety_system_prompt
+        },
+        {
+          role: "user",
+          content: text
+        }
+      ]
+      data = {
+        model: model,
+        messages: messages
+      }
+
+      response = HTTParty.post(
+        OPEN_AI_URL,
+        headers: headers,
+        body: data.to_json,
+        open_timeout: DCDO.get('openai_http_open_timeout', 5),
+        read_timeout: DCDO.get('openai_http_read_timeout', 30)
+      )
+      raise "OpenAI request failed with status #{response.code}: #{response.body}" unless response.success?
+      response.body
+    end
   end
 
-  def self.get_chat_completion_response_message(response)
-    # Parse the response JSON and return the chat response message and status
-    response_body = JSON.parse(response.body)
-    response_body = response_body['choices'][0]['message'] if response.code == 200
-    return {status: response.code, json: response_body}
+  def self.aichat_base_model_client
+    OpenAIChatRequester.new(OPENAI_CHAT_COMPLETION_API_KEY, AICHAT_GPT_MODEL)
+  end
+
+  def self.aichat_safety_client
+    OpenAIChatRequester.new(OPENAI_AICHAT_SAFETY_API_KEY, AICHAT_GPT_MODEL)
+  end
+
+  def self.aitutor_client
+    OpenAIChatRequester.new(OPENAI_CHAT_COMPLETION_API_KEY, GPT_MODEL)
   end
 end

--- a/dashboard/app/helpers/openai_chat_helper.rb
+++ b/dashboard/app/helpers/openai_chat_helper.rb
@@ -1,34 +1,36 @@
-class OpenaiChatHelper
-  attr_accessor :api_key, :model
+module OpenaiChatHelper
+  class Client
+    attr_accessor :api_key, :model
 
-  OPEN_AI_URL = "https://api.openai.com/v1/chat/completions"
-  DEFAULT_TEMPERATURE = 0
+    OPEN_AI_URL = "https://api.openai.com/v1/chat/completions"
+    DEFAULT_TEMPERATURE = 0
 
-  def initialize(api_key, model)
-    @api_key = api_key
-    @model = model
-  end
+    def initialize(api_key, model)
+      @api_key = api_key
+      @model = model
+    end
 
-  def request_chat_completion(messages, temperature = DEFAULT_TEMPERATURE)
-    # Set up the API endpoint URL and request headers
-    headers = {
-      "Content-Type" => "application/json",
-      "Authorization" => "Bearer #{api_key}"
-    }
-    headers["OpenAI-Organization"] = CDO.openai_chat_completion_org_id if CDO.openai_chat_completion_org_id
+    def request_chat_completion(messages, temperature = DEFAULT_TEMPERATURE)
+      # Set up the API endpoint URL and request headers
+      headers = {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer #{api_key}"
+      }
+      headers["OpenAI-Organization"] = CDO.openai_chat_completion_org_id if CDO.openai_chat_completion_org_id
 
-    data = {
-      model: model,
-      temperature: temperature,
-      messages: messages
-    }
+      data = {
+        model: model,
+        temperature: temperature,
+        messages: messages
+      }
 
-    HTTParty.post(
-      OPEN_AI_URL,
-      headers: headers,
-      body: data.to_json,
-      open_timeout: DCDO.get('openai_http_open_timeout', 5),
-      read_timeout: DCDO.get('openai_http_read_timeout', 30)
-    )
+      HTTParty.post(
+        OPEN_AI_URL,
+        headers: headers,
+        body: data.to_json,
+        open_timeout: DCDO.get('openai_http_open_timeout', 5),
+        read_timeout: DCDO.get('openai_http_read_timeout', 30)
+      )
+    end
   end
 end

--- a/dashboard/test/controllers/openai_chat_controller_test.rb
+++ b/dashboard/test/controllers/openai_chat_controller_test.rb
@@ -3,12 +3,13 @@ require 'test_helper'
 
 class OpenaiChatControllerTest < ActionController::TestCase
   setup do
-    response = Net::HTTPResponse.new(nil, '200', nil)
-    OpenaiChatHelper.stubs(:request_chat_completion).returns(response)
-    OpenaiChatHelper.stubs(:get_chat_completion_response_message).returns({status: 200, json: {}})
-    ShareFiltering.stubs(:find_failure).returns(nil)
+    mock_response = stub(
+      body: {choices: [{message: 'model response'}]}.stringify_keys.to_json,
+      code: 200
+    )
+    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
 
-    @controller = OpenaiChatController.new
+    ShareFiltering.stubs(:find_failure).returns(nil)
   end
 
   # Student without ai tutor access is unable to access the chat completion endpoint

--- a/dashboard/test/controllers/openai_chat_controller_test.rb
+++ b/dashboard/test/controllers/openai_chat_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class OpenaiChatControllerTest < ActionController::TestCase
   setup do
     mock_response = stub(
-      body: {choices: [{message: 'model response'}]}.stringify_keys.to_json,
+      body: {choices: [{message: {content: 'model response'}}]}.to_json,
       code: 200
     )
     OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)

--- a/dashboard/test/helpers/aichat_safety_helper_test.rb
+++ b/dashboard/test/helpers/aichat_safety_helper_test.rb
@@ -59,7 +59,13 @@ class AichatSafetyHelperTest < ActionView::TestCase
     DCDO.stubs(:get).with("aichat_openai_system_prompt", anything).returns('simple')
     ShareFiltering.stubs(:find_profanity_failure).returns(ShareFailure.new(ShareFiltering::FailureType::PROFANITY, @webpurify_profanity))
     AichatComprehendHelper.stubs(:get_toxicity).returns(@comprehend_response)
-    OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_profanity_json)
+    # OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_profanity_json)
+    mock_response = stub(
+      body: @openai_response_profanity_json,
+      code: 200,
+      success?: true
+    )
+    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
   end
 
   ROLES.each do |role|
@@ -81,7 +87,14 @@ class AichatSafetyHelperTest < ActionView::TestCase
   test "returns nil if no toxicity is detected" do
     AichatComprehendHelper.stubs(:get_toxicity).returns(nil)
     ShareFiltering.stubs(:find_profanity_failure).returns(nil)
-    OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_safe_json)
+    # OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_safe_json)
+    mock_response = stub(
+      body: @openai_response_safe_json,
+      code: 200,
+      success?: true
+    )
+    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
+
     DCDO.stubs(:get).with("aichat_safety_profane_word_blocklist", anything).returns([])
     ROLES.each do |role|
       SERVICES.each do |service|
@@ -94,19 +107,48 @@ class AichatSafetyHelperTest < ActionView::TestCase
 
   test "request_safety_check returns a valid response.body the first time it is called" do
     stub_safety_services('openai', 'user')
-    OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_safe_json).once
+    # OpenaiChatHelper.stubs(:request_safety_check).returns().once
+    mock_response = stub(
+      body: @openai_response_safe_json,
+      code: 200,
+      success?: true
+    )
+    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response).once
+
     AichatSafetyHelper.find_toxicity('user', 'clean message', 'en')
   end
 
   test "retries if request_safety_check returns a response.body other than INAPPROPRIATE or OK" do
     stub_safety_services('openai', 'user')
-    OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_invalid_json).returns(@openai_response_safe_json).twice
+    # OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_invalid_json).returns(@openai_response_safe_json).twice
+    mock_response_invalid = stub(
+      body: @openai_response_invalid_json,
+      code: 200,
+      success?: true
+    )
+    mock_response_safe = stub(
+      body: @openai_response_safe_json,
+      code: 200,
+      success?: true
+    )
+    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).
+      returns(mock_response_invalid).
+      returns(mock_response_safe).
+      twice
+
     AichatSafetyHelper.find_toxicity('user', 'clean message', 'en')
   end
 
   test "raises an error if request_safety_check returns a response.body other than INAPPROPRIATE or OK twice" do
     stub_safety_services('openai', 'user')
-    OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_invalid_json)
+    # OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_invalid_json)
+    mock_response = stub(
+      body: @openai_response_invalid_json,
+      code: 200,
+      success?: true
+    )
+    OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
+
     assert_raises do
       AichatSafetyHelper.find_toxicity('user', 'clean message', 'en')
     end

--- a/dashboard/test/helpers/aichat_safety_helper_test.rb
+++ b/dashboard/test/helpers/aichat_safety_helper_test.rb
@@ -59,12 +59,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
     DCDO.stubs(:get).with("aichat_openai_system_prompt", anything).returns('simple')
     ShareFiltering.stubs(:find_profanity_failure).returns(ShareFailure.new(ShareFiltering::FailureType::PROFANITY, @webpurify_profanity))
     AichatComprehendHelper.stubs(:get_toxicity).returns(@comprehend_response)
-    # OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_profanity_json)
-    mock_response = stub(
-      body: @openai_response_profanity_json,
-      code: 200,
-      success?: true
-    )
+    mock_response = create_stubbed_response(@openai_response_profanity_json)
     OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
   end
 
@@ -87,12 +82,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
   test "returns nil if no toxicity is detected" do
     AichatComprehendHelper.stubs(:get_toxicity).returns(nil)
     ShareFiltering.stubs(:find_profanity_failure).returns(nil)
-    # OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_safe_json)
-    mock_response = stub(
-      body: @openai_response_safe_json,
-      code: 200,
-      success?: true
-    )
+    mock_response = create_stubbed_response(@openai_response_safe_json)
     OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
 
     DCDO.stubs(:get).with("aichat_safety_profane_word_blocklist", anything).returns([])
@@ -107,12 +97,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
 
   test "request_safety_check returns a valid response.body the first time it is called" do
     stub_safety_services('openai', 'user')
-    # OpenaiChatHelper.stubs(:request_safety_check).returns().once
-    mock_response = stub(
-      body: @openai_response_safe_json,
-      code: 200,
-      success?: true
-    )
+    mock_response = create_stubbed_response(@openai_response_safe_json)
     OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response).once
 
     AichatSafetyHelper.find_toxicity('user', 'clean message', 'en')
@@ -120,17 +105,8 @@ class AichatSafetyHelperTest < ActionView::TestCase
 
   test "retries if request_safety_check returns a response.body other than INAPPROPRIATE or OK" do
     stub_safety_services('openai', 'user')
-    # OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_invalid_json).returns(@openai_response_safe_json).twice
-    mock_response_invalid = stub(
-      body: @openai_response_invalid_json,
-      code: 200,
-      success?: true
-    )
-    mock_response_safe = stub(
-      body: @openai_response_safe_json,
-      code: 200,
-      success?: true
-    )
+    mock_response_invalid = create_stubbed_response(@openai_response_invalid_json)
+    mock_response_safe = create_stubbed_response(@openai_response_safe_json)
     OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).
       returns(mock_response_invalid).
       returns(mock_response_safe).
@@ -141,12 +117,7 @@ class AichatSafetyHelperTest < ActionView::TestCase
 
   test "raises an error if request_safety_check returns a response.body other than INAPPROPRIATE or OK twice" do
     stub_safety_services('openai', 'user')
-    # OpenaiChatHelper.stubs(:request_safety_check).returns(@openai_response_invalid_json)
-    mock_response = stub(
-      body: @openai_response_invalid_json,
-      code: 200,
-      success?: true
-    )
+    mock_response = create_stubbed_response(@openai_response_invalid_json)
     OpenaiChatHelper::Client.any_instance.stubs(:request_chat_completion).returns(mock_response)
 
     assert_raises do
@@ -179,5 +150,13 @@ class AichatSafetyHelperTest < ActionView::TestCase
     when 'openai'
       assert_equal @openai_response, details
     end
+  end
+
+  def create_stubbed_response(body)
+    stub(
+      body: body,
+      code: 200,
+      success?: true
+    )
   end
 end

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -736,7 +736,7 @@ module SharedConstants
 
   # We should always specify a version for the LLM so the results don't unexpectedly change.
   # reference: https://platform.openai.com/docs/models/gpt-3-5
-  AI_TUTOR_CHAT_MODEL_VERISON = 'gpt-4o-2024-05-13'
+  AI_TUTOR_CHAT_MODEL_VERSION = 'gpt-4o-2024-05-13'
   AICHAT_MODEL_VERSION = 'gpt-4o-mini-2024-07-18'
 
   # These reflect the 'status' of an AI Interaction,


### PR DESCRIPTION
A prefactor in service of separating the API keys that AI Tutor, AI Chat's safety helper, and AI Chat's use of gpt-4o-mini as a base model. This change has us provide the appropriate API key (and model) in each use case.

1. Moves code that is specific to AI Tutor (get_chat_completion_response_message) and AI Chat's safety helper (request_safety_check) out of our OpenAI chat helper and into their respective consumers of the OpenAI API.
2. Refactors AI Chat's safety helper to use the generic request_chat_completion in our OpenAI chat helper.
3. Changes our OpenAI chat helper to include a class that is instantiated with an API key and a model ID, with a single instance method to make requests to OpenAI (request_chat_completion).

There's no functional change expected in this PR. A follow-up will add new API keys for AI Tutor and the AI Chat use of gpt-4o-mini as a base model (the safety use case already has its own API key, so will remain unchanged) so that we have different ones for each use case.

## Testing story

Tested manually that AI Tutor, safety checks on model customization updates, and normal chat completion requests continued to work. Updated unit tests.