### PR TITLE
feat(marketing): add jest unit tests

### DIFF
--- a/frontend/apps/marketing/jest.config.mjs
+++ b/frontend/apps/marketing/jest.config.mjs
@@ -1,0 +1,17 @@
+import nextJest from 'next/jest.js';
+
+const createJestConfig = nextJest({
+  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+  dir: './',
+});
+
+// Add any custom config to be passed to Jest
+/** @type {import('jest').Config} **/
+const config = {
+  coverageProvider: 'v8',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+};
+
+// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
+export default createJestConfig(config);

--- a/frontend/apps/marketing/package.json
+++ b/frontend/apps/marketing/package.json
@@ -22,7 +22,8 @@
     "lint:fix": "eslint --fix .",
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "prettier": "@code-dot-org/lint-config/prettier/index.mjs",
   "dependencies": {
@@ -35,12 +36,19 @@
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^15.0.3",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^9.16.0",
     "eslint-plugin-jest": "^28.9.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "prettier": "3.3.3",
+    "ts-node": "^10.9.2",
     "typescript": "^5"
   },
   "engines": {

--- a/frontend/apps/marketing/src/components/heading/__tests__/Heading.test.tsx
+++ b/frontend/apps/marketing/src/components/heading/__tests__/Heading.test.tsx
@@ -1,0 +1,36 @@
+import Heading from '@/components/heading';
+import {render, screen} from '@testing-library/react';
+
+describe('Heading Component', () => {
+  it('should render out all headings', async () => {
+    render(
+      <div>
+        <Heading visualAppearance={'heading-xxl'}>xxl - h1</Heading>
+        <Heading visualAppearance={'heading-xl'}>xl - h2</Heading>
+        <Heading visualAppearance={'heading-lg'}>lg - h3</Heading>
+        <Heading visualAppearance={'heading-md'}>md - h4</Heading>
+        <Heading visualAppearance={'heading-sm'}>sm - h5</Heading>
+        <Heading visualAppearance={'heading-xs'}>xs - h6</Heading>
+      </div>,
+    );
+
+    expect(screen.getByRole('heading', {level: 1})).toHaveTextContent(
+      'xxl - h1',
+    );
+    expect(screen.getByRole('heading', {level: 2})).toHaveTextContent(
+      'xl - h2',
+    );
+    expect(screen.getByRole('heading', {level: 3})).toHaveTextContent(
+      'lg - h3',
+    );
+    expect(screen.getByRole('heading', {level: 4})).toHaveTextContent(
+      'md - h4',
+    );
+    expect(screen.getByRole('heading', {level: 5})).toHaveTextContent(
+      'sm - h5',
+    );
+    expect(screen.getByRole('heading', {level: 6})).toHaveTextContent(
+      'xs - h6',
+    );
+  });
+});

--- a/frontend/apps/marketing/src/components/paragraph/__tests__/Paragraph.test.tsx
+++ b/frontend/apps/marketing/src/components/paragraph/__tests__/Paragraph.test.tsx
@@ -1,0 +1,14 @@
+import Paragraph from '@/components/paragraph';
+import {render, screen} from '@testing-library/react';
+
+describe('Paragraph Component', () => {
+  it('should render out the text', async () => {
+    render(
+      <Paragraph visualAppearance={'body-two'} isStrong={false}>
+        Hello World!
+      </Paragraph>,
+    );
+
+    expect(screen.getByText('Hello World!')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/marketing/src/contentful/__tests__/client.test.ts
+++ b/frontend/apps/marketing/src/contentful/__tests__/client.test.ts
@@ -1,0 +1,38 @@
+import {_private} from '@/contentful/client';
+import {createClient} from 'contentful';
+
+const DEFAULT_PROPS = {
+  space: 'space',
+  environment: 'test',
+  host: 'test-host',
+  accessToken: 'token',
+};
+
+jest.mock('contentful', () => ({
+  createClient: jest.fn().mockReturnValue('client'),
+}));
+
+describe('Contentful Client Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a client if all necessary props are provided', () => {
+    const result = _private.getContentfulClient(DEFAULT_PROPS);
+
+    expect(createClient).toHaveBeenCalledWith(DEFAULT_PROPS);
+    expect(result).not.toBe(undefined);
+  });
+
+  it('should return undefined if not all necessary props are provided', () => {
+    const props = {
+      ...DEFAULT_PROPS,
+      token: undefined,
+    };
+
+    const result = _private.getContentfulClient(props);
+
+    expect(createClient).not.toHaveBeenCalledWith(props);
+    expect(result).toBe(undefined);
+  });
+});

--- a/frontend/apps/marketing/src/contentful/client.ts
+++ b/frontend/apps/marketing/src/contentful/client.ts
@@ -1,27 +1,41 @@
 import {createClient} from 'contentful';
 
+type ClientProps = {
+  space: string;
+  environment?: string;
+  host?: string;
+  accessToken: string;
+};
+
 /**
  * For values and documentation, please refer to .env.example
  */
-const clientProps = {
+const clientProps: ClientProps = {
   space: process.env.CONTENTFUL_SPACE_ID!,
   environment: process.env.CONTENTFUL_ENV_ID,
   host: process.env.CONTENTFUL_API_HOST,
   accessToken: process.env.CONTENTFUL_TOKEN!,
 };
 
-/**
- * Check if all the required environment variables are available.
- * If not, the client will not be created.
- */
-const isEnvironmentAvailable = Object.values(clientProps).every(
-  value => !!value,
-);
+function getContentfulClient(props: ClientProps) {
+  /**
+   * Check if all the required environment variables are available.
+   * If not, the client will not be created.
+   */
+  const isEnvironmentAvailable = Object.values(props).every(value => !!value);
 
-if (!isEnvironmentAvailable) {
-  console.warn(
-    'Contentful client is not available, no content will be fetched from Contentful.',
-  );
+  if (!isEnvironmentAvailable) {
+    console.warn(
+      '⚠️ Contentful client is not available, no content will be fetched from Contentful. Please check that frontend/apps/marketing/.env is populated.',
+    );
+  }
+
+  return isEnvironmentAvailable ? createClient(props) : undefined;
 }
 
-export default isEnvironmentAvailable ? createClient(clientProps) : undefined;
+// Exported for unit testing only
+export const _private = {
+  getContentfulClient,
+};
+
+export default getContentfulClient(clientProps);

--- a/frontend/apps/marketing/src/setupTests.ts
+++ b/frontend/apps/marketing/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/apps/marketing/tsconfig.json
+++ b/frontend/apps/marketing/tsconfig.json
@@ -20,7 +20,8 @@
     },
     "allowJs": true,
     "module": "esnext",
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "types": ["node", "jest", "@testing-library/jest-dom"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1052,16 +1052,23 @@ __metadata:
     "@code-dot-org/component-library": "workspace:*"
     "@contentful/experiences-sdk-react": "npm:^1.30.3"
     "@next/eslint-plugin-next": "npm:^15.0.3"
+    "@testing-library/dom": "npm:^10.4.0"
+    "@testing-library/jest-dom": "npm:^6.6.3"
+    "@testing-library/react": "npm:^16.2.0"
+    "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^20"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
     contentful: "npm:^11.2.5"
     eslint: "npm:^9.16.0"
     eslint-plugin-jest: "npm:^28.9.0"
+    jest: "npm:^29.7.0"
+    jest-environment-jsdom: "npm:^29.7.0"
     next: "npm:^15.1.2"
     prettier: "npm:3.3.3"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
+    ts-node: "npm:^10.9.2"
     typescript: "npm:^5"
   languageName: unknown
   linkType: soft
@@ -1278,6 +1285,15 @@ __metadata:
   dependencies:
     is-plain-obj: "npm:^3.0.0"
   checksum: 10c0/cdeb1239b459d4c0796a0367bfd784f1f2b6b27956bba00fd7b0c80ecbe93a33d0856a49dc525f5f6ce6b5488835c224868fa17c67eeb6b7170d6cc6a9641fe0
+  languageName: node
+  linkType: hard
+
+"@cspotcode/source-map-support@npm:^0.8.0":
+  version: 0.8.1
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:0.3.9"
+  checksum: 10c0/05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
   languageName: node
   linkType: hard
 
@@ -2319,7 +2335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.1.0":
+"@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
@@ -2347,6 +2363,16 @@ __metadata:
   version: 1.5.0
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
   checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.0.3"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
+  checksum: 10c0/fa425b606d7c7ee5bfa6a31a7b050dd5814b4082f318e0e4190f991902181b4330f43f4805db1dd4f2433fd0ed9cc7a7b9c2683f1deeab1df1b0a98b1e24055b
   languageName: node
   linkType: hard
 
@@ -3966,6 +3992,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/react@npm:^16.2.0":
+  version: 16.2.0
+  resolution: "@testing-library/react@npm:16.2.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    "@testing-library/dom": ^10.0.0
+    "@types/react": ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^18.0.0 || ^19.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/7adaedaf237002b42e04a6261d2756074a19cbca0f0c79ba375660f618e123c0ee56256ced00aeb0bb7225ba1a8a81b92b692cca053521a21bb92a8cace1e4c6
+  languageName: node
+  linkType: hard
+
 "@testing-library/user-event@npm:14.5.2":
   version: 14.5.2
   resolution: "@testing-library/user-event@npm:14.5.2"
@@ -3986,6 +4032,34 @@ __metadata:
   version: 0.23.0
   resolution: "@tootallnate/quickjs-emscripten@npm:0.23.0"
   checksum: 10c0/2a939b781826fb5fd3edd0f2ec3b321d259d760464cf20611c9877205aaca3ccc0b7304dea68416baa0d568e82cd86b17d29548d1e5139fa3155a4a86a2b4b49
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node10@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node10@npm:1.0.11"
+  checksum: 10c0/28a0710e5d039e0de484bdf85fee883bfd3f6a8980601f4d44066b0a6bcd821d31c4e231d1117731c4e24268bd4cf2a788a6787c12fc7f8d11014c07d582783c
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node12@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node12@npm:1.0.11"
+  checksum: 10c0/dddca2b553e2bee1308a056705103fc8304e42bb2d2cbd797b84403a223b25c78f2c683ec3e24a095e82cd435387c877239bffcb15a590ba817cd3f6b9a99fd9
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node14@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@tsconfig/node14@npm:1.0.3"
+  checksum: 10c0/67c1316d065fdaa32525bc9449ff82c197c4c19092b9663b23213c8cbbf8d88b6ed6a17898e0cbc2711950fbfaf40388938c1c748a2ee89f7234fc9e7fe2bf44
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "@tsconfig/node16@npm:1.0.4"
+  checksum: 10c0/05f8f2734e266fb1839eb1d57290df1664fe2aa3b0fdd685a9035806daa635f7519bf6d5d9b33f6e69dd545b8c46bd6e2b5c79acb2b1f146e885f7f11a42a5bb
   languageName: node
   linkType: hard
 
@@ -5582,7 +5656,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^8.0.2":
+"acorn-walk@npm:^8.0.2, acorn-walk@npm:^8.1.1":
   version: 8.3.4
   resolution: "acorn-walk@npm:8.3.4"
   dependencies:
@@ -5591,7 +5665,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.1.0, acorn@npm:^8.11.0, acorn@npm:^8.14.0, acorn@npm:^8.8.1, acorn@npm:^8.8.2":
+"acorn@npm:^8.1.0, acorn@npm:^8.11.0, acorn@npm:^8.14.0, acorn@npm:^8.4.1, acorn@npm:^8.8.1, acorn@npm:^8.8.2":
   version: 8.14.0
   resolution: "acorn@npm:8.14.0"
   bin:
@@ -5854,6 +5928,13 @@ __metadata:
   version: 1.0.0
   resolution: "archy@npm:1.0.0"
   checksum: 10c0/200c849dd1c304ea9914827b0555e7e1e90982302d574153e28637db1a663c53de62bad96df42d50e8ce7fc18d05e3437d9aa8c4b383803763755f0956c7d308
+  languageName: node
+  linkType: hard
+
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 10c0/070ff801a9d236a6caa647507bdcc7034530604844d64408149a26b9e87c2f97650055c0f049abd1efc024b334635c01f29e0b632b371ac3f26130f4cf65997a
   languageName: node
   linkType: hard
 
@@ -7326,6 +7407,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: 10c0/157cbc59b2430ae9a90034a5f3a1b398b6738bf510f713edc4d4e45e169bc514d3d99dd34d8d01ca7ae7830b5b8b537e46ae8f3c8f932371b0875c0151d7ec91
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -7775,6 +7863,13 @@ __metadata:
   version: 29.6.3
   resolution: "diff-sequences@npm:29.6.3"
   checksum: 10c0/32e27ac7dbffdf2fb0eb5a84efd98a9ad084fbabd5ac9abb8757c6770d5320d2acd172830b28c4add29bb873d59420601dfc805ac4064330ce59b1adfd0593b2
+  languageName: node
+  linkType: hard
+
+"diff@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "diff@npm:4.0.2"
+  checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
   languageName: node
   linkType: hard
 
@@ -11943,6 +12038,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-error@npm:^1.1.1":
+  version: 1.3.6
+  resolution: "make-error@npm:1.3.6"
+  checksum: 10c0/171e458d86854c6b3fc46610cfacf0b45149ba043782558c6875d9f42f222124384ad0b468c92e996d815a8a2003817a710c0a160e49c1c394626f76fa45396f
+  languageName: node
+  linkType: hard
+
 "make-fetch-happen@npm:^13.0.0":
   version: 13.0.1
   resolution: "make-fetch-happen@npm:13.0.1"
@@ -15667,6 +15769,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.9.2":
+  version: 10.9.2
+  resolution: "ts-node@npm:10.9.2"
+  dependencies:
+    "@cspotcode/source-map-support": "npm:^0.8.0"
+    "@tsconfig/node10": "npm:^1.0.7"
+    "@tsconfig/node12": "npm:^1.0.7"
+    "@tsconfig/node14": "npm:^1.0.0"
+    "@tsconfig/node16": "npm:^1.0.2"
+    acorn: "npm:^8.4.1"
+    acorn-walk: "npm:^8.1.1"
+    arg: "npm:^4.1.0"
+    create-require: "npm:^1.1.0"
+    diff: "npm:^4.0.1"
+    make-error: "npm:^1.1.1"
+    v8-compile-cache-lib: "npm:^3.0.1"
+    yn: "npm:3.1.1"
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: 10c0/5f29938489f96982a25ba650b64218e83a3357d76f7bede80195c65ab44ad279c8357264639b7abdd5d7e75fc269a83daa0e9c62fd8637a3def67254ecc9ddc2
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^4.2.0":
   version: 4.2.0
   resolution: "tsconfig-paths@npm:4.2.0"
@@ -16241,6 +16381,13 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
+  languageName: node
+  linkType: hard
+
+"v8-compile-cache-lib@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "v8-compile-cache-lib@npm:3.0.1"
+  checksum: 10c0/bdc36fb8095d3b41df197f5fb6f11e3a26adf4059df3213e3baa93810d8f0cc76f9a74aaefc18b73e91fe7e19154ed6f134eda6fded2e0f1c8d2272ed2d2d391
   languageName: node
   linkType: hard
 
@@ -16873,6 +17020,13 @@ __metadata:
     buffer-crc32: "npm:~0.2.3"
     fd-slicer: "npm:~1.1.0"
   checksum: 10c0/f265002af7541b9ec3589a27f5fb8f11cf348b53cc15e2751272e3c062cd73f3e715bc72d43257de71bbaecae446c3f1b14af7559e8ab0261625375541816422
+  languageName: node
+  linkType: hard
+
+"yn@npm:3.1.1":
+  version: 3.1.1
+  resolution: "yn@npm:3.1.1"
+  checksum: 10c0/0732468dd7622ed8a274f640f191f3eaf1f39d5349a1b72836df484998d7d9807fbea094e2f5486d6b0cd2414aad5775972df0e68f8604db89a239f0f4bf7443
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds jest unit testing support for the marketing app including react testing library support with a couple test cases for both react and node files.