### PR TITLE
Music: extend check for end

### DIFF
--- a/apps/src/music/views/MusicLabView.tsx
+++ b/apps/src/music/views/MusicLabView.tsx
@@ -197,7 +197,7 @@ const MusicLabView: React.FunctionComponent<MusicLabViewProps> = ({
 
     // Show a little extra playback.  If there are any triggers, then play for longer in case
     // the user wants to trigger another sound.
-    const extraMeasures = blocklyWorkspace.hasAnyTriggers() ? 4 : 1;
+    const extraMeasures = blocklyWorkspace.hasAnyTriggers() ? 4 : 2;
 
     if (currentPlayheadPosition >= stopMeasure + extraMeasures) {
       setPlaying(false);


### PR DESCRIPTION
This modifies the behavior introduced in https://github.com/code-dot-org/code-dot-org/pull/63428 so that a song without triggers stops playing 2 measures after its end, rather than 1.  

This fixes a regression on levels such as https://studio.code.org/s/music-jam-2024/lessons/1/levels/6 which hold off showing a validation until measure [2](https://github.com/code-dot-org/code-dot-org/blob/5bf24dc73cc39d27eb330e14986be11e68127274/apps/src/music/views/MusicView.jsx#L452), which was also the time playback would stop if there were no sounds on the timeline.  The race between the check to stop and the check to show validation would lead to an inconsistent display of the validation feedback to the user.  With this change, the feedback is shown consistently again.

Thanks to @katiejofr for noticing this.
  