### PR TITLE
Remove A/B test scaffolding for requiring school info in new signup flow

### DIFF
--- a/apps/src/signUpFlow/FinishTeacherAccount.tsx
+++ b/apps/src/signUpFlow/FinishTeacherAccount.tsx
@@ -75,12 +75,6 @@ const FinishTeacherAccount: React.FunctionComponent<{
   const [errorCreatingAccountMessage, showErrorCreatingAccountMessage] =
     useState(false);
 
-  const isInSchoolRequiredExperiment = statsigReporter.getIsInExperiment(
-    'require_school_in_signup_v1',
-    'requireInfo',
-    false
-  );
-
   const showEducatorRole = statsigReporter.getIsInExperiment(
     'educator_role',
     'showEducatorRole',
@@ -152,16 +146,9 @@ const FinishTeacherAccount: React.FunctionComponent<{
       name?.trim() === '' ||
       name?.length > MAX_DISPLAY_NAME_LENGTH ||
       !gdprValid ||
-      (isInSchoolRequiredExperiment && schoolInfoInvalid(schoolInfo)) ||
+      schoolInfoInvalid(schoolInfo) ||
       (requireEducatorRole && !educatorRole),
-    [
-      gdprValid,
-      isInSchoolRequiredExperiment,
-      name,
-      schoolInfo,
-      requireEducatorRole,
-      educatorRole,
-    ]
+    [gdprValid, name, schoolInfo, requireEducatorRole, educatorRole]
   );
 
   const onNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -318,11 +305,7 @@ const FinishTeacherAccount: React.FunctionComponent<{
               dropdownTextThickness="thin"
             />
           )}
-          <SchoolDataInputs
-            {...schoolInfo}
-            includeHeaders={false}
-            markFieldsAsRequired={isInSchoolRequiredExperiment}
-          />
+          <SchoolDataInputs {...schoolInfo} includeHeaders={false} />
           {showGDPR && (
             <div>
               <BodyThreeText

--- a/apps/src/templates/SchoolDataInputs.jsx
+++ b/apps/src/templates/SchoolDataInputs.jsx
@@ -44,7 +44,6 @@ export default function SchoolDataInputs({
   usIp,
   containerClassName,
   includeHeaders = true,
-  markFieldsAsRequired = false,
   fieldNames = {
     country: 'user[school_info_attributes][country]',
     ncesSchoolId: 'user[school_info_attributes][school_id]',
@@ -97,9 +96,7 @@ export default function SchoolDataInputs({
 
   const computedStyleClass = classNames(
     style.schoolAssociationWrapper,
-    {
-      [style.requiredLabel]: markFieldsAsRequired,
-    },
+    style.requiredLabel,
     containerClassName
   );
 
@@ -220,7 +217,6 @@ export default function SchoolDataInputs({
 
 SchoolDataInputs.propTypes = {
   includeHeaders: PropTypes.bool,
-  markFieldsAsRequired: PropTypes.bool,
   fieldNames: PropTypes.object,
   containerClassName: PropTypes.string,
   schoolId: PropTypes.string.isRequired,

--- a/apps/src/templates/SchoolDataInputs.jsx
+++ b/apps/src/templates/SchoolDataInputs.jsx
@@ -96,7 +96,6 @@ export default function SchoolDataInputs({
 
   const computedStyleClass = classNames(
     style.schoolAssociationWrapper,
-    style.requiredLabel,
     containerClassName
   );
 

--- a/apps/src/templates/school-association.module.scss
+++ b/apps/src/templates/school-association.module.scss
@@ -16,6 +16,10 @@
   label {
     width: 100%;
     margin-bottom: 0;
+
+    span::after {
+      content: '*';
+    }
   }
 
   input,
@@ -50,12 +54,6 @@
   display: flex;
   flex-direction: column;
   gap: 1.125rem;
-}
-
-.schoolAssociationWrapper.requiredLabel label {
-  span::after {
-    content: '*';
-  }
 }
 
 .disabledLabel {

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -563,10 +563,10 @@ describe('FinishTeacherAccount', () => {
       const displayNameInput = screen.getAllByRole('textbox')[0];
       fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
 
-      fireEvent.change(screen.getAllByRole('combobox')[0], {
+      fireEvent.change(screen.getAllByRole('combobox')[1], {
         target: {value: 'AU'},
       });
-      fireEvent.change(screen.getAllByDisplayValue('')[1], {
+      fireEvent.change(screen.getAllByDisplayValue('')[0], {
         target: {value: 'Test School'},
       });
 

--- a/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
+++ b/apps/test/unit/signUpFlow/FinishTeacherAccountTest.tsx
@@ -247,6 +247,12 @@ describe('FinishTeacherAccount', () => {
     // Check that button is disabled until GDPR is checked (and other required fields are filled)
     const displayNameInput = screen.getAllByRole('textbox')[0];
     fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
+    fireEvent.change(screen.getAllByRole('combobox')[0], {
+      target: {value: 'AU'},
+    });
+    fireEvent.change(screen.getAllByDisplayValue('')[0], {
+      target: {value: 'Test School'},
+    });
     const finishSignUpButton = screen.getByRole('button', {
       name: locale.go_to_my_account(),
     });
@@ -274,7 +280,10 @@ describe('FinishTeacherAccount', () => {
         email: email,
         name: name,
         email_preference_opt_in: true,
-        school_info_attributes: undefined,
+        school_info_attributes: {
+          country: 'AU',
+          school_name: 'Test School',
+        },
         country_code: 'US',
         educator_role: null,
       },
@@ -295,6 +304,12 @@ describe('FinishTeacherAccount', () => {
     // Fill in fields
     fireEvent.change(screen.getAllByDisplayValue('')[0], {
       target: {value: name},
+    });
+    fireEvent.change(screen.getAllByRole('combobox')[0], {
+      target: {value: 'AU'},
+    });
+    fireEvent.change(screen.getAllByDisplayValue('')[0], {
+      target: {value: 'Test School'},
     });
     fireEvent.click(screen.getByRole('checkbox'));
 
@@ -351,7 +366,10 @@ describe('FinishTeacherAccount', () => {
         email: email,
         name: name,
         email_preference_opt_in: true,
-        school_info_attributes: undefined,
+        school_info_attributes: {
+          country: 'AU',
+          school_name: 'Test School',
+        },
         country_code: 'US',
         educator_role: null,
       },
@@ -370,6 +388,12 @@ describe('FinishTeacherAccount', () => {
     // Fill in fields
     fireEvent.change(screen.getAllByDisplayValue('')[0], {
       target: {value: name},
+    });
+    fireEvent.change(screen.getAllByRole('combobox')[0], {
+      target: {value: 'AU'},
+    });
+    fireEvent.change(screen.getAllByDisplayValue('')[0], {
+      target: {value: 'Test School'},
     });
     fireEvent.click(screen.getByRole('checkbox'));
 
@@ -424,7 +448,10 @@ describe('FinishTeacherAccount', () => {
         email: email,
         name: name,
         email_preference_opt_in: true,
-        school_info_attributes: undefined,
+        school_info_attributes: {
+          country: 'AU',
+          school_name: 'Test School',
+        },
         country_code: 'US',
         educator_role: null,
       },
@@ -446,6 +473,12 @@ describe('FinishTeacherAccount', () => {
     // Fill in fields
     fireEvent.change(screen.getAllByDisplayValue('')[0], {
       target: {value: name},
+    });
+    fireEvent.change(screen.getAllByRole('combobox')[0], {
+      target: {value: 'AU'},
+    });
+    fireEvent.change(screen.getAllByDisplayValue('')[0], {
+      target: {value: 'Test School'},
     });
     fireEvent.click(screen.getByRole('checkbox'));
 
@@ -530,6 +563,13 @@ describe('FinishTeacherAccount', () => {
       const displayNameInput = screen.getAllByRole('textbox')[0];
       fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
 
+      fireEvent.change(screen.getAllByRole('combobox')[0], {
+        target: {value: 'AU'},
+      });
+      fireEvent.change(screen.getAllByDisplayValue('')[1], {
+        target: {value: 'Test School'},
+      });
+
       const finishSignUpButton = screen.getByRole('button', {
         name: locale.go_to_my_account(),
       });
@@ -556,6 +596,13 @@ describe('FinishTeacherAccount', () => {
 
       const displayNameInput = screen.getAllByRole('textbox')[0];
       fireEvent.change(displayNameInput, {target: {value: 'FirstName'}});
+
+      fireEvent.change(screen.getAllByRole('combobox')[1], {
+        target: {value: 'AU'},
+      });
+      fireEvent.change(screen.getAllByDisplayValue('')[0], {
+        target: {value: 'Test School'},
+      });
 
       let finishSignUpButton = screen.getByRole('button', {
         name: locale.go_to_my_account(),


### PR DESCRIPTION
Removes the A/B test scaffolding for requiring school info in the new signup flow created here:
- [Add A/B test scaffolding](https://github.com/code-dot-org/code-dot-org/pull/62571)
- [Add asterisks for required questions](https://github.com/code-dot-org/code-dot-org/pull/62729)

This PR also ensures that school info is always required now in the new signup flow.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?selectedIssue=ACQ-3016)

## Testing story
Updating unit tests.
